### PR TITLE
[FIX] web_editor: traceback on opening product

### DIFF
--- a/addons/web_editor/static/src/js/backend/QWebPlugin.js
+++ b/addons/web_editor/static/src/js/backend/QWebPlugin.js
@@ -135,6 +135,9 @@ export class QWebPlugin {
     }
     _selectQwebNode(editor) {
         editor.addDomListener(editor.document, 'selectionchange', e => {
+            if (!e.target?.getSelection) {
+                return;
+            }
             const selection = e.target.getSelection();
             const qwebNode = selection.anchorNode && closestElement(selection.anchorNode, '[t-field],[t-esc],[t-out]');
             if (qwebNode){


### PR DESCRIPTION
**Current behavior before PR:**

Opening product or creating new products gives traceback.

**Desired behavior after PR is merged:**

Now opening product or creating new products not gives traceback.

task-3568388

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
