### PR TITLE
[FIX] hr, mail: no crash on empty member.persona 

### DIFF
--- a/addons/hr/static/src/core/web/thread_actions.js
+++ b/addons/hr/static/src/core/web/thread_actions.js
@@ -26,7 +26,6 @@ threadActionsRegistry.add("open-hr-profile", {
     async setup(action) {
         const component = useComponent();
         const orm = useService("orm");
-        const store = useService("mail.store");
         let employeeId;
         if (!component.thread?.correspondent?.employeeId && component.thread?.chatPartner) {
             const employees = await orm.silent.searchRead(
@@ -35,12 +34,9 @@ threadActionsRegistry.add("open-hr-profile", {
                 ["id"]
             );
             employeeId = employees[0]?.id;
-        }
-        if (employeeId) {
-            store.Persona.insert({
-                ...component.thread.correspondent,
-                employeeId,
-            });
+            if (employeeId) {
+                component.thread.chatPartner.employeeId = employeeId;
+            }
         }
     },
     sequence: 16,

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -194,6 +194,8 @@ export const storeService = {
                                                         l1.add(item);
                                                     } else if (cmd === "ADD.noinv") {
                                                         l1.__addNoinv(item);
+                                                    } else if (cmd === "DELETE.noinv") {
+                                                        l1.__deleteNoinv(item);
                                                     } else {
                                                         l1.delete(item);
                                                     }
@@ -203,6 +205,8 @@ export const storeService = {
                                                     l1.add(cmdData);
                                                 } else if (cmd === "ADD.noinv") {
                                                     l1.__addNoinv(cmdData);
+                                                } else if (cmd === "DELETE.noinv") {
+                                                    l1.__deleteNoinv(cmdData);
                                                 } else {
                                                     l1.delete(cmdData);
                                                 }
@@ -226,22 +230,25 @@ export const storeService = {
                                     l1.clear();
                                     l1.push(...collection);
                                 } else {
-                                    let isAddNoinv = false;
                                     // [Record.one] =
                                     if (Record.isCommand(val)) {
                                         const [cmd, cmdData] = val.at(-1);
-                                        isAddNoinv = cmd === "ADD.noinv";
-                                        val = ["ADD", "ADD.noinv"].includes(cmd) ? cmdData : null;
+                                        if (cmd === "ADD") {
+                                            l1.add(cmdData);
+                                        } else if (cmd === "ADD.noinv") {
+                                            l1.__addNoinv(cmdData);
+                                        } else if (cmd === "DELETE.noinv") {
+                                            l1.__deleteNoinv(cmdData);
+                                        } else {
+                                            l1.delete(cmdData);
+                                        }
+                                        return true;
                                     }
                                     if ([null, false, undefined].includes(val)) {
                                         delete receiver[name];
                                         return true;
                                     }
-                                    if (isAddNoinv) {
-                                        l1.__addNoinv(val);
-                                    } else {
-                                        l1.add(val);
-                                    }
+                                    l1.add(val);
                                 }
                                 return true;
                             },
@@ -262,7 +269,7 @@ export const storeService = {
                                 newVal.__store__ = res.store;
                             }
                             newVal.name = name;
-                            newVal.owner = this;
+                            newVal.owner = proxy;
                             this.__rels__.set(name, newVal);
                             this.__invs__ = new RecordInverses();
                             this[name] = newVal;

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -227,8 +227,11 @@ export const storeService = {
                                     for (const r2 of oldRecords) {
                                         r2.__invs__.delete(r1.localId, name);
                                     }
+                                    // l1 and collection could be same record list,
+                                    // save before clear to not push mutated recordlist that is empty
+                                    const col = [...collection];
                                     l1.clear();
-                                    l1.push(...collection);
+                                    l1.push(...col);
                                 } else {
                                     // [Record.one] =
                                     if (Record.isCommand(val)) {


### PR DESCRIPTION
Steps to reproduce:
- install `hr_homeworking`
- connect as Mitchell Admin
- make a private chat with Marc Demo
- `@mention` Marc Demo
=> crash (cannot read name of undefined (reading persona))

This happens because a spread record was inserted in model,
and in this scenario the record list in data can be the exact same
as the record list used in the model. The internal code of assigning
a many list is to `clear()` and then `push()` from data, but if the
data mutates from the `clear()`, then the `push()` does nothing and
the resulting relation is emptied.

This commit fixes the issue by keeping a copy of collection before
`clear()` so that push applies on original data that is intended by
insert.

This commit also adapt code in hr to not use spread record to insert
Persona. While it works with the fix, it's simpler to just update the
appropriate field and also more efficient, because spread a record
has to process all fields as an insert, wasting CPU time.