### PR TITLE
[FIX] l10n_ar: traceback filter

### DIFF
--- a/addons/l10n_ar/views/res_partner_view.xml
+++ b/addons/l10n_ar/views/res_partner_view.xml
@@ -44,7 +44,7 @@
         <field name="inherit_id" ref="base.view_res_partner_filter"/>
         <field name="arch" type="xml">
             <field name="category_id" position="after">
-                <field name="l10n_ar_afip_responsibility_type_id" invisible="'AR' not in fiscal_country_codes"/>
+                <field name="l10n_ar_afip_responsibility_type_id"/>
             </field>
             <filter name="salesperson" position="before">
                 <filter string="AFIP Responsibility Type" name="l10n_ar_afip_responsibility_type_id_filter" context="{'group_by': 'l10n_ar_afip_responsibility_type_id'}"/>


### PR DESCRIPTION
It seems that the invisible is not working on filter and so the fiscal country_code cannot be evaluated which causes a Traceback when trying to access the res_partner form view.

task: 3270458

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
