### PR TITLE
[IMP] spreadsheet: allow to download a shared dashboard

### DIFF
--- a/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
+++ b/addons/spreadsheet/views/public_readonly_spreadsheet_templates.xml
@@ -15,6 +15,9 @@
                 <div t-out="spreadsheet_name" class="text-primary fw-bold ps-3"/>
                 <div class="fst-italic flex-fill ps-3">
                     Frozen and copied on <span t-field="share.create_date"/>
+                    <div class="d-inline-flex">
+                        <a class="btn btn-secondary btn-block o_download_btn" t-att-href="props['downloadExcelUrl']" title="Download"><i class="fa fa-download"/></a>
+                    </div>
                 </div>
                 <div class="d-table my-auto">
                     <t t-call="portal.user_dropdown">


### PR DESCRIPTION
## Task Description

The aim of this PR is to be able to download a shared dashboard. This is done by adding a "Download" button on the shared dashboard (next to the frozen date), which allow to export the dashboard as an .xlsx file.

## Related Task

Task: 3512907

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
