### PR TITLE
[FIX] sale{_expense}: delivered quantity with analytic

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -740,9 +740,9 @@ class SaleOrderLine(models.Model):
             so_line = lines_map[so_line_id]
             result.setdefault(so_line_id, 0.0)
             uom = product_uom_map.get(item['product_uom_id'][0])
-            # avoid counting unit_amount twice when dealing with multiple analytic lines on the same move line
-            if item['move_line_id'] == 1 and item['__count'] > 1:
-                qty = item['unit_amount'] / item['__count']
+            # avoid counting unit_amount several times when dealing with multiple analytic lines on the same move line
+            if item['move_line_id'] >= 1 and item['__count'] > 1:
+                qty = item['unit_amount'] / (item['__count'] / item['move_line_id'])
             else:
                 qty = item['unit_amount']
             if so_line.product_uom.category_id == uom.category_id:


### PR DESCRIPTION
[FIX] sale{_expense}: delivered quantity with analytic

When reinvoicing an expense with multiple analytic
accounts, the sale order line's quantity delivered
is wrongly computed

Steps:

- Activate analytic accounting
- Have a product X that can be expensed
- Create a sale order SO for product X, confirm it
- Create an expense with product X, quantity 2, SO
  as "Customer to reinvoice" and 2 other analytic
  accounts
- Approve and post expense entries
- Repeat the 2 last steps
- Go to the sale order
-> the quantity delivered on the expense line
   is set to 12, it should be 4

opw-3513969