### PR TITLE
[FIX] account_peppol: fix config setting option

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -350,7 +350,7 @@
                         </block>
                         <field name="is_account_peppol_eligible" invisible="1"/>
                         <block title="PEPPOL Electronic Document Invoicing" id="peppol" invisible="not is_account_peppol_eligible">
-                            <div class="col-12 col-lg-12 o_setting_box">
+                            <div id="account_peppol_install" class="col-12 col-lg-12 o_setting_box">
                                 <div class="o_setting_left_pane">
                                     <field name="module_account_peppol" readonly="False"/>
                                 </div>
@@ -359,7 +359,6 @@
                                     <div class="text-muted">
                                         Allow sending and receiving invoices through the PEPPOL network
                                     </div>
-                                    <div id="account_peppol"/>
                                 </div>
                             </div>
                         </block>

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -35,7 +35,6 @@ class AccountEdiProxyClientUser(models.Model):
             ):
                 self.company_id.write({
                     'account_peppol_proxy_state': 'not_registered',
-                    'is_account_peppol_participant': False,
                     'account_peppol_migration_key': False,
                 })
                 # commit the above changes before raising below

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -38,9 +38,6 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.is_account_peppol_participant', readonly=False,
         help='Register as a PEPPOL user',
     )
-    has_peppol_participant = fields.Boolean(
-        compute='_compute_has_peppol_participant'
-    )
     account_peppol_edi_mode = fields.Selection(
         selection=[('demo', 'Demo'), ('test', 'Test'), ('prod', 'Live')],
         compute='_compute_account_peppol_edi_mode',
@@ -116,14 +113,6 @@ class ResConfigSettings(models.TransientModel):
                 config.account_peppol_endpoint_warning = _("The endpoint number might not be correct. "
                                                            "Please check if you entered the right identification number.")
 
-    @api.depends('company_id.is_account_peppol_participant')
-    def _compute_has_peppol_participant(self):
-        number_of_peppol_participants = len(self.env['res.company'].sudo().search([
-            ('is_account_peppol_participant', '=', True)
-        ]))
-        for config in self:
-            config.has_peppol_participant = number_of_peppol_participants > 0
-
     # -------------------------------------------------------------------------
     # BUSINESS ACTIONS
     # -------------------------------------------------------------------------
@@ -143,6 +132,8 @@ class ResConfigSettings(models.TransientModel):
 
         if not self.account_peppol_phone_number:
             raise ValidationError(_("Please enter a phone number to verify your application."))
+        if not self.account_peppol_contact_email:
+            raise ValidationError(_("Please enter a primary contact email to verify your application."))
 
         company = self.company_id
         edi_proxy_client = self.env['account_edi_proxy_client.user']

--- a/addons/account_peppol/tests/test_peppol_messages.py
+++ b/addons/account_peppol/tests/test_peppol_messages.py
@@ -28,7 +28,6 @@ class TestPeppolMessage(TestAccountMoveSendCommon):
 
         cls.env.company.write({
             'country_id': cls.env.ref('base.be').id,
-            'is_account_peppol_participant': True,
             'peppol_eas': '0208',
             'peppol_endpoint': '0477472701',
             'account_peppol_proxy_state': 'active',

--- a/addons/account_peppol/tests/test_peppol_participant.py
+++ b/addons/account_peppol/tests/test_peppol_participant.py
@@ -25,7 +25,6 @@ class TestPeppolParticipant(TransactionCase):
 
     def _get_participant_vals(self):
         return {
-            'is_account_peppol_participant': True,
             'account_peppol_eas': '9925',
             'account_peppol_endpoint': '0000000000',
             'account_peppol_phone_number': '+32483123456',
@@ -90,7 +89,6 @@ class TestPeppolParticipant(TransactionCase):
     def test_create_participant_missing_data(self):
         # creating a participant without eas/endpoint/document should not be possible
         settings = self.env['res.config.settings'].create({
-            'is_account_peppol_participant': True,
             'account_peppol_eas': False,
             'account_peppol_endpoint': False,
         })
@@ -181,7 +179,6 @@ class TestPeppolParticipant(TransactionCase):
                 self.assertRecordValues(
                     settings, [{
                         'account_peppol_migration_key': False,
-                        'is_account_peppol_participant': False,
                         'account_peppol_proxy_state': 'not_registered',
                     }]
                 )

--- a/addons/account_peppol/views/res_config_settings_views.xml
+++ b/addons/account_peppol/views/res_config_settings_views.xml
@@ -5,29 +5,27 @@
         <field name="model">res.config.settings</field>
         <field name="inherit_id" ref="account.res_config_settings_view_form"/>
         <field name="arch" type="xml">
-            <div id="account_peppol" position="replace">
-                <field name="has_peppol_participant" invisible="1"/>
-                <div id="account_peppol" class="mt-3">
+            <xpath expr="//div[@id='account_peppol_install']" position="replace">
+                <div id="account_peppol">
                     <div class="col-12 col-lg-12 o_setting_box">
                         <field name="account_peppol_proxy_state" invisible="1"/>
-                        <div class="o_setting_left_pane">
-                            <field name="is_account_peppol_participant"
-                                   invisible="account_peppol_proxy_state != 'not_registered'"/>
-                        </div>
                         <div class="o_setting_right_pane border-0">
-                            <div invisible="account_peppol_proxy_state != 'not_registered'">
-                                <label for="is_account_peppol_participant" string="Use PEPPOL Invoicing"/>
+                            <div class="mb-2">
+                                <span class="o_form_label">
+                                    Peppol Details
+                                </span>
                                 <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
-                                <div class="text-muted">
+                            </div>
+                            <div invisible="account_peppol_proxy_state != 'not_registered'">
+                                <div class="text-muted oe_inline">
                                     Start sending and receiving documents via Peppol as soon as your registration is complete.
                                 </div>
                                 <div class="alert alert-warning mt-3"
                                      role="alert"
-                                     invisible="not is_account_peppol_participant or not account_peppol_endpoint_warning">
+                                     invisible="not account_peppol_endpoint_warning">
                                     <field name="account_peppol_endpoint_warning"/>
                                 </div>
-                                <div class="pt-3"
-                                     invisible="not is_account_peppol_participant">
+                                <div class="pt-3">
                                     <div class="row">
                                         <label string="Peppol EAS"
                                                for="account_peppol_eas"
@@ -43,23 +41,22 @@
                                 </div>
                             </div>
                             <div class="row"
-                                 invisible="not is_account_peppol_participant or account_peppol_proxy_state not in ('not_registered', 'not_verified')">
+                                 invisible="account_peppol_proxy_state not in ('not_registered', 'not_verified')">
                                 <label string="Phone Number"
                                        for="account_peppol_phone_number"
                                        class="col-lg-3 o_light_label"/>
                                 <field name="account_peppol_phone_number"
-                                       required="is_account_peppol_participant and account_peppol_proxy_state in ('not_registered', 'not_verified')"/>
+                                       required="account_peppol_proxy_state == 'not_verified'"/>
                             </div>
                             <div class="row"
-                                 invisible="not is_account_peppol_participant or account_peppol_proxy_state in ('rejected', 'canceled', 'sent_verification')">
+                                 invisible="account_peppol_proxy_state in ('rejected', 'canceled', 'sent_verification')">
                                 <label string="Primary contact email"
                                        for="account_peppol_contact_email"
                                        class="col-lg-3 o_light_label"/>
-                                <field name="account_peppol_contact_email"
-                                       required="is_account_peppol_participant"/>
+                                <field name="account_peppol_contact_email"/>
                             </div>
                             <div class="content-group pt-3"
-                                 invisible="account_peppol_proxy_state != 'not_registered' or not is_account_peppol_participant">
+                                 invisible="account_peppol_proxy_state != 'not_registered'">
                                 <span>
                                     I want to migrate my Peppol connection to Odoo (optional):
                                 </span>
@@ -70,8 +67,7 @@
                                     <field name="account_peppol_migration_key"/>
                                 </div>
                             </div>
-                            <div class="row mb-3"
-                                 invisible="not is_account_peppol_participant">
+                            <div class="row mb-3">
                                 <div class="content-group mt-3"
                                      invisible="account_peppol_proxy_state in ('rejected', 'not_registered', 'canceled', 'not_verified', 'sent_verification')">
                                     <div class="row">
@@ -79,7 +75,7 @@
                                                for="account_peppol_purchase_journal_id"
                                                class="col-lg-3 o_light_label"/>
                                         <field name="account_peppol_purchase_journal_id"
-                                               required="is_account_peppol_participant and account_peppol_proxy_state not in ('rejected', 'not_registered', 'canceled', 'not_verified', 'sent_verification')"/>
+                                               required="account_peppol_proxy_state not in ('rejected', 'canceled', 'not_verified', 'not_registered', 'sent_verification')"/>
                                     </div>
                                 </div>
                                 <div class="content-group mt-3"
@@ -88,7 +84,7 @@
                                         We sent a verification code to
                                         <field name="account_peppol_phone_number"
                                                nolabel="1"
-                                               readonly="is_account_peppol_participant and account_peppol_proxy_state == 'sent_verification'"/>.
+                                               readonly="account_peppol_proxy_state == 'sent_verification'"/>.
                                     </span>
                                     <div class="row mt-1 ps-3">
                                         <field name="account_peppol_verification_code" widget="verification_code"/>
@@ -174,11 +170,7 @@
                         </div>
                     </div>
                 </div>
-            </div>
-            <field name="module_account_peppol" position="attributes">
-                <!-- When any company has Peppol enabled, we prevent users from accidentally uninstalling the module -->
-                <attribute name="readonly">has_peppol_participant</attribute>
-            </field>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
The res config settings view contains block in which peppol can be
enabled. Enabling peppol using the checkbox inside the block installs
the peppol module. Once installed, the "Use Peppol invoicing" option is
available, which is itself a checkbox, nested inside of the previous
one. This gives the appearance of duplication, and in addition it's not
relevant at this point to provide the user the option to uninstall
peppol from this menu.

The solution is to replace this content in the view when peppol is
installed, such that the peppol options are always displayed, and the
enable peppol checkbox is replaced.

For this reason, references to the "is_account_peppol_participant" have
been removed, as its use was primarily for hiding/displaying these
settings. The field is no longer useful, and should, references to be
removed in a later Paccount_R have been removed, as  its use was
primarily forhiding/displaying these settings. The field is no longer
useful, and should be removed in a later upgrade script.
Before:
![image](https://github.com/odoo/odoo/assets/46533567/c0ba7435-9387-4fcb-a4a4-320230054f1a)

After:
![image](https://github.com/odoo/odoo/assets/46533567/5b8f56f6-b419-4121-9733-64a9142ebc4c)


task-id: none