### PR TITLE
[FIX] hr_recruitment_skills: display skill type

### DIFF
--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -14,7 +14,7 @@
                             <field mode="tree" nolabel="1" name="applicant_skill_ids" widget="skills_one2many"
                                 context="{'default_applicant_id': id}">
                                 <tree>
-                                    <field name="skill_type_id" column_invisible="True"/>
+                                    <field name="skill_type_id" optional="hidden"/>
                                     <field name="skill_id"/>
                                     <field name="skill_level_id"/>
                                     <field name="level_progress" widget="progressbar"/>


### PR DESCRIPTION
Issue:
------
All skills are displayed in the "Other" type (after_saving).

Solution:
---------
Remove `column_invisible` attribute and add optional attribute.

Note:
Use the commit b11b09405bf2b104d3e8e2ed419045d75e55957f solution.

opw-3537736