### PR TITLE
[FIX] web: useAutofocus should not depend on ui_service & include popover in ui_service

### DIFF
--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -1,5 +1,6 @@
 /** @odoo-module **/
 
+import { useActiveElement } from "../ui/ui_service";
 import { usePosition } from "../position/position_hook";
 
 const { Component } = owl;
@@ -10,6 +11,7 @@ export class Popover extends Component {
             margin: 16,
             position: this.props.position,
         });
+        useActiveElement("popper");
     }
 }
 

--- a/addons/web/static/src/core/popover/popover.xml
+++ b/addons/web/static/src/core/popover/popover.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.PopoverWowl" owl="1">
-        <div role="tooltip" class="o_popover"
+        <div role="tooltip" class="o_popover" t-ref="popper"
             t-att-class="props.popoverClass"
             t-on-popover-compute="compute"
         >

--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -52,7 +52,7 @@ export function useAutofocus(params = {}) {
     useEffect(
         function autofocus() {
             const target = comp.el.querySelector(selector);
-            if (target && (!uiService?.activeElement || uiService.activeElement.contains(target))) {
+            if (target && (!uiService || !uiService.activeElement || uiService.activeElement.contains(target))) {
                 target.focus();
                 if (["INPUT", "TEXTAREA"].includes(target.tagName) && target.type !== 'number') {
                     const inputEl = target;

--- a/addons/web/static/src/core/utils/hooks.js
+++ b/addons/web/static/src/core/utils/hooks.js
@@ -35,18 +35,24 @@ const { onMounted, onPatched, onWillPatch, onWillUnmount, useComponent } = owl;
  */
 export function useAutofocus(params = {}) {
     const comp = useComponent();
+    const { services } = comp.env;
+
+    let uiService = undefined;
+    if ("ui" in services) {
+        uiService = useService("ui");
+    }
+
     // Prevent autofocus in mobile
     if (comp.env.isSmall) {
         return () => {};
     }
 
-    const uiService = useService("ui");
     const selector = params.selector || "[autofocus]";
     let forceFocusCount = 0;
     useEffect(
         function autofocus() {
             const target = comp.el.querySelector(selector);
-            if (target && uiService.activeElement.contains(target)) {
+            if (target && (!uiService?.activeElement || uiService.activeElement.contains(target))) {
                 target.focus();
                 if (["INPUT", "TEXTAREA"].includes(target.tagName) && target.type !== 'number') {
                     const inputEl = target;

--- a/addons/web/static/tests/core/popover/popover_hook_tests.js
+++ b/addons/web/static/tests/core/popover/popover_hook_tests.js
@@ -2,10 +2,12 @@
 
 import { usePopover } from "@web/core/popover/popover_hook";
 import { popoverService } from "@web/core/popover/popover_service";
+import { uiService } from "@web/core/ui/ui_service";
 import { registry } from "@web/core/registry";
 import { registerCleanup } from "../../helpers/cleanup";
 import { clearRegistryWithCleanup, makeTestEnv } from "../../helpers/mock_env";
 import { getFixture, nextTick } from "../../helpers/utils";
+import { makeFakeLocalizationService } from "@web/../tests/helpers/mock_services";
 
 const { Component, mount, xml } = owl;
 
@@ -36,6 +38,8 @@ QUnit.module("Popover hook", {
     async beforeEach() {
         clearRegistryWithCleanup(mainComponents);
         registry.category("services").add("popover", popoverService);
+        registry.category("services").add("ui", uiService);
+        registry.category("services").add("localization", makeFakeLocalizationService());
 
         fixture = getFixture();
         env = await makeTestEnv();

--- a/addons/web/static/tests/core/popover/popover_service_tests.js
+++ b/addons/web/static/tests/core/popover/popover_service_tests.js
@@ -5,6 +5,8 @@ import { registry } from "@web/core/registry";
 import { registerCleanup } from "../../helpers/cleanup";
 import { clearRegistryWithCleanup, makeTestEnv } from "../../helpers/mock_env";
 import { click, getFixture, nextTick } from "../../helpers/utils";
+import { makeFakeLocalizationService } from "@web/../tests/helpers/mock_services";
+import { uiService } from "@web/core/ui/ui_service";
 
 const { Component, mount, xml } = owl;
 
@@ -37,6 +39,8 @@ QUnit.module("Popover service", {
     async beforeEach() {
         clearRegistryWithCleanup(mainComponents);
         registry.category("services").add("popover", popoverService);
+        registry.category("services").add("ui", uiService);
+        registry.category("services").add("localization", makeFakeLocalizationService());
 
         fixture = getFixture();
         env = await makeTestEnv();

--- a/addons/web/static/tests/core/popover/popover_tests.js
+++ b/addons/web/static/tests/core/popover/popover_tests.js
@@ -3,9 +3,13 @@
 import { Popover } from "@web/core/popover/popover";
 import { registerCleanup } from "../../helpers/cleanup";
 import { getFixture } from "../../helpers/utils";
+import { makeTestEnv } from "@web/../tests/helpers/mock_env";
+import { registry } from "@web/core/registry";
+import { uiService } from "@web/core/ui/ui_service";
 
 const { mount } = owl;
 
+let env;
 let fixture;
 let popoverTarget;
 
@@ -29,6 +33,9 @@ QUnit.module("Popover", {
         popoverTarget.id = "target";
         fixture.appendChild(popoverTarget);
 
+        registry.category("services").add("ui", uiService);
+        env = await makeTestEnv();
+
         registerCleanup(() => {
             fixture.removeChild(popoverTarget);
         });
@@ -39,6 +46,7 @@ QUnit.test("popover can have custom class", async (assert) => {
     const popover = await mount(Popover, {
         target: fixture,
         props: { target: popoverTarget, popoverClass: "custom-popover" },
+        env,
     });
 
     assert.containsOnce(fixture, ".o_popover.custom-popover");
@@ -49,6 +57,7 @@ QUnit.test("popover is rendered nearby target (default)", async (assert) => {
     const popover = await mount(Popover, {
         target: fixture,
         props: { target: popoverTarget },
+        env,
     });
 
     const popoverEl = fixture.querySelector(".o_popover");
@@ -60,6 +69,7 @@ QUnit.test("popover is rendered nearby target (bottom)", async (assert) => {
     const popover = await mount(Popover, {
         target: fixture,
         props: { target: popoverTarget, position: "bottom" },
+        env,
     });
 
     const popoverEl = fixture.querySelector(".o_popover");
@@ -71,6 +81,7 @@ QUnit.test("popover is rendered nearby target (top)", async (assert) => {
     const popover = await mount(Popover, {
         target: fixture,
         props: { target: popoverTarget, position: "top" },
+        env,
     });
 
     const popoverEl = fixture.querySelector(".o_popover");
@@ -82,6 +93,7 @@ QUnit.test("popover is rendered nearby target (left)", async (assert) => {
     const popover = await mount(Popover, {
         target: fixture,
         props: { target: popoverTarget, position: "left" },
+        env,
     });
 
     const popoverEl = fixture.querySelector(".o_popover");
@@ -93,9 +105,20 @@ QUnit.test("popover is rendered nearby target (right)", async (assert) => {
     const popover = await mount(Popover, {
         target: fixture,
         props: { target: popoverTarget, position: "right" },
+        env,
     });
 
     const popoverEl = fixture.querySelector(".o_popover");
     assert.ok(pointsTo(popoverEl, "right"));
     popover.destroy();
+});
+
+QUnit.test("Popover is included in ui_service activeElement", async (assert) => {
+    const popoverComponent = await mount(Popover, {
+        target: fixture,
+        props: { target: popoverTarget },
+        env,
+    });
+
+    assert.strictEqual(popoverComponent.env.services.ui.activeElement, fixture.querySelector(".o_popover"))
 });

--- a/addons/web/static/tests/core/utils/hooks_tests.js
+++ b/addons/web/static/tests/core/utils/hooks_tests.js
@@ -118,16 +118,16 @@ QUnit.module("utils", () => {
 
         QUnit.test("useAutofocus: does not strictly depend on uiService", async function (assert) {
             class MyComponent extends Component {
-                static template = xml`
-                    <span>
-                        <input type="text" t-ref="autofocus" />
-                    </span>
-                `;
-
                 setup() {
                     this.inputRef = useAutofocus();
                 }
             }
+
+            MyComponent.template = xml`
+                <span>
+                    <input type="text" t-ref="autofocus" />
+                </span>
+            `;
 
             const env = await makeTestEnv();
             Object.defineProperty(env, "isSmall", {

--- a/addons/web/static/tests/core/utils/hooks_tests.js
+++ b/addons/web/static/tests/core/utils/hooks_tests.js
@@ -116,6 +116,37 @@ QUnit.module("utils", () => {
             comp.destroy();
         });
 
+        QUnit.test("useAutofocus: does not strictly depend on uiService", async function (assert) {
+            class MyComponent extends Component {
+                static template = xml`
+                    <span>
+                        <input type="text" t-ref="autofocus" />
+                    </span>
+                `;
+
+                setup() {
+                    this.inputRef = useAutofocus();
+                }
+            }
+
+            const env = await makeTestEnv();
+            Object.defineProperty(env, "isSmall", {
+                get() {
+                    return undefined;
+                },
+            });
+
+            const target = getFixture();
+            const comp = await mount(MyComponent, target, { env });
+            await nextTick();
+
+            assert.strictEqual(document.activeElement, comp.inputRef.el);
+
+            comp.render();
+            await nextTick();
+            assert.strictEqual(document.activeElement, comp.inputRef.el);
+        });
+
         QUnit.test("useAutofocus: autofocus outside of active element doesn't work (CommandPalette)", async function (assert) {
             class MyComponent extends Component {
                 setup() {


### PR DESCRIPTION
[[FIX] web: remove useAutofocus strict dependence with ui_service](https://github.com/odoo/odoo/pull/139626/commits/7cfc42ce2b59d89d520cc4149efe70e241a79da0) 

Since https://github.com/odoo/odoo/pull/133292, useAutofocus is strictly dependent on the ui_service
meaning that we cannot use useAutofocus without the service.

useAutofocus does not need the ui_service but if it is present then
useAutofocus should check the activeElement.
This commit removes this strict dependency by checking if the ui_service
is available. If it is not, the activeElement is not checked.

[[FIX] web: include popover in ui_service activeElement](https://github.com/odoo/odoo/pull/139626/commits/e7ebb8b72afefbdae2f66b1ace2fc743df83e2cc) 

For the moment, popover is not included in the `activeElement` from
ui_service.
Meaning that the ui_service does not know if a popover is indeed the
current active element.

This commit introduces the popover in the ui_service.
One example of use case is that it allows the useAutofocus hook to
take the popover into account when discriminating what should indeed
be focused or not depending on the activeElement.