### PR TITLE
[FIX] mrp: compute workorder state when reservation_state is updated

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -148,7 +148,7 @@ class MrpWorkorder(models.Model):
                                      domain="[('allow_workorder_dependencies', '=', True), ('id', '!=', id), ('production_id', '=', production_id)]",
                                      copy=False)
 
-    @api.depends('production_availability', 'blocked_by_workorder_ids', 'blocked_by_workorder_ids.state')
+    @api.depends('production_id.reservation_state', 'blocked_by_workorder_ids', 'blocked_by_workorder_ids.state')
     def _compute_state(self):
         # Force the flush of the production_availability, the wo state is modify in the _compute_reservation_state
         # It is a trick to force that the state of workorder is computed as the end of the


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create Product A with BoM:
    - component: product B

- Make Product B also to manufacture
- no items of product B on hand
- Create MO for product A:
    - reserved: Not available
    - workorder state: waiting for component

- Create MO for product B and mark it as done
- back to product A MO:
    - Click on “check availability”

**Problem:**
The component 'Product B' is reserved, but the work order state is not
updated to 'Ready'.

For some reason, we use the 'production_availability' related field in
the dependencies instead of directly using the
'production_id.reservation_state' . As a result, the change is not
detected, and the '_compute_state' is not triggered.

https://github.com/odoo/odoo/blob/e8a7f4ba224fd4c79bdfe724a5243e190c19501f/addons/mrp/models/mrp_workorder.py#L168-L169


opw-3494132