### PR TITLE
[FIX] im_livechat, mail: use live chat user name when set

### DIFF
--- a/addons/im_livechat/static/src/embed/core_ui/message_patch.js
+++ b/addons/im_livechat/static/src/embed/core_ui/message_patch.js
@@ -13,6 +13,13 @@ patch(Message.prototype, {
         this.session = session;
     },
 
+    get authorName() {
+        if (this.props.message.originThread?.type === "livechat") {
+            return this.props.author.user_livechat_username || super.authorName;
+        }
+        return super.authorName;
+    },
+
     /**
      * @param {import("@im_livechat/embed/chatbot/chatbot_step_model").StepAnswer} answer
      */

--- a/addons/im_livechat/static/tests/embed/livechat_username_tests.js
+++ b/addons/im_livechat/static/tests/embed/livechat_username_tests.js
@@ -1,0 +1,40 @@
+/* @odoo-module */
+
+import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+
+import { loadDefaultConfig, start } from "@im_livechat/../tests/embed/helper/test_utils";
+
+import { Command } from "@mail/../tests/helpers/command";
+
+import { contains } from "@web/../tests/utils";
+import { cookie } from "@web/core/browser/cookie";
+
+QUnit.module("livechat user name");
+
+QUnit.test("Operator live chat name is used if set", async () => {
+    const pyEnv = await startServer();
+    const livechatChannelId = await loadDefaultConfig();
+    const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
+    pyEnv.cookie.set("dgid", guestId);
+    pyEnv["res.partner"].write([pyEnv.adminPartnerId], { user_livechat_username: "Bob" });
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.adminPartnerId }),
+            Command.create({ guest_id: guestId }),
+        ],
+        channel_type: "livechat",
+        livechat_channel_id: livechatChannelId,
+        livechat_operator_id: pyEnv.adminPartnerId,
+    });
+    const [channelInfo] = pyEnv.mockServer._mockDiscussChannelChannelInfo([channelId]);
+    cookie.set("im_livechat_session", JSON.stringify(channelInfo));
+    const env = await start();
+    pyEnv.withUser(pyEnv.adminUserId, () =>
+        env.services.rpc("/mail/message/post", {
+            post_data: { body: "Are you there?", message_type: "comment" },
+            thread_id: channelId,
+            thread_model: "discuss.channel",
+        })
+    );
+    await contains(".o-mail-Message-author", { text: "Bob" });
+});

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -225,6 +225,10 @@ export class Message extends Component {
         return this.threadService.avatarUrl(this.message.author, this.props.message.originThread);
     }
 
+    get authorName() {
+        return this.props.message.author?.name;
+    }
+
     get expandText() {
         return _t("Expand");
     }

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -33,7 +33,7 @@
                     <div class="w-100 o-min-width-0" t-att-class="{ 'flex-grow-1': message.composer }" t-ref="messageContent">
                         <div t-if="!props.squashed" class="o-mail-Message-header d-flex flex-wrap align-items-baseline mb-1 lh-1">
                             <span t-if="(message.author or message.email_from) and shouldDisplayAuthorName" class="o-mail-Message-author">
-                                <strong class="me-1 text-truncate"><t t-if="message.author" t-esc="message.author.name"/><t t-else="" t-esc="message.email_from"/></strong>
+                                <strong class="me-1 text-truncate"><t t-if="message.author" t-esc="authorName"/><t t-else="" t-esc="message.email_from"/></strong>
                             </span>
                             <t t-if="!isAlignedRight" t-call="mail.Message.notification"/>
                             <small t-if="!message.isTransient" class="o-mail-Message-date text-muted opacity-50" t-att-class="{ 'me-2': !isAlignedRight }" t-att-title="message.datetimeShort">


### PR DESCRIPTION
Before this commit, the real user name was shown instead of the live chat user name. This PR corrects this behavior.
