### PR TITLE
[FIX] web_editor: extend btn css for colorpicker btn

### DIFF
--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -63,22 +63,22 @@
     <div t-name="web_editor.ColorPalette" class="colorpicker" t-ref="el">
         <div class="o_we_colorpicker_switch_panel d-flex justify-content-end px-2">
             <t t-set="first_button_name"><t t-if="props.withCombinations">Theme</t><t t-else="">Solid</t></t>
-            <button type="button" tabindex="1" class="o_we_colorpicker_switch_pane_btn" t-attf-data-target="#{props.withCombinations ? 'color-combinations' : 'theme-colors'}"
+            <button type="button" tabindex="1" class="btn o_we_colorpicker_switch_pane_btn" t-attf-data-target="#{props.withCombinations ? 'color-combinations' : 'theme-colors'}"
                     t-att-title="first_button_name"
                     t-on-click="this._onSwitchPaneButtonClick">
                 <span t-out="first_button_name"/>
             </button>
-            <button type="button" tabindex="2" class="o_we_colorpicker_switch_pane_btn" data-target="custom-colors" title="Custom"
+            <button type="button" tabindex="2" class="btn o_we_colorpicker_switch_pane_btn" data-target="custom-colors" title="Custom"
                     t-on-click="this._onSwitchPaneButtonClick">
                 <span>Custom</span>
             </button>
-            <button type="button" tabindex="3" class="o_we_colorpicker_switch_pane_btn" data-target="gradients" title="Gradient"
+            <button type="button" tabindex="3" class="btn o_we_colorpicker_switch_pane_btn" data-target="gradients" title="Gradient"
                     t-on-click="this._onSwitchPaneButtonClick">
                 <span>Gradient</span>
             </button>
             <t t-if="props.resetButton">
                 <t t-set="trash_title"><t t-if="props.withCombinations">None</t><t t-else="">Reset</t></t>
-                <button type="button" class="fa fa-trash my-1 ms-5 py-0 o_we_color_btn o_colorpicker_reset o_we_hover_danger" t-att-title="trash_title" />
+                <button type="button" class="fa fa-trash my-1 ms-5 py-0 o_we_color_btn o_colorpicker_reset o_we_hover_danger btn" t-att-title="trash_title" />
             </t>
         </div>
         <div class="o_colorpicker_sections pt-2 px-2 pb-3" data-color-tab="color-combinations">


### PR DESCRIPTION
**Current behavior before PR:**

- In colorpicker's buttons has visible border and some other weird css because 
  `@extend .btn` is removed in ([1]) PR.

<ins>It was removed because of below mentioned reasons:</ins>

- When first encountering extend directive, the sass compiler has to scan all
  the already generated rules so that it can copy-paste those containing `.btn`
  and replace it with your selector instead.

- For the rest of the compilation, any time any scss file in the compilation
  unit uses the btn class, it needs to duplicate the selector.

**Desired behavior after PR is merged:**

- Now after replacing `@extend .btn` witn `@extend %btn` the colorpickers
  top buttons have same css as before.

[1]:https://github.com/odoo/odoo/pull/138467/commits/ed1b6ff06418e9797f0c64547a5a4098fa4675dd

task-3569372

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
