### PR TITLE
[FIX] web_editor: hide grid gap preview when toggling the mobile preview

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2644,6 +2644,12 @@ we-select.o_grid we-toggler {
     }
 
     &.o_we_grid_preview {
+        @include media-breakpoint-down(lg) {
+            // Hiding the preview in mobile view (-> no grid in mobile view). We
+            // cannot use `display: none` because it would prevent the animation
+            // to be played and so its listener would not remove the preview.
+            height: 0;
+        }
         pointer-events: none;
 
         .o_we_cell {


### PR DESCRIPTION
When changing the grid gaps (see commit [1]) a grid preview is displayed in order to visualize the changes. As it cannot be displayed in mobile view (otherwise, the layout looks broken), some code prevents it to be added in this case. However, a case has not been taken into account:
- In desktop view, change the gaps of a grid with the "Spacing (Y, X)" option.
- Before the preview disappears, quickly activate the mobile preview. => The preview is displayed (before disappearing).

This commit prevents the grid preview to be displayed in mobile view. To do so, its height is forced to 0. Note that `display` could be set to `none` instead but since it prevents the animation to be played, the preview would not be removed by its listener.

[1]: https://github.com/odoo/odoo/commit/4345df3aeeb83463d81bc24749856fef3a58fb3a

task-3555898