### PR TITLE
[IMP] base_import_module: use only one wizard

### DIFF
--- a/addons/base_import_module/views/base_import_module_view.xml
+++ b/addons/base_import_module/views/base_import_module_view.xml
@@ -5,26 +5,22 @@
             <field name="name">base.import.module.form</field>
             <field name="model">base.import.module</field>
             <field name="arch" type="xml">
-                <form string="Import module">
+                <form string="Install the application">
                     <field name="state" invisible="1"/>
-                    <separator string="Import Module" colspan="4"/>
-                    <p class="alert alert-warning" role="alert">Note: you can only import data modules (.xml files and static assets)</p>
+                    <p class="alert alert-warning" role="alert" invisible="state == 'done'">Note: you can only import data modules (.xml files and static assets)</p>
                     <group invisible="state != 'init'" col="4">
-                        <label for="module_file" string="Select module package to import (.zip file):" colspan="4"/>
-                        <field name="module_file" colspan="4" options="{'accepted_file_extensions': '.zip'}"/>
-
-                        <field name="force"/>
+                        <field name="module_file" string="Module file (.zip)" colspan="4" options="{'accepted_file_extensions': '.zip'}"/>
+                        <field name="force" colspan="4" groups="base.group_no_one"/>
                     </group>
                     <group invisible="state != 'done'" col="4">
                         <field name="import_message" colspan="4" nolabel="1" readonly="1"/>
                     </group>
                     <footer>
                         <div invisible="state != 'init'">
-                            <button name="import_module" string="Import App" type="object" class="btn-primary" data-hotkey="q"/>
+                            <button name="import_module" string="Install" type="object" class="btn-primary" data-hotkey="q"/>
                             <button special="cancel" data-hotkey="x" string="Cancel" class="btn-secondary"/>
                         </div>
                         <div invisible="state != 'done'">
-                            <button name="action_module_open" string="Open Modules" type="object" class="btn-primary" data-hotkey="q"/>
                             <button special="cancel" data-hotkey="x" string="Close" class="btn-secondary"/>
                         </div>
                     </footer>


### PR DESCRIPTION
The wizard is overriden by studio, but we don't really need it so, we modify it and we'll remove the override for studio.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
