### PR TITLE
[IMP] pos_online_payment_self_order,pos_self_order: kiosk online payment

### DIFF
--- a/addons/pos_online_payment_self_order/__manifest__.py
+++ b/addons/pos_online_payment_self_order/__manifest__.py
@@ -16,6 +16,7 @@
     'assets': {
         'pos_self_order.assets': [
             'pos_online_payment_self_order/static/src/**/*',
+            'web/static/lib/zxing-library/zxing-library.js',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/pos_online_payment_self_order/controllers/__init__.py
+++ b/addons/pos_online_payment_self_order/controllers/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import controllers
+from . import payment_portal

--- a/addons/pos_online_payment_self_order/controllers/payment_portal.py
+++ b/addons/pos_online_payment_self_order/controllers/payment_portal.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import http
+from odoo.http import request
+from odoo.addons.pos_online_payment.controllers.payment_portal import PaymentPortal
+
+class PaymentPortalSelfOrder(PaymentPortal):
+    @http.route()
+    def pos_order_pay(self, pos_order_id, access_token=None, exit_route=None):
+        self._send_notification_payment_status(pos_order_id, 'progress')
+        return super().pos_order_pay(pos_order_id, access_token=access_token, exit_route=exit_route)
+
+    @http.route()
+    def pos_order_pay_confirmation(self, pos_order_id, tx_id=None, access_token=None, exit_route=None, **kwargs):
+        result = super().pos_order_pay_confirmation(pos_order_id, tx_id=tx_id, access_token=access_token, exit_route=exit_route, **kwargs)
+        tx_sudo = request.env['payment.transaction'].sudo().search([('id', '=', tx_id)])
+
+        if tx_sudo.state not in ('authorized', 'done'):
+            self._send_notification_payment_status(pos_order_id, 'fail')
+        else:
+            self._send_notification_payment_status(pos_order_id, 'success')
+
+        return result
+
+    def _send_notification_payment_status(self, pos_order_id, status):
+        pos_order = request.env['pos.order'].sudo().browse(pos_order_id)
+
+        if pos_order.config_id.self_ordering_mode == 'kiosk':
+            request.env['bus.bus']._sendone(f'pos_config-{pos_order.config_id.access_token}', 'ONLINE_PAYMENT_STATUS', {
+                'status': status, # progress, success, fail
+                'order': pos_order._export_for_self_order(),
+            })

--- a/addons/pos_online_payment_self_order/static/src/pages/payment_page/payment_page.js
+++ b/addons/pos_online_payment_self_order/static/src/pages/payment_page/payment_page.js
@@ -1,0 +1,33 @@
+/** @odoo-module */
+import { patch } from "@web/core/utils/patch";
+import { PaymentPage } from "@pos_self_order/app/pages/payment_page/payment_page";
+
+patch(PaymentPage.prototype, {
+    async startPayment() {
+        let order = this.selfOrder.currentOrder;
+        const selfMode = this.selfOrder.config.self_ordering_mode;
+        const pm = this.selectedPaymentMethod;
+
+        if (selfMode !== "kiosk" || !pm || !pm.is_online_payment) {
+            return super.startPayment(...arguments);
+        } else {
+            order = await this.selfOrder.sendDraftOrderToServer();
+        }
+
+        const url = this.selfOrder.getOnlinePaymentUrl(order, false);
+        this.generateQrcodeImg(url);
+    },
+    get selectedPaymentIsOnline() {
+        const paymentMethods = this.selectedPaymentMethod;
+        return (
+            paymentMethods &&
+            paymentMethods.is_online_payment &&
+            this.selfOrder.config.self_ordering_mode === "kiosk"
+        );
+    },
+    generateQrcodeImg(url) {
+        const codeWriter = new window.ZXing.BrowserQRCodeSvgWriter();
+        const qr_code_svg = new XMLSerializer().serializeToString(codeWriter.write(url, 150, 150));
+        this.state.qrImage = "data:image/svg+xml;base64," + window.btoa(qr_code_svg);
+    },
+});

--- a/addons/pos_online_payment_self_order/static/src/pages/payment_page/payment_page.xml
+++ b/addons/pos_online_payment_self_order/static/src/pages/payment_page/payment_page.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_online_payment_self_order.PaymentPage" t-inherit="pos_self_order.PaymentPage" t-inherit-mode="extension">
+        <xpath expr="//div[hasclass('payment-state-container')]" position="after">
+            <div t-if="this.selectedPaymentIsOnline and !state.selection" class="d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center">
+                <h1 class="mb-4">Scan the QR code to pay</h1>
+                <div class="d-inline-flex flex-column border rounded p-4 bg-view mb-3">
+                    <img t-att-src="state.qrImage" />
+                </div>
+                <h3 t-if="selfOrder.onlinePaymentStatus === 'progress'">Payment in progress</h3>
+            </div>
+        </xpath>
+        <xpath expr="//div[hasclass('payment-state-container')]" position="attributes">
+            <attribute name="t-if">!this.selectedPaymentIsOnline and !state.selection</attribute>
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_online_payment_self_order/static/src/self_order_bus_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_bus_service.js
@@ -1,0 +1,23 @@
+/** @odoo-module */
+
+import { patch } from "@web/core/utils/patch";
+import { SelfOrderBus } from "@pos_self_order/app/self_order_bus_service";
+
+patch(SelfOrderBus.prototype, {
+    dispatch(message) {
+        super.dispatch(...arguments);
+
+        if (message.type === "ONLINE_PAYMENT_STATUS") {
+            this.ws_changeOnlinePaymentStatus(message.payload.status, message.payload.order);
+        }
+    },
+    ws_changeOnlinePaymentStatus(status, order) {
+        const currentOrder = this.selfOrder.currentOrder;
+        this.selfOrder.onlinePaymentStatus = status;
+        this.selfOrder.paymentError = status === "fail";
+
+        if (status === "success" && currentOrder.access_token === order.access_token) {
+            this.selfOrder.finalizeOrder();
+        }
+    },
+});

--- a/addons/pos_online_payment_self_order/static/src/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_service.js
@@ -4,31 +4,43 @@ import { SelfOrder } from "@pos_self_order/app/self_order_service";
 import { session } from "@web/session";
 
 patch(SelfOrder.prototype, {
-    openOnlinePaymentPage({
-        id: order_id,
-        access_token: order_access_token,
-        pos_config_id: order_pos_config_id,
-    }) {
+    async setup(...args) {
+        await super.setup(...args);
+        this.onlinePaymentStatus = null;
+    },
+    finalizeOrder() {
+        const order = this.currentOrder;
+
+        this.updateOrdersFromServer([order], [order.access_token]);
+        this.router.navigate("confirmation", {
+            orderAccessToken: order.access_token,
+            screenMode: "order",
+        });
+    },
+    getOnlinePaymentUrl(
+        { id: order_id, access_token: order_access_token, pos_config_id: order_pos_config_id },
+        exitRoute = true
+    ) {
         const baseUrl = session.base_url;
         const order = this.currentOrder;
         const tableIdentifier = this.table?.identifier;
-        let exitRouteUrl = `${baseUrl}/pos-self/${order_pos_config_id}`;
+        let exitRouteUrl = baseUrl;
 
-        if (this.config.self_ordering_pay_after === "each") {
-            exitRouteUrl += `/confirmation/${order.access_token}/order`;
+        if (exitRoute) {
+            exitRouteUrl += `/pos-self/${order_pos_config_id}`;
+
+            if (this.config.self_ordering_pay_after === "each") {
+                exitRouteUrl += `/confirmation/${order.access_token}/order`;
+            }
+
+            exitRouteUrl += `?access_token=${this.access_token}`;
+
+            if (tableIdentifier) {
+                exitRouteUrl += `&table_identifier=${tableIdentifier}`;
+            }
         }
 
-        exitRouteUrl += `?access_token=${this.access_token}`;
-
-        if (tableIdentifier) {
-            exitRouteUrl += `&table_identifier=${tableIdentifier}`;
-        }
-
-        const exitRoute = encodeURIComponent(exitRouteUrl);
-        window.open(
-            baseUrl +
-                `/pos/pay/${order_id}?access_token=${order_access_token}&exit_route=${exitRoute}`,
-            "_self"
-        );
+        const exit = encodeURIComponent(exitRouteUrl);
+        return `${baseUrl}/pos/pay/${order_id}?access_token=${order_access_token}&exit_route=${exit}`;
     },
 });

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -333,7 +333,7 @@ class PosConfig(models.Model):
     def _get_self_ordering_data(self):
         self.ensure_one()
         payment_search_params = self.current_session_id._loader_params_pos_payment_method()
-        payment_methods = self.payment_method_ids.filtered(lambda p: p.use_payment_terminal == 'adyen').read(payment_search_params['search_params']['fields'])
+        payment_methods = self.payment_method_ids.filtered(lambda p: p.use_payment_terminal == 'adyen' or p.is_online_payment).read(payment_search_params['search_params']['fields'])
         default_language = self.self_ordering_default_language_id.read(["code", "name", "iso_code", "flag_image_url"])
 
         return {
@@ -343,7 +343,7 @@ class PosConfig(models.Model):
             "company_color": self.company_id.color,
             "custom_links": self._get_self_order_custom_links(),
             "currency_id": self.currency_id.id,
-            "pos_payment_methods": payment_methods,
+            "pos_payment_methods": payment_methods if self.self_ordering_mode == "kiosk" else [],
             "pos_category": self._get_available_categories().read(["name", "sequence", "has_image"]),
             "products": self._get_available_products()._get_self_order_data(self),
             "combos": self._get_combos_data(),

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
@@ -39,7 +39,7 @@ export class OrderWidget extends Component {
     get buttonToShow() {
         const currentPage = this.router.activeSlot;
         const payAfter = this.selfOrder.config.self_ordering_pay_after;
-        const kioskPayment = this.selfOrder.pos_payment_methods.find((p) => !p.is_online_payment); // cannot be online payment in kiosk for instance
+        const kioskPayment = this.selfOrder.pos_payment_methods;
         const isNoLine = this.selfOrder.currentOrder.lines.length === 0;
 
         let label = "";

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.js
@@ -24,9 +24,7 @@ export class PaymentPage extends Component {
 
         onWillStart(async () => {
             const type = this.selfOrder.config.self_ordering_mode;
-            const paymentMethods = this.selfOrder.pos_payment_methods.filter(
-                (p) => !p.is_online_payment
-            );
+            const paymentMethods = this.selfOrder.pos_payment_methods;
 
             if (paymentMethods.length === 0 && type === "kiosk") {
                 await this.selfOrder.sendDraftOrderToServer();
@@ -44,14 +42,14 @@ export class PaymentPage extends Component {
         return this.selfOrder.paymentError || this.state.selection;
     }
 
-    get paymentMethods() {
-        return this.selfOrder.pos_payment_methods.filter((p) => !p.is_online_payment);
-    }
-
     selectMethod(methodId) {
         this.state.selection = false;
         this.state.paymentMethodId = methodId;
         this.startPayment();
+    }
+
+    get selectedPaymentMethod() {
+        return this.selfOrder.pos_payment_methods.find((p) => p.id === this.state.paymentMethodId);
     }
 
     async startPayment() {

--- a/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/payment_page/payment_page.xml
@@ -3,12 +3,12 @@
     <t t-name="pos_self_order.PaymentPage">
         <div t-if="state.selection" class="h-100 d-flex flex-wrap p-5 gap-5 align-items-center justify-content-center">
             <div
-                t-foreach="paymentMethods"
+                t-foreach="selfOrder.pos_payment_methods"
                 t-as="payment_method"
                 t-key="payment_method.id"
-                class="o_kiosk-card border rounded d-flex flex-column align-items-center justify-content-center"
+                class="o_kiosk-card border rounded d-flex flex-column align-items-center p-5 justify-content-center bg-white"
                 t-on-click="() => this.selectMethod(payment_method.id)">
-                <div class="h-75 fs-1 d-flex flex-column justify-content-center align-items-center">
+                <div class="h-75 fs-1 p-3 d-flex flex-column justify-content-center align-items-center">
                     <i class="fa fa-credit-card" aria-hidden="true"></i>
                 </div>
                 <div class="name w-100 d-flex justify-content-center align-items-center h-25">
@@ -16,15 +16,15 @@
                 </div>
             </div>
         </div>
-        <div class="d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center">
+        <div class="payment-state-container d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center">
             <h1 class="mb-4">Follow instructions on the terminal</h1>
             <div class="d-inline-flex flex-column border rounded p-4 bg-view mb-3">
                 <i class="fa fa-credit-card-alt fs-1" aria-hidden="true"></i>
             </div>
         </div>
-        <div t-if="showFooterBtn" class="px-3 py-4 d-flex gap-1 justify-content-center">
-            <button class="btn btn-primary btn-lg" t-on-click="() => this.router.back()">Back</button>
-            <button class="btn btn-info btn-lg" t-on-click="startPayment">Retry</button>
+        <div class="px-3 py-4 d-flex gap-1 justify-content-center">
+            <button class="btn btn-primary btn-lg" t-if="state.selection || selectedPaymentMethod.is_online_payment" t-on-click="() => this.router.back()">Back</button>
+            <button class="btn btn-info btn-lg" t-if="!state.selection and selfOrder.paymentError" t-on-click="startPayment">Retry</button>
         </div>
     </t>
 </templates>

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -222,7 +222,7 @@ export class SelfOrder extends Reactive {
         try {
             const rpcUrl = this.currentOrder.isAlreadySent
                 ? "/pos-self-order/update-existing-order"
-                : "/pos-self-order/process-new-order/self";
+                : `/pos-self-order/process-new-order/${this.config.self_ordering_mode}`;
 
             const order = await this.rpc(rpcUrl, {
                 order: this.currentOrder,


### PR DESCRIPTION
Online payment method added to kiosk. This works in the same way as in
the mobile SelfOrder, except that the payment page does not open
automatically in the kiosk. A QR code appears and the user is asked to
scan it to make the payment on their phone.

Once the QR code has been scanned, the page on the kiosk updates to show
"payment in progress", and once the payment has been validated, the
validation page appears on the kiosk. These different statuses are sent
via websocket.