### PR TITLE
[FIX] web_editor: transform URL in multiple text nodes

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -4282,6 +4282,19 @@ X[]
                 contentAfter: '<p>a http://test.com b <a href="http://test.com">http://test.com</a>[] c http://test.com d</p>',
                 //in reality: '<p>a http://test.com b <a href="http://test.com">http://test.com</a>&nbsp;[] c http://test.com d</p>'
             });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>http://test.com[]</p>',
+                stepFunction: async (editor) => {
+                    editor.testMode = false;
+                    const p = editor.editable.querySelector('p');
+                    const textNode = p.childNodes[0];
+                    // Simulate multiple text nodes in a p: <p>"http://test" ".com"</p>
+                    textNode.splitText(11);
+                    await insertText(editor, ' ');
+                },
+                contentAfter: '<p><a href="http://test.com">http://test.com</a>[]</p>',
+                // In reality, with a trusted event: '<p><a href="http://test.com">http://test.com</a>&nbsp;[]</p>'
+            });
         });
         it('should transform url after enter', async () => {
             await testEditor(BasicEditor, {


### PR DESCRIPTION
Before this commit, if a URL was contained in two or more text nodes, e.g. `<p>"link" ".com"</p>`, pressing the space key after the URL failed to convert it into a link. Such text node split can happen as a result of backspace or delete in the middle of a text node.

Moreover, if the last part of a word was a valid URL, without the whole word being one, e.g. "nonsense!link.com", that part of the word would be converted into a link, which is rarely what the user wants or expects.

This commit makes sure to include the adjacent previous text nodes in the search for a space that delimits the beginning of a potential URL. It also makes sure to only transform a link if the whole space-delimited word is a valid URL.

task-3468763
