### PR TITLE
[FIX] web: check the escaped values in domain

### DIFF
--- a/addons/web/static/src/legacy/js/core/domain.js
+++ b/addons/web/static/src/legacy/js/core/domain.js
@@ -90,10 +90,10 @@ var Domain = collections.Tree.extend({
             switch (this._data[1]) {
                 case "=":
                 case "==":
-                    return _.isEqual(fieldValue, this._data[2]);
+                    return _.isEqual(fieldValue, this._data[2]) || _.isEqual(fieldValue, _.unescape(this._data[2]));
                 case "!=":
                 case "<>":
-                    return !_.isEqual(fieldValue, this._data[2]);
+                    return !_.isEqual(fieldValue, this._data[2]) && !_.isEqual(fieldValue, _.unescape(this._data[2]));
                 case "<":
                     return (fieldValue < this._data[2]);
                 case ">":
@@ -116,7 +116,7 @@ var Domain = collections.Tree.extend({
                     if (fieldValue === false) {
                         return false;
                     }
-                    return (fieldValue.indexOf(this._data[2]) >= 0);
+                    return (fieldValue.indexOf(this._data[2]) >= 0) || (fieldValue.indexOf(_.unescape(this._data[2])) >= 0);
                 case "=like":
                     if (fieldValue === false) {
                         return false;
@@ -126,7 +126,7 @@ var Domain = collections.Tree.extend({
                     if (fieldValue === false) {
                         return false;
                     }
-                    return (fieldValue.toLowerCase().indexOf(this._data[2].toLowerCase()) >= 0);
+                    return (fieldValue.toLowerCase().indexOf(this._data[2].toLowerCase()) >= 0) || (fieldValue.toLowerCase().indexOf(_.unescape(this._data[2]).toLowerCase()) >= 0);
                 case "=ilike":
                     if (fieldValue === false) {
                         return false;


### PR DESCRIPTION
This change is being done so that the domain values having escaped characters can be applied correctly. The domain values can have escaped characters in them due to the changes made in [1].

[1] https://github.com/odoo/enterprise/pull/48909

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
