### PR TITLE
[FIX] spreadsheet_edition: fixes image export in .xlsx

### DIFF
--- a/addons/spreadsheet/models/spreadsheet_mixin.py
+++ b/addons/spreadsheet/models/spreadsheet_mixin.py
@@ -4,6 +4,7 @@ import io
 import zipfile
 import base64
 import json
+import re
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, MissingError
 
@@ -92,10 +93,9 @@ class SpreadsheetMixin(models.AbstractModel):
     def _get_file_content(self, file_path):
         if file_path.startswith('data:image/png;base64,'):
             return base64.b64decode(file_path.split(',')[1])
-        _, args = self.env['ir.http']._match(file_path)
+        match = re.match(r'/web/image/(\d+)', file_path)
         file_record = self.env['ir.binary']._find_record(
-            xmlid=args.get('xmlid'),
-            res_model=args.get('model', 'ir.attachment'),
-            res_id=args.get('id'),
+            res_model='ir.attachment',
+            res_id=int(match.group(1)),
         )
         return self.env['ir.binary']._get_stream_from(file_record).read()


### PR DESCRIPTION
## Task Description

o-spreadsheet now allows to insert images in a spreadsheet, and we also allow to export them inside .xlsx file. However, while this works as intended in a standalone o-spreadsheet server, it doens't work correctly in Odoo as the data of the image are not found while we try ton convert the spreadsheet to an xlsx file. This PR aims to simplify the request made to get the binary data of the image file.

## Related task

-Task: 3524473
-X-original-commit: 301a98c


Forward-Port-Of: odoo/enterprise#49066
Forward-Port-Of: odoo/enterprise#47928

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
