### PR TITLE
[IMP] point_of_sale,pos_*: automaticaly paid order when amount is 0

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/receipt_header/receipt_header.js
@@ -11,7 +11,6 @@ export class ReceiptHeader extends Component {
                 company: Object,
                 header: { type: [String, { value: false }], optional: true },
                 cashier: { type: String, optional: true },
-                trackingNumber: { type: String, optional: true },
                 "*": true,
             },
         },

--- a/addons/pos_online_payment_self_order/static/src/components/order_widget/order_widget.js
+++ b/addons/pos_online_payment_self_order/static/src/components/order_widget/order_widget.js
@@ -9,13 +9,19 @@ patch(OrderWidget.prototype, {
         const type = this.selfOrder.config.self_ordering_mode;
         const mode = this.selfOrder.config.self_ordering_pay_after;
         const isOnlinePayment = this.selfOrder.pos_payment_methods.find((p) => p.is_online_payment);
+        const order = this.selfOrder.currentOrder;
+        const isNoLine = order.lines.length === 0;
 
         if (type === "kiosk") {
             return super.buttonToShow;
         }
 
+        if (order.amount_total === 0 && !isNoLine) {
+            return { label: _t("Order"), disabled: false };
+        }
+
         if (mode === "each") {
-            return { label: buttonName, disabled: false };
+            return { label: buttonName, disabled: isNoLine };
         } else if (mode === "meal") {
             const order = this.selfOrder.currentOrder;
 

--- a/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/payment_screen/payment_screen.js
@@ -11,7 +11,7 @@ patch(PaymentScreen.prototype, {
         }
         // Take the first payment method as the main payment.
         const mainPayment = order.get_paymentlines()[0];
-        if (mainPayment.canBeAdjusted()) {
+        if (mainPayment && mainPayment.canBeAdjusted()) {
             return "TipScreen";
         }
         return super.nextScreen;

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -75,8 +75,10 @@ class PosSelfOrderController(http.Controller):
         # combo lines must be created after classic_line, as they need the classic line identifier
         lines = pos_config.env['pos.order.line'].create(classic_lines)
         lines += pos_config.env['pos.order.line'].create(combo_lines)
+
         order.write({
             'lines': lines,
+            'state': 'paid' if amount_total == 0 and pos_config.self_ordering_pay_after == 'each' else 'draft',
             'amount_tax': amount_total - amount_untaxed,
             'amount_total': amount_total,
         })

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.js
@@ -58,6 +58,10 @@ export class OrderWidget extends Component {
             disabled = !kioskPayment && !isMobilePayment;
         }
 
+        if (this.selfOrder.currentOrder.amount_total === 0) {
+            label = _t("Order");
+        }
+
         return { label, disabled };
     }
 

--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.xml
@@ -11,7 +11,7 @@
         <div class="d-flex justify-content-center align-items-center flex-column h-100 px-3 text-center">
             <h1 t-if="state.payment and selfOrder.config.self_ordering_pay_after !== 'each'" class="mb-4">Hope you enjoyed your meal!</h1>
             <h1 t-else="" class="mb-4">We're preparing your order!</h1>
-            <h3 t-if="state.payment" class="mt-3 text-muted">Pay at the cashier <t t-esc="selfOrder.formatMonetary(confirmedOrder.amount_total)" /></h3>
+            <h3 t-if="state.payment and confirmedOrder.state !== 'paid'" class="mt-3 text-muted">Pay at the cashier <t t-esc="selfOrder.formatMonetary(confirmedOrder.amount_total)" /></h3>
             <div class="d-inline-flex flex-column border rounded py-4 px-5 bg-view mb-3">
                 <span class="fs-2 text-muted">Your order number</span>
                 <span class="number lh-1" t-esc="confirmedOrder.trackingNumber" />


### PR DESCRIPTION
*: pos_online_payment_self_order,pos_restaurant,pos_self_order

Previously, when self order was set to "pay after each" and a user ordered an order with a total of $0.00, the order was not automatically set to paid status, as is the case with point_of_sale.

Now, when the self order is set to "pay after each" and an order with a total of $0.00 is placed, it will be automatically paid.

Minor fixes:
- A props has been removed from `ReceiptHeader` because it was causing an error in debug mode.
- In point_of_sale, when an order was placed with a total of $0.00, an error was raised during validation because no payment method was selected. Now, before checking this payment method, we first check whether it exists.

