### PR TITLE
[REF] web_editor, web: remove latest getBundle usages

### DIFF
--- a/addons/mass_mailing/static/tests/mass_mailing_html_tests.js
+++ b/addons/mass_mailing/static/tests/mass_mailing_html_tests.js
@@ -11,6 +11,8 @@ import {
 } from "@web/../tests/helpers/utils";
 import { assets } from "@web/core/assets";
 import { Wysiwyg } from '@web_editor/js/wysiwyg/wysiwyg';
+import { registry } from "@web/core/registry";
+import { makeFakeHTTPService } from "@web/../tests/helpers/mock_services";
 
 let serverData;
 let fixture;
@@ -45,6 +47,7 @@ QUnit.module('field html', (hooks) => {
         });
         serverData = { models };
         setupViewRegistries();
+        registry.category("services").add("http", makeFakeHTTPService());
 
         patchWithCleanup(Wysiwyg.prototype, {
             async _getColorpickerTemplate() {

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -207,9 +207,6 @@ export const loadJS = function (url) {
 export const loadCSS = function (url) {
     return assets.loadCSS(url);
 };
-export const getBundle = function (bundleName) {
-    return assets.getBundle(bundleName);
-};
 export const loadBundle = function (desc) {
     return assets.loadBundle(desc);
 };

--- a/addons/web/static/tests/setup.js
+++ b/addons/web/static/tests/setup.js
@@ -286,15 +286,8 @@ function removeUnwantedAttrsFromTemplates(attrs) {
 }
 
 function patchAssets() {
-    const { getBundle, loadJS, loadCSS } = assets;
+    const { loadJS, loadCSS } = assets;
     patch(assets, {
-        getBundle: memoize(async function (xmlID) {
-            console.log(
-                "%c[assets] fetch libs from xmlID: " + xmlID,
-                "color: #66e; font-weight: bold;"
-            );
-            return getBundle(xmlID);
-        }),
         loadJS: memoize(async function (ressource) {
             if (ressource.match(/\/static(\/\S+\/|\/)libs?/)) {
                 console.log(

--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -15,6 +15,7 @@ Odoo Web Editor widget.
         'data/editor_assets.xml',
         'views/editor.xml',
         'views/snippets.xml',
+        'views/wysiwyg_iframe_content.xml',
     ],
     'assets': {
 

--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -762,3 +762,22 @@ class Web_Editor(http.Controller):
     @http.route('/web_editor/tests', type='http', auth="user")
     def test_suite(self, mod=None, **kwargs):
         return request.render('web_editor.tests')
+
+    @http.route("/web_editor/wysiwyg_iframe", type='http', auth='none')
+    def get_wysiwyg_iframe_content(self, bundleNames, onUpdateIframeId, avoidDoubleLoad, content="", readonly=0):
+        bundles = bundleNames.split(",")
+        files = []
+        for bundle in bundles:
+            files += request.env["ir.qweb"]._get_asset_nodes(bundle, js=True, css=True, debug=request.session.debug)
+        jsLibs = [file[1] for file in files if file[0] == "script"]
+        cssLibs = [file[1] for file in files if file[0] == "link"]
+        return request.render(
+            "web_editor.wysiwyg_iframe_content",
+            {
+                'readonly':readonly,
+                'content':content,
+                'jsLibs':jsLibs,
+                'cssLibs':cssLibs,
+                'windowTop':"window.top." + onUpdateIframeId + "?.(" + avoidDoubleLoad + ");"
+            },
+        )

--- a/addons/web_editor/static/tests/html_field_tests.js
+++ b/addons/web_editor/static/tests/html_field_tests.js
@@ -10,6 +10,8 @@ import { onRendered } from "@odoo/owl";
 import { wysiwygData } from "@web_editor/../tests/test_utils";
 import { OdooEditor } from '@web_editor/js/editor/odoo-editor/src/OdooEditor';
 import { Wysiwyg } from "@web_editor/js/wysiwyg/wysiwyg";
+import { registry } from "@web/core/registry";
+import { makeFakeHTTPService } from "@web/../tests/helpers/mock_services";
 
 async function iframeReady(iframe) {
     const iframeLoadPromise = makeDeferred();
@@ -38,7 +40,7 @@ QUnit.module("WebEditor.HtmlField", ({ beforeEach }) => {
             },
         };
         target = getFixture();
-
+        registry.category("services").add("http", makeFakeHTTPService());
         setupViewRegistries();
     });
 

--- a/addons/web_editor/static/tests/test_wysiwyg_collaboration.js
+++ b/addons/web_editor/static/tests/test_wysiwyg_collaboration.js
@@ -10,7 +10,7 @@ import {
 import { Wysiwyg, stripHistoryIds } from '@web_editor/js/wysiwyg/wysiwyg';
 import { Mutex } from '@web/core/utils/concurrency';
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
-import { makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
+import { makeFakeHTTPService, makeFakeNotificationService } from "@web/../tests/helpers/mock_services";
 import { mount, getFixture } from "@web/../tests/helpers/utils";
 import { registry } from "@web/core/registry";
 
@@ -180,6 +180,9 @@ async function createPeers(peers) {
         registry.category("services").add("popover", { start: () => ({  }) }, {
             force: true,
         });
+        registry.category("services").add("http", makeFakeHTTPService(), {
+            force: true,
+        })
         const env = await makeTestEnv({
             mockRPC(route) {
                 if (route === "/web/dataset/call_kw/res.users/read") {

--- a/addons/web_editor/views/wysiwyg_iframe_content.xml
+++ b/addons/web_editor/views/wysiwyg_iframe_content.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="web_editor.wysiwyg_iframe_content">
+        <html>
+            <head>
+                <meta charset="utf-8" />
+                <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+                <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
+                <t t-foreach="jsLibs" t-as="item">
+                    <script type="text/javascript" t-att-src="item['src']"></script>
+                </t>
+                <t t-foreach="cssLibs" t-as="item">
+                    <link type="text/css" rel="stylesheet" t-att-href="item['href']"></link>
+                </t>
+                <t t-if="not readonly">
+                    <script type="text/javascript">
+                        odoo.define('root.widget', ['@web/legacy/js/core/widget'], function (require) {
+                            'use strict';
+                            var Widget = require('@web/legacy/js/core/widget')[Symbol.for("default")];
+                            var widget = new Widget();
+                            widget.appendTo(document.body);
+                            return widget;
+                        });
+                    </script>
+                </t>
+            </head>
+            <body 
+                t-att-class="readonly and 'o_in_iframe o_readonly' or 'o_in_iframe'" 
+                t-att-style="readonly and 'overflow: hidden;' or ''">
+                <div id="iframe_target">
+                    <t t-if="readonly" t-esc="content"></t>
+                </div>
+                <script type="text/javascript">
+                    odoo.define('web_editor.wysiwyg.iniframe', [], function (require) {
+                        'use strict';
+                        <t t-esc="windowTop"/>
+                    });
+                </script>
+            </body>
+        </html>
+    </template>
+</odoo>


### PR DESCRIPTION
In this commit, we remove three usages of the getBundle function from @web/core/assets.js. The final goal is to remove it totally to simplify the understanding of assets's API. To replace the use of getBundle in wysiwyg web editor, an xml template has been created on the server side and then called by http requests. During the request, we retrieve the list of assets (server side getbundle) to inject these into the xml template.

taskId : 3266441
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
