### PR TITLE
[IMP] account_peppol: improve move states and filters

### DIFF
--- a/addons/account_peppol/models/account_journal.py
+++ b/addons/account_peppol/models/account_journal.py
@@ -1,6 +1,6 @@
 # -*- coding:utf-8 -*-
 
-from odoo import fields, models
+from odoo import _, fields, models
 
 
 class AccountJournal(models.Model):
@@ -22,3 +22,14 @@ class AccountJournal(models.Model):
             ('company_id', 'in', self.company_id.ids),
         ])
         edi_users._peppol_get_message_status()
+
+    def action_peppol_ready_moves(self):
+        return {
+            'name': _("Peppol Ready invoices"),
+            'type': 'ir.actions.act_window',
+            'view_mode': 'list',
+            'res_model': 'account.move',
+            'context': {
+                'search_default_peppol_ready': 1,
+            }
+        }

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -58,7 +58,7 @@ def _mock_make_request(func, self, *args, **kwargs):
         return {
             'messages': [{
                 'message_uuid': 'demo_%s' % uuid.uuid4(),
-            } for i in args[1]],
+            } for i in args[1]['documents']],
         }
 
     endpoint = args[0].split('/')[-1]

--- a/addons/account_peppol/views/account_journal_dashboard_views.xml
+++ b/addons/account_peppol/views/account_journal_dashboard_views.xml
@@ -17,6 +17,9 @@
                             <div class="w-100">
                                 <a type="object" name="peppol_get_message_status" groups="account.group_account_invoice">Fetch Peppol invoice status</a>
                             </div>
+                            <div class="w-100">
+                                <a type="object" name="action_peppol_ready_moves" groups="account.group_account_invoice">Peppol ready invoices</a>
+                            </div>
                         </t>
                         <t t-elif="journal_type == 'purchase'">
                             <t t-if="record.is_peppol_journal.raw_value">

--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -72,7 +72,12 @@
         <field name="inherit_id" ref="account.view_account_invoice_filter"/>
         <field name="arch" type="xml">
             <xpath expr="//search/group/filter[@name='status']" position="after">
-                <filter string="PEPPOL state" name="peppol_move_state" context="{'group_by': 'peppol_move_state'}"/>
+                <filter string="Peppol status" name="peppol_move_state" context="{'group_by': 'peppol_move_state'}"/>
+            </xpath>
+            <xpath expr="//filter[@name='to_check']" position='after'>
+                <separator/>
+                <filter name="peppol_ready" string="Peppol Ready" domain="[('state', '=', 'posted'), ('peppol_move_state', '=', 'ready')]"/>
+                <separator/>
             </xpath>
         </field>
     </record>

--- a/addons/account_peppol/wizard/account_move_send.py
+++ b/addons/account_peppol/wizard/account_move_send.py
@@ -108,6 +108,10 @@ class AccountMoveSend(models.TransientModel):
 
         if all([self.checkbox_send_peppol, self.enable_peppol, self.enable_ubl_cii_xml, not self.checkbox_ubl_cii_xml]):
             self.checkbox_ubl_cii_xml = True
+        if self.checkbox_send_peppol and self.enable_peppol:
+            for move in self.move_ids:
+                if not move.peppol_move_state or move.peppol_move_state == 'ready':
+                    move.peppol_move_state = 'to_send'
 
         return super().action_send_and_print(force_synchronous=force_synchronous, allow_fallback_pdf=allow_fallback_pdf, **kwargs)
 


### PR DESCRIPTION
# Invoice states
Structure `peppol_move_state` according to the following logic:
1. Ready to Send / Invoices confirmed addressed to partners that are Peppol valid and not in one of the other statuses. Default behavior upon posting such an invoice.
2. Queued / In case of asynchronous sending only, the instruction to send has been given via the Send & Print but the cron wasn't run yet. It is still possible to cancel the sending.
3. Pending Reception / Too late to cancel, synchronous or asynchronous sending makes it now impossible to cancel the sending
4. Canceled / Once asked explicitly by the user. It's instant.
5. Done     / Upon confirmation or delivery received from the AP
6. Error / Upon confirmation of a notification of error received from the AP

# Journal Dashboard
Add an action on sale journals to open invoices that are ready to be sent via Peppol

# Other improvements
- Peppol ready filter in Customer Invoices view
- Rename `PEPPOL state` to `Peppol status` for consistency
- Pre-fill valid phone numbers in `account_peppol_phone_number` field
- Fix async sending in demo mode



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
