### PR TITLE
[FIX] spreadsheet_dashboard_sale: fix links to odoo menus

### DIFF
--- a/addons/spreadsheet_dashboard_sale/data/files/product_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale/data/files/product_dashboard.json
@@ -714,8 +714,8 @@
         "30212d4a-1f77-4cb8-8590-4eb34876e260": "sale.sale_menu_root",
         "e35856cf-9090-489b-b055-2d441380d954": "sale.sale_menu_root",
         "d0171069-d2cd-4c2c-a686-cd7515e93bb5": "sale.sale_menu_root",
-        "5f383918-4073-4f19-9cc9-603216c953ad": "sale.menu_sale_report",
-        "ec57f69b-f2b1-4dfc-990c-91ab61b526bf": "sale.menu_sale_report"
+        "5f383918-4073-4f19-9cc9-603216c953ad": "sale.menu_reporting_sales",
+        "ec57f69b-f2b1-4dfc-990c-91ab61b526bf": "sale.menu_reporting_sales"
     },
     "odooVersion": 4,
     "lists": {},

--- a/addons/spreadsheet_dashboard_sale/data/files/sales_dashboard.json
+++ b/addons/spreadsheet_dashboard_sale/data/files/sales_dashboard.json
@@ -2298,8 +2298,8 @@
         "a527960b-0812-4291-baba-f6b4b5280a0d": "sale.menu_sale_order",
         "51823220-f22b-4359-8711-579a249c91bb": "sale.menu_sale_quotations",
         "9a38934c-b454-4a4b-88aa-17d1b80dbf5f": "sale.menu_sale_order",
-        "67858d0e-b5ba-4a3c-bf9e-c0fceaeedf65": "sale.menu_sale_report",
-        "d43375c1-73a6-42a2-8dbd-0f13c285824f": "sale.menu_sale_report"
+        "67858d0e-b5ba-4a3c-bf9e-c0fceaeedf65": "sale.menu_reporting_sales",
+        "d43375c1-73a6-42a2-8dbd-0f13c285824f": "sale.menu_reporting_sales"
     },
     "odooVersion": 4,
     "lists": {


### PR DESCRIPTION
Since c418b35 the menu `sale.menu_sale_report` was split into multiple sub-menus. The dasboards weren't changed, which meant that the links of the scorecards in the dashboard were pointing to a menu without an actionID.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
