### PR TITLE
[IMP] test_lint: add check for populate

### DIFF
--- a/odoo/addons/test_lint/tests/__init__.py
+++ b/odoo/addons/test_lint/tests/__init__.py
@@ -10,5 +10,6 @@ from . import test_markers
 from . import test_onchange_domains
 from . import test_override_signatures
 from . import test_pofile
+from . import test_populate
 from . import test_pylint
 from . import test_routes

--- a/odoo/addons/test_lint/tests/test_populate.py
+++ b/odoo/addons/test_lint/tests/test_populate.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+from odoo.tools.misc import file_open
+from . import lint_case
+
+_logger = logging.getLogger(__name__)
+
+class TestPopulate(lint_case.LintCase):
+
+    def test_populate(self):
+        for python_file in self.iter_module_files('**/*.py'):
+            if python_file == __file__:
+                continue
+            with file_open(python_file) as f:
+                content = f.read()
+                if 'def _populate' in content and ('import random' in content or 'from random' in content):
+                    _logger.error('Using non seeded random in populate is forbidden in %s', python_file)


### PR DESCRIPTION
Base random should not be used since we should only use seeded random in populate. This check will ensure that we don't import random.

The correct way is to use the `random` kwarg in a populate.compute or use `populate.Random` in another context providing the mandatory arbitrary seed.

The check is quite naive for now.

Existing imports will be fixed in odoo/odoo#139150 and odoo/enterprise#49162