### PR TITLE
[IMP] core: clean up the ACL tracebacks some

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1935,7 +1935,7 @@ class IrModelAccess(models.Model):
                 group_info=group_info,
                 resolution_info=resolution_info)
 
-            raise AccessError(msg)
+            raise AccessError(msg) from None
 
         return has_access
 

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -969,7 +969,7 @@ class Cache(object):
             return cache_value
         except KeyError:
             if default is NOTHING:
-                raise CacheMiss(record, field)
+                raise CacheMiss(record, field) from None
             return default
 
     def set(self, record, field, value, dirty=False, check_dirty=True):


### PR DESCRIPTION
Currently if a record is not in the cache it raises a `CacheMiss` the handling of which leads to loading the record from the database (or something).

If an issue occurs during that loading, because the loading is an `except` scope the cache miss gets linked with the new one via

> During handling of the above exception, another exception occurred:

This is both noise (the cache miss is not actually relevant) and misleading, because the wording makes it look like an unrelated error occurred during handling.

- move the loading of the record out of the `except` to limit the scope of the `KeyError` and avoid "inheriting" it
- try to `from None` a few specific errors to remove implicit linkage, as the new error should have all relevant information, the key error / cache miss is just an implementation detail
