### PR TITLE
[FIX] website: adapt `.offcanvas` colors

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -124,9 +124,6 @@ li > p {
 .input-group {
     flex-flow: row nowrap;
 }
-.list-group-item:not([class*="list-group-item-"]):not(.active) {
-    color: color-contrast($list-group-bg);
-}
 
 %o-portal-breadcrumbs {
     background-color: inherit;

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -364,3 +364,23 @@ $pagination-padding-x-lg: $pagination-padding-x !default;
 
 $pagination-border-radius-lg: $pagination-border-radius !default;
 $pagination-border-radius-sm: $pagination-border-radius !default;
+
+// Offcanvas
+$offcanvas-bg-color: $body-bg !default;
+$offcanvas-color: $body-color !default;
+
+// Button close
+$btn-close-color: $body-color !default;
+
+// List group
+$list-group-bg: $body-bg !default;
+$list-group-color: $body-color !default;
+$list-group-border-color: $border-color !default;
+
+$list-group-hover-bg: rgba($body-color, 0.1) !default;
+
+$list-group-disabled-color: rgba($body-color, 0.6) !default;
+
+$list-group-action-color: $body-color !default;
+
+$list-group-action-active-bg: rgba($body-color, 0.15) !default;

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -327,11 +327,18 @@ $-seen-urls: ();
         --HeaderSeparator-bg-color: #{rgba($navbar-dark-active-color, .15)};
 
         @extend .navbar-dark;
+    }
 
-        .btn-close {
+    .btn-close {
+        // As $btn-close-color: $body-color, we only need the filter to be active in this case
+        @if (color-contrast($-menu-color) != color-contrast($body-bg)) {
+            // As btn-close icon is an svg, we change it's color via a filter
+            // Note that this filter will invert the color and not always make it white
+            // dark background -> white filter, light background -> black filter
             filter: $btn-close-white-filter;
         }
     }
+
     @include o-add-gradient('menu-gradient');
 }
 


### PR DESCRIPTION
This commit:
- Sets the `background-color` of `.offcanvas` to `$body-bg`as it was
fixed to `white which created color and contrast issue when the
background of the page was changed. (E.g.: When the background of the
page is dark, the text color will change to white. With the fixed white
background, the text is now unreadable)

- Removes the default `white` background on list-groups (it will be
useful if we want to make the frontend dark-mode compatible) and set's
it's color to default `$body-color`

- Overrides the `.btn-close` color that was always black even on dark
background. It's now based on body text color and will adapt depending
on the background color.

task-3559385
part-of-3097005

These changes are an extract from: https://github.com/odoo/odoo/pull/120302

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
