### PR TITLE
[IMP] web: Avoid getting acess error when changing active company on company depedant records

### DIFF
--- a/addons/web/static/tests/webclient/company_service_tests.js
+++ b/addons/web/static/tests/webclient/company_service_tests.js
@@ -7,12 +7,14 @@ import { session } from "@web/session";
 import { companyService } from "@web/webclient/company_service";
 import { makeTestEnv } from "../helpers/mock_env";
 import { patchWithCleanup } from "../helpers/utils";
+import { fieldService } from "@web/core/field_service";
 
 const serviceRegistry = registry.category("services");
 
 QUnit.module("company service");
 
 QUnit.test("reload webclient when updating a res.company", async (assert) => {
+    serviceRegistry.add("field", fieldService);
     serviceRegistry.add("company", companyService);
     serviceRegistry.add("orm", ormService);
     serviceRegistry.add("action", {
@@ -37,6 +39,7 @@ QUnit.test("reload webclient when updating a res.company", async (assert) => {
 QUnit.test(
     "do not reload webclient when updating a res.company, but there is an error",
     async (assert) => {
+        serviceRegistry.add("field", fieldService);
         serviceRegistry.add("company", companyService);
         serviceRegistry.add("orm", ormService);
         serviceRegistry.add("action", {
@@ -74,6 +77,7 @@ QUnit.test("extract allowed company ids from url hash", async (assert) => {
         },
     });
 
+    serviceRegistry.add("field", fieldService);
     serviceRegistry.add("company", companyService);
 
     Object.assign(browser.location, { hash: "cids=3-1" });

--- a/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
@@ -15,6 +15,7 @@ import { MobileSwitchCompanyMenu } from "@web/webclient/burger_menu/mobile_switc
 import { companyService } from "@web/webclient/company_service";
 import { uiService } from "@web/core/ui/ui_service";
 import { session } from "@web/session";
+import { fieldService } from "@web/core/field_service";
 
 const serviceRegistry = registry.category("services");
 let target;
@@ -51,6 +52,7 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
             current_company: 1,
         });
         serviceRegistry.add("ui", uiService);
+        serviceRegistry.add("field", fieldService);
         serviceRegistry.add("company", companyService);
         serviceRegistry.add("hotkey", hotkeyService);
     });

--- a/addons/web/static/tests/webclient/switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/switch_company_menu_tests.js
@@ -9,6 +9,7 @@ import { companyService } from "@web/webclient/company_service";
 import { click, getFixture, makeDeferred, mount, patchWithCleanup } from "../helpers/utils";
 import { uiService } from "@web/core/ui/ui_service";
 import { session } from "@web/session";
+import { fieldService } from "@web/core/field_service";
 
 const serviceRegistry = registry.category("services");
 
@@ -48,6 +49,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
             current_company: 3,
         });
         serviceRegistry.add("ui", uiService);
+        serviceRegistry.add("field", fieldService);
         serviceRegistry.add("company", companyService);
         serviceRegistry.add("hotkey", hotkeyService);
         target = getFixture();


### PR DESCRIPTION
Implemented an enhancement in the logNextCompanies function to improve user experience when changing active companies.
Previously, changing the active company could lead to an Access Error. The new implementation checks if the current page would result in an Access Error for the new active company:

1. An ORM call to 'check_access_rule' checks the accessibility of the current record based on the new active company.
2. If staying on the current page would not lead to an Access Error, the user remains there.
3. If it would lead to an Access Error, the user is redirected to the current App's Dashboard.

This eliminates the unnecessary friction of encountering an Access Error and having to manually navigate back to a usable page.

Task-3029616

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
