### PR TITLE
[FIX] web_editor: colorpicker buttons text partially hidden

### DIFF
--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -60,22 +60,22 @@
     <div t-name="web_editor.ColorPalette" class="colorpicker" t-ref="el">
         <div class="o_we_colorpicker_switch_panel d-flex justify-content-end px-2">
             <t t-set="first_button_name"><t t-if="props.withCombinations">Theme</t><t t-else="">Solid</t></t>
-            <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn btn" t-attf-data-target="#{props.withCombinations ? 'color-combinations' : 'theme-colors'}"
+            <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn" t-attf-data-target="#{props.withCombinations ? 'color-combinations' : 'theme-colors'}"
                     t-att-title="first_button_name"
                     t-on-click="this._onSwitchPaneButtonClick">
                 <span t-out="first_button_name"/>
             </button>
-            <button type="button" tabindex="2" class="o_we_colorpicker_switch_pane_btn btn" data-target="custom-colors" title="Custom"
+            <button type="button" tabindex="2" class="o_we_colorpicker_switch_pane_btn" data-target="custom-colors" title="Custom"
                     t-on-click="this._onSwitchPaneButtonClick">
                 <span>Custom</span>
             </button>
-            <button type="button" tabindex="3" class="o_we_colorpicker_switch_pane_btn btn" data-target="gradients" title="Gradient"
+            <button type="button" tabindex="3" class="o_we_colorpicker_switch_pane_btn" data-target="gradients" title="Gradient"
                     t-on-click="this._onSwitchPaneButtonClick">
                 <span>Gradient</span>
             </button>
             <t t-if="props.resetButton">
                 <t t-set="trash_title"><t t-if="props.withCombinations">None</t><t t-else="">Reset</t></t>
-                <button type="button" class="fa fa-trash my-1 ms-5 py-0 o_we_color_btn btn o_colorpicker_reset o_we_hover_danger" t-att-title="trash_title" />
+                <button type="button" class="fa fa-trash my-1 ms-5 py-0 o_we_color_btn o_colorpicker_reset o_we_hover_danger" t-att-title="trash_title" />
             </t>
         </div>
         <div class="o_colorpicker_sections pt-2 px-2 pb-3" data-color-tab="color-combinations">


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/commit/ee38c69503a0fd9175751f054d88bf760ec660b8

Before this commit, the padding of these buttons was too big and the text was partillay hidden.

This issue was introduced in the commit above. The selectors generated by the ´.extend´ were not correct and the css rules associated to ´.btn´ was never applied. It was therefore good to remove this rule but we shoudn't have added the ´.btn´ class.

Steps to reproduce:
- Go to website and open the Editor
- Click on "Edit"
- Drag and Drop "Text"
- Go to Customize
- Change the Background or the font color

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
