### PR TITLE
[FIX] point_of_sale: error handling

### DIFF
--- a/addons/point_of_sale/static/src/app/errors/error_handlers.js
+++ b/addons/point_of_sale/static/src/app/errors/error_handlers.js
@@ -26,7 +26,7 @@ function rpcErrorHandler(env, error, originalError) {
 registry.category("error_handlers").add("rpcErrorHandler", rpcErrorHandler);
 
 function offlineErrorHandler(env, error, originalError) {
-    if (error instanceof ConnectionLostError) {
+    if (error instanceof ConnectionLostError || originalError instanceof ConnectionLostError) {
         env.services.popup.add(OfflineErrorPopup);
         return true;
     }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -33,7 +33,11 @@ export class ReceiptScreen extends Component {
             // When the order is paid, if there is still a part of the order
             // to send in preparation it is automatically sent
             if (this.pos.orderPreparationCategories.size) {
-                await this.pos.sendOrderInPreparation(this.currentOrder);
+                try {
+                    await this.pos.sendOrderInPreparation(this.currentOrder);
+                } catch (error) {
+                    Promise.reject(error);
+                }
             }
         });
     }


### PR DESCRIPTION
Before, error handling didn't work in point_of_sale when offline. This was due to poor error handling.

Now, the "limited functionnalities" popup is displayed correctly.
