### PR TITLE
[POC] mail: improved important messages (2)

### DIFF
--- a/addons/mail/static/src/core/common/core.scss
+++ b/addons/mail/static/src/core/common/core.scss
@@ -18,7 +18,7 @@
 
 .o-discuss-badge, .o-discuss-badgeShape {
     display: flex;
-    transform: translate(0, 0) !important; // cancel systray style on badge
+    // transform: translate(0, 0) !important; // cancel systray style on badge
     font-size: 0.7em !important;
 }
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -1,6 +1,14 @@
 .o-mail-Message {
     transition: background-color .2s ease-out, opacity .5s ease-out, box-shadow .5s ease-out, transform .2s ease-out;
 
+    &.o-important {
+        box-shadow: inset -3px 0 0 rgba($warning, 0.75);
+        &.o-alignedLeft {
+            box-shadow: inset 3px 0 0 rgba($warning, 0.75);
+        }
+        background-color: rgba($warning, 0.05);
+    }
+
     &.o-highlighted {
         transform: translateY(-#{map-get($spacers, 3)});
     }
@@ -53,6 +61,12 @@
     button:hover, .focus {
         background-color: $o-gray-200 !important;
     }
+}
+
+.o-mail-Message-important {
+    z-index: $o-mail-NavigableList-zIndex - 2;
+    background-color: lighten($warning, 5%);
+    color: black;
 }
 
 .o-mail-Message-moreMenu {

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -71,16 +71,16 @@
                                    }"
                         >
                             <div class="o-mail-Message-content o-min-width-0" t-att-class="{ 'w-100': state.isEditing }">
-                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }">
+                                <div class="o-mail-Message-textContent position-relative d-flex" t-att-class="{ 'w-100': state.isEditing }" t-ref="textContent">
+                                    <!-- <div t-if="message.isSelfImportant and important.active" class="o-mail-Message-important position-absolute badge rounded-pill fw-bolder mx-1 o-z-index-1 py-1" t-att-style="`transform: translate(${important.x}px, ${important.y}px);`"><i class="fa fa-exclamation"/></div> -->
                                     <t t-if="message.type !== 'notification' and !message.isTransient and (message.hasTextContent or message.subtypeDescription or state.isEditing)">
                                         <LinkPreviewList t-if="!state.isEditing and message.linkPreviewSquash" linkPreviews="message.linkPreviews" deletable="false"/>
                                         <t t-else="">
                                             <div class="position-relative overflow-x-auto d-inline-block" t-att-class="{ 'w-100': state.isEditing }">
                                                 <div class="o-mail-Message-bubble rounded-bottom-3 position-absolute top-0 start-0 w-100 h-100" t-att-class="{
                                                     'border': state.isEditing and !message.isNote,
-                                                    'bg-info-light border border-info opacity-25': !message.isSelfAuthored and !message.isNote and !message.isHighlightedFromMention,
-                                                    'bg-success-light border border-success opacity-25': message.isSelfAuthored and !message.isNote and !message.isHighlightedFromMention,
-                                                    'bg-warning-light border border-warning opacity-50': message.isHighlightedFromMention,
+                                                    'bg-info-light border border-info opacity-25': !message.isSelfAuthored and !message.isNote,
+                                                    'bg-success-light border border-success opacity-25': message.isSelfAuthored and !message.isNote,
                                                     }" t-attf-class="{{ isAlignedRight ? 'rounded-start-3' : 'rounded-end-3' }}"/>
                                                 <div class="position-relative text-break o-mail-Message-body" t-att-class="{
                                                             'p-1': message.isNote,

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -206,8 +206,11 @@ export class Message extends Record {
         return this._store.self?.in(this.recipients);
     }
 
-    get isHighlightedFromMention() {
-        return this.isSelfMentioned && this.resModel === "discuss.channel";
+    get isSelfImportant() {
+        return (
+            this.resModel === "discuss.channel" &&
+            (this.isSelfMentioned || this.parentMessage?.author?.eq(this._store.self))
+        );
     }
 
     get isSelfAuthored() {

--- a/addons/mail/static/src/discuss/call/common/call.js
+++ b/addons/mail/static/src/discuss/call/common/call.js
@@ -17,6 +17,7 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { _t } from "@web/core/l10n/translation";
 import { useService } from "@web/core/utils/hooks";
+import { useResizeObserver } from "@mail/utils/common/hooks";
 
 /**
  * @typedef CardData
@@ -55,14 +56,10 @@ export class Call extends Component {
         });
         this.store = useState(useService("mail.store"));
         this.userSettings = useState(useService("mail.user_settings"));
-        onMounted(() => {
-            this.resizeObserver = new ResizeObserver(() => this.arrangeTiles());
-            this.resizeObserver.observe(this.grid.el);
-            this.arrangeTiles();
-        });
+        useResizeObserver("grid", () => this.arrangeTiles());
+        onMounted(() => this.arrangeTiles());
         onPatched(() => this.arrangeTiles());
         onWillUnmount(() => {
-            this.resizeObserver.disconnect();
             browser.clearTimeout(this.overlayTimeout);
         });
         useExternalListener(browser, "fullscreenchange", this.onFullScreenChange);

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -198,6 +198,32 @@ export function useVisible(refName, cb, { init = false } = {}) {
     return state;
 }
 
+export function useResizeObserver(refName, cb) {
+    const ref = useRef(refName);
+    const observer = new ResizeObserver(cb);
+    let el;
+    onMounted(observe);
+    onWillUnmount(() => {
+        if (!el) {
+            return;
+        }
+        observer.unobserve(el);
+    });
+    onPatched(observe);
+
+    function observe() {
+        if (ref.el !== el) {
+            if (el) {
+                observer.unobserve(el);
+            }
+            if (ref.el) {
+                observer.observe(ref.el);
+            }
+        }
+        el = ref.el;
+    }
+}
+
 /**
  * This hook eases adjusting scroll position by snapshotting scroll
  * properties of scrollable in onWillPatch / onPatched hooks.


### PR DESCRIPTION
Before this commit, was showing an orange bubble instead of blue/green. It was unclear why this change of color.

This commit changes the visual of such important messages using the background of whole message, rather than the bubble. It also adds an inset at the beginning, as the background has low opacity and it might not be visible enough by itself

Also make this important badge visible on messages that are reply to current user, and on messages that do not have text content.

Before:
![master](https://github.com/odoo/odoo/assets/6569390/008a5111-a499-4e43-9765-2dbf49db87e8)
![dark-master](https://github.com/odoo/odoo/assets/6569390/0f7d895a-6f0e-4e72-b4f0-0591f81c8616)



After:
![poc-2](https://github.com/odoo/odoo/assets/6569390/04773798-fb52-441d-b720-3d3f37877d88)
![dark-poc-2](https://github.com/odoo/odoo/assets/6569390/da2312f0-3048-4f19-abb3-18dd5040889f)
