### PR TITLE
[IMP] point_of_sale,pos_restaurant,pos_self_order: share kiosk orders with all pos_config

### DIFF
--- a/addons/pos_restaurant/static/src/app/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/app/product_screen/product_screen.js
@@ -16,6 +16,7 @@ patch(ProductScreen.prototype, {
     showReleaseBtn() {
         return (
             this.pos.config.module_pos_restaurant &&
+            this.pos.table &&
             !this.pos.orders.some(
                 (o) =>
                     o.tableId === this.pos.table.id && o.finalized === false && o.orderlines.length

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -51,13 +51,13 @@ patch(ActionpadWidget.prototype, {
         const categories = Object.values(orderChange).reduce((acc, curr) => {
             const categoryId = this.pos.db.product_by_id[curr.product_id].pos_categ_ids[0];
             const category = this.pos.db.category_by_id[categoryId];
-
-            if (!acc[category.id]) {
-                acc[category.id] = { count: curr.quantity, name: category.name };
-            } else {
-                acc[category.id].count += curr.quantity;
+            if (category) {
+                if (!acc[category.id]) {
+                    acc[category.id] = { count: curr.quantity, name: category.name };
+                } else {
+                    acc[category.id].count += curr.quantity;
+                }
             }
-
             return acc;
         }, {});
 

--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -44,7 +44,7 @@ patch(TicketScreen.prototype, {
         });
     },
     async _setOrder(order) {
-        if (!this.pos.config.module_pos_restaurant || this.pos.table) {
+        if (!this.pos.config.module_pos_restaurant || this.pos.table || !order.tableId) {
             return super._setOrder(...arguments);
         }
         // we came from the FloorScreen

--- a/addons/pos_restaurant/static/src/overrides/models/models.js
+++ b/addons/pos_restaurant/static/src/overrides/models/models.js
@@ -8,7 +8,7 @@ patch(Order.prototype, {
     setup(options) {
         super.setup(...arguments);
         if (this.pos.config.module_pos_restaurant) {
-            if (!this.tableId && !options.json && this.pos.table) {
+            if (this.defaultTableNeeded(options)) {
                 this.tableId = this.pos.table.id;
             }
             this.customerCount = this.customerCount || 1;
@@ -43,6 +43,9 @@ patch(Order.prototype, {
             return this.pos.tables_by_id[this.tableId];
         }
         return null;
+    },
+    defaultTableNeeded(options) {
+        return !this.tableId && !options.json && this.pos.table;
     },
 });
 

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -193,6 +193,7 @@ patch(PosStore.prototype, {
             );
             await this._syncTableOrdersToServer(); // to prevent losing the transferred orders
             const ordersJsons = await this._getTableOrdersFromServer(tableIds); // get all orders
+            await this._loadMissingProducts(ordersJsons);
             return ordersJsons;
         } else {
             return await super._getOrdersJson();

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -140,3 +140,25 @@ class PosOrder(models.Model):
     def _send_order(self):
         #This function is made to be overriden by pos_self_order_preparation_display
         pass
+
+    def get_standalone_self_order(self):
+        orders = self.env['pos.order'].search([
+            *self.env["pos.order"]._check_company_domain(self.env.company),
+            ('state', '=', 'draft'),
+            '|', ('pos_reference', 'ilike', 'Kiosk'),
+            ('pos_reference', 'ilike', 'Self-Order'),
+            ('table_id', '=', False),
+        ])
+        return orders
+
+    @api.model
+    def export_for_ui_shared_order(self, config_id):
+        orders = super().export_for_ui_shared_order(config_id)
+        self_orders = self.get_standalone_self_order().export_for_ui()
+        return orders + self_orders
+
+    @api.model
+    def export_for_ui_table_draft(self, table_ids):
+        orders = super().export_for_ui_table_draft(table_ids)
+        self_orders = self.get_standalone_self_order().export_for_ui()
+        return orders + self_orders

--- a/addons/pos_self_order/models/pos_session.py
+++ b/addons/pos_self_order/models/pos_session.py
@@ -33,3 +33,22 @@ class PosSession(models.Model):
         res = super()._loader_params_product_product()
         res['search_params']['fields'].append('self_order_available')
         return res
+
+    def _pos_data_process(self, loaded_data):
+        """
+        This is where we need to process the data if we can't do it in the loader/getter
+        """
+        super()._pos_data_process(loaded_data)
+        loaded_data["company_has_self_ordering"] = (
+            self.env["pos.config"]
+            .sudo()
+            .search_count(
+                [
+                    *self.env["pos.config"]._check_company_domain(self.env.company),
+                    '|', ("self_ordering_mode", "=", "kiosk"),
+                    ("self_ordering_mode", "=", "mobile"),
+                ],
+                limit=1,
+            )
+            > 0
+        )

--- a/addons/pos_self_order/static/src/app/models/line.js
+++ b/addons/pos_self_order/static/src/app/models/line.js
@@ -31,7 +31,7 @@ export class Line extends Reactive {
         this.full_product_name = line.full_product_name || "";
         this.product_id = line.product_id;
         this.qty = line.qty ? line.qty : 0;
-        this.customer_note = line.customer_note;
+        this.customer_note = line.customer_note || "";
         this.price_unit = line.price_unit || 0;
         this.price_subtotal_incl = line.price_subtotal_incl || 0;
         this.price_subtotal = line.price_subtotal || 0;

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -305,9 +305,11 @@ export class SelfOrder extends Reactive {
         let message = _t("Your order status has been changed");
 
         if (order.length === 0) {
-            throw new Error("Warning, no order with this access_token");
+            this.handleErrorNotification(new Error("Warning, no order with this access_token"));
         } else if (order.length !== 1) {
-            throw new Error("Warning, two orders with the same access_token");
+            this.handleErrorNotification(
+                new Error("Warning, two orders with the same access_token")
+            );
         } else {
             order[0].state = state;
         }

--- a/addons/pos_self_order/static/src/overrides/models/navbar.js
+++ b/addons/pos_self_order/static/src/overrides/models/navbar.js
@@ -1,0 +1,10 @@
+/** @odoo-module */
+
+import { Navbar } from "@point_of_sale/app/navbar/navbar";
+import { patch } from "@web/core/utils/patch";
+
+patch(Navbar.prototype, {
+    _shouldLoadOrders() {
+        return super._shouldLoadOrders() || this.pos.company_has_self_ordering;
+    },
+});

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -1,0 +1,19 @@
+/** @odoo-module */
+
+import { PosStore } from "@point_of_sale/app/store/pos_store";
+import { Order } from "@point_of_sale/app/store/models";
+import { patch } from "@web/core/utils/patch";
+
+patch(PosStore.prototype, {
+    // @Override
+    async _processData(loadedData) {
+        await super._processData(...arguments);
+        this.company_has_self_ordering = loadedData["company_has_self_ordering"];
+    },
+});
+
+patch(Order.prototype, {
+    defaultTableNeeded(options) {
+        return super.defaultTableNeeded(...arguments) && !this.name.includes("Kiosk") && !this.name.includes("Self-Order");
+    },
+});


### PR DESCRIPTION

This commit allows to share kiosk orders with all pos_configs. A new pos_session boolean attribute is added to check if there is a kiosk config in the company. In point_of_sale and pos_restaurant, if the company they belong to contains a kiosk config, the ticket_screen will retrieve the kiosk draft orders.

Related: https://github.com/odoo/enterprise/pull/49294