### PR TITLE
[IMP] mail, *: return recordset in channel create methods

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -811,14 +811,14 @@ class Meeting(models.Model):
         self.videocall_channel_id.channel_change_description(self.recurrence_id.name if self.recurrency else self.display_time)
 
     def _create_videocall_channel_id(self, name, partner_ids):
-        videocall_channel_id = self.env['discuss.channel'].create_group(partner_ids, default_display_mode='video_full_screen', name=name)
+        videocall_channel = self.env['discuss.channel'].create_group(partner_ids, default_display_mode='video_full_screen', name=name)
         # if recurrent event, set channel to all other records of the same recurrency
         if self.recurrency:
             recurrent_events_without_channel = self.env['calendar.event'].search([
                 ('recurrence_id', '=', self.recurrence_id.id), ('videocall_channel_id', '=', False)
             ])
-            recurrent_events_without_channel.videocall_channel_id = videocall_channel_id['id']
-        return videocall_channel_id['id']
+            recurrent_events_without_channel.videocall_channel_id = videocall_channel
+        return videocall_channel
 
     # ------------------------------------------------------------
     # ACTIONS

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -929,6 +929,7 @@ class Channel(models.Model):
 
     # User methods
     @api.model
+    @api.returns('self', lambda channel: channel._channel_info()[0])
     def channel_get(self, partners_to, pin=True):
         """ Get the canonical private channel between some partners, create it if needed.
             To reuse an old channel (conversation), this one must be private, and contains
@@ -987,7 +988,7 @@ class Channel(models.Model):
                 'name': ', '.join(self.env['res.partner'].sudo().browse(partners_to).mapped('name')),
             })
             channel._broadcast(partners_to)
-        return channel._channel_info()[0]
+        return channel
 
     def channel_fold(self, state=None, state_count=0):
         """ Update the fold_state of the given session. In order to syncronize web browser
@@ -1138,6 +1139,7 @@ class Channel(models.Model):
         self.add_members(self.env.user.partner_id.ids)
 
     @api.model
+    @api.returns('self', lambda channel: channel._channel_info()[0])
     def channel_create(self, name, group_id):
         """ Create a channel and add the current partner, broadcast it (to make the user directly
             listen to it when polling)
@@ -1157,9 +1159,10 @@ class Channel(models.Model):
         new_channel.message_post(body=notification, message_type="notification", subtype_xmlid="mail.mt_comment")
         channel_info = new_channel._channel_info()[0]
         self.env['bus.bus']._sendone(self.env.user.partner_id, 'mail.record/insert', {"Thread": channel_info})
-        return channel_info
+        return new_channel
 
     @api.model
+    @api.returns('self', lambda channel: channel._channel_info()[0])
     def create_group(self, partners_to, default_display_mode=False, name=''):
         """ Creates a group channel.
 
@@ -1177,7 +1180,7 @@ class Channel(models.Model):
             'name': name,
         })
         channel._broadcast(partners_to)
-        return channel._channel_info()[0]
+        return channel
 
     @api.model
     def get_mention_suggestions(self, search, limit=8):

--- a/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_as_guest.py
@@ -28,13 +28,13 @@ class TestMailPublicPage(HttpCase):
         )
         guest = self.env['mail.guest'].create({'name': 'Guest Mario'})
 
-        self.channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_create(group_id=None, name='Test channel')['id'])
+        self.channel = self.env['discuss.channel'].channel_create(group_id=None, name='Test channel')
         self.channel.allow_public_upload = True
         self.channel.add_members(portal_user.partner_id.ids)
         self.channel.add_members(internal_user.partner_id.ids)
         self.channel.add_members(guest_ids=[guest.id])
 
-        self.group = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=(internal_user + portal_user).partner_id.ids, name="Test group")['id'])
+        self.group = self.env['discuss.channel'].create_group(partners_to=(internal_user + portal_user).partner_id.ids, name="Test group")
         self.group.add_members(guest_ids=[guest.id])
         self.group.allow_public_upload = True
 

--- a/addons/mail/tests/discuss/test_discuss_channel_member.py
+++ b/addons/mail/tests/discuss/test_discuss_channel_member.py
@@ -56,7 +56,7 @@ class TestDiscussChannelMembers(MailCommon):
             'channel_type': 'channel',
             'group_public_id': cls.secret_group.id,
         })
-        cls.public_channel = cls.env['discuss.channel'].browse(cls.env['discuss.channel'].channel_create(group_id=None, name='Public channel of user 1')['id'])
+        cls.public_channel = cls.env['discuss.channel'].channel_create(group_id=None, name='Public channel of user 1')
         (cls.group | cls.group_restricted_channel | cls.public_channel).channel_member_ids.unlink()
 
     # ------------------------------------------------------------
@@ -243,7 +243,7 @@ class TestDiscussChannelMembers(MailCommon):
     # ------------------------------------------------------------
 
     def test_unread_counter_with_message_post(self):
-        channel_as_user_1 = self.env['discuss.channel'].browse(self.env['discuss.channel'].with_user(self.user_1).channel_create(group_id=None, name='Public channel')['id'])
+        channel_as_user_1 = self.env['discuss.channel'].with_user(self.user_1).channel_create(group_id=None, name='Public channel')
         channel_as_user_1.with_user(self.user_1).add_members(self.user_1.partner_id.ids)
         channel_as_user_1.with_user(self.user_1).add_members(self.user_2.partner_id.ids)
         channel_1_rel_user_2 = self.env['discuss.channel.member'].search([
@@ -260,8 +260,8 @@ class TestDiscussChannelMembers(MailCommon):
         self.assertEqual(channel_1_rel_user_2.message_unread_counter, 1, "should have 1 unread message after someone else posted a message")
 
     def test_unread_counter_with_message_post_multi_channel(self):
-        channel_1_as_user_1 = self.env['discuss.channel'].with_user(self.user_1).browse(self.env['discuss.channel'].with_user(self.user_1).channel_create(group_id=None, name='wololo channel')['id'])
-        channel_2_as_user_2 = self.env['discuss.channel'].with_user(self.user_2).browse(self.env['discuss.channel'].with_user(self.user_2).channel_create(group_id=None, name='walala channel')['id'])
+        channel_1_as_user_1 = self.env['discuss.channel'].with_user(self.user_1).channel_create(group_id=None, name='wololo channel')
+        channel_2_as_user_2 = self.env['discuss.channel'].with_user(self.user_2).channel_create(group_id=None, name='walala channel')
         channel_1_as_user_1.add_members(self.user_2.partner_id.ids)
         channel_2_as_user_2.add_members(self.user_1.partner_id.ids)
         channel_2_as_user_2.add_members(self.user_3.partner_id.ids)

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -17,7 +17,7 @@ class TestChannelInternals(MailCommon):
     @mute_logger('odoo.models.unlink')
     def test_01_join_call(self):
         """Join call should remove existing sessions, remove invitation, create a new session, and return data."""
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_create(name='Test Channel', group_id=self.env.ref('base.group_user').id)['id'])
+        channel = self.env['discuss.channel'].channel_create(name='Test Channel', group_id=self.env.ref('base.group_user').id)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         self.env['bus.bus'].sudo().search([]).unlink()
@@ -96,7 +96,7 @@ class TestChannelInternals(MailCommon):
     @mute_logger('odoo.models.unlink')
     def test_10_start_call_in_chat_should_invite_all_members_to_call(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_get(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)['id'])
+        channel = self.env['discuss.channel'].channel_get(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
         channel_member._rtc_join_call()
@@ -176,7 +176,7 @@ class TestChannelInternals(MailCommon):
     def test_11_start_call_in_group_should_invite_all_members_to_call(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
         channel_member_test_guest = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.guest_id == test_guest)
@@ -306,7 +306,7 @@ class TestChannelInternals(MailCommon):
     def test_20_join_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
@@ -450,7 +450,7 @@ class TestChannelInternals(MailCommon):
     def test_21_leave_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
@@ -542,7 +542,7 @@ class TestChannelInternals(MailCommon):
     def test_25_lone_call_participant_leaving_call_should_cancel_pending_invitations(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=(self.user_employee.partner_id + test_user.partner_id).ids)
         channel.add_members(guest_ids=test_guest.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member_test_user = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == test_user.partner_id)
@@ -632,7 +632,7 @@ class TestChannelInternals(MailCommon):
     def test_30_add_members_while_in_call_should_invite_new_members_to_call(self):
         test_user = self.env['res.users'].sudo().create({'name': "Test User", 'login': 'test'})
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda member: member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         self.env['bus.bus'].sudo().search([]).unlink()
@@ -748,7 +748,7 @@ class TestChannelInternals(MailCommon):
     @users('employee')
     @mute_logger('odoo.models.unlink')
     def test_40_leave_call_should_remove_existing_sessions_of_user_in_channel_and_return_data(self):
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         self.env['bus.bus'].sudo().search([]).unlink()
@@ -778,7 +778,7 @@ class TestChannelInternals(MailCommon):
     @users('employee')
     @mute_logger('odoo.models.unlink')
     def test_50_garbage_collect_should_remove_old_sessions_and_notify_data(self):
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         channel_member.rtc_session_ids.flush_model()
@@ -811,7 +811,7 @@ class TestChannelInternals(MailCommon):
     @users('employee')
     @mute_logger('odoo.models.unlink')
     def test_51_action_disconnect_should_remove_selected_session_and_notify_data(self):
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         channel_member._rtc_join_call()
         self.env['bus.bus'].sudo().search([]).unlink()
@@ -842,7 +842,7 @@ class TestChannelInternals(MailCommon):
     @users('employee')
     @mute_logger('odoo.models.unlink')
     def test_60_rtc_sync_sessions_should_gc_and_return_outdated_and_active_sessions(self):
-        channel = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)['id'])
+        channel = self.env['discuss.channel'].create_group(partners_to=self.user_employee.partner_id.ids)
         channel_member = channel.sudo().channel_member_ids.filtered(lambda channel_member: channel_member.partner_id == self.user_employee.partner_id)
         join_call_values = channel_member._rtc_join_call()
         test_guest = self.env['mail.guest'].sudo().create({'name': "Test Guest"})

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -67,22 +67,22 @@ class TestDiscussFullPerformance(HttpCase):
         self.env['discuss.channel'].sudo().search([('id', '!=', self.channel_general.id)]).unlink()
         self.user_root = self.env.ref('base.user_root')
         # create public channels
-        self.channel_channel_public_1 = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_create(name='public channel 1', group_id=None)['id'])
+        self.channel_channel_public_1 = self.env['discuss.channel'].channel_create(name='public channel 1', group_id=None)
         self.channel_channel_public_1.add_members((self.users[0] + self.users[2] + self.users[3] + self.users[4] + self.users[8]).partner_id.ids)
-        self.channel_channel_public_2 = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_create(name='public channel 2', group_id=None)['id'])
+        self.channel_channel_public_2 = self.env['discuss.channel'].channel_create(name='public channel 2', group_id=None)
         self.channel_channel_public_2.add_members((self.users[0] + self.users[2] + self.users[4] + self.users[7] + self.users[9]).partner_id.ids)
         # create group-restricted channels
-        self.channel_channel_group_1 = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_create(name='group restricted channel 1', group_id=self.env.ref('base.group_user').id)['id'])
+        self.channel_channel_group_1 = self.env['discuss.channel'].channel_create(name='group restricted channel 1', group_id=self.env.ref('base.group_user').id)
         self.channel_channel_group_1.add_members((self.users[0] + self.users[2] + self.users[3] + self.users[6] + self.users[12]).partner_id.ids)
-        self.channel_channel_group_2 = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_create(name='group restricted channel 2', group_id=self.env.ref('base.group_user').id)['id'])
+        self.channel_channel_group_2 = self.env['discuss.channel'].channel_create(name='group restricted channel 2', group_id=self.env.ref('base.group_user').id)
         self.channel_channel_group_2.add_members((self.users[0] + self.users[2] + self.users[6] + self.users[7] + self.users[13]).partner_id.ids)
         # create chats
-        self.channel_chat_1 = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_get((self.users[0] + self.users[14]).partner_id.ids)['id'])
-        self.channel_chat_2 = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_get((self.users[0] + self.users[15]).partner_id.ids)['id'])
-        self.channel_chat_3 = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_get((self.users[0] + self.users[2]).partner_id.ids)['id'])
-        self.channel_chat_4 = self.env['discuss.channel'].browse(self.env['discuss.channel'].channel_get((self.users[0] + self.users[3]).partner_id.ids)['id'])
+        self.channel_chat_1 = self.env['discuss.channel'].channel_get((self.users[0] + self.users[14]).partner_id.ids)
+        self.channel_chat_2 = self.env['discuss.channel'].channel_get((self.users[0] + self.users[15]).partner_id.ids)
+        self.channel_chat_3 = self.env['discuss.channel'].channel_get((self.users[0] + self.users[2]).partner_id.ids)
+        self.channel_chat_4 = self.env['discuss.channel'].channel_get((self.users[0] + self.users[3]).partner_id.ids)
         # create groups
-        self.channel_group_1 = self.env['discuss.channel'].browse(self.env['discuss.channel'].create_group((self.users[0] + self.users[12]).partner_id.ids)['id'])
+        self.channel_group_1 = self.env['discuss.channel'].create_group((self.users[0] + self.users[12]).partner_id.ids)
         # create livechats
         im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
         self.env['bus.presence'].create({'user_id': self.users[0].id, 'status': 'online'})  # make available for livechat (ignore leave)

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -332,9 +332,9 @@ class TestMessageAccess(MailCommon):
         cls.user_public = mail_new_test_user(cls.env, login='bert', groups='base.group_public', name='Bert Tartignole')
         cls.user_portal = mail_new_test_user(cls.env, login='chell', groups='base.group_portal', name='Chell Gladys')
 
-        cls.group_restricted_channel = cls.env['discuss.channel'].browse(cls.env['discuss.channel'].channel_create(name='Channel for Groups', group_id=cls.env.ref('base.group_user').id)['id'])
-        cls.public_channel = cls.env['discuss.channel'].browse(cls.env['discuss.channel'].channel_create(name='Public Channel', group_id=None)['id'])
-        cls.private_group = cls.env['discuss.channel'].browse(cls.env['discuss.channel'].create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")['id'])
+        cls.group_restricted_channel = cls.env['discuss.channel'].channel_create(name='Channel for Groups', group_id=cls.env.ref('base.group_user').id)
+        cls.public_channel = cls.env['discuss.channel'].channel_create(name='Public Channel', group_id=None)
+        cls.private_group = cls.env['discuss.channel'].create_group(partners_to=cls.user_employee_1.partner_id.ids, name="Group")
         cls.message = cls.env['mail.message'].create({
             'body': 'My Body',
             'model': 'discuss.channel',

--- a/addons/test_mail_full/tests/test_web_push.py
+++ b/addons/test_mail_full/tests/test_web_push.py
@@ -50,7 +50,7 @@ class TestWebPushNotification(SMSCommon):
             'name': 'Direct Message',
         })
 
-        cls.group_channel = cls.env['discuss.channel'].browse(cls.env['discuss.channel'].channel_create(name='Channel', group_id=None)['id'])
+        cls.group_channel = cls.env['discuss.channel'].channel_create(name='Channel', group_id=None)
         cls.group_channel.add_members((cls.user_email + cls.user_inbox).partner_id.ids)
 
         cls.env['mail.partner.device'].get_web_push_vapid_public_key()


### PR DESCRIPTION
* = calendar,test_discuss_full, test_mail, test_mail_full

Methods can be downgraded to channel_info when called by RPC. This increases the simplicity to use these methods in python.

https://github.com/odoo/enterprise/pull/49326

Taken from https://github.com/odoo/odoo/pull/138330 to ease its diff.