### PR TITLE
[FIX] web_editor: options.document in iframe Wysiwyg

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -62,6 +62,9 @@ patch(Wysiwyg.prototype, {
                 return this.$iframe && this.$iframe.length ? this.$iframe[0].getBoundingClientRect() : { top: 0, left: 0 };
             };
         }
+        if (this.$iframe && this.$iframe.length) {
+            options.document = this.$iframe[0].contentWindow.document;
+        }
         return options;
     },
     /**


### PR DESCRIPTION
Steps to reproduce:
- Create new mailing (mass_mailing)
- Type to '/' to open the Powerbox

The `getPowerboxElement` function fails to return the correct node because `this.options.document` is no longer the iframe document after the Wysiwyg component is re-rendered. This happens because when the Wysiwyg component has its props updated, its `options.document` is overwritten by its default option (the top document).

This commit makes sure that, when the editor is mounted inside an iframe, `options.document` evaluates to the iframe's document throughout the entirety of the Wysiwyg component lifecycle.

task-3548120
