### PR TITLE
[REF] web: remove orm service nameGet

### DIFF
--- a/addons/web/static/src/core/orm_service.js
+++ b/addons/web/static/src/core/orm_service.js
@@ -146,22 +146,6 @@ export class ORM {
     /**
      * @param {string} model
      * @param {number[]} ids
-     * @param {any} [kwargs={}]
-     * @returns {Promise<[number, string][]>}
-     */
-    nameGet(model, ids, kwargs = {}) {
-        validatePrimitiveList("ids", "number", ids);
-        if (!ids.length) {
-            return Promise.resolve([]);
-        }
-        return this.call(model, "read", [ids, ["display_name"]], kwargs).then(
-            (data) => data && data.map(({ id, display_name }) => [id, display_name])
-        );
-    }
-
-    /**
-     * @param {string} model
-     * @param {number[]} ids
      * @param {string[]} fields
      * @param {any} [kwargs={}]
      * @returns {Promise<any[]>}

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -323,10 +323,10 @@ export class PropertyValue extends Component {
      * @returns {array} [record id, record name]
      */
     async _nameGet(recordId) {
-        const result = await this.orm.nameGet(this.props.comodel, [recordId], {
+        const result = await this.orm.read(this.props.comodel, [recordId], ["display_name"], {
             context: this.props.context,
         });
-        return result[0];
+        return [result[0].id, result[0].display_name];
     }
 }
 

--- a/addons/web/static/src/views/fields/reference/reference_field.js
+++ b/addons/web/static/src/views/fields/reference/reference_field.js
@@ -179,13 +179,13 @@ export class ReferenceField extends Component {
             const { specialDataCaches, orm } = props.record.model;
             const key = `__reference__name_get-${recordData}`;
             if (!specialDataCaches[key]) {
-                specialDataCaches[key] = orm.nameGet(resModel, [resId]);
+                specialDataCaches[key] = orm.read(resModel, [resId], ["display_name"]);
             }
             const result = await specialDataCaches[key];
             return {
                 resId,
                 resModel,
-                displayName: result[0][1],
+                displayName: result[0].display_name,
             };
         }
         return false;

--- a/addons/web/static/tests/core/orm_service_tests.js
+++ b/addons/web/static/tests/core/orm_service_tests.js
@@ -146,28 +146,6 @@ QUnit.test("create method: several records", async (assert) => {
     });
 });
 
-QUnit.test("nameGet method", async (assert) => {
-    const [query, rpc] = makeFakeRPC();
-    serviceRegistry.add("rpc", rpc);
-    const env = await makeTestEnv();
-    const context = { complete: true };
-    await env.services.orm.nameGet("sale.order", [2, 5], { context });
-    assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/read");
-    assert.deepEqual(query.params, {
-        args: [[2, 5], ["display_name"]],
-        kwargs: {
-            context: {
-                complete: true,
-                lang: "en",
-                tz: "taht",
-                uid: 7,
-            },
-        },
-        method: "read",
-        model: "sale.order",
-    });
-});
-
 QUnit.test("read method", async (assert) => {
     const [query, rpc] = makeFakeRPC();
     serviceRegistry.add("rpc", rpc);
@@ -309,7 +287,9 @@ QUnit.test("test readGroup method removes duplicate values from groupby", async 
         { offset: 1 }
     );
     assert.strictEqual(query.route, "/web/dataset/call_kw/sale.order/read_group");
-    assert.deepEqual(query.params.kwargs.groupby, ["date_order:month"],
+    assert.deepEqual(
+        query.params.kwargs.groupby,
+        ["date_order:month"],
         "Duplicate values should be removed from groupby"
     );
 });


### PR DESCRIPTION
This commit removes all usages of the nameGet method of the orm service following changes introduced by https://github.com/odoo/odoo/pull/122085

task-3377209
