### PR TITLE
[FIX] mail: missing dependency for icon in public

### DIFF
--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -174,6 +174,7 @@ For more specific needs, you may also assign custom-defined actions
         ],
         'mail.assets_public': [
             'web/static/lib/jquery/jquery.js',
+            'web/static/lib/odoo_ui_icons/style.css',
             'web/static/src/libs/fontawesome/css/font-awesome.css',
             ('include', 'web._assets_helpers'),
             ('include', 'web._assets_backend_helpers'),


### PR DESCRIPTION
The right arrow icon on the public page relies on odoo-ui.
Currently, this file is not correctly imported into the public bundle, since
the icon is not showing.

This fix is to import the essential file into the public bundle.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
