### PR TITLE
[FIX] base: no need for dynamic allocation of attribute in error

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1627,16 +1627,16 @@ actual arch.
                     if key == 'group_by':  # only in context
                         if not isinstance(val_ast, ast.Str):
                             msg = _(
-                                '"group_by" value must be a string %(attribute)s=%(value)r',
-                                attribute=attr, value=expr,
+                                '"group_by" value must be a string context=%(value)r',
+                                value=expr,
                             )
                             self._raise_view_error(msg, node)
                         group_by = val_ast.s
                         fname = group_by.split(':')[0]
                         if fname not in name_manager.model._fields:
                             msg = _(
-                                'Unknown field "%(field)s" in "group_by" value in %(attribute)s=%(value)r',
-                                field=fname, attribute=attr, value=expr,
+                                'Unknown field "%(field)s" in "group_by" value in context=%(value)r',
+                                field=fname, value=expr,
                             )
                             self._raise_view_error(msg, node)
                     else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

We restrict the 'attr' value to 'context' in the if condition, so there is no need to dynamically pass the 'attr' value again for the error message since we do not expect a different value other than 'context'.

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
