### PR TITLE
[FIX] website_slides: allow digit-only input for duration field

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -1077,7 +1077,7 @@ class WebsiteSlides(WebsiteProfile):
 
         if post.get('duration'):
             # minutes to hours conversion
-            values['completion_time'] = int(post['duration']) / 60
+            values['completion_time'] = max(int(float(post['duration'])) / 60, 0)
 
         category = False
         # handle creation of new categories on the fly

--- a/addons/website_slides/static/src/xml/website_slides_upload.xml
+++ b/addons/website_slides/static/src/xml/website_slides_upload.xml
@@ -73,7 +73,7 @@
         <div class="form-group">
             <label for="duration" class="col-form-label">Duration</label>
             <div class="input-group">
-                <input type="number" id="duration" min="0" name="duration" placeholder="Estimated slide completion time" class="form-control"/>
+                <input type="number" id="duration" min="0" step="1" name="duration" placeholder="Estimated slide completion time" class="form-control"/>
                     <div class="input-group-prepend">
                     <span class="input-group-text">Minutes</span>
                 </div>


### PR DESCRIPTION
This error occurs when a user enters a float value in the `Duration` field.

Steps to produce :
- Install the `website_slides` module.
- Go to website > Courses > Open any course
- Click on `Add content` button > select any type of document(e.g web page)
- Give any title and give `Duration` value in float (e.g. 2.0 )
- Click on `Save & Publish` button > Error will be generated.

See the traceback :
```
ValueError: invalid literal for int() with base 10: '2.00'
  File "odoo/http.py", line 2138, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1714, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1741, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1942, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_slides/controllers/main.py", line 1428, in create_slide
    values['completion_time'] = int(post['duration']) / 60
```

This error occurs from here https://github.com/odoo/odoo/blob/d439fae7a27874ceeaab99cc4db5d28fcbe587c2/addons/website_slides/controllers/main.py#L1080 because it will get the duration time in type string and the value is 2.00 but when it tries to convert it into int it will give error. 
https://github.com/odoo/odoo/blob/d439fae7a27874ceeaab99cc4db5d28fcbe587c2/addons/website_slides/static/src/js/slides_upload.js#L120  from here It will be validating for values like 15.1 or 15.01 or other values but it is not working for the 15.0 or 15.00 and similar numeric formats.

after this commit, user will not able to input values other than digits

sentry-4532170208

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
