### PR TITLE
[POC] mail: improved important messages

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -18,7 +18,7 @@
 
 .o-discuss-badge, .o-discuss-badgeShape {
     display: flex;
-    transform: translate(0, 0) !important; // cancel systray style on badge
+    // transform: translate(0, 0) !important; // cancel systray style on badge
     font-size: 0.7em !important;
 }
 

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -35,6 +35,7 @@ import { useService } from "@web/core/utils/hooks";
 import { url } from "@web/core/utils/urls";
 import { useMessageActions } from "./message_actions";
 import { cookie } from "@web/core/browser/cookie";
+import { useResizeObserver } from "@mail/utils/common/hooks";
 
 /**
  * @typedef {Object} Props
@@ -109,6 +110,7 @@ export class Message extends Component {
         this.messageActions = useMessageActions();
         this.store = useState(useService("mail.store"));
         this.shadowBody = useRef("shadowBody");
+        this.textContentRef = useRef("textContent");
         this.rpc = useService("rpc");
         this.threadService = useState(useService("mail.thread"));
         this.messageService = useState(useService("mail.message"));
@@ -117,6 +119,8 @@ export class Message extends Component {
         this.dialog = useService("dialog");
         this.ui = useState(useService("ui"));
         this.openReactionMenu = this.openReactionMenu.bind(this);
+        useResizeObserver("body", () => this.render());
+        useResizeObserver("textContent", () => this.render());
         useChildSubEnv({
             message: this.props.message,
             alignedRight: this.isAlignedRight,
@@ -222,6 +226,38 @@ export class Message extends Component {
 
     get expandText() {
         return _t("Expand");
+    }
+
+    get important() {
+        let ref;
+        let offsetX;
+        let offsetY;
+        if (
+            !this.message.hasTextContent ||
+            (!this.state.isEditing && this.message.linkPreviewSquash)
+        ) {
+            // single file view
+            if (!this.textContentRef.el) {
+                return { active: false };
+            }
+            ref = this.textContentRef;
+            offsetX = 22;
+            offsetY = 10;
+        } else {
+            if (!this.messageBody.el) {
+                return { active: false };
+            }
+            ref = this.messageBody;
+            offsetX = 15;
+            offsetY = 5;
+        }
+        return {
+            active: true,
+            x:
+                (this.env.inChatWindow && this.isAlignedRight ? -1 : 1) *
+                (ref.el.clientWidth - offsetX),
+            y: offsetY,
+        };
     }
 
     get message() {

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -55,6 +55,12 @@
     }
 }
 
+.o-mail-Message-important {
+    z-index: $o-mail-NavigableList-zIndex - 2;
+    background-color: lighten($warning, 5%);
+    color: black;
+}
+
 .o-mail-Message-moreMenu {
     z-index: $o-mail-NavigableList-zIndex;
 }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -71,16 +71,16 @@
                                    }"
                         >
                             <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing }">
-                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
+                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }" t-ref="textContent">
+                                    <div t-if="message.isSelfImportant and important.active" class="o-mail-Message-important position-absolute badge rounded-pill fw-bolder mx-1 o-z-index-1 py-1" t-att-style="`transform: translate(${important.x}px, ${important.y}px);`"><i class="fa fa-exclamation"/></div>
                                     <t t-if="message.type !== 'notification' and !message.isTransient and (message.hasTextContent or message.subtypeDescription or state.isEditing)">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
                                                     'border': state.isEditing and !message.isNote,
-                                                    'bg-info-light border border-info opacity-25': !message.isSelfAuthored and !message.isNote and !message.isHighlightedFromMention,
-                                                    'bg-success-light border border-success opacity-25': message.isSelfAuthored and !message.isNote and !message.isHighlightedFromMention,
-                                                    'bg-warning-light border border-warning opacity-50': message.isHighlightedFromMention,
+                                                    'bg-info-light border border-info opacity-25': !message.isSelfAuthored and !message.isNote,
+                                                    'bg-success-light border border-success opacity-25': message.isSelfAuthored and !message.isNote,
                                                     }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.isNote,

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -206,8 +206,11 @@ export class Message extends Record {
         return this._store.self?.in(this.recipients);
     }
 
-    get isHighlightedFromMention() {
-        return this.isSelfMentioned && this.resModel === "discuss.channel";
+    get isSelfImportant() {
+        return (
+            this.resModel === "discuss.channel" &&
+            (this.isSelfMentioned || this.parentMessage?.author?.eq(this._store.self))
+        );
     }
 
     get isSelfAuthored() {

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -17,6 +17,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
+import { useResizeObserver } from "@mail/utils/common/hooks";
 
 /**
  * @typedef CardData
@@ -55,14 +56,10 @@ export class Call extends Component {
         });
         this.store = useState(useService("mail.store"));
         this.userSettings = useState(useService("mail.user_settings"));
-        onMounted(() => {
-            this.resizeObserver = new ResizeObserver(() => this.arrangeTiles());
-            this.resizeObserver.observe(this.grid.el);
-            this.arrangeTiles();
-        });
+        useResizeObserver("grid", () => this.arrangeTiles());
+        onMounted(() => this.arrangeTiles());
         onPatched(() => this.arrangeTiles());
         onWillUnmount(() => {
-            this.resizeObserver.disconnect();
             browser.clearTimeout(this.overlayTimeout);
         });
         useExternalListener(browser, "fullscreenchange", this.onFullScreenChange);

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -198,6 +198,32 @@ export function useVisible(refName, cb, { init = false } = {}) {
     return state;
 }
 
+export function useResizeObserver(refName, cb) {
+    const ref = useRef(refName);
+    const observer = new ResizeObserver(cb);
+    let el;
+    onMounted(observe);
+    onWillUnmount(() => {
+        if (!el) {
+            return;
+        }
+        observer.unobserve(el);
+    });
+    onPatched(observe);
+
+    function observe() {
+        if (ref.el !== el) {
+            if (el) {
+                observer.unobserve(el);
+            }
+            if (ref.el) {
+                observer.observe(ref.el);
+            }
+        }
+        el = ref.el;
+    }
+}
+
 /**
  * This hook eases adjusting scroll position by snapshotting scroll
  * properties of scrollable in onWillPatch / onPatched hooks.


### PR DESCRIPTION
Before this commit, was showing an orange bubble instead of blue/green. It was unclear why this change of color.

This commit changes the visual of such important messages by keeping original background color, but instead there's a '!' badge at the end of the message content.

Also make this important badge visible on messages that are reply to current user, and on messages that do not have text content.

Before:
![master](https://github.com/odoo/odoo/assets/6569390/5fd62c7c-169e-4b63-8966-eda812f32b0a)
![dark-master](https://github.com/odoo/odoo/assets/6569390/a6663450-e5d7-4191-8fc6-ded5800712dc)


After:
![poc-1](https://github.com/odoo/odoo/assets/6569390/9e9f3f5e-9ba1-422d-9825-0de5f791f607)
![dark-poc-1](https://github.com/odoo/odoo/assets/6569390/46c487f0-d12b-494b-9c97-5c483073bbea)
