### PR TITLE
[FIX] web: KanbanRenderer is rendered twice

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_renderer.js
+++ b/addons/web/static/src/views/kanban/kanban_renderer.js
@@ -279,7 +279,7 @@ export class KanbanRenderer extends Component {
     getGroupsOrRecords() {
         const { list } = this.props;
         if (list.isGrouped) {
-            return list.groups
+            return [...list.groups]
                 .sort((a, b) => (a.value && !b.value ? 1 : !a.value && b.value ? -1 : 0))
                 .map((group, i) => ({
                     group,

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -43,7 +43,7 @@ import { RelationalModel } from "@web/model/relational_model/relational_model";
 import { ViewButton } from "@web/views/view_button/view_button";
 import { AnimatedNumber } from "@web/views/view_components/animated_number";
 
-import { Component, onWillRender, xml } from "@odoo/owl";
+import { Component, onRendered, onWillRender, xml } from "@odoo/owl";
 import { SampleServer } from "@web/model/sample_server";
 import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 
@@ -520,7 +520,16 @@ QUnit.module("Views", (hooks) => {
     });
 
     QUnit.test("basic grouped rendering", async (assert) => {
-        assert.expect(13);
+        assert.expect(17);
+
+        patchWithCleanup(KanbanRenderer.prototype, {
+            setup() {
+                super.setup(...arguments);
+                onRendered(() => {
+                    assert.step("rendered");
+                });
+            },
+        });
 
         await makeView({
             type: "kanban",
@@ -551,6 +560,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group", 2);
         assert.containsOnce(target, ".o_kanban_group:first-child .o_kanban_record");
         assert.containsN(target, ".o_kanban_group:nth-child(2) .o_kanban_record", 3);
+        assert.verifySteps(["rendered"]);
 
         await toggleColumnActions(0);
 
@@ -578,6 +588,7 @@ QUnit.module("Views", (hooks) => {
         // changing its result.
         await validateSearch(target);
         assert.containsN(target, ".o_kanban_group:nth-child(2) .o_kanban_record", 3);
+        assert.verifySteps(["rendered"]);
     });
 
     QUnit.test(


### PR DESCRIPTION
Before this commit, the KanbanRenderer was rendered twice.

Why:
---
The "getGroupsOrRecords" function used in the KanbanRenderer templace uses the "sort" function on "list.groups". The "sort" function modifies the array on which it is called, which will generate a rerender because "list.groups" is reactive.

Solution:
---------
Call the "sort" function on a clone of "list.groups".

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
