### PR TITLE
[FIX] website: fix traceback on theme menu after adding a Google font

### DIFF
--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -224,7 +224,7 @@ const FontFamilyPickerUserValueWidget = SelectUserValueWidget.extend({
         if (this.googleLocalFonts.length) {
             const googleLocalFontsEls = fontEls.splice(-this.googleLocalFonts.length);
             googleLocalFontsEls.forEach((el, index) => {
-                $(el).append(renderToElement('website.delete_google_font_btn', {
+                $(el).append(renderToFragment('website.delete_google_font_btn', {
                     index: index,
                     local: true,
                 }));
@@ -234,7 +234,7 @@ const FontFamilyPickerUserValueWidget = SelectUserValueWidget.extend({
         if (this.googleFonts.length) {
             const googleFontsEls = fontEls.splice(-this.googleFonts.length);
             googleFontsEls.forEach((el, index) => {
-                $(el).append(renderToElement('website.delete_google_font_btn', {
+                $(el).append(renderToFragment('website.delete_google_font_btn', {
                     index: index,
                 }));
             });


### PR DESCRIPTION
Since [1], `qweb.render` was replaced in all Odoo by `renderToElement` and `renderToFragment`. However, in the case of the template `website.delete_google_font_btn`, if the font is served from Google, the template contains multiple root elements, which means it should be rendered by `renderToFragment`. This commit fixes that.

Steps to reproduce:
- Install Website.
- Go to website and start edit mode.
- Go to theme menu and open the "Font Family" menu.
- Click on Add custom font.
- Add a Google font (e.g. https://fonts.google.com/specimen/Tilt+Neon).
- Make sure serve from Google is selected.
- Try to open the theme menu again => Traceback

[1]: https://github.com/odoo/odoo/commit/f956e83c744bd9c970d3f16ce1cb3cff8bba2f6b

task-3557794
