### PR TITLE
[FIX] im_livechat, website_livechat: fix chatbot after reload

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -104,6 +104,7 @@ export class ChatBotService {
             // Answer was posted but is yet to be processed.
             this._processUserAnswer(this.livechatService.thread.newestMessage);
         }
+        this.shouldRestore = false;
     }
 
     /**

--- a/addons/website_livechat/static/tests/tours/website_livechat_chatbot_after_reload.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_chatbot_after_reload.js
@@ -1,0 +1,30 @@
+/* @odoo-module */
+
+import { registry } from "@web/core/registry";
+import { endDiscussion } from "./website_livechat_common";
+
+const messagesContain = (text) => `.o-mail-Message:contains("${text}")`;
+
+registry.category("web_tour.tours").add("website_livechat_chatbot_after_reload_tour", {
+    test: true,
+    shadow_dom: ".o-livechat-root",
+    steps: () => [
+        {
+            trigger: messagesContain("Hello! I'm a bot!"),
+        },
+        {
+            content: "Reload the page",
+            trigger: messagesContain("How can I help you?"),
+            run: () => location.reload(),
+        },
+        ...endDiscussion,
+        {
+            trigger: ".o-livechat-LivechatButton",
+            run: "click",
+        },
+        {
+            trigger: messagesContain("Hello! I'm a bot!"),
+            run: () => {},
+        },
+    ],
+});

--- a/addons/website_livechat/tests/test_chatbot_ui.py
+++ b/addons/website_livechat/tests/test_chatbot_ui.py
@@ -94,3 +94,6 @@ class TestLivechatChatbotUI(TestLivechatCommon, ChatbotCase):
                         ('mail_message_id', '=', conversation_message.id)
                     ], limit=1).user_script_answer_id
                 )
+
+    def test_chatbot_available_after_reload(self):
+        self.start_tour("/", "website_livechat_chatbot_after_reload_tour", step_delay=100)


### PR DESCRIPTION
Since [1], the live chat button is displayed after a conversation ended. This change introduced a bug with with the chat bot.

Steps to reproduce:
- Open a chat with the bot
- Reload the page
- Close the live chat
- Open another chat
- The bot does not start

[1]: https://github.com/odoo/odoo/pull/134513