### PR TITLE
[FIX] mass_mailing: add markup to preview mobile dialog

### DIFF
--- a/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
+++ b/addons/mass_mailing/static/src/js/mass_mailing_html_field.js
@@ -14,7 +14,7 @@ import { MassMailingMobilePreviewDialog } from "./mass_mailing_mobile_preview";
 import { getRangePosition } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 import { MassMailingWysiwyg } from '@mass_mailing/js/mass_mailing_wysiwyg';
 import { utils as uiUtils } from "@web/core/ui/ui_service";
-import { useSubEnv, status } from "@odoo/owl";
+import { useSubEnv, status, markup } from "@odoo/owl";
 
 export class MassMailingHtmlField extends HtmlField {
     static props = {
@@ -270,7 +270,7 @@ export class MassMailingHtmlField extends HtmlField {
             });
             this.mobilePreview = this.dialog.add(MassMailingMobilePreviewDialog, {
                 title: _t("Mobile Preview"),
-                preview: mailingHtml.body.innerHTML,
+                preview: markup(mailingHtml.body.innerHTML),
             }, {
                 onClose: () => $previewBtn.prop('disabled', false),
             });


### PR DESCRIPTION
This fix is only a missing of the commit 7f5a0ccf9e5fdf3f7fece8a9. As a reminder, in 7f5a0ccf9e5fdf3f7fece8a9, we check that the content of the dialog is markuped. If not, we escape it.
So in this commit, we add the markup to the "props.preview".

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
