### PR TITLE
[FIX] pos_self_order: print receipt only in kiosk mode

### DIFF
--- a/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
+++ b/addons/pos_self_order/static/src/app/pages/confirmation_page/confirmation_page.js
@@ -26,13 +26,14 @@ export class ConfirmationPage extends Component {
                 setTimeout(() => {
                     this.setDefautLanguage();
                 }, 5000);
+
+                setTimeout(() => {
+                    this.printer.print(OrderReceipt, {
+                        data: this.selfOrder.export_for_printing(this.selfOrder.currentOrder),
+                        formatCurrency: this.selfOrder.formatMonetary,
+                    });
+                }, 500);
             }
-            setTimeout(() => {
-                this.printer.print(OrderReceipt, {
-                    data: this.selfOrder.export_for_printing(this.selfOrder.currentOrder),
-                    formatCurrency: this.selfOrder.formatMonetary,
-                });
-            }, 500);
         });
 
         this.initOrder();

--- a/addons/pos_self_order/static/src/app/self_order_index.scss
+++ b/addons/pos_self_order/static/src/app/self_order_index.scss
@@ -12,6 +12,7 @@
 
 html, body {
     height: 100%;
+    overflow: hidden;
 }
 
 body {


### PR DESCRIPTION
Before, a receipt was automatically generated in the mobile self order and the confirmation screen would glitch when it was generated.

Now this receipt is only generated in kiosk mode and the confirmation screen no longer glitches due to a hidden overflow.
