### PR TITLE
[FIX] website_sale_loyalty: manage multi rewards with "Discount code"

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -103,7 +103,7 @@ class WebsiteSale(main.WebsiteSale):
             if reward_sudo in rewards:
                 coupon = coupon_
                 if code == coupon.code and (
-                    program_sudo.trigger == 'with_code'
+                    (program_sudo.trigger == 'with_code' and program_sudo.program_type != 'promo_code')
                     or (program_sudo.trigger == 'auto' and program_sudo.applies_on == 'future')
                 ):
                     return self.pricelist(code)

--- a/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
+++ b/addons/website_sale_loyalty/static/tests/tours/test_apply_discount_code.js
@@ -1,0 +1,69 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import tourUtils from 'website_sale.tour_utils';
+
+registry.category("web_tour.tours").add('apply_discount_code_program_multi_rewards', {
+    test: true,
+    url: '/shop?search=Super%20Chair',
+    steps: [
+        {
+            content: 'select Super Chair',
+            extra_trigger: '.oe_search_found',
+            trigger: '.oe_product_cart a:contains("Super Chair")',
+        },
+        {
+            content: 'Add Super Chair into cart',
+            trigger: 'a:contains(ADD TO CART)',
+        },
+        tourUtils.goToCart(),
+        {
+            content: 'Click on "I have a promo code"',
+            extra_trigger: '#cart_products',
+            trigger: '.show_coupon',
+        },
+        {
+            content: 'insert discount code',
+            trigger: 'form[name="coupon_code"] input[name="promo"]',
+            run: 'text 12345'
+        },
+        {
+            content: 'validate the promo code',
+            trigger: 'form[name="coupon_code"] .a-submit',
+        },
+        {
+            content: 'check reward',
+            trigger: '.alert:contains("10% on Super Chair")',
+            isCheck: true,
+        },
+        {
+            content: 'claim reward',
+            trigger: '.alert:contains("10% on Super Chair") .btn:contains("Claim")',
+        },
+        {
+            content: 'check claimed reward',
+            trigger: '.td-product_name:contains("10% on Super Chair")',
+            isCheck: true,
+        },
+        // Try to reapply the same promo code
+        {
+            content: 'Click on "I have a promo code"',
+            extra_trigger: '#cart_products',
+            trigger: '.show_coupon',
+        },
+        {
+            content: 'insert discount code',
+            trigger: 'form[name="coupon_code"] input[name="promo"]',
+            run: 'text 12345'
+        },
+        {
+            content: 'validate the promo code',
+            trigger: 'form[name="coupon_code"] .a-submit',
+        },
+        {
+            content: 'check refused message',
+            trigger: '.alert-danger:contains("This promo code is already applied")',
+            isCheck: true,
+        },
+    ],
+});

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -47,7 +47,7 @@
                                                 <div class="flex-grow-1">
                                                     <t t-set="program" t-value="reward.program_id"/>
                                                     <t t-set="points" t-value="website_sale_order._get_real_points_for_coupon(coupon)"/>
-                                                    <t t-if="program.program_type != 'ewallet' and (program.trigger == 'with_code' or (program.trigger == 'auto' and program.applies_on == 'future'))">
+                                                    <t t-if="program.program_type not in ['ewallet', 'promo_code'] and (program.trigger == 'with_code' or (program.trigger == 'auto' and program.applies_on == 'future'))">
                                                         <t t-if="program.program_type == 'gift_card'">
                                                             <strong t-esc="reward.description"/>
                                                             <strong> - </strong>
@@ -71,6 +71,9 @@
                                                             </t>
                                                         </div>
                                                     </t>
+                                                    <t t-elif="program.program_type == 'promo_code'">
+                                                        <strong t-esc="reward.description"/>
+                                                    </t>
                                                     <t t-else="">
                                                         <strong t-esc="reward.description"/>
                                                         <div t-if="program.portal_visible">
@@ -93,7 +96,7 @@
                                                         <t t-if="reward.program_id.program_type == 'ewallet'">
                                                             Pay with eWallet
                                                         </t>
-                                                        <t t-elif="reward.program_id.trigger == 'with_code' or (reward.program_id.trigger == 'auto' and reward.program_id.applies_on == 'future')">
+                                                        <t t-elif="(reward.program_id.trigger == 'with_code' and reward.program_id.program_type != 'promo_code') or (reward.program_id.trigger == 'auto' and reward.program_id.applies_on == 'future')">
                                                             Use
                                                         </t>
                                                         <t t-else="">Claim</t>


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create a promotion program with the type "Discount code";
- add a rule to trigger the promotion with the code "12345";
- add two rewards;
- go to ecommerce and create a cart;
- apply the promo code.

Issue:
------
It is not possible to claim a reward.

Cause:
------
When we apply the code "12345", we call the `pricelist` method, which will try to apply the code.
If it's not a coupon and it's not nominative, we create a loyalty card (a coupon) with a default code (for example: "044d-3364-42d0"). This previously created loyalty card is linked to the current sale order, which is only fair since we don't want to be able to apply it a second time.

The two rewards are linked to the same coupon and therefore have the same code (which is right because we can apply only one of these rewards).

This problem doesn't occur with a single reward, because when only one reward is detected, we automatically apply it when we call the `pricelist` method.

In the case of two rewards, it is possible to select the reward. This will trigger the `claim_reward` method.
In this method, if we use a coupon with a code (which is the case here, "044d-3364-42d0"), we call the `pricelist` method with this code.
This will trigger an error, as the code is already in use with the loyalty card linked to the sale order.

Solution:
---------
When claiming a reward generated by a program of the `promo_code` type, i.e. in the case of more than a rewards,
don't call the `pricelist` method (which triggers an error due to the code) but `_apply_reward`. This will apply the reward to the sale order.
A redirect will be use which will remove all "claimable and showable rewards" from this program. If we want to re-trigger it via code "12345", this will no longer be possible.

Note:
-----
Modification of the view to distinguish between coupons and "Discount Code" programs. The current display suggests that rewards are coupons (with the same code) that we use, whereas they are rewards that we can claim.
Furthermore, there's no description of the rewards.

opw-3520137