### PR TITLE
[FIX] spreadsheet: re-insert pivot w/ contextual domain

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_data_source.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_data_source.js
@@ -3,6 +3,7 @@
 import { _t } from "@web/core/l10n/translation";
 import { OdooViewsDataSource } from "../data_sources/odoo_views_data_source";
 import { SpreadsheetPivotModel } from "./pivot_model";
+import { Domain } from "@web/core/domain";
 
 export class PivotDataSource extends OdooViewsDataSource {
     /**
@@ -47,7 +48,15 @@ export class PivotDataSource extends OdooViewsDataSource {
                 metadataRepository: this._metadataRepository,
             }
         );
-        await model.load(this._initialSearchParams);
+
+        const userContext = this._orm.user.context;
+        const domain = new Domain(this._initialSearchParams.domain).toList({
+            ...this._initialSearchParams.context,
+            ...userContext,
+        });
+
+        const searchParams = { ...this._initialSearchParams, domain };
+        await model.load(searchParams);
         return model;
     }
 

--- a/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
+++ b/addons/spreadsheet/static/tests/charts/model/odoo_chart_plugin_test.js
@@ -8,6 +8,7 @@ import { createSpreadsheetWithChart, insertChartInSpreadsheet } from "../../util
 import { createModelWithDataSource, waitForDataSourcesLoaded } from "../../utils/model";
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { makeServerError } from "@web/../tests/helpers/mock_server";
+import { session } from "@web/session";
 
 const { toZone } = spreadsheet.helpers;
 
@@ -216,6 +217,7 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
 
     QUnit.test("can import (export) contextual domain", async function (assert) {
         const chartId = "1";
+        const uid = session.user_context.uid;
         const spreadsheetData = {
             sheets: [
                 {
@@ -251,7 +253,7 @@ QUnit.module("spreadsheet > odoo chart plugin", {}, () => {
             spreadsheetData,
             mockRPC: function (route, args) {
                 if (args.method === "web_read_group") {
-                    assert.deepEqual(args.kwargs.domain, [["foo", "=", 7]]);
+                    assert.deepEqual(args.kwargs.domain, [["foo", "=", uid]]);
                     assert.step("web_read_group");
                 }
             },

--- a/addons/spreadsheet/static/tests/lists/list_plugin_test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin_test.js
@@ -583,6 +583,7 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
     );
 
     QUnit.test("can import (export) contextual domain", async function (assert) {
+        const uid = session.user_context.uid;
         const spreadsheetData = {
             lists: {
                 1: {
@@ -598,7 +599,7 @@ QUnit.module("spreadsheet > list plugin", {}, () => {
             spreadsheetData,
             mockRPC: function (route, args) {
                 if (args.method === "search_read") {
-                    assert.deepEqual(args.kwargs.domain, [["foo", "=", 7]]);
+                    assert.deepEqual(args.kwargs.domain, [["foo", "=", uid]]);
                     assert.step("search_read");
                 }
             },

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
@@ -537,6 +537,7 @@ QUnit.module("spreadsheet > pivot plugin", {}, () => {
     });
 
     QUnit.test("can import (export) contextual domain", async (assert) => {
+        const uid = session.user_context.uid;
         const spreadsheetData = {
             pivots: {
                 1: {
@@ -554,7 +555,7 @@ QUnit.module("spreadsheet > pivot plugin", {}, () => {
             spreadsheetData,
             mockRPC: function (route, args) {
                 if (args.method === "read_group") {
-                    assert.deepEqual(args.kwargs.domain, [["foo", "=", 7]]);
+                    assert.deepEqual(args.kwargs.domain, [["foo", "=", uid]]);
                     assert.step("read_group");
                 }
             },


### PR DESCRIPTION
Re-inserting a pivot that had a contextual domain would fail because the data source would try to fetch the data with the domain as a string, but the domain should be a list at this point.

Task: [3553122](https://www.odoo.com/web#id=3553122&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
