### PR TITLE
[FIX] account_edi, web, mail: add attachment delete in public tour

### DIFF
--- a/addons/account_edi/models/ir_attachment.py
+++ b/addons/account_edi/models/ir_attachment.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
-from odoo import api, models, fields, _
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, models, _
 from odoo.exceptions import UserError
 
 
@@ -8,7 +9,8 @@ class IrAttachment(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_government_document(self):
-        linked_edi_documents = self.env['account.edi.document'].search([('attachment_id', 'in', self.ids)])
+        # sudo: account.edi.document - constraint that must be applied regardless of ACL
+        linked_edi_documents = self.env['account.edi.document'].sudo().search([('attachment_id', 'in', self.ids)])
         linked_edi_formats_ws = linked_edi_documents.edi_format_id.filtered(lambda edi_format: edi_format._needs_web_services())
         if linked_edi_formats_ws:
             raise UserError(_("You can't unlink an attachment being an EDI document sent to the government."))

--- a/addons/mail/static/tests/tours/discuss_channel_public_tour.js
+++ b/addons/mail/static/tests/tours/discuss_channel_public_tour.js
@@ -1,7 +1,7 @@
 /* @odoo-module */
 
 import { registry } from "@web/core/registry";
-import { createFile, inputFiles } from "@web/../tests/utils";
+import { click, contains, createFile, inputFiles } from "@web/../tests/utils";
 
 registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
     test: true,
@@ -122,7 +122,13 @@ registry.category("web_tour.tours").add("discuss_channel_public_tour.js", {
         {
             content: "Check edited message contains the extra attachment",
             trigger: '.o-mail-Message .o-mail-AttachmentCard:contains("extra.txt")',
-            run() {},
+            async run() {
+                await click(".o-mail-AttachmentCard-unlink", {
+                    parent: [".o-mail-AttachmentCard", { text: "extra.txt" }],
+                });
+                await click(".btn", { text: "Ok", parent: [".modal", { text: "Confirmation" }] });
+                await contains(".o-mail-AttachmentCard", { text: "extra.txt", count: 0 });
+            },
         },
     ],
 });

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -375,7 +375,7 @@ export function triggerEvent(el, selector, eventType, eventInit, options = {}) {
     const event = new Constructor(eventType, processParams(eventInit));
     target.dispatchEvent(event);
 
-    if (QUnit.config.debug) {
+    if (window.QUnit && QUnit.config.debug) {
         const group = `%c[${event.type.toUpperCase()}]`;
         console.groupCollapsed(group, "color: #b52c9b");
         console.log(target, event);


### PR DESCRIPTION
This allows better coverage of the feature and in particular its access check.

Taken from https://github.com/odoo/odoo/pull/138330 to ease its diff.