### PR TITLE
[FIX] pos_loyalty, loyalty: Force python domain evaluation

### DIFF
--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -11,3 +11,26 @@ class LoyaltyReward(models.Model):
         for vals in res:
             vals.update({'taxes_id': False})
         return res
+
+    def _should_compute_all_discount_product(self, reward):
+        parent_res = super()._should_compute_all_discount_product(reward)
+        if parent_res:
+            return parent_res
+        pos_loaded_data = self.env.context.get('loaded_data')
+        if not pos_loaded_data:
+            return False  # This is not PoS context
+
+        reward_discount_product_domain = reward._get_discount_product_domain()
+        if not reward_discount_product_domain:
+            return False
+        pos_loaded_data_product_product = pos_loaded_data['product.product']
+        if not pos_loaded_data_product_product:
+            return False  # No products were loaded in the PoS, so we don't care on the way it is loaded
+        pos_product_product_loaded_fields = pos_loaded_data_product_product[0].keys()
+        rewards_forced_python_loaded = self.env.context.get('rewards_forced_python_loaded')
+        for leaf in reward_discount_product_domain:
+            field = leaf[0]
+            if len(leaf) == 3 and field not in pos_product_product_loaded_fields:
+                rewards_forced_python_loaded[reward] = field
+                return True  # The field won't be loaded in the JS, so we must evaluate in the python side
+        return False

--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -7,7 +7,7 @@ import concurrency from 'web.concurrency';
 import { Gui } from 'point_of_sale.Gui';
 import { round_decimals,round_precision } from 'web.utils';
 import core from 'web.core';
-import { Domain, InvalidDomainError } from '@web/core/domain';
+import { Domain } from '@web/core/domain';
 import { sprintf } from '@web/core/utils/strings';
 
 const _t = core._t;
@@ -131,15 +131,14 @@ const PosLoyaltyGlobalState = (PosGlobalState) => class PosLoyaltyGlobalState ex
                 .filter((product) => domain.contains(product))
                 .forEach(product => reward.all_discount_product_ids.add(product.id));
         } catch (error) {
-            if (!(error instanceof InvalidDomainError)) {
-                throw error
-            }
+            console.error(error);
             const index = this.rewards.indexOf(reward);
             if (index != -1) {
                 Gui.showPopup('ErrorPopup', {
                     title: _t('A reward could not be loaded'),
                     body:  sprintf(
-                        _t('The reward "%s" contain an error in its domain, your domain must be compatible with the PoS client'),
+                        _t('The reward "%s" contain an error in its domain, your domain must be compatible with the PoS client') +
+                        `\n\nTechnical details:\n${error.name}: ${error.message}`,
                         this.rewards[index].description)
                     });
                 this.rewards[index] = null;


### PR DESCRIPTION
[FIX] pos_loyalty: force `all_discount_product_ids` domain evaluation on python

#### To reproduce:
 1. Install PoS
 2. In the PoS config, enable "Promotions, Coupons, Gift Card & Loyalty Program"
 3. Go to Products > Discount & Loyalty
 4. Open the form view of "15% on next order"
 5. Change the reward to:
  - Discount: Specific Product
  - Discount Product Domain (! only appear in debug mode) > edit domain: 
  `[("name", "ilike", "chair")]`
  Then save (the whole loyalty program)
 6. Open the PoS session
 -> JS traceback `TypeError: fieldValue.toLowerCase is not a function as matchCondition`
 
#### Before this commit:
This happened as the PoS JS load only certain fields of the products.
When the domain try to use a field which was not loaded, it will fail to compute the domain. 
I propose to fix this issue by evaluating the domain from the Python side instead.
Currently, this is automatic IF you set the `loyalty.compute_all_discount_product_ids` system parameter as `enabled`.
But in this case, every PoS session will load with this process which can lead to performance issues.

#### After this commit:
This PR propose to use the same Python domain evaluation only if the domain is detected to have at least one field
which is not loaded from the PoS JS side (which will likely cause a JS error). 

#### Note
There is an existing try catch which catch for "InvalidDomain" exception with a friendly error message.
Unfortunately, it does not help here as another exception happen (which is not caught).
In addition, even if it was caught, it looks like the PoS continues to open after that.
So this part will be also modified to prevent the PoS from opening if there was an error on the promotion loading.

opw-3495793