### PR TITLE
[FIX] web: MonetaryField symbol position

### DIFF
--- a/addons/web/static/src/views/fields/monetary/monetary_field.xml
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.xml
@@ -4,8 +4,9 @@
     <t t-name="web.MonetaryField" owl="1">
         <span t-if="props.readonly" t-esc="formattedValue" />
         <div class="text-nowrap d-inline-flex w-100 align-items-baseline" t-else="">
-            <span t-if="!props.hideSymbol and currency" t-out="currencySymbol" />
+            <span t-if="!props.hideSymbol and currency and currency.position === 'before'" t-out="currencySymbol" />
             <input t-ref="numpadDecimal" t-att-id="props.id" t-att-type="props.inputType" t-att-placeholder="props.placeholder" class="o_input flex-grow-1 flex-shrink-1"/>
+            <span t-if="!props.hideSymbol and currency and currency.position === 'after'" t-out="currencySymbol" />
         </div>
     </t>
 

--- a/addons/web/static/tests/views/fields/monetary_field_tests.js
+++ b/addons/web/static/tests/views/fields/monetary_field_tests.js
@@ -258,7 +258,7 @@ QUnit.module("Fields", (hooks) => {
                 3: {
                     name: "VEF",
                     symbol: "Bs.F",
-                    position: "after",
+                    position: "before",
                     digits: [0, 4],
                 },
             },
@@ -352,9 +352,9 @@ QUnit.module("Fields", (hooks) => {
             "The input should be rendered without the currency symbol."
         );
         assert.strictEqual(
-            target.querySelector(".o_field_widget input").parentNode.children[0].textContent,
+            target.querySelector(".o_field_widget input").parentNode.children[1].textContent,
             "Bs.F",
-            "The input should be preceded by a span containing the currency symbol."
+            "The input should be followed by a span containing the currency symbol."
         );
 
         await editInput(target, ".o_field_widget input", "99.111111111");
@@ -592,9 +592,9 @@ QUnit.module("Fields", (hooks) => {
         await click(euroM2OListItem);
 
         assert.strictEqual(
-            target.querySelector(".o_field_monetary div :first-child").textContent +
-                target.querySelector(".o_field_monetary div :last-child").value,
-            "€4.20",
+            target.querySelector(".o_field_monetary div :first-child").value +
+                target.querySelector(".o_field_monetary div :last-child").textContent,
+            "4.20€",
             "The value should be formatted with new currency on blur."
         );
 
@@ -636,9 +636,9 @@ QUnit.module("Fields", (hooks) => {
         await click(euroM2OListItem);
 
         assert.strictEqual(
-            target.querySelector(".o_field_monetary div :first-child").textContent +
-                target.querySelector(".o_field_monetary div :last-child").value,
-            "€4.20",
+            target.querySelector(".o_field_monetary div :first-child").value +
+                target.querySelector(".o_field_monetary div :last-child").textContent,
+            "4.20€",
             "The value should be formatted with new currency on blur."
         );
 


### PR DESCRIPTION
In readonly mode, the monetary field places the currency symbol in the correct position, because it uses formatMonetary/formatCurrency. But, in edit mode, the symbol is always at the start.

With this fix, the symbol is in the correct position in both modes.