### PR TITLE
[FIX] *: remove populate call to random

### DIFF
--- a/addons/hr_holidays/populate/hr_leave.py
+++ b/addons/hr_holidays/populate/hr_leave.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import datetime
-import random
 
 from odoo import models
 from odoo.tools import populate
@@ -45,27 +44,22 @@ class HolidaysRequest(models.Model):
         employee_by_company = {k: list(v) for k, v in groupby(employee_records, key=lambda rec: rec['company_id'].id)}
         company_by_type = {rec.id: rec.company_id.id for rec in self.env['hr.leave.type'].browse(hr_leave_type_ids)}
 
-
         def compute_employee_id(random=None, values=None, **kwargs):
             company_id = company_by_type[values['holiday_status_id']]
             return random.choice(employee_by_company[company_id]).id
 
-        def compute_date_from(counter, **kwargs):
-            date_from = datetime.datetime.now().replace(hour=0, minute=0, second=0)\
-                + relativedelta(days=int(3 * int(counter)))
-            return date_from
+        def compute_request_date_from(counter, **kwargs):
+            return datetime.datetime.today() + relativedelta(days=int(3 * int(counter)))
 
-        def compute_date_to(counter, **kwargs):
-            date_to = datetime.datetime.now().replace(hour=23, minute=59, second=59)\
-                + relativedelta(days=int(3 * int(counter))  + random.randint(0, 2))
-            return date_to
+        def compute_request_date_to(counter, random=None, **kwargs):
+            return datetime.datetime.today() + relativedelta(days=int(3 * int(counter)) + random.randint(0, 2))
 
         return [
             ('holiday_status_id', populate.randomize(allocationless_leave_type_ids)),
             ('employee_id', populate.compute(compute_employee_id)),
             ('holiday_type', populate.constant('employee')),
-            ('date_from', populate.compute(compute_date_from)),
-            ('date_to', populate.compute(compute_date_to)),
+            ('request_date_from', populate.compute(compute_request_date_from)),
+            ('request_date_to', populate.compute(compute_request_date_to)),
             ('state', populate.randomize([
                 'draft',
                 'confirm',

--- a/addons/resource/populate/resource_calendar.py
+++ b/addons/resource/populate/resource_calendar.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-import random
-
 from odoo import models
 from odoo.tools import populate
 
@@ -25,6 +23,7 @@ class ResourceCalendar(models.Model):
 
     def _populate(self, size):
         records = super()._populate(size)
+        random = populate.Random('calendar')
 
         # Randomly remove 1 half day from schedule
         a_lot = records.filtered_domain([("name", "like", "A lot")])

--- a/addons/website_slides/populate/slide_channel_partner.py
+++ b/addons/website_slides/populate/slide_channel_partner.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import random
 from collections import defaultdict
 
 from odoo import models
@@ -14,6 +13,7 @@ class SlideChannelPartner(models.Model):
     _populate_sizes = {'small': 150, 'medium': 3_000, 'large': 150_000}
 
     def _populate_factories(self):
+        random = populate.Random('slidechannelpartners')
         partner_ids = self.env.registry.populated_models['res.partner']
         partner_not_company_ids = (
             self.env['res.partner'].search([('id', 'in', partner_ids), ('is_company', '=', False)]).ids


### PR DESCRIPTION
*:
- hr_holidays
- resource
- website_slides

Before this commit, the populate files for the listed modules
were calling the random python library.
As we don't want non-deterministic populate, this import has
been changed to use the odoo Random tool which allows deterministic
randomization through seeds.
This commit also changes the way populate works for leaves in hr_holidays
so that they fit the current way of defining leaves.