### PR TITLE
[FIX] web_editor: transform URL in multiple text nodes

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -3491,6 +3491,25 @@ X[]
                 },
                 contentAfter: '<p>a http://test.com b <a href="http://test.com">http://test.com</a>&nbsp;[] c http://test.com d</p>',
             });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>http://test.com[]</p>',
+                stepFunction: async (editor) => {
+                    editor.testMode = false;
+                    const p = editor.editable.querySelector('p');
+                    // Simulate multiple text nodes in a p: <p>"http://test" ".com"</p>
+                    const firstTextNode = p.childNodes[0];
+                    const secondTextNode = firstTextNode.splitText(11); 
+                    const selection = document.getSelection();
+                    const anchorOffset = selection.anchorOffset;
+                    triggerEvent(editor.editable, 'keydown', {key: ' ', code: 'Space'});
+                    secondTextNode.textContent = ".com\u00a0";
+                    selection.extend(secondTextNode, anchorOffset + 1);
+                    selection.collapseToEnd();
+                    triggerEvent(editor.editable, 'input', {data: ' ', inputType: 'insertText' });
+                    triggerEvent(editor.editable, 'keyup', {key: ' ', code: 'Space'});
+                },
+                contentAfter: '<p><a href="http://test.com">http://test.com</a>&nbsp;[]</p>',
+            });
         });
         it('should not transform url after two space', async () => {
             await testEditor(BasicEditor, {


### PR DESCRIPTION
Before this commit, if a URL was contained in two or more text nodes, e.g. `<p>"link" ".com"</p>`, pressing the space key after the URL failed to convert it into a link. Such text node split can happen as a result of backspace or delete in the middle of a text node.

Moreover, if the last part of a word was a valid URL, without the whole word being one, e.g. "nonsense!link.com", that part of the word would be converted into a link, which is rarely what the user wants or expects.

This commit makes sure to include the adjacent previous text nodes in the search for a space that delimits the beginning of a potential URL. It also makes sure to only transform a link if the whole space-delimited word is a valid URL.

task-3468763
