### PR TITLE
[FIX] website_sale: checkout summary offset header

### DIFF
--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -679,6 +679,13 @@ a.no-decoration {
     .o_total_border {
         border: $border-width solid $border-color;
 
+        // TODO VCR This value should adapt to the offsetHeight
+        // of the header this is an arbitrary value as a temporary solution
+        // to offset the summary regarding the tallest header (Magazine)
+        @include media-breakpoint-up(lg) {
+            top: 9rem;
+        }
+
         @include media-breakpoint-down(lg) {
             border: 0;
         }


### PR DESCRIPTION
This PR offset the cart_summary of the size of the tallest header to make sure the header is not hiding the cart summary when the user scrolls in the checkout.

This is a temporary solution and the real header height should be used as a value instead of the default's one.

task-3551420

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
