### PR TITLE
[IMP] hr_attendance: do not slow down webclient for attendance item

### DIFF
--- a/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
+++ b/addons/hr_attendance/static/src/components/attendance_menu/attendance_menu.js
@@ -1,7 +1,7 @@
 /* @odoo-module */
 
 
-import { Component, useState, onWillStart } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { deserializeDateTime } from "@web/core/l10n/dates";
@@ -23,14 +23,12 @@ export class ActivityMenu extends Component {
         this.state = useState({
             checkedIn: false,
             isDisplayed: false
-            });
+        });
         this.date_formatter = registry.category("formatters").get("float_time")
         this.onClickSignInOut = useDebounced(this.signInOut, 200, true);
-        onWillStart(this.onWillStart);
-    }
-
-    async onWillStart() {
-        await this.searchReadEmployee();
+        // load data but do not wait for it to render to prevent from delaying
+        // the whole webclient
+        this.searchReadEmployee();
     }
 
     async searchReadEmployee(){
@@ -76,4 +74,4 @@ export const systrayAttendance = {
 
 registry
     .category("systray")
-    .add("hr_attendance.attendance_menu", systrayAttendance, { sequence: 100 });
+    .add("hr_attendance.attendance_menu", systrayAttendance, { sequence: 101 });

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -86,10 +86,12 @@ class Http(models.AbstractModel):
         mods = odoo.conf.server_wide_modules or []
         if request.db:
             mods = list(request.registry._init_modules) + mods
+        is_internal_user = user.has_group('base.group_user')
         session_info = {
             "uid": session_uid,
             "is_system": user._is_system() if session_uid else False,
             "is_admin": user._is_admin() if session_uid else False,
+            "is_internal_user": is_internal_user,
             "user_context": user_context,
             "db": self.env.cr.dbname,
             "user_settings": self.env['res.users.settings']._find_or_create_for_user(user)._res_users_settings_format(),
@@ -119,7 +121,7 @@ class Http(models.AbstractModel):
         }
         if request.session.debug:
             session_info['bundle_params']['debug'] = request.session.debug
-        if self.env.user.has_group('base.group_user'):
+        if is_internal_user:
             # the following is only useful in the context of a webclient bootstrapping
             # but is still included in some other calls (e.g. '/web/session/authenticate')
             # to avoid access errors and unnecessary information, it is only included for users

--- a/addons/web/static/src/core/user_service.js
+++ b/addons/web/static/src/core/user_service.js
@@ -19,6 +19,8 @@ export const userService = {
                 kwargs: { context },
             });
         });
+        groupCache.cache["base.group_user"] = session.is_internal_user;
+        groupCache.cache["base.group_system"] = session.is_system;
         const accessRightCache = new Cache((model, operation) => {
             const url = `/web/dataset/call_kw/${model}/check_access_rights`;
             return rpc(url, {


### PR DESCRIPTION
The attendance systray item needs data to determine whether or not it should be displayed, and what to display. Before this commit, it fetched it in the standard way, in onWillStart, and returned the fetch promise.

However, for a systray item, it's better not to wait for the promise, such that the webclient doesn't wait for it to be mounted. In the case of this item, it is simply not displayed until data is fetched, and when it is displayed, it's the right most item so it doesn't produce any flickering.

This allows to save several ms on specific screens (e.g. home menu).

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
