### PR TITLE
[FIX] mail: channel name overwritten

### DIFF
--- a/addons/mail/static/src/core/common/autoresize_input.js
+++ b/addons/mail/static/src/core/common/autoresize_input.js
@@ -66,7 +66,9 @@ export class AutoresizeInput extends Component {
     }
 
     onValidate() {
-        this.props.onValidate(this.state.value);
+        if (this.state.value !== this.props.value) {
+            this.props.onValidate(this.state.value);
+        }
         this.state.value = this.props.value;
     }
 


### PR DESCRIPTION
**Before this PR:**
When user creates a  channel by auto-subscribing and open it in another
window through the notification, the name of the channel get overwritten.

**After this PR:**
Then channel name does not gets overwritten.

task-3570377