### PR TITLE
[IMP] pos_restaurant: default floor plan when new config

### DIFF
--- a/addons/pos_restaurant/data/pos_restaurant_data.xml
+++ b/addons/pos_restaurant/data/pos_restaurant_data.xml
@@ -15,5 +15,11 @@
         <function model="pos.config" name="_setup_main_restaurant_defaults">
             <value eval="[ref('pos_config_main_restaurant')]"/>
         </function>
+
+        <function model="restaurant.floor" name="unlink">
+            <value model="restaurant.floor" eval="obj().search([
+                    ('pos_config_ids', 'in', ref('pos_config_main_restaurant')),
+                ]).id"/>
+        </function>
     </data>
 </odoo>

--- a/addons/pos_restaurant/models/res_config_settings.py
+++ b/addons/pos_restaurant/models/res_config_settings.py
@@ -36,3 +36,9 @@ class ResConfigSettings(models.TransientModel):
                 res_config.pos_set_tip_after_payment = res_config.pos_config_id.set_tip_after_payment
             else:
                 res_config.pos_set_tip_after_payment = False
+
+    @api.onchange('pos_module_pos_restaurant')
+    def _onchange_pos_module_pos_restaurant(self):
+        if self.pos_module_pos_restaurant:
+            self.pos_config_id._setup_default_floor(self.pos_config_id)
+            self.pos_floor_ids = self.pos_config_id.floor_ids

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -52,6 +52,7 @@ class TestFrontend(odoo.tests.HttpCase):
             'printer_ids': [(4, printer.id)],
             'iface_tipproduct': False,
         })
+        pos_config.floor_ids.unlink()
 
         main_floor = self.env['restaurant.floor'].create({
             'name': 'Main Floor',


### PR DESCRIPTION
In this commit a new default floor plan is added along with one table when creating a new restaurant pos_config. It ensures that the default floor is removed for the demo data and for the tests.

