### PR TITLE
[FIX] point_of_sale: fix daily sale report in closing popup

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1530,6 +1530,8 @@ class ReportSaleDetails(models.AbstractModel):
             'date_start': data.get('date_start'),
             'date_stop': data.get('date_stop')
         })
+        if not data['session_ids'] and docids:
+            data['session_ids'] = docids
         configs = self.env['pos.config'].browse(data['config_ids'])
         data.update(self.get_sale_details(data['date_start'], data['date_stop'], configs.ids, data['session_ids']))
         return data


### PR DESCRIPTION
The daily sale report in closing popup was crashing because the backend was not correctly handling the frontend request. This commit fixes the argument handling when the daily sale report is called by the front end.


