### PR TITLE
[FIX] web: calculate specialData when record is updated

### DIFF
--- a/addons/calendar/static/src/views/fields/many2many_attendee.js
+++ b/addons/calendar/static/src/views/fields/many2many_attendee.js
@@ -11,7 +11,7 @@ export class Many2ManyAttendee extends Many2ManyTagsAvatarField {
     setup() {
         super.setup();
         this.specialData = useSpecialData((orm, props) => {
-            const { context, name, record } = this.props;
+            const { context, name, record } = props;
             return orm.call(
                 "res.partner",
                 "get_attendee_detail",

--- a/addons/web/static/src/model/relational_model/utils.js
+++ b/addons/web/static/src/model/relational_model/utils.js
@@ -647,7 +647,7 @@ export function useRecordObserver(callback) {
             async (record) => {
                 if (firstCall) {
                     firstCall = false;
-                    await callback(record);
+                    await callback(record, props);
                     def.resolve();
                 } else {
                     return batched(
@@ -657,7 +657,7 @@ export function useRecordObserver(callback) {
                                 // We must do it manually.
                                 return;
                             }
-                            await callback(record);
+                            await callback(record, props);
                             def.resolve();
                         },
                         () => new Promise((resolve) => window.requestAnimationFrame(resolve))

--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -407,6 +407,7 @@ QUnit.module("Fields", (hooks) => {
                 ".o_statusbar_status button:not(.dropdown-toggle)"
             );
             await click(buttons[buttons.length - 1]);
+            await nextTick();
             assert.containsN(target, ".o_statusbar_status button:not(.dropdown-toggle)", 2);
         }
     );

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -54,6 +54,7 @@ import { CharField } from "@web/views/fields/char/char_field";
 import { DateTimeField } from "@web/views/fields/datetime/datetime_field";
 import { Field } from "@web/views/fields/field";
 import { IntegerField } from "@web/views/fields/integer/integer_field";
+import { useSpecialData } from "@web/views/fields/relational_utils";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { FormController } from "@web/views/form/form_controller";
 import { companyService } from "@web/webclient/company_service";
@@ -14223,5 +14224,40 @@ QUnit.module("Views", (hooks) => {
             resId: 1,
         });
         assert.strictEqual(target.querySelector(".o_breadcrumb").innerText, "Unnamed");
+    });
+
+    QUnit.test("field with special data", async function (assert) {
+        class MyWidget extends Component {
+            static template = xml`<div>MyWidget</div>`;
+            setup() {
+                this.specialData = useSpecialData((orm, props) => {
+                    const { record } = props;
+                    return orm.call("my.model", "get_special_data", [record.data.int_field]);
+                });
+            }
+        }
+        widgetRegistry.add("my_widget", {
+            component: MyWidget,
+        });
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="int_field" />
+                    <widget name="my_widget" />
+                </form>`,
+            resId: 2,
+            async mockRPC(route, args) {
+                if (args.method === "get_special_data") {
+                    assert.step(`get_special_data ${args.args[0]}`);
+                    return {};
+                }
+            },
+        });
+
+        await editInput(target, "[name='int_field'] input", "42");
+        assert.verifySteps(["get_special_data 9", "get_special_data 42"]);
     });
 });


### PR DESCRIPTION
Before this commit, specialData is only recaculted when the props change, but not if a value inside the props.record changes. For example, when we update record, the props do not change but the values inside record do. We want to recalculate the specialData if it is based on a record value.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
