### PR TITLE
[FIX] website, web_editor: adapt disabled inputs background color

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -858,7 +858,7 @@ blockquote {
             @if ($-bg-color == $light and $-bg-color != $body-bg) {
                 --o-input-bg: #{$body-bg};
                 --o-input-border-color: var(--o-border-color);
-                --o-input-placeholder-color: #{rgba(color-contrast($body-bg), .5)};
+                --o-input-placeholder-color: #{rgba(color-contrast($body-bg), .66)};
             }
         }
     }

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -246,7 +246,10 @@ $input-border-color: var(--o-input-border-color, #{$light}) !default;
 $input-color: color-contrast($light) !default;
 $input-focus-bg: $body-bg !default;
 $input-focus-color: $body-color !default;
-$input-placeholder-color: var(--o-input-placeholder-color, #{rgba($input-color, .5)}) !default;
+$input-placeholder-color: var(--o-input-placeholder-color, #{rgba($input-color, .66)}) !default;
+
+$input-disabled-bg: color-mix(in srgb, var(--o-input-bg, #{$light}) 50%, transparent) !default;
+$input-disabled-border-color: color-mix(in srgb, var(--o-input-border-color, #{$light}) 50%, transparent) !default;
 
 $form-check-input-border: ($input-border-width or 1px) solid $input-border-color !default;
 $form-range-track-bg: $light !default;


### PR DESCRIPTION
Before this commit, disabled inputs background color was set to Bootstrap default value (`$gray-200`). Since the input background color is now based on `o-color-3`, it was creating inconsistencies. This commit fixes that issue.

This commit also darkens the placeholder color as it was not readable enough on the new light background.

task-3565420
part-of-task-3097005

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
