### PR TITLE
[FIX] website_slides: unwanted html text

### DIFF
--- a/addons/website_slides/static/src/xml/slide_quiz.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz.xml
@@ -3,7 +3,7 @@
     <t t-name="slide.slide.quiz">
         <div class="o_wslides_fs_quiz_container o_wslides_wrap h-100 w-100 overflow-auto pb-5">
             <div class="container">
-                <div t-if="widget.quiz.description_safe" t-esc="widget.quiz.description_safe" class="mt-3" />
+                <div t-if="widget.quiz.description_safe" t-out="widget.quiz.description_safe" class="mt-3" />
                 <div t-foreach="widget.quiz.questions" t-as="question" t-key="question_index"
                      t-attf-class="o_wslides_js_lesson_quiz_question mt-5 mb-4 #{widget.slide.completed ? 'completed-disabled' : ''}"
                      t-att-data-question-id="question.id" t-att-data-title="question.question">


### PR DESCRIPTION
**How to reproduce:**

1. Open any course having a quiz.
2. Select quiz content.
-> In the quiz template we can see that the html content is not sanitized.

**Technical:**
I think the issue arises after this commit  https://github.com/odoo/odoo/commit/0d7acf60b4cca84a8c700edd97af8c4de6b78010

**After this PR:**
Now t-esc is deprecated and the HTML text is not sanitized in the template so instead of t-esc we are using t-out.

Task-3555159
