### PR TITLE
[IMP] tools: combine Markup and gettext

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -6,7 +6,7 @@ from dateutil.relativedelta import relativedelta
 from hashlib import sha256
 from json import dumps
 import logging
-from markupsafe import Markup, escape
+from markupsafe import Markup
 from psycopg2 import OperationalError
 import re
 from textwrap import shorten
@@ -2363,11 +2363,9 @@ class AccountMove(models.Model):
             default['date'] = self.company_id._get_user_fiscal_lock_date() + timedelta(days=1)
         copied_am = super().copy(default)
         message_origin = '' if not copied_am.auto_post_origin_id else \
-            (Markup('<br/>') + _('This recurring entry originated from %s')) % copied_am.auto_post_origin_id._get_html_link()
-        message_content = _('This entry has been reversed from %s') if default.get('reversed_entry_id') else _('This entry has been duplicated from %s')
-        copied_am._message_log(body=
-            (escape(message_content) % self._get_html_link()) + message_origin,
-        )
+            (Markup('<br/>') + _('This recurring entry originated from %s', copied_am.auto_post_origin_id._get_html_link()))
+        message_content = _('This entry has been reversed from %s', self._get_html_link()) if default.get('reversed_entry_id') else _('This entry has been duplicated from %s', self._get_html_link())
+        copied_am._message_log(body=message_content + message_origin)
 
         return copied_am
 

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from contextlib import contextmanager
 from datetime import date, timedelta
 from functools import lru_cache
-from markupsafe import escape
 
 from odoo import api, fields, models, Command, _
 from odoo.exceptions import ValidationError, UserError
@@ -1548,7 +1547,7 @@ class AccountMoveLine(models.Model):
                     for line in self.filtered(lambda l: l.move_id.id == move_id):
                         tracking_value_ids = line._mail_track(ref_fields, modified_lines)[1]
                         if tracking_value_ids:
-                            msg = escape(_("Journal Item %s updated")) % line._get_html_link(title=f"#{line.id}")
+                            msg = _("Journal Item %s updated", line._get_html_link(title=f"#{line.id}"))
                             line.move_id._message_log(
                                 body=msg,
                                 tracking_value_ids=tracking_value_ids

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from markupsafe import escape
-
 from odoo import models, fields, api, _, Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.misc import format_date, formatLang
@@ -913,9 +911,9 @@ class AccountPayment(models.Model):
             })
             paired_payment.move_id._post(soft=False)
             payment.paired_internal_transfer_payment_id = paired_payment
-            body = escape(_("This payment has been created from:")) + payment._get_html_link()
+            body = _("This payment has been created from:") + payment._get_html_link()
             paired_payment.message_post(body=body)
-            body = escape(_("A second payment has been created:")) + paired_payment._get_html_link()
+            body = _("A second payment has been created:") + paired_payment._get_html_link()
             payment.message_post(body=body)
 
             lines = (payment.move_id.line_ids + paired_payment.move_id.line_ids).filtered(

--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import base64
 from collections import defaultdict
-from markupsafe import escape
 
 import werkzeug
 import werkzeug.exceptions
@@ -255,7 +254,7 @@ class ResPartnerBank(models.Model):
 
         res = super().create(vals_list)
         for account in res:
-            msg = escape(_("Bank Account %s created")) % account._get_html_link(title=f"#{account.id}")
+            msg = _("Bank Account %s created", account._get_html_link(title=f"#{account.id}"))
             account.partner_id._message_log(body=msg)
         return res
 
@@ -292,7 +291,7 @@ class ResPartnerBank(models.Model):
         for account, initial_values in account_initial_values.items():
             tracking_value_ids = account._mail_track(fields_definition, initial_values)[1]
             if tracking_value_ids:
-                msg = escape(_("Bank Account %s updated")) % account._get_html_link(title=f"#{account.id}")
+                msg = _("Bank Account %s updated", account._get_html_link(title=f"#{account.id}"))
                 account.partner_id._message_log(body=msg, tracking_value_ids=tracking_value_ids)
                 if 'partner_id' in initial_values:  # notify previous partner as well
                     initial_values['partner_id']._message_log(body=msg, tracking_value_ids=tracking_value_ids)
@@ -301,7 +300,7 @@ class ResPartnerBank(models.Model):
     def unlink(self):
         # EXTENDS base res.partner.bank
         for account in self:
-            msg = escape(_("Bank Account %s with number %s deleted")) % (account._get_html_link(title=f"#{account.id}"), account.acc_number)
+            msg = _("Bank Account %s with number %s deleted", account._get_html_link(title=f"#{account.id}"), account.acc_number)
             account.partner_id._message_log(body=msg)
         return super().unlink()
 

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 from odoo import models, fields, api
-from markupsafe import escape
 from odoo.tools.translate import _
 from odoo.exceptions import UserError
 
@@ -125,7 +124,7 @@ class AccountMoveReversal(models.TransientModel):
         for moves, default_values_list, is_cancel_needed in batches:
             new_moves = moves._reverse_moves(default_values_list, cancel=is_cancel_needed)
             moves._message_log_batch(
-                bodies=dict((move.id, escape(_('This entry has been %s')) % reverse._get_html_link(title=_("reversed"))) for move, reverse in zip(moves, new_moves))
+                bodies={move.id: _('This entry has been %s', reverse._get_html_link(title=_("reversed"))) for move, reverse in zip(moves, new_moves)}
             )
 
             if is_modify:

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from dateutil.relativedelta import relativedelta
-from markupsafe import escape
 import json
 from odoo import models, fields, api, _, Command
 from odoo.tools import format_date
@@ -240,13 +239,13 @@ class AccruedExpenseRevenue(models.TransientModel):
         }])
         reverse_move._post()
         for order in orders_with_entries:
-            body = escape(_(
+            body = _(
                 'Accrual entry created on %(date)s: %(accrual_entry)s.\
-                    And its reverse entry: %(reverse_entry)s.')) % {
-                'date': self.date,
-                'accrual_entry': move._get_html_link(),
-                'reverse_entry': reverse_move._get_html_link(),
-            }
+                    And its reverse entry: %(reverse_entry)s.',
+                date=self.date,
+                accrual_entry=move._get_html_link(),
+                reverse_entry=reverse_move._get_html_link(),
+            )
             order.message_post(body=body)
         return {
             'name': _('Accrual Moves'),

--- a/addons/account_debit_note/wizard/account_debit_note.py
+++ b/addons/account_debit_note/wizard/account_debit_note.py
@@ -2,7 +2,7 @@
 from odoo import models, fields, api
 from odoo.tools.translate import _
 from odoo.exceptions import UserError
-from markupsafe import escape
+
 
 class AccountDebitNote(models.TransientModel):
     """
@@ -71,7 +71,7 @@ class AccountDebitNote(models.TransientModel):
         for move in self.move_ids.with_context(include_business_fields=True): #copy sale/purchase links
             default_values = self._prepare_default_values(move)
             new_move = move.copy(default=default_values)
-            move_msg = escape(_("This debit note was created from: %s")) % move._get_html_link()
+            move_msg = _("This debit note was created from: %s", move._get_html_link())
             new_move.message_post(body=move_msg)
             new_moves |= new_move
 

--- a/addons/account_fleet/models/account_move.py
+++ b/addons/account_fleet/models/account_move.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import escape
 from odoo import models, fields, api, _
 
 
@@ -19,7 +18,7 @@ class AccountMove(models.Model):
         posted = super()._post(soft)  # We need the move name to be set, but we also need to know which move are posted for the first time.
         for line in (not_posted_before & posted).line_ids.filtered(lambda ml: ml.vehicle_id and ml.move_id.move_type == 'in_invoice'):
             val = line._prepare_fleet_log_service()
-            log = escape(_('Service Vendor Bill: %s')) % line.move_id._get_html_link()
+            log = _('Service Vendor Bill: %s', line.move_id._get_html_link())
             val_list.append(val)
             log_list.append(log)
         log_service_ids = self.env['fleet.vehicle.log.services'].create(val_list)

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -1,6 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import escape
 from odoo import api, fields, models, SUPERUSER_ID, _
 
 
@@ -215,7 +214,7 @@ class PaymentTransaction(models.Model):
         """
         super()._finalize_post_processing()
         for tx in self.filtered('payment_id'):
-            message = escape(_("The payment related to the transaction with reference %(ref)s has been posted: %(link)s")) % {
-                'ref':tx.reference, 'link':tx.payment_id._get_html_link()
-            }
+            message = _("The payment related to the transaction with reference %(ref)s has been posted: %(link)s",
+                ref=tx.reference, link=tx.payment_id._get_html_link(),
+            )
             tx._log_message_on_linked_documents(message)

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -7,7 +7,7 @@ import threading
 from ast import literal_eval
 from collections import OrderedDict, defaultdict
 from datetime import date, datetime, timedelta
-from markupsafe import Markup, escape
+from markupsafe import Markup
 from psycopg2 import sql
 
 from odoo import api, fields, models, tools, SUPERUSER_ID
@@ -1319,7 +1319,7 @@ class Lead(models.Model):
             'meeting_user_time': meeting_usertime,
         }
         message = Markup("<p>%(meeting)s<br/>%(subject_string)s %(subject_link)s<br/>%(duration)s<p>") % {
-            'meeting': escape(_("Meeting scheduled at %s")) % meeting_time,
+            'meeting': _("Meeting scheduled at %s", meeting_time),
             'subject_string': _("Subject: "),
             'subject_link': meeting._get_html_link(),
             'duration': _("Duration: %s", duration),

--- a/addons/crm_livechat/models/discuss_channel.py
+++ b/addons/crm_livechat/models/discuss_channel.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import escape
 from odoo import models, _
 from odoo.tools import html2plaintext
 
@@ -16,7 +15,7 @@ class DiscussChannel(models.Model):
             msg = _('Create a new lead (/lead lead title)')
         else:
             lead = self._convert_visitor_to_lead(partner, key)
-            msg = escape(_('Created a new lead: %s')) % lead._get_html_link()
+            msg = _('Created a new lead: %s', lead._get_html_link())
         self._send_transient_message(partner, msg)
 
     def _convert_visitor_to_lead(self, partner, key):

--- a/addons/hr_expense/models/account_move.py
+++ b/addons/hr_expense/models/account_move.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import escape
-
 from odoo import models, fields, api, _
 from odoo.exceptions import UserError
 from odoo.tools.misc import frozendict
@@ -29,7 +27,7 @@ class AccountMove(models.Model):
 
     def _creation_message(self):
         if self.expense_sheet_id:
-            return escape(_("Expense entry created from: %s")) % self.expense_sheet_id._get_html_link()
+            return _("Expense entry created from: %s", self.expense_sheet_id._get_html_link())
         return super()._creation_message()
 
     @api.depends('expense_sheet_id')

--- a/addons/hr_expense/models/account_payment.py
+++ b/addons/hr_expense/models/account_payment.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import escape
-
 from odoo import models, _
 from odoo.exceptions import UserError
 
@@ -40,7 +38,7 @@ class AccountPayment(models.Model):
         # EXTENDS mail
         self.ensure_one()
         if self.move_id.expense_sheet_id:
-            return escape(_("Payment created for: %s")) % self.move_id.expense_sheet_id._get_html_link()
+            return _("Payment created for: %s", self.move_id.expense_sheet_id._get_html_link())
         return super()._creation_message()
 
     def unlink(self):

--- a/addons/hr_recruitment_survey/wizard/survey_invite.py
+++ b/addons/hr_recruitment_survey/wizard/survey_invite.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import Markup, escape
+from markupsafe import Markup
 
 from odoo import fields, models, _
 from odoo.tools.misc import clean_context
@@ -39,10 +39,10 @@ class SurveyInvite(models.TransientModel):
             partner = self.applicant_id.partner_id
             survey_link = survey._get_html_link(title=survey.title)
             partner_link = partner._get_html_link()
-            content = escape(_('The survey %(survey_link)s has been sent to %(partner_link)s')) % {
-                'survey_link': survey_link,
-                'partner_link': partner_link,
-            }
+            content = _('The survey %(survey_link)s has been sent to %(partner_link)s',
+                survey_link=survey_link,
+                partner_link=partner_link,
+            )
             body = Markup('<p>%s</p>') % content
             self.applicant_id.message_post(body=body)
         return super().action_invite()

--- a/addons/hr_skills_slides/models/slide_channel.py
+++ b/addons/hr_skills_slides/models/slide_channel.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import Markup, escape
+from markupsafe import Markup
 
 from odoo import fields, models, _
 from odoo.tools import html2plaintext
@@ -50,11 +50,11 @@ class SlideChannelPartner(models.Model):
         super()._send_completed_mail()
         for scp in self:
             if self.env.user.employee_ids:
-                msg = escape(_('The employee has completed the course %s')) % \
+                msg = _('The employee has completed the course %s',
                     Markup('<a href="%(link)s">%(course)s</a>') % {
                         'link': scp.channel_id.website_url,
                         'course': scp.channel_id.name,
-                    }
+                })
                 self.env.user.employee_id.message_post(body=msg)
 
 class Channel(models.Model):
@@ -65,11 +65,11 @@ class Channel(models.Model):
         if member_status == 'joined':
             for channel in self:
                 channel._message_employee_chatter(
-                    escape(_('The employee subscribed to the course %s')) % \
-                    Markup('<a href="%(link)s">%(course)s</a>') % {
-                        'link': channel.website_url,
-                        'course': channel.name
-                    },
+                    _('The employee subscribed to the course %s',
+                        Markup('<a href="%(link)s">%(course)s</a>') % {
+                            'link': channel.website_url,
+                            'course': channel.name
+                    }),
                     target_partners
                 )
         return res
@@ -81,10 +81,11 @@ class Channel(models.Model):
 
         for channel in self:
             channel._message_employee_chatter(
-                Markup(_('The employee left the course <a href="%(link)s">%(course)s</a>')) % {
-                    'link': channel.website_url,
-                    'course': channel.name,
-                },
+                _('The employee left the course %s',
+                    Markup('<a href="%(link)s">%(course)s</a>') % {
+                        'link': channel.website_url,
+                        'course': channel.name,
+                }),
                 partners)
         return res
 

--- a/addons/im_livechat_mail_bot/models/mail_bot.py
+++ b/addons/im_livechat_mail_bot/models/mail_bot.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import Markup, escape
+from markupsafe import Markup
 from odoo import models, _
 
 
@@ -22,6 +22,6 @@ class MailBot(models.AbstractModel):
             # repeat question if needed
             elif odoobot_state == 'onboarding_canned' and not self._is_help_requested(body):
                 self.env.user.odoobot_failed = True
-                return escape(_("Not sure what you are doing. Please, type %s and wait for the propositions. Select one of them and press enter.")) % \
-                    Markup("<span class=\"o_odoobot_command\">:</span>")
+                return _("Not sure what you are doing. Please, type %s and wait for the propositions. Select one of them and press enter.",
+                    Markup("<span class=\"o_odoobot_command\">:</span>"))
         return super(MailBot, self)._get_answer(record, body, values, command)

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -1,7 +1,7 @@
 import re
 
 from collections import defaultdict
-from markupsafe import escape, Markup
+from markupsafe import Markup
 
 from odoo import fields, models, api, _, Command
 from odoo.exceptions import UserError
@@ -454,7 +454,7 @@ class AccountMove(models.Model):
             })
             with other_invoice._get_edi_creation():
                 self._import_invoice_facturae_invoice(other_invoice, partner, node)
-                other_invoice.message_post(body=escape(_("Created from attachment in %s")) % invoice._get_html_link())
+                other_invoice.message_post(body=_("Created from attachment in %s", invoice._get_html_link()))
 
     def _import_invoice_facturae_invoice(self, invoice, partner, tree):
         logs = []

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -2,7 +2,6 @@
 
 import ast
 from dateutil.relativedelta import relativedelta
-from markupsafe import escape
 
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import UserError
@@ -348,7 +347,7 @@ class MaintenanceRequest(models.Model):
     def _get_activity_note(self):
         self.ensure_one()
         if self.equipment_id:
-            return escape(_('Request planned for %s')) % self.equipment_id._get_html_link()
+            return _('Request planned for %s', self.equipment_id._get_html_link())
         return False
 
     def activity_update(self):

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -7,7 +7,6 @@ from odoo.tools import float_compare, float_round
 from odoo.osv import expression
 
 from collections import defaultdict
-from markupsafe import escape
 
 class MrpUnbuild(models.Model):
     _name = "mrp.unbuild"
@@ -201,11 +200,11 @@ class MrpUnbuild(models.Model):
         produced_move_line_ids = produce_moves.mapped('move_line_ids').filtered(lambda ml: ml.qty_done > 0)
         consume_moves.mapped('move_line_ids').write({'produce_line_ids': [(6, 0, produced_move_line_ids.ids)]})
         if self.mo_id:
-            unbuild_msg = escape(_("%(qty)s %(measure)s unbuilt in %(order)s")) % {
-                'qty': self.product_qty,
-                'measure': self.product_uom_id.name,
-                'order': self._get_html_link(),
-            }
+            unbuild_msg = _("%(qty)s %(measure)s unbuilt in %(order)s",
+                qty=self.product_qty,
+                measure=self.product_uom_id.name,
+                order=self._get_html_link(),
+            )
             self.mo_id.message_post(
                 body=unbuild_msg,
                 subtype_xmlid='mail.mt_note',

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -6,7 +6,6 @@ from markupsafe import Markup
 from functools import partial
 from itertools import groupby
 from collections import defaultdict
-from markupsafe import escape
 
 import psycopg2
 import pytz
@@ -596,8 +595,8 @@ class PosOrder(models.Model):
     def _create_invoice(self, move_vals):
         self.ensure_one()
         new_move = self.env['account.move'].sudo().with_company(self.company_id).with_context(default_move_type=move_vals['move_type']).create(move_vals)
-        message = escape(_("This invoice has been created from the point of sale session: %s")) % \
-            self._get_html_link()
+        message = _("This invoice has been created from the point of sale session: %s",
+            self._get_html_link())
 
         new_move.message_post(body=message)
         if self.config_id.cash_rounding:

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -2,7 +2,6 @@
 
 from datetime import timedelta
 from itertools import groupby
-from markupsafe import escape
 
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.exceptions import AccessError, UserError, ValidationError
@@ -1078,8 +1077,8 @@ class SaleOrder(models.Model):
         self._recompute_taxes()
 
         if self.partner_id:
-            self.message_post(body=escape(_("Product taxes have been recomputed according to fiscal position %s.")) % \
-                self.fiscal_position_id._get_html_link() if self.fiscal_position_id else "",
+            self.message_post(body=_("Product taxes have been recomputed according to fiscal position %s.",
+                self.fiscal_position_id._get_html_link() if self.fiscal_position_id else "")
             )
 
     def _recompute_taxes(self):
@@ -1093,8 +1092,8 @@ class SaleOrder(models.Model):
         self._recompute_prices()
 
         if self.pricelist_id:
-            message = escape(_("Product prices have been recomputed according to pricelist %s.")) % \
-                self.pricelist_id._get_html_link()
+            message = _("Product prices have been recomputed according to pricelist %s.",
+                self.pricelist_id._get_html_link())
         else:
             message = _("Product prices have been recomputed.")
         self.message_post(body=message)
@@ -1696,7 +1695,7 @@ class SaleOrder(models.Model):
             order.activity_schedule(
                 'sale.mail_act_sale_upsell',
                 user_id=order.user_id.id or order.partner_id.user_id.id,
-                note=escape(_("Upsell %(order)s for customer %(customer)s")) % {"order":order_ref, "customer":customer_ref})
+                note=_("Upsell %(order)s for customer %(customer)s", order=order_ref, customer=customer_ref))
 
     def _prepare_analytic_account_data(self, prefix=None):
         """ Prepare SO analytic account creation values.

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import escape
-
 from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.exceptions import UserError
 from odoo.fields import Command
@@ -266,9 +264,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
             )
 
             order.with_user(poster).message_post(
-                body=escape(_(
-                    "%s has been created",
-                )) % invoice._get_html_link(title=_("Down payment invoice")),
+                body=_("%s has been created",
+                        invoice._get_html_link(title=_("Down payment invoice"))),
             )
 
             return invoice

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -2,7 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from collections import defaultdict
-from markupsafe import escape
 
 from odoo import api, Command, fields, models, _
 from odoo.exceptions import AccessError
@@ -115,7 +114,7 @@ class SaleOrderLine(models.Model):
                 line.sudo()._timesheet_service_generation()
                 # if the SO line created a task, post a message on the order
                 if line.task_id and not has_task:
-                    msg_body = escape(_("Task Created (%s): %s")) % (line.product_id.name, line.task_id._get_html_link())
+                    msg_body = _("Task Created (%s): %s", line.product_id.name, line.task_id._get_html_link())
                     line.order_id.message_post(body=msg_body)
 
         # Set a service SOL on the project, if any is given
@@ -243,7 +242,7 @@ class SaleOrderLine(models.Model):
         task = self.env['project.task'].sudo().create(values)
         self.write({'task_id': task.id})
         # post message on task
-        task_msg = escape(_("This task has been created from: %s (%s)")) % (
+        task_msg = _("This task has been created from: %s (%s)",
             self.order_id._get_html_link(),
             self.product_id.name
         )

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -4,7 +4,6 @@
 
 from collections import defaultdict
 from datetime import timedelta
-from markupsafe import escape
 from operator import itemgetter
 from re import findall as regex_findall
 
@@ -768,7 +767,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         if not documents or not doc_orig:
             return
 
-        msg = escape(_("The deadline has been automatically updated due to a delay on %s.")) % doc_orig[0]._get_html_link()
+        msg = _("The deadline has been automatically updated due to a delay on %s.", doc_orig[0]._get_html_link())
         msg_subject = _("Deadline updated due to delay on %s", doc_orig[0].name)
         # write the message on each document
         for doc in documents:

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -7,7 +7,6 @@ import time
 from ast import literal_eval
 from datetime import date, timedelta
 from collections import defaultdict
-from markupsafe import escape
 
 from odoo import SUPERUSER_ID, _, api, Command, fields, models
 from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
@@ -1363,7 +1362,7 @@ class Picking(models.Model):
                     'backorder_id': picking.id
                 })
                 picking.message_post(
-                    body=escape(_('The backorder %s has been created.')) % backorder_picking._get_html_link()
+                    body=_('The backorder %s has been created.', backorder_picking._get_html_link())
                 )
                 moves_to_backorder.write({'picking_id': backorder_picking.id})
                 moves_to_backorder.move_line_ids.package_level_id.write({'picking_id':backorder_picking.id})

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from markupsafe import escape
-
 from odoo import _, api, Command, fields, models
 from odoo.osv import expression
 from odoo.exceptions import ValidationError
@@ -241,7 +239,7 @@ class StockPicking(models.Model):
         pickings = self.filtered(lambda p: p.user_id.id != user_id)
         pickings.write({'user_id': user_id})
         for pick in pickings:
-            log_message = escape(_('Assigned to %s Responsible')) % pick.batch_id._get_html_link()
+            log_message = _('Assigned to %s Responsible', pick.batch_id._get_html_link())
             pick.message_post(body=log_message)
 
     def action_view_batch(self):

--- a/odoo/addons/test_translation_import/tests/test_term_count.py
+++ b/odoo/addons/test_translation_import/tests/test_term_count.py
@@ -2,6 +2,7 @@
 
 import base64
 import io
+from markupsafe import Markup
 
 from odoo.tests import common, tagged
 from odoo.tools.misc import file_open, mute_logger
@@ -218,6 +219,13 @@ class TestImport(common.TransactionCase):
         # source error: wrong arguments
         with self.assertRaises(KeyError):
             model_fr_BE.get_code_named_placeholder_translation(symbol="🧀"),
+
+        # correctly translate markup
+        self.assertEqual(
+            model_fr_BE.get_code_named_placeholder_translation(num=Markup(2), symbol="<🧀>"),
+            Markup("Code, 2, &lt;🧀&gt;, Français, Belgium"),
+            "Translation placeholders were not applied when using Markup"
+        )
 
 
 @tagged('post_install', '-at_install')

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -24,6 +24,7 @@ from os.path import join
 from pathlib import Path
 from babel.messages import extract
 from lxml import etree, html
+from markupsafe import escape, Markup
 from psycopg2.extras import Json
 
 import odoo
@@ -460,6 +461,8 @@ class GettextAlias(object):
         translation = self._get_translation(source)
         assert not (args and kwargs)
         if args or kwargs:
+            if any(isinstance(a, Markup) for a in itertools.chain(args, kwargs.values())):
+                translation = escape(translation)
             try:
                 return translation % (args or kwargs)
             except (TypeError, ValueError, KeyError):


### PR DESCRIPTION
Before this PR, if one wanted to combine translatable content and a markup object, it had to explicitly use `escape` which meants losing the fallback mechanism of gettext

```py
>>> escape(_("Order %s has been confirmed")) % Markup("<a>%s</a>") % order.name
Markup("Order <a>SO42</a> has been confirmed")
```
After this PR, it is possible to explictly give a Markup object to the gettext call
```py
>>> _("Order %s has been confirmed", Markup("<a>%s</a>") % order.name)
Markup("Order <a>SO42</a> has been confirmed")
```
Note that this also support complex sentences like
```py
>>> _("Order %(order)s has been confirmed at %(date)s",
...   order=Markup("<a>%s</a>") % order.name,
...   date=fields.Datetime.now())
Markup("Order <a>SO42</a> has been confirmed at 2023-10-20 10:33:4")
```
and the text content is correctly escaped when mixed with HTML
```py
>>> _("Received a message from %s <%s>",
...   msg.name,
...   Markup("<a href=mailto:%s>%s</a>") % (msg.email, msg.email))
Markup('Received a message from Foo &lt;<a href=mailto:foo@bar.com>foo@bar.com</a>&gt;')
```

**But** you can **not** do:
```py
>>> _("Received a message from <strong>%s</strong> <%s>",
...   msg.name,
...   Markup("<a href=mailto:%s>%s</a>") % (msg.email, msg.email))
Markup('Received a message from &lt;strong&gt;Foo&lt;/strong&gt; &lt;<a href=mailto:foo@bar.com>foo@bar.com</a>&gt;')
```
and btw, you can still not do
```py
>>> _(Markup("Received a message from <strong>%s</strong> <%s>"),
...   msg.name,
...   Markup("<a href=mailto:%s>%s</a>") % (msg.email, msg.email))
DeadKittenError: security is broken, translation export is broken
```
