### PR TITLE
[FIX] web_editor: make higher pillow version support

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -93,7 +93,9 @@ class Web_Editor(http.Controller):
         image = Image.new("RGBA", (width, height), color)
         draw = ImageDraw.Draw(image)
 
-        boxw, boxh = draw.textsize(icon, font=font_obj)
+        box = draw.textbbox((0, 0), icon, font=font_obj)
+        boxw = box[2] - box[0]
+        boxh = box[3] - box[1]
         draw.text((0, 0), icon, font=font_obj)
         left, top, right, bottom = image.getbbox()
 


### PR DESCRIPTION
Before this PR:
We used the .textsize method, which returned the height and width of the icon.
However, in the latest version of Pillow, this method was deprecated, resulting 
in errors in the log.

After this PR:
We have transitioned to using the textbbox method, which returns the coordinates
of the top, left, bottom, and right of the text's bounding box. From these coordinates,
we calculate the height and width of the text.

task-3502373
