### PR TITLE
[IMP] sql_db: postpone connection borrow

### DIFF
--- a/addons/hr_holidays/populate/hr_leave.py
+++ b/addons/hr_holidays/populate/hr_leave.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import datetime
-import random
 
 from odoo import models
 from odoo.tools import populate
@@ -55,7 +54,7 @@ class HolidaysRequest(models.Model):
                 + relativedelta(days=int(3 * int(counter)))
             return date_from
 
-        def compute_date_to(counter, **kwargs):
+        def compute_date_to(counter, random=None, **kwargs):
             date_to = datetime.datetime.now().replace(hour=23, minute=59, second=59)\
                 + relativedelta(days=int(3 * int(counter))  + random.randint(0, 2))
             return date_to


### PR DESCRIPTION
The main idea behind this pr is that we don't actually need to borrow the connection when instantiating a Cursor

```
with registry(dbname).cursor() as cr:
    if not_in_cache:
        cr.execute(...)
```

The current behavior is that the cursor will borrow a connection on the first line, when we only need it on the third line, if executed.

The proposed solution will make the _cnx and _obj lazy, postponed to when we need it. This means that if for some reason, no execute is done, the connection won't be borrowed.

The main motivation is to be able to access ormcached method with a specific cursor, without opening a connection if the value is in cache, mainly for routing maps in the context of read-only requests (we need the routing map to define if the route is readonly).


This is a poc that may need some tweak and tests regarding commit/close corner cases. We don't want to open a connection just to close it, close operation or reuse when closed operation should work the same way if cursor was used or not. 