### PR TITLE
[FIX] hr_homeworking: fix locale of homeworking day

### DIFF
--- a/addons/hr_homeworking/static/src/calendar/common/calendar_model.js
+++ b/addons/hr_homeworking/static/src/calendar/common/calendar_model.js
@@ -34,7 +34,7 @@ patch(AttendeeCalendarModel.prototype, {
         for (const day of rangeInterval) {
             const startDay = day.s;
             const dayISO = startDay.toISODate();
-            const dayName = startDay.setLocale("us").weekdayLong.toLowerCase();
+            const dayName = startDay.setLocale("en").weekdayLong.toLowerCase();
             if (!(dayISO in events)) {
                 events[dayISO] = {};
             }
@@ -50,7 +50,11 @@ patch(AttendeeCalendarModel.prototype, {
                         }
                     }
                     else {
-                        const {location_type} = res[employeeId][`${dayName}_location_id`];
+                        const locationKeyName = `${dayName}_location_id`;
+                        if (!(locationKeyName in res[employeeId])) {
+                            continue;
+                        }
+                        const {location_type} = res[employeeId][locationKeyName];
                         if (location_type in events[dayISO]) {
                             events[dayISO][location_type].push(this.createHomeworkingEventAt(res[employeeId], startDay, res[employeeId][`${dayName}_location_id`]));
                         } else {


### PR DESCRIPTION
Before this commit, when the locale was not in english, the following traceback was observed:

 ```
Uncaught (in promise) Error: The following error occurred in onWillStart: "res[employeeId][((intermediate value) + "_location_id")] is undefined"
    OwlError owl.js:87
    wrapError owl.js:2604
    onWillStart owl.js:2647
    useModelWithSampleData model.js:165
    setup calendar_controller.js:48
    setup attendee_calendar_controller.js:10
    setup appointment_calendar_controller.js:15
    setup google_calendar_controller.js:11
    setup hr_homeworking_calendar_controller.js:12
    setup microsoft_calendar_controller.js:11

 ```


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
