### PR TITLE
[FIX] microsoft_calendar: add security xml file to manifest

### DIFF
--- a/addons/microsoft_calendar/__manifest__.py
+++ b/addons/microsoft_calendar/__manifest__.py
@@ -8,6 +8,7 @@
     'depends': ['microsoft_account', 'calendar'],
     'data': [
         'data/microsoft_calendar_data.xml',
+        'security/microsoft_calendar_security.xml',
         'security/ir.model.access.csv',
         'wizard/reset_account_views.xml',
         'views/res_config_settings_views.xml',


### PR DESCRIPTION
Before this commit, the security XML file of microsoft_calendar module was not added in manifest, ignoring rules previously defined there. After this commit, the security XML file is now properly added.

Issue from task-id: 3410651
