### PR TITLE
[IMP] web: Company service refactor and improved ease of understanding

### DIFF
--- a/addons/account/static/src/components/systray_item/systray_item.js
+++ b/addons/account/static/src/components/systray_item/systray_item.js
@@ -18,8 +18,8 @@ export class AccountSystrayItem extends Component {
 export const systrayItem = {
     Component: AccountSystrayItem,
     isDisplayed : function(env) {
-        const { availableCompanies } = env.services.company;
-        return Object.keys(availableCompanies).length === 1;
+        const { allowedCompanies } = env.services.company;
+        return Object.keys(allowedCompanies).length === 1;
     },
 };
 

--- a/addons/web/static/src/webclient/burger_menu/burger_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/burger_menu.xml
@@ -26,7 +26,7 @@
               t-att-class="{o_burger_menu_app: !isUserMenuUnfolded, 'bg-view': isUserMenuUnfolded}">
               <!-- -->
               <t t-if="isUserMenuUnfolded">
-                  <MobileSwitchCompanyMenu t-if="Object.values(company.availableCompanies).length > 1" />
+                  <MobileSwitchCompanyMenu t-if="Object.values(company.allowedCompanies).length > 1" />
                   <BurgerUserMenu/>
               </t>
               <!-- Current App Sections -->

--- a/addons/web/static/src/webclient/burger_menu/mobile_switch_company_menu/mobile_switch_company_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/mobile_switch_company_menu/mobile_switch_company_menu.xml
@@ -4,7 +4,7 @@
 <t t-name="web.MobileSwitchCompanyMenu">
     <div class="o_burger_menu_companies p-3 bg-100">
         <div class="o_burger_menu_user_title h6 mb-3">Companies</div>
-        <t t-foreach="Object.values(companyService.availableCompanies)
+        <t t-foreach="Object.values(companyService.allowedCompaniesWithAncestors)
                       .filter((c) => !c.parent_id)
                       .sort((c1, c2) => c1.sequence - c2.sequence)
                      " t-as="company" t-key="company.id">
@@ -14,20 +14,23 @@
 </t>
 
 <t t-name="web.MobileSwitchCompanyItem">
-    <t t-set="id" t-value="props.company.id"/>
-    <t t-set="displayName" t-value="props.company.name"/>
-    <t t-set="isCompanySelected" t-value="selectedCompanies.includes(id)"/>
     <t t-set="checkIcon" t-value="isCompanySelected ? 'fa-check-square text-primary' : 'fa-square-o'"/>
-    <t t-set="isCompanyCurrent" t-value="companyService.currentCompany.id === id"/>
-    <div class="d-flex menu_companies_item" t-att-data-company-id="id">
-        <div class="border-end toggle_company" t-att-class="{'border-primary' : isCompanyCurrent}" t-on-click="() => this.toggleCompany(id)">
-            <span class="btn border-0 p-2">
+    <div class="d-flex menu_companies_item" t-att-class="{'disabled': !isCompanyAllowed }" t-att-data-company-id="props.company.id">
+        <div class="border-end toggle_company" t-att-class="{'border-primary' : isCurrent}" t-on-click="() => this.toggleCompany()">
+            <span class="btn border-0 p-2" t-att-class="{'disabled': !isCompanyAllowed }">
                 <i t-attf-class="fa fa-fw fs-2 m-0 {{checkIcon}}"/>
             </span>
         </div>
-        <div class="flex-grow-1 p-2 ms-1 log_into text-muted" t-att-class="{'alert-primary': isCompanyCurrent}" t-on-click="() => this.logIntoCompany(id)">
-            <span t-esc="displayName" class="company_label" t-att-class="isCompanyCurrent ? 'text-900 fw-bold' : ''"/>
-            <small t-if="isCompanyCurrent" class="ms-1">(current)</small>
+        <div
+            class="flex-grow-1 p-2 log_into"
+            t-att-class="{'alert-primary': isCurrent, 'text-muted': !isCompanyAllowed}" t-on-click="() => this.logIntoCompany()"
+        >
+            <span
+                t-esc="props.company.name" class="company_label"
+                t-att-class="isCurrent ? 'text-900 fw-bold' : ''"
+                t-att-style="'padding-left:' + (props.level * 10) + 'px';"
+            />
+            <small t-if="isCurrent" class="ms-1">(current)</small>
         </div>
     </div>
     <t t-foreach="props.company.child_ids" t-as="child" t-key="child">

--- a/addons/web/static/src/webclient/company_service.js
+++ b/addons/web/static/src/webclient/company_service.js
@@ -21,62 +21,54 @@ function formatCompanyIds(cids, separator = ",") {
     return cids.join(separator);
 }
 
-function computeAllowedCompanyIds(cids) {
+function computeActiveCompanyIds(cids) {
     const { user_companies } = session;
-    let allowedCompanyIds = cids || [];
+    let activeCompanyIds = cids || [];
     const availableCompaniesFromSession = user_companies.allowed_companies;
-    const notReallyAllowedCompanies = allowedCompanyIds.filter(
+    const notAllowedCompanies = activeCompanyIds.filter(
         (id) => !(id in availableCompaniesFromSession)
     );
 
-    if (!allowedCompanyIds.length || notReallyAllowedCompanies.length) {
-        allowedCompanyIds = [user_companies.current_company];
+    if (!activeCompanyIds.length || notAllowedCompanies.length) {
+        activeCompanyIds = [user_companies.current_company];
     }
-    return allowedCompanyIds;
+    return activeCompanyIds;
+}
+
+function getCompanyIdsFromBrowser(hash) {
+    let cids;
+    if ("cids" in hash) {
+        // backward compatibility s.t. old urls (still using "," as separator) keep working
+        // deprecated as of 17.0
+        let separator = CIDS_HASH_SEPARATOR;
+        if (typeof hash.cids === "string" && !hash.cids.includes(CIDS_HASH_SEPARATOR)) {
+            separator = ",";
+        }
+        cids = parseCompanyIds(hash.cids, separator);
+    } else if (cookie.get("cids")) {
+        cids = parseCompanyIds(cookie.get("cids"));
+    }
+    return cids || [];
 }
 
 export const companyService = {
     dependencies: ["user", "router", "action"],
     start(env, { user, router, action }) {
-        let cids;
-        const hash = router.current.hash;
-        if ("cids" in hash) {
-            // backward compatibility s.t. old urls (still using "," as separator) keep working
-            // deprecated as of 17.0
-            let separator = CIDS_HASH_SEPARATOR;
-            if (typeof hash.cids === "string" && !hash.cids.includes(CIDS_HASH_SEPARATOR)) {
-                separator = ",";
-            }
-            cids = parseCompanyIds(hash.cids, separator);
-        } else if (cookie.get("cids")) {
-            cids = parseCompanyIds(cookie.get("cids"));
-        }
+        const allowedCompanies = session.user_companies.allowed_companies;
+        const disallowedAncestorCompanies = session.user_companies.disallowed_ancestor_companies;
+        const allowedCompaniesWithAncestors = {
+            ...allowedCompanies,
+            ...disallowedAncestorCompanies,
+        };
+        const activeCompanyIds = computeActiveCompanyIds(
+            getCompanyIdsFromBrowser(router.current.hash)
+        );
 
-        const availableCompanies = session.user_companies.allowed_companies;
-        const unavailableAncestorCompanies = session.user_companies.disallowed_ancestor_companies;
-        const availableCompaniesWithAncestors = {
-            ...availableCompanies,
-            ...unavailableAncestorCompanies,
-        };
-        const allowedCompanyIds = computeAllowedCompanyIds(cids);
-        const nextAvailableCompanies = allowedCompanyIds.slice(); // not using a Set because order is important
-        nextAvailableCompanies.add = (companyId) => {
-            if (!nextAvailableCompanies.includes(companyId)) {
-                nextAvailableCompanies.push(companyId);
-                availableCompanies[companyId].child_ids.map(nextAvailableCompanies.add);
-            }
-        };
-        nextAvailableCompanies.remove = (companyId) => {
-            if (nextAvailableCompanies.includes(companyId)) {
-                nextAvailableCompanies.splice(nextAvailableCompanies.indexOf(companyId), 1);
-                availableCompanies[companyId].child_ids.map(nextAvailableCompanies.remove);
-            }
-        };
-
-        const cidsHash = formatCompanyIds(allowedCompanyIds, CIDS_HASH_SEPARATOR);
+        // update browser data
+        const cidsHash = formatCompanyIds(activeCompanyIds, CIDS_HASH_SEPARATOR);
         router.replaceState({ cids: cidsHash }, { lock: true });
-        cookie.set("cids", formatCompanyIds(allowedCompanyIds));
-        user.updateContext({ allowed_company_ids: allowedCompanyIds });
+        cookie.set("cids", formatCompanyIds(activeCompanyIds));
+        user.updateContext({ allowed_company_ids: activeCompanyIds });
 
         // reload the page if changes are being done to `res.company`
         env.bus.addEventListener("RPC:RESPONSE", (ev) => {
@@ -90,39 +82,48 @@ export const companyService = {
         });
 
         return {
-            availableCompanies,
-            unavailableAncestorCompanies,
-            nextAvailableCompanies,
-            get allowedCompanyIds() {
-                return allowedCompanyIds.slice();
+            allowedCompanies,
+            allowedCompaniesWithAncestors,
+            disallowedAncestorCompanies,
+
+            get activeCompanyIds() {
+                return activeCompanyIds.slice();
             },
+
             get currentCompany() {
-                return availableCompanies[allowedCompanyIds[0]];
+                return allowedCompanies[activeCompanyIds[0]];
             },
+
             getCompany(companyId) {
-                return availableCompaniesWithAncestors[companyId];
+                return allowedCompaniesWithAncestors[companyId];
             },
-            setCompanies(mode, companyId) {
-                if (mode === "toggle") {
-                    if (nextAvailableCompanies.includes(companyId)) {
-                        nextAvailableCompanies.remove(companyId);
-                    } else {
-                        nextAvailableCompanies.add(companyId);
+
+            /**
+             * @param {Array<>} companyIds - List of companies to log into
+             * @param {boolean} [includeChildCompanies=true] - If true, will also
+             * log into each child of each companyIds (default is true)
+             */
+            setCompanies(companyIds, includeChildCompanies = true) {
+                const newCompanyIds = companyIds.length ? companyIds : [activeCompanyIds[0]];
+
+                function addCompanies(companyIds) {
+                    for (const companyId of companyIds) {
+                        if (!newCompanyIds.includes(companyId)) {
+                            newCompanyIds.push(companyId);
+                            addCompanies(allowedCompanies[companyId].child_ids);
+                        }
                     }
-                } else if (mode === "loginto") {
-                    nextAvailableCompanies.splice(0, nextAvailableCompanies.length);
-                    nextAvailableCompanies.add(companyId);
                 }
-            },
-            logNextCompanies() {
-                const next = nextAvailableCompanies.length
-                    ? nextAvailableCompanies
-                    : [allowedCompanyIds[0]];
-                router.pushState(
-                    { cids: formatCompanyIds(next, CIDS_HASH_SEPARATOR) },
-                    { lock: true }
-                );
-                cookie.set("cids", formatCompanyIds(next));
+
+                if (includeChildCompanies) {
+                    addCompanies(
+                        companyIds.flatMap((companyId) => allowedCompanies[companyId].child_ids)
+                    );
+                }
+
+                const cidsHash = formatCompanyIds(newCompanyIds, CIDS_HASH_SEPARATOR);
+                router.pushState({ cids: cidsHash }, { lock: true });
+                cookie.set("cids", formatCompanyIds(newCompanyIds));
                 browser.setTimeout(() => browser.location.reload()); // history.pushState is a little async
             },
         };

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -7,10 +7,7 @@
             <i class="fa fa-building d-lg-none"/>
             <span class="oe_topbar_name d-none d-lg-block" t-esc="companyService.currentCompany.name"/>
         </t>
-        <t t-foreach="Object.values({
-                          ...companyService.availableCompanies,
-                          ...companyService.unavailableAncestorCompanies
-                      })
+        <t t-foreach="Object.values(companyService.allowedCompaniesWithAncestors)
                       .filter((c) => !c.parent_id)
                       .sort((c1, c2) => c1.sequence - c2.sequence)
                      " t-as="company" t-key="company.id">
@@ -21,13 +18,10 @@
 
 
 <t t-name="web.SwitchCompanyItem">
-    <t t-set="isCompanySelected" t-value="selectedCompanies.includes(props.company.id)"/>
-    <t t-set="isCompanyAvailable" t-value="props.company.id in companyService.availableCompanies"/>
-    <t t-set="isCurrent" t-value="props.company.id === companyService.currentCompany.id"/>
-    <DropdownItem class="'p-0 bg-white'" parentClosingMode="!isCompanyAvailable ? 'none' : 'all'">
+    <DropdownItem class="'p-0 bg-white'" parentClosingMode="!isCompanyAllowed ? 'none' : 'all'">
         <div
             class="d-flex"
-            t-att-class="!isCompanyAvailable ? 'disabled' : ''"
+            t-att-class="{ 'disabled': !isCompanyAllowed }"
             data-menu="company"
             t-att-data-company-id="props.company.id">
             <div
@@ -37,10 +31,10 @@
                 t-att-title="(isCompanySelected ? 'Hide ' : 'Show ') + props.company.name + ' content.'"
                 tabindex="0"
                 class="border-end toggle_company"
-                t-att-class="isCurrent ? 'border-primary' : !isCompanyAvailable ? 'disabled' : ''"
-                t-on-click.stop="() => isCompanyAvailable &amp;&amp; this.toggleCompany(props.company.id)">
+                t-att-class="{ 'border-primary': isCurrent, 'disabled': !isCompanyAllowed }"
+                t-on-click.stop="() => this.toggleCompany()">
 
-                <span class="btn border-0 p-2" t-att-class="isCompanyAvailable ? 'btn-light' : 'disabled'">
+                <span class="btn border-0 p-2" t-att-class="isCompanyAllowed ? 'btn-light' : 'disabled'">
                     <i class="fa fa-fw py-2" t-att-class="isCompanySelected ? 'fa-check-square text-primary' : 'fa-square-o'"/>
                 </span>
             </div>
@@ -52,8 +46,8 @@
                 t-att-title="'Switch to ' + props.company.name "
                 tabindex="0"
                 class="d-flex flex-grow-1 align-items-center py-0 log_into ps-2"
-                t-att-class="isCurrent ? 'alert-primary' : 'btn fw-normal border-0 ' + (isCompanyAvailable ? 'btn-light' : 'disabled')"
-                t-on-click="() => isCompanyAvailable &amp;&amp; this.logIntoCompany(props.company.id)">
+                t-att-class="isCurrent ? 'alert-primary' : 'btn fw-normal border-0 ' + (isCompanyAllowed ? 'btn-light' : 'disabled')"
+                t-on-click="() => this.logIntoCompany()">
 
                 <span
                     class='company_label pe-3'

--- a/addons/web/static/tests/helpers/mock_services.js
+++ b/addons/web/static/tests/helpers/mock_services.js
@@ -267,8 +267,8 @@ export function makeFakeUserService(hasGroup = () => false) {
 export const fakeCompanyService = {
     start() {
         return {
-            availableCompanies: {},
-            allowedCompanyIds: [],
+            allowedCompanies: {},
+            activeCompanyIds: [],
             currentCompany: {},
             setCompanies: () => {},
         };
@@ -282,7 +282,7 @@ export function makeFakeBarcodeService() {
                 bus: {
                     async addEventListener() {},
                     async removeEventListener() {},
-                }
+                },
             };
         },
     };

--- a/addons/web/static/tests/webclient/company_service_tests.js
+++ b/addons/web/static/tests/webclient/company_service_tests.js
@@ -79,15 +79,15 @@ QUnit.test("extract allowed company ids from url hash", async (assert) => {
     Object.assign(browser.location, { hash: "cids=3-1" });
     let env = await makeTestEnv();
     assert.deepEqual(
-        Object.values(env.services.company.availableCompanies).map((c) => c.id),
+        Object.values(env.services.company.allowedCompanies).map((c) => c.id),
         [1, 2, 3]
     );
-    assert.deepEqual(env.services.company.allowedCompanyIds, [3, 1]);
+    assert.deepEqual(env.services.company.activeCompanyIds, [3, 1]);
     assert.strictEqual(env.services.company.currentCompany.id, 3);
 
     // backward compatibility
     Object.assign(browser.location, { hash: "cids=3%2C1" });
     env = await makeTestEnv();
-    assert.deepEqual(env.services.company.allowedCompanyIds, [3, 1]);
+    assert.deepEqual(env.services.company.activeCompanyIds, [3, 1]);
     assert.strictEqual(env.services.company.currentCompany.id, 3);
 });

--- a/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
@@ -104,7 +104,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
          *   [ ] Company 2
          *   [ ] Company 3
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
         assert.containsN(scMenuEl, "[data-company-id]", 3);
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-square", 1);
@@ -138,7 +138,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
          *   [ ] Company 2
          *   [ ] Company 3
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
         assert.containsN(scMenuEl, "[data-company-id]", 3);
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-square", 1);
@@ -177,7 +177,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
          *   [ ] Company 3
          */
         assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 1 });
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
         assert.containsN(scMenuEl, "[data-company-id]", 3);
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-square", 1);
@@ -190,7 +190,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
          */
         await click(scMenuEl.querySelectorAll(".toggle_company")[0]);
         assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 1 });
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-squarqe", 0);
         assert.containsN(scMenuEl, "[data-company-id] .fa-square-o", 3);
@@ -210,7 +210,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
          *   [ ] Company 2
          *   [ ] Company 3
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
         assert.containsN(scMenuEl, "[data-company-id]", 3);
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-square", 1);
@@ -240,7 +240,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
          *   [ ] Company 2
          *   [x] **Company 3**
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3, 1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [3, 1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         assert.containsN(scMenuEl, "[data-company-id]", 3);
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-square", 2);
@@ -270,7 +270,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
          *   [x] **Company 2**
          *   [x] Company 3
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [2, 3]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [2, 3]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 2);
         assert.containsN(scMenuEl, "[data-company-id]", 3);
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-square", 2);
@@ -299,7 +299,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
          *   [ ] Company 2
          *   [ ] Company 3
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
         assert.containsN(scMenuEl, "[data-company-id]", 3);
         assert.containsN(scMenuEl, "[data-company-id] .fa-check-square", 1);

--- a/addons/web/static/tests/webclient/switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/switch_company_menu_tests.js
@@ -95,7 +95,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          *   [ ]    Hercules
          *   [ ]    Hulk
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [3]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(target.querySelector(".dropdown-toggle"));
         assert.containsN(target, "[data-company-id]", 5);
@@ -158,7 +158,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          *   [ ]    Hercules
          *   [ ]    Hulk
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [3]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(target.querySelector(".dropdown-toggle"));
         assert.containsN(target, "[data-company-id]", 5);
@@ -202,7 +202,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          *   [ ]    Hulk
          */
         assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 3 });
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [3]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(target.querySelector(".dropdown-toggle"));
         assert.containsN(target, "[data-company-id]", 5);
@@ -218,7 +218,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          */
         await click(target.querySelectorAll(".toggle_company")[0]);
         assert.deepEqual(scMenu.env.services.router.current.hash, { cids: 3 });
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [3]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         assert.containsOnce(target, ".dropdown-menu", "dropdown is still opened");
         assert.containsN(target, "[data-company-id] .fa-check-square", 0);
@@ -240,7 +240,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          *   [ ]    Hercules
          *   [ ]    Hulk
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [3]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(target.querySelector(".dropdown-toggle"));
         assert.containsN(target, "[data-company-id]", 5);
@@ -275,7 +275,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          *   [ ]    Hercules
          *   [ ]    Hulk
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3, 1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [3, 1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(target.querySelector(".dropdown-toggle"));
         assert.containsN(target, "[data-company-id]", 5);
@@ -310,7 +310,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          *   [ ]    Hercules
          *   [ ]    Hulk
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [2, 1]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [2, 1]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 2);
         await click(target.querySelector(".dropdown-toggle"));
         assert.containsN(target, "[data-company-id]", 5);
@@ -344,7 +344,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          *   [ ]    Hercules
          *   [ ]    Hulk
          */
-        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.deepEqual(scMenu.env.services.company.activeCompanyIds, [3]);
         assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
         await click(target.querySelector(".dropdown-toggle"));
         assert.containsN(target, "[data-company-id]", 5);


### PR DESCRIPTION
This commit refactors the company service to be split responsibilities. The selection logic is now entirely contained in the switch_company_menu, making the company service clearer.

The following variables have also been renamed:
- `availableCompanies` has been renamed to `allowedCompanies` to reflect the name from the python side
- `allowedCompanies` has been renamed to `activeCompanies`

Some features were missing on mobile:
- Indent has been added to SwitchMenuItem to display the hierachy of companies on mobile.
- Unallowed ancestor companies where not displayed on mobile.

*The functional aspect of the company service and company switch has not been changed.*

Enterprise PR: https://github.com/odoo/enterprise/pull/48862
Task: [3522168](https://www.odoo.com/mail/view?model=project.task&res_id=3522168)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
