### PR TITLE
[16.0][IMP] core: introduce OrderedWeakSet and revert #121849

### DIFF
--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -43,7 +43,6 @@ class StockPicking(models.Model):
             )
 
             positive_picking._create_move_from_pos_order_lines(positive_lines)
-            self.env.flush_all()
             try:
                 with self.env.cr.savepoint():
                     positive_picking._action_done()
@@ -63,7 +62,6 @@ class StockPicking(models.Model):
                 self._prepare_picking_vals(partner, return_picking_type, location_dest_id, return_location_id)
             )
             negative_picking._create_move_from_pos_order_lines(negative_lines)
-            self.env.flush_all()
             try:
                 with self.env.cr.savepoint():
                     negative_picking._action_done()

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1497,7 +1497,6 @@ Please change the quantity done or the rounding precision of your unit of measur
             if float_compare(taken_quantity, int(taken_quantity), precision_digits=rounding) != 0:
                 taken_quantity = 0
 
-        self.env.flush_all()
         try:
             with self.env.cr.savepoint():
                 if not float_is_zero(taken_quantity, precision_rounding=self.product_id.uom_id.rounding):

--- a/odoo/addons/base/tests/__init__.py
+++ b/odoo/addons/base/tests/__init__.py
@@ -53,6 +53,7 @@ from . import test_reports
 from . import test_test_retry
 from . import test_test_suite
 from . import test_tests_tags
+from . import test_transactions
 from . import test_form_create
 from . import test_cloc
 from . import test_profiler

--- a/odoo/addons/base/tests/test_transactions.py
+++ b/odoo/addons/base/tests/test_transactions.py
@@ -1,0 +1,41 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestTransactionEnvs(TransactionCase):
+    def test_transation_envs_weakrefs(self):
+        transaction = self.env.transaction
+        starting_envs = set(transaction.envs)
+        base_x = self.env['base'].with_context(test_stuff=False)
+        self.assertIn(base_x.env, transaction.envs)
+        del base_x
+        self.assertEqual(set(transaction.envs), starting_envs)
+
+    def do_stuff_with_env(self):
+        base_test = self.env['base'].with_context(test_stuff=False)
+        base_test |= self.env['base'].with_context(test_stuff=1)
+        base_test |= self.env['base'].with_context(test_stuff=2)
+        return base_test
+
+    def test_transation_envs_weakrefs_call(self):
+        transaction = self.env.transaction
+        starting_envs = set(transaction.envs)
+        self.do_stuff_with_env()
+        self.assertEqual(set(transaction.envs), starting_envs)
+
+    def test_transation_envs_weakrefs_return(self):
+        transaction = self.env.transaction
+        starting_envs = set(transaction.envs)
+        base_test = self.do_stuff_with_env()
+        self.assertEqual(set(transaction.envs), starting_envs | {base_test.env})
+
+    def test_transation_envs_ordered(self):
+        transaction = self.env.transaction
+        starting_envs = set(transaction.envs)
+        # create environments in a certain order, not sorted on item
+        items = [3, 8, 1, 5, 2, 7, 6, 9, 0, 4]
+        envs = [self.env(context={'item': item}) for item in items]
+        # check that those environments appear in order in transaction.envs
+        env_items = [env.context['item'] for env in transaction.envs if env not in starting_envs]
+        self.assertEqual(env_items, items)
+        del envs
+        self.assertEqual(set(transaction.envs), starting_envs)

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -856,6 +856,7 @@ class Transaction:
         self.registry = registry
         # weak set of environments
         self.envs = WeakSet()
+        self.envs.data = OrderedSet()  # make the weakset OrderedWeakSet
         # cache for all records
         self.cache = Cache()
         # fields to protect {field: ids}


### PR DESCRIPTION
Backport of #121604 
```

The Weakset Used for envs can lead to unpredictible behaviour when calling flush on the transaction because we iterate on the `envs`.

Since WeakSet.data is a set, the iteration will depends on the python hash seed.

This commit proposes to replace Transaction.envs.data by an OrderedSet to solve this issue.


```

Revert of #121849