### PR TITLE
[FIX] web: reload groups when a record is modified in list view

### DIFF
--- a/addons/web/static/src/views/relational_model.js
+++ b/addons/web/static/src/views/relational_model.js
@@ -452,7 +452,7 @@ export class Record extends DataPoint {
                 evalContext[fieldName] = false;
             } else if (isX2Many(this.fields[fieldName])) {
                 const list = this._cache[fieldName];
-                evalContext[fieldName] = list.currentIds;
+                evalContext[fieldName] = list && list.currentIds;
                 // ---> implied to initialize (resIds, commands) currentIds before loading static list
             } else if (value && this.fields[fieldName].type === "date") {
                 evalContext[fieldName] = serializeDate(value);
@@ -3587,21 +3587,15 @@ export class RelationalModel extends Model {
     }
 
     /**
-     * Reloads a given record and all related records (those sharing the same resId).
-     * A "record-updated" event containing the given and related records is then
-     * triggered on the model.
+     * Reloads all records.
      *
-     * @param {Record} record
      */
     async reloadRecords(record) {
         const records = this.rootType === "record" ? [this.root] : this.root.records;
-        const relatedRecords = records.filter(
-            (r) => r.id !== record.id && r.resId === record.resId
-        );
 
-        await Promise.all([record, ...relatedRecords].map((r) => r.load()));
+        await this.load();
 
-        this.trigger("record-updated", { record, relatedRecords });
+        this.trigger("record-updated", { record, relatedRecords: records });
         this.notify();
     }
 }


### PR DESCRIPTION
When we group by a field and we change this field on a record in the list view, the groups are not updated

Steps to reproduce:
1. Install CRM
2. Go to CRM, trigger the list view and add a group by on Stage
3. Select a record and change its stage
4. The record stays in the same group

There is a similar issue if you leave the "My Pipeline" filter and modify the salesperson to Marc Demo (the record will still be in the list view)

Solution:
Reload all the records when we modify a field in a list view

opw-3424430