### PR TITLE
[IMP] stock: move detailed operation view to smart button

### DIFF
--- a/addons/mrp/models/stock_picking.py
+++ b/addons/mrp/models/stock_picking.py
@@ -71,6 +71,11 @@ class StockPicking(models.Model):
         for picking in self:
             picking.has_kits = any(picking.move_ids.mapped('bom_line_id'))
 
+    def action_detailed_operations_view(self):
+        action = super().action_detailed_operations_view()
+        action['context']['has_kits'] = self.has_kits
+        return action
+
     def _less_quantities_than_expected_add_documents(self, moves, documents):
         documents = super(StockPicking, self)._less_quantities_than_expected_add_documents(moves, documents)
 

--- a/addons/mrp/views/stock_picking_views.xml
+++ b/addons/mrp/views/stock_picking_views.xml
@@ -119,7 +119,7 @@
         <field name="inherit_id" ref="stock.view_stock_move_line_detailed_operation_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="after">
-                <field name="description_bom_line" optional="show" column_invisible="not parent.has_kits"/>
+                <field name="description_bom_line" optional="show" column_invisible="not context.get('has_kits')"/>
             </xpath>
         </field>
     </record>

--- a/addons/product_expiry/views/stock_move_views.xml
+++ b/addons/product_expiry/views/stock_move_views.xml
@@ -49,7 +49,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lot_name']" position="after">
                 <field name="picking_type_use_existing_lots" column_invisible="True"/>
-                <field name="expiration_date" force_save="1" column_invisible="parent.picking_type_code != 'incoming'" readonly="picking_type_use_existing_lots"/>
+                <field name="expiration_date" force_save="1" column_invisible="context.get('picking_code') != 'incoming'" readonly="picking_type_use_existing_lots"/>
             </xpath>
             <xpath expr="//field[@name='lot_id']" position="after">
                 <field name="is_expired" column_invisible="True"/>

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -91,6 +91,8 @@ class StockMoveLine(models.Model):
     product_packaging_qty_done = fields.Float(
             string="Done Packaging Quantity",
             compute='_compute_product_packaging_qty_done')
+    picking_location_id = fields.Many2one(related='picking_id.location_id')
+    picking_location_dest_id = fields.Many2one(related='picking_id.location_dest_id')
 
     @api.depends('product_uom_id.category_id', 'product_id.uom_id.category_id', 'move_id.product_uom', 'product_id.uom_id')
     def _compute_product_uom_id(self):
@@ -971,6 +973,12 @@ class StockMoveLine(models.Model):
             'views': [[False, "form"]],
             'res_id': self.id,
         }
+
+    def action_put_in_pack(self):
+        self.picking_id.ensure_one()
+        self.picking_id.action_put_in_pack()
+        # because new lines can be created we need to reopen the operations view
+        return self.picking_id.action_detailed_operations_view()
 
     def _get_revert_inventory_move_values(self):
         self.ensure_one()

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -947,6 +947,25 @@ class Picking(models.Model):
         else:
             picking_to_reset.state = 'draft'
 
+    def action_detailed_operations_view(self):
+        view_id = self.env.ref('stock.view_stock_move_line_detailed_operation_tree').id
+        return {
+            'name': _('Detailed Operations'),
+            'view_mode': 'tree',
+            'type': 'ir.actions.act_window',
+            'res_model': 'stock.move.line',
+            'views': [(view_id, 'tree')],
+            'domain': [('id', 'in', self.move_line_ids.ids)],
+            'context': {
+                'default_picking_id': self.id,
+                'default_location_id': self.location_id.id,
+                'default_location_dest_id': self.location_dest_id.id,
+                'default_company_id': self.company_id.id,
+                'show_lots_text': self.show_lots_text,
+                'picking_code': self.picking_type_code,
+            }
+        }
+
     def _action_done(self):
         """Call `_action_done` on the `stock.move` of the `stock.picking` in `self`.
         This method makes sure every `stock.move.line` is linked to a `stock.move` by either

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -330,27 +330,35 @@
             <field name="model">stock.move.line</field>
             <field name="priority">1000</field>
             <field name="arch" type="xml">
-                <tree editable="bottom" decoration-muted="(state == 'done' and is_locked == True)" decoration-danger="qty_done&gt;reserved_uom_qty and state!='done' and parent.picking_type_code != 'incoming'" decoration-success="qty_done==reserved_uom_qty and state!='done' and not result_package_id">
+                <tree editable="bottom" decoration-muted="(state == 'done' and is_locked == True)" multi_edit="1">
+                    <header>
+                        <button class="btn-primary" name="action_put_in_pack" type="object" string="Put in Pack" groups="stock.group_tracking_lot"/>
+                    </header>
                     <field name="product_id" context="{'default_detailed_type': 'product'}" required="1" readonly="state == 'done' or move_id"/>
                     <field name="company_id" column_invisible="True"/>
                     <field name="move_id" column_invisible="True"/>
                     <field name="picking_id" column_invisible="True"/>
+                    <field name="picking_code" column_invisible="True"/>
+                    <field name="picking_location_id" column_invisible="True"/>
+                    <field name="picking_location_dest_id" column_invisible="True"/>
                     <field name="product_uom_category_id" column_invisible="True"/>
-                    <field name="package_id" column_invisible="True"/>
-                    <field name="result_package_id" column_invisible="True"/>
                     <field name="location_id" column_invisible="True"/>
                     <field name="location_dest_id" column_invisible="True"/>
-                    <field name="lot_id" groups="stock.group_production_lot" column_invisible="parent.show_lots_text" invisible="not lots_visible" context="{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id}" optional="show"/>
-                    <field name="lot_name" groups="stock.group_production_lot" column_invisible="not parent.show_lots_text" invisible="not lots_visible" context="{'default_product_id': product_id}"/>
-                    <field name="location_id" options="{'no_create': True}" column_invisible="parent.picking_type_code == 'incoming'" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
-                    <field name="location_dest_id" options="{'no_create': True}" column_invisible="parent.picking_type_code == 'outgoing'" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', parent.location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
-                    <field name="package_id" groups="stock.group_tracking_lot"/>
+                    <field name="quant_id" column_invisible="context.get('picking_code') == 'incoming'"
+                        domain="[('product_id', '=', product_id), ('location_id', 'child_of', picking_location_id)]"
+                        context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'tree_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
+                        widget="pick_from"
+                        options="{'no_open': True}"/>
+                    <field name="lot_id" column_invisible="context.get('show_lots_text')" groups="stock.group_production_lot" invisible="not lots_visible" context="{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id}" optional="show"/>
+                    <field name="lot_name" column_invisible="not context.get('show_lots_text')"  groups="stock.group_production_lot" invisible="not lots_visible" context="{'default_product_id': product_id}"/>
+                    <!-- <field name="location_id" options="{'no_create': True}"  groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', picking_location_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/> -->
+                    <field name="location_dest_id" options="{'no_create': True}" column_invisible="context.get('picking_code') == 'outgoing'" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', picking_location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>
+                    <field name="package_id" column_invisible="True"/>
                     <field name="result_package_id" groups="stock.group_tracking_lot"/>
                     <field name="lots_visible" column_invisible="True"/>
-                    <field name="owner_id" groups="stock.group_tracking_owner" column_invisible="parent.picking_type_code == 'incoming'"/>
+                    <field name="owner_id" groups="stock.group_tracking_owner" column_invisible="context.get('picking_code') == 'incoming'"/>
                     <field name="state" column_invisible="True"/>
                     <field name="is_initial_demand_editable" column_invisible="True"/>
-                    <field name="reserved_uom_qty" column_invisible="parent.picking_type_code == 'incoming'" readonly="not id" optional="show"/>
                     <field name="is_locked" column_invisible="True"/>
                     <field name="qty_done" readonly="state in ('done', 'cancel') and is_locked" force_save="1"/>
                     <field name="product_uom_id" force_save="1" readonly="state != 'draft' and id" groups="uom.group_uom"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -188,6 +188,15 @@
                                 <span class="o_stat_text">Operations</span>
                             </div>
                         </button>
+                        <button name="action_detailed_operations_view"
+                            class="oe_stat_button"
+                            icon="fa-bars"
+                            type="object"
+                            help="List view of detailed operations">
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_text">Detailed Operations</span>
+                            </div>
+                        </button>
                     </div>
                     <div class="oe_title">
                         <h1 class="d-flex">
@@ -243,24 +252,6 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Detailed Operations"
-                            name="detailed_operations"
-                            invisible="not show_operations">
-                            <field name="move_line_nosuggest_ids"
-                                   invisible="show_reserved"
-                                   readonly="not show_operations or state == 'cancel' or (state == 'done' and is_locked)"
-                                   context="{'tree_view_ref': 'stock.view_stock_move_line_detailed_operation_tree', 'default_picking_id': id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_company_id': company_id}"/>
-                            <field name="move_line_ids_without_package"
-                                   invisible="not show_reserved"
-                                   readonly="not show_operations or state == 'cancel' or (state == 'done' and is_locked)"
-                                   context="{'tree_view_ref': 'stock.view_stock_move_line_detailed_operation_tree', 'default_picking_id': id, 'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_company_id': company_id}"/>
-                            <field name="package_level_ids_details"
-                                   context="{'default_location_id': location_id, 'default_location_dest_id': location_dest_id, 'default_company_id': company_id}"
-                                   invisible="not picking_type_entire_packs or not show_operations"
-                                   readonly="state == 'done'" />
-                            <button class="oe_highlight" name="action_put_in_pack" type="object" string="Put in Pack" invisible="state in ('draft', 'done', 'cancel')" groups="stock.group_tracking_lot" data-hotkey="shift+g"/>
-                        </page>
-
                         <page string="Operations" name="operations">
                             <field name="move_ids_without_package" mode="tree,kanban"
                                 widget="stock_move_one2many"


### PR DESCRIPTION
After this commit, detailed operations is no longer a tab in the picking but under a smart button

TaskId: 3486636


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
