### PR TITLE
[FIX] fix dropping the facebook snippet onto the page

### DIFF
--- a/addons/website/static/src/snippets/s_facebook_page/000.js
+++ b/addons/website/static/src/snippets/s_facebook_page/000.js
@@ -26,7 +26,9 @@ const FacebookPageWidget = publicWidget.Widget.extend({
         delete params.id;
         params.width = clamp(Math.floor(this.$el.width()), 180, 500);
 
-        var src = $.param.querystring('https://www.facebook.com/plugins/page.php', params);
+        const searchParams = new URLSearchParams(params);
+        const src = "https://www.facebook.com/plugins/page.php?" + searchParams;
+
         this.$iframe = $('<iframe/>', {
             src: src,
             width: params.width,


### PR DESCRIPTION
Since commit [1], the 'jquery.ba-bbq' library has been removed. Now, when you drop the Facebook snippet into a page, there is a traceback.

This is because we were still using the 'querystring()' function from 'jquery.ba-bbq' to combine the parameters of the Facebook iframe's URL with its URL.

[1]: https://github.com/odoo/odoo/commit/507c36883675a45a15485ce5c73aa4557ba23639

task-3543529