### PR TITLE
[FIX] web, mail: correspondent can be null

### DIFF
--- a/addons/hr/static/src/core/web/thread_actions.js
+++ b/addons/hr/static/src/core/web/thread_actions.js
@@ -10,7 +10,7 @@ threadActionsRegistry.add("open-hr-profile", {
         return (
             component.thread?.type === "chat" &&
             component.props.chatWindow?.isOpen &&
-            component.thread.correspondent.employeeId
+            component.thread.chatPartner.employeeId
         );
     },
     icon: "fa fa-fw fa-id-card",

--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -81,7 +81,7 @@
     <div t-if="thread" class="o-mail-ChatWindow-threadAvatar my-0" t-attf-class="{{ threadActions.actions.length > 4 ? 'ms-1' : 'ms-3' }} me-1">
         <img class="rounded" t-att-src="thread.imgUrl" alt="Thread Image"/>
     </div>
-    <ThreadIcon t-if="thread and thread.type === 'chat' and thread.correspondent" thread="thread"/>
+    <ThreadIcon t-if="thread and thread.type === 'chat' and thread.chatPartner" thread="thread"/>
     <div t-if="!state.editingName" class="text-truncate fw-bold border border-transparent me-1 my-0" t-att-title="props.chatWindow.displayName" t-esc="props.chatWindow.displayName" t-att-class="thread ? 'ms-1' : 'ms-3'"/>
 </t>
 </templates>

--- a/addons/mail/static/src/core/common/discuss.xml
+++ b/addons/mail/static/src/core/common/discuss.xml
@@ -19,7 +19,7 @@
                 <t t-else="">
                     <ThreadIcon className="'me-2 align-self-center'" thread="thread"/>
                 </t>
-                <ImStatus t-if="thread and thread.type === 'chat' and thread.correspondent" className="'me-1'" persona="thread.correspondent" thread="thread" />
+                <ImStatus t-if="thread and thread.type === 'chat' and thread.chatPartner" className="'me-1'" persona="thread.chatPartner" thread="thread" />
                 <div class="d-flex flex-grow-1 align-self-center align-items-center h-100 py-2">
                     <AutoresizeInput
                         className="'o-mail-Discuss-threadName lead fw-bold flex-shrink-1 text-dark bg-view py-0'"

--- a/addons/mail/static/src/core/web/messaging_menu.scss
+++ b/addons/mail/static/src/core/web/messaging_menu.scss
@@ -1,7 +1,7 @@
 .o-mail-MessagingMenu {
     width: 450px;
     min-height: 50px;
-    max-height: Min(calc(100vh - 140px), 630px);
+    max-height: Min(calc(#{ $o-dropdown-max-height } - 5px), 630px); // -5px for borders
 
     hr {
         opacity: $hr-opacity / 2;

--- a/addons/mail/static/src/core/web/messaging_menu.xml
+++ b/addons/mail/static/src/core/web/messaging_menu.xml
@@ -86,7 +86,7 @@
                     onSwipeLeft="hasTouch() and threadService.canUnpin(thread) ? { action: () => this.threadService.unpin(thread), icon: 'fa-times-circle', bgColor: 'bg-danger' } : undefined"
                 >
                     <t t-set-slot="icon">
-                        <ImStatus t-if="thread.type === 'chat'" persona="thread.correspondent" thread="thread" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
+                        <ImStatus t-if="thread.type === 'chat'" persona="thread.chatPartner" thread="thread" className="'position-absolute top-100 start-100 translate-middle mt-n1 ms-n1'"/>
                     </t>
                     <t t-if="message" t-set-slot="body-icon">
                         <t t-if="message.isSelfAuthored">

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -186,6 +186,7 @@ $o-horizontal-padding: $o-spacer !default;
 $o-innergroup-rpadding: 45px !default;
 $o-dropdown-hpadding: 20px !default;
 $o-dropdown-vpadding: 3px !default;
+$o-dropdown-max-height: 70vh !default;
 
 $o-statbutton-height: 44px !default;
 $o-statbutton-vpadding: 0px !default;

--- a/addons/web/static/src/scss/ui.scss
+++ b/addons/web/static/src/scss/ui.scss
@@ -17,7 +17,7 @@
 }
 
 .dropdown-menu {
-    max-height: 70vh;
+    max-height: $o-dropdown-max-height;
     overflow: auto;
     background-clip: border-box;
 }


### PR DESCRIPTION
Correspondent in the thread can be null and lead to a crash when getting thread action and im status.

Replace correspondent with chatPartner when the type is chat.

The fix is to solve the problem so that it is not blocking systray and chatWindow tests related.

Also, this fix the small issue of systray overflowing issue.

![image](https://github.com/odoo/odoo/assets/26395662/d3f3da54-30dc-4cdb-b46a-0817a9218067)
![image](https://github.com/odoo/odoo/assets/26395662/ae7e6a19-dede-4f4e-a7ea-560736d3c944)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
