### PR TITLE
[REM] im_livechat: remove leftovers from is accessible

### DIFF
--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -30,17 +30,6 @@ class DiscussChannel(models.Model):
     _sql_constraints = [('livechat_operator_id', "CHECK((channel_type = 'livechat' and livechat_operator_id is not null) or (channel_type != 'livechat'))",
                          'Livechat Operator ID is required for a channel of type livechat.')]
 
-    def _compute_is_accessible(self):
-        super()._compute_is_accessible()
-        if self.env.user.has_group("im_livechat.im_livechat_group_manager"):
-            self.filtered(lambda channel: channel.channel_type == "livechat").is_accessible = True
-
-    def _search_is_accessible(self, operator, operand):
-        res = super()._search_is_accessible(operator, operand)
-        if self.env.user.has_group("im_livechat.im_livechat_group_manager"):
-            return expression.OR([res, [("channel_type", "=", "livechat")]])
-        return res
-
     @api.depends('message_ids')
     def _compute_duration(self):
         for record in self:


### PR DESCRIPTION
Follow-up of https://github.com/odoo/odoo/pull/138330

The computed field was removed during dev from the base module but the override was left by mistake.
