### PR TITLE
[FIX] web_editor: history dialog foreach key

### DIFF
--- a/addons/web_editor/static/src/components/history_dialog/history_dialog.xml
+++ b/addons/web_editor/static/src/components/history_dialog/history_dialog.xml
@@ -9,7 +9,7 @@
                     </t>
 
                     <t t-foreach="state.revisionsData" t-as="rev"
-                       t-key="rev.index">
+                       t-key="rev.revision_id">
                         <a type="object" href="#" role="button"
                            t-attf-class="btn btn-outline-primary #{state.revisionId === rev.revision_id ? 'active' : ''}"
                            t-on-click="() => this.updateCurrentRevision(rev.revision_id )">


### PR DESCRIPTION
Fix wrong Qweb foreach key reference in history dialog.


task-3560850


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
