### PR TITLE
[IMP] portal: allow addresses management

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -152,10 +152,10 @@ class PortalAccount(CustomerPortal):
     # My Home
     # ------------------------------------------------------------
 
-    def details_form_validate(self, data, partner_creation=False):
-        error, error_message = super(PortalAccount, self).details_form_validate(data)
+    def details_form_validate(self, data, partner_creation=False, partner=None):
+        error, error_message = super(PortalAccount, self).details_form_validate(data, partner_creation=partner_creation, partner=partner)
         # prevent VAT/name change if invoices exist
-        partner = request.env['res.users'].browse(request.uid).partner_id
+        partner = partner or request.env['res.users'].browse(request.uid).partner_id
         # Skip this test if we're creating a new partner as we won't ever block him from filling values.
         if not partner_creation and not partner.can_edit_vat():
             if 'vat' in data and (data['vat'] or False) != (partner.vat or False):

--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -251,6 +251,16 @@ img, .media_iframe_video, .o_image {
     > tbody.o_portal_report_tbody {
         vertical-align: middle;
     }
+
+    .o_portal_all_addresses {
+        @include media-breakpoint-down(md) {
+            overflow-x: auto;
+
+            .address_card-container {
+                width: auto;
+            }
+        }
+    }
 }
 
 .o_portal_wrap {

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -847,37 +847,39 @@
         <t t-call="portal.portal_layout">
             <h3>Your Account Address</h3>
             <t t-call="portal.address_card">
-                <t t-set="_classes" t-value="'w-md-50 bg-primary'"/>
+                <t t-set="_classes" t-value="'w-md-50 bg-primary border border-primary'"/>
             </t>
             <h4 class="mt32">Other Addresses</h4>
-            <ul class="list-unstyled d-flex flex-wrap gap-3">
+            <div t-if="partner.child_ids" class="row row-cols-md-2 row-cols-lg-3 g-3 flex-nowrap flex-md-wrap mb-2">
                 <t t-foreach="partner.child_ids" t-as="partner">
                     <t t-call="portal.address_card">
-                        <t t-set="_classes" t-value="'w-md-auto'"/>
+                        <t t-set="_classes" t-value="'col-md'"/>
                     </t>
                 </t>
-            </ul>
+            </div>
             <a href="/my/addresses/new" class="btn btn-primary justify-content-start align-items-center gap-3 h-100">Add an address</a>
         </t>
     </template>
 
     <template id="address_card">
-        <div t-attf-class="card w-100 {{ _classes }}">
-            <div class="card-body">
-                <a t-attf-href="/my/account?address={{partner.id}}" t-att-title="title" class="float-end ms-2">
-                    <i class="fa fa-pencil me-1"/>
-                    Edit
-                </a>
-                <h5>
-                    <i t-if="partner.type == 'invoice'" class="fa fa-fw fa-file-text-o text-primary" role="img"/>
-                    <i t-if="partner.type == 'delivery'" class="fa fa-truck fa-fw text-primary" role="img"/>
-                    <i t-if="partner.type == 'contact'" class="fa fa-address-card-o fa-fw text-primary" role="img"/>
-                    <t t-out="partner.name"/>
-                </h5>
-                <div class="d-flex flex-column">
-                    <span t-if="partner.email" t-out="partner.email"/>
-                    <span t-if="partner.zip" t-out="partner.zip + ' ' + partner.city"/>
-                    <span t-if="partner.state_id" t-out="partner.state_id.name + ' ' + partner.country_id.name"/>
+        <div class="address_card-container">
+            <div t-attf-class="card h-100 {{ _classes }}">
+                <div class="card-body">
+                    <a t-attf-href="/my/account?address={{partner.id}}" t-att-title="title" class="float-end ms-2">
+                        <i class="fa fa-pencil me-1"/>
+                        Edit
+                    </a>
+                    <span class="fw-bold">
+                        <i t-if="partner.type == 'invoice'" class="fa fa-fw fa-file-text-o text-primary" role="img"/>
+                        <i t-if="partner.type == 'delivery'" class="fa fa-truck fa-fw text-primary" role="img"/>
+                        <i t-if="partner.type == 'contact'" class="fa fa-address-card-o fa-fw text-primary" role="img"/>
+                        <t t-out="partner.name"/>
+                    </span>
+                    <div class="d-flex flex-column mt-2">
+                        <span t-if="partner.email" t-out="partner.email" class="small"/>
+                        <span t-if="partner.zip" t-out="partner.zip + ' ' + partner.city" class="small"/>
+                        <span t-if="partner.state_id" t-out="partner.state_id.name + ' ' + partner.country_id.name" class="small"/>
+                    </div>
                 </div>
             </div>
         </div>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -850,19 +850,17 @@
                 <t t-set="_classes" t-value="'w-md-50 bg-primary border border-primary'"/>
             </t>
             <h4 class="mt32">Other Addresses</h4>
-            <div t-if="partner.child_ids" class="row row-cols-md-2 row-cols-lg-3 g-3 flex-nowrap flex-md-wrap mb-2">
+            <div t-if="partner.child_ids" class="o_portal_all_addresses row row-cols-md-2 row-cols-lg-3 g-3 flex-nowrap flex-md-wrap mb-2">
                 <t t-foreach="partner.child_ids" t-as="partner">
-                    <t t-call="portal.address_card">
-                        <t t-set="_classes" t-value="'col-md'"/>
-                    </t>
+                    <t t-call="portal.address_card"/>
                 </t>
             </div>
-            <a href="/my/addresses/new" class="btn btn-primary justify-content-start align-items-center gap-3 h-100">Add an address</a>
+            <a href="/my/addresses/new" class="btn btn-primary justify-content-start align-items-center gap-3 h-100">Add address</a>
         </t>
     </template>
 
     <template id="address_card">
-        <div class="address_card-container">
+        <div class="address_card-container col-md">
             <div t-attf-class="card h-100 {{ _classes }}">
                 <div class="card-body">
                     <a t-attf-href="/my/account?address={{partner.id}}" t-att-title="title" class="float-end ms-2">

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -140,7 +140,11 @@
     <template id="portal_breadcrumbs" name="Portal Breadcrumbs">
         <ol t-if="page_name != 'home'" class="o_portal_submenu breadcrumb mb-0 flex-grow-1 px-0">
             <li class="breadcrumb-item ms-1"><a href="/my/home" aria-label="Home" title="Home"><i class="fa fa-home"/></a></li>
-            <li t-if="page_name == 'my_details'" class="breadcrumb-item">Details</li>
+            <li t-if="page_name == 'my_addresses'" class="breadcrumb-item">Addresses</li>
+            <t t-if="page_name == 'my_details'">
+                <li class="breadcrumb-item"><a href="/my/addresses" aria-label="Addresses" title="Addresses">Addresses</a></li>
+                <li class="breadcrumb-item">Details</li>
+            </t>
         </ol>
     </template>
 
@@ -231,8 +235,8 @@
                         <t t-call="portal.portal_docs_entry">
                             <t t-set="icon" t-value="'/portal/static/src/img/portal-addresses.svg'"/>
                             <t t-set="title">Addresses</t>
-                            <t t-set="text">Add, remove or modify your addresses</t>
-                            <t t-set="url" t-value="'/my/account'"/>
+                            <t t-set="text">Add or Modify your addresses</t>
+                            <t t-set="url" t-value="'/my/addresses'"/>
                             <t t-set="config_card" t-value="True"/>
                         </t>
                         <t t-call="portal.portal_docs_entry">
@@ -515,12 +519,21 @@
                 </t>
             </select>
         </div>
+        <div t-attf-class="col-xl-6 mb-3">
+            <label class="col-form-label label-optional" for="type">Use this address for</label>
+            <select name="type" t-attf-class="form-select">
+                <option value="other" t-att-selected="partner.type == 'other'"></option>
+                <option value="delivery" t-att-selected="partner.type == 'delivery'">Delivery</option>
+                <option value="invoice" t-att-selected="partner.type == 'invoice'">Invoice</option>
+                <option value="contact" t-att-selected="partner.type == 'contact'">Contact</option>
+            </select>
+        </div>
     </template>
 
     <template id="portal_my_details">
         <t t-call="portal.portal_layout">
             <t t-set="additional_title">Contact Details</t>
-            <form action="/my/account" method="post">
+            <form t-attf-action="/my/account?address={{partner.id}}" method="post">
                 <div class="row o_portal_details">
                     <div class="col-lg-8">
                         <div class="row">
@@ -528,7 +541,7 @@
                             <input type="hidden" name="redirect" t-att-value="redirect"/>
                         </div>
                         <div class="clearfix text-end mb-5">
-                            <a href="/my/" class="btn btn-secondary me-2">
+                            <a href="/my/addresses" class="btn btn-secondary me-2">
                                 Discard
                             </a>
                             <button type="submit" class="btn btn-primary float-end">
@@ -826,6 +839,46 @@
             <hr t-if="sales_user"/>
             <div class="o_my_contact" t-if="sales_user">
                 <t t-call="portal.portal_contact"/>
+            </div>
+        </div>
+    </template>
+
+    <template id="portal_my_addresses" name="Addresses">
+        <t t-call="portal.portal_layout">
+            <h3>Your Account Address</h3>
+            <t t-call="portal.address_card">
+                <t t-set="_classes" t-value="'w-md-50 bg-primary'"/>
+            </t>
+            <h4 class="mt32">Other Addresses</h4>
+            <ul class="list-unstyled d-flex flex-wrap gap-3">
+                <t t-foreach="partner.child_ids" t-as="partner">
+                    <t t-call="portal.address_card">
+                        <t t-set="_classes" t-value="'w-md-auto'"/>
+                    </t>
+                </t>
+            </ul>
+            <a href="/my/addresses/new" class="btn btn-primary justify-content-start align-items-center gap-3 h-100">Add an address</a>
+        </t>
+    </template>
+
+    <template id="address_card">
+        <div t-attf-class="card w-100 {{ _classes }}">
+            <div class="card-body">
+                <a t-attf-href="/my/account?address={{partner.id}}" t-att-title="title" class="float-end ms-2">
+                    <i class="fa fa-pencil me-1"/>
+                    Edit
+                </a>
+                <h5>
+                    <i t-if="partner.type == 'invoice'" class="fa fa-fw fa-file-text-o text-primary" role="img"/>
+                    <i t-if="partner.type == 'delivery'" class="fa fa-truck fa-fw text-primary" role="img"/>
+                    <i t-if="partner.type == 'contact'" class="fa fa-address-card-o fa-fw text-primary" role="img"/>
+                    <t t-out="partner.name"/>
+                </h5>
+                <div class="d-flex flex-column">
+                    <span t-if="partner.email" t-out="partner.email"/>
+                    <span t-if="partner.zip" t-out="partner.zip + ' ' + partner.city"/>
+                    <span t-if="partner.state_id" t-out="partner.state_id.name + ' ' + partner.country_id.name"/>
+                </div>
             </div>
         </div>
     </template>


### PR DESCRIPTION
This PR adds a new way of managing addresses, directly inside Portal.
> Note : this PR needs the Portal redesign   to be merged first in order to be fully functional.
task-3463335

- [x] Ensure #138077 is merged first
- [ ] Once you created a first address, the next one inherit country and the select is disabled but you can still save, and the address will be created.
- [ ] Related to above, saving the form with an error will create the error but for some reasons it breaks the "use this invoice for", making the icons invisible.
- [ ] Editing the address / creating new ones is sometimes impossible due to the fact that documents were already created.

## Description
Prior the Portal redesign, users were allowed to modify an address, but a single one, which was related to the contact. 
With this PR, we add the possibility for users to manage or/and add different addresses, for billing, shipping, and other purposes.

## New design

With this new design, we create two categories : 

1. the `Your account address` which is the one associated to the contact, and will be used by default ;
2. the `Other addresses` which contains other addresses set by the user that can be used for either for billing, shipping, or even both.

Note that we don't limit the number of addresses to three, the user can actually adds more than three but there are only three different types.

Master             |  master-portal-redesign-add-address-chgo
:-------------------------:|:-------------------------:
![image](https://github.com/odoo/odoo/assets/128030743/27e13d5c-f174-463f-9fe6-5a87e5cabd30")  |  ![image](https://github.com/odoo/odoo/assets/128030743/3368827e-71ef-4dd0-84fe-a23302075e95")

task-3570497