### PR TITLE
[FIX] web_editor: issue with embedded link

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -515,7 +515,7 @@ var SnippetEditor = Widget.extend({
         // Actually remove the snippet and its option UI.
         var $parent = this.$target.parent();
         this.$target.find('*').addBack().tooltip('dispose');
-        this.$target.remove();
+        this.$target.detach();
         this.$el.remove();
 
         var node = $parent[0];


### PR DESCRIPTION
**Current behavior before PR:**

- After a link or image is deleted using the 'Remove Block' button, all the
  changes made inside the DOM are not observed by the observer.

**Desired behavior after PR is merged:**

- Now, when a link or image is deleted using the 'Remove Block' button, all
  the changes made inside the DOM will be observed by the observer.

task:3557503