### PR TITLE
[IMP] mail: sort attachments on basis of type in discuss and chatter.

### DIFF
--- a/addons/mail/static/src/core/common/attachment_model.js
+++ b/addons/mail/static/src/core/common/attachment_model.js
@@ -146,6 +146,10 @@ export class Attachment extends Record {
         );
     }
 
+    get isMedia() {
+        return this.isImage || this.isVideo || this.isVoice;
+    }
+
     get defaultSource() {
         const route = url(this.urlRoute, this.urlQueryParams);
         const encodedRoute = encodeURIComponent(route);

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { Record } from "@mail/core/common/record";
+import { deserializeDateTime } from "@web/core/l10n/dates";
 
 export class LinkPreview extends Record {
     static id = "id";
@@ -59,6 +60,14 @@ export class LinkPreview extends Record {
         return !this.isImage && !this.isVideo;
     }
 
+    get monthYear() {
+        const message = this.message ?? this._store.Message.get(this.message_id);
+        if (!message) {
+            return undefined;
+        }
+        const datetime = deserializeDateTime(message.create_date);
+        return `${datetime.monthLong}, ${datetime.year}`;
+    }
 }
 
 LinkPreview.register();

--- a/addons/mail/static/src/core/web/chatter.scss
+++ b/addons/mail/static/src/core/web/chatter.scss
@@ -54,3 +54,51 @@
 .o-mail-Chatter button.o-active {
     color: $o-action !important;
 }
+
+
+.o-mail-Chatter-Attachment-title {
+    text-align: center;
+    width: 100%;
+    cursor: pointer;
+}
+
+.o-mail-Chatter-Attachment-title.active{
+    border-bottom: 4px solid #714B67 ;
+}
+
+.o-mail-ChatterAttachement-Panel-link{
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    flex-wrap: wrap;
+}
+
+.o-mail-LinkAttachment{
+    margin-top: 8px;
+    padding-top: 0 !important;
+    display: flex;
+    flex-direction: column;
+    margin-bottom: 8px;
+    > .o-mail-LinkPreviewList{
+        margin-top: 0px !important;
+    }
+
+    > .o-mail-LinkPreviewCard{
+        margin-bottom: 0px !important;
+    }
+
+    >.o-mail-LinkPreviewCard.card{
+        border-radius: 0.25rem 0.25rem 0rem 0rem !important;
+        border: 0px !important;
+        border-bottom: 1px solid rgba(255,255,255,0.125) !important;
+        box-shadow: 0 0 0 0 transparent !important; 
+    }
+}
+
+.o-mail-LinkAttachment-Content{
+    margin-left: 5px;
+    margin-right: 5px;
+    display: flex;
+    justify-content: space-between;
+}
+

--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -97,22 +97,51 @@
                 <t t-if="props.hasActivities and activities.length and !state.isSearchOpen">
                     <t t-call="mail.ActivityList"/>
                 </t>
-                <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative" t-ref="attachment-box">
+                <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative py-1 px-3" t-ref="attachment-box">
                     <div class="d-flex align-items-center">
                         <hr class="flex-grow-1"/>
                         <span class="p-3 fw-bold">
-                            Files
+                            Attachments
                         </span>
                         <hr class="flex-grow-1"/>
                     </div>
                     <div class="d-flex flex-column">
-                        <AttachmentList
-                            attachments="attachments"
-                            unlinkAttachment.bind="unlinkAttachment"
-                            imagesHeight="100"
-                        />
+                        <div class="flex-grow-1">
+                    </div>
+                    <div class="o-mail-Chatter-Attachment d-flex flex-column">
+                        <div class="o-mail-AttachmentpanelCatgory mb-2" t-on-click="(ev) => this.handleTabSelection(ev)">
+                            <div class="o-mail-AttachmentPanelCategory-title " t-att-class="state.current === 'media' ? 'active' : ''" data-tab="media" title="Media">
+                                Media
+                            </div>
+                            <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'link' ? 'active' : ''" data-tab="link" title="Links">
+                                Links
+                            </div>
+                            <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'file' ? 'active' : ''" data-tab="file" title="Files">
+                                Files
+                            </div>
+                        </div>
+                        <div class="o-mail-ChatterAttachement-Panel-media" t-if="this.state.current === 'media'">
+                            <p t-if="this.state.attachmentLength.media === 0" class="text-center fst-italic text-500 mt-4">This conversation doesn't have any media attachments.</p>
+                            <AttachmentList imagesHeight="100" attachments="getAttachment('media')"  unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                        </div>
+                        <div class="o-mail-ChatterAttachement-Panel-link" t-elif="this.state.current === 'link'">
+                            <p t-if="this.state.attachmentLength.link === 0" class="text-center fst-italic text-500 mt-4">This conversation doesn't have any link attachments.</p>
+                            <t t-foreach="getAttachment('link')" t-as="links" t-key="links.id">
+                                <div class="o-mail-LinkAttachment card rounded shadow-sm" >
+                                    <LinkPreview linkPreview="links" deletable="true" />
+                                    <div class="o-mail-LinkAttachment-Content">
+                                        <a href="links.source_url" t-esc="links.source_url"></a>
+                                    </div>
+                                </div>
+                            </t>
+                        </div>
+                        <div class="o-mail-ChatterAttachement-Panel-file" t-elif="this.state.current === 'file'">
+                            <p t-if="this.state.attachmentLength.file === 0" class="text-center fst-italic text-500 mt-4">This conversation doesn't have any file attachments.</p>
+                            <AttachmentList imagesHeight="100" attachments="getAttachment('file')"  unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                        </div>
+                    </div>
                         <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
-                            <t t-set-slot="toggler">
+                            <t t-set-slot="toggler" t-if="this.state.current != 'link'">
                                 <button class="btn btn-link" type="button" t-att-disabled="!state.thread.hasWriteAccess">
                                     <i class="fa fa-plus-square"/>
                                     Attach files
@@ -152,7 +181,7 @@
 <t t-name="mail.Chatter.attachFiles">
     <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
         <i class="fa fa-paperclip fa-lg me-1"/>
-        <span t-if="attachments.length > 0" t-esc="attachments.length"/>
+        <span t-if="total > 0" t-esc="total"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>
     </button>
 </t>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.js
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.js
@@ -3,8 +3,9 @@
 import { DateSection } from "@mail/core/common/date_section";
 import { ActionPanel } from "@mail/discuss/core/common/action_panel";
 import { AttachmentList } from "@mail/core/common/attachment_list";
+import { LinkPreview } from "@mail/core/common/link_preview";
 
-import { Component, onWillStart, onWillUpdateProps } from "@odoo/owl";
+import { Component, useState, onWillStart, onWillUpdateProps } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 import { useSequential, useVisible } from "@mail/utils/common/hooks";
 
@@ -13,7 +14,7 @@ import { useSequential, useVisible } from "@mail/utils/common/hooks";
  * @property {import("models").Thread} thread
  */
 export class AttachmentPanel extends Component {
-    static components = { ActionPanel, AttachmentList, DateSection };
+    static components = { ActionPanel, AttachmentList, DateSection, LinkPreview };
     static props = ["thread"];
     static template = "mail.AttachmentPanel";
 
@@ -36,19 +37,34 @@ export class AttachmentPanel extends Component {
                 this.threadService.fetchMoreAttachments(this.props.thread);
             }
         });
+        this.state = useState({
+            current: "media",
+            media: this.props.thread.attachments.filter((attachment) => attachment.isMedia).length,
+            linkPreviews: this.props.thread.messages.reduce(
+                (count, message) =>
+                    count + (message.linkPreviews && message.linkPreviews.length > 0 ? 1 : 0),
+                0
+            ),
+            files: this.props.thread.attachments.filter((attachment) => !attachment.isMedia).length,
+        });
     }
 
     /**
      * @return {Object<string, import("models").Attachment[]>}
      */
-    get attachmentsByDate() {
-        const attachmentsByDate = {};
-        for (const attachment of this.props.thread.attachments) {
-            const attachments = attachmentsByDate[attachment.monthYear] ?? [];
-            attachments.push(attachment);
-            attachmentsByDate[attachment.monthYear] = attachments;
+    categorizeAttachmentsByMonthYear(attachments, filterAttachments) {
+        const attachmentsArray = Array.from(attachments);
+        const attachmentByMonthYear = {};
+        for (const attachment of attachmentsArray) {
+            if (filterAttachments(attachment)) {
+                const { monthYear } = attachment;
+                if (!attachmentByMonthYear[monthYear]) {
+                    attachmentByMonthYear[monthYear] = [];
+                }
+                attachmentByMonthYear[monthYear].push(attachment);
+            }
         }
-        return attachmentsByDate;
+        return attachmentByMonthYear;
     }
 
     get hasToggleAllowPublicUpload() {
@@ -66,4 +82,49 @@ export class AttachmentPanel extends Component {
             })
         );
     }
+
+    categorizedAttachments(type) {
+        const { attachments, messages } = this.props.thread;
+        const linkAttachments = messages
+            .map((message) =>
+                message.linkPreviews && message.linkPreviews.length > 0
+                    ? message.linkPreviews[0]
+                    : null
+            )
+            .filter((linkPreview) => linkPreview !== null);
+        switch (type) {
+            case "media":
+                this.state.media = this.props.thread.attachments.filter(
+                    (attachment) => attachment.isMedia
+                ).length;
+                return this.categorizeAttachmentsByMonthYear(
+                    attachments,
+                    (attachment) => attachment.isMedia
+                );
+            case "link":
+                this.state.linkPreviews = this.props.thread.messages.reduce(
+                    (count, message) =>
+                        count + (message.linkPreviews && message.linkPreviews.length > 0 ? 1 : 0),
+                    0
+                );
+                return this.categorizeAttachmentsByMonthYear(linkAttachments, () => true);
+            case "file":
+                this.state.files = this.props.thread.attachments.filter(
+                    (attachment) => !attachment.isMedia
+                ).length;
+                return this.categorizeAttachmentsByMonthYear(
+                    attachments,
+                    (attachment) => !attachment.isMedia
+                );
+            default:
+                return {};
+        }
+    }
+
+    handleTabSelection = (ev) => {
+        if (ev.target.dataset.tab !== this.state.current) {
+            this.state.current = ev.target.dataset.tab;
+        }
+        ev.target.classList.toggle("active", true);
+    };
 }

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.scss
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.scss
@@ -1,0 +1,15 @@
+.o-mail-AttachmentpanelCatgory {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-around;
+}
+
+.o-mail-AttachmentPanelCategory-title {
+    text-align: center;
+    width: 100%;
+    cursor: pointer;
+}
+
+.o-mail-AttachmentPanelCategory-title.active{
+    border-bottom: 2px solid #714B67 ;
+}

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.xml
@@ -11,16 +11,57 @@
                     <t t-else="">File upload is disabled for external users</t>
                 </label>
             </div>
-            <div class="flex-grow-1" t-att-class="{
-                'd-flex justify-content-center align-items-center': props.thread.attachments.length === 0,
-            }">
-                <p t-if="props.thread.attachments.length === 0" class="text-center fst-italic text-500">
-                    <t t-if="props.thread.type === 'channel'">This channel doesn't have any attachments.</t>
-                    <t t-else="">This conversation doesn't have any attachments.</t>
-                </p>
-                <div t-else="" t-foreach="attachmentsByDate" t-as="dateDay" t-key="dateDay" class="d-flex flex-column">
-                    <DateSection date="dateDay" className="'my-1'"/>
-                    <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+            <div class="flex-grow-1">
+                <div class="d-flex flex-column">
+                    <div class="o-mail-AttachmentpanelCatgory" t-on-click="(ev) => this.handleTabSelection(ev)">
+                        <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'media' ? 'active' : ''" data-tab="media">
+                            Media
+                        </div>
+                        <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'links' ? 'active' : ''" data-tab="links">
+                            Links
+                        </div>
+                        <div class="o-mail-AttachmentPanelCategory-title" t-att-class="state.current === 'files' ? 'active' : ''" data-tab="files" title="Files">
+                            Files
+                        </div>
+                    </div>
+                    <div t-if="state.current === 'media'">
+                        <p t-if="state.media === 0" class="text-center fst-italic text-500 mt-4">
+                            <t t-if="props.thread.type === 'channel'">This channel doesn't have any media attachments.</t>
+                            <t t-else="" >This conversation doesn't have any media attachments.</t>
+                        </p>
+                        <div t-foreach="this.categorizedAttachments('media')" t-as="dateDay" t-key="dateDay">
+                            <DateSection date="dateDay" className="'my-1'"/>
+                            <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                        </div>
+                    </div>
+                    <div t-elif="state.current === 'links'">
+                        <p t-if="state.linkPreviews === 0" class="text-center fst-italic text-500 mt-4">
+                            <t t-if="props.thread.type === 'channel'">This channel doesn't have any links.</t>
+                            <t t-else="">This conversation doesn't have any links.</t>
+                        </p>
+                        <div t-foreach="this.categorizedAttachments('link')" t-as="links" t-key="link">
+                            <DateSection date="links" className="'my-1'"/>
+                            <!-- <LinkAttachment links="links_value"/> -->
+                            <t t-foreach="links_value" t-as="links" t-key="links.id">
+                                <div class="o-mail-LinkAttachment card rounded shadow-sm" >
+                                    <LinkPreview linkPreview="links" deletable="true" />
+                                    <div class="o-mail-LinkAttachment-Content">
+                                        <a href="links.source_url" t-esc="links.source_url"></a>
+                                    </div>
+                                </div>
+                            </t>
+                        </div>
+                    </div>
+                    <div t-elif="state.current === 'files'">
+                        <p t-if="state.files === 0" class="text-center fst-italic text-500 mt-4">
+                            <t t-if="props.thread.type === 'channel'">This channel doesn't have any file attachments.</t>
+                            <t t-else="">This conversation doesn't have any file attachments.</t>
+                        </p>
+                        <div t-foreach="this.categorizedAttachments('file')" t-as="dateDay" t-key="dateDay">
+                            <DateSection date="dateDay" className="'my-1'"/>
+                            <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                        </div>
+                    </div>
                 </div>
             </div>
             <span t-ref="load-older"/>


### PR DESCRIPTION
Before this commit:
The attachements that we displayed in the attachmentPanel were not sorted on
the basis of type, there were displayed just in the order in which they were
inserted.
    
After  this commit:
1. The attachments in the attachment panel are now sorted in three different
tab, namely 'Media', 'Links', 'Files'. Each attachment gets stored in its
respective tab.
2. Consider linkPreviews as attachement and store all the linkPreviews in the
tab 'Links'
    
task-3485793
