### PR TITLE
[IMP] account,analytic,hr_timesheet: harmonize analytic search view

### DIFF
--- a/addons/account/views/account_analytic_line_views.xml
+++ b/addons/account/views/account_analytic_line_views.xml
@@ -43,15 +43,22 @@
             <field name="name">account.analytic.line.select.inherit.account</field>
             <field name="model">account.analytic.line</field>
             <field name="inherit_id" ref="analytic.view_account_analytic_line_filter"/>
+            <field name="mode">primary</field>
             <field name="arch" type="xml">
                 <data>
                     <xpath expr="//field[@name='date']" position="after">
+                        <field name="account_id"/>
+                        <field name="plan_id"/>
                         <field name="product_id"/>
                         <field name="general_account_id"/>
                         <field name="partner_id" filter_domain="[('partner_id','child_of',self)]"/>
                     </xpath>
-                    <xpath expr="//group[@name='groupby']" position="after">
-                        <filter string="Financial Account" name="financialaccount" context="{'group_by':'general_account_id'}"/>
+                    <xpath expr="//group[@name='groupby']" position="inside">
+                        <separator/>
+                        <filter string="Analytic Account" name="group_by_analytic_account" context="{'group_by': 'account_id'}"/>
+                        <filter string="Analytic Plan" name="group_by_analytic_plan" context="{'group_by': 'plan_id'}"/>
+                        <filter string="Financial Account" name="group_by_financial_account" context="{'group_by':'general_account_id'}"/>
+                        <filter string="Category" name='category' context="{'group_by': 'category'}"/>
                         <filter string="Product" name="product" context="{'group_by':'product_id'}"/>
                         <filter string="Partner" name="partner" context="{'group_by':'partner_id'}"/>
                     </xpath>
@@ -70,22 +77,15 @@
             </field>
         </record>
 
-        <record id="view_account_analytic_line_filter_inherit" model="ir.ui.view">
-            <field name="name">account.analytic.line.select.inherit</field>
-            <field name="model">account.analytic.line</field>
-            <field name="inherit_id" ref="analytic.view_account_analytic_line_filter"/>
-            <field name="arch" type="xml">
-                <xpath expr="//filter[@name='group_date']" position="after">
-                    <filter string="Category" name='category' context="{'group_by': 'category'}"/>
-                </xpath>
-            </field>
+        <record id="analytic.account_analytic_line_action_entries" model="ir.actions.act_window">
+            <field name="search_view_id" ref="view_account_analytic_line_filter_inherit_account"/>
+            <field name="context">{'search_default_group_by_analytic_account': 1}</field>
         </record>
 
         <record id="action_analytic_reporting" model="ir.actions.act_window">
             <field name="name">Analytic Reporting</field>
             <field name="res_model">account.analytic.line</field>
-            <field name="view_mode">pivot</field>
-            <field name="search_view_id" ref="analytic.view_account_analytic_line_filter"/>
+            <field name="search_view_id" ref="view_account_analytic_line_filter_inherit_account"/>
             <field name="context">{'search_default_group_by_analytic_account': 1}</field>
         </record>
 

--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -38,7 +38,7 @@
         <menuitem id="menu_finance_reports" name="Reporting" sequence="20" groups="account.group_account_readonly,account.group_account_invoice">
             <menuitem id="account_reports_management_menu" name="Management" sequence="4">
                 <menuitem id="menu_action_account_invoice_report_all" name="Invoice Analysis" action="action_account_invoice_report_all" sequence="1"/>
-                <menuitem id="menu_action_analytic_reporting" action="action_analytic_reporting"/>
+                <menuitem id="menu_action_analytic_reporting" name="Analytic Reporting" action="action_analytic_reporting" groups="analytic.group_analytic_accounting"/>
             </menuitem>
             <menuitem id="account_reports_legal_statements_menu" name="Statement Reports" sequence="1" groups="account.group_account_readonly"/>
         </menuitem>

--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -28,12 +28,8 @@
             <search string="Search Analytic Lines">
                 <field name="name"/>
                 <field name="date"/>
-                <field name="account_id"/>
-                <field name="account_id" string="Cross by" filter_domain="[('move_line_id.analytic_line_ids.account_id', 'ilike', self)]"/>
-                <field name="plan_id"/>
-                <filter string="Date" name="date" date="date"/>
-                <filter string="Analytic Account" name="group_by_analytic_account" context="{'group_by': 'account_id'}"/>
-                <filter string="Analytic Plan" name="group_by_analytic_plan" context="{'group_by': 'plan_id'}"/>
+                <separator/>
+                <filter name="month" string="Date" date="date"/>
                 <group string="Group By..." expand="0" name="groupby">
                     <filter string="Date" name="group_date" context="{'group_by': 'date'}"/>
                 </group>

--- a/addons/hr_timesheet/report/hr_timesheet_report_view.xml
+++ b/addons/hr_timesheet/report/hr_timesheet_report_view.xml
@@ -81,28 +81,11 @@
         <record id="hr_timesheet_report_search" model="ir.ui.view">
             <field name="name">timesheets.analysis.report.search</field>
             <field name="model">timesheets.analysis.report</field>
+            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_search"/>
+            <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <search string="Timesheet">
-                    <field name="date"/>
-                    <field name="employee_id"/>
-                    <field name="project_id"/>
-                    <field name="ancestor_task_id" groups="project.group_subtask_project"/>
-                    <field name="task_id"/>
-                    <field name="name"/>
-                    <field name="department_id"/>
-                    <field name="manager_id"/>
-                    <filter name="mine" string="My Timesheets" domain="[('user_id', '=', uid)]"/>
-                    <separator/>
-                    <filter name="month" string="Date" date="date"/>
-                    <group expand="0" string="Group By">
-                        <filter string="Project" name="groupby_project" domain="[]" context="{'group_by': 'project_id'}"/>
-                        <filter string="Ancestor Task" name="groupby_parent_task" domain="[]" context="{'group_by': 'ancestor_task_id'}" groups="project.group_subtask_project"/>
-                        <filter string="Task" name="groupby_task" domain="[]" context="{'group_by': 'task_id'}"/>
-                        <filter string="Date" name="groupby_date" domain="[]" context="{'group_by': 'date'}" help="Timesheet by Date"/>
-                        <filter string="Department" name="groupby_department" domain="[]" context="{'group_by': 'department_id'}"/>
-                        <filter string="Manager" name="groupby_manager" domain="[]" context="{'group_by': 'manager_id'}"/>
-                        <filter string="Employee" name="groupby_employee" domain="[]" context="{'group_by': 'employee_id'}"/>
-                    </group>
+                <search position="attributes">
+                    <attribute name="string">Timesheet Report</attribute>
                 </search>
             </field>
         </record>

--- a/addons/hr_timesheet/report/hr_timesheet_report_view.xml
+++ b/addons/hr_timesheet/report/hr_timesheet_report_view.xml
@@ -81,11 +81,28 @@
         <record id="hr_timesheet_report_search" model="ir.ui.view">
             <field name="name">timesheets.analysis.report.search</field>
             <field name="model">timesheets.analysis.report</field>
-            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_search_base"/>
-            <field name="mode">primary</field>
             <field name="arch" type="xml">
-                <search position="attributes">
-                    <attribute name="string">Timesheet Report</attribute>
+                <search string="Timesheet">
+                    <field name="date"/>
+                    <field name="employee_id"/>
+                    <field name="project_id"/>
+                    <field name="ancestor_task_id" groups="project.group_subtask_project"/>
+                    <field name="task_id"/>
+                    <field name="name"/>
+                    <field name="department_id"/>
+                    <field name="manager_id"/>
+                    <filter name="mine" string="My Timesheets" domain="[('user_id', '=', uid)]"/>
+                    <separator/>
+                    <filter name="month" string="Date" date="date"/>
+                    <group expand="0" string="Group By">
+                        <filter string="Project" name="groupby_project" domain="[]" context="{'group_by': 'project_id'}"/>
+                        <filter string="Ancestor Task" name="groupby_parent_task" domain="[]" context="{'group_by': 'ancestor_task_id'}" groups="project.group_subtask_project"/>
+                        <filter string="Task" name="groupby_task" domain="[]" context="{'group_by': 'task_id'}"/>
+                        <filter string="Date" name="groupby_date" domain="[]" context="{'group_by': 'date'}" help="Timesheet by Date"/>
+                        <filter string="Department" name="groupby_department" domain="[]" context="{'group_by': 'department_id'}"/>
+                        <filter string="Manager" name="groupby_manager" domain="[]" context="{'group_by': 'manager_id'}"/>
+                        <filter string="Employee" name="groupby_employee" domain="[]" context="{'group_by': 'employee_id'}"/>
+                    </group>
                 </search>
             </field>
         </record>

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -166,8 +166,7 @@
             </field>
         </record>
 
-        <!-- Base search view, contains the fields and filters common to timesheet and timesheet report -->
-        <record id="hr_timesheet_line_search_base" model="ir.ui.view">
+        <record id="hr_timesheet_line_search" model="ir.ui.view">
             <field name="name">account.analytic.line.search</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
@@ -199,7 +198,7 @@
         <record id="hr_timesheet_line_my_timesheet_search" model="ir.ui.view">
             <field name="name">view.search.my.timesheet.menu</field>
             <field name="model">account.analytic.line</field>
-            <field name="inherit_id" ref="hr_timesheet_line_search_base"/>
+            <field name="inherit_id" ref="hr_timesheet_line_search"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
                 <field name="employee_id" position="replace"/>
@@ -209,16 +208,6 @@
                 <filter name="groupby_department" position="replace"/>
                 <filter name="groupby_manager" position="replace"/>
                 <filter name="groupby_employee" position="replace"/>
-            </field>
-        </record>
-
-        <record id="hr_timesheet_line_search" model="ir.ui.view">
-            <field name="name">view.search.my.timesheet.menu</field>
-            <field name="model">account.analytic.line</field>
-            <field name="inherit_id" ref="hr_timesheet_line_search_base"/>
-            <field name="mode">primary</field>
-            <field name="arch" type="xml">
-                <search position="inside"/>
             </field>
         </record>
 

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -169,29 +169,25 @@
         <record id="hr_timesheet_line_search" model="ir.ui.view">
             <field name="name">account.analytic.line.search</field>
             <field name="model">account.analytic.line</field>
+            <field name="inherit_id" ref="analytic.view_account_analytic_line_filter"/>
             <field name="arch" type="xml">
-                <search string="Timesheet">
-                    <field name="date"/>
+                <xpath expr="//group[@name='groupby']" position="before">
                     <field name="employee_id"/>
                     <field name="project_id"/>
                     <field name="task_id"/>
                     <field name="parent_task_id"/>
-                    <field name="name"/>
                     <field name="department_id"/>
                     <field name="manager_id"/>
                     <filter name="mine" string="My Timesheets" domain="[('user_id', '=', uid)]"/>
-                    <separator/>
-                    <filter name="month" string="Date" date="date"/>
-                    <group expand="0" string="Group By">
-                        <filter string="Project" name="groupby_project" domain="[]" context="{'group_by': 'project_id'}"/>
-                        <filter string="Parent Task" name="groupby_parent_task" domain="[]" context="{'group_by': 'parent_task_id'}"/>
-                        <filter string="Task" name="groupby_task" domain="[]" context="{'group_by': 'task_id'}"/>
-                        <filter string="Date" name="groupby_date" domain="[]" context="{'group_by': 'date'}" help="Timesheet by Date"/>
-                        <filter string="Department" name="groupby_department" domain="[]" context="{'group_by': 'department_id'}"/>
-                        <filter string="Manager" name="groupby_manager" domain="[]" context="{'group_by': 'manager_id'}"/>
-                        <filter string="Employee" name="groupby_employee" domain="[]" context="{'group_by': 'employee_id'}"/>
-                    </group>
-                </search>
+                </xpath>
+                <xpath expr="//group[@name='groupby']" position="inside">
+                    <filter string="Project" name="groupby_project" domain="[]" context="{'group_by': 'project_id'}"/>
+                    <filter string="Parent Task" name="groupby_parent_task" domain="[]" context="{'group_by': 'parent_task_id'}"/>
+                    <filter string="Task" name="groupby_task" domain="[]" context="{'group_by': 'task_id'}"/>
+                    <filter string="Department" name="groupby_department" domain="[]" context="{'group_by': 'department_id'}"/>
+                    <filter string="Manager" name="groupby_manager" domain="[]" context="{'group_by': 'manager_id'}"/>
+                    <filter string="Employee" name="groupby_employee" domain="[]" context="{'group_by': 'employee_id'}"/>
+                </xpath>
             </field>
         </record>
 

--- a/addons/sale_timesheet/__manifest__.py
+++ b/addons/sale_timesheet/__manifest__.py
@@ -16,7 +16,6 @@ have real delivered quantities in sales orders.
     'depends': ['sale_project', 'hr_timesheet'],
     'data': [
         'data/sale_service_data.xml',
-        'report/timesheets_analysis_views.xml',
         'security/ir.model.access.csv',
         'security/sale_timesheet_security.xml',
         'views/account_invoice_views.xml',
@@ -29,6 +28,7 @@ have real delivered quantities in sales orders.
         'views/sale_timesheet_portal_templates.xml',
         'views/project_sharing_views.xml',
         'views/project_portal_templates.xml',
+        'report/timesheets_analysis_views.xml',
         'report/report_timesheet_templates.xml',
         'report/project_report_view.xml',
         'wizard/project_create_sale_order_views.xml',

--- a/addons/sale_timesheet/report/timesheets_analysis_views.xml
+++ b/addons/sale_timesheet/report/timesheets_analysis_views.xml
@@ -53,34 +53,18 @@
     <record id="hr_timesheet_report_search_sale_timesheet" model="ir.ui.view">
         <field name="name">timesheets.analysis.report.search</field>
         <field name="model">timesheets.analysis.report</field>
-        <field name="inherit_id" ref="hr_timesheet.hr_timesheet_report_search"/>
+        <field name="inherit_id" ref="sale_timesheet.timesheet_view_search"/>
+        <field name="mode">primary</field>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='task_id']" position="after">
-                <field name="order_id" string="Sales Order" groups="sales_team.group_sale_salesman"/>
+            <search position="attributes">
+                    <attribute name="string">Timesheet Report</attribute>
+                </search>
+            <xpath expr="//field[@name='order_id']" position="after">
                 <field name="so_line" groups="sales_team.group_sale_salesman"/>
             </xpath>
-            <xpath expr="//filter[@name='month']" position="before">
-                <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('timesheet_invoice_type', '=', 'billable_fixed')]"
-                    groups="sales_team.group_sale_salesman"/>
-                <filter name="billable_time" string="Billed on Timesheets" domain="[('timesheet_invoice_type', '=', 'billable_time')]"
-                    groups="sales_team.group_sale_salesman"/>
-                <filter name="billable_milestones" string="Billed on Milestones" domain="[('timesheet_invoice_type', '=', 'billable_milestones')]"
-                    groups="sales_team.group_sale_salesman"/>
-                <filter name="billable_manual" string="Billed Manually" domain="[('timesheet_invoice_type', '=', 'billable_manual')]"
-                    groups="sales_team.group_sale_salesman"/>
-                <filter name="non_billable" string="Non-Billable" domain="[('timesheet_invoice_type', '=', 'non_billable')]"
-                    groups="sales_team.group_sale_salesman"/>
-                <separator/>
-            </xpath>
-            <xpath expr="//filter[@name='groupby_employee']" position="after">
+            <xpath expr="//filter[@name='groupby_sale_order_item']" position="before">
                 <filter string="Sales Order" name="groupby_sale_order" domain="[]"
                     context="{'group_by': 'order_id'}" groups="sales_team.group_sale_salesman"/>
-                <filter string="Sales Order Item" name="groupby_sale_order_item" domain="[]"
-                    context="{'group_by': 'so_line'}" groups="sales_team.group_sale_salesman"/>
-                <filter string="Invoice" name="groupby_invoice" domain="[]"
-                    context="{'group_by': 'timesheet_invoice_id'}" groups="sales_team.group_sale_salesman"/>
-                <filter string="Billable Type" name="groupby_timesheet_invoice_type" domain="[]"
-                    context="{'group_by': 'timesheet_invoice_type'}" groups="sales_team.group_sale_salesman"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/report/timesheets_analysis_views.xml
+++ b/addons/sale_timesheet/report/timesheets_analysis_views.xml
@@ -50,6 +50,41 @@
         </field>
     </record>
 
+    <record id="hr_timesheet_report_search_sale_timesheet" model="ir.ui.view">
+        <field name="name">timesheets.analysis.report.search</field>
+        <field name="model">timesheets.analysis.report</field>
+        <field name="inherit_id" ref="hr_timesheet.hr_timesheet_report_search"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='task_id']" position="after">
+                <field name="order_id" string="Sales Order" groups="sales_team.group_sale_salesman"/>
+                <field name="so_line" groups="sales_team.group_sale_salesman"/>
+            </xpath>
+            <xpath expr="//filter[@name='month']" position="before">
+                <filter name="billable_fixed" string="Billed at a Fixed Price" domain="[('timesheet_invoice_type', '=', 'billable_fixed')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <filter name="billable_time" string="Billed on Timesheets" domain="[('timesheet_invoice_type', '=', 'billable_time')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <filter name="billable_milestones" string="Billed on Milestones" domain="[('timesheet_invoice_type', '=', 'billable_milestones')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <filter name="billable_manual" string="Billed Manually" domain="[('timesheet_invoice_type', '=', 'billable_manual')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <filter name="non_billable" string="Non-Billable" domain="[('timesheet_invoice_type', '=', 'non_billable')]"
+                    groups="sales_team.group_sale_salesman"/>
+                <separator/>
+            </xpath>
+            <xpath expr="//filter[@name='groupby_employee']" position="after">
+                <filter string="Sales Order" name="groupby_sale_order" domain="[]"
+                    context="{'group_by': 'order_id'}" groups="sales_team.group_sale_salesman"/>
+                <filter string="Sales Order Item" name="groupby_sale_order_item" domain="[]"
+                    context="{'group_by': 'so_line'}" groups="sales_team.group_sale_salesman"/>
+                <filter string="Invoice" name="groupby_invoice" domain="[]"
+                    context="{'group_by': 'timesheet_invoice_id'}" groups="sales_team.group_sale_salesman"/>
+                <filter string="Billable Type" name="groupby_timesheet_invoice_type" domain="[]"
+                    context="{'group_by': 'timesheet_invoice_type'}" groups="sales_team.group_sale_salesman"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="timesheet_action_billing_report" model="ir.actions.act_window">
         <field name="name">Timesheets by Billing Type</field>
         <field name="res_model">timesheets.analysis.report</field>

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -4,7 +4,7 @@
     <record id="timesheet_view_search" model="ir.ui.view">
             <field name="name">account.analytic.line.search</field>
             <field name="model">account.analytic.line</field>
-            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_search_base"/>
+            <field name="inherit_id" ref="hr_timesheet.hr_timesheet_line_search"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='task_id']" position="after">
                     <field name="order_id" string="Sales Order" filter_domain="['|', ('so_line', 'ilike', self), ('order_id', 'ilike', self)]"/>


### PR DESCRIPTION
The aim is to harmonize the analytic search view between `hr_timesheet` and `account` by creating an inheritance from `analytic`.
This allows the accountant to have access to all the fields and filters defined in other modules.

task-3463639

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
