### PR TITLE
[FIX] stock: lotname field prevent save on "enter"

### DIFF
--- a/addons/stock/static/src/widgets/multiline_widget.js
+++ b/addons/stock/static/src/widgets/multiline_widget.js
@@ -1,0 +1,31 @@
+/** @odoo-module **/
+
+
+import { TextField } from "@web/views/fields/text/text_field";
+import { registry } from "@web/core/registry";
+import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
+
+const { useEffect, useRef } = owl;
+
+export class MultilineField extends TextField {
+    setup(){
+        const inputRef = useRef("textarea");
+        useEffect(
+            (inputEl) => {
+                if (inputEl) {
+                    inputEl.onkeydown=this.onKeydown;
+                }
+            },
+            () => [inputRef.el]
+        );
+        super.setup();
+    }
+    onKeydown(ev) {
+        const hotkey = getActiveHotkey(ev);
+        if(hotkey == "enter"){
+            ev.stopImmediatePropagation();
+        }
+    }
+}
+
+registry.category("fields").add("multiline_widget", MultilineField);

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -241,7 +241,7 @@
                             'default_product_id': parent.product_id,
                         }"
                     />
-                    <field name="lot_name" string="Lot/Serial Number" widget="text" groups="stock.group_production_lot"
+                    <field name="lot_name" string="Lot/Serial Number" widget="multiline_widget" groups="stock.group_production_lot"
                         placeholder="Write your SN/LN one by one or copy paste a list."
                         attrs="{'readonly': ['&amp;', ('package_level_id', '!=', False), ('parent.picking_type_entire_packs', '=', True)]}"
                         invisible="not context.get('show_lots_text')"/>


### PR DESCRIPTION
Steps to reproduce:
- On inventory overview edit delivery order setings: Create New = True // Use Existing ones = False
- Create a delivery for a serial tracked product
- Open detailed operation on the moveline
- Edit lotname field: type first SN then type "enter" to return to new line add next Serial Numbers and "enter"

Bug:
Each time enter is pressed all the current lines are added. Typing "Enter" triggers onKeydown of input_field_hook that commits the current changes which leads to the lines creation
this causes a problem since it makes physical barcode scanner impossible to Use

Fix:
Override onKeydown to prevent the other listeners from triggering

opw-3458055