### PR TITLE
[FIX] im_livechat: fix visitor leave session on log in

### DIFF
--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -90,7 +90,7 @@ export class LivechatService {
                 prevOdooVersion !== currOdooVersion ||
                 (this.sessionCookie && visitorUid !== userId)
             ) {
-                this.leaveSession();
+                this.leaveSession({ notifyServer: false });
             }
             browser.localStorage.setItem(ODOO_VERSION_KEY, currOdooVersion);
         }

--- a/addons/website_livechat/models/website.py
+++ b/addons/website_livechat/models/website.py
@@ -54,6 +54,8 @@ class Website(models.Model):
                         # linked to another guest in the meantime. We need to
                         # update the channel to link it to the current guest.
                         chat_request_channel.write({'channel_member_ids': [Command.unlink(channel_guest_member.id), Command.create({'guest_id': current_guest.id})]})
+                    if not current_guest and not channel_guest_member:
+                        return {}
                     if not current_guest:
                         channel_guest_member.guest_id._set_auth_cookie()
                         chat_request_channel = chat_request_channel.with_context(guest=channel_guest_member.guest_id.sudo(False))

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -13,18 +13,18 @@ registry.category("web_tour.tours").add("website_livechat_login_after_chat_start
         },
         {
             trigger: ".o-mail-Composer-input",
-            run: "text Hello",
+            run: "text Hello!",
         },
         {
             trigger: ".o-mail-Composer-input",
             run: function () {
-                $("o-mail-Composer-input").trigger(
-                    $.Event("keydown", { key: "Enter" })
+                this.$anchor[0].dispatchEvent(
+                    new KeyboardEvent("keydown", { key: "Enter", which: 13, bubbles: true })
                 );
             },
         },
         {
-            trigger: ".o-mail-Message-content:contains('Hello')",
+            trigger: ".o-mail-Message-content:contains('Hello!')",
         },
         {
             trigger: "a:contains(Sign in)",
@@ -73,18 +73,18 @@ registry.category("web_tour.tours").add("website_livechat_logout_after_chat_star
         },
         {
             trigger: ".o-mail-Composer-input",
-            run: "text Hello",
+            run: "text Hello!",
         },
         {
             trigger: ".o-mail-Composer-input",
             run: function () {
-                $(".o-mail-Composer-input").trigger(
-                    $.Event("keydown", { key: "Enter" })
+                this.$anchor[0].dispatchEvent(
+                    new KeyboardEvent("keydown", { key: "Enter", which: 13, bubbles: true })
                 );
             },
         },
         {
-            trigger: ".o-mail-Message-content:contains('Hello')",
+            trigger: ".o-mail-Message-content:contains('Hello!')",
         },
         {
             trigger: "header#top a:contains(Mitchell Admin)",


### PR DESCRIPTION
Before this commit, the `visitor_leave_session` route was called
when a user logged in: the session of the visitor is outdated and
will never be activated again. This causes an error with portal
users since channel members are not based on the guest but on the
current user when available. This commit fixes the issue by not
calling the route: the session will be garbage collected as all
the others.

Steps to reproduce the issue:
- Go to website livechat (public user)
- Start a chat and send a message
- Log in as portal user
- An error occurs