### PR TITLE
[IMP] l10n_jp: tax group name update

### DIFF
--- a/addons/l10n_jp/data/template/account.tax.group-jp.csv
+++ b/addons/l10n_jp/data/template/account.tax.group-jp.csv
@@ -1,4 +1,4 @@
 "id","name","country_id"
 "l10n_jp_tax_group_exempt","免税","base.jp"
-"l10n_jp_tax_group_8","消費税 8%","base.jp"
-"l10n_jp_tax_group_10","消費税 10%","base.jp"
+"l10n_jp_tax_group_8","8% 対象","base.jp"
+"l10n_jp_tax_group_10","10% 対象","base.jp"


### PR DESCRIPTION
Update the japanese tax group template names to
better fit the needs.

Task id #3315696

Done in 16.2 as before, everything is in English (I guess translation will work there?)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
