### PR TITLE
[FIX] stock: display full forecast when there is no quant

### DIFF
--- a/addons/stock/report/report_stock_quantity.py
+++ b/addons/stock/report/report_stock_quantity.py
@@ -161,6 +161,25 @@ FROM (SELECT
     FROM
         all_sm m
     WHERE
+        m.product_qty != 0
+    UNION ALL
+    SELECT
+        m.id,
+        m.product_id,
+        m.tmpl_id as product_tmpl_id,
+        'forecast' as state,
+        GENERATE_SERIES(
+            (now() at time zone 'utc')::date - interval '3month',
+            (now() at time zone 'utc')::date + interval '3month', '1 day'::interval)::date date,
+        0 AS product_qty,
+        m.company_id,
+        CASE
+            WHEN m.whs_id IS NOT NULL AND m.whd_id IS NULL THEN m.whs_id
+            WHEN m.whd_id IS NOT NULL AND m.whs_id IS NULL THEN m.whd_id
+        END AS warehouse_id
+    FROM
+        all_sm m
+    WHERE
         m.product_qty != 0) AS forecast_qty
 GROUP BY product_id, product_tmpl_id, state, date, company_id, warehouse_id
 );


### PR DESCRIPTION
**Quantity field is ignored in a sale order**

Impacted versions:
 
 - 16.0
 
Steps to reproduce:
1.- Create a new storable product
2.- Create an incoming transfer in the past with quantity equal to 1, within the past 3 months.
3.- To simulate the transfer being validated in the past, with the support tools change the date of the stock move to the one chosen for the transfer
4.- Create an outgoing transfer in the past with quantity equal to 1, within the past 3 months.
5.- To simulate the transfer being validated in the past, with the support tools change the date of the stock move to the one chosen for the transfer
6.- Verify the stock quant for the product does not exist, which it should not because it has quantity equal to 0
7.- Go to the forecast graph of the product, it will truncate to the day before the latest of the 2 transfers
 
Current behavior:
 
 - Forecast graph is truncated  to the day before the latest of the 2 transfers
Expected behavior:
- Forecast should show the past 3 months and the next 3 months
 
Notes:
In the table report_stock_quantity, the building process involves, for each product, creating a time series for all the quants that goes from 3 months in the past until 3 months in the future. Also, it involves, for done stock moves, a series that goes from 3 months in the past to 1 day before the move. If the quantity on hand is 0, the quant will momentarily have 0 quantity and then automatically delete. Therefore, the only information we will have if we only have done quantities are the time series for the moves. In the graph of forecasted inventory, we simply aggregate those results by product and date and that is how we obtain the forecast graph. However, if the on hand quantity is 0, and therefore there are no quants, and all the stock moves are done, then the datapoints will go from 3 months in the past to 1 day before the latest stock move. If that stock move is in the past, then we will not be able to see the present forecasted amount in the graph. By adding a time series for each product that goes back 3 months in the past to 3 months in the future, with quantity 0, this bug is fixed. This is because we add the dates we are missing and we do not affect the count for forecasted inventory, since we are only adding 0.

opw-3516127



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
