### PR TITLE
[FIX] hr_attendance : Remove pin code in demo data

### DIFF
--- a/addons/hr_attendance/data/hr_attendance_demo.xml
+++ b/addons/hr_attendance/data/hr_attendance_demo.xml
@@ -6,12 +6,10 @@
         </record>
 
         <record id="hr.employee_al" model="hr.employee">
-            <field name="pin">0000</field>
             <field name="barcode">123</field>
         </record>
 
         <record id="hr.employee_admin" model="hr.employee">
-            <field name="pin">0000</field>
             <field name="barcode">456</field>
         </record>
 


### PR DESCRIPTION
We're removing the default pin code on demo data to not restrict access to other apps that depend on it such as the new shop floor app


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
