### PR TITLE
[IMP] web, *: address issue with spinner in dialog box

### DIFF
--- a/addons/web/static/src/legacy/js/core/dialog.js
+++ b/addons/web/static/src/legacy/js/core/dialog.js
@@ -238,6 +238,13 @@ var Dialog = Widget.extend({
      *   `on_close` handler.
      */
     destroy: function (options) {
+        // If there are more than one modal shown do not remove the
+        // 'prevent-spinner' class
+        const numberOfModalShown = document.querySelectorAll(".modal_shown").length;
+        const spinnerEl = document.querySelector(".o_we_ui_loading");
+        if (spinnerEl && numberOfModalShown === 1) {
+            spinnerEl.classList.remove("prevent-spinner");
+        }
         // Need to trigger before real destroy but if 'closed' handler destroys
         // the widget again, we want to avoid infinite recursion
         if (!this.__closed) {

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3606,6 +3606,9 @@ var SnippetsMenu = Widget.extend({
         ];
         loaderContainer.classList.add(...loaderContainerClassList);
         loader.setAttribute('src', '/web/static/img/spin.svg');
+        if (document.querySelector("body").classList.contains("modal-open")) {
+            loaderContainer.classList.add("prevent-spinner");
+        }
         loaderContainer.appendChild(loader);
         return loaderContainer;
     },

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2546,6 +2546,9 @@ we-button:hover .o_we_shape_animated_label > span {
 }
 
 .o_we_ui_loading {
+    &.prevent-spinner {
+        display: none !important;
+    }
     @include o-position-absolute(0, 0, 0, 0);
     z-index: $o-we-zindex;
     background-color: $o-we-sidebar-content-backdrop-bg;


### PR DESCRIPTION
*: web_editor
This ensures that the loading spinner does not appear when a dialog box is open in the web editor. Additionally, appropriate checks have been implemented to manage scenarios where multiple modals are opened.

task-3557520