### PR TITLE
[IMP] product: move properties from product.product to product.template

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -101,8 +101,6 @@ class ProductProduct(models.Model):
     image_128 = fields.Image("Image 128", compute='_compute_image_128')
     can_image_1024_be_zoomed = fields.Boolean("Can Image 1024 be zoomed", compute='_compute_can_image_1024_be_zoomed')
     write_date = fields.Datetime(compute='_compute_write_date', store=True)
-    # Properties
-    product_properties = fields.Properties('Properties', definition='categ_id.product_properties_definition', copy=True)
 
     @api.depends('image_variant_1920', 'image_variant_1024')
     def _compute_can_image_variant_1024_be_zoomed(self):

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -156,6 +156,8 @@ class ProductTemplate(models.Model):
         comodel_name='product.tag',
         relation='product_tag_product_template_rel',
     )
+    # Properties
+    product_properties = fields.Properties('Properties', definition='categ_id.product_properties_definition', copy=True)
 
     def _compute_item_count(self):
         for template in self:
@@ -454,7 +456,7 @@ class ProductTemplate(models.Model):
 
     def _get_related_fields_variant_template(self):
         """ Return a list of fields present on template and variants models and that are related"""
-        return ['barcode', 'default_code', 'standard_price', 'volume', 'weight', 'packaging_ids']
+        return ['barcode', 'default_code', 'standard_price', 'volume', 'weight', 'packaging_ids', 'product_properties']
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -76,6 +76,9 @@
                     </p>
                 </page>
             </xpath>
+            <xpath expr="//group[@name='group_standard_price']" position="after">
+                <field name="product_properties" columns="2"/>
+            </xpath>
         </field>
     </record>
 
@@ -88,6 +91,7 @@
                 <field name="product_variant_count"/>
                 <field name="currency_id"/>
                 <field name="activity_state"/>
+                <field name="categ_id"/>
                 <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                 <templates>
                     <t t-name="kanban-box">
@@ -112,6 +116,9 @@
                                 </div>
                                 <div name="product_lst_price" class="mt-1">
                                     Price: <field name="list_price" widget="monetary" options="{'currency_field': 'currency_id', 'field_digits': True}"></field>
+                                </div>
+                                <div>
+                                    <field name="product_properties" widget="properties"/>
                                 </div>
                             </div>
                         </div>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -428,9 +428,6 @@
                 <field name="product_tag_ids" position="after">
                     <field name="additional_product_tag_ids" widget="many2many_tags"/>
                 </field>
-                <notebook position="before">
-                    <field name="product_properties" columns="2"/>
-                </notebook>
             </field>
         </record>
 
@@ -443,7 +440,6 @@
                     <field name="lst_price"/>
                     <field name="activity_state"/>
                     <field name="color"/>
-                    <field name="categ_id"/>
                     <progressbar field="activity_state" colors='{"planned": "success", "today": "warning", "overdue": "danger"}'/>
                     <templates>
                         <t t-name="kanban-box">
@@ -468,7 +464,6 @@
                                         Price: <field name="lst_price"></field>
                                     </div>
                                     <div name="tags"/>
-                                    <field name="product_properties" widget="properties"/>
                                 </div>
                             </div>
                         </t>


### PR DESCRIPTION
Purpose:
---------
[This commit]( https://github.com/odoo/odoo/commit/70043822103638f651a521bd2da36cfdfd86245e) added the properties field on the product.product template. However, the product.template model is more suitable to hold these properties as the product.product model already has attributes which are quite similar to properties.

Task-3570286
