### PR TITLE
[IMP] core: export record translation

### DIFF
--- a/odoo/addons/base/wizard/base_export_language.py
+++ b/odoo/addons/base/wizard/base_export_language.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import ast
 import base64
 import contextlib
 import io
@@ -23,8 +24,13 @@ class BaseLanguageExport(models.TransientModel):
     lang = fields.Selection(_get_languages, string='Language', required=True, default=NEW_LANG_KEY)
     format = fields.Selection([('csv','CSV File'), ('po','PO File'), ('tgz', 'TGZ Archive')],
                               string='File Format', required=True, default='po')
+    export_type = fields.Selection([('module', 'Module'), ('model', 'Model')],
+                                   string='Export Type', required=True, default='module')
     modules = fields.Many2many('ir.module.module', 'rel_modules_langexport', 'wiz_id', 'module_id',
                                string='Apps To Export', domain=[('state','=','installed')])
+    model_id = fields.Many2one('ir.model', string='Model to Export', domain=[('transient', '=', False)])
+    model_name = fields.Char(string="Model Name", related="model_id.model")
+    domain = fields.Char(string="Model Domain", default='[]')
     data = fields.Binary('File', readonly=True, attachment=False)
     state = fields.Selection([('choose', 'choose'), ('get', 'get')], # choose language or get the file
                              default='choose')
@@ -32,15 +38,21 @@ class BaseLanguageExport(models.TransientModel):
     def act_getfile(self):
         this = self[0]
         lang = this.lang if this.lang != NEW_LANG_KEY else False
-        mods = sorted(this.mapped('modules.name')) or ['all']
 
         with contextlib.closing(io.BytesIO()) as buf:
-            tools.trans_export(lang, mods, buf, this.format, self._cr)
+            if this.export_type == 'model':
+                ids = self.env[this.model_name].search(ast.literal_eval(this.domain)).ids
+                tools.trans_export_records(lang, this.model_name, ids, buf, this.format, self._cr)
+            else:
+                mods = sorted(this.mapped('modules.name')) or ['all']
+                tools.trans_export(lang, mods, buf, this.format, self._cr)
             out = base64.encodebytes(buf.getvalue())
 
         filename = 'new'
         if lang:
             filename = tools.get_iso_codes(lang)
+        elif this.export_type == 'model':
+            filename = this.model_name.replace('.', '_')
         elif len(mods) == 1:
             filename = mods[0]
         extension = this.format

--- a/odoo/addons/base/wizard/base_export_language_views.xml
+++ b/odoo/addons/base/wizard/base_export_language_views.xml
@@ -11,7 +11,11 @@
                     <group invisible="state != 'choose'" string="Export Settings">
                         <field name="lang"/>
                         <field name="format"/>
-                        <field name="modules" widget="many2many_tags" options="{'no_create': True}"/>
+                        <field name="export_type"/>
+                        <field name="modules" widget="many2many_tags" options="{'no_create': True}" invisible="export_type == 'model'"/>
+                        <field name="model_id" options="{'no_create': True}" invisible="export_type == 'module'"/>
+                        <field name="model_name" invisible="1"/>
+                        <field name="domain" widget="domain" options="{'model': 'model_name'}" invisible="export_type == 'module'"/>
                     </group>
                     <div invisible="state != 'get'">
                         <h2>Export Complete</h2>

--- a/odoo/addons/test_translation_import/data/test_translation_import_data.xml
+++ b/odoo/addons/test_translation_import/data/test_translation_import_data.xml
@@ -4,4 +4,7 @@
         <field name="name">Tableware</field>
         <field name="xml" type="xml"><form string="Fork"><div>Knife</div><div>Spoon</div></form></field>
     </record>
+    <record model="test.translation.import.model2" id="test_translation_import_model2_record1">
+        <field name="model1_id" ref="test_translation_import.test_translation_import_model1_record1"/>
+    </record>
 </odoo>

--- a/odoo/addons/test_translation_import/models/models.py
+++ b/odoo/addons/test_translation_import/models/models.py
@@ -25,3 +25,11 @@ class TestTranslationImportModel1(models.Model):
 
     def get_code_named_placeholder_translation(self, *args, **kwargs):
         return _('Code, %(num)s, %(symbol)s, English', *args, **kwargs)
+
+
+class TestTranslationImportModel2(models.Model):
+    _inherits = {'test.translation.import.model1': 'model1_id'}
+    _name = 'test.translation.import.model2'
+    _description = 'Translation Test 2'
+
+    model1_id = fields.Many2one('test.translation.import.model1', required=True, ondelete='cascade')

--- a/odoo/addons/test_translation_import/security/ir.model.access.csv
+++ b/odoo/addons/test_translation_import/security/ir.model.access.csv
@@ -1,2 +1,3 @@
 "id","name","model_id:id","group_id:id","perm_read","perm_write","perm_create","perm_unlink"
 "access_test_translation_import_model1","access.test.translation.import.model1","model_test_translation_import_model1",,0,0,0,0
+"access_test_translation_import_model2","access.test.translation.import.model2","model_test_translation_import_model2",,0,0,0,0

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -5,7 +5,7 @@ import io
 
 from odoo.tests import common, tagged
 from odoo.tools.misc import file_open, mute_logger
-from odoo.tools.translate import TranslationModuleReader, code_translations, CodeTranslations, PYTHON_TRANSLATION_COMMENT, JAVASCRIPT_TRANSLATION_COMMENT, WEB_TRANSLATION_COMMENT
+from odoo.tools.translate import TranslationModuleReader, TranslationRecordReader, code_translations, CodeTranslations, PYTHON_TRANSLATION_COMMENT, JAVASCRIPT_TRANSLATION_COMMENT, WEB_TRANSLATION_COMMENT
 from odoo import Command
 from odoo.addons.base.models.ir_fields import BOOLEAN_TRANSLATIONS
 
@@ -386,3 +386,35 @@ class TestTranslationFlow(common.TransactionCase):
             'with spaces',
             'hello \\"world\\"',
         })
+
+    def test_export_records(self):
+        self.env["base.language.install"].create({
+            'overwrite': True,
+            'lang_ids': [(6, 0, [self.env.ref('base.lang_fr').id])],
+        }).lang_install()
+
+        model1_ids = self.env.ref('test_translation_import.test_translation_import_model1_record1').ids
+        po_reader = TranslationRecordReader(self.env.cr, 'test.translation.import.model1', model1_ids, lang='fr_FR')
+        translations = {line[4]: line[5] for line in po_reader}
+        self.assertDictEqual(
+            translations,
+            {
+                'Fork': 'Fourchette',
+                'Knife': 'Couteau',
+                'Spoon': 'Cuillère',
+                'Tableware': 'Vaisselle',
+            }
+        )
+
+        model2_ids = self.env.ref('test_translation_import.test_translation_import_model2_record1').ids
+        po_reader = TranslationRecordReader(self.env.cr, 'test.translation.import.model2', model2_ids, lang='fr_FR')
+        translations = {line[4]: line[5] for line in po_reader}
+        self.assertDictEqual(
+            translations,
+            {
+                'Fork': 'Fourchette',
+                'Knife': 'Couteau',
+                'Spoon': 'Cuillère',
+                'Tableware': 'Vaisselle',
+            }
+        )


### PR DESCRIPTION
Currently, bulk-importing translations for non-module loaded data is hard
1. PO file import works fine, but exporting a PO template for non-module loaded
data is near impossible (since PO exports will only export entire modules)
2. Import of translated values during csv/excel file import is not supported

This commit fix the issue by improve 1 which reuses the translation export
wizard for modules to export translations for non-module records. So that user
can export translations for selected records with a domain and import the po
file after translating

[DEBUG MODE] Settings -> Translations -> Export translations -> Export Type
("model") -> Select `Model to Export` and `Model Domain` -> Export
The framework will
1. create external ids for records without external ids
2. export translations for stored translated and inherited translated fields

task: 3463505

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
