### PR TITLE
[FIX] im_livechat: do not overwrite author of message format

### DIFF
--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -39,10 +39,8 @@ class MailMessage(models.Model):
                 if message_sudo.author_id:
                     vals.pop('email_from')
                 if message_sudo.author_id.user_livechat_username:
-                    vals['author'] = {
-                        'id': message_sudo.author_id.id,
-                        'user_livechat_username': message_sudo.author_id.user_livechat_username,
-                    }
+                    del vals['author']['name']
+                    vals['author']['user_livechat_username'] = message_sudo.author_id.user_livechat_username
                 if discuss_channel.chatbot_current_step_id \
                         and message_sudo.author_id == discuss_channel.chatbot_current_step_id.chatbot_script_id.operator_partner_id:
                     chatbot_message_id = self.env['chatbot.message'].sudo().search([

--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -160,6 +160,7 @@ class TestGetDiscussChannel(TestImLivechatCommon):
         channel.with_user(operator).message_post(body='Hello', message_type='comment', subtype_xmlid='mail.mt_comment')
         message_formats = channel.with_user(None).sudo()._channel_fetch_message()
         self.assertEqual(len(message_formats), 1)
+        self.assertNotIn('name', message_formats[0]['author'])
         self.assertEqual(message_formats[0]['author']['id'], operator.partner_id.id)
         self.assertEqual(message_formats[0]['author']['user_livechat_username'], operator.livechat_username)
         self.assertFalse(message_formats[0].get('email_from'), "should not send email_from to livechat user")

--- a/addons/im_livechat/tests/test_message.py
+++ b/addons/im_livechat/tests/test_message.py
@@ -22,7 +22,7 @@ class TestImLivechatMessage(HttpCase):
                 'odoobot_state': 'disabled',
                 'signature': '--\nErnest',
             },
-            {'name': 'test1', 'login': 'test1', 'password': self.password, 'email': 'test1@example.com'},
+            {'name': 'test1', 'login': 'test1', 'password': self.password, 'email': 'test1@example.com', 'livechat_username': 'chuck'},
         ])
 
     @users('emp')
@@ -57,7 +57,7 @@ class TestImLivechatMessage(HttpCase):
             'author': {
                 'id': self.users[1].partner_id.id,
                 'is_company': self.users[1].partner_id.is_company,
-                'name': "test1",
+                'user_livechat_username': self.users[1].livechat_username,
                 'type': "partner",
                 'user': {
                     'id': self.users[1].id,


### PR DESCRIPTION
Before this commit, the `_message_format` override of the live chat
module would overwrite the author. Since [1], values provided by the
live chat override are incomplete which result in incorrect message
display in the discuss app. This commit modify the live chat override
to enrich the author instead of totally overwriting it.

Steps to reproduce:
- Log in with mitchell admin
- Change its live chat user name in its profile
- Open a chat with a visitor
- Send a message with mitchell
- The message is incorrectly marked as sent by the visitor

[1]: https://github.com/odoo/odoo/pull/137276