### PR TITLE
[IMP] spreadsheet: add date from_to global filter

### DIFF
--- a/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.js
@@ -1,0 +1,40 @@
+/** @odoo-module */
+
+import { Component } from "@odoo/owl";
+import { _t } from "@web/core/l10n/translation";
+import { DateTimeInput } from "@web/core/datetime/datetime_input";
+import { serializeDate, deserializeDate } from "@web/core/l10n/dates";
+
+export class DateFromToValue extends Component {
+    static template = "spreadsheet.DateFromToValue";
+    static components = { DateTimeInput };
+    static props = {
+        onFromToChanged: Function,
+        from: { type: String, optional: true },
+        to: { type: String, optional: true },
+    };
+    fromPlaceholder = _t("Date from...");
+    toPlaceholder = _t("Date to...");
+
+    onDateFromChanged(dateFrom) {
+        this.props.onFromToChanged({
+            from: dateFrom && serializeDate(dateFrom.startOf("day")),
+            to: this.props.to,
+        });
+    }
+
+    onDateToChanged(dateTo) {
+        this.props.onFromToChanged({
+            from: this.props.from,
+            to: dateTo && serializeDate(dateTo.endOf("day")),
+        });
+    }
+
+    get dateFrom() {
+        return this.props.from && deserializeDate(this.props.from);
+    }
+
+    get dateTo() {
+        return this.props.to && deserializeDate(this.props.to);
+    }
+}

--- a/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <div t-name="spreadsheet.DateFromToValue" class="date_filter_values">
+        <DateTimeInput
+            value="dateFrom"
+            type="'date'"
+            placeholder="fromPlaceholder"
+            onChange.bind="onDateFromChanged"
+        />
+        <i class="oi oi-arrow-right"></i>
+        <DateTimeInput
+            value="dateTo"
+            type="'date'"
+            placeholder="toPlaceholder"
+            onChange.bind="onDateToChanged"
+        />
+    </div>
+</templates>

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -3,6 +3,7 @@
 import { MultiRecordSelector } from "@web/core/record_selectors/multi_record_selector";
 import { RELATIVE_DATE_RANGE_TYPES } from "@spreadsheet/helpers/constants";
 import { DateFilterValue } from "../filter_date_value/filter_date_value";
+import { DateFromToValue } from "../filter_date_from_to_value/filter_date_from_to_value";
 
 import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";
@@ -48,7 +49,7 @@ export class FilterValue extends Component {
     }
 }
 FilterValue.template = "spreadsheet_edition.FilterValue";
-FilterValue.components = { DateFilterValue, MultiRecordSelector };
+FilterValue.components = { DateFilterValue, DateFromToValue, MultiRecordSelector };
 FilterValue.props = {
     filter: Object,
     model: Object,

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.scss
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.scss
@@ -7,4 +7,9 @@
     .o_datepicker_input {
         color: $o-main-text-color;
     }
+    .date_filter_values {
+        display: flex;
+        gap: map-get($spacers, 2);
+        align-items: baseline;
+    }
 }

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.xml
@@ -2,9 +2,10 @@
 <templates>
     <t t-name="spreadsheet_edition.FilterValue"
        >
-        <div class="o-filter-value d-flex align-items-start w-100">
-            <t t-set="filter"
-                t-value="props.filter"/>
+        <t t-set="filter"
+            t-value="props.filter"/>
+        <div class="o-filter-value d-flex align-items-start w-100" 
+            t-att-class="filter.rangeType === 'from_to' ? 'o-filter-value-double-size':''">
             <t t-set="filterValue"
                 t-value="getters.getGlobalFilterValue(filter.id) || []"/>
             <div t-if="filter.type === 'text'" class="w-100">
@@ -22,10 +23,6 @@
                     update="(resIds) => this.onTagSelected(filter.id, resIds)" />
             </span>
             <div t-if="filter.type === 'date'" class="w-100">
-                <DateFilterValue t-if="filter.rangeType !== 'relative'"
-                    period="filterValue &amp;&amp; filterValue.period"
-                    yearOffset="filterValue &amp;&amp; filterValue.yearOffset"
-                    onTimeRangeChanged="(value) => this.onDateInput(filter.id, value)" />
                 <select t-if="filter.rangeType === 'relative'"
                     t-on-change="(e) => this.onDateInput(filter.id, e.target.value || undefined)"
                     class="date_filter_values o_input me-3"
@@ -40,6 +37,15 @@
                         </option>
                     </t>
                 </select>
+                <DateFromToValue t-elif="filter.rangeType === 'from_to'"
+                    from="filterValue?.from"
+                    to="filterValue?.to"
+                    onFromToChanged="(value) => this.onDateInput(filter.id, value)"/>
+
+                <DateFilterValue t-else=""
+                    period="filterValue?.period"
+                    yearOffset="filterValue?.yearOffset"
+                    onTimeRangeChanged="(value) => this.onDateInput(filter.id, value)"/>
             </div>
             <i t-if="getters.isGlobalFilterActive(filter.id)"
                 class="fa fa-times btn btn-link text-muted o_side_panel_filter_icon ms-1"

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 /**
- * @typedef {"fixedPeriod"|"relative"} RangeType
+ * @typedef {"fixedPeriod"|"relative"|"from_to"} RangeType
  *
  * @typedef {"last_month" | "last_week" | "last_year" | "last_three_years" | "this_month" | "this_quarter" | "this_year"} RelativePeriod
  *

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.scss
@@ -67,16 +67,16 @@
         .o-filter-value {
             min-height: 25px;
             min-width: 100px;
+            flex-basis: 100px;
+            flex-grow: 1;
 
             .o_multi_record_selector {
                 width: 100%;
             }
+        }
 
-            .date_filter_values {
-                display: flex;
-                gap: map-get($spacers, 2);
-                align-items: baseline;
-            }
+        .o-filter-value-double-size {
+            flex-basis: 200px;
         }
     }
 }


### PR DESCRIPTION
Adds in date type global filters a new category
"From / To" allowing to define a domain between
two dates.

Task: [3516362](https://www.odoo.com/web#id=3516362&menu_id=4720&cids=1&action=333&active_id=2328&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
