### PR TITLE
[IMP] pos_self_order: various modifications

### DIFF
--- a/addons/pos_self_order/__manifest__.py
+++ b/addons/pos_self_order/__manifest__.py
@@ -16,6 +16,7 @@
         "views/pos_config_view.xml",
         "views/pos_session_view.xml",
         "views/custom_link_views.xml",
+        "views/pos_restaurant_views.xml",
         "views/product_views.xml",
         "data/init_access.xml",
         "data/custom_link_data.xml",

--- a/addons/pos_self_order/models/pos_restaurant.py
+++ b/addons/pos_self_order/models/pos_restaurant.py
@@ -14,7 +14,6 @@ class RestaurantTable(models.Model):
         "Security Token",
         copy=False,
         required=True,
-        readonly=True,
         default=lambda self: self._get_identifier(),
     )
 

--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -1,6 +1,6 @@
-# -*- codingimport base64
+# -*- coding: utf-8 -*-
+
 import qrcode
-import base64
 import zipfile
 from io import BytesIO
 

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -33,17 +33,23 @@ export class ProductCard extends Component {
             return;
         }
 
-        const pic = this.selfRef.el.querySelector(".o_self_order_item_card_image");
+        let pic = this.selfRef.el.querySelector(".o_self_order_item_card_image");
         if (!pic) {
-            return;
+            pic = this.selfRef.el.querySelector(".o_self_order_item_card_no_image");
         }
 
         const picRect = pic.getBoundingClientRect();
         const clonedPic = pic.cloneNode(true);
         const toOrderRect = toOrder.getBoundingClientRect();
 
-        clonedPic.classList.remove('w-100', 'h-100');
-        clonedPic.classList.add('position-fixed', 'border', 'border-white', 'border-4', 'z-index-1');
+        clonedPic.classList.remove("w-100", "h-100");
+        clonedPic.classList.add(
+            "position-fixed",
+            "border",
+            "border-white",
+            "border-4",
+            "z-index-1"
+        );
         clonedPic.style.top = `${picRect.top}px`;
         clonedPic.style.left = `${picRect.left}px`;
         clonedPic.style.width = `${picRect.width}px`;
@@ -53,9 +59,10 @@ export class ProductCard extends Component {
         document.body.appendChild(clonedPic);
 
         requestAnimationFrame(() => {
-            let offsetTop = (toOrderRect.top - picRect.top) - picRect.height * 0.5;
-            let offsetLeft = (toOrderRect.left - picRect.left) - picRect.width * 0.25;
-            clonedPic.style.transform = 'translateY(' + offsetTop +'px) translateX(' + offsetLeft +'px) scale(0.5)';
+            const offsetTop = toOrderRect.top - picRect.top - picRect.height * 0.5;
+            const offsetLeft = toOrderRect.left - picRect.left - picRect.width * 0.25;
+            clonedPic.style.transform =
+                "translateY(" + offsetTop + "px) translateX(" + offsetLeft + "px) scale(0.5)";
             clonedPic.style.opacity = "0"; // Fading out the card
         });
 

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.scss
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.scss
@@ -26,3 +26,9 @@
     left: 22px;
     top: 4px;
 }
+
+.o_self_order_item_card_no_image {
+    span {
+        color: #DFDFDF;
+    }
+}

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.xml
@@ -12,12 +12,15 @@
             <div
                 class="ratio ratio-1x1 w-25 w-sm-50 w-md-100"
                 t-att-class="{
-                    'd-none d-md-block': !props.product.has_image
+                    'd-md-block': !props.product.has_image
                 }">
-                <div class="placeholder-glow">
-                    <div class="placeholder w-100 h-100 bg-300 rounded"/>
+                <div class="placeholder-glow o_self_order_item_card_no_image">
+                    <div t-attf-class="{{ props.product.has_image ? 'placeholder' : 'd-flex align-items-center justify-content-center h-100' }} bg-200 w-100 h-100 rounded">
+                        <span t-if="!props.product.has_image" t-esc="props.product.name" class="text-center text-white fs-2 fw-bold mb-1 mb-sm-2"/>
+                    </div>
                 </div>
                 <img
+                    t-if="props.product.has_image"
                     class="o_self_order_item_card_image w-100 rounded"
                     t-attf-src="/menu/get-image/{{ props.product.id }}/512?unique={{props.product.write_date}}"
                     alt="Product image"

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.js
@@ -97,10 +97,10 @@ export class CartPage extends Component {
         if (table) {
             this.selfOrder.table = table;
             this.router.addTableIdentifier(table);
+            this.pay();
         }
 
         this.state.selectTable = false;
-        this.pay();
     }
 
     getChildLines(line) {

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.scss
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.scss
@@ -11,6 +11,10 @@
         &.active {
             color: $headings-color;
 
+            &.active-no-image{
+                outline: 1px solid $o-action;
+            }
+
             img {
                 outline: 1px solid $o-action;
             }

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.scss
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.scss
@@ -11,12 +11,9 @@
         &.active {
             color: $headings-color;
 
-            &.active-no-image{
+            div {
                 outline: 1px solid $o-action;
-            }
-
-            img {
-                outline: 1px solid $o-action;
+                border-radius: 0.25rem;
             }
         }
     }

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -11,27 +11,20 @@
                         t-key="category.id"
                         t-ref="category_{{category.id}}"
                         t-attf-class="nav-link category-item flex-shrink-0 p-0"
-                        t-att-class="{
-                            'active-no-image border border-sm rounded p-1 d-flex align-items-center': !category.has_image
-                        }"
                         t-attf-href="#scrollspy_{{category.id}}">
-                        <div t-if="category.has_image" class="ratio ratio-1x1 mb-1">
-                            <div class="placeholder-glow">
-                                <div class="placeholder w-100 h-100 bg-300 rounded"/>
+                        <div class="ratio ratio-1x1 mb-1">
+                            <div t-att-class="{'placeholder-glow': category.has_image}">
+                                <div class="w-100 h-100 bg-200 rounded d-flex align-items-center justify-content-center" t-att-class="{'placeholder': category.has_image}">
+                                    <small class="d-block fw-bold text-white text-center" t-esc="category.name"/>
+                                </div>
                             </div>
-                            <img class="rounded w-100 h-100"
+                            <img t-if="category.has_image"  class="rounded w-100 h-100"
                                 t-attf-src="/pos-self/get-category-image/{{ category.id }}"
                                 alt="Product image"
                                 loading="lazy"
                                 onerror="this.remove()" />
                         </div>
-                        <small
-                            class="d-block fw-bold text-center"
-                            t-att-class="{
-                                'py-2' : !category.has_image,
-                                'text-truncate' : category.has_image,
-                            }"
-                            t-esc="category.name"/>
+                        <small class="d-block fw-bold text-center" t-esc="category.name"/>
                     </a>
                 </nav>
 

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -11,6 +11,9 @@
                         t-key="category.id"
                         t-ref="category_{{category.id}}"
                         t-attf-class="nav-link category-item flex-shrink-0 p-0"
+                        t-att-class="{
+                            'active-no-image border border-sm rounded p-1 d-flex align-items-center': !category.has_image
+                        }"
                         t-attf-href="#scrollspy_{{category.id}}">
                         <div t-if="category.has_image" class="ratio ratio-1x1 mb-1">
                             <div class="placeholder-glow">

--- a/addons/pos_self_order/views/pos_restaurant_views.xml
+++ b/addons/pos_self_order/views/pos_restaurant_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="pos_self_order_table_form_view" model="ir.ui.view">
+        <field name="name">Restaurant Table</field>
+        <field name="model">restaurant.table</field>
+        <field name="inherit_id" ref="pos_restaurant.view_restaurant_table_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//group[@col='2']" position="inside">
+                <field name="identifier" groups="base.group_no_one" />
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -12,14 +12,29 @@
             </xpath>
             <block id="restaurant_section" position="after">
                 <block title="Mobile self-order &amp; Kiosk" id="self_ordering_section">
-                    <setting string="QR menu &amp; Kiosk activation" help="Let your customers order using their mobile or a kiosk.">
-                        <field name="pos_self_ordering_mode" />
+                    <setting string="QR menu &amp; Kiosk activation" help="Let your customers order using their mobile or a kiosk.">a
+                        <div class="content-group row">
+                            <label for="pos_self_ordering_mode" class="col-lg-4" string="Self Ordering"/>
+                            <field name="pos_self_ordering_mode" />
+                        </div>
                         <div class="d-flex flex-column align-items-start w-50" invisible="pos_self_ordering_mode == 'nothing'">
                             <button class="btn-link p-0" icon="oi-arrow-right" name="preview_self_order_app" type="object" string="Preview Web interface"/>
                             <button class="btn-link p-0" icon="oi-arrow-right" name="custom_link_action" type="object" string="Home buttons"/>
                             <button class="btn-link p-0" icon="oi-arrow-right" name="generate_qr_codes_page" type="object" string="Print QR Codes" invisible="not pos_self_ordering_mode in ['consultation', 'mobile']"/>
                             <button class="btn-link p-0" icon="oi-arrow-right" name="generate_qr_codes_zip" type="object" string="Download QR Codes" invisible="not pos_self_ordering_mode in ['consultation', 'mobile']"/>
                             <button groups="base.group_no_one" class="btn-link p-0" icon="oi-arrow-right" name="update_access_tokens" type="object" string="Reset QR Codes" invisible="not pos_self_ordering_mode in ['consultation', 'mobile']"/>
+                        </div>
+                        <div class="content-group row mt-4" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
+                            <label for="pos_self_ordering_service_mode" class="col-lg-4" string="Service at" />
+                            <field name="pos_self_ordering_service_mode" readonly="not pos_module_pos_restaurant and pos_self_ordering_mode != 'kiosk'" />
+                        </div>
+                        <div class="content-group row" groups="base.group_no_one" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
+                            <label for="pos_self_ordering_default_user_id" class="col-lg-4" string="Default User"/>
+                            <field name="pos_self_ordering_default_user_id" />
+                        </div>
+                        <div id="self-payment-after" class="content-group row" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
+                            <label string="Pay after" for="pos_self_ordering_pay_after" class="col-lg-4"/>
+                            <field name="pos_self_ordering_pay_after" readonly="pos_self_ordering_mode == 'kiosk' or (pos_self_ordering_service_mode == 'counter' and pos_self_ordering_mode == 'mobile')" widget="upgrade_selection"/>
                         </div>
                     </setting>
                     <setting string="Splash screens" help="Personalize your splash screen by adding one or multiple images to create a slideshow" invisible="pos_self_ordering_mode == 'nothing'">
@@ -43,20 +58,6 @@
                     <setting string="Customize Header" help="Add an image to brand your header." invisible="pos_self_ordering_mode == 'nothing'">
                         <field name="pos_self_ordering_image_brand_name" invisible ="1"/>
                         <field name="pos_self_ordering_image_brand" class="w-100" filename="pos_self_ordering_image_brand_name"/>
-                    </setting>
-                    <setting string="Options" help="All options for your Self devices" invisible="pos_self_ordering_mode in ['nothing', 'consultation']">
-                        <div class="content-group row" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
-                            <label for="pos_self_ordering_service_mode" class="col-lg-4" string="Service at" />
-                            <field name="pos_self_ordering_service_mode" readonly="not pos_module_pos_restaurant and pos_self_ordering_mode != 'kiosk'" />
-                        </div>
-                        <div class="content-group row" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
-                            <label for="pos_self_ordering_default_user_id" class="col-lg-4" string="Default User"/>
-                            <field name="pos_self_ordering_default_user_id" />
-                        </div>
-                        <div id="self-payment-after" class="content-group row" invisible="not pos_self_ordering_mode in ['kiosk', 'mobile']">
-                            <label string="Pay after" for="pos_self_ordering_pay_after" class="col-lg-4"/>
-                            <field name="pos_self_ordering_pay_after" readonly="pos_self_ordering_mode == 'kiosk' or (pos_self_ordering_service_mode == 'counter' and pos_self_ordering_mode == 'mobile')" widget="upgrade_selection"/>
-                        </div>
                     </setting>
                     <setting string="Eat in / Take out" help="Adjust the tax rate based on whether customers are dining in or opting for takeout." invisible="not pos_self_ordering_mode in ['mobile', 'kiosk']">
                         <field name="pos_self_ordering_takeaway"/>

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -18,6 +18,7 @@
                             <button class="btn-link p-0" icon="oi-arrow-right" name="preview_self_order_app" type="object" string="Preview Web interface"/>
                             <button class="btn-link p-0" icon="oi-arrow-right" name="custom_link_action" type="object" string="Home buttons"/>
                             <button class="btn-link p-0" icon="oi-arrow-right" name="generate_qr_codes_page" type="object" string="Print QR Codes" invisible="not pos_self_ordering_mode in ['consultation', 'mobile']"/>
+                            <button class="btn-link p-0" icon="oi-arrow-right" name="generate_qr_codes_zip" type="object" string="Download QR Codes" invisible="not pos_self_ordering_mode in ['consultation', 'mobile']"/>
                             <button groups="base.group_no_one" class="btn-link p-0" icon="oi-arrow-right" name="update_access_tokens" type="object" string="Reset QR Codes" invisible="not pos_self_ordering_mode in ['consultation', 'mobile']"/>
                         </div>
                     </setting>


### PR DESCRIPTION
Previously, QR codes could only be obtained by printing an A4 page.
The problem The problem was that some customers would want to create a
specific design and get the raw image of the QR code directly.

A button has now been added to the settings to download a zip file
containing all the QR codes in PNG format.

A change has been made to the restaurant table form to enable editing of
the access ID. editing of the access ID. This is useful if a customer
has reset his QR codes and wishes to put them back.

Previously, the "close" button in the table selection popup didn't work.
This has been corrected with this PR.

Small design change to the display of products that don't have an image
in the selfOrder.