### PR TITLE
[IMP] l10n_au: Remittance Advice

### DIFF
--- a/addons/account/views/report_payment_receipt_templates.xml
+++ b/addons/account/views/report_payment_receipt_templates.xml
@@ -5,7 +5,7 @@
             <t t-set="o" t-value="o.with_context(lang=lang)"/>
             <t t-set="values" t-value="o._get_payment_receipt_report_values()"/>
             <div class="page">
-                <h3><strong>Payment Receipt: <span t-field="o.name"/></strong></h3>
+                <h3><strong id="payment_title">Payment Receipt: <span t-field="o.name"/></strong></h3>
                 <div class="mb-4 mt-3">
                     <div name="date" class="row">
                         <div class="col-6" t-if="o.date">

--- a/addons/l10n_au/__manifest__.py
+++ b/addons/l10n_au/__manifest__.py
@@ -26,6 +26,7 @@ Also:
         'views/report_invoice.xml',
         'views/res_company_views.xml',
         'views/res_partner_bank_views.xml',
+        'views/report_payment_receipt_templates.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_au/views/report_payment_receipt_templates.xml
+++ b/addons/l10n_au/views/report_payment_receipt_templates.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="report_payment_receipt_document" inherit_id="account.report_payment_receipt_document">
+        <xpath expr="//strong[@id='payment_title']" position="replace">
+            <!-- Customary in Australia to use the term "Remittance Advice" for payments to suppliers -->
+            <t t-if="o.company_id.account_fiscal_country_id.code == 'AU' and o.partner_type == 'supplier'">
+                <strong>Remittance Advice: <span t-field="o.name"/></strong>
+            </t>
+            <t t-else="">
+                <strong>Payment Receipt: <span t-field="o.name"/></strong>
+            </t>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
In AU, it is customary to name proof of payment documents with different headers if the partner is a customer or a supplier.

If the partner is a customer, the current "Payment Receipt" is expected.
If the partner is a supplier, "Remittance Advice" is expected.

This change will bring this to the payment receipt report if:
- the Australian localisation is installed
- either the company or the partner are from Australia

Task id #3465257

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
