### PR TITLE
[FIX] web_editor: fix the installation of new app through the editor

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3943,7 +3943,7 @@ var SnippetsMenu = Widget.extend({
                 classes: 'btn-primary',
                 click: function () {
                     this.$footer.find('.btn').toggleClass('o_hidden');
-                    this.orm.call("ir.module.module", "button_immediate_install", [[moduleID]]).then(() => {
+                    self.orm.call("ir.module.module", "button_immediate_install", [[moduleID]]).then(() => {
                         self.trigger_up('request_save', {
                             invalidateSnippetCache: true,
                             _toMutex: true,


### PR DESCRIPTION
Steps to reproduce:
- Go on the website in edit mode.
- Try to to click on "Install" on the "Add to Cart Button" snippet (make sure that the eCommerce is not installed).
- Click on "Save and Install" on the appeared modal.

-> Traceback of type "Cannot read properties of undefined" appears. This can be explained because a regular function has been used for the `click` event of the "Save and Install" button. Regular function have their own `this` context which is determined by how the function is called. In this case, `this` refers to the instance of the `Dialog` and not `SnippetsMenu` anymore. To solve the problem, `orm` is called by `self` that refers to the `SnippetsMenu`.
Note: the same principle is used for the button defined in `_onDeleteBtnClick`. However, this time, the arrow function has been used for the `click` event. In this case, there are no change to do as the `this` is inherited from the context in which it is defined (`this` refers here to `SnippetsMenu`).

task-3543554