### PR TITLE
[FIX] repair: handle parse-error if reinstall repair module

### DIFF
--- a/addons/repair/__init__.py
+++ b/addons/repair/__init__.py
@@ -16,3 +16,10 @@ def _create_warehouse_data(env):
         picking_type_vals = warehouse._create_or_update_sequences_and_picking_types()
         if picking_type_vals:
             warehouse.write(picking_type_vals)
+
+def uninstall_hook(env):
+    #clean-up sequences at uninstall
+    sequence_ids = env["stock.warehouse"].search([
+        ('repair_type_id', '!=', False)
+    ]).mapped('repair_type_id.sequence_id.id')
+    env['ir.sequence'].browse(sequence_ids).unlink()

--- a/addons/repair/__manifest__.py
+++ b/addons/repair/__manifest__.py
@@ -39,6 +39,7 @@ The following topics are covered by this module:
     ],
     'demo': ['data/repair_demo.xml'],
     'post_init_hook': '_create_warehouse_data',
+    'uninstall_hook': 'uninstall_hook',
     'installable': True,
     'application': True,
     'license': 'LGPL-3',


### PR DESCRIPTION
When users try to reinstall the "repair", a traceback will be generated.

Traceback:
```UserError: Sequences Info-Kod Skopje  Sequence RO already exist.
  File "odoo/tools/convert.py", line 550, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 451, in _tag_record
    record = model._load_records([data], self.mode == 'update')
  File "odoo/models.py", line 4729, in _load_records
    records = self._load_records_create([data['values'] for data in to_create])
  File "odoo/models.py", line 4640, in _load_records_create
    return self.create(values)
  File "<decorator-gen-215>", line 2, in create
  File "odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "addons/stock/models/stock_picking.py", line 122, in create
    return super().create(vals_list)
  File "<decorator-gen-12>", line 2, in create
  File "odoo/api.py", line 415, in _model_create_multi
    return create(self, arg)
  File "odoo/models.py", line 4274, in create
    records = self._create(data_list)
  File "odoo/models.py", line 4548, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "odoo/models.py", line 1454, in _validate_fields
    check(self)
  File "addons/stock/models/stock_picking.py", line 286, in _check_sequence_code
    raise UserError(_("Sequences %s already exist.",
ParseError: while parsing /home/odoo/src/odoo/saas-16.4/addons/repair/data/repair_data.xml:9, somewhere inside
<record id="picking_type_warehouse0_repair" model="stock.picking.type" forcecreate="0">
        <field name="name">Repairs</field>
        <field name="code">repair_operation</field>
        <field name="company_id" ref="base.main_company"/>
        <field name="default_location_src_id" ref="stock.stock_location_stock"/>
        <field name="default_location_dest_id" model="stock.location" search="[('usage'...
  File "odoo/modules/registry.py", line 113, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 613, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 679, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 599, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 563, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
```

When users try to reinstall the "repair", a traceback will be generated. Because duplicate sequence records exist, they raise the ParseError.

This commit solves the above issue by clean-up sequences the "repair" module uninstallation time.

code reference:
https://github.com/odoo/odoo/blob/a7f2d4420541ec9e974b961dd7bc9e5477ba999c/addons/stock/models/stock_picking.py#L286

https://github.com/odoo/odoo/blob/a7f2d4420541ec9e974b961dd7bc9e5477ba999c/addons/repair/data/repair_data.xml#L9

sentry-4570653150