### PR TITLE
[FIX] website_sale: add checksum in t-cache to manage tax changes

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -411,6 +411,13 @@ class WebsiteSale(http.Controller):
 
         products_prices = lazy(lambda: products._get_sales_prices(pricelist))
 
+        # Compute the sum of all product prices which will be displayed on the ecommerce products grid.
+        # Using this `checksum` to cache the template allows to takes into account all factors
+        # that influence the price of a product (product, pricelist, taxes, fiscal position, etc.).
+        # To manage the case where the sum of prices is the same in several situations,
+        # it is necessary to add this key to the existing cached keys.
+        checksum = sum([price['price_reduce'] for price in products_prices.values()])
+
         fiscal_position_id = website._get_current_fiscal_position_id(request.env.user.partner_id)
 
         values = {
@@ -438,6 +445,7 @@ class WebsiteSale(http.Controller):
             'get_product_prices': lambda product: lazy(lambda: products_prices[product.id]),
             'float_round': tools.float_round,
             'fiscal_position_id': fiscal_position_id,
+            'checksum': checksum,
         }
         if filter_by_price_enabled:
             values['min_price'] = min_price or available_min_price

--- a/addons/website_sale/static/tests/tours/website_sale_fiscal_position_tour.js
+++ b/addons/website_sale/static/tests/tours/website_sale_fiscal_position_tour.js
@@ -34,4 +34,26 @@ odoo.define('website_sale_tour.website_sale_fiscal_position_tour', function (req
         run: function() {} // Check
     },
     ]);
+
+    tour.register('website_sale_tax_change_tour_1', {
+        test: true,
+        url: '/shop?search=Super%20Product'
+    }, [
+    {
+        content: "Check price",
+        trigger: ".oe_product:contains('Super product') .product_price:contains('100.00')",
+        run: function() {} // Check
+    },
+    ]);
+
+    tour.register('website_sale_tax_change_tour_2', {
+        test: true,
+        url: '/shop?search=Super%20Product'
+    }, [
+    {
+        content: "Check price",
+        trigger: ".oe_product:contains('Super product') .product_price:contains('90.91')",
+        run: function() {} // Check
+    },
+    ]);
 });

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -408,10 +408,10 @@
         </t>
     </template>
 
-    <!-- Add the fiscal position in the t-cache key after all overrides -->
+    <!-- Add the fiscal position and checksum in the t-cache key after all overrides -->
     <template id="products_fiscal_position" inherit_id="website_sale.products" priority="99">
         <xpath expr="//div[starts-with(@t-cache, 'pricelist,products')]" position="attributes">
-            <attribute name="t-cache" add="fiscal_position_id" separator=","/>
+            <attribute name="t-cache" add="fiscal_position_id,checksum" separator=","/>
         </xpath>
     </template>
 


### PR DESCRIPTION
Steps + Explanation:
--------------------
- install ecommerce
- use Customizable Desk product which costs $750
- website must be "Tax Exclude"
- Add a 15% excluded tax on the product ($750 exc | $862.50 inc)
- go to the shop ==> On the shop we see $750
- change the tax to included in price ($652.17 exc | $750 inc)
- go to the shop ==> On the shop we see $750 ==> Template doesn't change ==> Template is cached
- click on the product ==> The price flip to $652.17 ==> Because template is not cached
- go back to shop ==> The price flip to $750 ==> Normal because Template is cached

- launch server using multiple workers (A and B) [`--workers=2`]
- go to the shop
==> Worker A give the correct value because we restart the server and cached templates are removed ==> We see the correct value $652.17
==> We cache this template for Worker A
- change the tax to excluded in price ($750 exc | $862.50 inc)
- go to the shop
==> When Worker B is used we will see $750 and when Worker A is used, we will see $652.17

Note:
-----
This problem appears in single-worker mode, but is not "annoying". If we go to the shop and then modify a tax, the shop page will not be updated accordingly.

Solution:
---------
Current cache key (`pricelist,products,fiscal_position_id`) does not take into account tax changes.
This key must be added to the existing cached key to handle the case where the sum of the prices is equal.
This solution makes it possible to take into account the slightest change that affects the price displayed on the website.

opw-3567996