### PR TITLE
[FIX] bus: fix websocket events tests

### DIFF
--- a/addons/bus/static/tests/assets_watchdog_tests.js
+++ b/addons/bus/static/tests/assets_watchdog_tests.js
@@ -2,16 +2,19 @@
 
 import { getPyEnv } from "@bus/../tests/helpers/mock_python_environment";
 import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
+import { assetsWatchdogService } from "@bus/services/assets_watchdog_service";
 
 import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { click, contains } from "@web/../tests/utils";
 import { createWebClient } from "@web/../tests/webclient/helpers";
 import { browser } from "@web/core/browser/browser";
+import { registry } from "@web/core/registry";
 
 QUnit.module("Bus Assets WatchDog");
 
 QUnit.test("can listen on bus and displays notifications in DOM", async (assert) => {
     addBusServicesToRegistry();
+    registry.category("services").add("assetsWatchdog", assetsWatchdogService);
     patchWithCleanup(browser, {
         setTimeout(fn) {
             return super.setTimeout(fn, 0);

--- a/addons/bus/static/tests/helpers/test_utils.js
+++ b/addons/bus/static/tests/helpers/test_utils.js
@@ -1,6 +1,5 @@
 /* @odoo-module */
 
-import { assetsWatchdogService } from "@bus/services/assets_watchdog_service";
 import { busParametersService } from "@bus/bus_parameters_service";
 import { busService } from "@bus/services/bus_service";
 import { multiTabService } from "@bus/multi_tab_service";
@@ -11,7 +10,6 @@ import { registry } from "@web/core/registry";
 export function addBusServicesToRegistry() {
     registry
         .category("services")
-        .add("assetsWatchdog", assetsWatchdogService)
         .add("bus.parameters", busParametersService)
         .add("bus_service", busService)
         .add("presence", presenceService)


### PR DESCRIPTION
[1] tried to remove nondeterminism from bus tests. However, several
issues remain:

- the asset watchdog bundle is added to the registry during bus tests.
Websocket tests wait for the `connect` event after starting the environment.
This `connect` event can be triggered sooner than expected since the asset
watchdog services starts the bus.
- a the random delay is added to the reconnection attempts.
- `nextTick` is kept when waiting for a client to leave the worker.
- `waitFor*` helpers should use `unpatch` when they are done.

This commit fixes those issues.

[1]: https://github.com/odoo/odoo/pull/138221