### PR TITLE
[FIX] mail: do not reload chatter when not needed

### DIFF
--- a/addons/mail/static/src/views/web/form/form_controller.js
+++ b/addons/mail/static/src/views/web/form/form_controller.js
@@ -7,6 +7,10 @@ import { x2ManyCommands } from "@web/core/orm_service";
 patch(FormController.prototype, {
     onWillLoadRoot(nextConfiguration) {
         super.onWillLoadRoot(...arguments);
+        this.env.bus.trigger("MAIL:RELOAD-CHATTER", {
+            model: nextConfiguration.resModel,
+            id: nextConfiguration.resId,
+        });
         const isSameThread =
             this.model.root?.resId === nextConfiguration.resId &&
             this.model.root?.resModel === nextConfiguration.resModel;


### PR DESCRIPTION
This RPC /mail/thread/data is called on every form view change, even when not saved.
It comes from the chatter onWillUpdateProps and calling `load` then `fetchData`
We don't want to reload chatter when every time props updates. Do it when the record `onWillLoadRoot`

Task: 3569123

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
