### PR TITLE
[FIX] web, mail: AutoFocus hook should be generic

### DIFF
--- a/addons/mail/static/src/core/common/search_messages_panel.js
+++ b/addons/mail/static/src/core/common/search_messages_panel.js
@@ -25,7 +25,6 @@ export class SearchMessagesPanel extends Component {
     static template = "mail.SearchMessagesPanel";
 
     setup() {
-        useAutofocus();
         this.state = useState({ searchTerm: "", searchedTerm: "" });
         this.messageSearch = useMessageSearch(this.props.thread);
         useAutofocus();

--- a/addons/web/static/src/core/commands/command_palette.js
+++ b/addons/web/static/src/core/commands/command_palette.js
@@ -111,7 +111,11 @@ export class CommandPalette extends Component {
         this._sessionId = CommandPalette.lastSessionId++;
         this.DefaultCommandItem = DefaultCommandItem;
         this.activeElement = useService("ui").activeElement;
-        this.inputRef = useAutofocus();
+        this.inputRef = useAutofocus({
+            condition: (el) => {
+                return !this.activeElement || this.activeElement.contains(el);
+            },
+        });
 
         useHotkey("Enter", () => this.executeSelectedCommand(), { bypassEditableProtection: true });
         useHotkey("Control+Enter", () => this.executeSelectedCommand(true), {

--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -36,12 +36,19 @@ import { status, useComponent, useEffect, useRef, onWillUnmount } from "@odoo/ow
  * @param {string} [params.refName] override the ref name "autofocus"
  * @param {boolean} [params.selectAll] if true, will select the entire text value.
  * @param {boolean} [params.mobile] if true, will autofocus on mobile devices.
+ * @param {function} [params.condition] set a condition to check if the element fits the autofocus criteria.
  * @returns {Ref} the element reference
  */
-export function useAutofocus({ refName, selectAll, mobile } = {}) {
+export function useAutofocus({
+    refName,
+    selectAll,
+    mobile,
+    condition = () => {
+        return true;
+    },
+} = {}) {
     const comp = useComponent();
     const ref = useRef(refName || "autofocus");
-    const uiService = useService("ui");
 
     // Prevent autofocus in mobile
     if (!mobile && comp.env.isSmall) {
@@ -54,7 +61,7 @@ export function useAutofocus({ refName, selectAll, mobile } = {}) {
     // LEGACY
     useEffect(
         (el) => {
-            if (el && (!uiService.activeElement || uiService.activeElement.contains(el))) {
+            if (el && condition?.(el)) {
                 el.focus();
                 if (["INPUT", "TEXTAREA"].includes(el.tagName) && el.type !== "number") {
                     el.selectionEnd = el.value.length;

--- a/addons/web/static/tests/core/utils/hooks_tests.js
+++ b/addons/web/static/tests/core/utils/hooks_tests.js
@@ -14,9 +14,6 @@ import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { destroy, getFixture, makeDeferred, mount, nextTick } from "@web/../tests/helpers/utils";
 
 import { Component, onMounted, useState, xml } from "@odoo/owl";
-import { dialogService } from "@web/core/dialog/dialog_service";
-import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
-import { CommandPalette } from "@web/core/commands/command_palette";
 const serviceRegistry = registry.category("services");
 
 QUnit.module("utils", () => {
@@ -274,45 +271,6 @@ QUnit.module("utils", () => {
             assert.strictEqual(document.activeElement, comp.inputRef.el);
             assert.strictEqual(comp.inputRef.el.selectionStart, 0);
             assert.strictEqual(comp.inputRef.el.selectionEnd, 10);
-        });
-
-        QUnit.test("useAutofocus: autofocus outside of active element doesn't work (CommandPalette)", async function (assert) {
-            class MyComponent extends Component {
-                setup() {
-                    this.inputRef = useAutofocus();
-                }
-                get OverlayContainer() {
-                    return registry.category("main_components").get("OverlayContainer");
-                }
-            }
-            MyComponent.template = xml`
-                <div>
-                    <input type="text" t-ref="autofocus" />
-                    <div class="o_dialog_container"/>
-                    <t t-component="OverlayContainer.Component" t-props="OverlayContainer.props" />
-                </div>
-            `;
-
-            registry.category("services").add("ui", uiService);
-            registry.category("services").add("dialog", dialogService);
-            registry.category("services").add("hotkey", hotkeyService);
-
-            const config = { providers: [] };
-            const env = await makeTestEnv();
-            const target = getFixture();
-            const comp = await mount(MyComponent, target , { env });
-            await nextTick();
-
-            assert.strictEqual(document.activeElement, comp.inputRef.el);
-
-            env.services.dialog.add(CommandPalette, { config });
-            await nextTick();
-            assert.containsOnce(target, ".o_command_palette");
-            assert.notStrictEqual(document.activeElement, comp.inputRef.el);
-
-            comp.render();
-            await nextTick();
-            assert.notStrictEqual(document.activeElement, comp.inputRef.el);
         });
 
         QUnit.module("useBus");


### PR DESCRIPTION
Currently, when there is an input within a popover, the AutoFocus hook is not working well due to the check for activeElement.

The fix is to provide a function parameter to check the situation rather than put it inside the hook thus, it can be used as a generic hook as it was.

Also, remove the duplicate useAutofocus in `mail` code.

Related PR: https://github.com/odoo/odoo/pull/139124

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
