### PR TITLE
[FIX] point_of_sale: prevent traceback of keyerror 'iface_tipproduct'

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -392,7 +392,7 @@ class PosConfig(models.Model):
         return pos_configs
 
     def _reset_default_on_vals(self, vals):
-        if 'tip_product_id' in vals and vals['iface_tipproduct'] and not vals['tip_product_id']:
+        if 'tip_product_id' in vals and not vals['tip_product_id'] and 'iface_tipproduct' in vals and vals['iface_tipproduct']:
             default_product = self.env.ref('point_of_sale.product_product_tip', False)
             if default_product:
                 vals['tip_product_id'] = default_product.id


### PR DESCRIPTION
This issue occurs when the admin selects the `multi employees per session` to give access to employees.
when the employees create a new session of shop and then try to open `Point of Sales` in the Configuration Menu, at that time the error will be generated.

step to reproduce-
- install the `Point of Sale`.
- open Point of Sale > Configuration Menu > Settings.
- click on `Multi Employees per Session` in the PoS Interface.
- open Dashboard > New session of shop > Select Cashier(random) > create one order > lock.
- again click  Configuration Menu > Settings.
- click on `point of sales` above `Share Open Orders` in the PoS Interface
- the error will be generated.

sentry traceback-
```
KeyError: 'iface_tipproduct'
  File "odoo/http.py", line 2139, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1715, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1742, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1943, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 464, in call_kw
    result = _call_kw_model_create(method, model, args, kwargs)
  File "odoo/api.py", line 444, in _call_kw_model_create
    result = method(recs, *args, **kwargs)
  File "<decorator-gen-363>", line 2, in create
  File "odoo/api.py", line 414, in _model_create_multi
    return create(self, [arg])
  File "addons/point_of_sale/models/res_config_settings.py", line 152, in create
    pos_config.write(pos_fields_vals)
  File "addons/pos_restaurant/models/pos_config.py", line 89, in write
    return super().write(vals)
  File "addons/point_of_sale/models/pos_config.py", line 408, in write
    self._reset_default_on_vals(vals)
  File "addons/point_of_sale/models/pos_config.py", line 395, in _reset_default_on_vals
    if 'tip_product_id' in vals and vals['iface_tipproduct'] and not vals['tip_product_id']:
```

After this commit, the user can easily open a point of sale from the settings of the Configuration Menu.

sentry-4550823176
