### PR TITLE
[FIX] bus: authenticate on the correct env

### DIFF
--- a/addons/bus/websocket.py
+++ b/addons/bus/websocket.py
@@ -782,14 +782,13 @@ class WebsocketRequest:
         appropriate ir.websocket method since only two events are
         tolerated: `subscribe` and `update_presence`.
         """
-        ir_websocket = self.env['ir.websocket']
-        ir_websocket._authenticate()
+        self.env['ir.websocket']._authenticate()
         if context:
             self.update_context(**context)
         if event_name == 'subscribe':
-            ir_websocket._subscribe(data)
+            self.env['ir.websocket']._subscribe(data)
         if event_name == 'update_presence':
-            ir_websocket._update_bus_presence(**data)
+            self.env['ir.websocket']._update_bus_presence(**data)
 
     def _get_session(self):
         session = root.session_store.get(self.ws._session.sid)


### PR DESCRIPTION
`_authenticate` is updating the `env`, but it updated the `env` of
`ir_websocket` instead of `self`. There was then a mismatch between
the `update_context` and the current user.

This was highlighted in another PR that removed sudo from these methods
with the hope on relying on ACL, which depends on current user and other
context values at the same time.

Taken from https://github.com/odoo/odoo/pull/138330 to ease its diff.