### PR TITLE
[FIX] packaging: rpm and src fixes

### DIFF
--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -32,7 +32,7 @@ RUN dnf update -d 0 -e 0 -y && \
         python3-markupsafe \
         python3-mock \
         python3-num2words \
-        python3-ofxparse \
+        python3-ofxparse.noarch \
         python3-passlib \
         python3-pillow \
         python3-polib \

--- a/setup/package.dfsrc
+++ b/setup/package.dfsrc
@@ -1,6 +1,6 @@
 # Please note that this Dockerfile is used for testing nightly builds and should
 # not be used to deploy Odoo
-FROM debian:buster
+FROM debian:bookworm
 MAINTAINER Odoo S.A. <info@odoo.com>
 
 RUN apt-get update && \
@@ -23,15 +23,12 @@ RUN apt-get update -qq &&  \
 		libldap2-dev \
 		libsasl2-dev \
 		python3-pip \
+		python3-venv \
 		python3-wheel \
 		build-essential \
 		python3 -y && \
 	rm -rf /var/lib/apt/lists/*
 
-RUN pip3 install --upgrade pip
-
 COPY requirements.txt /opt/release/requirements.txt
-
-RUN pip3 install -r /opt/release/requirements.txt
 
 RUN echo "PS1=\"[\u@nightly-tests] # \"" > ~/.bashrc

--- a/setup/package.py
+++ b/setup/package.py
@@ -295,11 +295,14 @@ class DockerTgz(Docker):
         logging.info('Start testing python tgz package')
         cmds = [
             'service postgresql start',
-            'pip3 install /data/src/odoo_%s.%s.tar.gz' % (VERSION, TSTAMP),
             'su postgres -s /bin/bash -c "createuser -s odoo"',
+            'su odoo -s /bin/bash -c "python3 -m venv /var/lib/odoo/odoovenv"',
+            'su odoo -s /bin/bash -c "/var/lib/odoo/odoovenv/bin/python3 -m pip install --upgrade pip"',
+            'su odoo -s /bin/bash -c "/var/lib/odoo/odoovenv/bin/python3 -m pip install -r /opt/release/requirements.txt"',
+            f'su odoo -s /bin/bash -c "/var/lib/odoo/odoovenv/bin/python3 -m pip install /data/src/odoo_{VERSION}.{TSTAMP}.tar.gz"',
             'su odoo -s /bin/bash -c "createdb mycompany"',
-            'su odoo -s /bin/bash -c "odoo -d mycompany -i base --stop-after-init"',
-            'su odoo -s /bin/bash -c "odoo -d mycompany --pidfile=/data/src/odoo.pid"',
+            'su odoo -s /bin/bash -c "/var/lib/odoo/odoovenv/bin/odoo -d mycompany -i base --stop-after-init"',
+            'su odoo -s /bin/bash -c "/var/lib/odoo/odoovenv/bin/odoo -d mycompany --pidfile=/data/src/odoo.pid"',
         ]
         self.run(' && '.join(cmds), self.args.build_dir, 'odoo-src-test-%s' % TSTAMP, user='root', detach=True, exposed_port=8069, timeout=300)
         self.test_odoo()

--- a/setup/package.py
+++ b/setup/package.py
@@ -297,7 +297,7 @@ class DockerTgz(Docker):
             'service postgresql start',
             'pip3 install /data/src/odoo_%s.%s.tar.gz' % (VERSION, TSTAMP),
             'su postgres -s /bin/bash -c "createuser -s odoo"',
-            'su postgres -s /bin/bash -c "createdb mycompany"',
+            'su odoo -s /bin/bash -c "createdb mycompany"',
             'su odoo -s /bin/bash -c "odoo -d mycompany -i base --stop-after-init"',
             'su odoo -s /bin/bash -c "odoo -d mycompany --pidfile=/data/src/odoo.pid"',
         ]
@@ -364,7 +364,8 @@ class DockerRpm(Docker):
         cmds = [
             'su postgres -c "/usr/bin/pg_ctl -D /var/lib/postgres/data start"',
             'sleep 5',
-            'su postgres -c "createdb mycompany"',
+            'su postgres -c "createuser -s odoo"',
+            'su odoo -c "createdb mycompany"',
             'dnf install -d 0 -e 0 /data/src/odoo_%s.%s.rpm -y' % (VERSION, TSTAMP),
             'su odoo -s /bin/bash -c "odoo -c /etc/odoo/odoo.conf -d mycompany -i base --stop-after-init"',
             'su odoo -s /bin/bash -c "odoo -c /etc/odoo/odoo.conf -d mycompany --pidfile=/data/src/odoo.pid"',

--- a/setup/rpm/odoo.spec
+++ b/setup/rpm/odoo.spec
@@ -1,6 +1,7 @@
 %global name odoo
 %global release 1
 %global unmangled_version %{version}
+%global __requires_exclude ^.*odoo/addons/mail/static/scripts/odoo-mailgate.py$
 
 Summary: Odoo Server
 Name: %{name}


### PR DESCRIPTION
* Fix obscure bug of python3-ofxparse refusing to install in Fedora 38
* Fix postgresql public schema permissions issue in packaging tests
* Remove python2.7 rpm dependency because of a private script
* Use the latest Debian to produce and test the source package using a venv in Docker container
