### PR TITLE
[IMP] *: support of set and some set operations in field attributes

### DIFF
--- a/addons/web/static/src/core/py_js/py_builtin.js
+++ b/addons/web/static/src/core/py_js/py_builtin.js
@@ -25,7 +25,7 @@ export const BUILTINS = {
                 if (value instanceof Array) {
                     return !!value.length;
                 }
-                return true;
+                return Object.keys(value).length !== 0;
         }
         return true;
     },

--- a/addons/web/static/src/views/fields/domain/domain_field.js
+++ b/addons/web/static/src/views/fields/domain/domain_field.js
@@ -5,7 +5,7 @@ import { Component, onWillStart, onWillUpdateProps, useState } from "@odoo/owl";
 import { Domain, InvalidDomainError } from "@web/core/domain";
 import { DomainSelector } from "@web/core/domain_selector/domain_selector";
 import { DomainSelectorDialog } from "@web/core/domain_selector_dialog/domain_selector_dialog";
-import { EvaluationError } from "@web/core/py_js/py_interpreter";
+import { EvaluationError } from "@web/core/py_js/py_builtin";
 import { registry } from "@web/core/registry";
 import { SelectCreateDialog } from "@web/views/view_dialogs/select_create_dialog";
 import { standardFieldProps } from "../standard_field_props";

--- a/addons/web/static/tests/core/py_js/py_interpreter_tests.js
+++ b/addons/web/static/tests/core/py_js/py_interpreter_tests.js
@@ -290,6 +290,15 @@ QUnit.module("py", {}, () => {
         QUnit.module("conversions");
 
         QUnit.test("to bool", (assert) => {
+            assert.strictEqual(evaluateExpr("bool()"), false);
+            assert.strictEqual(evaluateExpr("bool(0)"), false);
+            assert.strictEqual(evaluateExpr("bool(1)"), true);
+            assert.strictEqual(evaluateExpr("bool(False)"), false);
+            assert.strictEqual(evaluateExpr("bool(True)"), true);
+            assert.strictEqual(evaluateExpr("bool({})"), false);
+            assert.strictEqual(evaluateExpr("bool({ 'a': 1 })"), true);
+            assert.strictEqual(evaluateExpr("bool([])"), false);
+            assert.strictEqual(evaluateExpr("bool([1])"), true);
             assert.strictEqual(evaluateExpr("bool('')"), false);
             assert.strictEqual(evaluateExpr("bool('foo')"), true);
             assert.strictEqual(
@@ -384,28 +393,28 @@ QUnit.module("py", {}, () => {
         });
 
         QUnit.test("use contextual values", (assert) => {
-            assert.strictEqual(evaluateBooleanExpr("a", {a: 12}), true);
-            assert.strictEqual(evaluateBooleanExpr("a", {a: 0}), false);
-            assert.strictEqual(evaluateBooleanExpr("0 + 3 - a", {a: 1}), true);
-            assert.strictEqual(evaluateBooleanExpr("0 + 3 - a - 2", {a: 1}), false);
-            assert.strictEqual(evaluateBooleanExpr("0 + 3 - a - b", {a: 1, b: 2}), false);
-            assert.strictEqual(evaluateBooleanExpr('a', {a: "foo"}), true);
-            assert.strictEqual(evaluateBooleanExpr("a", {a: [1]}), true);
-            assert.strictEqual(evaluateBooleanExpr("a", {a: []}), false);
+            assert.strictEqual(evaluateBooleanExpr("a", { a: 12 }), true);
+            assert.strictEqual(evaluateBooleanExpr("a", { a: 0 }), false);
+            assert.strictEqual(evaluateBooleanExpr("0 + 3 - a", { a: 1 }), true);
+            assert.strictEqual(evaluateBooleanExpr("0 + 3 - a - 2", { a: 1 }), false);
+            assert.strictEqual(evaluateBooleanExpr("0 + 3 - a - b", { a: 1, b: 2 }), false);
+            assert.strictEqual(evaluateBooleanExpr('a', { a: "foo" }), true);
+            assert.strictEqual(evaluateBooleanExpr("a", { a: [1] }), true);
+            assert.strictEqual(evaluateBooleanExpr("a", { a: [] }), false);
         });
 
         QUnit.test("throw if has missing value", (assert) => {
-            assert.throws(() => evaluateBooleanExpr("a", {b: 0}));
+            assert.throws(() => evaluateBooleanExpr("a", { b: 0 }));
             assert.strictEqual(evaluateBooleanExpr("1 or a"), true);  // do not throw (lazy value)
             assert.throws(() => evaluateBooleanExpr("0 or a"));
-            assert.throws(() => evaluateBooleanExpr("a or b", {b: true}));
-            assert.throws(() => evaluateBooleanExpr("a and b", {b: true}));
+            assert.throws(() => evaluateBooleanExpr("a or b", { b: true }));
+            assert.throws(() => evaluateBooleanExpr("a and b", { b: true }));
             assert.throws(() => evaluateBooleanExpr("a()"));
             assert.throws(() => evaluateBooleanExpr("a[0]"));
             assert.throws(() => evaluateBooleanExpr("a.b"));
-            assert.throws(() => evaluateBooleanExpr("0 + 3 - a", {b: 1}));
-            assert.throws(() => evaluateBooleanExpr("0 + 3 - a - 2", {b: 1}));
-            assert.throws(() => evaluateBooleanExpr("0 + 3 - a - b", {b: 2}));
+            assert.throws(() => evaluateBooleanExpr("0 + 3 - a", { b: 1 }));
+            assert.throws(() => evaluateBooleanExpr("0 + 3 - a - 2", { b: 1 }));
+            assert.throws(() => evaluateBooleanExpr("0 + 3 - a - b", { b: 2 }));
         });
     });
 });

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3930,6 +3930,10 @@ class TestValidationTools(common.BaseCase):
             view_validation.get_expression_field_names("(datetime.datetime.combine(context_today(), datetime.time(x,y,z)).to_utc()).strftime('%Y-%m-%d %H:%M:%S')"),
             {'x', 'y', 'z'},
         )
+        self.assertEqual(
+            view_validation.get_expression_field_names("set(field).intersection([1, 2])"),
+            {'field'},
+        )
 
 class TestAccessRights(common.TransactionCase):
 

--- a/odoo/tools/view_validation.py
+++ b/odoo/tools/view_validation.py
@@ -39,6 +39,7 @@ IGNORED_IN_EXPRESSION = {
     'float',
     'str',
     'unicode',
+    'set',
 }
 
 


### PR DESCRIPTION
The PR https://github.com/odoo/odoo/pull/104741 have recently modify how the modifiers required, readonly,
invisible, and column_invisible are defined. They are now given by Python expressions instead of domains. This will require at some point to migrate domains like [("user_ids", "in", [1, 2])] to equivalent Python expressions. For simplicity, we have chosen to translate those kind of domains using set intersections. For the last example, we get "set(user_ids).intersection([1, 2])".

In the present PR, we
- make py_js support sets and some basic set operations (e.g. intersection) (second commit)
- make easy the edition of simple set intersections in the ExpressionEditor (third commit)
- allow views to be validated if they contain fields attributes involving sets (fourth commit). This is useful in Studio for 
  example.

Co-authored-by: Mathieu Duckerts-Antoine <dam@odoo.com>
Co-authored-by: Christophe Matthieu <chm@odoo.com>
