### PR TITLE
[FIX] payment_stripe: add 'off_session' by default

### DIFF
--- a/addons/payment_stripe/static/src/js/checkout_form.js
+++ b/addons/payment_stripe/static/src/js/checkout_form.js
@@ -15,10 +15,8 @@ checkoutForm.include({
             ...this._super(...arguments),
             mode: 'payment',
             amount: parseInt(this.stripeInlineFormValues['minor_amount']),
+            setupFutureUsage: 'off_session',
         };
-        if (this.stripeInlineFormValues['is_tokenization_required']) {
-            elementsOptions.setupFutureUsage = 'off_session';
-        }
         return elementsOptions;
     },
 


### PR DESCRIPTION
Issue:
------
When we use stripe to pay for a subscription via ecommerce, we get the following error message:
```
The provided setup_future_usage (off_session) does not match
the expected setup_future_usage (null).
Try confirming with a Payment Intent that is configured
to use the same parameters as the Stripe Elements.
```

Cause:
------
We don't send a value for `setup_future_usage` for the Stripe Element in this case resulting in an intention to pay with a value equal to `null` and not `off_session`.

Solution:
---------
Add `setup_future_usage` to the _getElementsOptions with `off_session` by default. The commit [^1] manages the case of updating the value of this parameter according to tokenization.

[^1]: 9d8da1d14484fa466bb67e8002ce15526ebef676

opw-3541316