### PR TITLE
[FIX] mail: fetch channel members when opening a discuss thread

### DIFF
--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -164,6 +164,9 @@ export class Composer extends Component {
             () => [this.props.composer.forceCursorMove]
         );
         onMounted(() => {
+            if (this.thread && !["chatter", "mailbox"].includes(this.thread.type)) {
+                this.threadService.fetchChannelMembers(this.thread);
+            }
             this.ref.el.scrollTo({ top: 0, behavior: "instant" });
         });
     }


### PR DESCRIPTION
Before this PR, channel member were not fetched when a discuss thread was open. This make the mention to an other user of the channel impossible. This PR fix this issue by fetching the channel member when the thread is open.

Task-3546165
