### PR TITLE
[FIX] point_of_sale: fix traceback when creating combo

### DIFF
--- a/addons/point_of_sale/models/pos_combo.py
+++ b/addons/point_of_sale/models/pos_combo.py
@@ -54,4 +54,4 @@ class PosCombo(models.Model):
     def _compute_base_price(self):
         for rec in self:
             # Use the lowest price of the combo lines as the base price
-            rec.base_price = min(rec.combo_line_ids.mapped("product_id.lst_price"))
+            rec.base_price = min(rec.combo_line_ids.mapped("product_id.lst_price")) if rec.combo_line_ids else 0


### PR DESCRIPTION
Previously, when you wanted to create a combo from a product form, a traceback was raised because you were trying to calculate the minimum price of non-existent combo_line_ids.

Now the code has been adjusted and there's no more trackback.
