### PR TITLE
[FIX] payment_adyen: not send False information

### DIFF
--- a/addons/payment_adyen_paybylink/utils.py
+++ b/addons/payment_adyen_paybylink/utils.py
@@ -12,14 +12,21 @@ def format_partner_address(partner):
     """
     STREET_FORMAT = '%(street_number)s/%(street_number2)s %(street_name)s'
     street_data = split_street_with_params(partner.street, STREET_FORMAT)
-    return {
+    if partner.country_id.code not in ["CA", "US", "GB"]:
+        stateOrProvince = partner.state_id.code or ''
+    else:
+        stateOrProvince = partner.state_id.code
+    address = {
         'city': partner.city,
         'country': partner.country_id.code or 'ZZ',  # 'ZZ' if the country is not known.
-        'stateOrProvince': partner.state_id.code,
+        'stateOrProvince': stateOrProvince,
         'postalCode': partner.zip,
         'street': street_data['street_name'],
         'houseNumberOrName': street_data['street_number'],
     }
+    if False in address.values():
+        raise ValueError("Address can't contain False values")
+    return address
 
 
 # The method is copy-pasted from `base_address_extended` with small modifications.


### PR DESCRIPTION
If customer did not have address,email and telephone fields, "False" would be send to Adyen resulting in these field containing False values, which in some cases was falsely triggering anti-fraud system.

task-3159378

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
