### PR TITLE
[FIX] web: remove arrow from statusbar side dropdowns

### DIFF
--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.scss
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.scss
@@ -17,7 +17,7 @@
             &.o_first {
                 @include border-end-radius($border-radius);
                 padding-right: $o-horizontal-padding; // Compensate container padding
-                overflow-x: hidden; // to prevent horizontal scroll due to last arrow
+                overflow: hidden; // to prevent scroll due to last arrow
             }
 
             &.o_last {
@@ -25,7 +25,8 @@
                 padding-left: $o-horizontal-padding;
             }
 
-            &:not(.o_first) {
+            &:not(.o_first),
+            &:not(.o_last) {
                 &:before, &:after {
                     @include o-position-absolute(-$border-width, -$o-statusbar-arrow-width);
                     display: block;

--- a/addons/web/static/src/views/fields/statusbar/statusbar_field.xml
+++ b/addons/web/static/src/views/fields/statusbar/statusbar_field.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="web.StatusBarField.Dropdown" owl="1">
-        <t t-esc="label" />
         <Dropdown toggler="'parent'">
             <t t-foreach="items" t-as="item" t-key="item.value">
                 <DropdownItem
@@ -12,6 +11,8 @@
                 </DropdownItem>
             </t>
         </Dropdown>
+        <!-- Must be below the dropdown menu to align with the caret (if any) -->
+        <t t-esc="label" />
     </t>
 
     <t t-name="web.StatusBarField" owl="1">


### PR DESCRIPTION
This commit removes the caret from the statusbar side dropdowns as it was not intended to appear and causes the buttons to be misaligned.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
