### PR TITLE
[FIX] (account_)payment, sale: check document access in payment routes

### DIFF
--- a/addons/payment/controllers/portal.py
+++ b/addons/payment/controllers/portal.py
@@ -154,7 +154,9 @@ class PaymentPortal(portal.CustomerPortal):
             **portal_page_values,
             **payment_form_values,
             **payment_context,
-            **self._get_extra_payment_form_values(**kwargs),
+            **self._get_extra_payment_form_values(
+                **payment_context, currency_id=currency.id, **kwargs
+            ),  # Pass the payment context to allow overriding modules to check document access.
         }
         return request.render(self._get_payment_page_template_xmlid(**kwargs), rendering_context)
 

--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -1,12 +1,15 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
 from unittest.mock import ANY, patch
 
-from odoo.fields import Command
+from odoo.exceptions import AccessError
 from odoo.tests import tagged, JsonRpcException
 from odoo.tools import mute_logger
 
 from odoo.addons.account_payment.tests.common import AccountPaymentCommon
 from odoo.addons.payment.tests.http_common import PaymentHttpCommon
+from odoo.addons.portal.controllers.portal import CustomerPortal
+from odoo.addons.sale.controllers.portal import PaymentPortal
 from odoo.addons.sale.tests.common import SaleCommon
 
 
@@ -384,6 +387,50 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
         invoice = self.sale_order.invoice_ids
         self.assertTrue(len(invoice) == 1)
         self.assertTrue(invoice.line_ids[0].is_downpayment)
+
+    def test_check_portal_access_token_before_rerouting_flow(self):
+        """ Test that access to the provided sales order is checked against the portal access token
+        before rerouting the payment flow. """
+        payment_portal_controller = PaymentPortal()
+
+        with patch.object(CustomerPortal, '_document_check_access') as mock:
+            payment_portal_controller._get_extra_payment_form_values()
+            self.assertEqual(
+                mock.call_count, 0, msg="No check should be made when sale_order_id is not provided."
+            )
+
+            mock.reset_mock()
+
+            payment_portal_controller._get_extra_payment_form_values(
+                sale_order_id=self.sale_order.id, access_token='whatever'
+            )
+            self.assertEqual(
+                mock.call_count, 1, msg="The check should be made as sale_order_id is provided."
+            )
+
+    def test_check_payment_access_token_before_rerouting_flow(self):
+        """ Test that access to the provided sales order is checked against the payment access token
+        before rerouting the payment flow. """
+        payment_portal_controller = PaymentPortal()
+
+        def _document_check_access_mock(*_args, **_kwargs):
+            raise AccessError('')
+
+        with patch.object(
+            CustomerPortal, '_document_check_access', _document_check_access_mock
+        ), patch('odoo.addons.payment.utils.check_access_token') as check_payment_access_token_mock:
+            try:
+                payment_portal_controller._get_extra_payment_form_values(
+                    sale_order_id=self.sale_order.id, access_token='whatever'
+                )
+            except Exception:
+                pass  # We don't care if it runs or not; we only count the calls.
+            self.assertEqual(
+                check_payment_access_token_mock.call_count,
+                1,
+                msg="The access token should be checked again as a payment access token if the"
+                    " check as a portal access token failed.",
+            )
 
     @mute_logger('odoo.http')
     def test_transaction_route_rejects_unexpected_kwarg(self):


### PR DESCRIPTION
Commit 4d1a1f1c introduced a systematic check on the kwargs passed to transaction routes of modules integrating with online payments, but failed to check the access token of documents whose ID is passed to payment routes. This allowed retrieving the access token of such documents by visiting a route that did not check the document access (e.g., /my/payment_method) and passing an arbitrary document ID (e.g, sale_order_id=123). The route's controller would reroute the payment flow to the document's portal page and render the landing route of the flow on the payment form, with the access token included.

This commit makes sure that we always check the access token of a document before reading rerouting a payment flow.
