### PR TITLE
[IMP] spreadsheet: improve wrong linked menu handling

### DIFF
--- a/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.js
+++ b/addons/spreadsheet/static/src/chart/odoo_menu/figure_component.js
@@ -3,17 +3,28 @@
 import { patch } from "@web/core/utils/patch";
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { useService } from "@web/core/utils/hooks";
+import { _t } from "@web/core/l10n/translation";
 
 patch(spreadsheet.components.FigureComponent.prototype, {
     setup() {
         super.setup();
         this.menuService = useService("menu");
         this.actionService = useService("action");
+        this.notificationService = useService("notification");
     },
     async navigateToOdooMenu() {
         const menu = this.env.model.getters.getChartOdooMenu(this.props.figure.id);
         if (!menu) {
             throw new Error(`Cannot find any menu associated with the chart`);
+        }
+        if (!menu.actionID) {
+            this.notificationService.add(
+                _t(
+                    "The menu linked to this chart doesn't have an corresponding action. Please link the chart to another menu."
+                ),
+                { type: "danger" }
+            );
+            return;
         }
         await this.actionService.doAction(menu.actionID);
     },

--- a/addons/spreadsheet/tests/validate_spreadsheet_data.py
+++ b/addons/spreadsheet/tests/validate_spreadsheet_data.py
@@ -182,7 +182,7 @@ def fields_in_spreadsheet(data):
     return dict(fields_by_model)
 
 
-def xml_ids_in_spreadsheet(data):
+def menus_xml_ids_in_spreadsheet(data):
 
     return set(data.get("chartOdooMenusReferences", {}).values()) | {
         url[len(xml_id_url_prefix):]
@@ -212,9 +212,14 @@ class ValidateSpreadsheetData(TransactionCase):
                     if field.relational:
                         field_model = field.comodel_name
 
-        for xml_id in xml_ids_in_spreadsheet(data):
+        for xml_id in menus_xml_ids_in_spreadsheet(data):
             record = self.env.ref(xml_id, raise_if_not_found=False)
             if not record:
                 raise AssertionError(
                     f"xml id '{xml_id}' used in spreadsheet '{spreadsheet_name}' does not exist"
+                )
+            # check that the menu has an action. Root menus always have an action.
+            if not record.action and record.parent_id.id:
+                raise AssertionError(
+                    f"menu with xml id '{xml_id}' used in spreadsheet '{spreadsheet_name}' does not have an action"
                 )


### PR DESCRIPTION
If a chart was linked to an odoo menu, but the odoo menu didn't have an action, the user would get a traceback when clicking on the chart.

This commit:
- Improves dashboard validation. Now we test that the menu is linked to an action, in addition to testing that the menu exists
- Send a "danger" notification when the user clicks on a chart with a menu without an action linked to it, rather than a traceback

Task: [3563450](https://www.odoo.com/web#id=3563450&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
