### PR TITLE
[IMP] [16.0] account: Make sure the `_validate_parent_sequence` is enforced

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -143,7 +143,7 @@ class AccountReport(models.Model):
     @api.constrains('line_ids')
     def _validate_parent_sequence(self):
         previous_lines = self.env['account.report.line']
-        for line in self.line_ids:
+        for line in self.line_ids.sorted('sequence'):
             if line.parent_id and line.parent_id not in previous_lines:
                 raise ValidationError(
                     _('Line "%s" defines line "%s" as its parent, but appears before it in the report. '
@@ -295,6 +295,10 @@ class AccountReportLine(models.Model):
         for report_line in self:
             if report_line.parent_id.groupby:
                 raise ValidationError(_("A line cannot have both children and a groupby value (line '%s').", report_line.parent_id.name))
+
+    @api.constrains('parent_id', 'sequence', 'report_id')
+    def _validate_parent_sequence(self):
+        self.report_id._validate_parent_sequence()
 
     @api.constrains('expression_ids', 'groupby')
     def _validate_formula(self):


### PR DESCRIPTION
**Problem:** The function `_validate_parent_sequence` is used to check data constraints related to the `sequence` field of the `account.report.line` model. However, there are two cases that have bypassed it.

1. insert/create `account.report.line` records (No through the `account.report model`)
2. create a new `account.report.line` record (Operations on the `account.report` form): sequence > sequence of parent

**Expect:** In the two cases mentioned, the operation will be blocked if it violates constraints.











---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
