### PR TITLE
[FIX] mail: attribute with object value isn't rendering properly in owl template

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_menu.xml
+++ b/addons/mail/static/src/core/common/message_reaction_menu.xml
@@ -6,7 +6,7 @@
             <div class="d-flex h-100" t-on-keydown="onKeydown" t-ref="root">
                 <div class="d-flex overflow-auto flex-column bg-100 p-2 h-100 border-end">
                     <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
-                        <button class="btn p-1 rounded-2 mx-2 py-0 d-flex align-items-center" t-att-class="{ 'bg-200 border-primary': reaction.eq(state.reaction) }" t-att-title="getEmojiShortcode(reaction)" t-att-data-reaction="reaction" t-on-click="() => state.reaction = reaction">
+                        <button class="btn p-1 rounded-2 mx-2 py-0 d-flex align-items-center" t-att-class="{ 'bg-200 border-primary': reaction.eq(state.reaction) }" t-att-title="getEmojiShortcode(reaction)" t-on-click="() => state.reaction = reaction">
                             <span class="mx-1 fs-2" t-esc="reaction.content"/>
                             <span class="mx-1 pe-2" t-att-class="{ 'text-primary': reaction.eq(state.reaction) }" t-esc="reaction.count"/>
                         </button>

--- a/addons/mail/static/tests/message/message_tests.js
+++ b/addons/mail/static/tests/message/message_tests.js
@@ -1619,3 +1619,25 @@ QUnit.test("Can edit a message only containing an attachment", async () => {
     await click(".o-mail-Message [title='Edit']");
     await contains(".o-mail-Message-editable .o-mail-Composer-input");
 });
+
+QUnit.test("Click on view reactions shows the reactions on the message", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_type: "channel",
+        name: "channel1",
+    });
+    pyEnv["mail.message"].create({
+        body: "Hello world",
+        res_id: channelId,
+        message_type: "comment",
+        model: "discuss.channel",
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await click("[title='Add a Reaction']");
+    await click(".o-Emoji", { text: "😅" });
+    await contains(".o-mail-MessageReaction", { text: "😅1" });
+    await click(".o-mail-Message [title='Expand']");
+    await click(".o-mail-Message [title='View Reactions']");
+    await contains(".o-mail-MessageReactionMenu", { text: "😅1" });
+});


### PR DESCRIPTION
`t-att` doesn't render the object and there is no use case for `t-att-data-reaction` in the current code.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
