### PR TITLE
[IMP] pos_self_order: layout enhancement

### DIFF
--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.xml
@@ -9,33 +9,31 @@
                         <div class="row g-2 g-md-3 g-xl-4 justify-content-between justify-content-md-start row-cols-2 row-cols-sm-3 row-cols-md-4 row-cols-xl-5 row-cols-xxl-6 mb-5">
                             <t t-foreach="availableAttributeValue(attribute)" t-as="value" t-key="value.id">
                                 <div class="col">
-                                    <div class="self_order_attribute_selection_option ratio ratio-16x9 w-100">
-                                        <label t-attf-for="{{ attribute.id }}_{{ value.id }}"
-                                                t-attf-class="{{ this.isChecked(attribute, value) ? 'text-bg-primary border-primary active' : '' }}
-                                                d-flex flex-column align-items-center justify-content-center rounded border">
-                                            <div class="name position-relative d-flex flex-column justify-content-center align-items-center flex-grow-1 w-100 py-2 text-center">
-                                                <span t-out="value.name"/>
-                                                <span t-if="value.price_extra.list_price">
-                                                    + <t t-out="selfOrder.formatMonetary(value.price_extra.list_price)" />
-                                                </span>
-                                            </div>
-                                        </label>
-                                        <input
-                                            type="radio"
-                                            class="d-none"
-                                            t-if="attribute.display_type !== 'multi'"
-                                            t-att-value="value.id"
-                                            t-attf-id="{{ attribute.id }}_{{ value.id }}"
-                                            t-model="this.selectedValues[attribute.id]" />
-                                        <input
-                                            type="checkbox"
-                                            class="d-none"
-                                            t-else=""
-                                            t-att-checked="this.isChecked(attribute, value)"
-                                            t-att-value="value.id"
-                                            t-model="this.selectedValues[attribute.id][value.id]"
-                                            t-attf-id="{{ attribute.id }}_{{ value.id }}" />
-                                    </div>
+                                    <label t-attf-for="{{ attribute.id }}_{{ value.id }}"
+                                            t-attf-class="self_order_attribute_selection_option {{ this.isChecked(attribute, value) ? 'text-bg-primary border-primary active' : '' }}
+                                            d-flex align-items-center justify-content-center h-100 rounded border ratio ratio-16x9">
+                                        <div class="name position-relative d-flex flex-column justify-content-center align-items-center flex-grow-1 w-100 p-4 text-center">
+                                            <span t-out="value.name"/>
+                                            <span t-if="value.price_extra.list_price">
+                                                + <t t-out="selfOrder.formatMonetary(value.price_extra.list_price)" />
+                                            </span>
+                                        </div>
+                                    </label>
+                                    <input
+                                        type="radio" 
+                                        class="d-none"
+                                        t-if="attribute.display_type !== 'multi'"
+                                        t-att-value="value.id"
+                                        t-attf-id="{{ attribute.id }}_{{ value.id }}"
+                                        t-model="this.selectedValues[attribute.id]" />
+                                    <input
+                                        type="checkbox"
+                                        class="d-none"
+                                        t-else=""
+                                        t-att-checked="this.isChecked(attribute, value)"
+                                        t-att-value="value.id"
+                                        t-model="this.selectedValues[attribute.id][value.id]"
+                                        t-attf-id="{{ attribute.id }}_{{ value.id }}" />
                                 </div>
                                 <div t-if="this.isChecked(attribute, value) and selfOrder.attributeValueById[value.id].is_custom" class="col w-100 order-2">
                                     <input type="text" t-model="this.env.customValues[value.id].custom_value" class="form-control form-control-lg" placeholder="Enter your custom value" />

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.xml
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.xml
@@ -10,12 +10,12 @@
                 <span class="px-1"/><!-- Spacer -->
             </button>
             <button t-attf-class="btn btn-secondary btn-lg d-none d-sm-inline text-nowrap" t-on-click="onClickleftButton" t-esc="leftButton.name" />
-            <div class="d-flex align-items-center flex-grow-1 w-100 w-md-auto">
+            <div class="d-flex align-items-center justify-content-end flex-grow-1 w-100 w-md-auto">
                 <div class="to-order">
-                    <span>To Order</span>
+                    <span>Your Order</span>
                     <div class="d-flex align-items-center">
                         <span class="o-so-tabular-nums badge text-bg-secondary rounded" t-esc="lineNotSend.count"/>
-                        <span class="o-so-tabular-nums mx-2" t-if="selfOrder.currentOrder.lines.length" t-esc="selfOrder.formatMonetary(lineNotSend.price)" />
+                        <span class="o-so-tabular-nums mx-2" t-esc="selfOrder.formatMonetary(lineNotSend.price)" />
                     </div>
                 </div>
             </div>

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -7,7 +7,7 @@
             </div>
             <div class="order-content flex-grow-1 overflow-auto pb-4">
                 <t t-foreach="linesToDisplay" t-as="line" t-key="line.uuid">
-                    <div t-if="!line.combo_parent_uuid" class="gap-3 py-3 py-lg-4 px-3 bg-view border-bottom">
+                    <div t-if="!line.combo_parent_uuid" class="py-2 py-lg-4 px-3 bg-view border-bottom">
                         <t t-set="childLines" t-value="getChildLines(line)"/>
                         <t t-set="product" t-value="this.selfOrder.productByIds[line.product_id]"/>
 
@@ -54,7 +54,7 @@
                             </div>
                         </div>
 
-                        <div class="product-controllers d-flex flex-wrap flex-grow-1 align-items-center justify-content-between mt-3">
+                        <div class="product-controllers d-flex flex-wrap flex-grow-1 align-items-center justify-content-between mt-2">
                             <div>
                                 <div t-if="!selfOrder.currentOrder.isSavedOnServer" class="btn-group">
                                     <button
@@ -82,7 +82,7 @@
             </div>
         </div>
         <div class="order-price d-flex-column flex-grow-0">
-            <div class="absolute-content-price d-flex flex-column flex-grow-0 justify-content-center p-3 border-top bg-view text-end lh-sm">
+            <div class="absolute-content-price d-flex flex-column flex-grow-0 justify-content-center py-2 py-lg-3 px-3 border-bottom border-top bg-view text-end lh-sm">
                 <p class="o-so-tabular-nums mb-0 fw-bolder">Total: <t t-esc="selfOrder.formatMonetary(selfOrder.currentOrder.amount_total)" /></p>
                 <p class="o-so-tabular-nums mb-0 text-muted">Taxes: <t t-esc="selfOrder.formatMonetary(selfOrder.currentOrder.amount_tax)" /></p>
             </div>

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -62,12 +62,12 @@
                     t-attf-id="scrollspy_{{category.id}}"
                     t-attf-categId="{{category.id}}"
                     t-ref="productsWithCategory_{{category.id}}"
-                    class="product-list-category d-empty-none bg-view py-4 px-3 mb-3">
+                    class="product-list-category d-empty-none bg-view px-3 pb-4">
                     <t t-set="products" t-value="selfOrder.productsGroupedByCategory[category.id]" />
                     <t t-set="availableProducts" t-value="!state.searchInput ? products : getFilteredProducts(products)" />
                     <t t-set="nbrItem" t-value="availableProducts.length + nbrItem" />
                     <t t-if="availableProducts.length > 0">
-                        <h2 t-esc="category.name" class="mb-4 display-6 fw-bold"/>
+                        <h2 t-esc="category.name" class="pt-4 pb-2 px-3 mb-4 mx-n3 bg-200 display-6 fw-bold"/>
                         <div class="o-so-products-row">
                             <t t-foreach="availableProducts" t-as="product" t-key="product.id">
                                 <ProductCard product="product" currentProductCard="product.id === selfOrder.lastEditedProductId and currentProductCard"/>


### PR DESCRIPTION
In this commit, we improved a few UI elements across pages.

task-3557715

<h2>Changes</h2>

<h4>Product List Page</h4>
<p>Moved the category title to a gray section for clearer spacing and strengthened the association between category names and respective products.</p>

![image](https://github.com/odoo/odoo/assets/80678921/6af64046-c1b8-4e7b-b4b2-e44b7c2fa868)

<h4>Product Variant Page</h4>
<p>Fixed an issue where long variant text would overlap with other variants and thus we adjusted the height of variants based on the tallest content in the row. All variants on the same row are now consistently sized.</p>

![image](https://github.com/odoo/odoo/assets/80678921/a3e29c24-88e4-4262-a16e-e7e79b650616)

<h4>Cart Page</h4>
<p>Condensed product lines for better mobile viewing and to reduce the need for excessive vertical scrolling.</p>

![image](https://github.com/odoo/odoo/assets/80678921/0901e2f1-42d3-4af1-b02a-95d2d57d23f1)

<h4>Footer:</h4>
<p>We renamed a few strings and move the order total to the right, also cart now displays 0.00 even when empty</p>

![image](https://github.com/odoo/odoo/assets/80678921/1422a661-82cc-40b8-83ce-a36a7acb6cbb)

task-3557715

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
