### PR TITLE
[FIX] sale_stock: no return picking when no backorder

### DIFF
--- a/addons/purchase_stock/models/purchase.py
+++ b/addons/purchase_stock/models/purchase.py
@@ -521,9 +521,11 @@ class PurchaseOrderLine(models.Model):
         qty = 0.0
         outgoing_moves, incoming_moves = self._get_outgoing_incoming_moves()
         for move in outgoing_moves:
-            qty -= move.product_uom._compute_quantity(move.product_uom_qty, self.product_uom, rounding_method='HALF-UP')
+            qty_to_compute = move.quantity_done if move.state == 'done' else move.product_uom_qty
+            qty -= move.product_uom._compute_quantity(qty_to_compute, self.product_uom, rounding_method='HALF-UP')
         for move in incoming_moves:
-            qty += move.product_uom._compute_quantity(move.product_uom_qty, self.product_uom, rounding_method='HALF-UP')
+            qty_to_compute = move.quantity_done if move.state == 'done' else move.product_uom_qty
+            qty += move.product_uom._compute_quantity(qty_to_compute, self.product_uom, rounding_method='HALF-UP')
         return qty
 
     def _check_orderpoint_picking_type(self):

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -237,9 +237,11 @@ class SaleOrderLine(models.Model):
         qty = 0.0
         outgoing_moves, incoming_moves = self._get_outgoing_incoming_moves()
         for move in outgoing_moves:
-            qty += move.product_uom._compute_quantity(move.product_uom_qty, self.product_uom, rounding_method='HALF-UP')
+            qty_to_compute = move.quantity_done if move.state == 'done' else move.product_uom_qty
+            qty += move.product_uom._compute_quantity(qty_to_compute, self.product_uom, rounding_method='HALF-UP')
         for move in incoming_moves:
-            qty -= move.product_uom._compute_quantity(move.product_uom_qty, self.product_uom, rounding_method='HALF-UP')
+            qty_to_compute = move.quantity_done if move.state == 'done' else move.product_uom_qty
+            qty -= move.product_uom._compute_quantity(qty_to_compute, self.product_uom, rounding_method='HALF-UP')
         return qty
 
     def _get_outgoing_incoming_moves(self):


### PR DESCRIPTION
Case:
- create an SO for 3 units of product A
- validate and open the delivery picking
- put 2 in quantity done, validate
- do NOT create a backorder
- return on the SO, put 2 in ordered quantity field
- save

Issue: a return picking is create for the 1 unit that was removed from the SO

Before, product_uom_qty was changed on stock move at validation to match quantity_done. Now it stays the same so another value has to be used in _get_qty_procurement for 'done' stock moves. This fix ensures that the correct quantity is used depending on the state of the stock move. With that, the float_compare in _action_launch_stock_rule will correctly redirect to continue if necessary.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
