### PR TITLE
[IMP] spreadsheet: remove default exports

### DIFF
--- a/addons/spreadsheet/static/src/chart/data_source/chart_data_source.js
+++ b/addons/spreadsheet/static/src/chart/data_source/chart_data_source.js
@@ -2,9 +2,9 @@
 
 import { OdooViewsDataSource } from "@spreadsheet/data_sources/odoo_views_data_source";
 import { _t } from "@web/core/l10n/translation";
-import { GraphModel as ChartModel} from "@web/views/graph/graph_model";
+import { GraphModel as ChartModel } from "@web/views/graph/graph_model";
 
-export default class ChartDataSource extends OdooViewsDataSource {
+export class ChartDataSource extends OdooViewsDataSource {
     /**
      * @override
      * @param {Object} services Services (see DataSource)

--- a/addons/spreadsheet/static/src/chart/index.js
+++ b/addons/spreadsheet/static/src/chart/index.js
@@ -9,8 +9,8 @@ chartComponentRegistry.add("odoo_bar", ChartJsComponent);
 chartComponentRegistry.add("odoo_line", ChartJsComponent);
 chartComponentRegistry.add("odoo_pie", ChartJsComponent);
 
-import OdooChartCorePlugin from "./plugins/odoo_chart_core_plugin";
-import ChartOdooMenuPlugin from "./plugins/chart_odoo_menu_plugin";
-import OdooChartUIPlugin from "./plugins/odoo_chart_ui_plugin";
+import { OdooChartCorePlugin } from "./plugins/odoo_chart_core_plugin";
+import { ChartOdooMenuPlugin } from "./plugins/chart_odoo_menu_plugin";
+import { OdooChartUIPlugin } from "./plugins/odoo_chart_ui_plugin";
 
 export { OdooChartCorePlugin, ChartOdooMenuPlugin, OdooChartUIPlugin };

--- a/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
+++ b/addons/spreadsheet/static/src/chart/odoo_chart/odoo_chart.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { AbstractChart, CommandResult } from "@odoo/o-spreadsheet";
-import ChartDataSource from "../data_source/chart_data_source";
+import { ChartDataSource } from "../data_source/chart_data_source";
 
 /**
  * @typedef {import("@web/search/search_model").SearchParams} SearchParams

--- a/addons/spreadsheet/static/src/chart/plugins/chart_odoo_menu_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/chart_odoo_menu_plugin.js
@@ -3,7 +3,7 @@
 import { coreTypes, CorePlugin } from "@odoo/o-spreadsheet";
 
 /** Plugin that link charts with Odoo menus. It can contain either the Id of the odoo menu, or its xml id. */
-export default class ChartOdooMenuPlugin extends CorePlugin {
+export class ChartOdooMenuPlugin extends CorePlugin {
     constructor(config) {
         super(config);
         this.odooMenuReference = {};

--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
@@ -2,7 +2,7 @@
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { checkFilterFieldMatching } from "@spreadsheet/global_filters/helpers";
-import CommandResult from "../../o_spreadsheet/cancelled_reason";
+import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
 import { Domain } from "@web/core/domain";
 
 const { CorePlugin } = spreadsheet;
@@ -14,7 +14,7 @@ const { CorePlugin } = spreadsheet;
  * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").FieldMatching} FieldMatching
  */
 
-export default class OdooChartCorePlugin extends CorePlugin {
+export class OdooChartCorePlugin extends CorePlugin {
     constructor(config) {
         super(config);
 

--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_ui_plugin.js
@@ -3,13 +3,13 @@
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { Domain } from "@web/core/domain";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
-import ChartDataSource from "../data_source/chart_data_source";
+import { ChartDataSource } from "../data_source/chart_data_source";
 import { sprintf } from "@web/core/utils/strings";
 import { _t } from "@web/core/l10n/translation";
 
 const { UIPlugin } = spreadsheet;
 
-export default class OdooChartUIPlugin extends UIPlugin {
+export class OdooChartUIPlugin extends UIPlugin {
     constructor(config) {
         super(config);
         this.dataSources = config.custom.dataSources;

--- a/addons/spreadsheet/static/src/data_sources/server_data.js
+++ b/addons/spreadsheet/static/src/data_sources/server_data.js
@@ -215,7 +215,7 @@ export class ServerData {
 /**
  * Collect multiple requests into a single batch.
  */
-export default class BatchEndpoint {
+export class BatchEndpoint {
     /**
      * @param {object} orm
      * @param {string} resModel

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -3,7 +3,7 @@
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { Domain } from "@web/core/domain";
 
-import CommandResult from "@spreadsheet/o_spreadsheet/cancelled_reason";
+import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 import { RELATIVE_DATE_RANGE_TYPES } from "@spreadsheet/helpers/constants";
 
 /**

--- a/addons/spreadsheet/static/src/global_filters/index.js
+++ b/addons/spreadsheet/static/src/global_filters/index.js
@@ -2,7 +2,7 @@
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
 
-import GlobalFiltersUIPlugin from "./plugins/global_filters_ui_plugin";
+import { GlobalFiltersUIPlugin } from "./plugins/global_filters_ui_plugin";
 import { GlobalFiltersCorePlugin } from "./plugins/global_filters_core_plugin";
 const { inverseCommandRegistry } = spreadsheet.registries;
 

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_core_plugin.js
@@ -24,7 +24,7 @@
 export const globalFiltersFieldMatchers = {};
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
-import CommandResult from "@spreadsheet/o_spreadsheet/cancelled_reason";
+import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 import { checkFiltersTypeValueCombination } from "@spreadsheet/global_filters/helpers";
 import { _t } from "@web/core/l10n/translation";
 import { escapeRegExp } from "@web/core/utils/strings";

--- a/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
+++ b/addons/spreadsheet/static/src/global_filters/plugins/global_filters_ui_plugin.js
@@ -13,7 +13,7 @@ import { Domain } from "@web/core/domain";
 import { constructDateRange, getPeriodOptions, QUARTER_OPTIONS } from "@web/search/utils/dates";
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
-import CommandResult from "@spreadsheet/o_spreadsheet/cancelled_reason";
+import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 
 import { isEmpty } from "@spreadsheet/helpers/helpers";
 import { FILTER_DATE_OPTION } from "@spreadsheet/assets_backend/constants";
@@ -43,7 +43,7 @@ const MONTHS = {
 const { UuidGenerator, createEmptyExcelSheet } = spreadsheet.helpers;
 const uuidGenerator = new UuidGenerator();
 
-export default class GlobalFiltersUIPlugin extends spreadsheet.UIPlugin {
+export class GlobalFiltersUIPlugin extends spreadsheet.UIPlugin {
     constructor(config) {
         super(config);
         this.orm = config.custom.env?.services.orm;

--- a/addons/spreadsheet/static/src/ir_ui_menu/index.js
+++ b/addons/spreadsheet/static/src/ir_ui_menu/index.js
@@ -3,7 +3,7 @@
 import { registry } from "@web/core/registry";
 import * as spreadsheet from "@odoo/o-spreadsheet";
 
-import IrMenuPlugin from "./ir_ui_menu_plugin";
+import { IrMenuPlugin } from "./ir_ui_menu_plugin";
 
 import {
     isMarkdownIrMenuIdUrl,

--- a/addons/spreadsheet/static/src/ir_ui_menu/ir_ui_menu_plugin.js
+++ b/addons/spreadsheet/static/src/ir_ui_menu/ir_ui_menu_plugin.js
@@ -2,7 +2,7 @@
 import * as spreadsheet from "@odoo/o-spreadsheet";
 const { CorePlugin } = spreadsheet;
 
-export default class IrMenuPlugin extends CorePlugin {
+export class IrMenuPlugin extends CorePlugin {
     constructor(config) {
         super(config);
         this.env = config.custom.env;

--- a/addons/spreadsheet/static/src/list/index.js
+++ b/addons/spreadsheet/static/src/list/index.js
@@ -5,8 +5,8 @@ import * as spreadsheet from "@odoo/o-spreadsheet";
 
 import "./list_functions";
 
-import ListCorePlugin from "@spreadsheet/list/plugins/list_core_plugin";
-import ListUIPlugin from "@spreadsheet/list/plugins/list_ui_plugin";
+import { ListCorePlugin } from "@spreadsheet/list/plugins/list_core_plugin";
+import { ListUIPlugin } from "@spreadsheet/list/plugins/list_ui_plugin";
 
 import { SEE_RECORD_LIST, SEE_RECORD_LIST_VISIBLE } from "./list_actions";
 const { inverseCommandRegistry } = spreadsheet.registries;

--- a/addons/spreadsheet/static/src/list/list_data_source.js
+++ b/addons/spreadsheet/static/src/list/list_data_source.js
@@ -31,7 +31,7 @@ const { DEFAULT_LOCALE } = spreadsheet.constants;
  * @property {Object} context
  */
 
-export default class ListDataSource extends OdooViewsDataSource {
+export class ListDataSource extends OdooViewsDataSource {
     /**
      * @override
      * @param {Object} services Services (see DataSource)

--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
-import CommandResult from "../../o_spreadsheet/cancelled_reason";
+import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
 import { getMaxObjectId } from "../../helpers/helpers";
 import { TOP_LEVEL_STYLE } from "../../helpers/constants";
 import { _t } from "@web/core/l10n/translation";
@@ -31,7 +31,7 @@ import { Domain } from "@web/core/domain";
 
 const { CorePlugin } = spreadsheet;
 
-export default class ListCorePlugin extends CorePlugin {
+export class ListCorePlugin extends CorePlugin {
     constructor(config) {
         super(config);
 

--- a/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_ui_plugin.js
@@ -3,7 +3,7 @@
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { getFirstListFunction, getNumberOfListFormulas } from "../list_helpers";
 import { Domain } from "@web/core/domain";
-import ListDataSource from "../list_data_source";
+import { ListDataSource } from "../list_data_source";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 
 const { astToFormula } = spreadsheet;
@@ -12,7 +12,7 @@ const { astToFormula } = spreadsheet;
  * @typedef {import("./list_core_plugin").SpreadsheetList} SpreadsheetList
  */
 
-export default class ListUIPlugin extends spreadsheet.UIPlugin {
+export class ListUIPlugin extends spreadsheet.UIPlugin {
     constructor(config) {
         super(config);
         /** @type {string} */

--- a/addons/spreadsheet/static/src/o_spreadsheet/cancelled_reason.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/cancelled_reason.js
@@ -1,6 +1,6 @@
 /** @odoo-module */
 
-export default {
+export const CommandResult = {
     Success: "Success", // should be imported from o-spreadsheet instead of redefined here
     FilterNotFound: "FilterNotFound",
     InvalidFilterMove: "InvalidFilterMove",

--- a/addons/spreadsheet/static/src/o_spreadsheet/migration.js
+++ b/addons/spreadsheet/static/src/o_spreadsheet/migration.js
@@ -237,7 +237,7 @@ function migrate5to6(data) {
     return data;
 }
 
-export default class OdooVersion extends CorePlugin {
+export class OdooVersion extends CorePlugin {
     export(data) {
         data.odooVersion = ODOO_VERSION;
     }

--- a/addons/spreadsheet/static/src/pivot/index.js
+++ b/addons/spreadsheet/static/src/pivot/index.js
@@ -3,8 +3,8 @@ import { _t } from "@web/core/l10n/translation";
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
 
-import PivotCorePlugin from "./plugins/pivot_core_plugin";
-import PivotUIPlugin from "./plugins/pivot_ui_plugin";
+import { PivotCorePlugin } from "./plugins/pivot_core_plugin";
+import { PivotUIPlugin } from "./plugins/pivot_ui_plugin";
 
 import { SEE_RECORDS_PIVOT, SEE_RECORDS_PIVOT_VISIBLE } from "./pivot_actions";
 

--- a/addons/spreadsheet/static/src/pivot/pivot_data_source.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_data_source.js
@@ -4,7 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import { OdooViewsDataSource } from "../data_sources/odoo_views_data_source";
 import { SpreadsheetPivotModel } from "./pivot_model";
 
-export default class PivotDataSource extends OdooViewsDataSource {
+export class PivotDataSource extends OdooViewsDataSource {
     /**
      *
      * @override

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_plugin.js
@@ -27,7 +27,7 @@ import { CorePlugin, helpers } from "@odoo/o-spreadsheet";
 import { makePivotFormula } from "../pivot_helpers";
 import { getMaxObjectId } from "@spreadsheet/helpers/helpers";
 import { SpreadsheetPivotTable } from "../pivot_table";
-import CommandResult from "../../o_spreadsheet/cancelled_reason";
+import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
 import { _t } from "@web/core/l10n/translation";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
 import { sprintf } from "@web/core/utils/strings";
@@ -36,7 +36,7 @@ import { Domain } from "@web/core/domain";
 
 const { isDefined } = helpers;
 
-export default class PivotCorePlugin extends CorePlugin {
+export class PivotCorePlugin extends CorePlugin {
     constructor(config) {
         super(config);
 

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -7,7 +7,7 @@ import { FILTER_DATE_OPTION, monthsOptions } from "@spreadsheet/assets_backend/c
 import { Domain } from "@web/core/domain";
 import { NO_RECORD_AT_THIS_POSITION } from "../pivot_model";
 import { globalFiltersFieldMatchers } from "@spreadsheet/global_filters/plugins/global_filters_core_plugin";
-import PivotDataSource from "../pivot_data_source";
+import { PivotDataSource } from "../pivot_data_source";
 
 const { astToFormula } = spreadsheet;
 const { DateTime } = luxon;
@@ -49,7 +49,7 @@ function pivotPeriodToFilterValue(timeRange, value) {
     }
 }
 
-export default class PivotUIPlugin extends spreadsheet.UIPlugin {
+export class PivotUIPlugin extends spreadsheet.UIPlugin {
     constructor(config) {
         super(config);
         /** @type {string} */

--- a/addons/spreadsheet/static/tests/data_fetching/server_data_test.js
+++ b/addons/spreadsheet/static/tests/data_fetching/server_data_test.js
@@ -2,7 +2,7 @@
 
 import { nextTick } from "@web/../tests/helpers/utils";
 import { LoadingDataError } from "@spreadsheet/o_spreadsheet/errors";
-import BatchEndpoint, { Request, ServerData } from "@spreadsheet/data_sources/server_data";
+import { BatchEndpoint, Request, ServerData } from "@spreadsheet/data_sources/server_data";
 
 QUnit.module("spreadsheet server data", {}, () => {
     QUnit.test("simple synchronous get", async (assert) => {

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { nextTick, patchDate } from "@web/../tests/helpers/utils";
-import CommandResult from "@spreadsheet/o_spreadsheet/cancelled_reason";
+import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 import { Model, DispatchResult } from "@odoo/o-spreadsheet";
 import {
     createModelWithDataSource,
@@ -41,7 +41,7 @@ import {
     assertDateDomainEqual,
     getDateDomainDurationInDays,
 } from "@spreadsheet/../tests/utils/date_domain";
-import GlobalFiltersUIPlugin from "@spreadsheet/global_filters/plugins/global_filters_ui_plugin";
+import { GlobalFiltersUIPlugin } from "@spreadsheet/global_filters/plugins/global_filters_ui_plugin";
 import { migrate } from "@spreadsheet/o_spreadsheet/migration";
 const { DateTime } = luxon;
 
@@ -233,11 +233,10 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
     );
     QUnit.test("Can save a value to an existing global filter", async function (assert) {
         const { model } = await createSpreadsheetWithPivotAndList();
-        await addGlobalFilter(
-            model,
-            LAST_YEAR_GLOBAL_FILTER,
-            { pivot: DEFAULT_FIELD_MATCHINGS, list: DEFAULT_FIELD_MATCHINGS }
-        );
+        await addGlobalFilter(model, LAST_YEAR_GLOBAL_FILTER, {
+            pivot: DEFAULT_FIELD_MATCHINGS,
+            list: DEFAULT_FIELD_MATCHINGS,
+        });
         const gf = model.getters.getGlobalFilters()[0];
         let result = await setGlobalFilterValue(model, {
             id: gf.id,
@@ -1392,7 +1391,7 @@ QUnit.module("spreadsheet > Global filters model", {}, () => {
                     type: "date",
                     label: "date filter 1",
                     rangeType: "fixedPeriod",
-                    defaultValue: "this_month"
+                    defaultValue: "this_month",
                 },
                 {
                     pivot: { 1: { chain: "date", type: "date" } },

--- a/addons/spreadsheet/static/tests/lists/list_plugin_test.js
+++ b/addons/spreadsheet/static/tests/lists/list_plugin_test.js
@@ -4,7 +4,7 @@ import { session } from "@web/session";
 import { nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 import { makeServerError } from "@web/../tests/helpers/mock_server";
 
-import CommandResult from "@spreadsheet/o_spreadsheet/cancelled_reason";
+import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 import { createModelWithDataSource, waitForDataSourcesLoaded } from "../utils/model";
 import { addGlobalFilter, selectCell, setCellContent } from "../utils/commands";
 import {

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
@@ -10,7 +10,7 @@ import {
 } from "@spreadsheet/../tests/utils/getters";
 import { createSpreadsheetWithPivot } from "@spreadsheet/../tests/utils/pivot";
 import { getBasicPivotArch } from "@spreadsheet/../tests/utils/data";
-import CommandResult from "@spreadsheet/o_spreadsheet/cancelled_reason";
+import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 import { addGlobalFilter, setCellContent } from "@spreadsheet/../tests/utils/commands";
 import {
     createModelWithDataSource,

--- a/addons/spreadsheet/static/tests/utils/pivot.js
+++ b/addons/spreadsheet/static/tests/utils/pivot.js
@@ -3,7 +3,7 @@
 import { PivotArchParser } from "@web/views/pivot/pivot_arch_parser";
 import { nextTick } from "@web/../tests/helpers/utils";
 
-import PivotDataSource from "@spreadsheet/pivot/pivot_data_source";
+import { PivotDataSource } from "@spreadsheet/pivot/pivot_data_source";
 import { getBasicServerData } from "./data";
 import { createModelWithDataSource, waitForDataSourcesLoaded } from "./model";
 

--- a/addons/spreadsheet_account/static/src/index.js
+++ b/addons/spreadsheet_account/static/src/index.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import * as spreadsheet from "@odoo/o-spreadsheet";
-import AccountingPlugin from "./plugins/accounting_plugin";
+import { AccountingPlugin } from "./plugins/accounting_plugin";
 import { getFirstAccountFunction, getNumberOfAccountFormulas } from "./utils";
 import { parseAccountingDate } from "./accounting_functions";
 import { camelToSnakeObject } from "@spreadsheet/helpers/helpers";

--- a/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
+++ b/addons/spreadsheet_account/static/src/plugins/accounting_plugin.js
@@ -8,7 +8,7 @@ const DATA_SOURCE_ID = "ACCOUNTING_AGGREGATES";
  * @typedef {import("../accounting_functions").DateRange} DateRange
  */
 
-export default class AccountingPlugin extends spreadsheet.UIPlugin {
+export class AccountingPlugin extends spreadsheet.UIPlugin {
     constructor(config) {
         super(config);
         this.dataSources = config.custom.dataSources;


### PR DESCRIPTION
This commit removes the default exports from the spreadsheet module. They don't bring anything except confusion when importing a mix of default and named exports.

Task: [3559536](https://www.odoo.com/web#id=3559536&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
