### PR TITLE
[FIX] base,ir_property,write(): clear_caches too often

### DIFF
--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -113,9 +113,9 @@ class Property(models.Model):
         if self._ids:
             self.env.cr.execute(
                 'SELECT EXISTS (SELECT 1 FROM ir_property WHERE id in %s AND res_id IS NULL)', [self._ids])
-            default_set = self.env.cr.rowcount == 1 or any(
-                v.get('res_id') is False
-                for v in values
+            default_set = self.env.cr.rowcount == 1 and self.env.cr.fetchone()[0] or any(
+                v.res_id is False
+                for v in self
             )
         r = super(Property, self).write(self._update_values(values))
         if default_set:


### PR DESCRIPTION
Fixes a bug which causes that: self.flush() and self.clear_caches() were called on every property write/update.
The same bug exists in other Odoo versions, causing the cache clearing too often.

Description of the issue/feature this PR addresses:
https://github.com/odoo/odoo/issues/79459#issuecomment-1744913884

Current behavior before PR:
The code below contains couple of problems - default_set is always True, because, the SELECT query always returns a single row. Additionally, the "or any" part is also wrong, because values do not have "res_id" property. They are strings.

```
self.env.cr.execute(
                'SELECT EXISTS (SELECT 1 FROM ir_property WHERE id in %s AND res_id IS NULL)', [self._ids])
            default_set = self.env.cr.rowcount == 1 or any(
                v.get('res_id') is False
                for v in values
            )
```
Desired behavior after PR is merged:
If the property is not a default property (valid across the system, for every company_id), there will be no self.flush() and self.clear_caches() called on property value update.
It significantly improves the performance of processes involving updating of multiple properties.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
