### PR TITLE
[IMP] web: autocomplete, add input class prop

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -378,6 +378,7 @@ Object.assign(AutoComplete, {
         dropdown: { type: Boolean, optional: true },
         autofocus: { type: Boolean, optional: true },
         class: { type: String, optional: true },
+        inputClass: { type: String, optional: true },
     },
     defaultProps: {
         placeholder: "",
@@ -387,6 +388,7 @@ Object.assign(AutoComplete, {
         onChange: () => {},
         onBlur: () => {},
         onFocus: () => {},
+        inputClass: "",
     },
     timeout: 250,
 });

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -6,7 +6,7 @@
             <input
                 type="text"
                 t-att-id="props.id"
-                class="o-autocomplete--input o_input"
+                t-attf-class="o-autocomplete--input o_input #{props.inputClass}"
                 autocomplete="off"
                 t-att-placeholder="props.placeholder"
                 t-model="state.value"


### PR DESCRIPTION
Prior to this commit we weren't able to add classes of input in AutoComplete template.

This commit add a prop to be able to add extra classes on this input.


task-3511096


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
