### PR TITLE
[IMP] payment_razorpay{,auto}: add reccuring payment

### DIFF
--- a/addons/payment_razorpay_auto/__init__.py
+++ b/addons/payment_razorpay_auto/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import controllers
+from . import models

--- a/addons/payment_razorpay_auto/__manifest__.py
+++ b/addons/payment_razorpay_auto/__manifest__.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "Payment Provider: Razorpay Auto",
+    'version': '1.0',
+    'category': 'Accounting/Payment Providers',
+    'sequence': 355,
+    'summary': "A payment provider covering reccuring payments.",
+    'depends': ['payment_razorpay'],
+    'data': [
+        'views/payment_templates.xml',
+        'data/payment_provider_data.xml',
+    ],
+    'assets': {
+        'web.assets_frontend': [
+            'payment_razorpay_auto/static/src/js/payment_form.js',
+        ],
+    },
+    "icon": "/payment_razorpay/static/description/icon.png",
+    'license': 'LGPL-3',
+}

--- a/addons/payment_razorpay_auto/controllers/__init__.py
+++ b/addons/payment_razorpay_auto/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import portal

--- a/addons/payment_razorpay_auto/controllers/portal.py
+++ b/addons/payment_razorpay_auto/controllers/portal.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.payment.controllers import portal as payment_portal
+
+
+class PaymentPortal(payment_portal.PaymentPortal):
+
+    def _create_transaction(self, *args, razorpay_payment_method=False, custom_create_values=None, **kwargs):
+        """ Override of payment to add the sale order id in the custom create values.
+
+        :param int sale_order_id: The sale order for which a payment id made, as a `sale.order` id
+        :param dict custom_create_values: Additional create values overwriting the default ones
+        :return: The result of the parent method
+        :rtype: recordset of `payment.transaction`
+        """
+        if razorpay_payment_method:
+            if custom_create_values is None:
+                custom_create_values = {}
+            if 'razorpay_payment_method' not in custom_create_values:
+                custom_create_values['razorpay_payment_method'] = razorpay_payment_method
+
+        return super()._create_transaction(
+            *args, custom_create_values=custom_create_values, **kwargs
+        )

--- a/addons/payment_razorpay_auto/data/payment_provider_data.xml
+++ b/addons/payment_razorpay_auto/data/payment_provider_data.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+
+    <record id="payment.payment_provider_razorpay" model="payment.provider">
+        <field name="allow_tokenization">True</field>
+        <field name="inline_form_view_id" ref="inline_form"/>
+    </record>
+
+</odoo>

--- a/addons/payment_razorpay_auto/models/__init__.py
+++ b/addons/payment_razorpay_auto/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import payment_provider
+from . import payment_transaction

--- a/addons/payment_razorpay_auto/models/payment_provider.py
+++ b/addons/payment_razorpay_auto/models/payment_provider.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class PaymentProvider(models.Model):
+    _inherit = 'payment.provider'
+
+    #=== COMPUTE METHODS ===#
+
+    def _compute_feature_support_fields(self):
+        """ Override of `payment` to enable additional features. """
+        super()._compute_feature_support_fields()
+        self.filtered(lambda p: p.code == 'razorpay').update({
+            'support_tokenization': True,
+        })
+
+    # === BUSINESS METHODS ===#
+
+    def _get_validation_amount(self):
+        if self.code == 'razorpay':
+            return 1.0
+        return super()._get_validation_amount()

--- a/addons/payment_razorpay_auto/models/payment_transaction.py
+++ b/addons/payment_razorpay_auto/models/payment_transaction.py
@@ -1,0 +1,186 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import logging
+import pprint
+import time
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, models, _
+from odoo.exceptions import ValidationError, UserError
+
+
+_logger = logging.getLogger(__name__)
+
+
+class PaymentTransaction(models.Model):
+    _inherit = 'payment.transaction'
+
+    razorpay_payment_method = fields.Selection(([('card', 'Card'), ('upi', 'UPI/QR')]), default=False)
+
+    def _should_not_proccess_rendering_values_for_razorpay(self):
+        return super()._should_not_proccess_rendering_values_for_razorpay() or self.tokenize
+
+    # TO-DO: Move this method directly into payment_razorpay
+    def _create_order(self, customer_id=False, is_payment_capture=False):
+        # Initiate the payment and retrieve the related order id.
+        # TO DO master: remove customer from context and add it into argument
+        order_payload = self.with_context(razorpay_customer_id=customer_id)._razorpay_prepare_order_request_payload()
+        if is_payment_capture:
+            order_payload.update(payment_capture=True)
+        _logger.info(
+            "Payload of '/orders' request for transaction with reference %s:\n%s",
+            self.reference, pprint.pformat(order_payload)
+        )
+        order_response = self.provider_id._razorpay_make_request(endpoint='orders', payload=order_payload)
+        _logger.info(
+            "Response of '/orders' request for transaction with reference %s:\n%s",
+            self.reference, pprint.pformat(order_response)
+        )
+        return order_response
+
+    def _get_specific_processing_values(self, processing_values):
+        """ Override of `payment` to return razorpay-specific processing values.
+
+        Note: self.ensure_one() from `_get_processing_values`
+
+        :param dict processing_values: The generic and specific processing values of the
+                                       transaction.
+        :return: The dict of provider-specific processing values.
+        :rtype: dict
+        """
+        res = super()._get_specific_processing_values(processing_values)
+        if self.provider_code != 'razorpay' or not self.tokenize:
+            return res
+
+        # Retrive related customer
+        partner = self.env['res.partner'].browse(processing_values.get('partner_id'))
+        phone = self._validate_and_sanatize_phone_number(partner.phone)
+        customer_payload = {
+            'name': partner.name,
+            'email': partner.email,
+            'contact': phone,
+            'fail_existing': '0',
+        }
+        _logger.info(
+            "Payload of '/customers' request for transaction with reference %s:\n%s",
+            self.reference, pprint.pformat(customer_payload)
+        )
+        customer_response = self.provider_id._razorpay_make_request(endpoint='customers', payload=customer_payload)
+        _logger.info(
+            "Response of '/customers' request for transaction with reference %s:\n%s",
+            self.reference, pprint.pformat(customer_response)
+        )
+        data = {
+            'razorpay_key_id': self.provider_id.razorpay_key_id,
+            'customer_id': customer_response['id'],
+            'is_tokenize_request': not self.provider_id._is_tokenization_required(),
+        }
+        order_response = self._create_order(customer_id=customer_response['id'])
+        return {
+            **data,
+            'order_id': order_response['id'],
+        }
+
+    def _should_rendering_values_return_condition(self):
+        return super()._should_rendering_values_return_condition() or self.tokenize
+
+    def _get_razorpay_order_token_data(self):
+        self.ensure_one()
+        today = datetime.today()
+        token_expiry_date = today + relativedelta(years=10) # default years error when we use UPI
+        token_expiry_timeslamp = time.mktime(token_expiry_date.timetuple())
+        return {
+            "expire_at": token_expiry_timeslamp,
+            "frequency": "as_presented",
+        }
+
+    def _razorpay_prepare_order_request_payload(self):
+        payload = super()._razorpay_prepare_order_request_payload()
+        if self.env.context.get('razorpay_customer_id'):
+            if payload['currency'] != 'INR':
+                ValidationError(_("Currency should be 'INR' to create a token in razorpay recurring"))
+            payload.update({
+                "token": self._get_razorpay_order_token_data(),
+                'customer_id': self.env.context['razorpay_customer_id'],
+                "method": self.razorpay_payment_method,
+            })
+        return payload
+
+    def _razorpay_tokenize_from_notification_data(self, notification_data):
+        """ Create a new token based on the notification data.
+
+        :param dict notification_data: The notification data built with Razorpay objects.
+                                       See `_process_notification_data`.
+        :return: None
+        """
+        # Create the token.
+        if self.razorpay_payment_method == 'card':
+            payment_details = notification_data.get('card', {}).get('last4', 'dummy')
+        elif self.razorpay_payment_method == 'upi':
+            temp_vpa = notification_data.get('vpa', 'test@dummy')
+            payment_details = temp_vpa[temp_vpa.find('@') - 1:]
+
+        token = self.env['payment.token'].create({
+            'provider_id': self.provider_id.id,
+            'payment_details': payment_details,
+            'partner_id': self.partner_id.id,
+            'provider_ref': f"{notification_data['customer_id']},{notification_data['token_id']}",
+            'verified': True,
+        })
+        self.write({
+            'token_id': token,
+            'tokenize': False,
+        })
+        _logger.info(
+            "created token with id %(token_id)s for partner with id %(partner_id)s from "
+            "transaction with reference %(ref)s",
+            {
+                'token_id': token.id,
+                'partner_id': self.partner_id.id,
+                'ref': self.reference,
+            },
+        )
+
+    def _send_payment_request(self):
+        """ Override of payment to send a payment request to Razorpay for reccuring payment with a token.
+
+        Note: self.ensure_one()
+
+        :return: None
+        :raise: UserError if the transaction is not linked to a token
+        """
+        super()._send_payment_request()
+        if self.provider_code != 'razorpay':
+            return
+
+        if not self.token_id:
+            raise UserError("Razorpay: " + _("The transaction is not linked to a token."))
+
+        order_response = self._create_order(is_payment_capture=True)
+        # Create recurring payment
+        phone = self._validate_and_sanatize_phone_number(self.partner_id.phone)
+        customer_id, token_id = self.token_id.provider_ref.split(',')
+        recurring_payment_payload = {
+            'email': self.partner_id.email,
+            'contact': phone,
+            'amount': order_response['amount'],
+            'currency': self.currency_id.name,
+            'order_id': order_response['id'],
+            'customer_id': customer_id,
+            'token': token_id,
+            'description': self.reference,
+            'recurring': "1",
+        }
+        _logger.info(
+            "Payload of '/payments/create/recurring' request for transaction with reference %s:\n%s",
+            self.reference, pprint.pformat(recurring_payment_payload)
+        )
+        recurring_payment_response = self.provider_id._razorpay_make_request(
+            endpoint='payments/create/recurring', payload=recurring_payment_payload
+        )
+        _logger.info(
+            "Response of '/payments/create/recurring' request for transaction with reference %s:\n%s",
+            self.reference, pprint.pformat(recurring_payment_response)
+        )

--- a/addons/payment_razorpay_auto/static/src/js/payment_form.js
+++ b/addons/payment_razorpay_auto/static/src/js/payment_form.js
@@ -1,0 +1,104 @@
+/** @odoo-module **/
+/* global Razorpay */
+
+import { _t } from "@web/core/l10n/translation";
+import checkoutForm from "@payment/js/checkout_form";
+import manageForm from "@payment/js/manage_form";
+
+
+const razorpayMixin = {
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Add `sale_order_id` to the transaction route params if it is provided.
+     *
+     * @override method from payment.payment_form_mixin
+     * @private
+     * @param {string} code - The code of the selected payment option's provider
+     * @param {number} paymentOptionId - The id of the selected payment option
+     * @param {string} flow - The online payment flow of the selected payment option
+     * @return {object} The extended transaction route params
+     */
+    _prepareTransactionRouteParams: function (code, paymentOptionId, flow) {
+        const transactionRouteParams = this._super(...arguments);
+        if (code !== 'razorpay') {
+            return transactionRouteParams;
+        }
+        let paymentMethod = false;
+        const paymentMethodCardInput = document.getElementById('pament_method_card');
+        const paymentMethodUpiInput = document.getElementById('pament_method_upi');
+        if (paymentMethodCardInput.checked) {
+            paymentMethod = paymentMethodCardInput.value;
+        }
+        else if (paymentMethodUpiInput.checked) {
+            paymentMethod = paymentMethodUpiInput.value;
+        }
+        return {
+            ...transactionRouteParams,
+            'razorpay_payment_method': paymentMethod,
+        };
+    },
+
+     /**
+     * Redirect the customer to Razorpay hosted payment page.
+     *
+     * @override method from payment.payment_form_mixin
+     * @private
+     * @param {string} provider - The provider of the payment option's acquirer
+     * @param {number} paymentOptionId - The id of the payment option handling the transaction
+     * @param {object} processingValues - The processing values of the transaction
+     * @return {undefined}
+     */
+    _processRedirectPayment(provider, paymentOptionId, processingValues) {
+        if (provider !== 'razorpay' || !(this.txContext.tokenizationRequested || processingValues.is_tokenize_request)) {
+            this._super(...arguments);
+            return;
+        }
+        const razorpayOptions = this._prepareRazorpayOptions(processingValues);
+        const rzp = Razorpay(razorpayOptions);
+        rzp.open();
+        rzp.on('payment.failed', (resp) => {
+            this._displayError(
+                _t("Server Error"),
+                _t("We are not able to process your payment."),
+                resp.error.description,
+            );
+        });
+    },
+
+    /**
+     * Prepare the options to init the RazorPay JS Object
+     *
+     * Function overriden in internal module
+     *
+     * @param {object} processingValues
+     * @return {object}
+     */
+    _prepareRazorpayOptions(processingValues) {
+        return Object.assign({}, processingValues, {
+            "key": processingValues.razorpay_key_id,
+            "order_id": processingValues.order_id,
+            "customer_id": processingValues.customer_id,
+            "description": processingValues.reference,
+            "recurring": "1",
+            "handler": (resp) => {
+                if (resp.razorpay_payment_id && resp.razorpay_order_id && resp.razorpay_signature) {
+                    window.location = '/payment/status';
+
+                }
+            },
+            "modal": {
+                "ondismiss": () => {
+                        window.location.reload();
+                    }
+            },
+        });
+    },
+
+};
+
+checkoutForm.include(razorpayMixin);
+manageForm.include(razorpayMixin);

--- a/addons/payment_razorpay_auto/views/payment_templates.xml
+++ b/addons/payment_razorpay_auto/views/payment_templates.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="inline_form">
+        <div t-attf-id="razorpay-container-{{provider_id}}">
+            <div class="row">
+                <div class="input-group mt-0">
+                    <label class="me-2 my-0">
+                        <b>Payment Method:</b>
+                    </label>
+                    <label class="radio-inline mt-0">
+                        <input type="radio" name="pament_method_option" id="pament_method_card" value="card" checked="True"/>Card
+                    </label>
+                    <label class="radio-inline ms-2 mt-0">
+                        <input type="radio" name="pament_method_option" id="pament_method_upi" value="upi"/>UPI/QR
+                    </label>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template id="checkout" inherit_id="payment.checkout">
+        <xpath expr="." position="inside">
+            <t t-call="payment_razorpay_auto.sdk_assets"/>
+        </xpath>
+    </template>
+
+    <template id="manage" inherit_id="payment.manage">
+        <xpath expr="." position="inside">
+            <t t-call="payment_razorpay_auto.sdk_assets"/>
+        </xpath>
+    </template>
+
+    <template id="sdk_assets">
+        <script src="https://checkout.razorpay.com/v1/checkout.js"/>
+    </template>
+</odoo>


### PR DESCRIPTION
Before this commit razorpay does not provide saving
card and payment data to reuse that same method
when customer with same method is doing payments.

This commit allow razorpay to save payment details
and create token to use that token to do other
payments via that token.

task-3495914