### PR TITLE
[IMP] mail: remove link from creation notification

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1151,9 +1151,7 @@ class Channel(models.Model):
         new_channel = self.create(vals)
         group = self.env['res.groups'].search([('id', '=', group_id)]) if group_id else None
         new_channel.group_public_id = group.id if group else None
-        notification = (Markup('<div class="o_mail_notification">%s</div>') % _("created %(link)s")) % {
-            'link': Markup('<a href="#" class="o_channel_redirect" data-oe-id="%s">#%s</a>') % (new_channel.id, new_channel.name)
-        }
+        notification = Markup('<div class="o_mail_notification">created this channel.</div>')
         new_channel.message_post(body=notification, message_type="notification", subtype_xmlid="mail.mt_comment")
         channel_info = new_channel._channel_info()[0]
         self.env['bus.bus']._sendone(self.env.user.partner_id, 'mail.record/insert', {"Thread": channel_info})

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -114,7 +114,7 @@
         'mt-2': prevMsg and !prevMsg.isNotification,
     }" t-ref="root">
         <i t-if="msg.notificationIcon" t-attf-class="{{ msg.notificationIcon }} me-1"/>
-        <span class="o-mail-NotificationMessage-author d-inline mx-1" t-if="msg.author and !msg.body.includes(escape(msg.author.name))" t-esc="msg.author.name"/> <t t-out="msg.body"/>
+        <span class="o-mail-NotificationMessage-author d-inline" t-if="msg.author and !msg.body.includes(escape(msg.author.name))" t-esc="msg.author.name"/> <t t-out="msg.body"/>
     </div>
 </t>
 


### PR DESCRIPTION
Previously, a link was included when creating a channel, but this was unnecessary since there is no way to see the link when you are not in the channel.
This commit removes the link while keeping the notification to show the author and time of channel creation.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
