### PR TITLE
[FIX] web: fix pager when using a many2many field

### DIFF
--- a/addons/web/static/src/model/relational_model/static_list.js
+++ b/addons/web/static/src/model/relational_model/static_list.js
@@ -843,6 +843,11 @@ export class StaticList extends DataPoint {
         this._commands = [x2ManyCommands.set(ids)].concat(updateCommandsToKeep);
         this._currentIds = [...ids];
         this.count = this._currentIds.length;
+        if (this._currentIds.length > this.limit) {
+            this._tmpIncreaseLimit = this._currentIds.length - this.limit;
+            const nextLimit = this.limit + this._tmpIncreaseLimit;
+            this.model._updateConfig(this.config, { limit: nextLimit }, { reload: false });
+        }
     }
 
     async _resequence(movedId, targetId) {

--- a/addons/web/static/tests/views/fields/many2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_field_tests.js
@@ -1817,8 +1817,6 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test("many2many list add *many* records, remove, re-add", async function (assert) {
-        assert.expect(5);
-
         serverData.models.partner.fields.timmy.domain = [["color", "=", 2]];
         serverData.models.partner.fields.timmy.onChange = true;
         serverData.models.partner_type.fields.product_ids = {
@@ -1827,8 +1825,8 @@ QUnit.module("Fields", (hooks) => {
             relation: "product",
         };
 
-        for (var i = 0; i < 50; i++) {
-            var new_record_partner_type = { id: 100 + i, display_name: "batch" + i, color: 2 };
+        for (let i = 0; i < 50; i++) {
+            const new_record_partner_type = { id: 100 + i, display_name: "batch" + i, color: 2 };
             serverData.models.partner_type.records.push(new_record_partner_type);
         }
 
@@ -1866,7 +1864,7 @@ QUnit.module("Fields", (hooks) => {
         // First round: add 51 records in batch
         await click(target.querySelector(".o_field_x2many_list_row_add a"));
 
-        var $modal = $(".modal-lg");
+        let $modal = $(".modal-lg");
 
         assert.equal($modal.length, 1, "There should be one modal");
 
@@ -1881,26 +1879,43 @@ QUnit.module("Fields", (hooks) => {
             "We should have added all the records present in the search view to the m2m field"
         ); // the 50 in batch + 'gold'
 
+        assert.containsNone(
+            target,
+            ".o_field_many2many.o_field_widget .o_field_x2many.o_field_x2many_list .o_cp_pager",
+            "pager should not be displayed"
+        );
+
         await clickSave(target);
 
+        assert.containsOnce(
+            target,
+            ".o_field_many2many.o_field_widget .o_field_x2many.o_field_x2many_list .o_cp_pager",
+            "pager should not be displayed"
+        );
+
+        const pagerValue = target.querySelector(
+            ".o_field_many2many.o_field_widget .o_field_x2many.o_field_x2many_list .o_pager_value"
+        );
+        assert.strictEqual(pagerValue.textContent, "1-40", "The pager should be updated.");
+
         // Secound round: remove one record
-        var trash_buttons = $(target).find(
+        const trash_buttons = $(target).find(
             ".o_field_many2many.o_field_widget .o_field_x2many.o_field_x2many_list .o_list_record_remove"
         );
 
         await click(trash_buttons.first()[0]);
 
-        var pager_limit = $(target).find(
+        const pager_limit = $(target).find(
             ".o_field_many2many.o_field_widget .o_field_x2many.o_field_x2many_list .o_pager_limit"
         );
-        assert.equal(pager_limit.text(), "50", "We should have 50 records in the m2m field");
+        assert.strictEqual(pager_limit.text(), "50", "We should have 50 records in the m2m field");
 
         // Third round: re-add 1 records
         await click($(target).find(".o_field_x2many_list_row_add a")[0]);
 
         $modal = $(".modal-lg");
 
-        assert.equal($modal.length, 1, "There should be one modal");
+        assert.strictEqual($modal.length, 1, "There should be one modal");
 
         await click($modal.find("thead input[type=checkbox]")[0]);
         await nextTick();


### PR DESCRIPTION
Before this commit, adding more records to a many2many field than the limit of the pager did not update the pager. This commit fixes this issue by updating the limit of the pager.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
