### PR TITLE
[IMP] pos*: improve tracking_number computation and payment method auto selected

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -116,7 +116,7 @@ class PosOrder(models.Model):
     @api.depends('sequence_number', 'session_id')
     def _compute_tracking_number(self):
         for record in self:
-            record.tracking_number = str(record.session_id.id)[-1] + str(record.sequence_number)[-2:]
+            record.tracking_number = str((record.session_id.id % 10) * 100 + record.sequence_number % 100).zfill(3)
 
     @api.model
     def _process_order(self, order, draft, existing_order):

--- a/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/payment_screen/payment_screen.js
@@ -15,7 +15,7 @@ import { ConnectionLostError } from "@web/core/network/rpc_service";
 import { PaymentScreenPaymentLines } from "@point_of_sale/app/screens/payment_screen/payment_lines/payment_lines";
 import { PaymentScreenStatus } from "@point_of_sale/app/screens/payment_screen/payment_status/payment_status";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
-import { Component, useState, useRef } from "@odoo/owl";
+import { Component, useState, useRef, onMounted } from "@odoo/owl";
 import { renderToElement } from "@web/core/utils/render";
 import { Numpad } from "@point_of_sale/app/generic_components/numpad/numpad";
 import { floatIsZero } from "@web/core/utils/numbers";
@@ -46,7 +46,15 @@ export class PaymentScreen extends Component {
         this.payment_interface = null;
         this.error = false;
         this.validateOrder = useAsyncLockedMethod(this.validateOrder);
+        onMounted(this.onMounted);
     }
+
+    onMounted() {
+        if (this.payment_methods_from_config.length == 1) {
+            this.addNewPaymentLine(this.payment_methods_from_config[0]);
+        }
+    }
+
     getNumpadButtons() {
         return [
             { value: "1" },

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -66,7 +66,6 @@ export class ProductCard extends Component {
 
     scaleUpPrice() {
         const priceElement = document.querySelector(".total-price");
-        console.log(priceElement);
 
         if (!priceElement) {
             return;

--- a/addons/pos_self_order/static/src/app/models/order.js
+++ b/addons/pos_self_order/static/src/app/models/order.js
@@ -55,8 +55,8 @@ export class Order extends Reactive {
         if (this.pos_reference) {
             const reference = this.pos_reference;
             const arrRef = reference.split(" ")[1].split("-");
-            const sessionID = parseInt(arrRef[0]).toString();
-            const sequence = parseInt(arrRef[2]).toString();
+            const sessionID = arrRef[0][4];
+            const sequence = arrRef[2].substr(2, 2);
             const trackingNumber = sessionID + sequence;
             return trackingNumber;
         }

--- a/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml
@@ -17,7 +17,7 @@
                                 <div class="d-flex align-items-center justify-content-between">
                                     <div class="d-flex flex-column">
                                         <h6 class="m-0" t-esc="order.pos_reference"/>
-                                        <span class="text-muted">Tracking number: <t t-esc="order.tracking_number" /></span>
+                                        <span class="text-muted">Tracking number: <t t-esc="order.trackingNumber" /></span>
                                     </div>
                                     <span
                                         class="badge py-2 rounded-pill text-capitalize"


### PR DESCRIPTION
pos*: point_of_sale, pos_self_order

In this PR, we improve the tracking_number computation decreasing the number of string manipulation and increasing the number of int manipulation in the backend. In the frontend, the computation of the tracking_number was wrong. It was previously taking the whole session id and concatenate it with the whole sequence number. We also fix that. It now takes the last digit of the session id and the 2 last digits of the sequence number. We also improve the payment_screen. Now, when the user arrives on the payment_screen. If there is only 1 payment method. This payment_method will be chose by default.

We also fix the display of the tracking number in the order reminder page in pos_self_order.

Enterprise PR: https://github.com/odoo/enterprise/pull/48991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
