### PR TITLE
[PERF] sale_stock: speed up _compute_sale_order_ids

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -162,13 +162,15 @@ class StockLot(models.Model):
 
     @api.depends('name')
     def _compute_sale_order_ids(self):
-        sale_orders = defaultdict(lambda: self.env['sale.order'])
-        for move_line in self.env['stock.move.line'].search([('lot_id', 'in', self.ids), ('state', '=', 'done')]):
-            move = move_line.move_id
-            if move.picking_id.location_dest_id.usage == 'customer' and move.sale_line_id.order_id:
-                sale_orders[move_line.lot_id.id] |= move.sale_line_id.order_id
         for lot in self:
-            lot.sale_order_ids = sale_orders[lot.id]
+            stock_moves = self.env['stock.move.line'].search([
+                ('lot_id', '=', lot.id),
+                ('state', '=', 'done')
+            ]).mapped('move_id')
+            stock_moves = stock_moves.filtered(
+                lambda move: move.picking_id.location_dest_id.usage == 'customer' and move.state == 'done'
+            )
+            lot.sale_order_ids = stock_moves.mapped('sale_line_id.order_id')
             lot.sale_order_count = len(lot.sale_order_ids)
 
     def action_view_so(self):


### PR DESCRIPTION

with huge number of move lines linked ot the lot, it's raising an error that thread have been out of time limit.

- Traceback: https://pad.odoo.com/p/YvGo7NMZIQLbHdPifSYd

- Before PR(used by '--limit-time-real 5000'):
```
 field: stock.lot.sale_order_count
===========> stock.lot(120,) 13473
Finished In:0:01:29.305642 for sale_count
```

- After PR:
```
 field: stock.lot.sale_order_count
===========> stock.lot(120,) 13473
Finished In:0:00:10.713359 for sale_count
```

- Actually database is loaded with huge data linked to the lot:
```
1152357_org_16.0=> with lot_count AS(
select lot.id id, count(sml.id) count from stock_move_line sml join stock_lot lot on sml.lot_id = lot.id where state='done' group by lot.id)
select count(id) from lot_count where count > 50000;
 count
-------
    31
(1 row)
```

- UPG-1152357
- OPW-3519422


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
