### PR TITLE
[IMP] pos_restaurant: improve preparation display demo data

### DIFF
--- a/addons/pos_restaurant/data/pos_restaurant_demo.xml
+++ b/addons/pos_restaurant/data/pos_restaurant_demo.xml
@@ -741,7 +741,7 @@
             <field name="pos_reference">Order 00002-001-0000</field>
             <field name="partner_id" ref="base.res_partner_1" />
             <field name="table_id" ref="table_01" />
-            <field name="customer_count">2</field>
+            <field name="customer_count">8</field>
         </record>
 
         <record id="pos_orderline_2" model="pos.order.line" forcecreate="False">
@@ -819,7 +819,7 @@
             <field name="pos_reference">Order 00002-003-0000</field>
             <field name="partner_id" ref="base.res_partner_4" />
             <field name="table_id" ref="table_04" />
-            <field name="customer_count">2</field>
+            <field name="customer_count">5</field>
         </record>
 
         <record id="pos_orderline_6" model="pos.order.line" forcecreate="False">

--- a/addons/pos_restaurant/data/pos_restaurant_onboarding_open_session.xml
+++ b/addons/pos_restaurant/data/pos_restaurant_onboarding_open_session.xml
@@ -21,7 +21,7 @@
         <field name="amount_return">0.0</field>
         <field name="pos_reference">Order 00002-001-0000</field>
         <field name="table_id" ref="table_01" />
-        <field name="customer_count">2</field>
+        <field name="customer_count">8</field>
     </record>
 
     <record id="pos_orderline_2" model="pos.order.line" forcecreate="False">
@@ -97,7 +97,7 @@
         <field name="amount_return">0.0</field>
         <field name="pos_reference">Order 00002-003-0000</field>
         <field name="table_id" ref="table_04" />
-        <field name="customer_count">2</field>
+        <field name="customer_count">5</field>
     </record>
 
     <record id="pos_orderline_6" model="pos.order.line" forcecreate="False">


### PR DESCRIPTION
The demo data linked to the preparation display (in restaurant)
where a bit light.
The enterprise PR adds more data to the demo data and move some
to previous stages so that user can play more with them.
In this commit we adapt the number of customer to the corresponding
orders that have more orderlines.

Enterprise PR: https://github.com/odoo/enterprise/pull/48841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
