### PR TITLE
[REF] *: keyboard: replace deprecated charCode, keyCode and which pro…

### DIFF
--- a/addons/account/static/tests/tours/tax_group_tests.js
+++ b/addons/account/static/tests/tours/tax_group_tests.js
@@ -93,7 +93,7 @@ registry.category("web_tour.tours").add('account_tax_group', {
         trigger: 'div[name="invoice_line_ids"] tbody tr.o_data_row .o_list_number[name="quantity"] input',
         run: function (actions) {
             let keydownEvent = jQuery.Event('keydown');
-            keydownEvent.which = 13;
+            keydownEvent.key = "Enter";
             this.$anchor.trigger(keydownEvent);
         },
     },

--- a/addons/barcodes/static/tests/helpers.js
+++ b/addons/barcodes/static/tests/helpers.js
@@ -4,17 +4,8 @@ import { triggerEvent } from "@web/../tests/helpers/utils";
 
 export function simulateBarCode(chars, target = document.body, selector = undefined) {
     for (let char of chars) {
-        let keycode;
-        if (char === "Enter") {
-            keycode = $.ui.keyCode.ENTER;
-        } else if (char === "Tab") {
-            keycode = $.ui.keyCode.TAB;
-        } else {
-            keycode = char.charCodeAt(0);
-        }
         triggerEvent(target, selector, "keydown", {
             key: char,
-            keyCode: keycode,
         });
     }
 }

--- a/addons/barcodes/static/tests/mobile/barcode_mobile_tests.js
+++ b/addons/barcodes/static/tests/mobile/barcode_mobile_tests.js
@@ -10,17 +10,8 @@
     var triggerEvent = testUtils.dom.triggerEvent;
 
     function triggerKeyDown(char, target = document.body) {
-        let keycode;
-        if (char === 'Enter') {
-            keycode = $.ui.keyCode.ENTER;
-        } else if (char === "Tab") {
-            keycode = $.ui.keyCode.TAB;
-        } else {
-            keycode = char.charCodeAt(0);
-        }
         triggerEvent(target, 'keydown', {
             key: char,
-            keyCode: keycode,
         });
     }
 

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
@@ -20,7 +20,7 @@ export class BomOverviewControlPanel extends Component {
     }
 
     onKeyPress(ev) {
-        if (ev.keyCode === 13 || ev.which === 13) {
+        if (ev.key === "Enter") {
             ev.preventDefault();
             this.updateQuantity(ev);
         }

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -4,7 +4,7 @@
     <t t-name="point_of_sale.ProductCard">
         <article tabindex="0" 
             t-attf-class="{{props.class}} product position-relative btn btn-light d-flex align-items-stretch p-0 m-0 text-start cursor-pointer overflow-hidden transition-base" 
-            t-on-keypress="(event) => event.which === 32 ? props.onClick(event) : ()=>{}" 
+            t-on-keypress="(event) => event.code === 'Space' ? props.onClick(event) : ()=>{}"
             t-on-click="props.onClick" 
             t-att-data-product-id="props.productId" 
             t-attf-aria-labelledby="article_product_{{props.productId}}">

--- a/addons/purchase/static/src/js/tours/purchase.js
+++ b/addons/purchase/static/src/js/tours/purchase.js
@@ -61,10 +61,6 @@ registry.category("web_tour.tours").add("purchase_tour", {
             run: function (actions) {
                 var $input = this.$anchor.find("input");
                 actions.text("DESK0001", $input.length === 0 ? this.$anchor : $input);
-                // fake keydown to trigger search
-                var keyDownEvent = jQuery.Event("keydown");
-                keyDownEvent.which = 42;
-                this.$anchor.trigger(keyDownEvent);
                 var $descriptionElement = $('.o_form_editable textarea[name="name"]');
                 // when description changes, we know the product has been created
                 $descriptionElement.change(function () {

--- a/addons/sale/static/src/js/tours/sale.js
+++ b/addons/sale/static/src/js/tours/sale.js
@@ -106,10 +106,6 @@ registry.category("web_tour.tours").add("sale_quote_tour", {
         run: function (actions) {
             var $input = this.$anchor.find("input");
             actions.text("DESK0001", $input.length === 0 ? this.$anchor : $input);
-            // fake keydown to trigger search
-            var keyDownEvent = jQuery.Event("keydown");
-            keyDownEvent.which = 42;
-            this.$anchor.trigger(keyDownEvent);
             var $descriptionElement = $(".o_form_editable textarea[name='name']");
             // when description changes, we know the product has been created
             $descriptionElement.change(function () {

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -108,12 +108,11 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
      */
     _onKeyDown: function (event) {
         var self = this;
-        var keyCode = event.keyCode;
 
         // If user is answering a text input, do not handle keydown
         // CTRL+enter will force submission (meta key for Mac)
         if ((this.$("textarea").is(":focus") || this.$('input').is(':focus')) &&
-            (!(event.ctrlKey || event.metaKey) || keyCode !== 13)) {
+            (!(event.ctrlKey || event.metaKey) || event.key !== "Enter")) {
             return;
         }
         // If in session mode and question already answered, do not handle keydown
@@ -121,22 +120,22 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
             return;
         }
         // Disable all navigation keys when zoom modal is open, except the ESC.
-        if ((this.imgZoomer && !this.imgZoomer.isDestroyed()) && keyCode !== 27) {
+        if ((this.imgZoomer && !this.imgZoomer.isDestroyed()) && event.key !== "Escape") {
             return;
         }
 
-        var letter = String.fromCharCode(keyCode).toUpperCase();
+        var letter = event.key.toUpperCase();
 
         // Handle Start / Next / Submit
-        if (keyCode === 13 || keyCode === 39) {  // Enter or arrow-right: go Next
+        if (event.key === "Enter" || event.key === "ArrowRight") {  // Enter or arrow-right: go Next
             event.preventDefault();
             if (!this.preventEnterSubmit) {
                 this._submitForm({
                     isFinish: this.el.querySelectorAll('button[value="finish"]').length !== 0,
-                    nextSkipped: this.el.querySelectorAll('button[value="next_skipped"]').length !== 0 ? keyCode === 13 : false,
+                    nextSkipped: this.el.querySelectorAll('button[value="next_skipped"]').length !== 0 ? event.key === "Enter" : false,
                 });
             }
-        } else if (keyCode === 37) {  // arrow-left: previous (if available)
+        } else if (event.key === "ArrowLeft") {  // arrow-left: previous (if available)
             // It's easier to actually click on the button (if in the DOM) as it contains necessary
             // data that are used in the event handler.
             // Again, global selector necessary since the navigation is outside of the form.

--- a/addons/survey/static/src/js/survey_quick_access.js
+++ b/addons/survey/static/src/js/survey_quick_access.js
@@ -56,7 +56,7 @@ publicWidget.registry.SurveyQuickAccessWidget = publicWidget.Widget.extend({
     },
 
     _onKeyPress: function (event) {
-        if (event.keyCode === 13) {  // Enter
+        if (event.key === "Enter") {
             event.preventDefault();
             this._submitCode();
         }

--- a/addons/survey/static/src/js/survey_session_manage.js
+++ b/addons/survey/static/src/js/survey_session_manage.js
@@ -134,18 +134,12 @@ publicWidget.registry.SurveySessionManage = publicWidget.Widget.extend(SurveyPre
     /**
      * Listeners for keyboard arrow / spacebar keys.
      *
-     * - 39 = arrow-right
-     * - 32 = spacebar
-     * - 37 = arrow-left
-     *
      * @param {KeyboardEvent} ev
      */
     _onKeyDown: function (ev) {
-        var keyCode = ev.keyCode;
-
-        if (keyCode === 39 || keyCode === 32) {
+        if (ev.key === "ArrowRight" || ev.key === " ") {
             this._onNext(ev);
-        } else if (keyCode === 37) {
+        } else if (ev.key === "ArrowLeft") {
             this._onBack(ev);
         }
     },

--- a/addons/survey/static/tests/tours/survey_tour_session_manage.js
+++ b/addons/survey/static/tests/tours/survey_tour_session_manage.js
@@ -36,13 +36,13 @@ const getChartData = () => {
 
 const nextScreen = () => {
     const e = $.Event('keydown');
-    e.keyCode = 39; // arrow-right
+    e.key = "ArrowRight";
     $(document).trigger(e);
 };
 
 const previousScreen = () => {
     const e = $.Event('keydown');
-    e.keyCode = 37; // arrow-left
+    e.key = "ArrowLeft";
     $(document).trigger(e);
 };
 

--- a/addons/survey/static/tests/tours/survey_tour_session_start.js
+++ b/addons/survey/static/tests/tours/survey_tour_session_start.js
@@ -20,7 +20,7 @@ registry.category("web_tour.tours").add('test_survey_session_start_tour', {
     trigger: 'h1',
     run: function () {
         var e = $.Event('keydown');
-        e.keyCode = 39; // arrow-right
+        e.key = "ArrowRight";
         $(document).trigger(e); // start session
     }
 }, {

--- a/addons/web/static/src/core/colorpicker/colorpicker.js
+++ b/addons/web/static/src/core/colorpicker/colorpicker.js
@@ -372,7 +372,7 @@ export class Colorpicker extends Component {
      * @param {Event} ev
      */
     _onKeypress(ev) {
-        if (ev.charCode === $.ui.keyCode.ENTER) {
+        if (ev.key === "Enter") {
             if (ev.target.tagName === "INPUT") {
                 this._onChangeInputs(ev);
             }

--- a/addons/web/static/src/legacy/js/core/dialog.js
+++ b/addons/web/static/src/legacy/js/core/dialog.js
@@ -367,8 +367,8 @@ var Dialog = Widget.extend({
      * @private
      */
     _onFooterButtonKeyDown: function (e) {
-        switch(e.which) {
-            case $.ui.keyCode.TAB:
+        switch(e.key) {
+            case "Tab":
                 if (!e.shiftKey && e.target.classList.contains("btn-primary")) {
                     e.preventDefault();
                     var $primaryButton = $(e.target);

--- a/addons/web/static/tests/core/dropdown_tests.js
+++ b/addons/web/static/tests/core/dropdown_tests.js
@@ -794,9 +794,6 @@ QUnit.module("Components", ({ beforeEach }) => {
             // Define the ArrowDown key with standard API (for hotkey_service)
             key: "ArrowDown",
             code: "ArrowDown",
-            // Define the ArrowDown key with deprecated API (for bootstrap)
-            keyCode: 40,
-            which: 40,
         });
         select.dispatchEvent(ev);
         await nextTick();
@@ -806,9 +803,6 @@ QUnit.module("Components", ({ beforeEach }) => {
             // Define the ESC key with standard API (for hotkey_service)
             key: "Escape",
             code: "Escape",
-            // Define the ESC key with deprecated API (for bootstrap)
-            keyCode: 27,
-            which: 27,
         });
         select.dispatchEvent(ev);
         await nextTick();

--- a/addons/web/static/tests/helpers/utils.js
+++ b/addons/web/static/tests/helpers/utils.js
@@ -243,7 +243,6 @@ const mapKeyboardEvent = (args) => ({
     ...args,
     bubbles: true,
     cancelable: true,
-    keyCode: args.which,
 });
 
 /**

--- a/addons/web/static/tests/legacy/helpers/test_utils_dom.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_dom.js
@@ -16,7 +16,7 @@ import { delay } from "@web/core/utils/concurrency";
     //-------------------------------------------------------------------------
 
     // TriggerEvent helpers
-    const keyboardEventBubble = args => Object.assign({}, args, { bubbles: true, keyCode: args.which });
+    const keyboardEventBubble = args => Object.assign({}, args, { bubbles: true});
     const mouseEventMapping = args => Object.assign({}, args, {
         bubbles: true,
         cancelable: true,

--- a/addons/web/static/tests/legacy/helpers/test_utils_fields.js
+++ b/addons/web/static/tests/legacy/helpers/test_utils_fields.js
@@ -11,13 +11,6 @@
 
     import testUtilsDom from "@web/../tests/legacy/helpers/test_utils_dom";
 
-    const ARROW_KEYS_MAPPING = {
-        down: 'ArrowDown',
-        left: 'ArrowLeft',
-        right: 'ArrowRight',
-        up: 'ArrowUp',
-    };
-
     //-------------------------------------------------------------------------
     // Public functions
     //-------------------------------------------------------------------------
@@ -67,31 +60,13 @@
      *
      * @param {string} type type of key event ('press', 'up' or 'down')
      * @param {jQuery} $el
-     * @param {number|string} keyCode used as number, but if string, it'll check if
-     *   the string corresponds to a key -otherwise it will keep only the first
-     *   char to get a letter key- and convert it into a keyCode.
+     * @param {string} key
      * @returns {Promise}
      */
-    function triggerKey(type, $el, keyCode) {
+    function triggerKey(type, $el, key) {
         type = 'key' + type;
         const params = {};
-        if (typeof keyCode === 'string') {
-            // Key (new API)
-            if (keyCode in ARROW_KEYS_MAPPING) {
-                params.key = ARROW_KEYS_MAPPING[keyCode];
-            } else {
-                params.key = keyCode[0].toUpperCase() + keyCode.slice(1).toLowerCase();
-            }
-            // KeyCode/which (jQuery)
-            if (keyCode.length > 1) {
-                keyCode = keyCode.toUpperCase();
-                keyCode = $.ui.keyCode[keyCode];
-            } else {
-                keyCode = keyCode.charCodeAt(0);
-            }
-        }
-        params.keyCode = keyCode;
-        params.which = keyCode;
+        params.key = key;
         return testUtilsDom.triggerEvent($el, type, params);
     }
 
@@ -99,11 +74,11 @@
      * Helper to trigger a keydown event on an element.
      *
      * @param {jQuery} $el
-     * @param {number|string} keyCode @see triggerKey
+     * @param {number|string} key @see triggerKey
      * @returns {Promise}
      */
-    function triggerKeydown($el, keyCode) {
-        return triggerKey('down', $el, keyCode);
+    function triggerKeydown($el, key) {
+        return triggerKey('down', $el, key);
     }
 
     export default {

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -1383,12 +1383,12 @@ const InputUserValueWidget = UnitUserValueWidget.extend({
         if (!params.unit && !params.step) {
             return;
         }
-        switch (ev.which) {
-            case $.ui.keyCode.ENTER:
+        switch (ev.key) {
+            case "Enter":
                 this._onUserValueChange(ev);
                 break;
-            case $.ui.keyCode.UP:
-            case $.ui.keyCode.DOWN: {
+            case "ArrowUp":
+            case "ArrowDown": {
                 const input = ev.currentTarget;
                 let value = parseFloat(input.value || input.placeholder);
                 if (isNaN(value)) {
@@ -1399,7 +1399,7 @@ const InputUserValueWidget = UnitUserValueWidget.extend({
                     step = 1.0;
                 }
 
-                const increasing = ev.which === $.ui.keyCode.UP;
+                const increasing = ev.key === "ArrowUp";
                 const hasMin = ('min' in params);
                 const hasMax = ('max' in params);
 
@@ -2947,7 +2947,7 @@ const Many2oneUserValueWidget = SelectUserValueWidget.extend({
      * @private
      */
     _onSearchKeydown(ev) {
-        if (ev.which !== $.ui.keyCode.ENTER) {
+        if (ev.key !== "Enter") {
             return;
         }
         const action = () => {

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -968,7 +968,7 @@ export class ColorPalette extends Component {
      * @param {Event} ev
      */
     _onGradientInputKeyPress(ev) {
-        if (ev.charCode === $.ui.keyCode.ENTER) {
+        if (ev.key === "Enter") {
             ev.preventDefault();
             this._onGradientInputChange();
         }

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -457,7 +457,7 @@ export class LinkTools extends Link {
      * @param {Event} ev
      */
     _onKeyPressCustomBorderWidth(ev) {
-        if (ev.keyCode === $.ui.keyCode.ENTER) {
+        if (ev.key === "Enter") {
             this._onChangeCustomBorderWidth(ev);
         }
     }

--- a/addons/web_editor/static/tests/test_utils.js
+++ b/addons/web_editor/static/tests/test_utils.js
@@ -6,7 +6,6 @@ import { patch } from "@web/core/utils/patch";
 import * as OdooEditorLib from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
 import { Wysiwyg } from '@web_editor/js/wysiwyg/wysiwyg';
 import options from "@web_editor/js/editor/snippets.options";
-import { range } from "@web/core/utils/numbers";
 import { TABLE_ATTRIBUTES, TABLE_STYLES } from '@web_editor/js/backend/convert_inline';
 
 const COLOR_PICKER_TEMPLATE = `
@@ -251,39 +250,6 @@ export function wysiwygData(data) {
 }
 
 /**
- * Char codes.
- */
-var keyboardMap = {
-    "8": "BACKSPACE",
-    "9": "TAB",
-    "13": "ENTER",
-    "16": "SHIFT",
-    "17": "CONTROL",
-    "18": "ALT",
-    "19": "PAUSE",
-    "20": "CAPS_LOCK",
-    "27": "ESCAPE",
-    "32": "SPACE",
-    "33": "PAGE_UP",
-    "34": "PAGE_DOWN",
-    "35": "END",
-    "36": "HOME",
-    "37": "LEFT",
-    "38": "UP",
-    "39": "RIGHT",
-    "40": "DOWN",
-    "45": "INSERT",
-    "46": "DELETE",
-    "91": "OS_KEY", // 'left command': Windows Key (Windows) or Command Key (Mac)
-    "93": "CONTEXT_MENU", // 'right command'
-};
-range(40, 127).forEach((keyCode) => {
-    if (!keyboardMap[keyCode]) {
-        keyboardMap[keyCode] = String.fromCharCode(keyCode);
-    }
-});
-
-/**
  * Perform a series of tests (`keyboardTests`) for using keyboard inputs.
  *
  * @see wysiwyg_keyboard_tests.js
@@ -316,13 +282,6 @@ var testKeyboard = function ($editable, assert, keyboardTests, addTests) {
 
     function keydown(target, keypress) {
         var $target = $(target.tagName ? target : target.parentNode);
-        if (!keypress.keyCode) {
-            keypress.keyCode = +Object.keys(keyboardMap).find((key) => {
-                return key === keypress.key;
-            });
-        } else {
-            keypress.key = keyboardMap[keypress.keyCode] || String.fromCharCode(keypress.keyCode);
-        }
         var event = $.Event("keydown", keypress);
         $target.trigger(event);
 
@@ -417,12 +376,11 @@ var testKeyboard = function ($editable, assert, keyboardTests, addTests) {
                 }
             }
             setTimeout(function () {
-                if (step.keyCode || step.key) {
+                if (step.key) {
                     var target = Wysiwyg.getRange().ec;
                     if (window.location.search.indexOf('notrycatch') !== -1) {
                         keydown(target, {
                             key: step.key,
-                            keyCode: step.keyCode,
                             ctrlKey: !!step.ctrlKey,
                             shiftKey: !!step.shiftKey,
                             altKey: !!step.altKey,
@@ -432,7 +390,6 @@ var testKeyboard = function ($editable, assert, keyboardTests, addTests) {
                         try {
                             keydown(target, {
                                 key: step.key,
-                                keyCode: step.keyCode,
                                 ctrlKey: !!step.ctrlKey,
                                 shiftKey: !!step.shiftKey,
                                 altKey: !!step.altKey,
@@ -444,11 +401,10 @@ var testKeyboard = function ($editable, assert, keyboardTests, addTests) {
                     }
                 }
                 setTimeout(function () {
-                    if (step.keyCode || step.key) {
+                    if (step.key) {
                         var $target = $(target.tagName ? target : target.parentNode);
                         $target.trigger($.Event('keyup', {
                             key: step.key,
-                            keyCode: step.keyCode,
                             ctrlKey: !!step.ctrlKey,
                             shiftKey: !!step.shiftKey,
                             altKey: !!step.altKey,
@@ -586,15 +542,7 @@ var select = (function () {
  */
 var keydown = function (key, $editable, options) {
     var keyPress = {};
-    if (typeof key === 'string') {
-        keyPress.key = key;
-        keyPress.keyCode = +Object.keys(keyboardMap).find((k) => {
-            return k === key;
-        });
-    } else {
-        keyPress.key = keyboardMap[key] || String.fromCharCode(key);
-        keyPress.keyCode = key;
-    }
+    keyPress.key = key;
     var range = Wysiwyg.getRange();
     if (!range) {
         console.error("Editor have not any range");

--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -297,10 +297,10 @@ export class RunningTourActionHelper {
             values.$element.trigger("input");
         } else {
             values.$element.focusIn();
-            values.$element.trigger($.Event("keydown", { key: "_", keyCode: 95 }));
+            values.$element.trigger($.Event("keydown", { key: "_" }));
             values.$element.text(text).trigger("input");
             values.$element.focusInEnd();
-            values.$element.trigger($.Event("keyup", { key: "_", keyCode: 95 }));
+            values.$element.trigger($.Event("keyup", { key: "_" }));
         }
         values.$element[0].dispatchEvent(new Event("change", { bubbles: true, cancelable: false }));
     }
@@ -403,8 +403,6 @@ export class RunningTourActionHelper {
                 eventOptions.key = keyCode;
             } else {
                 const code = parseInt(keyCode, 10);
-                eventOptions.keyCode = code;
-                eventOptions.which = code;
                 if (
                     code === 32 || // spacebar
                     (code > 47 && code < 58) || // number keys
@@ -571,8 +569,6 @@ export const stepUtils = {
                     cancelable: true,
                     key: "Enter",
                     code: "Enter",
-                    which: 13,
-                    keyCode: 13,
                 });
                 action.tip_widget.$anchor[0].dispatchEvent(keyEventEnter);
             },

--- a/addons/website/static/src/components/dialog/seo.js
+++ b/addons/website/static/src/components/dialog/seo.js
@@ -214,7 +214,7 @@ class MetaKeywords extends Component {
 
     onKeyup(ev) {
         // Add keyword on enter.
-        if (ev.keyCode === 13) {
+        if (ev.key === "Enter") {
             this.addKeyword(this.state.keyword);
         }
     }

--- a/addons/website/static/src/js/utils.js
+++ b/addons/website/static/src/js/utils.js
@@ -229,7 +229,7 @@ function prompt(options, _qweb) {
         });
         if (field.is('input[type="text"], select')) {
             field.keypress(function (e) {
-                if (e.which === 13) {
+                if (e.key === "Enter") {
                     e.preventDefault();
                     dialog.find('.btn-primary').trigger('click');
                 }

--- a/addons/website/static/src/snippets/s_searchbar/000.js
+++ b/addons/website/static/src/snippets/s_searchbar/000.js
@@ -239,24 +239,24 @@ publicWidget.registry.searchBar = publicWidget.Widget.extend({
      * @private
      */
     _onKeydown: function (ev) {
-        switch (ev.which) {
-            case $.ui.keyCode.ESCAPE:
+        switch (ev.key) {
+            case "Escape":
                 this._render();
                 break;
-            case $.ui.keyCode.UP:
-            case $.ui.keyCode.DOWN:
+            case "ArrowUp":
+            case "ArrowDown":
                 ev.preventDefault();
                 if (this.$menu) {
                     const focusableEls = [this.$input[0], ...this.$menu[0].children];
                     const focusedEl = document.activeElement;
                     const currentIndex = focusableEls.indexOf(focusedEl) || 0;
-                    const delta = ev.which === $.ui.keyCode.UP ? focusableEls.length - 1 : 1;
+                    const delta = ev.key === "ArrowUp" ? focusableEls.length - 1 : 1;
                     const nextIndex = (currentIndex + delta) % focusableEls.length;
                     const nextFocusedEl = focusableEls[nextIndex];
                     nextFocusedEl.focus();
                 }
                 break;
-            case $.ui.keyCode.ENTER:
+            case "Enter":
                 this.limit = 0; // prevent autocomplete
                 break;
         }

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -123,7 +123,7 @@ wTourUtils.dragNDrop({
         actionHelper.text('translated Parseltongue text');
         const { Wysiwyg } = odoo.loader.modules.get('@web_editor/js/wysiwyg/wysiwyg');
         Wysiwyg.setRange(this.$anchor.contents()[0], 22);
-        this.$anchor.trigger($.Event("keyup", {key: '_', keyCode: 95}));
+        this.$anchor.trigger($.Event("keyup", {key: '_'}));
         this.$anchor.trigger('input');
     },
 }, {
@@ -134,7 +134,7 @@ wTourUtils.dragNDrop({
         this.$anchor.prepend('&lt;{translated}&gt;');
         const { Wysiwyg } = odoo.loader.modules.get('@web_editor/js/wysiwyg/wysiwyg');
         Wysiwyg.setRange(this.$anchor.contents()[0], 0);
-        this.$anchor.trigger($.Event("keyup", {key: '_', keyCode: 95}));
+        this.$anchor.trigger($.Event("keyup", {key: '_'}));
         this.$anchor.trigger('input');
     },
 }, {

--- a/addons/website_links/static/src/js/website_links.js
+++ b/addons/website_links/static/src/js/website_links.js
@@ -420,7 +420,7 @@ publicWidget.registry.websiteLinks = publicWidget.Widget.extend({
      * @param {Event} ev
      */
     _onUrlKeyUp: function (ev) {
-        if (!$('#btn_shorten_url').hasClass('btn-copy') || ev.which === 13) {
+        if (!$('#btn_shorten_url').hasClass('btn-copy') || ev.key === "Enter") {
             return;
         }
 

--- a/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
+++ b/addons/website_livechat/static/tests/tours/website_livechat_session_user_changes.js
@@ -19,7 +19,7 @@ registry.category("web_tour.tours").add("website_livechat_login_after_chat_start
             trigger: ".o-mail-Composer-input",
             run: function () {
                 $("o-mail-Composer-input").trigger(
-                    $.Event("keydown", { which: $.ui.keyCode.ENTER })
+                    $.Event("keydown", { key: "Enter" })
                 );
             },
         },
@@ -79,7 +79,7 @@ registry.category("web_tour.tours").add("website_livechat_logout_after_chat_star
             trigger: ".o-mail-Composer-input",
             run: function () {
                 $(".o-mail-Composer-input").trigger(
-                    $.Event("keydown", { which: $.ui.keyCode.ENTER })
+                    $.Event("keydown", { key: "Enter" })
                 );
             },
         },

--- a/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
+++ b/addons/website_slides/static/src/js/slides_course_fullscreen_player.js
@@ -399,7 +399,7 @@
          * @param {Event} ev
          */
         _onKeypress: function (ev) {
-            if (ev.keyCode === $.ui.keyCode.ENTER) {
+            if (ev.key === "Enter") {
                 ev.preventDefault();
                 this._onShareByEmailClick();
             }

--- a/addons/website_slides/static/src/js/slides_embed.js
+++ b/addons/website_slides/static/src/js/slides_embed.js
@@ -199,10 +199,10 @@ $(function () {
 
         // switching slide with keyboard
         $(document).keydown(function (ev) {
-            if (ev.keyCode === 37 || ev.keyCode === 38) {
+            if (ev.key === "ArrowLeft" || ev.key === "ArrowUp") {
                 embeddedViewer.previous();
             }
-            if (ev.keyCode === 39 || ev.keyCode === 40) {
+            if (ev.key === "ArrowRight" || ev.key === "ArrowDown") {
                 embeddedViewer.next();
             }
         });

--- a/addons/website_slides/static/src/js/slides_share.js
+++ b/addons/website_slides/static/src/js/slides_share.js
@@ -27,7 +27,7 @@ export const ShareMail = publicWidget.Widget.extend({
      * @param {Event} ev
      */
     _onKeypress: function (ev) {
-        if (ev.keyCode === $.ui.keyCode.ENTER) {
+        if (ev.key === "Enter") {
             ev.preventDefault();
             this._sendMail();
         }


### PR DESCRIPTION
…perties

These properties are deprecated.

We should consider to use `KeyboardEvent.key` or `KeyboardEvent.code` for new code. Note that we prefer to use the `key` property as multiple physical keys can send the same value (e.g. Enter can also be sent by the numeric pad). We should only use `code` when we explicitly want to target a single physical key on the keyboard.

By doing this, we can now remove the dependency of `jQuery.ui.keyCode` that was used as mapping of key code descriptions to their numeric values.

References:
https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode (deprecated) https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode (deprecated) https://developer.mozilla.org/en-US/docs/Web/API/UIEvent/which (deprecated)

https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key

https://api.jqueryui.com/1.12/jQuery.ui.keyCode/

Some links that helps:
https://w3c.github.io/uievents/tools/key-event-viewer.html https://www.toptal.com/developers/keycode/table

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
