### PR TITLE
[FIX] web: fix radio btn-group with btn-light

### DIFF
--- a/addons/web/static/src/scss/bootstrap_review_frontend.scss
+++ b/addons/web/static/src/scss/bootstrap_review_frontend.scss
@@ -60,7 +60,8 @@ $o-btn-outline-border-width-defaults: () !default;
 }
 
 // Highlight '.btn-group's active buttons
-.btn-group .btn-light.active {
+.btn-group .btn-light.active,
+.btn-group .btn-check:checked + .btn-light {
     box-shadow: inset 0 0 0 $border-width $component-active-bg;
     border-color: transparent;
     background-color: mix($component-active-bg, $light, 10%);


### PR DESCRIPTION
The new frontend redesign includes the same logic for btn-light inside a button group but it applies only if the label gets the active class.

btn-group can also be composed of checkbox or radio buttons, which rely  on the checked attribute to define the active state.

task-3551245

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
