### PR TITLE
[FIX] portal: wrong alert link color

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -139,7 +139,7 @@
         <div t-ignore="true" class="text-center">
             <t t-if="custom_html" t-out="custom_html"/>
             <t t-else="">This is a preview of the customer portal.</t>
-            <a t-att-href="backend_url"><i class="oi oi-arrow-right me-1"/>Back to edit mode</a>
+            <a class="alert-link" t-att-href="backend_url"><i class="oi oi-arrow-right me-1"/>Back to edit mode</a>
         </div>
         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
     </template>


### PR DESCRIPTION
When previewing a quotation or an invoice from a customer, an alert is displayed in the portal to go back to edit mode.

The color of this link was previously using primary because it was missing the `alert-link` class. The primary being purple in the base theme since the frontend redesign it became more noticeable.

task-3553146

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
