### PR TITLE
[REM] event_sale: remove seats_available_insufficient

### DIFF
--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -146,7 +146,6 @@ class TestEventSale(TestEventSaleCommon):
             'email': 'manual.email.2@test.example.com',
         })
 
-        self.assertFalse(editor.seats_available_insufficient)
         editor.action_make_registration()
 
         # check editor correctly created new registrations with information coming from it or SO as fallback
@@ -226,8 +225,6 @@ class TestEventSale(TestEventSaleCommon):
             'default_sale_order_id': customer_so.id
         }).create({})
 
-        self.assertFalse(editor.seats_available_insufficient)
-
         editor.action_make_registration()
         self.assertEqual(len(self.event_0.registration_ids), TICKET_COUNT)
         self.assertTrue(all(reg.state == "open" for reg in self.event_0.registration_ids))
@@ -275,8 +272,6 @@ class TestEventSale(TestEventSaleCommon):
             'default_sale_order_id': customer_so.id
         }).create({})
 
-        self.assertTrue(editor.seats_available_insufficient)
-
         with self.assertRaises(ValidationError):
             editor.action_make_registration()
 
@@ -321,8 +316,6 @@ class TestEventSale(TestEventSaleCommon):
         editor = self.env['registration.editor'].with_context({
             'default_sale_order_id': customer_so.id
         }).create({})
-
-        self.assertTrue(editor.seats_available_insufficient)
 
         with self.assertRaises(ValidationError):
             editor.action_make_registration()

--- a/addons/event_sale/wizard/event_edit_registration.py
+++ b/addons/event_sale/wizard/event_edit_registration.py
@@ -12,37 +12,6 @@ class RegistrationEditor(models.TransientModel):
 
     sale_order_id = fields.Many2one('sale.order', 'Sales Order', required=True, ondelete='cascade')
     event_registration_ids = fields.One2many('registration.editor.line', 'editor_id', string='Registrations to Edit')
-    seats_available_insufficient = fields.Boolean(
-        'Not enough seats for all registrations', compute='_compute_seats_available_insufficient', readonly=True)
-
-    @api.depends('event_registration_ids')
-    def _compute_seats_available_insufficient(self):
-        for editor in self:
-            editor.seats_available_insufficient = False
-
-            events_counts = Counter()
-            event_tickets_counts = defaultdict(Counter)
-
-            for registration in editor.event_registration_ids:
-                events_counts[registration.event_id] += 1
-                event_tickets_counts[registration.event_id][registration.event_ticket_id] += 1
-
-            for event, nb_seats_event in events_counts.items():
-                # Check nb of seats in each event for all registrations on sale order
-                try:
-                    event._check_seats_availability(nb_seats_event)
-                except ValidationError:
-                    editor.seats_available_insufficient = True
-                    break
-                # Check nb of seats for each ticket of the event for all registrations on sale order
-                for ticket, nb_seats_ticket in event_tickets_counts[event].items():
-                    try:
-                        ticket._check_seats_availability(nb_seats_ticket)
-                    except ValidationError:
-                        editor.seats_available_insufficient = True
-                        break
-                if editor.seats_available_insufficient:
-                    break
 
     @api.model
     def default_get(self, fields):

--- a/addons/event_sale/wizard/event_edit_registration.xml
+++ b/addons/event_sale/wizard/event_edit_registration.xml
@@ -6,12 +6,6 @@
             <field name="model">registration.editor</field>
             <field name="arch" type="xml">
                 <form string="Registration">
-                    <field name="seats_available_insufficient" invisible="1"/>
-                    <div class="alert alert-warning m-0" role="alert" invisible="not seats_available_insufficient">
-                        <p class="my-0">
-                            <span>Not enough seats available. All registrations were created as "Unconfirmed" and can be updated later on.</span>
-                        </p>
-                    </div>
                     <sheet>
                         <p>Before updating the linked registrations of <field name="sale_order_id" readonly="1" class="oe_inline"/>
                         please give attendee details.</p>


### PR DESCRIPTION
Remove the seats_available_insufficient flow on the event registration editor. As it's no longer possible to confirm an SO and create draft registration.
Indeed the registration state is linked to the sale order state. And a validation error is directly raised if there are not enough seats to confirm the SO.

task-3555628
