### PR TITLE
[IMP] pos_self_order, *: notify backend payment

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1197,6 +1197,9 @@ class PosOrder(models.Model):
         """
         return self.mapped(self._export_for_ui) if self else []
 
+    def _send_order(self):
+        # This function is made to be overriden by pos_self_order_preparation_display
+        pass
 
 class PosOrderLine(models.Model):
     _name = "pos.order.line"

--- a/addons/point_of_sale/tests/test_anglo_saxon.py
+++ b/addons/point_of_sale/tests/test_anglo_saxon.py
@@ -92,6 +92,7 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
             'amount_tax': 0,
             'amount_paid': 0,
             'amount_return': 0,
+            'last_order_preparation_change': '{}'
         })
 
         # I make a payment to fully pay the order
@@ -172,6 +173,7 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
             'amount_tax': 0,
             'amount_paid': 0,
             'amount_return': 0,
+            'last_order_preparation_change': '{}'
         }
 
         return self.PosOrder.create(pos_order_values)
@@ -257,6 +259,7 @@ class TestAngloSaxonFlow(TestAngloSaxonCommon):
             'amount_tax': 0,
             'amount_paid': 0,
             'amount_return': 0,
+            'last_order_preparation_change': '{}'
         })
 
         # I make a payment to fully pay the order

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -55,6 +55,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_tax': 0.0,
             'amount_paid': 0.0,
             'amount_return': 0.0,
+            'last_order_preparation_change': '{}'
         })
 
         payment_context = {"active_ids": order.ids, "active_id": order.id}
@@ -153,6 +154,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_tax': 0.0,
             'amount_return': 0.0,
             'to_invoice': False,
+            'last_order_preparation_change': '{}'
             })
 
         payment_context = {"active_ids": order.ids, "active_id": order.id}
@@ -230,6 +232,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_total': untax1 + untax2 + atax1 + atax2,
             'amount_paid': 0,
             'amount_return': 0,
+            'last_order_preparation_change': '{}'
         })
 
         context_make_payment = {
@@ -295,6 +298,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_total': untax1 + untax2 + atax1 + atax2,
             'amount_paid': 0,
             'amount_return': 0,
+            'last_order_preparation_change': '{}'
         })
 
         context_make_payment = {
@@ -359,6 +363,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_total': untax1 + untax2 + atax1 + atax2,
             'amount_paid': 0,
             'amount_return': 0,
+            'last_order_preparation_change': '{}'
         })
 
         context_make_payment = {
@@ -461,6 +466,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
                 'amount_total': 2 * (untax + atax),
                 'amount_paid': 0,
                 'amount_return': 0,
+                'last_order_preparation_change': '{}'
             })
 
             context_make_payment = {
@@ -519,6 +525,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_total': untax1 + untax2 + atax1 + atax2,
             'amount_paid': 0.0,
             'amount_return': 0.0,
+            'last_order_preparation_change': '{}'
         })
 
         # I click on the "Make Payment" wizard to pay the PoS order
@@ -579,7 +586,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
               'price_subtotal': 0.9,
               'price_subtotal_incl': 1.04,
               'qty': 1,
-              'tax_ids': [(6, 0, self.led_lamp.taxes_id.ids)]}]],
+              'tax_ids': [(6, 0, self.led_lamp.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)]}]],
            'name': 'Order 00042-003-0014',
            'partner_id': False,
            'pos_session_id': current_session.id,
@@ -610,7 +617,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
               'price_subtotal': 1.2,
               'price_subtotal_incl': 1.38,
               'qty': 1,
-              'tax_ids': [(6, 0, self.whiteboard_pen.taxes_id.ids)]}]],
+              'tax_ids': [(6, 0, self.whiteboard_pen.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids)]}]],
            'name': 'Order 00043-003-0014',
            'partner_id': self.partner1.id,
            'pos_session_id': current_session.id,
@@ -641,7 +648,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
               'price_subtotal': 1.28,
               'price_subtotal_incl': 1.47,
               'qty': 1,
-              'tax_ids': [[6, False, self.newspaper_rack.taxes_id.ids]]}]],
+              'tax_ids': [[6, False, self.newspaper_rack.taxes_id.filtered(lambda t: t.company_id.id == self.env.company.id).ids]]}]],
            'name': 'Order 00044-003-0014',
            'partner_id': False,
            'pos_session_id': current_session.id,
@@ -762,6 +769,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_total': untax1 + untax2 + atax1 + atax2,
             'amount_paid': 0.0,
             'amount_return': 0.0,
+            'last_order_preparation_change': '{}'
         })
 
         # I check that the total of the order is now equal to (450*2 +
@@ -855,6 +863,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_total': 855 * 2,
             'amount_paid': 0.0,
             'amount_return': 0.0,
+            'last_order_preparation_change': '{}'
         })
 
         # I click on the "Make Payment" wizard to pay the PoS order
@@ -1030,6 +1039,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_paid': 0,
             'amount_return': 0,
             'shipping_date': fields.Date.today(),
+            'last_order_preparation_change': '{}'
         })
 
         context_make_payment = {
@@ -1073,7 +1083,8 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_tax': 0.0,
             'amount_paid': 0.0,
             'amount_return': 0.0,
-            'to_invoice': True
+            'to_invoice': True,
+            'last_order_preparation_change': '{}'
         })
 
         payment_context = {"active_ids": order.ids, "active_id": order.id}
@@ -1337,6 +1348,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_tax': 0.0,
             'amount_return': 0.0,
             'to_invoice': False,
+            'last_order_preparation_change': '{}'
             })
 
         payment_context = {"active_ids": order.ids, "active_id": order.id}
@@ -1403,7 +1415,8 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_tax': 0.0,
             'amount_paid': 10,
             'amount_return': 0.0,
-            'to_invoice': True
+            'to_invoice': False,
+            'last_order_preparation_change': '{}'
         })
         #create a payment
         payment_context = {"active_ids": order.ids, "active_id": order.id}
@@ -1464,6 +1477,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_tax': 0.0,
             'amount_return': 0.0,
             'to_invoice': False,
+            'last_order_preparation_change': '{}'
             })
 
         payment_context = {"active_ids": order.ids, "active_id": order.id}
@@ -1590,7 +1604,8 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_total': 6.0,
             'amount_tax': 0.0,
             'amount_return': 0.0,
-            'to_invoice': True,
+            'to_invoice': False,
+            'last_order_preparation_change': '{}'
             })
 
         #pay for the order with customer account
@@ -1689,6 +1704,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_tax': 20.0,
             'amount_return': 0.0,
             'to_invoice': False,
+            'last_order_preparation_change': '{}'
             })
         #make payment
         payment_context = {"active_ids": order.ids, "active_id": order.id}
@@ -1784,6 +1800,7 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
             'amount_tax': 0.0,
             'amount_return': 0.0,
             'to_invoice': False,
+            'last_order_preparation_change': '{}',
             'shipping_date': fields.Date.today(),
             })
         #make payment

--- a/addons/point_of_sale/wizard/pos_payment.py
+++ b/addons/point_of_sale/wizard/pos_payment.py
@@ -61,10 +61,10 @@ class PosMakePayment(models.TransientModel):
                 'payment_method_id': init_data['payment_method_id'][0],
             })
 
-        if order._is_pos_order_paid():
-            order.action_pos_order_paid()
-            order._create_order_picking()
-            order._compute_total_cost_in_real_time()
+        if order.state == 'draft' and order._is_pos_order_paid():
+            order._process_saved_order(False)
+            if order.state in {'paid', 'done', 'invoiced'}:
+                order._send_order()
             return {'type': 'ir.actions.act_window_close'}
 
         return self.launch_payment()

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -70,6 +70,7 @@ class TestPosMrp(TestPointOfSaleCommon):
             'amount_tax': 0.0,
             'amount_return': 0.0,
             'to_invoice': False,
+            'last_order_preparation_change': '{}'
         })
         payment_context = {"active_ids": order.ids, "active_id": order.id}
         order_payment = self.PosMakePayment.with_context(**payment_context).create({

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -67,15 +67,13 @@ class PosOrder(models.Model):
             merged_tax_details[tax_id]['base'] += tax_obj['base']
         return list(merged_tax_details.values())
 
-    @api.model
-    def create_from_ui(self, orders, draft=False):
-        orders = super().create_from_ui(orders, draft)
-        order_ids = self.env['pos.order'].browse([order['id'] for order in orders])
+    def _process_saved_order(self, draft):
+        res = super()._process_saved_order(draft)
 
         if self.env.context.get('from_self') is not True:
-            self._send_notification(order_ids)
+            self._send_notification(self)
 
-        return orders
+        return res
 
     @api.model
     def remove_from_ui(self, server_ids):
@@ -136,10 +134,6 @@ class PosOrder(models.Model):
             ],
             "tax_details": self._compute_tax_details(),
         }
-
-    def _send_order(self):
-        #This function is made to be overriden by pos_self_order_preparation_display
-        pass
 
     def get_standalone_self_order(self):
         orders = self.env['pos.order'].search([


### PR DESCRIPTION
*: point_of_sale

Updates the self-order UI and preparation display when a POS order is paid from the backend interface. The preparation display is notified following what has been done in 4b2f14db946cb266feba3ab856d359faca919014.

task-id: 3568361
related: https://github.com/odoo/enterprise/pull/49599