### PR TITLE
[FIX] {im,website}_livechat: only send guest token when available

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -225,10 +225,12 @@ export class LivechatService {
     }
 
     async initializePersistedSession() {
-        await this.busService.updateContext({
-            ...this.busService.context,
-            guest_token: this.guestToken,
-        });
+        if (this.guestToken) {
+            await this.busService.updateContext({
+                ...this.busService.context,
+                guest_token: this.guestToken,
+            });
+        }
         if (this.busService.isActive) {
             this.busService.forceUpdateChannels();
         } else {

--- a/addons/website_livechat/static/tests/tours/website_livechat_as_portal.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_as_portal.js
@@ -1,0 +1,29 @@
+/* @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("website_livechat_as_portal_tour", {
+    test: true,
+    shadow_dom: ".o-livechat-root",
+    steps: () => [
+        {
+            trigger: ".o-livechat-LivechatButton",
+        },
+        {
+            trigger: ".o-mail-Composer-input",
+            run: "text Hello, I need help!",
+        },
+        {
+            trigger: ".o-mail-Composer-input",
+            run() {
+                this.$anchor[0].dispatchEvent(
+                    new KeyboardEvent("keydown", { key: "Enter", which: 13, bubbles: true })
+                );
+            },
+        },
+        {
+            trigger: ".o-mail-Message:contains('Hello, I need help!')",
+            isCheck: true,
+        },
+    ],
+});

--- a/addons/website_livechat/tests/test_livechat_basic_flow.py
+++ b/addons/website_livechat/tests/test_livechat_basic_flow.py
@@ -5,6 +5,7 @@ import datetime
 
 from odoo import tests, _
 from odoo.addons.website_livechat.tests.common import TestLivechatCommon
+from odoo.tests.common import new_test_user
 
 
 @tests.tagged('post_install', '-at_install')
@@ -140,3 +141,7 @@ class TestLivechatBasicFlowHttpCase(tests.HttpCase, TestLivechatCommon):
         self.assertEqual(channel.livechat_active, True, "The livechat session must be active as the visitor did not left the conversation yet.")
 
         return channel
+
+    def test_livechat_as_portal_user(self):
+        new_test_user(self.env, login="portal_user", groups="base.group_portal")
+        self.start_tour("/my", "website_livechat_as_portal_tour", login="portal_user")


### PR DESCRIPTION
Before this commit, live chat would fail for guest portal. In this scenario, there is no guest token. Before this commit, the guest token was sent anyway with `null` as value which caused a crash.
