### PR TITLE
[FIX] web: make calendar popover responsive

### DIFF
--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -22,7 +22,7 @@ export class Popover extends Component {
             right: "end",
         };
         el.classList = [
-            "o_popover popover mw-100 shadow-sm",
+            "o_popover popover mw-25 shadow-sm",
             `bs-popover-${directionMap[direction]}`,
             `o-popover-${direction}`,
             `o-popover--${position}`,

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.js
@@ -2,6 +2,7 @@
 
 import { Dialog } from "@web/core/dialog/dialog";
 import { is24HourFormat } from "@web/core/l10n/dates";
+import { registry } from "@web/core/registry";
 import { Field } from "@web/views/fields/field";
 import { Record } from "@web/views/record";
 import { getFormattedDateSpan } from '@web/views/calendar/utils';
@@ -23,6 +24,19 @@ export class CalendarCommonPopover extends Component {
     }
     get isEventDeletable() {
         return this.props.model.canDelete;
+    }
+
+    getFormattedValue(fieldName, record) {
+        const fieldInfo = this.props.model.popoverFields[fieldName];
+        const field = this.props.model.fields[fieldName];
+        let format;
+        const formattersRegistry = registry.category("formatters");
+        if (fieldInfo.widget && formattersRegistry.contains(fieldInfo.widget)) {
+            format = formattersRegistry.get(fieldInfo.widget);
+        } else {
+            format = formattersRegistry.get(field.type);
+        }
+        return format(record.data[fieldName]);
     }
 
     computeDateTimeAndDuration() {

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.scss
@@ -6,6 +6,14 @@ $o-cw-popup-avatar-size: 16px;
     max-width: 328px;
     font-size: $font-size-base;
 
+    .role-container span {
+        display: block;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 100%;
+    }
+
     .card-header,
     .card-header .popover-header {
         font-size: 1.05em;

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_popover.xml
@@ -17,8 +17,8 @@
 
     <t t-name="web.CalendarCommonPopover.popover" owl="1">
         <div class="card-header d-flex justify-content-between py-2 pe-2">
-            <h4 class="p-0 pt-1">
-                <span class="popover-header border-0" t-esc="props.record.title" />
+            <h4 class="p-0 pt-1 text-truncate">
+                <span class="popover-header border-0" t-esc="props.record.title" t-att-data-tooltip="props.record.title"/>
             </h4>
             <span class="o_cw_popover_close ms-4 mt-2 me-2" t-on-click.stop="() => props.close()">
                 <i class="fa fa-close" />
@@ -48,7 +48,7 @@
                 <t t-foreach="slot.record.fieldNames" t-as="fieldName" t-key="fieldName">
                     <t t-if="!slot.record.isInvisible(fieldName)">
                         <t t-set="fieldInfo" t-value="props.model.popoverFields[fieldName]" />
-                        <li class="list-group-item flex-shrink-0 d-flex flex-wrap align-items-center" t-att-class="fieldInfo.rawAttrs.class">
+                        <li class="list-group-item d-flex text-nowrap align-items-center" t-att-class="fieldInfo.rawAttrs.class" t-att-data-tooltip="getFormattedValue(fieldName, slot.record)">
                             <strong class="me-2">
                                 <t t-if="fieldInfo.options.icon">
                                     <b>
@@ -59,8 +59,8 @@
                                     <t t-esc="fieldInfo.string" />:
                                 </t>
                             </strong>
-                            <div class="flex-grow-1">
-                                <Field name="fieldName" record="slot.record" fieldInfo="fieldInfo" type="fieldInfo.widget" />
+                            <div class="role-container text-truncate">
+                                <Field name="fieldName" class="'w-100'" record="slot.record" fieldInfo="fieldInfo" type="fieldInfo.widget" />
                             </div>
                         </li>
                     </t>

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -194,7 +194,7 @@ export class CalendarFilterPanel extends Component {
             { section, filter },
             {
                 closeOnClickAway: false,
-                popoverClass: "o-calendar-filter--tooltip",
+                popoverClass: "o-calendar-filter--tooltip mw-25",
                 position: "top",
             }
         );

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -131,7 +131,7 @@
     <t t-name="web.CalendarFilterPanel.tooltip" owl="1">
         <div class="card">
             <h6
-                class="text-center card-header"
+                class="text-center card-header text-truncate"
                 t-esc="props.filter.label"
             />
             <div class="card-body">

--- a/addons/web/static/tests/core/popover/popover_tests.js
+++ b/addons/web/static/tests/core/popover/popover_tests.js
@@ -141,7 +141,7 @@ QUnit.test("reposition popover should properly change classNames", async (assert
     // Should have classes for a "bottom-middle" placement
     assert.strictEqual(
         popover.className,
-        "o_popover popover mw-100 shadow-sm bs-popover-bottom o-popover-bottom o-popover--bm"
+        "o_popover popover mw-25 shadow-sm bs-popover-bottom o-popover-bottom o-popover--bm"
     );
     assert.strictEqual(arrow.className, "popover-arrow start-0 end-0 mx-auto");
 
@@ -154,7 +154,7 @@ QUnit.test("reposition popover should properly change classNames", async (assert
     // Should have classes for a "right-end" placement
     assert.strictEqual(
         popover.className,
-        "o_popover popover mw-100 shadow-sm bs-popover-end o-popover-right o-popover--re"
+        "o_popover popover mw-25 shadow-sm bs-popover-end o-popover-right o-popover--re"
     );
     assert.strictEqual(arrow.className, "popover-arrow top-auto");
 });


### PR DESCRIPTION
Versions:
---------
- 16.0

Steps to reproduce:
-------------------
- go to the planning calendar.
- hover over a record in the sidebar of the calendar, and then
- click on "Shifts" in the calendar entries.

Issue:
------
1. the size of the popover enlarges when the content of the field
is large, and the child element does not inherit the width of its parent elements.

2. The size of the popover becomes larger when hovering 
over the calendar filter tooltip.

Cause:
------
The popover title is taking up the full 100% width. Additionally, 
the popover title and body expand in response to the content 
of the fields, causing the popover size to become larger.

Solution:
---------
Setting a maximum width and enabling text truncation will make it 
appear more visually appealing. Additionally, set a maximum 
width of 25% and enable text truncation."


**task-3446307**