### PR TITLE
[IMP] repair: select operation type on create repair

### DIFF
--- a/addons/repair/models/product.py
+++ b/addons/repair/models/product.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class Product(models.Model):
@@ -21,4 +21,29 @@ class Product(models.Model):
 class ProductTemplate(models.Model):
     _inherit = "product.template"
 
+    @api.model
+    def _default_repair_picking_type_id(self):
+        company_id = (self.company_id or self.env.company).id
+        return self.env['stock.picking.type'].search([('code', '=', 'repair_operation'), ('company_id', '=?', company_id)], limit=1, order="id asc")
+
     create_repair = fields.Boolean('Create Repair', help="Create a linked Repair Order on Sale Order confirmation of this product.", groups='stock.group_stock_user')
+    show_repair_picking_type = fields.Boolean('Show Repair Picking Type', compute="_compute_show_repair_picking_type", groups='stock.group_stock_user')
+    repair_picking_type_id = fields.Many2one('stock.picking.type', string='Operation Type', domain=lambda self: [('code', '=', 'repair_operation'), ('company_id', '=?', self.company_id.id)],
+                                             help="The Operation Type in which the Repair Order is created on Create Repair action.", default=_default_repair_picking_type_id, groups='stock.group_stock_user')
+
+    @api.depends('create_repair')
+    def _compute_show_repair_picking_type(self):
+        company_ids = set(self.company_id.mapped('id'))
+        company_ids.add(self.env.company.id)
+        ro_type_counts = self.env['stock.picking.type']._read_group(
+            [
+                ('code', '=', 'repair_operation'),
+                ('company_id', 'in', list(company_ids)),
+            ],
+            groupby=['company_id'],
+            aggregates=['id:count'],
+        )
+        ro_type_counts = {key.id: value for key, value in ro_type_counts}
+        for product in self:
+            company_id = (product.company_id or self.env.company).id
+            product.show_repair_picking_type = product.create_repair and ro_type_counts[company_id] > 1

--- a/addons/repair/models/sale_order.py
+++ b/addons/repair/models/sale_order.py
@@ -94,12 +94,14 @@ class SaleOrderLine(models.Model):
             if not line.product_template_id.sudo().create_repair or line.move_ids.sudo().repair_id or float_compare(line.product_uom_qty, 0, precision_rounding=line.product_uom.rounding) <= 0:
                 continue
             order = line.order_id
+            product_repair_picking_type = line.product_template_id.sudo().repair_picking_type_id
+            picking_type_id = product_repair_picking_type.id if product_repair_picking_type.warehouse_id.id == order.warehouse_id.id else order.warehouse_id.repair_type_id.id
             new_repair_vals.append({
                 'state': 'confirmed',
                 'partner_id': order.partner_id.id,
                 'sale_order_id': order.id,
                 'sale_order_line_id': line.id,
-                'picking_type_id': order.warehouse_id.repair_type_id.id,
+                'picking_type_id': picking_type_id,
             })
         if new_repair_vals:
             self.env['repair.order'].sudo().create(new_repair_vals)

--- a/addons/repair/views/product_views.xml
+++ b/addons/repair/views/product_views.xml
@@ -8,6 +8,8 @@
         <field name="arch" type="xml">
             <xpath expr="//group[@name='group_general']/field[@name='uom_po_id']" position="after">
                 <field name="create_repair" invisible="detailed_type not in ('consu', 'product', 'service')"/>
+                <field name="show_repair_picking_type" invisible="1"/>
+                <field name="repair_picking_type_id" invisible='not show_repair_picking_type'/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
If several repair operation types exist, add an extra 'Operation Type' field when the user checks 'Create Repair' checkbox on product form

Current behavior before PR:
When a product trigger the creation of a Repair Order from a Sale Order, it takes the repair picking type of the warehouse bind to the Sale Order to create the Repair Order.

Desired behavior after PR is merged:
When a product trigger the creation of a Repair Order from a Sale Order, it takes the repair picking type set on the product if specified. Otherwise, it takes the repair picking type of the warehouse bind to the Sale Order.

Task : 3546220


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
