### PR TITLE
[FIX][IMP] hr,web_hierarchy: hr presence status icon and org chart

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -61,6 +61,8 @@
                             </div>
                             <div class="o_employee_avatar m-0 p-0">
                                 <field name="avatar_1920" widget='image' class="oe_avatar" options='{"zoom": true, "preview_image":"avatar_128"}'/>
+                                <field name="show_hr_icon_display" invisible="1" />
+                                <field name="hr_icon_display" class="d-flex align-items-end fs-6 o_employee_availability" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
                             </div>
                         </div>
                         <group>

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -79,7 +79,8 @@
                             </div>
                             <div class="o_employee_avatar m-0 p-0">
                                 <field name="image_1920" widget='image' class="oe_avatar m-0" options='{"zoom": true, "preview_image":"avatar_128"}'/>
-                                <field name="hr_icon_display" class="d-flex align-items-end fs-6 o_employee_availability" widget="hr_presence_status"/>
+                                <field name="show_hr_icon_display" invisible="1" />
+                                <field name="hr_icon_display" class="d-flex align-items-end fs-6 o_employee_availability" invisible="not show_hr_icon_display or not id" widget="hr_presence_status"/>
                             </div>
                         </div>
                         <group>

--- a/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
+++ b/addons/hr_holidays/static/src/components/hr_presence_status/hr_presence_status.js
@@ -5,12 +5,11 @@ import { patch } from "@web/core/utils/patch";
 import { HrPresenceStatus } from "@hr/components/hr_presence_status/hr_presence_status";
 
 patch(HrPresenceStatus.prototype, {
-    get classNames() {
-        const classNames = super.classNames;
+    get icon() {
         if (this.value.startsWith("presence_holiday")) {
-            return `${classNames} fa-plane`;
+            return "fa-plane";
         }
-        return classNames;
+        return super.icon;
     },
 
     get color() {

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -196,7 +196,6 @@
             <xpath expr="//div[@name='button_box']" position="inside">
                 <field name="show_leaves" invisible="1"/>
                 <field name="is_absent" invisible="1"/>
-                <field name="hr_icon_display" invisible="1"/>
                 <button disabled="1"
                         class="oe_stat_button"
                         invisible="not is_absent">

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -119,9 +119,6 @@
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name = "priority" eval="20" />
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='hr_icon_display']" position="attributes">
-                <attribute name="invisible">not last_activity or not id</attribute>
-            </xpath>
             <xpath expr="//group[@name='managers']" position="inside">
                 <field name="leave_manager_id" widget="many2one_avatar_user"/>
             </xpath>

--- a/addons/hr_org_chart/tests/test_employee.py
+++ b/addons/hr_org_chart/tests/test_employee.py
@@ -88,8 +88,6 @@ class TestEmployee(TestHrCommon):
         self.assertEqual(len(result), 3)
         for emp in employees:
             emp_dict = {'id': emp.id, 'parent_id': emp.parent_id.id and (emp.parent_id.id, emp.parent_id.display_name)}
-            if emp == self.employee_georges:
-                emp_dict['__focus__'] = True
             self.assertIn(emp_dict, result)
 
         self.employee_pierre.parent_id = self.employee_georges
@@ -97,14 +95,12 @@ class TestEmployee(TestHrCommon):
         self.assertEqual(len(result), 3)
         for emp in employees:
             emp_dict = {'id': emp.id, 'parent_id': emp.parent_id.id and (emp.parent_id.id, emp.parent_id.display_name)}
-            if emp == self.employee_georges:
-                emp_dict['__focus__'] = True
             self.assertIn(emp_dict, result)
 
         result = HrEmployee.hierarchy_read([('id', '=', self.employee_pierre.id)], ['id'], 'parent_id')
         self.assertEqual(len(result), 2)
         self.assertIn(
-            {'id': self.employee_pierre.id, 'parent_id': (self.employee_georges.id, self.employee_georges.name), '__focus__': True},
+            {'id': self.employee_pierre.id, 'parent_id': (self.employee_georges.id, self.employee_georges.name)},
             result
         )
         self.assertIn(

--- a/addons/hr_org_chart/views/hr_views.xml
+++ b/addons/hr_org_chart/views/hr_views.xml
@@ -25,7 +25,7 @@
         <field name="inherit_id" ref="hr.view_employee_form"/>
         <field name="arch" type="xml">
             <xpath expr="//div[@name='button_box']" position="inside">
-                <button name="%(hr_org_chart.action_hr_employee_org_chart)d" string="Org Chart" type="action" context="{'hierarchy_res_id': id}" invisible="not parent_id and not child_ids"/>
+                <button name="%(hr_org_chart.action_hr_employee_org_chart)d" icon="fa-users" string="Org Chart" type="action" context="{'hierarchy_res_id': id}" invisible="not parent_id and not child_ids"/>
             </xpath>
             <div id="o_work_employee_main" position="after">
                 <div id="o_employee_right" class="col-lg-4 px-0 ps-lg-5 pe-lg-0">

--- a/addons/web_hierarchy/models/models.py
+++ b/addons/web_hierarchy/models/models.py
@@ -35,10 +35,8 @@ class Base(models.AbstractModel):
                 )
             }
         result = records.read(fields)
-        if children_ids_per_record_id or focus_record:
+        if children_ids_per_record_id:
             for record_data in result:
                 if record_data['id'] in children_ids_per_record_id:
                     record_data['__child_ids__'] = children_ids_per_record_id[record_data['id']]
-                if record_data['id'] == focus_record.id:
-                    record_data['__focus__'] = True
         return result

--- a/addons/web_hierarchy/static/src/hierarchy_card.scss
+++ b/addons/web_hierarchy/static/src/hierarchy_card.scss
@@ -33,10 +33,6 @@
             cursor: pointer;
         }
 
-        &.o_hierarchy_node_highlighted {
-            border: 3px solid green;
-        }
-
         .o_hierarchy_node_header {
             height: 30px;
 

--- a/addons/web_hierarchy/static/src/hierarchy_card.xml
+++ b/addons/web_hierarchy/static/src/hierarchy_card.xml
@@ -12,11 +12,9 @@
                     <i class="fa fa-chevron-up"/>
                 </button>
             </div>
-            <div class="o_hierarchy_node w-100 h-100 d-flex flex-column justify-content-between"
+            <div class="o_hierarchy_node w-100 h-100 d-flex flex-column justify-content-between border"
                 t-att-class="{
-                    o_hierarchy_node_highlighted: props.node.isFocused,
-                    border: !props.node.isFocused,
-                    'border-bottom-0': !props.node.isFocused and (props.node.nodes.length or props.node.canShowChildNodes),
+                    'border-bottom-0': props.node.nodes.length or props.node.canShowChildNodes,
                 }"
                 t-att-data-node-id="props.node.id"
                 t-on-click.synthetic="onGlobalClick"

--- a/addons/web_hierarchy/static/src/hierarchy_model.js
+++ b/addons/web_hierarchy/static/src/hierarchy_model.js
@@ -81,15 +81,6 @@ export class HierarchyNode {
     }
 
     /**
-     * Is the current node focused?
-     *
-     * @returns {Boolean}
-     */
-    get isFocused() {
-        return Boolean(this.data.__focus__);
-    }
-
-    /**
      * Get parent field name
      *
      * @returns {String}
@@ -680,11 +671,7 @@ export class HierarchyModel extends Model {
         const resultStringified = JSON.stringify(result);
         const recordsPerParentId = {};
         const recordPerId = {};
-        let focusedRecord = null;
         for (const record of result) {
-            if (record.__focus__) {
-                focusedRecord = record;
-            }
             recordPerId[record.id] = record;
             const parentId = getIdOfMany2oneField(record[this.parentFieldName]);
             if (!(parentId.toString() in recordsPerParentId)) {
@@ -693,8 +680,6 @@ export class HierarchyModel extends Model {
             recordsPerParentId[parentId].push(record);
         }
         const data = [];
-        const parentId = focusedRecord ? getIdOfMany2oneField(focusedRecord[this.parentFieldName]) : false;
-        const parentFocusedRecord = parentId && parentId in recordPerId ? recordPerId[parentId.toString()] : { id: false };
         const recordIds = []; // to check if we have only one arborescence to display otherwise we display the result as the kanban view
         for (const [parentId, records] of Object.entries(recordsPerParentId)) {
             if (!parentId || !(parentId in recordPerId)) {
@@ -712,12 +697,7 @@ export class HierarchyModel extends Model {
             }
         }
         if (!data.length && result?.length) {
-            if (focusedRecord) {
-                let record = parentFocusedRecord || focusedRecord;
-                data.push(record);
-            } else {
-                data.push(recordPerId[Object.keys(recordsPerParentId)[0]])
-            }
+            data.push(recordPerId[Object.keys(recordsPerParentId)[0]]);
         }
         return data;
     }

--- a/addons/web_hierarchy/static/src/hierarchy_view.scss
+++ b/addons/web_hierarchy/static/src/hierarchy_view.scss
@@ -1,4 +1,4 @@
-.o_control_panel_navigation .o_switch_view .o_hierarchy_icon { // button in view switcher
+.o_hierarchy_icon { // hierarchy icon
     rotate: 90deg;
 }
 

--- a/addons/web_hierarchy/static/tests/hierarchy_view_tests.js
+++ b/addons/web_hierarchy/static/tests/hierarchy_view_tests.js
@@ -89,7 +89,6 @@ QUnit.module("Views", (hooks) => {
         assert.containsOnce(target, ".o_hierarchy_line_right");
         assert.containsN(target, ".o_hierarchy_node_container", 3);
         assert.containsN(target, ".o_hierarchy_node", 3);
-        assert.containsNone(target, ".o_hierarchy_node_highlighted");
         assert.containsN(target, ".o_hierarchy_node_button", 2);
         assert.containsOnce(target, ".o_hierarchy_node_button.btn-primary");
         assert.strictEqual(target.querySelector(".o_hierarchy_node_button.btn-primary").textContent.trim(), "Unfold 1");
@@ -251,8 +250,10 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_hierarchy_row", 2);
         assert.containsN(target, ".o_hierarchy_node", 2);
         assert.containsN(target, ".o_hierarchy_separator", 1);
-        assert.containsOnce(target, ".o_hierarchy_node_highlighted");
-        assert.strictEqual(target.querySelector(".o_hierarchy_node_highlighted").textContent.trim(), "LouisJosephine");
+        assert.deepEqual(
+            getNodesTextContent(target.querySelectorAll(".o_hierarchy_node_content")),
+            ["JosephineAlbert", "LouisJosephine"],
+        );
     });
 
     QUnit.test("search record in hierarchy view with child field name defined in the arch", async function (assert) {
@@ -267,8 +268,10 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_hierarchy_row", 2);
         assert.containsN(target, ".o_hierarchy_node", 2);
         assert.containsN(target, ".o_hierarchy_separator", 1);
-        assert.containsOnce(target, ".o_hierarchy_node_highlighted");
-        assert.strictEqual(target.querySelector(".o_hierarchy_node_highlighted").textContent.trim(), "LouisJosephine");
+        assert.deepEqual(
+            getNodesTextContent(target.querySelectorAll(".o_hierarchy_node_content")),
+            ["JosephineAlbert", "LouisJosephine"],
+        );
     });
 
     QUnit.test("fetch parent record", async function (assert) {
@@ -282,8 +285,6 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_hierarchy_row", 2);
         assert.containsN(target, ".o_hierarchy_node", 2);
         assert.containsN(target, ".o_hierarchy_separator", 1);
-        assert.containsOnce(target, ".o_hierarchy_node_highlighted");
-        assert.strictEqual(target.querySelector(".o_hierarchy_node_highlighted").textContent.trim(), "LouisJosephine");
         let rows = target.querySelectorAll(".o_hierarchy_row");
         let row = rows[0];
         assert.containsOnce(row, ".o_hierarchy_node");
@@ -300,8 +301,6 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_hierarchy_row", 3);
         assert.containsN(target, ".o_hierarchy_node", 4);
         assert.containsN(target, ".o_hierarchy_separator", 2);
-        assert.containsOnce(target, ".o_hierarchy_node_highlighted");
-        assert.strictEqual(target.querySelector(".o_hierarchy_node_highlighted").textContent.trim(), "LouisJosephine");
         rows = target.querySelectorAll(".o_hierarchy_row");
         row = rows[0];
         assert.containsOnce(row, ".o_hierarchy_node");
@@ -682,8 +681,5 @@ QUnit.module("Views", (hooks) => {
             ["JosephineAlbert", "LisaJosephine", "LouisJosephine"]
         );
         assert.containsOnce(target, ".o_hierarchy_node_container button[name=hierarchy_search_parent_node]");
-        assert.containsOnce(target, ".o_hierarchy_node_highlighted");
-        assert.containsOnce(target, ".o_hierarchy_node.o_hierarchy_node_highlighted");
-        assert.strictEqual(target.querySelector(".o_hierarchy_node_highlighted .o_hierarchy_node_content").textContent, "LisaJosephine");
     });
 });


### PR DESCRIPTION
## [FIX] hr,hr_holidays: show icon even if employee has no user linked

Before this commit, in the form view of employee, the presence status
icon displayed in the top right of the avatar image is hidden if there
is no last activity or no user linked to the employee.

This commit changes the visibility condition to have the same
visibility condition defined in the kanban view for the same icon.

## [FIX] hr_holidays: fix hr_presence_status widget

Before this commit, when the employee is off (because he is on leave)
then the presence status icon displayed in org chart, kanban and form view
should be `fa-plan`. It is not the case because `fa-circle` is also added
by mistake.

This commit changes the patch made in `hr_holidays` module to correctly
replace the icon by the `fa-plane` when the employee is on leave.

## [FIX] hr_org_chart: add icon in stat button to go to org chart view

[IMP] hr{_holidays}: show hr presence status icon in employee public form view

Before this commit, the hr presence status icon is displayed in kanban
view of `hr.employee.public` model but not in form view.

This commit adds the icon in the form view of `hr.employee.public`
at the same place than the icon in form view of `hr.employee` model.

## [FIX] web_hierarchy: apply style on all hierarchy icon

Before this commit, the style added in `o_hierarchy_icon` class
was only on the button in view switcher.

This commit changes the selector to be sure to apply the same style
on any icon with `o_hierarchy_icon` class.

## [FIX] web_hierarchy,hr_org_chart: remove highlight on focus record

Before this commit, the highlight added on a focus record, that styling
added was useful when we displayed only the first result in the search
to be able to build a tree but since now all the records found with
the search made by the user are shown without building a tree if it
is not possible then it is no longer needed to highlight the records
found.

This commit removes the highlight added on the focused record, the one
found by the search since it is not really needed.

task-3556262

task-3556262