### PR TITLE
[FIX] project: fixes the overflow of frequency & hovering on assignee buttons

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -150,7 +150,7 @@
                                                 <field name="rating_status" widget="radio" class="o_row"/>
                                                 <div  invisible="rating_status != 'periodic'"  required="rating_status == 'periodic'">
                                                     <label for="rating_status_period" string="Frequency"/>
-                                                    <field name="rating_status_period"/>
+                                                    <field class="mx-3 w-auto" name="rating_status_period"/>
                                                 </div>
                                                 <span colspan="2" class="text-muted o_row ps-1">
                                                     <i class="fa fa-lightbulb-o pe-2"/>


### PR DESCRIPTION
In this PR fixes the following issue:
 - This pull request addresses a mobile view issue in the 'customer ratings' section by setting 
    the 'frequency' field width to 'auto.' This adjustment prevents content overflow on mobile devices, 
    enhancing user experience. Your review and feedback are appreciated for seamless integration.

- I'm submitting a pull request to address an issue in the 'project.task' kanban card. The problem is 
  the persistent visibility of the 'Assign People' button for sub-tasks, causing UI clutter. My solution 
  involves displaying the 'Assign People' button only upon hovering over a sub-task line within the 
  'project.task' kanban card's sub-tasks list. Your review and feedback on this change are appreciated.

task- 3549267
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
