### PR TITLE
[REM] web: pwa registration success log

### DIFF
--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -113,9 +113,6 @@ export class WebClient extends Component {
         if ("serviceWorker" in navigator) {
             navigator.serviceWorker
                 .register("/web/service-worker.js", { scope: "/web" })
-                .then((registration) => {
-                    console.info("Registration successful, scope is:", registration.scope);
-                })
                 .catch((error) => {
                     console.error("Service worker registration failed, error:", error);
                 });


### PR DESCRIPTION
odoo/odoo#136944 removed the log from website_event_track, but despite noting the discontinuity I missed that *a new instance of the log line had been added in 16.1* and that is likely why 16.1 was suddently spammed with that: website_event_track (likely) only installs its PWA when opening an event on website, but since odoo/enterprise#35322 the web client tries to install its PWA *every time it's loaded*, which can be up to once per test for qunit tests (if they need a webclient).

In odoo/odoo#133560 this registration was moved from enterprise to community, so needs to be nuked here as well.

Follows the removal of this log line in odoo/enterprise#48831.
