### PR TITLE
[FIX] base: flush env on `ir.property` creation

### DIFF
--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -124,12 +124,12 @@ class Property(models.Model):
             for record in self
         )
         r = super().write(values)
+        self.env.flush_all()
         if default_set:
             # DLE P44: test `test_27_company_dependent`
             # Easy solution, need to flush write when changing a property.
             # Maybe it would be better to be able to compute all impacted cache value and update those instead
             # Then clear_cache must be removed as well.
-            self.env.flush_all()
             self.env.registry.clear_cache()
         return r
 


### PR DESCRIPTION
Versions:
---------
- 16.4e+

Steps to reproduce:
-------------------
1. create a new database with industry_fsm_sale_report, planning and no demo data;
2. enable debug mode;
3. go to settings;
4. load demo data.

Issue:
------
Fails to load demo data due to a `KeyError` on `planning.slot.allocated_hours`.

Cause:
------
In enterprise, `industry_fsm_sale_report` creates field `x_model` via a demo xml file, adding it to the`fsm_worksheet_template2` model, created in `industry_fsm_report`. For some reason this interacts with `planning` when loading demo data post-initialization, despite no direct connection.

Commit c002e2eb379e8a3db90b45269f8ff2b7e246c8b2 added the option to install demo data post-initialization, on the task it was noted that this follows a different graph path than installing during initialisation.

This did not cause this particular problem until commit dda0f64cf7dae49347f4360e115e5d51294bdf6d, which prevented unneeded calls to `clear_caches` in `ir_property`, and as a side-effect calls to `env.flush_all` as well, leading to this error.

Solution:
---------
Using `flush_all` on every call to `Property.create` instead of only when a default property is created, appears to be enough to prevent this error during.

opw-3517083