### PR TITLE
[IMP] website_sale: add product customization option in product carousel

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -387,8 +387,8 @@ class Website(Home):
         request.session[f'website_{view_id}_layout_mode'] = layout_mode
 
     @http.route('/website/snippet/filters', type='json', auth='public', website=True)
-    def get_dynamic_filter(self, filter_id, template_key, limit=None, search_domain=None, with_sample=False):
-        dynamic_filter = request.env['website.snippet.filter'].sudo().search(
+    def get_dynamic_filter(self, filter_id, template_key, limit=None, search_domain=None, with_sample=False, context=None):
+        dynamic_filter = request.env['website.snippet.filter'].sudo().with_context(context or {}).search(
             [('id', '=', filter_id)] + request.website.website_domain()
         )
         return dynamic_filter and dynamic_filter._render(template_key, limit, search_domain, with_sample) or []

--- a/addons/website_sale/data/product_snippet_template_data.xml
+++ b/addons/website_sale/data/product_snippet_template_data.xml
@@ -28,8 +28,9 @@
                                 <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                             </div>
                             <div class="o_dynamic_snippet_btn_wrapper" t-if="record._website_show_quick_add()">
-                                <button type="button" role="button" class="btn btn-primary js_add_cart ms-auto" title="Add to Cart">
+                                <button type="button" role="button" class="btn btn-primary js_add_cart ms-auto" title="Add to Cart" t-att-data-has-attributes="record.has_configurable_attributes">
                                     <i class="fa fa-fw fa-shopping-cart"/>
+                                    <input type="hidden" name="product_id" t-att-value="record.id"/>
                                 </button>
                             </div>
                         </div>
@@ -212,8 +213,9 @@
                         </div>
                         <div class="card-title h6 flex-grow-1 w-100 mt-2 mb-3" t-field="record.display_name"/>
                         <div class="text-end o_dynamic_snippet_btn_wrapper" t-if="record._website_show_quick_add()">
-                            <button type="button" role="button" class="btn btn-primary js_add_cart w-100" title="Add to Cart">
+                            <button type="button" role="button" class="btn btn-primary js_add_cart w-100" title="Add to Cart" t-att-data-has-attributes="record.has_configurable_attributes">
                                 Add to Cart
+                                <input type="hidden" name="product_id" t-att-value="record.id"/>
                             </button>
                         </div>
                     </div>
@@ -247,8 +249,9 @@
                                 </div>
                                 <div class="card-text text-muted" t-field="record.description_sale"/>
                                 <div class="mt-4">
-                                    <button t-if="record._website_show_quick_add()" type="button" role="button" class="btn btn-primary js_add_cart mt-1" title="Add to Cart">
+                                    <button t-if="record._website_show_quick_add()" type="button" role="button" class="btn btn-primary js_add_cart mt-1" title="Add to Cart" t-att-data-has-attributes="record.has_configurable_attributes">
                                         Add to Cart
+                                        <input type="hidden" name="product_id" t-att-value="record.id"/>
                                     </button>
                                     <a class="btn btn-link me-1 mt-1" t-att-href="record.website_url">
                                         View Product
@@ -295,8 +298,9 @@
                                         <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                                     </div>
                                     <div t-if="record._website_show_quick_add()" class="o_dynamic_snippet_btn_wrapper ms-auto">
-                                        <button type="button" role="button" class="btn btn-primary js_add_cart" title="Add to Cart">
+                                        <button type="button" role="button" class="btn btn-primary js_add_cart" title="Add to Cart" t-att-data-has-attributes="record.has_configurable_attributes">
                                             <i class="fa fa-fw fa-shopping-cart"/>
+                                            <input type="hidden" name="product_id" t-att-value="record.id"/>
                                         </button>
                                     </div>
                                 </div>
@@ -335,8 +339,9 @@
                                 <t t-call="website_sale.price_dynamic_filter_template_product_product"/>
                             </div>
                             <div t-if="record._website_show_quick_add()" class="o_dynamic_snippet_btn_wrapper">
-                                <button type="button" role="button" class="btn btn-primary js_add_cart" title="Add to Cart">
+                                <button type="button" role="button" class="btn btn-primary js_add_cart" title="Add to Cart" t-att-data-has-attributes="record.has_configurable_attributes">
                                     Add to Cart
+                                    <input type="hidden" name="product_id" t-att-value="record.id"/>
                                 </button>
                             </div>
                         </div>

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -53,9 +53,8 @@ class WebsiteSnippetFilter(models.Model):
         return samples
 
     def _filter_records_to_values(self, records, is_sample=False):
-        if self.model_name == 'product.product':
-            if not self.env.context.get('show_variants') and not is_sample:
-                records = records and records.product_tmpl_id.product_variant_id
+        if self.model_name == 'product.product' and not self.env.context.get('show_variants') and not is_sample:
+            records = records and records.product_tmpl_id.product_variant_id
         res_products = super()._filter_records_to_values(records, is_sample)
         if self.model_name == 'product.product':
             for res_product in res_products:

--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -53,6 +53,9 @@ class WebsiteSnippetFilter(models.Model):
         return samples
 
     def _filter_records_to_values(self, records, is_sample=False):
+        if self.model_name == 'product.product':
+            if not self.env.context.get('show_variants') and not is_sample:
+                records = records and records.product_tmpl_id.product_variant_id
         res_products = super()._filter_records_to_values(records, is_sample)
         if self.model_name == 'product.product':
             for res_product in res_products:
@@ -61,6 +64,8 @@ class WebsiteSnippetFilter(models.Model):
                     res_product.update(product._get_combination_info_variant())
                     if records.env.context.get('add2cart_rerender'):
                         res_product['_add2cart_rerender'] = True
+                    if not self.env.context.get('show_variants'):
+                        product.display_name = product.name
         return res_products
 
     @api.model

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -103,9 +103,7 @@ const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
         const productTemplateId = $("#product_details").find(".product_template_id");
         return Object.assign(this._super.apply(this, arguments), {
             productTemplateId: productTemplateId && productTemplateId.length ? productTemplateId[0].value : undefined,
-            context: {
-                show_variants: this.el.dataset.showVariants,
-            },
+            context: { show_variants: this.el.dataset.showVariants, },
         });
     },
 });
@@ -140,20 +138,19 @@ const DynamicSnippetProductsCard = WebsiteSale.extend({
         const isVariant = ev.currentTarget.closest('[data-show-variants=true]');
         const hasAttributes = ev.currentTarget.dataset.hasAttributes;
         if (!isVariant && hasAttributes) {
-            this._handleAdd($card);
-        } else {
-            const data = await rpc("/shop/cart/update_json", {
-                product_id: $card.find('input[data-product-id]').data('product-id'),
-                add_qty: 1,
-                display: false,
+            return this._handleAdd($card);
+        }
+        const data = await rpc("/shop/cart/update_json", {
+            product_id: $card.find('input[data-product-id]').data('product-id'),
+            add_qty: 1,
+            display: false,
+        });
+        wSaleUtils.updateCartNavBar(data);
+        wSaleUtils.showCartNotification(this.call.bind(this), data.notification_info);
+        if (this.add2cartRerender) {
+            this.trigger_up('widgets_start_request', {
+                $target: this.$el.closest('.s_dynamic'),
             });
-            wSaleUtils.updateCartNavBar(data);
-            wSaleUtils.showCartNotification(this.call.bind(this), data.notification_info);
-            if (this.add2cartRerender) {
-                this.trigger_up('widgets_start_request', {
-                    $target: this.$el.closest('.s_dynamic'),
-                });
-            }
         }
     },
     /**

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/000.js
@@ -102,6 +102,9 @@ const DynamicSnippetProducts = DynamicSnippetCarousel.extend({
         const productTemplateId = $("#product_details").find(".product_template_id");
         return Object.assign(this._super.apply(this, arguments), {
             productTemplateId: productTemplateId && productTemplateId.length ? productTemplateId[0].value : undefined,
+            context: {
+                show_variants: this.el.dataset.showVariants,
+            },
         });
     },
 });

--- a/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
+++ b/addons/website_sale/static/src/snippets/s_dynamic_snippet_products/options.js
@@ -80,6 +80,7 @@ const dynamicSnippetProductsOptions = s_dynamic_snippet_carousel_options.extend(
      */
     _setOptionsDefaultValues: function () {
         this._setOptionValue('productCategoryId', 'all');
+        this._setOptionValue('showVariants', true);
         this._super.apply(this, arguments);
     },
 });

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
@@ -28,6 +28,10 @@
                     data-allow-delete="true"
                     data-fakem2m="true"
                     data-select-data-attribute=""/>
+                <we-checkbox string="Show variant"
+                             data-select-data-attribute="true"
+                             data-attribute-name="showVariants"
+                             data-no-preview="true"/>
                 <we-input string="Product names" class="o_we_large" data-name="product_names_opt"
                     data-attribute-name="productNames" data-no-preview="true" data-select-data-attribute=""
                     placeholder="e.g. lamp,bin" title="Comma-separated list of parts of product names, barcodes or internal reference"/>

--- a/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
+++ b/addons/website_sale/views/snippets/s_dynamic_snippet_products.xml
@@ -29,9 +29,9 @@
                     data-fakem2m="true"
                     data-select-data-attribute=""/>
                 <we-checkbox string="Show variant"
-                             data-select-data-attribute="true"
-                             data-attribute-name="showVariants"
-                             data-no-preview="true"/>
+                    data-select-data-attribute="true"
+                    data-attribute-name="showVariants"
+                    data-no-preview="true"/>
                 <we-input string="Product names" class="o_we_large" data-name="product_names_opt"
                     data-attribute-name="productNames" data-no-preview="true" data-select-data-attribute=""
                     placeholder="e.g. lamp,bin" title="Comma-separated list of parts of product names, barcodes or internal reference"/>


### PR DESCRIPTION
**Version**
- master

Before this PR, the dynamic product carousel displayed the products including their variants.
After this, users can decide whether they want to show the variants or not.

With this PR,
- Introduced a toggle button in the editor panel for a dynamic product carousel to switch between `products with variants` and `products without variants`.

1. Added `show variant` toggle option:
![option](https://github.com/odoo/odoo/assets/125337508/7ea943e5-4b94-4cb7-b313-d2688f6dece8)

2. Product carousel with show variant = False. It will display only the main product.
![without_variant](https://github.com/odoo/odoo/assets/125337508/b6eba11c-6302-4cb4-a761-756bc2980796)

3. Product carousel with show variant = True. It will display all product variants.
![with_variant](https://github.com/odoo/odoo/assets/125337508/1337b21a-8b3d-443f-901b-ed464d8caad8)

task-3266832

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
