### PR TITLE
[FIX] web: domain field: foldable invalid domain

### DIFF
--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -135,7 +135,7 @@ export class DomainField extends Component {
             throw new Error(`Invalid model: ${resModel}`);
         }
 
-        let promises;
+        let promises = [];
         const domain = this.getDomain(props);
         try {
             const tree = treeFromDomain(domain, { distributeNot: !this.env.debug });

--- a/addons/web/static/src/views/fields/domain/domain_field.xml
+++ b/addons/web/static/src/views/fields/domain/domain_field.xml
@@ -5,7 +5,7 @@
         <div t-att-class="{ o_inline_mode: !props.editInDialog }">
             <t t-set="resModel" t-value="getResModel()"/>
             <t t-if="resModel">
-                <t t-if="props.isFoldable and state.folded">
+                <t t-if="props.isFoldable and state.folded and state.isValid">
                     <div class="d-flex align-items-center" t-on-click="() => state.folded = false">
                         <i data-tooltip="Modify filter" class="fa fa-lg fa-caret-right pe-2"/>
                         <div class="d-print-contents">
@@ -40,7 +40,7 @@
                 </t>
                 <t t-else="">
                     <div class="d-flex">
-                        <a t-if="props.isFoldable" t-on-click="fold">
+                        <a t-if="props.isFoldable and state.isValid" t-on-click="fold">
                             <i class="fa fa-lg fa-caret-down pe-2"></i>
                         </a>
                         <DomainSelector

--- a/addons/web/static/tests/views/fields/domain_field_tests.js
+++ b/addons/web/static/tests/views/fields/domain_field_tests.js
@@ -1102,4 +1102,40 @@ QUnit.module("Fields", (hooks) => {
             '[("id", "=", 1)]'
         );
     });
+
+    QUnit.test(
+        "foldable domain field unfolds and hides caret when domain is invalid",
+        async function (assert) {
+            serverData.models.partner.records[0].foo = "[";
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                resId: 1,
+                serverData,
+                arch: `
+                <form>
+                    <sheet>
+                        <group>
+                            <field name="foo" widget="domain" options="{'model': 'partner_type', 'foldable': true}" />
+                        </group>
+                    </sheet>
+                </form>`,
+            });
+            assert.strictEqual(
+                target.querySelector(".o_field_domain span").textContent,
+                " Invalid domain "
+            );
+            assert.containsNone(target, ".fa-caret-down");
+            assert.strictEqual(
+                target.querySelector(".o_domain_selector_row").textContent,
+                " This domain is not supported. Reset domain"
+            );
+            await click(target, ".o_domain_selector_row button");
+            assert.strictEqual(
+                target.querySelector(".o_field_domain span").textContent,
+                "Match all records"
+            );
+        }
+    );
 });


### PR DESCRIPTION
This commit fixes an issue with the domain field where a traceback would be launched when an invalid domain is received. It also changes how invalid domains are displayed in foldable domain fields to match their display inside the domain selector.

