### PR TITLE
[IMP] point_of_sale,pos_self_order: various changes

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -328,7 +328,7 @@ class PosOrder(models.Model):
     has_refundable_lines = fields.Boolean('Has Refundable Lines', compute='_compute_has_refundable_lines')
     refunded_orders_count = fields.Integer(compute='_compute_refund_related_fields')
     ticket_code = fields.Char(help='5 digits alphanumeric code to be used by portal user to request an invoice')
-    tracking_number = fields.Char(string="Tracking Number", compute='_compute_tracking_number')
+    tracking_number = fields.Char(string="Short order number", compute='_compute_tracking_number')
 
     @api.depends('lines.refund_orderline_ids', 'lines.refunded_orderline_id')
     def _compute_refund_related_fields(self):

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -291,7 +291,7 @@ class PosOrder(models.Model):
     session_id = fields.Many2one(
         'pos.session', string='Session', required=True, index=True,
         domain="[('state', '=', 'opened')]")
-    config_id = fields.Many2one('pos.config', related='session_id.config_id', string="Point of Sale", readonly=False)
+    config_id = fields.Many2one('pos.config', related='session_id.config_id', string="Point of Sale", readonly=False, store=True)
     currency_id = fields.Many2one('res.currency', related='config_id.currency_id', string="Currency")
     currency_rate = fields.Float("Currency Rate", compute='_compute_currency_rate', compute_sudo=True, store=True, digits=0, readonly=True,
         help='The rate of the currency to the currency of rate applicable at the date of the order')

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -264,6 +264,7 @@
                 <field name="name" decoration-bf="1"/>
                 <field name="session_id"  readonly="state != 'draft'"/>
                 <field name="date_order"/>
+                <field name="config_id" />
                 <field name="pos_reference"/>
                 <field name="partner_id"/>
                 <field string="Cashier" name="user_id" widget="many2one_avatar_user" readonly="state in ['done', 'invoiced']"/>
@@ -383,6 +384,7 @@
                 <field name="user_id"/>
                 <field name="partner_id"/>
                 <field name="session_id"/>
+                <field name="config_id"/>
                 <field name="lines" string="Product" filter_domain="[('lines.product_id', 'ilike', self)]"/>
                 <filter string="Invoiced" name="invoiced" domain="[('state', '=', 'invoiced')]"/>
                 <filter string="Posted" name="posted" domain="[('state', '=', 'done')]"/>
@@ -391,6 +393,7 @@
                 <group expand="0" string="Group By">
                     <filter string="Session" name="session" domain="[]" context="{'group_by': 'session_id'}"/>
                     <filter string="User" name="user_id" domain="[]" context="{'group_by': 'user_id'}"/>
+                    <filter string="Point of Sale" name="config_id" domain="[]" context="{'group_by': 'config_id'}"/>
                     <filter string="Customer" name="customer" domain="[]" context="{'group_by': 'partner_id'}"/>
                     <filter string="Status" name="status" domain="[]" context="{'group_by': 'state'}"/>
                     <filter string="Order Date" name="order_month" domain="[]" context="{'group_by': 'date_order'}"/>

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -145,7 +145,7 @@ class ProductProduct(models.Model):
                 "name": self._get_name(),
                 "id": self.id,
                 "description_self_order": self.description_self_order,
-                "pos_categ_ids": self.pos_categ_ids.mapped("name") or ["Other"],
+                "pos_categ_ids": self.pos_categ_ids.read(["id", "name"]) or [{"id": 0, "name": "Uncategorised"}],
                 "pos_combo_ids": self.combo_ids.mapped("id") or False,
                 "is_pos_groupable": self.uom_id.is_pos_groupable,
                 "write_date": self.write_date.timestamp(),

--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -71,7 +71,7 @@ class ResConfigSettings(models.TransientModel):
             "type": "ir.actions.act_window",
             "res_model": "pos_self_order.custom_link",
             "views": [[False, "tree"]],
-            "domain": [['pos_config_ids', 'in', self.pos_config_id.id]],
+            "domain": ['|', ['pos_config_ids', 'in', self.pos_config_id.id], ["pos_config_ids", "=", False]],
         }
 
     def generate_qr_codes_page(self):

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
@@ -13,7 +13,7 @@
             <h1 t-else="" class="mb-4">We're preparing your order!</h1>
             <h3 t-if="state.payment" class="mt-3 text-muted">Pay at the cashier <t t-esc="selfOrder.formatMonetary(confirmedOrder.amount_total)" /></h3>
             <div class="d-inline-flex flex-column border rounded py-4 px-5 bg-view mb-3">
-                <span class="fs-2 text-muted">Your tracking number</span>
+                <span class="fs-2 text-muted">Your short order number</span>
                 <span class="number lh-1" t-esc="confirmedOrder.trackingNumber" />
             </div>
             <h3 t-if="selfOrder.table.name || confirmedOrder.table_stand_number" class="text-muted mb-3">

--- a/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/order_history_page/order_history_page.xml
@@ -17,7 +17,7 @@
                                 <div class="d-flex align-items-center justify-content-between">
                                     <div class="d-flex flex-column">
                                         <h6 class="m-0" t-esc="order.pos_reference"/>
-                                        <span class="text-muted">Tracking number: <t t-esc="order.trackingNumber" /></span>
+                                        <span class="text-muted">Short order number: <t t-esc="order.trackingNumber" /></span>
                                     </div>
                                     <span
                                         class="badge py-2 rounded-pill text-capitalize"

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.js
@@ -26,7 +26,7 @@ export class ProductListPage extends Component {
         });
         this.categoryButton = Object.fromEntries(
             Array.from(this.selfOrder.categoryList).map((category) => {
-                return [category.name, useRef(`category_${category.name}`)];
+                return [category.id, useRef(`category_${category.id}`)];
             })
         );
 
@@ -75,12 +75,6 @@ export class ProductListPage extends Component {
             },
             () => [this.selfOrder.currentCategory]
         );
-    }
-
-    get productCategory() {
-        const productByCat = this.selfOrder.productsGroupedByCategory;
-        const currentCategory = this.selfOrder.currentCategory;
-        return productByCat[currentCategory] ? productByCat[currentCategory] : [];
     }
 
     focusSearch() {

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -9,7 +9,7 @@
                         t-foreach="Array.from(selfOrder.categoryList)"
                         t-as="category"
                         t-key="category.id"
-                        t-ref="category_{{category.name}}"
+                        t-ref="category_{{category.id}}"
                         t-attf-class="nav-link category-item flex-shrink-0 p-0"
                         t-attf-href="#scrollspy_{{category.id}}">
                         <div t-if="category.has_image" class="ratio ratio-1x1 mb-1">
@@ -61,9 +61,9 @@
                     t-key="category.id"
                     t-attf-id="scrollspy_{{category.id}}"
                     t-attf-categId="{{category.id}}"
-                    t-ref="productsWithCategory_{{category.name}}"
+                    t-ref="productsWithCategory_{{category.id}}"
                     class="product-list-category d-empty-none bg-view py-4 px-3 mb-3">
-                    <t t-set="products" t-value="selfOrder.productsGroupedByCategory[category.name]" />
+                    <t t-set="products" t-value="selfOrder.productsGroupedByCategory[category.id]" />
                     <t t-set="availableProducts" t-value="!state.searchInput ? products : getFilteredProducts(products)" />
                     <t t-set="nbrItem" t-value="availableProducts.length + nbrItem" />
                     <t t-if="availableProducts.length > 0">

--- a/addons/pos_self_order/static/src/app/pages/stand_number_page/stand_number_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/stand_number_page/stand_number_page.xml
@@ -4,7 +4,7 @@
         <div class="self_order_stand_number d-flex flex-column flex-grow-1 justify-content-between px-3 overflow-y-auto">
 
             <div class="text-center pt-3">
-                <h1>Get a tracker and enter it's number here</h1>
+                <h1>Get a tracker and enter its number here</h1>
                 <div class="input-number form-contol form-control-lg text-center">
                     <span t-esc="tableInput" class="display-1"/>
                 </div>

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -122,28 +122,28 @@ export class SelfOrder extends Reactive {
         });
 
         this.productsGroupedByCategory = this.products.reduce((acc, product) => {
-            product.pos_categ_ids.map((pos_categ_ids) => {
-                acc[pos_categ_ids] = acc[pos_categ_ids] || [];
-                acc[pos_categ_ids].push(product);
+            product.pos_categ_ids.map((categ) => {
+                acc[categ.id] = acc[categ.id] || [];
+                acc[categ.id].push(product);
             });
             return acc;
         }, {});
 
+        if (this.productsGroupedByCategory[0]) {
+            this.pos_category.push({
+                has_image: false,
+                id: 0,
+                name: _t("Uncategorised"),
+                sequence: 9999,
+            });
+        }
+
         this.categoryList = new Set(
             this.pos_category
                 .sort((a, b) => a.sequence - b.sequence)
-                .filter((c) => this.productsGroupedByCategory[c.name])
+                .filter((c) => this.productsGroupedByCategory[c.id])
                 .sort((a, b) => categorySorter(a, b, this.config.iface_start_categ_id))
         );
-
-        if (this.categoryList.size === 0) {
-            this.categoryList.add({
-                has_image: false,
-                id: 0,
-                name: _t("Other"),
-                sequence: -1,
-            });
-        }
 
         this.currentCategory = this.pos_category.length > 0 ? [...this.categoryList][0] : null;
     }
@@ -392,17 +392,17 @@ export class SelfOrder extends Reactive {
     handleProductChanges(payload) {
         const product = new Product(payload.product, this.show_prices_with_tax_included);
         this.productByIds[payload.product.id] = product;
-        for (const categ_name of payload.product.pos_categ_ids) {
-            if (!this.pos_category.map((c) => c.name).includes(categ_name)) {
+        for (const categ of payload.product.pos_categ_ids) {
+            if (!this.pos_category.map((c) => c.id).includes(categ.id)) {
                 continue;
             }
-            const index = this.productsGroupedByCategory[categ_name].findIndex(
+            const index = this.productsGroupedByCategory[categ.id].findIndex(
                 (p) => p.id === product.id
             );
             if (index >= 0) {
-                this.productsGroupedByCategory[categ_name][index] = product;
+                this.productsGroupedByCategory[categ.id][index] = product;
             } else {
-                this.productsGroupedByCategory[categ_name].push(product);
+                this.productsGroupedByCategory[categ.id].push(product);
             }
         }
     }

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//setting[@id='payment_methods_new']" position="before">
                 <div class="o_notification_alert alert alert-warning" role="alert" invisible="not is_kiosk_mode">
-                    <span>Please note that the kiosk only works with Adyen terminals</span>
+                    <span>Please note that the kiosk only works with Adyen &amp; Stripe terminals</span>
                 </div>
             </xpath>
             <block id="restaurant_section" position="after">


### PR DESCRIPTION
**Commit 1:**
Fix a typo on stand_number_page.xml

**Commit 2:**
If a pos_config has no category restrictions and receives a product with
no category, a default category named "uncategorised" will be created.

Technical change: previously, categories were grouped according to their
name, the problem being that if two categories had the same name, this
would cause problems; now they are grouped by their ID.

**Commit 3:**
Added the ability to group orders by point of sale in the order backend
view.

Added "point of sale" column to this same view.

**Commit 4:**
Change of domain applied when clicking on the "home buttons" button of
a self order, now showing buttons linked to its pos_config + those
linked to no pos_config.

**Commit 5:**
"Tacking number" has been renamed everywhere "short order number" in
point of sale and self order.

**Commit 6:**
Stripe terminal payment will arrive in a future PR.

Linked: https://github.com/odoo/odoo/pull/138646