### PR TITLE
[IMP] base_vat: Belgium VAT number update

### DIFF
--- a/addons/base_vat/tests/test_validate_ruc.py
+++ b/addons/base_vat/tests/test_validate_ruc.py
@@ -84,6 +84,10 @@ class TestStructure(SavepointCase):
         test_partner = self.env['res.partner'].create({'name': "Turlututu", 'country_id': self.env.ref('base.fr').id})
         test_partner.write({'vat': "EU528003646", 'country_id': None})
 
+    def test_vat_be_update(self):
+        """ Test that belgium VAT numbers can now begin with BE1xxx.xxx.xxx """
+        test_partner = self.env['res.partner'].create({'name': "My BE company", 'country_id': self.env.ref('base.be').id})
+        test_partner.write({'vat': "BE1234558590"})
 
 @tagged('-standard', 'external')
 class TestStructureVIES(TestStructure):


### PR DESCRIPTION
Problem
---------
Belgium VAT numbers can now begin with a 1, i.e. BE1xxx.xxx.xxx.

Solution
---------
Currently, an external library is used to compute the Belgium VAT number validity: https://github.com/arthurdejong/python-stdnum/blob/master/stdnum/be/vat.py This library does not check the first number of the VAT number. Thus, it is already possible to craft a VAT number that begins with 1 and respect the checksum. A test has been added to make sure that Belgium VAT numbers can begin with a 1.

task-3559570

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
