### PR TITLE
[IMP] pos_restaurant: display ticket screen filter in the search bar

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/navbar.xml
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.xml
@@ -27,7 +27,7 @@
                                 <li class="ticket-button" t-on-click="onTicketButtonClick">
                                     <a class="dropdown-item with-badge py-2">
                                         Orders
-                                        <span class="badge text-bg-info rounded-pill py-1 ms-2" t-esc="orderCount"/>
+                                        <span t-if="orderCount>0" class="badge text-bg-info rounded-pill py-1 ms-2" t-esc="orderCount"/>
                                     </a>
                                 </li>
                                 <li t-if="showCashMoveButton" class="menu-item navbar-button" t-on-click="onCashMoveButtonClick">

--- a/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
+++ b/addons/pos_restaurant/static/src/overrides/components/navbar/navbar.js
@@ -15,7 +15,7 @@ patch(Navbar.prototype, {
         return super.orderCount;
     },
     _shouldLoadOrders() {
-        return super._shouldLoadOrders() || (this.pos.config.module_pos_restaurant && !this.pos.table);
+        return super._shouldLoadOrders() || this.pos.config.module_pos_restaurant;
     },
     onSwitchButtonClick() {
         const mode = this.pos.floorPlanStyle == "kanban" ? "default" : "kanban";

--- a/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/ticket_screen/ticket_screen.js
@@ -57,12 +57,6 @@ patch(TicketScreen.prototype, {
             ? Boolean(this.pos.table)
             : super.allowNewOrders;
     },
-    _getOrderList() {
-        if (this.pos.table) {
-            return this.pos.getTableOrders(this.pos.table.id);
-        }
-        return super._getOrderList(...arguments);
-    },
     async settleTips() {
         // set tip in each order
         for (const order of this.getFilteredOrderList()) {

--- a/addons/pos_restaurant/static/src/overrides/models/pos_store.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_store.js
@@ -229,6 +229,15 @@ patch(PosStore.prototype, {
         }
         return super._createOrder(...arguments);
     },
+    getDefaultSearchDetails() {
+        if (this.table && this.table.id) {
+            return {
+                fieldName: "TABLE",
+                searchTerm: this.table.name,
+            };
+        }
+        return super.getDefaultSearchDetails();
+    },
     loadRestaurantFloor() {
         // we do this in the front end due to the circular/recursive reference needed
         // Ignore floorplan features if no floor specified.


### PR DESCRIPTION
Prior to this commit when the ticket screen was opened from a table, the orders were filtered by context. This commit displays the filter in the search bar so it can be removed. This allows the user to simply remove the search to display all orders.

