### PR TITLE
[IMP] account, purchase, sale, l10n_br_sales, l10n_{ar,cl}: Ui fix

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -115,10 +115,7 @@
                                     </th>
                                     <th name="th_taxes" t-attf-class="text-start {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}"><span>Taxes</span></th>
                                     <th name="th_subtotal" class="text-end">
-                                        <span>Tax excl.</span>
-                                    </th>
-                                    <th t-if="o.tax_calculation_rounding_method == 'round_per_line'" name="th_total" class="text-end">
-                                        <span>Tax incl.</span>
+                                        <span>Amount</span>
                                     </th>
                                 </tr>
                             </thead>
@@ -149,9 +146,6 @@
                                             </td>
                                             <td name="td_subtotal" class="text-end o_price_total">
                                                 <span class="text-nowrap" t-field="line.price_subtotal">27.00</span>
-                                            </td>
-                                            <td t-if="o.tax_calculation_rounding_method == 'round_per_line'" name="td_total" class="text-end o_price_total">
-                                                <span class="text-nowrap" t-field="line.price_total">31.05</span>
                                             </td>
                                         </t>
                                         <t t-elif="line.display_type == 'line_section'">

--- a/addons/l10n_ar/views/report_invoice.xml
+++ b/addons/l10n_ar/views/report_invoice.xml
@@ -142,14 +142,11 @@
         <xpath expr="//th[@name='th_subtotal']/span" position="replace">
             <span>Amount</span>
         </xpath>
-        <xpath expr="//th[@name='th_total']/span" position="replace"/>
         <span t-field="line.price_subtotal" position="attributes">
             <attribute name="t-field"></attribute>
             <attribute name="t-out">l10n_ar_values['price_subtotal']</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
-
-        <span t-field="line.price_total" position="replace"/>
 
         <t t-set="tax_totals" position="attributes">
             <attribute name="t-value">o._l10n_ar_get_invoice_totals_for_report()</attribute>

--- a/addons/l10n_br_sales/report/sale_order_templates.xml
+++ b/addons/l10n_br_sales/report/sale_order_templates.xml
@@ -15,9 +15,6 @@
         <td name="td_taxes" position="replace"/>
         <th name="th_subtotal" position="replace"/>
         <td name="td_subtotal" position="replace"/>
-        <xpath expr="//th[@name='th_total']/span" position="replace">
-            <span>Total</span>
-        </xpath>
         <xpath expr="//t[@t-call='sale.document_tax_totals']" position="replace">
             <t t-call="l10n_br_sales.document_tax_totals_brazil"/>
         </xpath>

--- a/addons/l10n_br_sales/views/sale_portal_templates.xml
+++ b/addons/l10n_br_sales/views/sale_portal_templates.xml
@@ -5,13 +5,10 @@
         <th id="taxes_header" position="replace"/>
         <!-- hide the taxes td -->
         <td id="taxes" position="replace"/>
-        <!-- hide the "Tax excl." th -->
+        <!-- hide the "Amount" th -->
         <th id="subtotal_header" position="replace"/>
-        <!-- hide the "Tax excl." td -->
+        <!-- hide the "Amount" td -->
         <td id='subtotal' position="replace"/>
-        <xpath expr="//th[@id='total_header']/span" position="replace">
-            <span>Total</span>
-        </xpath>
         <xpath expr="//t[@t-call='sale.sale_order_portal_content_totals_table']" position="replace">
             <table class="table table-sm">
                 <t t-set="tax_totals" t-value="sale_order.tax_totals"/>

--- a/addons/l10n_cl/views/report_invoice.xml
+++ b/addons/l10n_cl/views/report_invoice.xml
@@ -178,15 +178,11 @@
             <span>Amount</span>
         </xpath>
 
-        <xpath expr="//th[@name='th_total']/span" position="replace"/>
-
         <span t-field="line.price_subtotal" position="attributes">
             <attribute name="t-field"></attribute>
             <attribute name="t-out">l10n_cl_values['price_subtotal']</attribute>
             <attribute name="t-options">{"widget": "monetary", "display_currency": o.currency_id}</attribute>
         </span>
-
-        <span t-field="line.price_total" position="replace"/>
 
         <t t-set="tax_totals" position="attributes">
             <attribute name="t-value">o._l10n_cl_get_invoice_totals_for_report()</attribute>

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -54,10 +54,7 @@
                         <th name="th_quantity" class="text-end"><strong>Qty</strong></th>
                         <th name="th_price_unit" class="text-end"><strong>Unit Price</strong></th>
                         <th name="th_subtotal" class="text-end">
-                            <strong>Tax excl.</strong>
-                        </th>
-                        <th t-if="o.company_id.tax_calculation_rounding_method == 'round_per_line'" name="th_total" class="text-end">
-                            <strong>Tax incl.</strong>
+                            <strong>Amount</strong>
                         </th>
                     </tr>
                 </thead>
@@ -65,7 +62,6 @@
                     <t t-set="current_subtotal" t-value="0"/>
                     <t t-foreach="o.order_line" t-as="line">
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
-                        <t t-set="current_total" t-value="current_subtotal + line.price_total" t-if="o.company_id.tax_calculation_rounding_method == 'round_per_line'"/>
 
                         <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                             <t t-if="not line.display_type">
@@ -90,10 +86,6 @@
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_subtotal"
-                                        t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
-                                </td>
-                                <td t-if="o.company_id.tax_calculation_rounding_method == 'round_per_line'" class="text-end">
-                                    <span t-field="line.price_total"
                                         t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                 </td>
                             </t>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -267,10 +267,7 @@
                                 <span>Taxes</span>
                             </th>
                             <th class="text-end" t-if="order.state in ['purchase', 'done']" >
-                                <span>Tax excl.</span>
-                            </th>
-                            <th class="text-end" t-if="order.state in ['purchase', 'done'] and order.tax_calculation_rounding_method == 'round_per_line'" >
-                                <span>Tax incl.</span>
+                                <span>Amount</span>
                             </th>
                         </tr>
                     </thead>
@@ -281,7 +278,6 @@
                           <t t-foreach="order.order_line" t-as="line">
 
                               <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
-                          <t t-set="current_total" t-value="current_subtotal + line.price_total" t-if="order.tax_calculation_rounding_method == 'round_per_line'"/>
 
                             <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic text-break' if line.display_type == 'line_note' else ''">
                                 <t t-if="not line.display_type">
@@ -321,9 +317,6 @@
                                     </td>
                                     <td class="text-end" t-if="not update_dates and order.state in ['purchase', 'done']">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
-                                    </td>
-                                    <td class="text-end" t-if="not update_dates and order.state in ['purchase', 'done'] and order.tax_calculation_rounding_method == 'round_per_line'" >
-                                        <span class="oe_order_line_price_total" t-field="line.price_total"/>
                                     </td>
                                 </t>
                                 <t t-if="line.display_type == 'line_section'">

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -82,10 +82,7 @@
                         </th>
                         <th name="th_taxes" class="text-end">Taxes</th>
                         <th name="th_subtotal" class="text-end">
-                            <span>Tax excl.</span>
-                        </th>
-                        <th t-if="doc.company_id.tax_calculation_rounding_method == 'round_per_line'" name="th_total" class="text-end">
-                            <span>Tax incl.</span>
+                            <span>Amount</span>
                         </th>
                     </tr>
                 </thead>
@@ -96,7 +93,6 @@
                     <t t-foreach="lines_to_report" t-as="line">
 
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
-                        <t t-set="current_total" t-value="current_subtotal + line.price_total" t-if="doc.company_id.tax_calculation_rounding_method == 'round_per_line'"/>
 
                         <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                             <t t-if="not line.display_type">
@@ -121,9 +117,6 @@
                                 </td>
                                 <td t-if="not line.is_downpayment" name="td_subtotal" class="text-end o_price_total">
                                     <span t-field="line.price_subtotal">27.00</span>
-                                </td>
-                                <td name="td_total" class="text-end o_price_total" t-if="doc.company_id.tax_calculation_rounding_method == 'round_per_line'" >
-                                    <span t-field="line.price_total">31.05</span>
                                 </td>
                             </t>
                             <t t-elif="line.display_type == 'line_section'">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -541,10 +541,7 @@
                                     <span>Taxes</span>
                                 </th>
                                 <th class="text-end" id="subtotal_header">
-                                    <span>Tax excl.</span>
-                                </th>
-                                <th class="text-end" t-if="sale_order.tax_calculation_rounding_method == 'round_per_line'" id="total_header">
-                                    <span>Tax incl.</span>
+                                    <span>Amount</span>
                                 </th>
                             </tr>
                         </thead>
@@ -556,7 +553,6 @@
                             <t t-foreach="lines_to_report" t-as="line">
 
                                 <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
-                                <t t-set="current_total" t-value="current_subtotal + line.price_total" t-if="sale_order.tax_calculation_rounding_method == 'round_per_line'"/>
 
                                 <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
                                     <t t-if="not line.display_type">
@@ -590,9 +586,6 @@
                                         </td>
                                         <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
-                                        </td>
-                                        <td class="text-end" t-if="sale_order.tax_calculation_rounding_method == 'round_per_line' and not line.is_downpayment" >
-                                            <span class="oe_order_line_price_total" t-field="line.price_total"/>
                                         </td>
                                     </t>
                                     <t t-if="line.display_type == 'line_section'">


### PR DESCRIPTION
In this pr: https://github.com/odoo/enterprise/pull/30853 we've merged two
settings into one to make Tax calculation & display more coherent. In the case
of a "Tax per line" computation, the column "Tax Included" is optional=hide in
the backend, but we've elected to put it in the PDF all the time.

This task we will only change the pdf and portal (preview):
1. Remove the "Tax Incl" column on all relevant templates (pdf/portal).
2. Rename the "Tax Excl" column to "Amount".

task-3552656




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
