### PR TITLE
[FIX] purchase_{stock}: Enhancements to Replenish Wizard and Vendor Data

### DIFF
--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -59,10 +59,13 @@ class ProductReplenish(models.TransientModel):
         self.ensure_one()
         orderpoint = self.env["stock.warehouse.orderpoint"].search([("product_id", "=", self.product_id.id), ("warehouse_id", "=", self.warehouse_id.id)], limit=1)
         if not orderpoint:
-            orderpoint = self.env["stock.warehouse.orderpoint"].create({
+            orderpoint_vals = {
                 "product_id": self.product_id.id,
                 "warehouse_id": self.warehouse_id.id,
-            })
+            }
+            if 'buy' in self.route_id.rule_ids.mapped('action'):
+                orderpoint_vals["supplier_id"] = self.supplier_id.id
+            orderpoint = self.env["stock.warehouse.orderpoint"].create(orderpoint_vals)
         action = orderpoint.action_stock_replenishment_info()
 
         action["context"] = {

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -91,6 +91,18 @@ class StockReplenishmentInfo(models.TransientModel):
                 'replenishment_history': replenishment_history
             })
 
+    def action_reopen_replenish_wizard(self):
+        if self._context.get('replenish_id'):
+            replenish = self.env['product.replenish'].browse(self._context.get('replenish_id'))
+            return {
+                'type': 'ir.actions.act_window',
+                'name': 'Replenish',
+                'res_model': 'product.replenish',
+                'res_id': replenish.id,
+                'target': 'new',
+                'view_mode': 'form',
+            }
+        return {'type': 'ir.actions.act_window_close'}
 
 class StockReplenishmentOption(models.TransientModel):
     _name = 'stock.replenishment.option'

--- a/addons/stock/wizard/stock_replenishment_info.xml
+++ b/addons/stock/wizard/stock_replenishment_info.xml
@@ -22,7 +22,7 @@
                     </page>
                 </notebook>
                 <footer>
-                    <button string="Close" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                    <button name="action_reopen_replenish_wizard" type="object" string="Close" class="btn-secondary" data-hotkey="x"/>
                 </footer>
             </form>
         </field>


### PR DESCRIPTION
Before this commit
===================
Clicking the 'i' button in the replenish wizard currently results in exiting the
 wizard entirely, rather than returning to the initial screen as intended.
Additionally, the initial click on the 'replenish' button pre-selects the vendor, but upon reopening the wizard, the vendor field appears blank.

After this commit
===================
This commit ensures that when you click the 'i' button within the replenish wizard and close the button of the wizard, you will be returned to the initial wizard.
Upon clicking the replenish button, the vendor data will now consistently be filled, unlike the previous behavior.

Task: 3551496