### PR TITLE
[IMP] website: add signature to form

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -12,7 +12,8 @@ from odoo import http, SUPERUSER_ID, _, _lt
 from odoo.addons.base.models.ir_qweb_fields import nl2br, nl2br_enclose
 from odoo.http import request
 from odoo.tools import plaintext2html
-from odoo.exceptions import ValidationError, UserError
+from odoo.exceptions import AccessDenied, ValidationError, UserError
+from odoo.tools.misc import hmac, consteq
 
 
 class WebsiteForm(http.Controller):
@@ -71,7 +72,17 @@ class WebsiteForm(http.Controller):
                 self.insert_attachment(model_record, id_record, data['attachments'])
                 # in case of an email, we want to send it immediately instead of waiting
                 # for the email queue to process
+
                 if model_name == 'mail.mail':
+                    form_has_email_cc = {'email_cc', 'email_bcc'} & kwargs.keys() or \
+                        'email_cc' in kwargs["website_form_signature"]
+                    # remove the email_cc information from the signature
+                    kwargs["website_form_signature"] = kwargs["website_form_signature"].split(':')[0]
+                    if kwargs.get("email_to"):
+                        value = kwargs['email_to'] + (':email_cc' if form_has_email_cc else '')
+                        hash_value = hmac(model_record.env, 'website_form_signature', value)
+                        if not consteq(kwargs["website_form_signature"], hash_value):
+                            raise AccessDenied('invalid website_form_signature')
                     request.env[model_name].sudo().browse(id_record).send()
 
         # Some fields have additional SQL constraints that we can't check generically
@@ -183,7 +194,7 @@ class WebsiteForm(http.Controller):
                     custom_fields.append((_('email'), field_value))
 
             # If it's a custom field
-            elif field_name != 'context':
+            elif field_name not in ('context', 'website_form_signature'):
                 custom_fields.append((field_name, field_value))
 
         data['custom'] = "\n".join([u"%s : %s" % v for v in custom_fields])
@@ -216,7 +227,8 @@ class WebsiteForm(http.Controller):
     def insert_record(self, request, model, values, custom, meta=None):
         model_name = model.sudo().model
         if model_name == 'mail.mail':
-            values.update({'reply_to': values.get('email_from')})
+            email_from = _('"%s form submission" <%s>') % (request.env.company.name, request.env.company.email)
+            values.update({'reply_to': values.get('email_from'), 'email_from': email_from})
         record = request.env[model_name].with_user(SUPERUSER_ID).with_context(
             mail_create_nosubscribe=True,
             commit_assetsbundle=False,

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -4,6 +4,8 @@
 import logging
 import uuid
 import werkzeug
+from odoo.tools.misc import hmac
+from lxml import etree
 
 from odoo import api, fields, models
 from odoo import tools
@@ -491,6 +493,33 @@ class View(models.Model):
         return super()._get_allowed_root_attrs() + [
             'data-bg-video-src', 'data-shape', 'data-scroll-background-ratio',
         ]
+
+    def _get_combined_arch(self):
+        root = super(View, self)._get_combined_arch()
+        if not root.findall('.//form'):  # Most efficient way to discard the function if there is no form in the view
+            return root
+        nodes = root.xpath('.//form[contains(@action, "/website/form/")]')
+        for form in nodes:
+            existing_hash_node = form.find('.//input[@type="hidden"][@name="website_form_signature"]')
+            if existing_hash_node is not None:
+                existing_hash_node.getparent().remove(existing_hash_node)
+            input_nodes = form.xpath('.//input[contains(@name, "email_")]')
+            form_values = {input_node.attrib['name']: input_node for input_node in input_nodes}
+            # if this form does not send an email, ignore. But at this stage,
+            # the value of email_to can still be None in case of default value
+            if 'email_to' not in form_values.keys():
+                continue
+            elif not form_values['email_to'].attrib.get('value'):
+                form_values['email_to'].attrib['value'] = self.env.company.email
+            has_cc = {'email_cc', 'email_bcc'} & form_values.keys()
+            value = form_values['email_to'].attrib['value'] + (':email_cc' if has_cc else '')
+            hash_value = hmac(self.sudo().env, 'website_form_signature', value)
+            hash_node = '<input type="hidden" class="form-control s_website_form_input s_website_form_custom" name="website_form_signature" value=""/>'
+            if has_cc:
+                hash_value += ':email_cc'
+            form_values['email_to'].addnext(etree.fromstring(hash_node))
+            form_values['email_to'].getnext().attrib['value'] = hash_value
+        return root
 
     # --------------------------------------------------------------------------
     # Snippet saving

--- a/addons/website/models/website_form.py
+++ b/addons/website/models/website_form.py
@@ -31,13 +31,16 @@ class website_form_model(models.Model):
         builders and are writable. By default no field is writable by the
         form builder.
         """
-        included = {
-            field.name
-            for field in self.env['ir.model.fields'].sudo().search([
-                ('model_id', '=', self.id),
-                ('website_form_blacklisted', '=', False)
-            ])
-        }
+        if self.model == "mail.mail":
+            included = {'email_from', 'email_to', 'email_cc', 'email_bcc', 'body', 'reply_to', 'subject'}
+        else:
+            included = {
+                field.name
+                for field in self.env['ir.model.fields'].sudo().search([
+                    ('model_id', '=', self.id),
+                    ('website_form_blacklisted', '=', False)
+                ])
+            }
         return {
             k: v for k, v in self.get_authorized_fields(self.model).items()
             if k in included

--- a/addons/website/static/tests/tours/website_form_editor_frontend.js
+++ b/addons/website/static/tests/tours/website_form_editor_frontend.js
@@ -28,7 +28,8 @@ registry.category("web_tour.tours").add("website_form_editor_tour_submit", {
                         ":has(.s_website_form_field.s_website_form_required:has(label:contains('State')):has(select[name='State'][required]:has(option[value='France'])))" +
                         ":has(.s_website_form_field:has(label:contains('State')):has(select[name='State'][required]:has(option[value='Canada'])))" +
                         ":has(.s_website_form_field:has(label:contains('Invoice Scan')))" +
-                        ":has(.s_website_form_field:has(input[name='email_to'][value='test@test.test']))",
+                        ":has(.s_website_form_field:has(input[name='email_to'][value='test@test.test']))" + 
+                        ":has(.s_website_form_field:has(input[name='website_form_signature']))",
         trigger:  ".s_website_form_send"
     },
     {


### PR DESCRIPTION
This commits add a signature to the website_form.

The purpose of this modification is to allow the controllers to be able to verify that the form was originally generated from the view.

This prevent the end user to submit arbitrary values to the website_form controller.

In this commit, email_cc and email_bcc are treated as the same fied as it holds the same function

This does not offer protection against submission replay. Previous versions of the form are not invalidated by editing the view.

If one need to completely reset that protection and invalidate the previously generated website_form, the only solution is currently to change the database secret.
