### PR TITLE
[FIX] calendar: show quick create form view dialog after parser rework

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -359,6 +359,7 @@
             <calendar js_class="attendee_calendar" string="Meetings" date_start="start" date_stop="stop" date_delay="duration" all_day="allday"
                 event_open_popup="true"
                 event_limit="5"
+                quick_create="true"
                 quick_create_view_id="%(calendar.view_calendar_event_form_quick_create)d"
                 color="partner_ids">
                 <field name="location" invisible="not location" options="{'icon': 'fa fa-map-marker'}"/>


### PR DESCRIPTION
https://github.com/odoo/odoo/pull/138042 reworked how we define quick create in calendar views. Before we had to specify only a single attribute, but now they were split into two (a boolean and a form view id). This commit fixes the calendar view definition in the calendar module to add also the boolean attribute.

task-3551177

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
