### PR TITLE
[FIX] account_peppol: Fetch button not showing when after peppol setup

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -150,6 +150,7 @@ class ResCompany(models.Model):
                     *self.env['account.journal']._check_company_domain(company),
                     ('type', '=', 'purchase'),
                 ], limit=1)
+                company.peppol_purchase_journal_id.is_peppol_journal = True
             else:
                 company.peppol_purchase_journal_id = False
 


### PR DESCRIPTION
Problem
---------
Directly after setting up peppol, the fetch button on the purchase journal (in the dashboard) is not showing.

Objective
---------
Make sure the button is shown directly after the journal is set up.

Solution
---------
When setting up peppol, the compute function that computes the peppol purchase account is triggered. However, this function would not set up the journal's `is_peppol_journal` to true. Thus, no button was showing. Adding that line solves the issue.

linked PR: https://github.com/odoo/odoo/pull/137840

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
