### PR TITLE
[FIX] project: Empty task display name on creation

### DIFF
--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -169,7 +169,6 @@ class Task(models.Model):
     @api.depends('allow_timesheets', 'planned_hours', 'encode_uom_in_days', 'remaining_hours')
     @api.depends_context('hr_timesheet_display_remaining_hours')
     def _compute_display_name(self):
-        super()._compute_display_name()
         if self.env.context.get('hr_timesheet_display_remaining_hours'):
             for task in self:
                 if task.allow_timesheets and task.planned_hours > 0 and task.encode_uom_in_days:


### PR DESCRIPTION
Steps:
- install 'hr_timesheet' module.
- Go to project, select one.
- Add a task.

Issue:
The task's display name is set to ``Project.task,<record_id>``.

Cause:
In ``_compute_display_name()`` the ``super._compute_display_name()`` is called, which refers directly to the ``BaseModel._compute_display_name()``. We can solve it just by deleting that call.

opw-3513609

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
