### PR TITLE
[FIX] web: search view: evaluate invisible attrs

### DIFF
--- a/addons/web/static/src/search/search_arch_parser.js
+++ b/addons/web/static/src/search/search_arch_parser.js
@@ -107,8 +107,8 @@ export class SearchArchParser {
     visitField(node) {
         this.pushGroup("field");
         const preField = { type: "field" };
-        if (node.getAttribute("invisible") === "True" || node.getAttribute("invisible") === "1") {
-            preField.invisible = "True";
+        if (node.hasAttribute("invisible")) {
+            preField.invisible = node.getAttribute("invisible");
         }
         if (node.hasAttribute("domain")) {
             preField.domain = node.getAttribute("domain");
@@ -219,8 +219,8 @@ export class SearchArchParser {
                 preSearchItem.domain = stringRepr;
             }
         }
-        if (node.getAttribute("invisible") === "True" || node.getAttribute("invisible") === "1") {
-            preSearchItem.invisible = "True";
+        if (node.hasAttribute("invisible")) {
+            preSearchItem.invisible = node.getAttribute("invisible");
             const fieldName = preSearchItem.fieldName;
             if (fieldName && !this.fields[fieldName]) {
                 // In some case when a field is limited to specific groups

--- a/addons/web/static/src/search/search_model.js
+++ b/addons/web/static/src/search/search_model.js
@@ -640,7 +640,7 @@ export class SearchModel extends EventBus {
             custom: true,
         };
         if (invisible) {
-            preSearchItem.invisible = true;
+            preSearchItem.invisible = "True";
         }
         if (["date", "datetime"].includes(fieldType)) {
             this.searchItems[this.nextId] = Object.assign(
@@ -774,10 +774,9 @@ export class SearchModel extends EventBus {
     getSearchItems(predicate) {
         const searchItems = [];
         Object.values(this.searchItems).forEach((searchItem) => {
-            if (
-                (!("invisible" in searchItem) || !searchItem.invisible) &&
-                (!predicate || predicate(searchItem))
-            ) {
+            const isInvisible =
+                "invisible" in searchItem && evaluateExpr(searchItem.invisible, this.globalContext);
+            if (!isInvisible && (!predicate || predicate(searchItem))) {
                 const enrichedSearchitem = this._enrichItem(searchItem);
                 if (enrichedSearchitem) {
                     searchItems.push(enrichedSearchitem);
@@ -832,7 +831,7 @@ export class SearchModel extends EventBus {
             const preFilter = {
                 description,
                 domain: toDomain(tree),
-                invisible: true,
+                invisible: "True",
                 type: "filter",
             };
             if (context) {

--- a/addons/web/static/tests/search/search_model_tests.js
+++ b/addons/web/static/tests/search/search_model_tests.js
@@ -965,6 +965,44 @@ QUnit.module("Search", (hooks) => {
         assert.deepEqual(model.domain, [["date_deadline", "<", "2021-09-17"]]);
     });
 
+    QUnit.test("field tags with invisible attribute", async function (assert) {
+        const model = await makeSearchModel({
+            serverData,
+            searchViewArch: `
+                    <search>
+                        <field name="foo" invisible="context.get('abc')"/>
+                        <field name="bar" invisible="context.get('def')"/>
+                        <field name="float_field" invisible="1"/>
+                    </search>
+                `,
+            context: { abc: true },
+        });
+        assert.deepEqual(
+            model.getSearchItems((f) => f.type === "field").map((item) => item.fieldName),
+            ["bar"]
+        );
+    });
+
+    QUnit.test("filter tags with invisible attribute", async function (assert) {
+        const model = await makeSearchModel({
+            serverData,
+            searchViewArch: `
+                    <search>
+                        <filter name="filter1" string="Invisible ABC" domain="[]" invisible="context.get('abc')"/>
+                        <filter name="filter2" string="Invisible DEF" domain="[]" invisible="context.get('def')"/>
+                        <filter name="filter3" string="Always invisible" domain="[]" invisible="1"/>
+                    </search>
+                `,
+            context: { abc: true },
+        });
+        assert.deepEqual(
+            model
+                .getSearchItems((item) => ["filter", "dateFilter"].includes(item.type))
+                .map((item) => item.name),
+            ["filter2"]
+        );
+    });
+
     QUnit.test("no search items created for search panel sections", async function (assert) {
         const model = await makeSearchModel({
             serverData,


### PR DESCRIPTION
Since [1], invisible attributes on views are no longer evaluated server-side. In search views, field and filter nodes can have an invisible attribute which can be static ("1" or "True") or dynamic, depending on the context (e.g. "context.get('something')"). Before [1], in the arch received by the client, the value of the invisible attribute was always static as "context.get(...)" expressions were evaluated server-side. This is no longer the case, and we thus have to evaluate the expression client side.

Before this commit, the invisible attributes in search archs were simply ignored if they weren't static. This could be observed for instance in Project > open a project: the "Private tasks" filter was available even though it is dynamically invisible, and shouldn't be there.

This commit ensures the invisible attributes are always taken into account and evaluated.

[1] odoo/odoo@ba1a5509fa49fd846739252d16083dd8cb334b53

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
