### PR TITLE
 [IMP] bus: clean and make bus tests more robust

### DIFF
--- a/addons/bus/static/tests/assets_watchdog_tests.js
+++ b/addons/bus/static/tests/assets_watchdog_tests.js
@@ -1,45 +1,31 @@
 /* @odoo-module */
 
-import { busService } from "@bus/services/bus_service";
-import { busParametersService } from "@bus/bus_parameters_service";
-import { presenceService } from "@bus/services/presence_service";
-import { multiTabService } from "@bus/multi_tab_service";
 import { getPyEnv } from "@bus/../tests/helpers/mock_python_environment";
+import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
 
-import { assetsWatchdogService } from "@bus/services/assets_watchdog_service";
-import { browser } from "@web/core/browser/browser";
-import { registry } from "@web/core/registry";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
-import { createWebClient } from "@web/../tests/webclient/helpers";
 import { click, contains } from "@web/../tests/utils";
+import { createWebClient } from "@web/../tests/webclient/helpers";
+import { browser } from "@web/core/browser/browser";
 
-const serviceRegistry = registry.category("services");
+QUnit.module("Bus Assets WatchDog");
 
-QUnit.module("Bus Assets WatchDog", (hooks) => {
-    hooks.beforeEach((assert) => {
-        serviceRegistry.add("assetsWatchdog", assetsWatchdogService);
-        serviceRegistry.add("bus_service", busService);
-        serviceRegistry.add("bus.parameters", busParametersService);
-        serviceRegistry.add("presence", presenceService);
-        serviceRegistry.add("multi_tab", multiTabService);
-        patchWithCleanup(browser, {
-            setTimeout(fn) {
-                return super.setTimeout(fn, 0);
-            },
-            location: {
-                reload: () => assert.step("reloadPage"),
-            },
-        });
+QUnit.test("can listen on bus and displays notifications in DOM", async (assert) => {
+    addBusServicesToRegistry();
+    patchWithCleanup(browser, {
+        setTimeout(fn) {
+            return super.setTimeout(fn, 0);
+        },
+        location: {
+            reload: () => assert.step("reloadPage"),
+        },
     });
-
-    QUnit.test("can listen on bus and displays notifications in DOM", async (assert) => {
-        await createWebClient({});
-        const pyEnv = await getPyEnv();
-        pyEnv["bus.bus"]._sendone("broadcast", "bundle_changed", {
-            server_version: "NEW_MAJOR_VERSION",
-        });
-        await contains(".o_notification", { text: "The page appears to be out of date." });
-        await click(".o_notification_buttons .btn-primary", { text: "Refresh" });
-        assert.verifySteps(["reloadPage"]);
+    await createWebClient({});
+    const pyEnv = await getPyEnv();
+    pyEnv["bus.bus"]._sendone("broadcast", "bundle_changed", {
+        server_version: "NEW_MAJOR_VERSION",
     });
+    await contains(".o_notification", { text: "The page appears to be out of date." });
+    await click(".o_notification_buttons .btn-primary", { text: "Refresh" });
+    assert.verifySteps(["reloadPage"]);
 });

--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -1,673 +1,603 @@
 /** @odoo-module **/
 
-import { busService } from "@bus/services/bus_service";
-import { presenceService } from "@bus/services/presence_service";
-import { busParametersService } from "@bus/bus_parameters_service";
-import { multiTabService } from "@bus/multi_tab_service";
-import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
+import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
 import { waitUntilSubscribe } from "@bus/../tests/helpers/websocket_event_deferred";
+import { busParametersService } from "@bus/bus_parameters_service";
+import { WEBSOCKET_CLOSE_CODES } from "@bus/workers/websocket_worker";
 
-import { browser } from "@web/core/browser/browser";
-import { registry } from "@web/core/registry";
-import { session } from "@web/session";
-import { makeDeferred, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
+import { makeDeferred, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { browser } from "@web/core/browser/browser";
+import { session } from "@web/session";
 
-QUnit.module(
-    "Bus",
-    {
-        beforeEach: function () {
-            const customMultiTabService = {
-                ...multiTabService,
-                start() {
-                    const originalMultiTabService = multiTabService.start(...arguments);
-                    originalMultiTabService.TAB_HEARTBEAT_PERIOD = 10;
-                    originalMultiTabService.MAIN_TAB_HEARTBEAT_PERIOD = 1;
-                    return originalMultiTabService;
-                },
-            };
-            registry.category("services").add("bus.parameters", busParametersService);
-            registry.category("services").add("bus_service", busService);
-            registry.category("services").add("presence", presenceService);
-            registry.category("services").add("multi_tab", customMultiTabService);
+QUnit.module("Bus");
+
+QUnit.test("notifications received from the channel", async function (assert) {
+    addBusServicesToRegistry();
+    const pyEnv = await startServer();
+    const env = await makeTestEnv({ activateMockServer: true });
+    await env.services["bus_service"].start();
+    env.services["bus_service"].addEventListener("notification", ({ detail: notifications }) => {
+        assert.step("notification - " + notifications.map((notif) => notif.payload).toString());
+    });
+    env.services["bus_service"].addChannel("lambda");
+    await waitUntilSubscribe("lambda");
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
+    await nextTick();
+
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "epsilon");
+    await nextTick();
+
+    assert.verifySteps(["notification - beta", "notification - epsilon"]);
+});
+
+QUnit.test("notifications not received after stoping the service", async function (assert) {
+    addBusServicesToRegistry();
+    const pyEnv = await startServer();
+    const firstTabEnv = await makeTestEnv({ activateMockServer: true });
+    const secondTabEnv = await makeTestEnv({ activateMockServer: true });
+    await firstTabEnv.services["bus_service"].start();
+    await secondTabEnv.services["bus_service"].start();
+
+    firstTabEnv.services["bus_service"].addEventListener(
+        "notification",
+        ({ detail: notifications }) => {
+            assert.step(
+                "1 - notification - " + notifications.map((notif) => notif.payload).toString()
+            );
+        }
+    );
+    firstTabEnv.services["bus_service"].addChannel("lambda");
+    secondTabEnv.services["bus_service"].addEventListener(
+        "notification",
+        ({ detail: notifications }) => {
+            assert.step(
+                "2 - notification - " + notifications.map((notif) => notif.payload).toString()
+            );
+        }
+    );
+    await waitUntilSubscribe("lambda");
+    // both tabs should receive the notification
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
+    await nextTick();
+    secondTabEnv.services["bus_service"].stop();
+    await nextTick();
+    // only first tab should receive the notification since the
+    // second tab has called the stop method.
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "epsilon");
+    await nextTick();
+
+    assert.verifySteps([
+        "1 - notification - beta",
+        "2 - notification - beta",
+        "1 - notification - epsilon",
+    ]);
+});
+
+QUnit.test("notifications still received after disconnect/reconnect", async function (assert) {
+    addBusServicesToRegistry();
+    const pyEnv = await startServer();
+    const env = await makeTestEnv({ activateMockServer: true });
+    await env.services["bus_service"].start();
+    env.services["bus_service"].addEventListener("notification", ({ detail: notifications }) => {
+        assert.step("notification - " + notifications.map((notif) => notif.payload).toString());
+    });
+    env.services["bus_service"].addChannel("lambda");
+    await waitUntilSubscribe("lambda");
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
+    pyEnv.simulateConnectionLost(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
+    // Give websocket worker a tick to try to restart
+    await nextTick();
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "gamma");
+    // Give bus service a tick to receive the notification from
+    // postMessage.
+    await nextTick();
+
+    assert.verifySteps(["notification - beta", "notification - gamma"]);
+});
+
+QUnit.test("tabs share message from a channel", async function (assert) {
+    addBusServicesToRegistry();
+    const pyEnv = await startServer();
+    const steps = [];
+    // main
+    const mainEnv = await makeTestEnv({ activateMockServer: true });
+    mainEnv.services["bus_service"].addEventListener(
+        "notification",
+        ({ detail: notifications }) => {
+            steps.push(
+                "main - notification - " + notifications.map((notif) => notif.payload).toString()
+            );
+        }
+    );
+    mainEnv.services["bus_service"].addChannel("lambda");
+
+    // slave
+    const slaveEnv = await makeTestEnv();
+    slaveEnv.services["bus_service"].start();
+
+    slaveEnv.services["bus_service"].addEventListener(
+        "notification",
+        ({ detail: notifications }) => {
+            steps.push(
+                "slave - notification - " + notifications.map((notif) => notif.payload).toString()
+            );
+        }
+    );
+    await slaveEnv.services["bus_service"].addChannel("lambda");
+    await waitUntilSubscribe("lambda");
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
+    // Wait one tick for the worker `postMessage` to reach the bus_service.
+    await nextTick();
+    // Wait another tick for the `bus.trigger` to reach the listeners.
+    await nextTick();
+
+    assert.deepEqual(steps.sort(), ["main - notification - beta", "slave - notification - beta"]);
+});
+
+QUnit.test("second tab still receives notifications after main pagehide", async function (assert) {
+    addBusServicesToRegistry();
+    const pyEnv = await startServer();
+    const steps = [];
+    // main
+    const mainEnv = await makeTestEnv({ activateMockServer: true });
+    mainEnv.services["bus_service"].start();
+    mainEnv.services["bus_service"].addEventListener(
+        "notification",
+        ({ detail: notifications }) => {
+            steps.push(
+                "main - notification - " + notifications.map((notif) => notif.payload).toString()
+            );
+        }
+    );
+    mainEnv.services["bus_service"].addChannel("lambda");
+
+    // second env
+    // prevent second tab from receiving pagehide event.
+    patchWithCleanup(browser, {
+        addEventListener(eventName, callback) {
+            if (eventName === "pagehide") {
+                return;
+            }
+            super.addEventListener(eventName, callback);
         },
-    },
-    function () {
-        QUnit.test("notifications received from the channel", async function (assert) {
-            assert.expect(3);
+    });
+    const secondEnv = await makeTestEnv({ activateMockServer: true });
+    secondEnv.services["bus_service"].addEventListener(
+        "notification",
+        ({ detail: notifications }) => {
+            steps.push(
+                "slave - notification - " + notifications.map((notif) => notif.payload).toString()
+            );
+        }
+    );
+    secondEnv.services["bus_service"].addChannel("lambda");
+    await waitUntilSubscribe("lambda");
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
+    await nextTick();
 
-            const pyEnv = await startServer();
-            const env = await makeTestEnv({ activateMockServer: true });
-            await env.services["bus_service"].start();
-            env.services["bus_service"].addEventListener(
-                "notification",
-                ({ detail: notifications }) => {
-                    assert.step(
-                        "notification - " + notifications.map((notif) => notif.payload).toString()
-                    );
+    // simulate unloading main
+    window.dispatchEvent(new Event("pagehide"));
+    await nextTick();
+
+    pyEnv["bus.bus"]._sendone("lambda", "notifType", "gamma");
+    await nextTick();
+
+    assert.deepEqual(steps.sort(), [
+        "main - notification - beta",
+        "slave - notification - beta",
+        "slave - notification - gamma",
+    ]);
+});
+
+QUnit.test("two tabs calling addChannel simultaneously", async function (assert) {
+    addBusServicesToRegistry();
+    const channelPatch = () => ({
+        addChannel(channel) {
+            assert.step("Tab " + this.__tabId__ + ": addChannel " + channel);
+            super.addChannel(...arguments);
+        },
+        deleteChannel(channel) {
+            assert.step("Tab " + this.__tabId__ + ": deleteChannel " + channel);
+            super.deleteChannel(...arguments);
+        },
+    });
+    const firstTabEnv = await makeTestEnv({ activateMockServer: true });
+    const secondTabEnv = await makeTestEnv({ activateMockServer: true });
+    firstTabEnv.services["bus_service"].__tabId__ = 1;
+    secondTabEnv.services["bus_service"].__tabId__ = 2;
+    patchWithCleanup(firstTabEnv.services["bus_service"], channelPatch());
+    patchWithCleanup(secondTabEnv.services["bus_service"], channelPatch());
+    firstTabEnv.services["bus_service"].addChannel("alpha");
+    secondTabEnv.services["bus_service"].addChannel("alpha");
+    firstTabEnv.services["bus_service"].addChannel("beta");
+    secondTabEnv.services["bus_service"].addChannel("beta");
+
+    await waitUntilSubscribe("alpha", "beta");
+
+    assert.verifySteps([
+        "Tab 1: addChannel alpha",
+        "Tab 2: addChannel alpha",
+        "Tab 1: addChannel beta",
+        "Tab 2: addChannel beta",
+    ]);
+});
+
+QUnit.test("two tabs adding a different channel", async function (assert) {
+    addBusServicesToRegistry();
+    const pyEnv = await startServer();
+    const firstTabEnv = await makeTestEnv({ activateMockServer: true });
+    const secondTabEnv = await makeTestEnv({ activateMockServer: true });
+    firstTabEnv.services["bus_service"].addEventListener(
+        "notification",
+        ({ detail: notifications }) => {
+            assert.step(
+                "first - notification - " + notifications.map((notif) => notif.payload).toString()
+            );
+        }
+    );
+    secondTabEnv.services["bus_service"].addEventListener(
+        "notification",
+        ({ detail: notifications }) => {
+            assert.step(
+                "second - notification - " + notifications.map((notif) => notif.payload).toString()
+            );
+        }
+    );
+    firstTabEnv.services["bus_service"].addChannel("alpha");
+    secondTabEnv.services["bus_service"].addChannel("beta");
+    await waitUntilSubscribe("alpha", "beta");
+    pyEnv["bus.bus"]._sendmany([
+        ["alpha", "notifType", "alpha"],
+        ["beta", "notifType", "beta"],
+    ]);
+    await nextTick();
+
+    assert.verifySteps(["first - notification - alpha,beta", "second - notification - alpha,beta"]);
+});
+
+QUnit.test("channel management from multiple tabs", async function (assert) {
+    addBusServicesToRegistry();
+    patchWebsocketWorkerWithCleanup({
+        _sendToServer({ event_name, data }) {
+            assert.step(`${event_name} - [${data.channels.toString()}]`);
+            super._sendToServer(...arguments);
+        },
+    });
+
+    const firstTabEnv = await makeTestEnv();
+    const secTabEnv = await makeTestEnv();
+    firstTabEnv.services["bus_service"].addChannel("channel1");
+    await nextTick();
+    // this should not trigger a subscription since the channel1 was
+    // aleady known.
+    secTabEnv.services["bus_service"].addChannel("channel1");
+    await nextTick();
+    // removing channel1 from first tab should not trigger
+    // re-subscription since the second tab still listens to this
+    // channel.
+    firstTabEnv.services["bus_service"].deleteChannel("channel1");
+    await nextTick();
+    // this should trigger a subscription since the channel2 was not
+    // known.
+    secTabEnv.services["bus_service"].addChannel("channel2");
+    await nextTick();
+
+    assert.verifySteps(["subscribe - [channel1]", "subscribe - [channel1,channel2]"]);
+});
+
+QUnit.test("channels subscription after disconnection", async function (assert) {
+    addBusServicesToRegistry();
+    const worker = patchWebsocketWorkerWithCleanup();
+    const env = await makeTestEnv({ activateMockServer: true });
+    env.services["bus_service"].start();
+    await waitUntilSubscribe();
+    worker.websocket.close(WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT);
+    await waitUntilSubscribe();
+    assert.ok(
+        true,
+        "No error means waitUntilSubscribe resolves twice thus two subscriptions were triggered as expected"
+    );
+});
+
+QUnit.test(
+    "Last notification id is passed to the worker on service start",
+    async function (assert) {
+        addBusServicesToRegistry();
+        const pyEnv = await startServer();
+        let updateLastNotificationDeferred = makeDeferred();
+        patchWebsocketWorkerWithCleanup({
+            _onClientMessage(_, { action, data }) {
+                if (action === "initialize_connection") {
+                    assert.step(`${action} - ${data["lastNotificationId"]}`);
+                    updateLastNotificationDeferred.resolve();
                 }
-            );
-            env.services["bus_service"].addChannel("lambda");
-            await waitUntilSubscribe("lambda");
-            pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
-            await nextTick();
-
-            pyEnv["bus.bus"]._sendone("lambda", "notifType", "epsilon");
-            await nextTick();
-
-            assert.verifySteps(["notification - beta", "notification - epsilon"]);
+                return super._onClientMessage(...arguments);
+            },
         });
+        const env1 = await makeTestEnv();
+        env1.services["bus_service"].start();
+        env1.services["bus_service"].addChannel("lambda");
+        await waitUntilSubscribe("lambda");
+        await updateLastNotificationDeferred;
+        // First bus service has never received notifications thus the
+        // default is 0.
+        assert.verifySteps(["initialize_connection - 0"]);
 
-        QUnit.test("notifications not received after stoping the service", async function (assert) {
-            assert.expect(4);
+        pyEnv["bus.bus"]._sendmany([
+            ["lambda", "notifType", "beta"],
+            ["lambda", "notifType", "beta"],
+        ]);
+        // let the bus service store the last notification id.
+        await nextTick();
 
-            const pyEnv = await startServer();
-            const firstTabEnv = await makeTestEnv({ activateMockServer: true });
-            const secondTabEnv = await makeTestEnv({ activateMockServer: true });
-            await firstTabEnv.services["bus_service"].start();
-            await secondTabEnv.services["bus_service"].start();
-
-            firstTabEnv.services["bus_service"].addEventListener(
-                "notification",
-                ({ detail: notifications }) => {
-                    assert.step(
-                        "1 - notification - " +
-                            notifications.map((notif) => notif.payload).toString()
-                    );
-                }
-            );
-            firstTabEnv.services["bus_service"].addChannel("lambda");
-            secondTabEnv.services["bus_service"].addEventListener(
-                "notification",
-                ({ detail: notifications }) => {
-                    assert.step(
-                        "2 - notification - " +
-                            notifications.map((notif) => notif.payload).toString()
-                    );
-                }
-            );
-            await waitUntilSubscribe("lambda");
-            // both tabs should receive the notification
-            pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
-            await nextTick();
-            secondTabEnv.services["bus_service"].stop();
-            await nextTick();
-            // only first tab should receive the notification since the
-            // second tab has called the stop method.
-            pyEnv["bus.bus"]._sendone("lambda", "notifType", "epsilon");
-            await nextTick();
-
-            assert.verifySteps([
-                "1 - notification - beta",
-                "2 - notification - beta",
-                "1 - notification - epsilon",
-            ]);
-        });
-
-        QUnit.test(
-            "notifications still received after disconnect/reconnect",
-            async function (assert) {
-                assert.expect(3);
-
-                const pyEnv = await startServer();
-                const env = await makeTestEnv({ activateMockServer: true });
-                await env.services["bus_service"].start();
-                env.services["bus_service"].addEventListener(
-                    "notification",
-                    ({ detail: notifications }) => {
-                        assert.step(
-                            "notification - " +
-                                notifications.map((notif) => notif.payload).toString()
-                        );
-                    }
-                );
-                env.services["bus_service"].addChannel("lambda");
-                await waitUntilSubscribe("lambda");
-                pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
-                pyEnv.simulateConnectionLost(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE);
-                // Give websocket worker a tick to try to restart
-                await nextTick();
-                pyEnv["bus.bus"]._sendone("lambda", "notifType", "gamma");
-                // Give bus service a tick to receive the notification from
-                // postMessage.
-                await nextTick();
-
-                assert.verifySteps(["notification - beta", "notification - gamma"]);
-            }
-        );
-
-        QUnit.test("tabs share message from a channel", async function (assert) {
-            assert.expect(1);
-
-            const pyEnv = await startServer();
-            const steps = [];
-            // main
-            const mainEnv = await makeTestEnv({ activateMockServer: true });
-            mainEnv.services["bus_service"].addEventListener(
-                "notification",
-                ({ detail: notifications }) => {
-                    steps.push(
-                        "main - notification - " +
-                            notifications.map((notif) => notif.payload).toString()
-                    );
-                }
-            );
-            mainEnv.services["bus_service"].addChannel("lambda");
-
-            // slave
-            const slaveEnv = await makeTestEnv();
-            slaveEnv.services["bus_service"].start();
-
-            slaveEnv.services["bus_service"].addEventListener(
-                "notification",
-                ({ detail: notifications }) => {
-                    steps.push(
-                        "slave - notification - " +
-                            notifications.map((notif) => notif.payload).toString()
-                    );
-                }
-            );
-            await slaveEnv.services["bus_service"].addChannel("lambda");
-            await waitUntilSubscribe("lambda");
-            pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
-            // Wait one tick for the worker `postMessage` to reach the bus_service.
-            await nextTick();
-            // Wait another tick for the `bus.trigger` to reach the listeners.
-            await nextTick();
-
-            assert.deepEqual(steps.sort(), [
-                "main - notification - beta",
-                "slave - notification - beta",
-            ]);
-        });
-
-        QUnit.test(
-            "second tab still receives notifications after main pagehide",
-            async function (assert) {
-                assert.expect(1);
-
-                const pyEnv = await startServer();
-                const steps = [];
-                // main
-                const mainEnv = await makeTestEnv({ activateMockServer: true });
-                mainEnv.services["bus_service"].start();
-                mainEnv.services["bus_service"].addEventListener(
-                    "notification",
-                    ({ detail: notifications }) => {
-                        steps.push(
-                            "main - notification - " +
-                                notifications.map((notif) => notif.payload).toString()
-                        );
-                    }
-                );
-                mainEnv.services["bus_service"].addChannel("lambda");
-
-                // second env
-                // prevent second tab from receiving pagehide event.
-                patchWithCleanup(browser, {
-                    addEventListener(eventName, callback) {
-                        if (eventName === "pagehide") {
-                            return;
-                        }
-                        super.addEventListener(eventName, callback);
-                    },
-                });
-                const secondEnv = await makeTestEnv({ activateMockServer: true });
-                secondEnv.services["bus_service"].addEventListener(
-                    "notification",
-                    ({ detail: notifications }) => {
-                        steps.push(
-                            "slave - notification - " +
-                                notifications.map((notif) => notif.payload).toString()
-                        );
-                    }
-                );
-                secondEnv.services["bus_service"].addChannel("lambda");
-                await waitUntilSubscribe("lambda");
-                pyEnv["bus.bus"]._sendone("lambda", "notifType", "beta");
-                await nextTick();
-
-                // simulate unloading main
-                window.dispatchEvent(new Event("pagehide"));
-                await nextTick();
-
-                pyEnv["bus.bus"]._sendone("lambda", "notifType", "gamma");
-                await nextTick();
-
-                assert.deepEqual(steps.sort(), [
-                    "main - notification - beta",
-                    "slave - notification - beta",
-                    "slave - notification - gamma",
-                ]);
-            }
-        );
-
-        QUnit.test("two tabs calling addChannel simultaneously", async function (assert) {
-            assert.expect(5);
-
-            const channelPatch = () => ({
-                addChannel(channel) {
-                    assert.step("Tab " + this.__tabId__ + ": addChannel " + channel);
-                    super.addChannel(...arguments);
-                },
-                deleteChannel(channel) {
-                    assert.step("Tab " + this.__tabId__ + ": deleteChannel " + channel);
-                    super.deleteChannel(...arguments);
-                },
-            });
-            const firstTabEnv = await makeTestEnv({ activateMockServer: true });
-            const secondTabEnv = await makeTestEnv({ activateMockServer: true });
-            firstTabEnv.services["bus_service"].__tabId__ = 1;
-            secondTabEnv.services["bus_service"].__tabId__ = 2;
-            patchWithCleanup(firstTabEnv.services["bus_service"], channelPatch());
-            patchWithCleanup(secondTabEnv.services["bus_service"], channelPatch());
-            firstTabEnv.services["bus_service"].addChannel("alpha");
-            secondTabEnv.services["bus_service"].addChannel("alpha");
-            firstTabEnv.services["bus_service"].addChannel("beta");
-            secondTabEnv.services["bus_service"].addChannel("beta");
-
-            await waitUntilSubscribe("alpha", "beta");
-
-            assert.verifySteps([
-                "Tab 1: addChannel alpha",
-                "Tab 2: addChannel alpha",
-                "Tab 1: addChannel beta",
-                "Tab 2: addChannel beta",
-            ]);
-        });
-
-        QUnit.test("two tabs adding a different channel", async function (assert) {
-            assert.expect(3);
-
-            const pyEnv = await startServer();
-            const firstTabEnv = await makeTestEnv({ activateMockServer: true });
-            const secondTabEnv = await makeTestEnv({ activateMockServer: true });
-            firstTabEnv.services["bus_service"].addEventListener(
-                "notification",
-                ({ detail: notifications }) => {
-                    assert.step(
-                        "first - notification - " +
-                            notifications.map((notif) => notif.payload).toString()
-                    );
-                }
-            );
-            secondTabEnv.services["bus_service"].addEventListener(
-                "notification",
-                ({ detail: notifications }) => {
-                    assert.step(
-                        "second - notification - " +
-                            notifications.map((notif) => notif.payload).toString()
-                    );
-                }
-            );
-            firstTabEnv.services["bus_service"].addChannel("alpha");
-            secondTabEnv.services["bus_service"].addChannel("beta");
-            await waitUntilSubscribe("alpha", "beta");
-            pyEnv["bus.bus"]._sendmany([
-                ["alpha", "notifType", "alpha"],
-                ["beta", "notifType", "beta"],
-            ]);
-            await nextTick();
-
-            assert.verifySteps([
-                "first - notification - alpha,beta",
-                "second - notification - alpha,beta",
-            ]);
-        });
-
-        QUnit.test("channel management from multiple tabs", async function (assert) {
-            assert.expect(3);
-
-            patchWebsocketWorkerWithCleanup({
-                _sendToServer({ event_name, data }) {
-                    assert.step(`${event_name} - [${data.channels.toString()}]`);
-                    super._sendToServer(...arguments);
-                },
-            });
-
-            const firstTabEnv = await makeTestEnv();
-            const secTabEnv = await makeTestEnv();
-            firstTabEnv.services["bus_service"].addChannel("channel1");
-            await nextTick();
-            // this should not trigger a subscription since the channel1 was
-            // aleady known.
-            secTabEnv.services["bus_service"].addChannel("channel1");
-            await nextTick();
-            // removing channel1 from first tab should not trigger
-            // re-subscription since the second tab still listens to this
-            // channel.
-            firstTabEnv.services["bus_service"].deleteChannel("channel1");
-            await nextTick();
-            // this should trigger a subscription since the channel2 was not
-            // known.
-            secTabEnv.services["bus_service"].addChannel("channel2");
-            await nextTick();
-
-            assert.verifySteps(["subscribe - [channel1]", "subscribe - [channel1,channel2]"]);
-        });
-
-        QUnit.test("channels subscription after disconnection", async function (assert) {
-            const worker = patchWebsocketWorkerWithCleanup();
-            const env = await makeTestEnv({ activateMockServer: true });
-            env.services["bus_service"].start();
-            await waitUntilSubscribe();
-            worker.websocket.close(WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT);
-            await waitUntilSubscribe();
-            assert.ok(
-                true,
-                "No error means waitUntilSubscribe resolves twice thus two subscriptions were triggered as expected"
-            );
-        });
-
-        QUnit.test(
-            "Last notification id is passed to the worker on service start",
-            async function (assert) {
-                const pyEnv = await startServer();
-                let updateLastNotificationDeferred = makeDeferred();
-                patchWebsocketWorkerWithCleanup({
-                    _onClientMessage(_, { action, data }) {
-                        if (action === "initialize_connection") {
-                            assert.step(`${action} - ${data["lastNotificationId"]}`);
-                            updateLastNotificationDeferred.resolve();
-                        }
-                        return super._onClientMessage(...arguments);
-                    },
-                });
-                const env1 = await makeTestEnv();
-                env1.services["bus_service"].start();
-                env1.services["bus_service"].addChannel("lambda");
-                await waitUntilSubscribe("lambda");
-                await updateLastNotificationDeferred;
-                // First bus service has never received notifications thus the
-                // default is 0.
-                assert.verifySteps(["initialize_connection - 0"]);
-
-                pyEnv["bus.bus"]._sendmany([
-                    ["lambda", "notifType", "beta"],
-                    ["lambda", "notifType", "beta"],
-                ]);
-                // let the bus service store the last notification id.
-                await nextTick();
-
-                updateLastNotificationDeferred = makeDeferred();
-                const env2 = await makeTestEnv();
-                await env2.services["bus_service"].start();
-                await updateLastNotificationDeferred;
-                // Second bus service sends the last known notification id.
-                assert.verifySteps([`initialize_connection - 2`]);
-            }
-        );
-
-        QUnit.test("Websocket disconnects upon user log out", async function (assert) {
-            // first tab connects to the worker with user logged.
-            patchWithCleanup(session, {
-                user_id: 1,
-            });
-            const connectionInitializedDeferred = makeDeferred();
-            let connectionOpenedDeferred = makeDeferred();
-            patchWebsocketWorkerWithCleanup({
-                _initializeConnection(client, data) {
-                    super._initializeConnection(client, data);
-                    connectionInitializedDeferred.resolve();
-                },
-            });
-
-            const firstTabEnv = await makeTestEnv();
-            await firstTabEnv.services["bus_service"].start();
-            firstTabEnv.services["bus_service"].addEventListener("connect", () => {
-                if (session.user_id) {
-                    assert.step("connect");
-                }
-                connectionOpenedDeferred.resolve();
-                connectionOpenedDeferred = makeDeferred();
-            });
-            firstTabEnv.services["bus_service"].addEventListener("disconnect", () => {
-                assert.step("disconnect");
-            });
-            await connectionInitializedDeferred;
-            await connectionOpenedDeferred;
-
-            // second tab connects to the worker after disconnection: user_id
-            // is now false.
-            patchWithCleanup(session, {
-                user_id: false,
-            });
-            const env2 = await makeTestEnv();
-            await env2.services["bus_service"].start();
-
-            assert.verifySteps(["connect", "disconnect"]);
-        });
-
-        QUnit.test("Websocket reconnects upon user log in", async function (assert) {
-            // first tab connects to the worker with no user logged.
-            patchWithCleanup(session, {
-                user_id: false,
-            });
-            const connectionInitializedDeferred = makeDeferred();
-            let websocketConnectedDeferred = makeDeferred();
-            patchWebsocketWorkerWithCleanup({
-                _initializeConnection(client, data) {
-                    super._initializeConnection(client, data);
-                    connectionInitializedDeferred.resolve();
-                },
-            });
-
-            const firstTabEnv = await makeTestEnv();
-            await firstTabEnv.services["bus_service"].start();
-            firstTabEnv.services["bus_service"].addEventListener("connect", () => {
-                assert.step("connect");
-                websocketConnectedDeferred.resolve();
-                websocketConnectedDeferred = makeDeferred();
-            });
-            firstTabEnv.services["bus_service"].addEventListener("disconnect", () => {
-                assert.step("disconnect");
-            });
-            await connectionInitializedDeferred;
-            await websocketConnectedDeferred;
-
-            // second tab connects to the worker after connection: user_id
-            // is now set.
-            patchWithCleanup(session, {
-                user_id: 1,
-            });
-            const env = await makeTestEnv();
-            await env.services["bus_service"].start();
-            await websocketConnectedDeferred;
-            assert.verifySteps(["connect", "disconnect", "connect"]);
-        });
-
-        QUnit.test(
-            "WebSocket connects with URL corresponding to given serverURL",
-            async function (assert) {
-                patchWebsocketWorkerWithCleanup();
-                const serverURL = "http://random-website.com";
-                patchWithCleanup(busParametersService, {
-                    start() {
-                        return {
-                            ...super.start(...arguments),
-                            serverURL,
-                        };
-                    },
-                });
-                const websocketCreatedDeferred = makeDeferred();
-                patchWithCleanup(window, {
-                    WebSocket: function (url) {
-                        assert.step(url);
-                        websocketCreatedDeferred.resolve();
-                        return new EventTarget();
-                    },
-                });
-                const env = await makeTestEnv();
-                env.services["bus_service"].start();
-                await websocketCreatedDeferred;
-                assert.verifySteps([`${serverURL.replace("http", "ws")}/websocket`]);
-            }
-        );
-
-        QUnit.test("Disconnect on offline, re-connect on online", async function (assert) {
-            patchWebsocketWorkerWithCleanup();
-            let websocketConnectedDeferred = makeDeferred();
-            const env = await makeTestEnv();
-            env.services["bus_service"].addEventListener("connect", () => {
-                assert.step("connect");
-                websocketConnectedDeferred.resolve();
-                websocketConnectedDeferred = makeDeferred();
-            });
-            env.services["bus_service"].addEventListener("disconnect", () =>
-                assert.step("disconnect")
-            );
-            await env.services["bus_service"].start();
-            await websocketConnectedDeferred;
-            window.dispatchEvent(new Event("offline"));
-            await nextTick();
-            window.dispatchEvent(new Event("online"));
-            await websocketConnectedDeferred;
-            assert.verifySteps(["connect", "disconnect", "connect"]);
-        });
-
-        QUnit.test(
-            "No disconnect on change offline/online when bus inactive",
-            async function (assert) {
-                patchWebsocketWorkerWithCleanup();
-                const env = await makeTestEnv();
-                env.services["bus_service"].addEventListener("connect", () =>
-                    assert.step("connect")
-                );
-                env.services["bus_service"].addEventListener("disconnect", () =>
-                    assert.step("disconnect")
-                );
-                window.dispatchEvent(new Event("offline"));
-                await nextTick();
-                window.dispatchEvent(new Event("online"));
-                await nextTick();
-                assert.verifySteps([]);
-            }
-        );
-
-        QUnit.test("Can reconnect after late close event", async function (assert) {
-            let subscribeSent = 0;
-            const closeDeferred = makeDeferred();
-            let openDeferred = makeDeferred();
-            const worker = patchWebsocketWorkerWithCleanup({
-                _onWebsocketOpen() {
-                    super._onWebsocketOpen();
-                    openDeferred.resolve();
-                },
-                _sendToServer({ event_name }) {
-                    if (event_name === "subscribe") {
-                        subscribeSent++;
-                    }
-                },
-            });
-            const pyEnv = await startServer();
-            const env = await makeTestEnv();
-            env.services["bus_service"].start();
-            await openDeferred;
-            patchWithCleanup(worker.websocket, {
-                close(code = WEBSOCKET_CLOSE_CODES.CLEAN, reason) {
-                    this.readyState = 2;
-                    if (code === WEBSOCKET_CLOSE_CODES.CLEAN) {
-                        closeDeferred.then(() => {
-                            // Simulate that the connection could not be closed cleanly.
-                            super.close(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE, reason);
-                        });
-                    } else {
-                        super.close(code, reason);
-                    }
-                },
-            });
-            env.services["bus_service"].addEventListener("connect", () => assert.step("connect"));
-            env.services["bus_service"].addEventListener("disconnect", () =>
-                assert.step("disconnect")
-            );
-            env.services["bus_service"].addEventListener("reconnecting", () =>
-                assert.step("reconnecting")
-            );
-            env.services["bus_service"].addEventListener("reconnect", () =>
-                assert.step("reconnect")
-            );
-            // Connection will be closed when passing offline. But the close event
-            // will be delayed to come after the next open event. The connection
-            // will thus be in the closing state in the meantime.
-            window.dispatchEvent(new Event("offline"));
-            await nextTick();
-            openDeferred = makeDeferred();
-            // Worker reconnects upon the reception of the online event.
-            window.dispatchEvent(new Event("online"));
-            await openDeferred;
-            closeDeferred.resolve();
-            // Trigger the close event, it shouldn't have any effect since it is
-            // related to an old connection that is no longer in use.
-            await nextTick();
-            openDeferred = makeDeferred();
-            // Server closes the connection, the worker should reconnect.
-            pyEnv.simulateConnectionLost(WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT);
-            await openDeferred;
-            await nextTick();
-            // 3 connections were opened, so 3 subscriptions are expected.
-            assert.strictEqual(subscribeSent, 3);
-            assert.verifySteps([
-                "connect",
-                "disconnect",
-                "connect",
-                "disconnect",
-                "reconnecting",
-                "reconnect",
-            ]);
-        });
-
-        QUnit.test(
-            "Fallback on simple worker when shared worker failed to initialize",
-            async function (assert) {
-                const originalSharedWorker = browser.SharedWorker;
-                const originalWorker = browser.Worker;
-                patchWithCleanup(browser, {
-                    SharedWorker: function (url, options) {
-                        assert.step("shared-worker creation");
-                        const sw = new originalSharedWorker(url, options);
-                        // Simulate error during shared worker creation.
-                        setTimeout(() => sw.dispatchEvent(new Event("error")));
-                        return sw;
-                    },
-                    Worker: function (url, options) {
-                        assert.step("worker creation");
-                        return new originalWorker(url, options);
-                    },
-                });
-                patchWithCleanup(window.console, {
-                    warn(message) {
-                        assert.step(message);
-                    },
-                });
-                const env = await makeTestEnv();
-                await env.services["bus_service"].start();
-                assert.verifySteps([
-                    "shared-worker creation",
-                    'Error while loading "bus_service" SharedWorker, fallback on Worker.',
-                    "worker creation",
-                ]);
-            }
-        );
-
-        QUnit.test("subscribe to single notification", async (assert) => {
-            const pyEnv = await startServer();
-            const env = await makeTestEnv({ activateMockServer: true });
-            env.services["bus_service"].start();
-            const messageReceivedDeferred = makeDeferred();
-            env.services["bus_service"].subscribe("message", (payload) => {
-                assert.deepEqual({ body: "hello", id: 1 }, payload);
-                assert.step("message");
-                messageReceivedDeferred.resolve();
-            });
-            await waitUntilSubscribe();
-            pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "message", {
-                body: "hello",
-                id: 1,
-            });
-            await messageReceivedDeferred;
-            assert.verifySteps(["message"]);
-        });
+        updateLastNotificationDeferred = makeDeferred();
+        const env2 = await makeTestEnv();
+        await env2.services["bus_service"].start();
+        await updateLastNotificationDeferred;
+        // Second bus service sends the last known notification id.
+        assert.verifySteps([`initialize_connection - 2`]);
     }
 );
+
+QUnit.test("Websocket disconnects upon user log out", async function (assert) {
+    addBusServicesToRegistry();
+    // first tab connects to the worker with user logged.
+    patchWithCleanup(session, {
+        user_id: 1,
+    });
+    const connectionInitializedDeferred = makeDeferred();
+    let connectionOpenedDeferred = makeDeferred();
+    patchWebsocketWorkerWithCleanup({
+        _initializeConnection(client, data) {
+            super._initializeConnection(client, data);
+            connectionInitializedDeferred.resolve();
+        },
+    });
+
+    const firstTabEnv = await makeTestEnv();
+    await firstTabEnv.services["bus_service"].start();
+    firstTabEnv.services["bus_service"].addEventListener("connect", () => {
+        if (session.user_id) {
+            assert.step("connect");
+        }
+        connectionOpenedDeferred.resolve();
+        connectionOpenedDeferred = makeDeferred();
+    });
+    firstTabEnv.services["bus_service"].addEventListener("disconnect", () => {
+        assert.step("disconnect");
+    });
+    await connectionInitializedDeferred;
+    await connectionOpenedDeferred;
+
+    // second tab connects to the worker after disconnection: user_id
+    // is now false.
+    patchWithCleanup(session, {
+        user_id: false,
+    });
+    const env2 = await makeTestEnv();
+    await env2.services["bus_service"].start();
+
+    assert.verifySteps(["connect", "disconnect"]);
+});
+
+QUnit.test("Websocket reconnects upon user log in", async function (assert) {
+    addBusServicesToRegistry();
+    // first tab connects to the worker with no user logged.
+    patchWithCleanup(session, {
+        user_id: false,
+    });
+    const connectionInitializedDeferred = makeDeferred();
+    let websocketConnectedDeferred = makeDeferred();
+    patchWebsocketWorkerWithCleanup({
+        _initializeConnection(client, data) {
+            super._initializeConnection(client, data);
+            connectionInitializedDeferred.resolve();
+        },
+    });
+
+    const firstTabEnv = await makeTestEnv();
+    await firstTabEnv.services["bus_service"].start();
+    firstTabEnv.services["bus_service"].addEventListener("connect", () => {
+        assert.step("connect");
+        websocketConnectedDeferred.resolve();
+        websocketConnectedDeferred = makeDeferred();
+    });
+    firstTabEnv.services["bus_service"].addEventListener("disconnect", () => {
+        assert.step("disconnect");
+    });
+    await connectionInitializedDeferred;
+    await websocketConnectedDeferred;
+
+    // second tab connects to the worker after connection: user_id
+    // is now set.
+    patchWithCleanup(session, {
+        user_id: 1,
+    });
+    const env = await makeTestEnv();
+    await env.services["bus_service"].start();
+    await websocketConnectedDeferred;
+    assert.verifySteps(["connect", "disconnect", "connect"]);
+});
+
+QUnit.test("WebSocket connects with URL corresponding to given serverURL", async function (assert) {
+    addBusServicesToRegistry();
+    patchWebsocketWorkerWithCleanup();
+    const serverURL = "http://random-website.com";
+    patchWithCleanup(busParametersService, {
+        start() {
+            return {
+                ...super.start(...arguments),
+                serverURL,
+            };
+        },
+    });
+    const websocketCreatedDeferred = makeDeferred();
+    patchWithCleanup(window, {
+        WebSocket: function (url) {
+            assert.step(url);
+            websocketCreatedDeferred.resolve();
+            return new EventTarget();
+        },
+    });
+    const env = await makeTestEnv();
+    env.services["bus_service"].start();
+    await websocketCreatedDeferred;
+    assert.verifySteps([`${serverURL.replace("http", "ws")}/websocket`]);
+});
+
+QUnit.test("Disconnect on offline, re-connect on online", async function (assert) {
+    addBusServicesToRegistry();
+    patchWebsocketWorkerWithCleanup();
+    let websocketConnectedDeferred = makeDeferred();
+    const env = await makeTestEnv();
+    env.services["bus_service"].addEventListener("connect", () => {
+        assert.step("connect");
+        websocketConnectedDeferred.resolve();
+        websocketConnectedDeferred = makeDeferred();
+    });
+    env.services["bus_service"].addEventListener("disconnect", () => assert.step("disconnect"));
+    await env.services["bus_service"].start();
+    await websocketConnectedDeferred;
+    window.dispatchEvent(new Event("offline"));
+    await nextTick();
+    window.dispatchEvent(new Event("online"));
+    await websocketConnectedDeferred;
+    assert.verifySteps(["connect", "disconnect", "connect"]);
+});
+
+QUnit.test("No disconnect on change offline/online when bus inactive", async function (assert) {
+    addBusServicesToRegistry();
+    patchWebsocketWorkerWithCleanup();
+    const env = await makeTestEnv();
+    env.services["bus_service"].addEventListener("connect", () => assert.step("connect"));
+    env.services["bus_service"].addEventListener("disconnect", () => assert.step("disconnect"));
+    window.dispatchEvent(new Event("offline"));
+    await nextTick();
+    window.dispatchEvent(new Event("online"));
+    await nextTick();
+    assert.verifySteps([]);
+});
+
+QUnit.test("Can reconnect after late close event", async function (assert) {
+    addBusServicesToRegistry();
+    let subscribeSent = 0;
+    const closeDeferred = makeDeferred();
+    let openDeferred = makeDeferred();
+    const worker = patchWebsocketWorkerWithCleanup({
+        _onWebsocketOpen() {
+            super._onWebsocketOpen();
+            openDeferred.resolve();
+        },
+        _sendToServer({ event_name }) {
+            if (event_name === "subscribe") {
+                subscribeSent++;
+            }
+        },
+    });
+    const pyEnv = await startServer();
+    const env = await makeTestEnv();
+    env.services["bus_service"].start();
+    await openDeferred;
+    patchWithCleanup(worker.websocket, {
+        close(code = WEBSOCKET_CLOSE_CODES.CLEAN, reason) {
+            this.readyState = 2;
+            if (code === WEBSOCKET_CLOSE_CODES.CLEAN) {
+                closeDeferred.then(() => {
+                    // Simulate that the connection could not be closed cleanly.
+                    super.close(WEBSOCKET_CLOSE_CODES.ABNORMAL_CLOSURE, reason);
+                });
+            } else {
+                super.close(code, reason);
+            }
+        },
+    });
+    env.services["bus_service"].addEventListener("connect", () => assert.step("connect"));
+    env.services["bus_service"].addEventListener("disconnect", () => assert.step("disconnect"));
+    env.services["bus_service"].addEventListener("reconnecting", () => assert.step("reconnecting"));
+    env.services["bus_service"].addEventListener("reconnect", () => assert.step("reconnect"));
+    // Connection will be closed when passing offline. But the close event
+    // will be delayed to come after the next open event. The connection
+    // will thus be in the closing state in the meantime.
+    window.dispatchEvent(new Event("offline"));
+    await nextTick();
+    openDeferred = makeDeferred();
+    // Worker reconnects upon the reception of the online event.
+    window.dispatchEvent(new Event("online"));
+    await openDeferred;
+    closeDeferred.resolve();
+    // Trigger the close event, it shouldn't have any effect since it is
+    // related to an old connection that is no longer in use.
+    await nextTick();
+    openDeferred = makeDeferred();
+    // Server closes the connection, the worker should reconnect.
+    pyEnv.simulateConnectionLost(WEBSOCKET_CLOSE_CODES.KEEP_ALIVE_TIMEOUT);
+    await openDeferred;
+    await nextTick();
+    // 3 connections were opened, so 3 subscriptions are expected.
+    assert.strictEqual(subscribeSent, 3);
+    assert.verifySteps([
+        "connect",
+        "disconnect",
+        "connect",
+        "disconnect",
+        "reconnecting",
+        "reconnect",
+    ]);
+});
+
+QUnit.test(
+    "Fallback on simple worker when shared worker failed to initialize",
+    async function (assert) {
+        addBusServicesToRegistry();
+        const originalSharedWorker = browser.SharedWorker;
+        const originalWorker = browser.Worker;
+        patchWithCleanup(browser, {
+            SharedWorker: function (url, options) {
+                assert.step("shared-worker creation");
+                const sw = new originalSharedWorker(url, options);
+                // Simulate error during shared worker creation.
+                setTimeout(() => sw.dispatchEvent(new Event("error")));
+                return sw;
+            },
+            Worker: function (url, options) {
+                assert.step("worker creation");
+                return new originalWorker(url, options);
+            },
+        });
+        patchWithCleanup(window.console, {
+            warn(message) {
+                assert.step(message);
+            },
+        });
+        const env = await makeTestEnv();
+        await env.services["bus_service"].start();
+        assert.verifySteps([
+            "shared-worker creation",
+            'Error while loading "bus_service" SharedWorker, fallback on Worker.',
+            "worker creation",
+        ]);
+    }
+);
+
+QUnit.test("subscribe to single notification", async (assert) => {
+    addBusServicesToRegistry();
+    const pyEnv = await startServer();
+    const env = await makeTestEnv({ activateMockServer: true });
+    env.services["bus_service"].start();
+    const messageReceivedDeferred = makeDeferred();
+    env.services["bus_service"].subscribe("message", (payload) => {
+        assert.deepEqual({ body: "hello", id: 1 }, payload);
+        assert.step("message");
+        messageReceivedDeferred.resolve();
+    });
+    await waitUntilSubscribe();
+    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "message", {
+        body: "hello",
+        id: 1,
+    });
+    await messageReceivedDeferred;
+    assert.verifySteps(["message"]);
+});

--- a/addons/bus/static/tests/helpers/test_utils.js
+++ b/addons/bus/static/tests/helpers/test_utils.js
@@ -1,0 +1,19 @@
+/* @odoo-module */
+
+import { assetsWatchdogService } from "@bus/services/assets_watchdog_service";
+import { busParametersService } from "@bus/bus_parameters_service";
+import { multiTabService } from "@bus/multi_tab_service";
+import { busService } from "@bus/services/bus_service";
+import { presenceService } from "@bus/services/presence_service";
+
+import { registry } from "@web/core/registry";
+
+export function addBusServicesToRegistry() {
+    registry
+        .category("services")
+        .add("assetsWatchdog", assetsWatchdogService)
+        .add("bus.parameters", busParametersService)
+        .add("bus_service", busService)
+        .add("presence", presenceService)
+        .add("multi_tab", multiTabService);
+}

--- a/addons/bus/static/tests/helpers/test_utils.js
+++ b/addons/bus/static/tests/helpers/test_utils.js
@@ -2,8 +2,8 @@
 
 import { assetsWatchdogService } from "@bus/services/assets_watchdog_service";
 import { busParametersService } from "@bus/bus_parameters_service";
-import { multiTabService } from "@bus/multi_tab_service";
 import { busService } from "@bus/services/bus_service";
+import { multiTabService } from "@bus/multi_tab_service";
 import { presenceService } from "@bus/services/presence_service";
 
 import { registry } from "@web/core/registry";

--- a/addons/bus/static/tests/helpers/websocket_event_deferred.js
+++ b/addons/bus/static/tests/helpers/websocket_event_deferred.js
@@ -1,9 +1,13 @@
 /* @odoo-module */
 
-import { registry } from "@web/core/registry";
+import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
 
+import { registry } from "@web/core/registry";
 import { makeDeferred } from "@web/../tests/helpers/utils";
 
+// should be enough to decide whether or not notifications/channel
+// subscriptions... are received.
+const TIMEOUT = 500;
 const callbackRegistry = registry.category("mock_server_websocket_callbacks");
 
 /**
@@ -17,9 +21,11 @@ const callbackRegistry = registry.category("mock_server_websocket_callbacks");
 export function waitUntilSubscribe(...requiredChannels) {
     const subscribeDeferred = makeDeferred();
     const failTimeout = setTimeout(() => {
-        subscribeDeferred.reject(new Error(`Waited 1s for ${requiredChannels} subscription`));
-        console.error(`Waited 1s for ${requiredChannels} subscription`);
-    }, 1000);
+        subscribeDeferred.reject(
+            new Error(`Waited ${TIMEOUT}ms for ${requiredChannels} subscription.`)
+        );
+        console.error(`Waited ${TIMEOUT}ms for ${requiredChannels} subscription.`);
+    }, TIMEOUT);
     const lastCallback = callbackRegistry.get("subscribe", () => {});
     callbackRegistry.add(
         "subscribe",
@@ -37,4 +43,130 @@ export function waitUntilSubscribe(...requiredChannels) {
         { force: true }
     );
     return subscribeDeferred;
+}
+
+/**
+ * Returns a deferred that resolves when the given channel(s) addition/deletion
+ * is notified to the websocket worker.
+ *
+ * @param {string[]} channels
+ * @param {object} [options={}]
+ * @param {"add"|"delete"} [options.operation="add"]
+ *
+ * @returns {import("@web/core/utils/concurrency").Deferred} */
+export function waitForChannels(channels, { operation = "add" } = {}) {
+    const successDeferred = makeDeferred();
+    const failTimeout = setTimeout(() => {
+        const failMessage = `Waited ${TIMEOUT}ms for ${channels.join(", ")} to be ${
+            operation === "add" ? "added" : "deleted"
+        }`;
+        QUnit.assert.ok(false, failMessage);
+        successDeferred.resolve();
+    }, TIMEOUT);
+    const channelsSeen = new Set();
+    patchWebsocketWorkerWithCleanup({
+        async [operation === "add" ? "_addChannel" : "_deleteChannel"](client, channel) {
+            await super[operation === "add" ? "_addChannel" : "_deleteChannel"](client, channel);
+            if (channels.includes(channel)) {
+                channelsSeen.add(channel);
+            }
+            if (channelsSeen.size === channels.length) {
+                QUnit.assert.ok(
+                    true,
+                    `Channel(s) ${channels.join(", ")} ${
+                        operation === "add" ? "added" : "deleted"
+                    }.`
+                );
+                successDeferred.resolve();
+                clearTimeout(failTimeout);
+            }
+        },
+    });
+    return successDeferred;
+}
+
+/**
+ * @typedef {Object} ExpectedNotificationOptions
+ * @property {boolean} [received=true]
+ * @typedef {[env: import("@web/env").OdooEnv, notificationType: string, notificationPayload: any, options: ExpectedNotificationOptions]} ExpectedNotification
+ */
+
+/**
+ * Wait for a notification to be received/not received. Returns
+ * a deferred that resolves when the assertion is done.
+ *
+ * @param {ExpectedNotification} notification
+ * @returns {import("@web/core/utils/concurrency").Deferred}
+ */
+function _waitNotification(notification) {
+    const [env, type, payload, { received = true } = {}] = notification;
+    const notificationDeferred = makeDeferred();
+    const failTimeout = setTimeout(() => {
+        QUnit.assert.ok(
+            !received,
+            `Notification of type "${type}" with payload ${payload} not received.`
+        );
+        env.services["bus_service"].removeEventListener("notification", callback);
+        notificationDeferred.resolve();
+    }, TIMEOUT);
+    const callback = ({ detail: notifications }) => {
+        for (const notification of notifications) {
+            if (notification.type !== type) {
+                continue;
+            }
+            if (JSON.stringify(notification.payload) === JSON.stringify(payload)) {
+                QUnit.assert.ok(
+                    received,
+                    `Notification of type "${type}" with payload ${JSON.stringify(
+                        payload
+                    )} receveived.`
+                );
+                notificationDeferred.resolve();
+                clearTimeout(failTimeout);
+                env.services["bus_service"].removeEventListener("notification", callback);
+            }
+        }
+    };
+    env.services["bus_service"].addEventListener("notification", callback);
+    return notificationDeferred;
+}
+
+/**
+ * Wait for the expected notifications to be received/not received. Returns
+ * a deferred that resolves when the assertion is done.
+ *
+ * @param {ExpectedNotification[]} expectedNotifications
+ * @returns {import("@web/core/utils/concurrency").Deferred}
+ */
+export function waitNotifications(...expectedNotifications) {
+    return Promise.all(
+        expectedNotifications.map((expectedNotification) => _waitNotification(expectedNotification))
+    );
+}
+
+/**
+ * Returns a deferred that resolves when an event matching the given type is
+ * received.
+ *
+ * @typedef {"connect"|"disconnect"|"reconnect"|"reconnecting"|"notification"} EventType
+ * @param {import("@web/env").OdooEnv} env
+ * @param {EventType} eventType
+ * @param {object} [options={}]
+ * @param {boolean} [options.received=true]
+ */
+export function waitForEvent(env, eventType, { received = true } = {}) {
+    const eventReceivedDeferred = makeDeferred();
+    const failTimeout = setTimeout(() => {
+        env.services["bus_service"].removeEventListener(eventType, callback);
+        QUnit.assert.ok(!received, `Waited ${TIMEOUT}ms for ${eventType} event.`);
+        eventReceivedDeferred.resolve();
+    }, TIMEOUT);
+    const callback = () => {
+        env.services["bus_service"].removeEventListener(eventType, callback);
+        QUnit.assert.ok(received, `Event of type "${eventType}" received.`);
+        eventReceivedDeferred.resolve();
+        clearTimeout(failTimeout);
+    };
+    env.services["bus_service"].addEventListener(eventType, callback);
+    return eventReceivedDeferred;
 }

--- a/addons/bus/static/tests/multi_tab_service_tests.js
+++ b/addons/bus/static/tests/multi_tab_service_tests.js
@@ -1,111 +1,95 @@
 /** @odoo-module **/
 
-import { multiTabService } from "../src/multi_tab_service";
+import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
 
 import { browser } from "@web/core/browser/browser";
-import { registry } from "@web/core/registry";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { patchWithCleanup, nextTick } from "@web/../tests/helpers/utils";
 
-QUnit.module("bus", function () {
-    QUnit.module("multi_tab_service_tests.js");
+QUnit.module("multi_tab_service_tests.js");
 
-    QUnit.test("multi tab service elects new master on pagehide", async function (assert) {
-        assert.expect(5);
+QUnit.test("multi tab service elects new master on pagehide", async function (assert) {
+    addBusServicesToRegistry();
+    const firstTabEnv = await makeTestEnv();
+    assert.ok(firstTabEnv.services["multi_tab"].isOnMainTab(), "only tab should be the main one");
 
-        registry.category("services").add("multi_tab", multiTabService);
-
-        const firstTabEnv = await makeTestEnv();
-        assert.ok(
-            firstTabEnv.services["multi_tab"].isOnMainTab(),
-            "only tab should be the main one"
-        );
-
-        // prevent second tab from receiving pagehide event.
-        patchWithCleanup(browser, {
-            addEventListener(eventName, callback) {
-                if (eventName === "pagehide") {
-                    return;
-                }
-                super.addEventListener(eventName, callback);
-            },
-        });
-        const secondTabEnv = await makeTestEnv();
-        firstTabEnv.services["multi_tab"].bus.addEventListener("no_longer_main_tab", () =>
-            assert.step("tab1 no_longer_main_tab")
-        );
-        secondTabEnv.services["multi_tab"].bus.addEventListener("no_longer_main_tab", () =>
-            assert.step("tab2 no_longer_main_tab")
-        );
-        window.dispatchEvent(new Event("pagehide"));
-
-        // Let the multi tab elect a new main.
-        await nextTick();
-        assert.notOk(firstTabEnv.services["multi_tab"].isOnMainTab());
-        assert.ok(secondTabEnv.services["multi_tab"].isOnMainTab());
-        assert.verifySteps(["tab1 no_longer_main_tab"]);
-    });
-
-    QUnit.test("multi tab allow to share values between tabs", async function (assert) {
-        assert.expect(3);
-
-        registry.category("services").add("multi_tab", multiTabService);
-
-        const firstTabEnv = await makeTestEnv();
-        const secondTabEnv = await makeTestEnv();
-
-        firstTabEnv.services["multi_tab"].setSharedValue("foo", 1);
-        assert.deepEqual(secondTabEnv.services["multi_tab"].getSharedValue("foo"), 1);
-        firstTabEnv.services["multi_tab"].setSharedValue("foo", 2);
-        assert.deepEqual(secondTabEnv.services["multi_tab"].getSharedValue("foo"), 2);
-
-        firstTabEnv.services["multi_tab"].removeSharedValue("foo");
-        assert.notOk(secondTabEnv.services["multi_tab"].getSharedValue("foo"));
-    });
-
-    QUnit.test("multi tab triggers shared_value_updated", async function (assert) {
-        assert.expect(4);
-
-        registry.category("services").add("multi_tab", multiTabService);
-
-        const firstTabEnv = await makeTestEnv();
-        const secondTabEnv = await makeTestEnv();
-
-        secondTabEnv.services["multi_tab"].bus.addEventListener(
-            "shared_value_updated",
-            ({ detail }) => {
-                assert.step(`${detail.key} - ${JSON.parse(detail.newValue)}`);
+    // prevent second tab from receiving pagehide event.
+    patchWithCleanup(browser, {
+        addEventListener(eventName, callback) {
+            if (eventName === "pagehide") {
+                return;
             }
-        );
-        firstTabEnv.services["multi_tab"].setSharedValue("foo", "bar");
-        firstTabEnv.services["multi_tab"].setSharedValue("foo", "foo");
-        firstTabEnv.services["multi_tab"].removeSharedValue("foo");
-
-        await nextTick();
-        assert.verifySteps(["foo - bar", "foo - foo", "foo - null"]);
+            super.addEventListener(eventName, callback);
+        },
     });
+    const secondTabEnv = await makeTestEnv();
+    firstTabEnv.services["multi_tab"].bus.addEventListener("no_longer_main_tab", () =>
+        assert.step("tab1 no_longer_main_tab")
+    );
+    secondTabEnv.services["multi_tab"].bus.addEventListener("no_longer_main_tab", () =>
+        assert.step("tab2 no_longer_main_tab")
+    );
+    window.dispatchEvent(new Event("pagehide"));
 
-    QUnit.test("multi tab triggers become_master", async function (assert) {
-        registry.category("services").add("multi_tab", multiTabService);
+    // Let the multi tab elect a new main.
+    await nextTick();
+    assert.notOk(firstTabEnv.services["multi_tab"].isOnMainTab());
+    assert.ok(secondTabEnv.services["multi_tab"].isOnMainTab());
+    assert.verifySteps(["tab1 no_longer_main_tab"]);
+});
 
-        await makeTestEnv();
-        // prevent second tab from receiving pagehide event.
-        patchWithCleanup(browser, {
-            addEventListener(eventName, callback) {
-                if (eventName === "pagehide") {
-                    return;
-                }
-                super.addEventListener(eventName, callback);
-            },
-        });
-        const secondTabEnv = await makeTestEnv();
-        secondTabEnv.services["multi_tab"].bus.addEventListener("become_main_tab", () =>
-            assert.step("become_main_tab")
-        );
-        window.dispatchEvent(new Event("pagehide"));
+QUnit.test("multi tab allow to share values between tabs", async function (assert) {
+    addBusServicesToRegistry();
+    const firstTabEnv = await makeTestEnv();
+    const secondTabEnv = await makeTestEnv();
 
-        // Let the multi tab elect a new main.
-        await nextTick();
-        assert.verifySteps(["become_main_tab"]);
+    firstTabEnv.services["multi_tab"].setSharedValue("foo", 1);
+    assert.deepEqual(secondTabEnv.services["multi_tab"].getSharedValue("foo"), 1);
+    firstTabEnv.services["multi_tab"].setSharedValue("foo", 2);
+    assert.deepEqual(secondTabEnv.services["multi_tab"].getSharedValue("foo"), 2);
+
+    firstTabEnv.services["multi_tab"].removeSharedValue("foo");
+    assert.notOk(secondTabEnv.services["multi_tab"].getSharedValue("foo"));
+});
+
+QUnit.test("multi tab triggers shared_value_updated", async function (assert) {
+    addBusServicesToRegistry();
+    const firstTabEnv = await makeTestEnv();
+    const secondTabEnv = await makeTestEnv();
+
+    secondTabEnv.services["multi_tab"].bus.addEventListener(
+        "shared_value_updated",
+        ({ detail }) => {
+            assert.step(`${detail.key} - ${JSON.parse(detail.newValue)}`);
+        }
+    );
+    firstTabEnv.services["multi_tab"].setSharedValue("foo", "bar");
+    firstTabEnv.services["multi_tab"].setSharedValue("foo", "foo");
+    firstTabEnv.services["multi_tab"].removeSharedValue("foo");
+
+    await nextTick();
+    assert.verifySteps(["foo - bar", "foo - foo", "foo - null"]);
+});
+
+QUnit.test("multi tab triggers become_master", async function (assert) {
+    addBusServicesToRegistry();
+    await makeTestEnv();
+    // prevent second tab from receiving pagehide event.
+    patchWithCleanup(browser, {
+        addEventListener(eventName, callback) {
+            if (eventName === "pagehide") {
+                return;
+            }
+            super.addEventListener(eventName, callback);
+        },
     });
+    const secondTabEnv = await makeTestEnv();
+    secondTabEnv.services["multi_tab"].bus.addEventListener("become_main_tab", () =>
+        assert.step("become_main_tab")
+    );
+    window.dispatchEvent(new Event("pagehide"));
+
+    // Let the multi tab elect a new main.
+    await nextTick();
+    assert.verifySteps(["become_main_tab"]);
 });

--- a/addons/bus/static/tests/simple_notification_tests.js
+++ b/addons/bus/static/tests/simple_notification_tests.js
@@ -1,29 +1,20 @@
 /* @odoo-module */
 
-import { busService } from "@bus/services/bus_service";
-import { busParametersService } from "@bus/bus_parameters_service";
-import { multiTabService } from "@bus/multi_tab_service";
 import { simpleNotificationService } from "@bus/simple_notification_service";
+import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
 import { getPyEnv } from "@bus/../tests/helpers/mock_python_environment";
 
-import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
+import { browser } from "@web/core/browser/browser";
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { contains } from "@web/../tests/utils";
 import { createWebClient } from "@web/../tests/webclient/helpers";
 
-const serviceRegistry = registry.category("services");
-
-QUnit.module("simple_notification", {
-    beforeEach() {
-        serviceRegistry.add("bus_service", busService);
-        serviceRegistry.add("bus.parameters", busParametersService);
-        serviceRegistry.add("multi_tab", multiTabService);
-        serviceRegistry.add("simple_notification", simpleNotificationService);
-    },
-});
+QUnit.module("simple_notification");
 
 QUnit.test("receive and display simple notification with message", async () => {
+    addBusServicesToRegistry();
+    registry.category("services").add("simple_notification", simpleNotificationService);
     await createWebClient({});
     const pyEnv = await getPyEnv();
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "simple_notification", {
@@ -33,6 +24,8 @@ QUnit.test("receive and display simple notification with message", async () => {
 });
 
 QUnit.test("receive and display simple notification with title", async () => {
+    addBusServicesToRegistry();
+    registry.category("services").add("simple_notification", simpleNotificationService);
     await createWebClient({});
     const pyEnv = await getPyEnv();
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "simple_notification", {
@@ -43,6 +36,8 @@ QUnit.test("receive and display simple notification with title", async () => {
 });
 
 QUnit.test("receive and display simple notification with specific type", async () => {
+    addBusServicesToRegistry();
+    registry.category("services").add("simple_notification", simpleNotificationService);
     await createWebClient({});
     const pyEnv = await getPyEnv();
     pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "simple_notification", {
@@ -53,6 +48,8 @@ QUnit.test("receive and display simple notification with specific type", async (
 });
 
 QUnit.test("receive and display simple notification as sticky", async () => {
+    addBusServicesToRegistry();
+    registry.category("services").add("simple_notification", simpleNotificationService);
     await createWebClient({});
     const pyEnv = await getPyEnv();
     patchWithCleanup(browser, {

--- a/addons/bus/static/tests/websocket_worker_tests.js
+++ b/addons/bus/static/tests/websocket_worker_tests.js
@@ -8,8 +8,6 @@ import { nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 QUnit.module("Websocket Worker");
 
 QUnit.test("connect event is broadcasted after calling start", async function (assert) {
-    assert.expect(2);
-
     const worker = patchWebsocketWorkerWithCleanup({
         broadcast(type) {
             assert.step(`broadcast ${type}`);
@@ -22,8 +20,6 @@ QUnit.test("connect event is broadcasted after calling start", async function (a
 });
 
 QUnit.test("disconnect event is broadcasted", async function (assert) {
-    assert.expect(3);
-
     const worker = patchWebsocketWorkerWithCleanup({
         broadcast(type) {
             assert.step(`broadcast ${type}`);
@@ -40,8 +36,6 @@ QUnit.test("disconnect event is broadcasted", async function (assert) {
 });
 
 QUnit.test("reconnecting/reconnect event is broadcasted", async function (assert) {
-    assert.expect(5);
-
     // Patch setTimeout in order for the worker to reconnect immediatly.
     patchWithCleanup(window, {
         setTimeout: (fn) => fn(),
@@ -67,8 +61,6 @@ QUnit.test("reconnecting/reconnect event is broadcasted", async function (assert
 });
 
 QUnit.test("notification event is broadcasted", async function (assert) {
-    assert.expect(3);
-
     const notifications = [
         {
             id: 70,


### PR DESCRIPTION
This PR cleans the bus tests by:

This commit cleans the bus tests by:
- flattening the tests structure by putting tests outside
of the `QUnit.module` function.
- removing unnecessary `assert.expect` calls.
- adding an helper to add common bus service to the registry

At the same time, it makes bus tests more robust by implementing
functions that wait for some events instead of relying
on `nextTick` that might or not be sufficient.

fixes runbot-23097