### PR TITLE
[MERGE] mail: cleanup mail.message model (shortcode, link)

### DIFF
--- a/addons/mail/controllers/link_preview.py
+++ b/addons/mail/controllers/link_preview.py
@@ -18,8 +18,8 @@ class LinkPreviewController(http.Controller):
         if not message.is_current_user_or_guest_author and not guest.env.user._is_admin():
             return
         if clear:
-            guest.env["mail.link.preview"]._clear_link_previews(message.sudo())
-        guest.env["mail.link.preview"].sudo()._create_link_previews(message)
+            message.sudo().link_preview_ids._unlink_and_notify()
+        guest.env["mail.link.preview"].sudo()._create_from_message_and_notify(message)
 
     @http.route("/mail/link_preview/delete", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
@@ -30,4 +30,4 @@ class LinkPreviewController(http.Controller):
             return
         if not link_preview_sudo.message_id.is_current_user_or_guest_author and not guest.env.user._is_admin():
             return
-        link_preview_sudo._delete_and_notify()
+        link_preview_sudo._unlink_and_notify()

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -178,7 +178,6 @@ class Message(models.Model):
     # as the cache value for this inverse one2many is up-to-date.
     # Besides for new messages, and messages never sending emails, there was no mail, and it was searching for nothing.
     mail_ids = fields.One2many('mail.mail', 'mail_message_id', string='Mails', groups="base.group_system")
-    canned_response_ids = fields.One2many('mail.shortcode', 'message_ids', string="Canned Responses", store=False)
     reaction_ids = fields.One2many('mail.message.reaction', 'message_id', string="Reactions", groups="base.group_system")
 
     @api.depends('body', 'subject')

--- a/addons/mail/models/mail_shortcode.py
+++ b/addons/mail/models/mail_shortcode.py
@@ -19,5 +19,4 @@ class MailShortcode(models.Model):
     substitution = fields.Text('Substitution', required=True,
         help="Content that will automatically replace the shortcut of your choosing. This content can still be adapted before sending your message.")
     description = fields.Char('Description')
-    message_ids = fields.Many2one('mail.message', string="Messages", store=False)
     last_used = fields.Datetime('Last Used', help="Last time this shortcode was used")

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2746,7 +2746,7 @@ class MailThread(models.AbstractModel):
         for values in values_list:
             create_values = dict(values)
             # Avoid warnings about non-existing fields
-            for x in ('from', 'to', 'cc', 'canned_response_ids'):
+            for x in ('from', 'to', 'cc'):
                 create_values.pop(x, None)
             create_values['partner_ids'] = [Command.link(pid) for pid in (create_values.get('partner_ids') or [])]
             create_values_list.append(create_values)

--- a/addons/mail/models/res_company.py
+++ b/addons/mail/models/res_company.py
@@ -36,7 +36,7 @@ class Company(models.Model):
                 company.catchall_email = ''
                 company.catchall_formatted = ''
 
-    @api.depends('partner_id.email_formatted', 'catchall_formatted')
+    @api.depends('partner_id', 'catchall_formatted')
     def _compute_email_formatted(self):
         for company in self:
             if company.partner_id.email_formatted:

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -499,7 +499,6 @@ class TestMessageNotify(TestMessagePostCommon):
 
         for parameters in [
             {'message_type': 'comment'},
-            {'canned_response_ids': []},
             {'child_ids': []},
             {'mail_ids': []},
             {'notification_ids': []},


### PR DESCRIPTION
Remove useless link between message and shortcodes

There is a o2m / m2o link between mail.message and mail.shortcode. However
this link is not used: 'messages' (m2o from shortcode to message) is never
set. Anyway there is no usage of this link: shortcodes are replaced in
message body and that's it.

Improve link preview code
  * remove useless indirections;
  * improve performance of link creation, cleanly support batch-creation;
  * name methods according to ORM;
  * use tools for html empty;

Also cleanup link preview tests: concatenate tests when possible, improve
setup, use real-life scenarios (using 'message_post' notably), remove useless
data creation.

Task-3557985 (Mail: Message cleanup (shortcode, link))
Prepares Task-36879 (Mail: Support MultiCompany Aliases)