### PR TITLE
[IMP] sale{project,timesheet}: Generic Improvement

### DIFF
--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -46,6 +46,12 @@
                     </p>
                 </page>
             </xpath>
+            <xpath expr="//field[@name='allow_billable']" position="after">
+                <div invisible="not allow_billable or not allow_timesheets" class="text-muted">
+                    Timesheets without a sales order item are
+                    <field name="billing_type" nolabel="1"/>
+                </div>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
**Before this commit:**
An internal use case of training cannot be handeled with the current ux. Basically, training is sold to customers. It is given by a consultant who needs to timesheet their time. With the current implementation, each training would generate 1 SO per customer per training. This makes it impossible to timesheet because the consultant cannot split nor multiply their time per person attending the training.
Because of that, timesheets cannot be billable which leads the reporting to be inaccurate.

**After this commit:**
A billable project has an option 'billable manually', its timesheets are considered billed manually when the option is set.

task-3565762