### PR TITLE
[FIX] partner_autocomplete: fix Partner Autocomplete not working on VAT

### DIFF
--- a/addons/partner_autocomplete/models/res_company.py
+++ b/addons/partner_autocomplete/models/res_company.py
@@ -31,6 +31,19 @@ class ResCompany(models.Model):
             res.iap_enrich_auto()
         return res
 
+    @api.model
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+
+        if view_type == 'form':
+            for node in arch.xpath(
+                "//field[@name='name']"
+                "|//field[@name='vat']"
+            ):
+                node.attrib['widget'] = 'field_partner_autocomplete'
+
+        return arch, view
+
     def iap_enrich_auto(self):
         """ Enrich company. This method should be called by automatic processes
         and a protection is added to avoid doing enrich in a loop. """

--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -181,3 +181,16 @@ class ResPartner(models.Model):
             self._update_autocomplete_data(values.get('vat', False))
 
         return res
+
+    @api.model
+    def _get_view(self, view_id=None, view_type='form', **options):
+        arch, view = super()._get_view(view_id, view_type, **options)
+
+        if view_type == 'form':
+            for node in arch.xpath(
+                "//field[@name='name']"
+                "|//field[@name='vat']"
+            ):
+                node.attrib['widget'] = 'field_partner_autocomplete'
+
+        return arch, view

--- a/addons/partner_autocomplete/views/res_company_views.xml
+++ b/addons/partner_autocomplete/views/res_company_views.xml
@@ -5,12 +5,6 @@
         <field name="model">res.company</field>
         <field name="inherit_id" ref="base.view_company_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_title')]/h1/field[@name='name']" position="attributes">
-                <attribute name="widget">field_partner_autocomplete</attribute>
-            </xpath>
-            <xpath expr="//field[@name='vat']" position="attributes">
-                <attribute name="widget">field_partner_autocomplete</attribute>
-            </xpath>
             <xpath expr="//field[@name='company_registry']" position="after">
                 <field name="partner_gid" invisible="1"/>
                 <field name="iap_enrich_auto_done" invisible="1"/>

--- a/addons/partner_autocomplete/views/res_partner_views.xml
+++ b/addons/partner_autocomplete/views/res_partner_views.xml
@@ -5,15 +5,6 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_title')]/h1/field[@id='company']" position="attributes">
-                <attribute name="widget">field_partner_autocomplete</attribute>
-            </xpath>
-            <xpath expr="//div[hasclass('oe_title')]/h1/field[@id='individual']" position="attributes">
-                <attribute name="widget">field_partner_autocomplete</attribute>
-            </xpath>
-            <xpath expr="//field[@name='vat']" position="attributes">
-                <attribute name="widget">field_partner_autocomplete</attribute>
-            </xpath>
             <xpath expr="//field[last()]" position="after">
                 <field name="partner_gid" invisible="True"/>
                 <field name="additional_info" invisible="True"/>
@@ -26,12 +17,6 @@
         <field name="model">res.partner</field>
         <field name="inherit_id" ref="base.view_partner_simple_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[hasclass('oe_title')]/h1/field[@id='company']" position="attributes">
-                <attribute name="widget">field_partner_autocomplete</attribute>
-            </xpath>
-            <xpath expr="//div[hasclass('oe_title')]/h1/field[@id='individual']" position="attributes">
-                <attribute name="widget">field_partner_autocomplete</attribute>
-            </xpath>
             <xpath expr="//field[last()]" position="after">
                 <field name="partner_gid" invisible="True"/>
                 <field name="additional_info" invisible="True"/>


### PR DESCRIPTION
Since b1f1f21, Partner Autocomplete wouldn't work anymore on VAT numbers as the field on which the widget was added was replaced by another one, without the widget.

To fix this, the widget will now be added dynamically in `_get_view` so that it happens after modifications made through view inheritance.

Another way of fixing this was proposed in b14a3af, but required an upgrade of the `base_vat` module.
