### PR TITLE
[IMP] account: set to draft CABA and Exchange Differential entries

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3985,9 +3985,9 @@ class AccountMove(models.Model):
             exchange_move_ids = set([row[0] for row in self._cr.fetchall()])
 
         for move in self:
-            if move.id in exchange_move_ids:
+            if not self._context.get("force_draft_in_fx_and_caba_entries") and move.id in exchange_move_ids:
                 raise UserError(_('You cannot reset to draft an exchange difference journal entry.'))
-            if move.tax_cash_basis_rec_id or move.tax_cash_basis_origin_move_id:
+            if not self._context.get("force_draft_in_fx_and_caba_entries") and (move.tax_cash_basis_rec_id or move.tax_cash_basis_origin_move_id):
                 # If the reconciliation was undone, move.tax_cash_basis_rec_id will be empty;
                 # but we still don't want to allow setting the caba entry to draft
                 # (it'll have been reversed automatically, so no manual intervention is required),


### PR DESCRIPTION
Using an attribute in the context to force the change of the state of the accounting entries for CABA and Exchange Differential to "draft." This is to allow the deletion of these entries to facilitate the accounting audit process. As the number of lines in the accounting entries generated by these transactions can grow significantly, this occurs each time a payment that has generated CABA or Exchange Differential entries is canceled or unreconciled, reverse lines are generated for these entries. Setting the posted journal entries to "draft" when canceling by using the button_cancel method was introduced in [1], this not allow to delete the CABA or Exchange Differential entries generated in the unreconcile and reconcile process.

[1] https://github.com/odoo/odoo/commit/1de5c98
Related: https://github.com/odoo/odoo/pull/96134

**Journal entries generated after doing the next:**

1. Confirm a vendor bill
2. Register a payment
3. Unreconcile
4. Reconcile again

![image](https://github.com/odoo/odoo/assets/130611250/753d301b-f212-49f3-8753-40f813b4d856)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
