### PR TITLE
[FIX] hr_homeworking: fix homeworking using localized week name for t…

### DIFF
--- a/addons/hr_homeworking/static/src/calendar/common/calendar_model.js
+++ b/addons/hr_homeworking/static/src/calendar/common/calendar_model.js
@@ -34,7 +34,7 @@ patch(AttendeeCalendarModel.prototype, {
         for (const day of rangeInterval) {
             const startDay = day.s;
             const dayISO = startDay.toISODate();
-            const dayName = startDay.weekdayLong.toLowerCase();
+            const dayName = startDay.setLocale("us").weekdayLong.toLowerCase();
             if (!(dayISO in events)) {
                 events[dayISO] = {};
             }


### PR DESCRIPTION
…echnical field

https://github.com/odoo/odoo/pull/137502 changed how we handle homeworking records. However, it would throw a traceback if luxon was using any non english localizations to get the week name of a date. This commit fixes this by setting the us location before getting the weekname as we rely on it to get the default data for that day.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
