### PR TITLE
[REF] *: add chartjs assets bundle

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -206,8 +206,7 @@
             'web/static/lib/ace/mode-js.js',
             'web/static/lib/ace/mode-qweb.js',
             'web/static/lib/stacktracejs/stacktrace.js',
-            'web/static/lib/Chart/Chart.js',
-            'web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
+            ('include', "web.chartjs_lib"),
 
             # 'web/static/tests/legacy/main_tests.js',
             'web/static/tests/helpers/**/*.js',

--- a/addons/spreadsheet/static/src/assets_backend/helpers.js
+++ b/addons/spreadsheet/static/src/assets_backend/helpers.js
@@ -1,12 +1,11 @@
 /** @odoo-module */
 
-import { loadJS } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 
 /**
  * Load external libraries required for o-spreadsheet
  * @returns {Promise<void>}
  */
 export async function loadSpreadsheetDependencies() {
-    await loadJS("/web/static/lib/Chart/Chart.js");
-    await loadJS("/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js");
+    await loadBundle("web.chartjs_lib");
 }

--- a/addons/spreadsheet/static/src/helpers/model.js
+++ b/addons/spreadsheet/static/src/helpers/model.js
@@ -3,7 +3,7 @@ import { DataSources } from "@spreadsheet/data_sources/data_sources";
 import { Model, parse, helpers, iterateAstNodes } from "@odoo/o-spreadsheet";
 import { migrate } from "@spreadsheet/o_spreadsheet/migration";
 import { _t } from "@web/core/l10n/translation";
-import { loadJS } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 
 const { toCartesian, UuidGenerator, createEmptySheet } = helpers;
 const uuidGenerator = new UuidGenerator();
@@ -67,8 +67,7 @@ export async function freezeOdooData(model) {
         }
         for (const figure of sheet.figures) {
             if (figure.tag === "chart" && figure.data.type.startsWith("odoo_")) {
-                await loadJS("/web/static/lib/Chart/Chart.js");
-                await loadJS("/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js");
+                await loadBundle("web.chartjs_lib");
                 const img = odooChartToImage(model, figure);
                 figure.tag = "image";
                 figure.data = {

--- a/addons/spreadsheet/static/tests/utils/ui.js
+++ b/addons/spreadsheet/static/tests/utils/ui.js
@@ -4,7 +4,7 @@ import { Spreadsheet } from "@odoo/o-spreadsheet";
 import { registerCleanup } from "@web/../tests/helpers/cleanup";
 import { makeTestEnv } from "@web/../tests/helpers/mock_env";
 import { getFixture, nextTick } from "@web/../tests/helpers/utils";
-import { loadJS, templates } from "@web/core/assets";
+import { loadBundle, templates } from "@web/core/assets";
 import { PublicReadonlySpreadsheet } from "@spreadsheet/public_readonly_app/public_readonly";
 
 import { App } from "@odoo/owl";
@@ -18,8 +18,7 @@ import { registry } from "@web/core/registry";
  * @returns {Promise<HTMLElement>}
  */
 export async function mountSpreadsheet(model) {
-    await loadJS("/web/static/lib/Chart/Chart.js");
-    await loadJS("/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js");
+    await loadBundle("web.chartjs_lib");
     const app = new App(Spreadsheet, {
         props: { model },
         templates: templates,

--- a/addons/survey/__manifest__.py
+++ b/addons/survey/__manifest__.py
@@ -61,8 +61,7 @@ sent mails with personal token for the invitation of the survey.
     'sequence': 220,
     'assets': {
         'survey.survey_assets': [
-            'web/static/lib/Chart/Chart.js',
-            'web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
+            ('include', "web.chartjs_lib"),
             'survey/static/src/js/survey_image_zoomer.js',
             '/survey/static/src/xml/survey_image_zoomer_templates.xml',
             'survey/static/src/js/survey_quick_access.js',

--- a/addons/survey/static/src/js/survey_result.js
+++ b/addons/survey/static/src/js/survey_result.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { _t } from "@web/core/l10n/translation";
-import { loadJS } from "@web/core/assets";
+import { loadBundle, loadJS } from "@web/core/assets";
 import { SurveyImageZoomer } from "@survey/js/survey_image_zoomer";
 import publicWidget from "@web/legacy/js/public/public_widget";
 
@@ -90,10 +90,6 @@ publicWidget.registry.SurveyResultPagination = publicWidget.Widget.extend({
  *
  */
 publicWidget.registry.SurveyResultChart = publicWidget.Widget.extend({
-    jsLibs: [
-        '/web/static/lib/Chart/Chart.js',
-        '/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
-    ],
 
     //--------------------------------------------------------------------------
     // Widget
@@ -134,6 +130,10 @@ publicWidget.registry.SurveyResultChart = publicWidget.Widget.extend({
                 self.chart = self._loadChart();
             }
         });
+    },
+
+    willStart: async function () {
+        await loadBundle("web.chartjs_lib");
     },
 
     // -------------------------------------------------------------------------

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -437,8 +437,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/lib/ace/mode-qweb.js',
             'web/static/lib/ace/theme-monokai.js',
             'web/static/lib/stacktracejs/stacktrace.js',
-            'web/static/lib/Chart/Chart.js',
-            'web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
+            ('include', "web.chartjs_lib"),
             'web/static/lib/jSignature/jSignatureCustom.js',
             'web/static/src/libs/jSignatureCustom.js',
 
@@ -478,6 +477,10 @@ This module provides the core of the Odoo Web Client.
         'web.assets_clickbot': [
             'web/static/src/webclient/clickbot/clickbot.js',
         ],
+        "web.chartjs_lib" : [
+            '/web/static/lib/Chart/Chart.js',
+            '/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
+        ]
     },
     'bootstrap': True,  # load translations for login screen,
     'license': 'LGPL-3',

--- a/addons/web/static/src/views/fields/gauge/gauge_field.js
+++ b/addons/web/static/src/views/fields/gauge/gauge_field.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { _t } from "@web/core/l10n/translation";
-import { loadJS } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { registry } from "@web/core/registry";
 import { formatFloat } from "@web/core/utils/numbers";
 import { standardFieldProps } from "@web/views/fields/standard_field_props";
@@ -13,7 +13,7 @@ export class GaugeField extends Component {
         this.chart = null;
         this.canvasRef = useRef("canvas");
 
-        onWillStart(() => loadJS("/web/static/lib/Chart/Chart.js"));
+        onWillStart(async () => await loadBundle("web.chartjs_lib"));
 
         useEffect(() => {
             this.renderChart();

--- a/addons/web/static/src/views/fields/journal_dashboard_graph/journal_dashboard_graph_field.js
+++ b/addons/web/static/src/views/fields/journal_dashboard_graph/journal_dashboard_graph_field.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import { loadJS } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { registry } from "@web/core/registry";
 import { getColor, hexToRGBA } from "@web/core/colors/colors";
 import { standardFieldProps } from "../standard_field_props";
@@ -20,7 +20,7 @@ export class JournalDashboardGraphField extends Component {
         this.canvasRef = useRef("canvas");
         this.data = JSON.parse(this.props.record.data[this.props.name]);
 
-        onWillStart(() => loadJS("/web/static/lib/Chart/Chart.js"));
+        onWillStart(async () => await loadBundle("web.chartjs_lib"));
 
         useEffect(() => {
             this.renderChart();

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -5,7 +5,7 @@ import { getBorderWhite, DEFAULT_BG, getColor, hexToRGBA } from "@web/core/color
 import { formatFloat } from "@web/views/fields/formatters";
 import { SEP } from "./graph_model";
 import { sortBy } from "@web/core/utils/arrays";
-import { loadJS } from "@web/core/assets";
+import { loadBundle } from "@web/core/assets";
 import { renderToString } from "@web/core/utils/render";
 import { useService } from "@web/core/utils/hooks";
 
@@ -58,8 +58,7 @@ export class GraphRenderer extends Component {
         this.legendTooltip = null;
 
         onWillStart(async () => {
-            await loadJS("/web/static/lib/Chart/Chart.js");
-            await loadJS("/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js");
+            await loadBundle("web.chartjs_lib");
         });
 
         useEffect(() => this.renderChart());

--- a/addons/website/static/src/snippets/s_chart/000.js
+++ b/addons/website/static/src/snippets/s_chart/000.js
@@ -1,15 +1,12 @@
 /** @odoo-module **/
 
+import { loadBundle } from "@web/core/assets";
 import publicWidget from "@web/legacy/js/public/public_widget";
 import weUtils from "@web_editor/js/common/utils";
 
 const ChartWidget = publicWidget.Widget.extend({
     selector: '.s_chart',
     disabledInEditableMode: false,
-    jsLibs: [
-        '/web/static/lib/Chart/Chart.js',
-        '/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
-    ],
 
     /**
      * @override
@@ -122,6 +119,10 @@ const ChartWidget = publicWidget.Widget.extend({
         window.Chart.Tooltip.positioners.custom = (elements, eventPosition) => eventPosition;
         this.chart = new window.Chart(canvas, chartData);
         return this._super.apply(this, arguments);
+    },
+
+    willStart: async function () {
+        await loadBundle("web.chartjs_lib");
     },
     /**
      * @override

--- a/addons/website_links/static/src/js/website_links_charts.js
+++ b/addons/website_links/static/src/js/website_links_charts.js
@@ -1,14 +1,11 @@
 /** @odoo-module **/
 
+import { loadBundle } from "@web/core/assets";
 import { _t } from "@web/core/l10n/translation";
 import publicWidget from "@web/legacy/js/public/public_widget";
 const { DateTime } = luxon;
 
 var BarChart = publicWidget.Widget.extend({
-    jsLibs: [
-        '/web/static/lib/Chart/Chart.js',
-        '/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
-    ],
     /**
      * @constructor
      * @param {Object} parent
@@ -67,13 +64,12 @@ var BarChart = publicWidget.Widget.extend({
         var context = canvas.getContext('2d');
         new Chart(context, config);
     },
+    willStart: async function () {
+        await loadBundle("web.chartjs_lib");
+    },
 });
 
 var PieChart = publicWidget.Widget.extend({
-    jsLibs: [
-        '/web/static/lib/Chart/Chart.js',
-        '/web/static/lib/chartjs-adapter-luxon/chartjs-adapter-luxon.js',
-    ],
     /**
      * @override
      * @param {Object} parent
@@ -117,6 +113,9 @@ var PieChart = publicWidget.Widget.extend({
         var canvas = this.$('canvas')[0];
         var context = canvas.getContext('2d');
         new Chart(context, config);
+    },
+    willStart: async function () {
+        await loadBundle("web.chartjs_lib");
     },
 });
 


### PR DESCRIPTION
In the goal of simplify assets loading, in this commit we create a new
assets bundle for chartJS and its luxon adapter.
With this, we can now use loadBundle instead of load these two libraries
with loadJS.

task-3562357