### PR TITLE
[FIX] crm: allow portal user to see opportunity stage name

### DIFF
--- a/addons/crm/security/ir.model.access.csv
+++ b/addons/crm/security/ir.model.access.csv
@@ -2,6 +2,7 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_crm_lead_manager,crm.lead.manager,model_crm_lead,sales_team.group_sale_manager,1,1,1,1
 access_crm_lead,crm.lead,model_crm_lead,sales_team.group_sale_salesman,1,1,1,0
 access_crm_stage,crm.stage,model_crm_stage,base.group_user,1,0,0,0
+access_crm_stage_portal,crm.stage,model_crm_stage,base.group_portal,1,0,0,0
 access_crm_stage_manager,crm.stage,model_crm_stage,sales_team.group_sale_manager,1,1,1,1
 access_res_partner_manager,res.partner.crm.manager,base.model_res_partner,sales_team.group_sale_manager,1,0,0,0
 access_res_partner_category_manager,res.partner.category.crm.manager,base.model_res_partner_category,sales_team.group_sale_manager,1,0,0,0


### PR DESCRIPTION
Steps to reproduce:

  - Install module `website_crm_partner_assign` (for test purposes)
  - Create an `Opportunity` for portal user X (with expected revenue)
  - Open opportunity, and click on "Forward to Partner" in action menu
  - Select portal user X as `Forward Leads To` recipient, then send
  - Login as portal user X
  - Open user opportunities (in `My Account` menu)

Issue:

  Page `403: Forbidden`.

Cause:

  Since the following commit, only internal users has read access to
  `crm.stage` model:
  https://github.com/odoo/odoo/commit/604a47ead80eb8a07102a978f364d82776f69da3

Solution:

  Add access right for portal users on `crm.stage` model to allow read
  access.

opw-3557869