### PR TITLE
[FIX] web_editor, website: fix CSS 'string' boolean values

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -322,7 +322,12 @@ function _getCSSVariableValue(key, htmlStyle) {
     // quoted for strings or non quoted for colors, numbers, etc. However,
     // Chrome has the annoying behavior of changing the single-quotes to
     // double-quotes when reading them through getPropertyValue...
-    return value.replace(/"/g, "'");
+    value = value.replace(/"/g, "'");
+    // Prevent Python boolean style and keep safe retro-compatibility
+    if (["'True'", "'False'"].includes(value)) {
+        value = value.replace(/'/g, "").toLowerCase();
+    }
+    return value;
 }
 /**
  * Normalize a color in case it is a variable name so it can be used outside of

--- a/addons/website/models/assets.py
+++ b/addons/website/models/assets.py
@@ -130,6 +130,11 @@ class Assets(models.AbstractModel):
                     r"var\(--([0-9]+)\)",
                     lambda matchobj: "var(--#{" + matchobj.group(1) + "})",
                     value)
+            # Prevent stringed python boolean values in CSS
+            if value is True:
+                value = 'true'
+            elif value is False:
+                value = 'false'
             pattern = "'%s': %%s,\n" % name
             regex = re.compile(pattern % ".+")
             replacement = pattern % value

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1569,7 +1569,7 @@ options.registry.OptionsTab = options.Class.extend({
         if (methodName === 'customizeButtonStyle') {
             const isOutline = weUtils.getCSSVariableValue(`btn-${params.button}-outline`);
             const isFlat = weUtils.getCSSVariableValue(`btn-${params.button}-flat`);
-            return isFlat === "'True'" ? 'flat' : isOutline === "'True'" ? 'outline' : 'fill';
+            return isFlat === "true" ? 'flat' : isOutline === "true" ? 'outline' : 'fill';
         }
         return this._super(...arguments);
     },


### PR DESCRIPTION
Before this commit, the CSS variables --btn-*-outline and --btn-*-flat
when set to true had the value in python style `'True'` (Bug introduced
in [1]).
This commit fixes the CSS boolean values applied in the
`customizeButtonStyle` function with `true` and `false` instead of
`'True'` and `'False'`.
A workaround has been added to the `_getCSSvariableValue` function in
web_editor to maintain retro-compatibility.

[1]: https://github.com/odoo/odoo/commit/388e4bb

Related to task-137409