### PR TITLE
Font-style and font-size interaction review

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -797,7 +797,6 @@ export class OdooEditor extends EventTarget {
                 }
                 if (this.options.useResponsiveFontSizes) {
                     const fontSizeClassName = optionEl.dataset.applyClass;
-                    this.execCommand("setFontSize", undefined);
                     this.execCommand("setFontSizeClassName", fontSizeClassName);
                 } else {
                     applyFontSizeREM(optionEl.dataset.value);

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -335,6 +335,7 @@ export const editorCommands = {
         ));
         const [startContainer, startOffset, endContainer, endOffset] = [firstLeaf(range.startContainer), range.startOffset, lastLeaf(range.endContainer), range.endOffset];
         for (const block of deepestSelectedBlocks) {
+            let newEl;
             if (
                 ['P', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'BLOCKQUOTE'].includes(
                     block.nodeName,
@@ -344,39 +345,39 @@ export const editorCommands = {
                 if (inLI && tagName === "P") {
                     inLI.oToggleList(0);
                 } else {
-                    const newEl = setTagName(block, tagName);
-                    // Remove font size style and classes on the new element and
-                    // all its descendants.
-                    const fontSizedEls = newEl.querySelectorAll(`
-                        .h1, .h2, .h3, .h4, .h5, .h6,
-                        [style*='font-size'],
-                        ${FONT_SIZE_CLASSES.map(className => `.${className}`)}
-                    `);
-                    for (const fontSizedEl of [...fontSizedEls, newEl]) {
-                        fontSizedEl.style.removeProperty("font-size");
-                        fontSizedEl.classList.remove(
-                            ...FONT_SIZE_CLASSES,
-                            ...TEXT_STYLE_CLASSES,
-                            // We want to be able to edit the case
-                            // `<h2 class="h3">`  but in that case, we want to
-                            // display "Header 2" and not "Header 3" as it is
-                            // more important to display the semantic tag being
-                            // used(especially for h1 ones). This is why those
-                            // are not in `TEXT_STYLE_CLASSES`.
-                            "h1", "h2", "h3", "h4", "h5", "h6"
-                        );
-                    }
-                    if (extraClass) {
-                        newEl.classList.add(extraClass);
-                    }
+                    newEl = setTagName(block, tagName);
                 }
             } else {
                 // eg do not change a <div> into a h1: insert the h1
                 // into it instead.
-                const newBlock = editor.document.createElement(tagName);
+                newEl = editor.document.createElement(tagName);
                 const children = [...block.childNodes];
-                block.insertBefore(newBlock, block.firstChild);
-                children.forEach(child => newBlock.appendChild(child));
+                block.insertBefore(newEl, block.firstChild);
+                children.forEach(child => newEl.appendChild(child));
+            }
+            // Remove font size style and classes on the new element and
+            // all its descendants.
+            const fontSizedEls = newEl.querySelectorAll(`
+                .h1, .h2, .h3, .h4, .h5, .h6,
+                [style*='font-size'],
+                ${FONT_SIZE_CLASSES.map(className => `.${className}`)}
+            `);
+            for (const fontSizedEl of [...fontSizedEls, newEl]) {
+                fontSizedEl.style.removeProperty("font-size");
+                fontSizedEl.classList.remove(
+                    ...FONT_SIZE_CLASSES,
+                    ...TEXT_STYLE_CLASSES,
+                    // We want to be able to edit the case
+                    // `<h2 class="h3">`  but in that case, we want to
+                    // display "Header 2" and not "Header 3" as it is
+                    // more important to display the semantic tag being
+                    // used(especially for h1 ones). This is why those
+                    // are not in `TEXT_STYLE_CLASSES`.
+                    "h1", "h2", "h3", "h4", "h5", "h6"
+                );
+            }
+            if (extraClass) {
+                newEl.classList.add(extraClass);
             }
         }
         const newRange = new Range();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -345,17 +345,27 @@ export const editorCommands = {
                     inLI.oToggleList(0);
                 } else {
                     const newEl = setTagName(block, tagName);
-                    newEl.classList.remove(
-                        ...FONT_SIZE_CLASSES,
-                        ...TEXT_STYLE_CLASSES,
-                        // We want to be able to edit the case `<h2 class="h3">`
-                        // but in that case, we want to display "Header 2" and
-                        // not "Header 3" as it is more important to display
-                        // the semantic tag being used (especially for h1 ones).
-                        // This is why those are not in `TEXT_STYLE_CLASSES`.
-                        "h1", "h2", "h3", "h4", "h5", "h6"
-                    );
-                    delete newEl.style.fontSize;
+                    // Remove font size style and classes on the new element and
+                    // all its descendants.
+                    const fontSizedEls = newEl.querySelectorAll(`
+                        .h1, .h2, .h3, .h4, .h5, .h6,
+                        [style*='font-size'],
+                        ${FONT_SIZE_CLASSES.map(className => `.${className}`)}
+                    `);
+                    for (const fontSizedEl of [...fontSizedEls, newEl]) {
+                        fontSizedEl.style.removeProperty("font-size");
+                        fontSizedEl.classList.remove(
+                            ...FONT_SIZE_CLASSES,
+                            ...TEXT_STYLE_CLASSES,
+                            // We want to be able to edit the case
+                            // `<h2 class="h3">`  but in that case, we want to
+                            // display "Header 2" and not "Header 3" as it is
+                            // more important to display the semantic tag being
+                            // used(especially for h1 ones). This is why those
+                            // are not in `TEXT_STYLE_CLASSES`.
+                            "h1", "h2", "h3", "h4", "h5", "h6"
+                        );
+                    }
                     if (extraClass) {
                         newEl.classList.add(extraClass);
                     }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -369,9 +369,6 @@ export const editorCommands = {
                     if (extraClass) {
                         newEl.classList.add(extraClass);
                     }
-                    if (newEl.classList.length === 0) {
-                        newEl.removeAttribute("class");
-                    }
                 }
             } else {
                 // eg do not change a <div> into a h1: insert the h1

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -376,6 +376,13 @@ export const editorCommands = {
                     "h1", "h2", "h3", "h4", "h5", "h6"
                 );
             }
+            // Unwrap sub-elements
+            for (const el of
+                    newEl.querySelectorAll("h1, h2, h3, h4, h5, h6, p, pre, blockquote, small")) {
+                if (el.attributes.length === 0) {
+                    unwrapContents(el);
+                }
+            }
             if (extraClass) {
                 newEl.classList.add(extraClass);
             }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -973,9 +973,6 @@ const formatsSpecs = {
         },
         removeStyle: (node) => {
             node.classList.remove(...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES);
-            if (node.classList.length === 0) {
-                node.removeAttribute("class");
-            }
         },
     },
     switchDirection: {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1115,8 +1115,16 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
                     tag.remove();
                     formatSpec.addStyle(getOrCreateSpan(selectedTextNode, inlineAncestors), formatProps);
                 }
-            } else if (formatName !== 'fontSize' || formatProps.size !== undefined) {
-                formatSpec.addStyle(getOrCreateSpan(selectedTextNode, inlineAncestors), formatProps);
+            } else {
+                let stylableEl;
+                if (inlineAncestors.length === 0
+                        && parentNode.textContent === selectedTextNode.textContent) {
+                    stylableEl = parentNode;
+                    removeFormat(stylableEl, formatSpec);
+                } else {
+                    stylableEl = getOrCreateSpan(selectedTextNode, inlineAncestors);
+                }
+                formatSpec.addStyle(stylableEl, formatProps);
             }
         }
     }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -967,7 +967,10 @@ const formatsSpecs = {
         isFormatted: hasClass,
         hasStyle: (node, props) => FONT_SIZE_CLASSES
             .find(cls => node.classList.contains(cls)),
-        addStyle: (node, props) => node.classList.add(props.className),
+        addStyle: (node, props) => {
+            node.classList.add(props.className);
+            node.style.removeProperty("font-size");
+        },
         removeStyle: (node) => {
             node.classList.remove(...FONT_SIZE_CLASSES, ...TEXT_STYLE_CLASSES);
             if (node.classList.length === 0) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -778,7 +778,7 @@ describe('Format', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<h1>[ab</h1><p>]cd</p>',
                 stepFunction: setFontSize('36px'),
-                contentAfter: '<h1><span style="font-size: 36px;">[ab]</span></h1><p>cd</p>',
+                contentAfter: '<h1 style="font-size: 36px;">[ab]</h1><p>cd</p>',
             });
         });
         it('should get ready to type with a different font size', async () => {
@@ -865,21 +865,21 @@ describe('Format', () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<table><tbody><tr><td class="o_selected_td"><p>[<br></p></td><td class="o_selected_td"><p><br></p>]</td></tr><tr><td><p><br></p></td><td><p><br></p></td></tr></tbody></table>',
                 stepFunction: setFontSize('48px'),
-                contentAfter: '<table><tbody><tr><td><p><span style="font-size: 48px;">[]<br></span></p></td><td><p><span style="font-size: 48px;"><br></span></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td></tr></tbody></table>',
+                contentAfter: '<table><tbody><tr><td><p style="font-size: 48px;">[]<br></p></td><td><p style="font-size: 48px;"><br></p></td></tr><tr><td><p><br></p></td><td><p><br></p></td></tr></tbody></table>',
             });
         });
         it('should add font size in all table cells', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<table><tbody><tr><td class="o_selected_td"><p>[<br></p></td><td class="o_selected_td"><p><br></p></td></tr><tr><td class="o_selected_td"><p><br></p></td><td class="o_selected_td"><p><br>]</p></td></tr></tbody></table>',
                 stepFunction: setFontSize('36px'),
-                contentAfter: '<table><tbody><tr><td><p><span style="font-size: 36px;">[]<br></span></p></td><td><p><span style="font-size: 36px;"><br></span></p></td></tr><tr><td><p><span style="font-size: 36px;"><br></span></p></td><td><p><span style="font-size: 36px;"><br></span></p></td></tr></tbody></table>',
+                contentAfter: '<table><tbody><tr><td><p style="font-size: 36px;">[]<br></p></td><td><p style="font-size: 36px;"><br></p></td></tr><tr><td><p style="font-size: 36px;"><br></p></td><td><p style="font-size: 36px;"><br></p></td></tr></tbody></table>',
             });
         });
         it('should add font size in selected table cells with h1 as first child', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: '<table><tbody><tr><td class="o_selected_td"><h1>[<br></h1></td><td class="o_selected_td"><h1><br>]</h1></td></tr><tr><td><h1><br></h1></td><td><h1><br></h1></td></tr></tbody></table>',
                 stepFunction: setFontSize('18px'),
-                contentAfter: '<table><tbody><tr><td><h1><span style="font-size: 18px;">[]<br></span></h1></td><td><h1><span style="font-size: 18px;"><br></span></h1></td></tr><tr><td><h1><br></h1></td><td><h1><br></h1></td></tr></tbody></table>',
+                contentAfter: '<table><tbody><tr><td><h1 style="font-size: 18px;">[]<br></h1></td><td><h1 style="font-size: 18px;"><br></h1></td></tr><tr><td><h1><br></h1></td><td><h1><br></h1></td></tr></tbody></table>',
             });
         });
     });

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -5,6 +5,7 @@ import { _t } from "@web/core/l10n/translation";
 import { useService, useBus } from "@web/core/utils/hooks";
 import { useHotkey } from '@web/core/hotkeys/hotkey_hook';
 import { Wysiwyg } from "@web_editor/js/wysiwyg/wysiwyg";
+import wUtils from "@website/js/utils";
 import weUtils from '@web_editor/js/common/utils';
 import { isMediaElement } from '@web_editor/js/editor/odoo-editor/src/utils/utils';
 
@@ -938,6 +939,14 @@ export class WysiwygAdapterComponent extends Wysiwyg {
             field: $editable.data('oe-field'),
             type: $editable.data('oe-type'),
         };
+    }
+    /**
+     * @override
+     */
+    _updateEditorUI(e) {
+        super._updateEditorUI(...arguments);
+        const editedEl = this.odooEditor.document.getSelection().anchorNode?.parentNode;
+        wUtils.handleTextStyleVisibility(editedEl, this.el.querySelector("#style"))
     }
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -326,6 +326,9 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
      */
     _addToolbar() {
         this._super(...arguments);
+        const editedEl = this._getSelection().anchorNode?.parentNode;
+        wUtils.handleTextStyleVisibility(editedEl, this.el.querySelector("#style"))
+
         this.$('#o_we_editor_toolbar_container > we-title > span').after($(`
             <div class="btn fa fa-fw fa-2x o_we_highlight_animated_text d-none
                 ${this.$body.hasClass('o_animated_text_highlighted') ? 'fa-eye text-success' : 'fa-eye-slash'}"

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -388,6 +388,22 @@ function isMobile(self) {
     return isMobile;
 }
 
+/**
+ * Handles the visibility of the text style dropdown.
+ *
+ * @param {HTMLElement} selectedEl - the currently edited element
+ * @param {HTMLElement} styleDropdownEl - the style dropdown
+ */
+function handleTextStyleVisibility(selectedEl, styleDropdownEl) {
+    // For the header text element, we don't want users to change the tag name.
+    let hideStyleDropdown;
+    if (selectedEl) {
+        hideStyleDropdown = selectedEl
+            .closest('[data-oe-model="ir.ui.view"][data-oe-field="arch"].s_text_block');
+    }
+    styleDropdownEl?.classList.toggle("d-none", !!hideStyleDropdown);
+}
+
 export default {
     loadAnchors: loadAnchors,
     autocompleteWithPages: autocompleteWithPages,
@@ -400,4 +416,5 @@ export default {
     generateGMapIframe: generateGMapIframe,
     generateGMapLink: generateGMapLink,
     isMobile: isMobile,
+    handleTextStyleVisibility: handleTextStyleVisibility,
 };


### PR DESCRIPTION
This PR is a follow-up of https://github.com/odoo/odoo/pull/129791
It permits to:
- prevent unnecessary elements on text option change
- remove font size classes / style on text style change
- set font size class in a single command
- remove dead code to delete empty class attribute
- clean dom after text style change in `<li>`
- unwrap sub text style element on text style change
-  hide text style dropdown for text element in the header

task-1958098