### PR TITLE
[IMP] web: domain field: edit domain button is available while loading records count

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -78,9 +78,9 @@
                                 />
                             </t>
 
-                            <t t-if="props.editInDialog and !props.readonly">
-                                <button class="btn btn-sm btn-primary o_field_domain_dialog_button" t-on-click.prevent="onEditDialogBtnClick">Edit Domain</button>
-                            </t>
+                        </t>
+                        <t t-if="props.editInDialog and !props.readonly">
+                            <button class="btn btn-sm btn-primary o_field_domain_dialog_button" t-on-click.prevent="onEditDialogBtnClick">Edit Domain</button>
                         </t>
                     </div>
                 </t>

--- a/addons/web/static/tests/views/fields/domain_field_tests.js
+++ b/addons/web/static/tests/views/fields/domain_field_tests.js
@@ -955,6 +955,45 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test(
+        "edit domain button is available even while loading records count",
+        async function (assert) {
+            serverData.models.partner.fields.display_name.default = "[]";
+            patchWithCleanup(odoo, {
+                debug: true,
+            });
+            const searchCountDeffered = makeDeferred();
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                <form>
+                    <field name="display_name" widget="domain" options="{'model': 'partner', 'in_dialog': True}"/>
+                </form>`,
+                mockRPC: async (route) => {
+                    if (route === "/web/dataset/call_kw/partner/search_count") {
+                        await searchCountDeffered;
+                    }
+                    if (route === "/web/domain/validate") {
+                        return true;
+                    }
+                },
+            });
+            assert.containsNone(target, ".modal");
+            assert.containsOnce(target, ".o_field_domain_dialog_button");
+            await click(target, ".o_field_domain_dialog_button");
+            searchCountDeffered.resolve();
+            assert.containsOnce(target, ".modal");
+            await click(target, ".modal-footer .btn-primary");
+            assert.containsNone(target, ".modal");
+            assert.strictEqual(
+                target.querySelector(".o_domain_show_selection_button").textContent,
+                "5 record(s) "
+            );
+        }
+    );
+
+    QUnit.test(
         "quick check on save if domain has been edited via the  debug input",
         async function (assert) {
             patchWithCleanup(odoo, { debug: true });


### PR DESCRIPTION
This commit removes the requirement that the records count should be set before the edit domain button is shown for domains which must be edited in a dialog. This could be annoying in cases the records count loads slowly.

task-3561782
