### PR TITLE
[FIX] stock: removed duplicate field from scrap wizard

### DIFF
--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -52,7 +52,7 @@ class StockScrap(models.Model):
         ('done', 'Done')],
         string='Status', default="draft", readonly=True, tracking=True)
     date_done = fields.Datetime('Date', readonly=True)
-    should_replenish = fields.Boolean(string='Replenish Quantities')
+    should_replenish = fields.Boolean(string='Replenish Scrapped Quantities')
 
     @api.depends('product_id')
     def _compute_product_uom_id(self):

--- a/addons/stock/views/stock_scrap_views.xml
+++ b/addons/stock/views/stock_scrap_views.xml
@@ -171,7 +171,6 @@
                                 <field name="product_uom_category_id" invisible="1"/>
                                 <field name="product_uom_id" readonly="tracking == 'serial'" groups="uom.group_uom"/>
                             </div>
-                            <field name="should_replenish"/>
                             <field name="lot_id" groups="stock.group_production_lot"
                                 context="{'default_company_id': company_id, 'default_product_id': product_id}"
                                 invisible="not product_id or tracking == 'none'"


### PR DESCRIPTION
With this commit, a duplicate replenished quantity field in the Scrap Wizard has been removed. Furthermore, the label for that field has been updated from "Replenish quantity" to "Replenish Scrapped Quantities."

Task: 3559195