### PR TITLE
[FIX] website_slides: force the save of the url on slide

### DIFF
--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -560,11 +560,18 @@ class Slide(models.Model):
 
     @api.onchange('slide_category')
     def _on_change_slide_category(self):
-        """ Prevents mis-match when ones uploads an image and then a pdf without saving the form. """
+        """ Prevents mis-match when ones uploads an image and then a pdf without saving the form.
+        Also erases the html_content/url when the category should not have a html_content/url"""
         if self.slide_category != 'infographic' and self.image_binary_content:
             self.image_binary_content = False
         elif self.slide_category != 'document' and self.document_binary_content:
             self.document_binary_content = False
+
+        if self.slide_category != 'article' and self.html_content:
+            self.html_content = False
+
+        if self.slide_category not in ['infographic', 'document', 'video'] and self.url:
+            self.url = False
 
     @api.depends('name', 'channel_id.website_id.domain')
     def _compute_website_url(self):

--- a/addons/website_slides/views/slide_slide_views.xml
+++ b/addons/website_slides/views/slide_slide_views.xml
@@ -128,28 +128,24 @@
                                             'invisible': [('slide_category', 'not in', ['infographic', 'document'])]}" />
                                         <field name="video_url" attrs="{
                                             'required': [('slide_category', '=', 'video')],
-                                            'invisible': [('slide_category', '!=', 'video')],
-                                            'readonly': [('slide_category', '!=', 'video')]}"
+                                            'invisible': [('slide_category', '!=', 'video')]}"
                                             placeholder='e.g "www.youtube.com/watch?v=ebBez6bcSEc"'
                                             widget="url"/>
                                         <field name="document_google_url" attrs="{
-                                            'invisible': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'document')],
-                                            'readonly': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'document')]}"
+                                            'invisible': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'document')]}"
                                             placeholder='e.g "https://drive.google.com/file/..."'
                                             widget="url"/>
                                         <field name="image_google_url" attrs="{
-                                            'invisible': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'infographic')],
-                                            'readonly': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'infographic')]}"
+                                            'invisible': ['|', ('source_type', '!=', 'external'), ('slide_category', '!=', 'infographic')]}"
                                             placeholder='e.g "https://drive.google.com/file/..."'
                                             widget="url"/>
                                         <field name="document_binary_content" string="" options="{'accepted_file_extensions': '.pdf'}"
                                             attrs="{
-                                                'invisible': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'document')],
-                                                'readonly': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'document')]}"/>
+                                                'invisible': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'document')]}"/>
                                         <field name="image_binary_content" string="" options="{'accepted_file_extensions': 'image/*'}"
                                             attrs="{
-                                                'invisible': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'infographic')],
-                                                'readonly': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'infographic')]}"/>
+                                                'invisible': ['|', ('source_type', '=', 'external'), ('slide_category', '!=', 'infographic')]}"/>
+                                        <field name="html_content" invisible="1"/>
                                     </group>
                                     <group name="related_details">
                                         <field name="user_id" string="Responsible" widget="many2one_avatar"/>


### PR DESCRIPTION
When we remove the url of a slide and then change its content type, the slide url has not been removed so we cannot change the HTML of the slide because of the constraint `exclusion_html_content_and_url`

Steps to reproduce:
1. Install eLearning
2. Go to eLearning and open course "Taking care of Trees"
3. Open slide "How to plant a potted tree"
4. Remove the video url and change the content type to "Article"
5. Save the slide and the save the course
6. Open slide "How to plant a potted tree" again and click on the "Go to Website" smart button
7. Click on "Edit" in the top right and add some content in the slide html content (white rectangle just above the tabs)
8. Click on "Save", a validation error is thrown

Solution:
Remove the readonly modifier on the url fields and binary fields so they can be deleted when we remove their value and change the slide_category
Also, reset the `html_content` field when we change the slide_category to something else than 'article' (only articles should have a `html_content`) and reset the `url` field when we change the category to one that doesn't need an url
The readonly modifier was also removed from fields `document_binary_content` and `image_binary_content` as it prevented the `_on_change_slide_category` to have any effect

Problem:
The readonly modifiers present on the url and binary fields protects the field against changes (in `_isFieldProtected`) and prevents the change to be written on the record
It is also impossible to change a slide category from 'article' to 'video' if the user already wrote something in `html_content` (because `html_content` will not be totally empty and `video_url` will be required so the constraint `exclusion_html_content_and_url` will never be satisfied)

opw-3461266