### PR TITLE
[REF] account,*: refactoring of the Send & Print wizard (part 1)

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -126,7 +126,7 @@ class PortalAccount(CustomerPortal):
         if report_type == 'pdf' and download:
             # Send & Print wizard with only the 'download' checkbox to get the official attachment(s)
             template = request.env.ref(invoice_sudo._get_mail_template())
-            attachment_ids = invoice_sudo._generate_pdf_and_send_invoice(template, checkbox_send_mail=False, checkbox_download=True)
+            attachment_ids = invoice_sudo._generate_pdf_and_send_invoice(template, bypass_download=True, checkbox_send_mail=False, checkbox_download=True)
             attachments = request.env['ir.attachment'].browse(attachment_ids)
             if len(attachments) > 1:
                 filename = invoice_sudo._get_invoice_report_filename(extension='zip')

--- a/addons/account/wizard/account_move_send_views.xml
+++ b/addons/account/wizard/account_move_send_views.xml
@@ -95,8 +95,7 @@
                     </button>
                     <button string="Cancel"
                             data-hotkey="x"
-                            name="action_cancel"
-                            type="object"
+                            special="cancel"
                             class="btn-secondary"/>
                 </footer>
             </form>

--- a/addons/account_edi/wizard/account_move_send.py
+++ b/addons/account_edi/wizard/account_move_send.py
@@ -1,20 +1,19 @@
-# -*- coding: utf-8 -*-
-
-from odoo import models
+from odoo import api, models
 
 
-class AccountMoveSend(models.Model):
+class AccountMoveSend(models.TransientModel):
     _inherit = 'account.move.send'
 
+    @api.model
     def _get_mail_attachment_from_doc(self, doc):
         attachment_sudo = doc.sudo().attachment_id
         if attachment_sudo.res_model and attachment_sudo.res_id:
             return attachment_sudo
         return self.env['ir.attachment']
 
+    @api.model
     def _get_invoice_extra_attachments(self, move):
-        """ Returns extra edi attachments
-        """
+        """ Returns extra edi attachments. """
         result = super()._get_invoice_extra_attachments(move)
         for doc in move.edi_document_ids:
             result += self._get_mail_attachment_from_doc(doc)

--- a/addons/l10n_dk_oioubl/tests/test_xml_oioubl_dk.py
+++ b/addons/l10n_dk_oioubl/tests/test_xml_oioubl_dk.py
@@ -103,7 +103,7 @@ class TestUBLDK(TestUBLCommon, TestAccountMoveSendCommon):
             ],
         })
         invoice.action_post()
-        invoice._generate_pdf_and_send_invoice(self.move_template, from_cron=False, allow_fallback_pdf=False)
+        invoice._generate_pdf_and_send_invoice(self.move_template, allow_fallback_pdf=False)
         return invoice
 
     #########

--- a/addons/l10n_it_edi/models/res_company.py
+++ b/addons/l10n_it_edi/models/res_company.py
@@ -113,6 +113,5 @@ class ResCompany(models.Model):
 
     @api.depends("account_edi_proxy_client_ids")
     def _compute_l10n_it_edi_proxy_user_id(self):
-        self.ensure_one()
         for company in self:
             company.l10n_it_edi_proxy_user_id = company.account_edi_proxy_client_ids.filtered(lambda x: x.proxy_type == 'l10n_it_edi')

--- a/addons/l10n_it_edi/tests/test_account_move_send.py
+++ b/addons/l10n_it_edi/tests/test_account_move_send.py
@@ -45,7 +45,7 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
         results = wizard.action_send_and_print()
 
         # Asserts
-        self.assertEqual(wizard.mode, 'done')
+        self.assertEqual((invoice1 + invoice2).mapped('send_and_print_values'), [False, False])
         self.assertEqual(results['type'], 'ir.actions.act_url')
         self.assertEqual(1, len(self.get_attachments(invoice1.id)))
         self.assertTrue(invoice1.invoice_pdf_report_id)
@@ -75,7 +75,7 @@ class TestItAccountMoveSend(TestItEdi, TestAccountMoveSendCommon):
         results = wizard.action_send_and_print()
 
         # Asserts
-        self.assertEqual(wizard.mode, 'done')
+        self.assertEqual((invoice1 + invoice2).mapped('send_and_print_values'), [False, False])
         self.assertEqual(results['type'], 'ir.actions.act_url')
         self.assertEqual(2, len(self.get_attachments(invoice1.id)))
         self.assertTrue(invoice1.invoice_pdf_report_id)

--- a/addons/l10n_it_edi/wizard/account_move_send.py
+++ b/addons/l10n_it_edi/wizard/account_move_send.py
@@ -3,7 +3,7 @@
 from odoo import _, api, fields, models
 
 
-class AccountMoveSend(models.Model):
+class AccountMoveSend(models.TransientModel):
     _inherit = 'account.move.send'
 
     l10n_it_edi_warning_message = fields.Html(compute='_compute_l10n_it_edi_warning_message')
@@ -25,6 +25,13 @@ class AccountMoveSend(models.Model):
         store=True,
         readonly=False,
         help="Send the e-invoice XML to the Italian Tax Agency.")
+
+    def _get_wizard_values(self, move):
+        # EXTENDS 'account'
+        values = super()._get_wizard_values(move)
+        values['l10n_it_edi_checkbox_xml_export'] = self.l10n_it_edi_checkbox_xml_export
+        values['l10n_it_edi_checkbox_send'] = self.l10n_it_edi_checkbox_send
+        return values
 
     # -------------------------------------------------------------------------
     # COMPUTE/CONSTRAINS METHODS
@@ -60,57 +67,52 @@ class AccountMoveSend(models.Model):
         for wizard in self:
             wizard.l10n_it_edi_checkbox_send = not wizard.l10n_it_edi_readonly_send and wizard.l10n_it_edi_enable_send
 
-    def _get_available_field_values_in_multi(self, move):
-        # EXTENDS 'account'
-        values = super()._get_available_field_values_in_multi(move)
-        export = self.l10n_it_edi_checkbox_xml_export and move._l10n_it_edi_ready_for_xml_export()
-        values['l10n_it_edi_checkbox_xml_export'] = export
-        values['l10n_it_edi_checkbox_send'] = export or (bool(move.l10n_it_edi_attachment_id) and not move.l10n_it_edi_state)
-        return values
-
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
 
+    @api.model
     def _need_invoice_document(self, invoice):
         # EXTENDS 'account'
         return super()._need_invoice_document(invoice) and not invoice.l10n_it_edi_attachment_id
 
     @api.model
-    def _get_invoice_extra_attachments(self, move):
+    def _get_invoice_extra_attachments(self, invoice):
         # EXTENDS 'account'
-        return super()._get_invoice_extra_attachments(move) + move.l10n_it_edi_attachment_id
+        return super()._get_invoice_extra_attachments(invoice) + invoice.l10n_it_edi_attachment_id
 
+    @api.model
     def _hook_invoice_document_before_pdf_report_render(self, invoice, invoice_data):
         # EXTENDS 'account'
         super()._hook_invoice_document_before_pdf_report_render(invoice, invoice_data)
-        if self.l10n_it_edi_checkbox_xml_export and invoice._l10n_it_edi_ready_for_xml_export():
+        if invoice_data.get('l10n_it_edi_checkbox_xml_export') and invoice._l10n_it_edi_ready_for_xml_export():
             if errors := invoice._l10n_it_edi_export_data_check():
                 message = _("Errors occured while creating the e-invoice file.")
                 message += "\n- " + "\n- ".join(errors)
                 invoice_data['error'] = message
 
+    @api.model
     def _hook_invoice_document_after_pdf_report_render(self, invoice, invoice_data):
         # EXTENDS 'account'
         super()._hook_invoice_document_after_pdf_report_render(invoice, invoice_data)
-        if self.l10n_it_edi_checkbox_xml_export and invoice._l10n_it_edi_ready_for_xml_export():
+        if invoice_data.get('l10n_it_edi_checkbox_xml_export') and invoice._l10n_it_edi_ready_for_xml_export():
             invoice_data['l10n_it_edi_values'] = invoice._l10n_it_edi_get_attachment_values(
                 pdf_values=invoice_data['pdf_attachment_values'])
 
+    @api.model
     def _call_web_service_after_invoice_pdf_render(self, invoices_data):
         # EXTENDS 'account'
         super()._call_web_service_after_invoice_pdf_render(invoices_data)
-        if self.l10n_it_edi_checkbox_send:
-            attachments_vals = {}
-            moves = self.env['account.move']
-            for move in invoices_data:
-                if move._l10n_it_edi_ready_for_xml_export():
-                    moves |= move
-                    if attachment := move.l10n_it_edi_attachment_id:
-                        attachments_vals[move] = {'name': attachment.name, 'raw': attachment.raw}
-                    else:
-                        attachments_vals[move] = invoices_data[move]['l10n_it_edi_values']
-            moves._l10n_it_edi_send(attachments_vals)
+        attachments_vals = {}
+        moves = self.env['account.move']
+        for move, move_data in invoices_data.items():
+            if move_data.get('l10n_it_edi_checkbox_send') and move._l10n_it_edi_ready_for_xml_export():
+                moves |= move
+                if attachment := move.l10n_it_edi_attachment_id:
+                    attachments_vals[move] = {'name': attachment.name, 'raw': attachment.raw}
+                else:
+                    attachments_vals[move] = invoices_data[move]['l10n_it_edi_values']
+        moves._l10n_it_edi_send(attachments_vals)
 
     def _link_invoice_documents(self, invoice, invoice_data):
         # EXTENDS 'account'

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -104,7 +104,7 @@ class TestUBLRO(TestUBLCommon):
         })
         invoice = self.create_move("out_invoice", send=False)
         with self.assertRaisesRegex(UserError, "doesn't have a country code prefix in their Company ID"):
-            invoice._generate_pdf_and_send_invoice(self.move_template, from_cron=False, allow_fallback_pdf=False)
+            invoice._generate_pdf_and_send_invoice(self.move_template, allow_fallback_pdf=False)
 
     def test_export_no_vat_but_have_company_id_with_prefix(self):
         self.company_data['company'].write({
@@ -119,7 +119,7 @@ class TestUBLRO(TestUBLCommon):
         self.company_data['company'].vat = '1234567897'
         invoice = self.create_move("out_invoice", send=False)
         with self.assertRaisesRegex(UserError, "doesn't have a country code prefix in their VAT"):
-            invoice._generate_pdf_and_send_invoice(self.move_template, from_cron=False, allow_fallback_pdf=False)
+            invoice._generate_pdf_and_send_invoice(self.move_template, allow_fallback_pdf=False)
 
     def test_export_constraints(self):
         self.company_data['company'].company_registry = None
@@ -128,10 +128,10 @@ class TestUBLRO(TestUBLCommon):
             self.company_data["company"][required_field] = None
             invoice = self.create_move("out_invoice", send=False)
             with self.assertRaisesRegex(UserError, "required"):
-                invoice._generate_pdf_and_send_invoice(self.move_template, from_cron=False, allow_fallback_pdf=False)
+                invoice._generate_pdf_and_send_invoice(self.move_template, allow_fallback_pdf=False)
             self.company_data["company"][required_field] = prev_val
 
         self.company_data["company"].city = "Bucharest"
         invoice = self.create_move("out_invoice", send=False)
         with self.assertRaisesRegex(UserError, "city name must be 'SECTORX'"):
-            invoice._generate_pdf_and_send_invoice(self.move_template, from_cron=False, allow_fallback_pdf=False)
+            invoice._generate_pdf_and_send_invoice(self.move_template, allow_fallback_pdf=False)


### PR DESCRIPTION
Currently the Send & Print wizard is stored as regular model
and not a TransientModel.
This cause multiple problems including concurrency ones.
This PR switches the wizard back to a regular transient one.
We instead store the values of the wizard that needs to be
processed asynchronously in the related move.

task-id: 3415101