### PR TITLE
[FIX] website_sale: fix the configurator's select's arrow color

### DIFF
--- a/addons/website_sale/static/src/scss/product_configurator.scss
+++ b/addons/website_sale/static/src/scss/product_configurator.scss
@@ -78,7 +78,7 @@ option.css_not_available {
 }
 
 select.form-select.css_attribute_select {
-    background-image: str-replace(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='175' height='100' fill='#{theme-color('primary')}'><polygon points='0,0 100,0 50,50'/></svg>"), "#", "%23") ;
+    background-image: str-replace(url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='175' height='100' fill='#{$input-color}'><polygon points='0,0 100,0 50,50'/></svg>"), "#", "%23") ;
     background-size: 20px;
     background-position: 100% 65%;
     background-repeat: no-repeat;


### PR DESCRIPTION
This commit makes the arrow of `.css_attribute_select` fields in the product configurator modal match the color of the text of the input. This ensures that the arrow is always visible with any input background color

task-3559424
part-of-3097005

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
