### PR TITLE
[FIX] pos_self_order: put table number back in the confirmation page

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
@@ -19,7 +19,7 @@
             <h3 t-if="selfOrder.table.name || confirmedOrder.table_stand_number" class="text-muted mb-3">
                 Service at table
                 <t t-if="selfOrder.config.self_ordering_mode === 'mobile'" t-esc="selfOrder.table.name + ' (' + selfOrder.table.floor_name + ')'" />
-                <t t-else="" t-esc="selfOrder.tablePadNumber" />
+                <t t-else="" t-esc="confirmedOrder.table_stand_number" />
             </h3>
             <h3 t-else="">Order to pick-up at the counter</h3>
         </div>


### PR DESCRIPTION
Before this commit, the table number was not displayed on the confirmation page of the POS Self Order app. This is due to two PR being merged at the same time, one that removed the field from the model and the other using it. This is now fixed by using another field instead of the removed one.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
