### PR TITLE
[FIX] spreadsheet[_dashboard]: avoid flicker

### DIFF
--- a/addons/spreadsheet/static/src/components/share_button/share_button.js
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.js
@@ -17,7 +17,7 @@ export class SpreadsheetShareButton extends Component {
     static template = "spreadsheet.ShareButton";
     static components = { Dropdown, DropdownItem, CopyButton };
     static props = {
-        model: Model,
+        model: { type: Model, optional: true },
         onSpreadsheetShared: Function,
     };
 

--- a/addons/spreadsheet/static/src/components/share_button/share_button.xml
+++ b/addons/spreadsheet/static/src/components/share_button/share_button.xml
@@ -7,6 +7,7 @@
       menuClass="'spreadsheet_share_dropdown d-flex flex-column'"
       position="'bottom-end'"
       onOpened.bind="onOpened"
+      disabled="!props.model"
     >
       <t t-set-slot="toggler">
         <i class="fa fa-share-alt"/>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -14,7 +14,7 @@
                 />
             </t>
             <t t-set-slot="control-panel-navigation-additional">
-                <SpreadsheetShareButton t-if="status === Status.Loaded" t-key="activeDashboardId" model="state.activeDashboard.model" onSpreadsheetShared.bind="shareSpreadsheet"/>
+                <SpreadsheetShareButton t-key="activeDashboardId" model="state.activeDashboard?.model" onSpreadsheetShared.bind="shareSpreadsheet"/>
             </t>
         </ControlPanel>
         <t t-set="dashboard" t-value="state.activeDashboard"/>


### PR DESCRIPTION
In the dashboard action, when switching from dashboard to dashboard, the size of the control panel flickers. That's because the Share button is not displays while the dashboard is loading and it takes some place, making the control panel taller when it's displayed.

With this commit, the Share button is always displayed (disabled when the model isn't loaded). In addition to fix the size flickering issue, it's also less things appearing/disappearing from the UI (less sapin de Noël)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
