### PR TITLE
[REM] pos_self_order: remove owl="1" from the templates

### DIFF
--- a/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
+++ b/addons/pos_self_order/static/src/app/components/product_info_popup/product_info_popup.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
-    <t t-name="pos_self_order.ProductInfoPopup" owl="1">
+    <t t-name="pos_self_order.ProductInfoPopup">
         <div class="self_order_product_info_popup o_dialog" t-att-id="id">
             <div role="dialog" class="modal d-block" tabindex="-1">
                 <div class="modal-dialog" role="document" t-on-click.stop="">


### PR DESCRIPTION
As all the templates are now imported in the owl app, there is not need anymore to specify the owl="1" attribute in the templates.

Ref-https://github.com/odoo/odoo/pull/130467
Related Enterprise PR-https://github.com/odoo/enterprise/pull/48964 

task-3508331


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
