### PR TITLE
[FIX] mail: close message reactions menu with no reactions

### DIFF
--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -32,17 +32,17 @@ export class MessageReactionMenu extends Component {
         useExternalListener(document, "keydown", this.onKeydown);
         onExternalClick("root", () => this.props.close());
         useEffect(
-            (reactions) => {
-                const activeReaction = reactions.find(
+            () => {
+                const activeReaction = this.props.message.reactions.find(
                     ({ content }) => content === this.state.reaction.content
                 );
-                if (reactions.length === 0) {
+                if (this.props.message.reactions.length === 0) {
                     this.props.close();
                 } else if (!activeReaction) {
-                    this.state.reaction = reactions[0];
+                    this.state.reaction = this.props.message.reactions[0];
                 }
             },
-            () => [this.props.message.reactions]
+            () => [this.props.message.reactions.length]
         );
         onWillStart(async () => {
             const { emojis } = await loadEmoji();


### PR DESCRIPTION
Currently, if all reactions are deleted from reactions menu, the menu remains open. This commit force it close in case of having no reactions.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
