### PR TITLE
[FIX] website_slides: prevent constraint error when changing the type

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -491,6 +491,13 @@ class Slide(models.Model):
             values['is_preview'] = True
             values['is_published'] = True
 
+        # if the slide type is changed, remove the existing url or html_content
+        if values.get('slide_type'):
+            if self.url:
+                self.url = False
+            elif self.html_content:
+                self.html_content = False
+
         res = super(Slide, self).write(values)
         if values.get('is_published'):
             self.date_published = datetime.datetime.now()

--- a/addons/website_slides/tests/__init__.py
+++ b/addons/website_slides/tests/__init__.py
@@ -5,6 +5,7 @@ from . import common
 from . import test_attendee
 from . import test_karma
 from . import test_security
+from . import test_slide_slide
 from . import test_slide_utils
 from . import test_statistics
 from . import test_ui_wslides

--- a/addons/website_slides/tests/test_slide_slide.py
+++ b/addons/website_slides/tests/test_slide_slide.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.website_slides.tests import common as slides_common
+
+
+class TestSlideInternals(slides_common.SlidesCase):
+
+    def test_change_content_type(self):
+        """ To prevent constraint violation when changing type from video to webpage and vice-versa """
+        slide = self.env['slide.slide'].create({
+            'channel_id': self.channel.id,
+            'slide_type': 'video',
+            'is_published': True,
+            'url':'https://youtu.be/W0JQcpGLSFw'
+        })
+
+        # Changing type to webpage
+        slide.slide_type = 'webpage'
+        slide.html_content = "<p>Hello</p>"
+        self.assertTrue(slide.html_content)
+
+        # Changing type to document
+        slide.slide_type = 'document'
+        self.assertFalse(slide.html_content, "html_content should be empty")


### PR DESCRIPTION
Before
========
Modifying the type of content from video to webpage or webpage to video violates the constraint.

Technical
========
When we change the 'slide_type' of the slide.slide model from video to any other type, or from webpage to any other type, the value url or html_content is not removed and remains same. However, when switching between video and webpage, the 'exclusion_html_content_and_url' constraint is violated because one of them should be null.

After
======
When the type of content is changed, the existing URL or HTML content is removed as they are no longer needed.


Task-3474466