### PR TITLE
[FIX] account_peppol: Fix kanban button display

### DIFF
--- a/addons/account_peppol/views/account_journal_dashboard_views.xml
+++ b/addons/account_peppol/views/account_journal_dashboard_views.xml
@@ -14,11 +14,15 @@
                 <xpath expr="//t[@id='account.JournalBodySalePurchase']//div" position="inside">
                     <t t-if="record.account_peppol_proxy_state.raw_value == 'active'">
                         <t t-if="journal_type == 'sale'">
-                            <a type="object" name="peppol_get_message_status" groups="account.group_account_invoice">Fetch Peppol invoice status</a>
+                            <div class="w-100">
+                                <a type="object" name="peppol_get_message_status" groups="account.group_account_invoice">Fetch Peppol invoice status</a>
+                            </div>
                         </t>
                         <t t-elif="journal_type == 'purchase'">
                             <t t-if="record.is_peppol_journal.raw_value">
-                                <a type="object" name="peppol_get_new_documents" groups="account.group_account_invoice">Fetch from Peppol</a>
+                                <div class="w-100">
+                                    <a type="object" name="peppol_get_new_documents" groups="account.group_account_invoice">Fetch from Peppol</a>
+                                </div>
                             </t>
                         </t>
                     </t>


### PR DESCRIPTION
Problem
---------
When zoomed in, the peppol buttons would be displayed inline with
previous buttons in the journal cards. This is not user friendly.

Objective
---------
Make sure the buttons are displayed under (new line) the previous one on
the kanban card.

Solution
---------
Encompass the buttons in div tags.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
