### PR TITLE
[REM] survey: remove obsolete patch on X2ManyFieldDialog

### DIFF
--- a/addons/survey/static/src/question_page/question_page_one2many_field.js
+++ b/addons/survey/static/src/question_page/question_page_one2many_field.js
@@ -3,29 +3,9 @@
 import { _t } from "@web/core/l10n/translation";
 import { QuestionPageListRenderer } from "./question_page_list_renderer";
 import { registry } from "@web/core/registry";
-import { useOpenX2ManyRecord, useX2ManyCrud, X2ManyFieldDialog } from "@web/views/fields/relational_utils";
-import { patch } from '@web/core/utils/patch';
+import { useOpenX2ManyRecord, useX2ManyCrud } from "@web/views/fields/relational_utils";
 import { X2ManyField, x2ManyField } from "@web/views/fields/x2many/x2many_field";
 import { useSubEnv } from "@odoo/owl";
-
-patch(X2ManyFieldDialog.prototype, {
-    /**
-     * Re-enable buttons after our error is thrown because blocking normal
-     * behavior is required to not close the dialog and stay in edition but
-     * the buttons are required to try and save again after changing form data.
-     *
-     * @override
-     */
-    async saveAndNew() {
-        const res = super.saveAndNew(...arguments);
-        if (this.record.resModel === 'survey.question') {
-            const btns = this.modalRef.el.querySelectorAll(".modal-footer button"); // see XManyFieldDialog.disableButtons
-            this.enableButtons(btns);
-        }
-        return res;
-    }
-});
-
 
 /**
  * For convenience, we'll prevent closing the question form dialog and


### PR DESCRIPTION
Since commit https://github.com/odoo/odoo/commit/e17c2135cb24aa600eeff9426b93665537a33d00, if an error is thrown
during the "save" of X2ManyFieldDialog, the buttons are enabled().

So the patch on X2ManyFieldDialog in question_page_one2many_field.js is
no longer useful. So we're going to remove it.