### PR TITLE
[FIX] stock: no backorder for return pickings

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1122,6 +1122,8 @@ class Picking(models.Model):
 
         # Call `_action_done`.
         pickings_not_to_backorder = self.filtered(lambda p: p.picking_type_id.create_backorder == 'never')
+        if self.env.context.get('display_detailed_backorder'):
+            pickings_not_to_backorder |= self.filtered(lambda p: p.return_id and p not in pickings_not_to_backorder)
         if self.env.context.get('picking_ids_not_to_backorder'):
             pickings_not_to_backorder |= self.browse(self.env.context['picking_ids_not_to_backorder']).filtered(
                 lambda p: p.picking_type_id.create_backorder != 'always'


### PR DESCRIPTION
[FIX] stock: no backorder for return pickings in barcode

To reproduce:
1. Open picking OUT/0002 in barcode and click return products
2. Set the amount to 10 manually
3. Click validate

Existing behavior:
When trying to confirm a return picking in barcode, depending on the
settings on the specific picking type, the user would sometimes be asked
to create a backorder. For returns, this is not necessary as another
return for the same picking could always be generated instead of
creating the backorder.

Expected behavior:
This commit ignores the setting of the 'create_backorder' option on the
picking type when confirming a return picking in barcode and never
generates or asks for a backorder in this case.

Task: 3548962
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
