### PR TITLE
[FIX] web: graph: position correctly tooltips

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -110,16 +110,16 @@ export class GraphRenderer extends Component {
     customTooltip(data, metaData, context) {
         const tooltipModel = context.tooltip;
         const { measure, measures, disableLinking, mode } = metaData;
-        this.rootRef.el.style.cursor = "";
+        this.containerRef.el.style.cursor = "";
         this.removeTooltips();
         if (tooltipModel.opacity === 0 || tooltipModel.dataPoints.length === 0) {
             return;
         }
         if (!disableLinking && mode !== "line") {
-            this.rootRef.el.style.cursor = "pointer";
+            this.containerRef.el.style.cursor = "pointer";
         }
         const chartAreaTop = this.chart.chartArea.top;
-        const viewContentTop = this.rootRef.el.getBoundingClientRect().top;
+        const viewContentTop = this.containerRef.el.getBoundingClientRect().top;
         const innerHTML = renderToString("web.GraphRenderer.CustomTooltip", {
             maxWidth: getMaxWidth(this.chart.chartArea),
             measure: measures[measure].string,


### PR DESCRIPTION
Since c8ca9da7bcee2c122a9d6cf8cda89f02823ba42d, the tooltips in the charts can come out of the container and make the scrollbar appear, which is not desired. In this commit, we fix that.

task-3568895
