### PR TITLE
[16][FIX] sale: sale reporting menu non inheritable. Action defined in root menu directly.

### DIFF
--- a/addons/sale/views/sale_menus.xml
+++ b/addons/sale/views/sale_menus.xml
@@ -72,9 +72,15 @@
 
         <menuitem id="menu_sale_report"
             name="Reporting"
-            action="action_order_report_all"
             groups="sales_team.group_sale_manager"
-            sequence="40"/>
+            sequence="40">
+
+            <menuitem id="menu_report_product_all"
+                name="Sales"
+                action="action_order_report_all"
+                sequence="10"/>
+
+        </menuitem>
 
         <menuitem id="menu_sale_config"
             name="Configuration"

--- a/addons/spreadsheet_dashboard_sale/data/files/product_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale/data/files/product_dashboard.json
@@ -703,8 +703,8 @@
         "30212d4a-1f77-4cb8-8590-4eb34876e260": "sale.sale_menu_root",
         "e35856cf-9090-489b-b055-2d441380d954": "sale.sale_menu_root",
         "d0171069-d2cd-4c2c-a686-cd7515e93bb5": "sale.sale_menu_root",
-        "5f383918-4073-4f19-9cc9-603216c953ad": "sale.menu_sale_report",
-        "ec57f69b-f2b1-4dfc-990c-91ab61b526bf": "sale.menu_sale_report"
+        "5f383918-4073-4f19-9cc9-603216c953ad": "sale.menu_report_product_all",
+        "ec57f69b-f2b1-4dfc-990c-91ab61b526bf": "sale.menu_report_product_all"
     },
     "odooVersion": 4,
     "lists": {},

--- a/addons/spreadsheet_dashboard_sale/data/files/sales_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale/data/files/sales_dashboard.json
@@ -2409,8 +2409,8 @@
         "a527960b-0812-4291-baba-f6b4b5280a0d": "sale.menu_sale_order",
         "51823220-f22b-4359-8711-579a249c91bb": "sale.menu_sale_quotations",
         "9a38934c-b454-4a4b-88aa-17d1b80dbf5f": "sale.menu_sale_order",
-        "67858d0e-b5ba-4a3c-bf9e-c0fceaeedf65": "sale.menu_sale_report",
-        "d43375c1-73a6-42a2-8dbd-0f13c285824f": "sale.menu_sale_report"
+        "67858d0e-b5ba-4a3c-bf9e-c0fceaeedf65": "sale.menu_report_product_all",
+        "d43375c1-73a6-42a2-8dbd-0f13c285824f": "sale.menu_report_product_all"
     },
     "odooVersion": 4,
     "lists": {


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The sale reporting menu is defined directly in root reporting menu, so if other module adds a new report menu child of sale_reporting menu root the main sale reporting report is not accesible.
This behavior only occurs in version 16.

**Current behavior before PR:**

User goes to:
1 - Sales
2 - Reporting
The sale report is opened

**Desired behavior after PR is merged:**
The user goes to
1 - Sales
2 - Reporting
3 - Sales
The sale report is opened


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr

cc @Tecnativa
ping @CarlosRoca13 @chienandalu 

