### PR TITLE
[FIX] product: speed up _name_search when variants are disabled

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -578,7 +578,7 @@ class ProductTemplate(models.Model):
         # FIXME awa: this is really not performant at all but after discussing with the team
         # we don't see another way to do it
         tmpl_without_variant_ids = []
-        if not limit or len(searched_ids) < limit:
+        if self.env.user.has_group('product.group_product_variant') and (not limit or len(searched_ids) < limit):
             tmpl_without_variant_ids = self.env['product.template'].search(
                 [('id', 'not in', self.env['product.template']._search([('product_variant_ids.active', '=', True)]))]
             )


### PR DESCRIPTION
## Before this commit:
`_name_search` would scan the entire `product.product` table to find templates without any corresponding variants, which is expensive for databases with numerous products.

## After this commit:
`_name_search` skips templates without variants when variants are disabled, as each template should have exactly one variant.

### Benchmark for ~600k products
| Before | After |
|--------|--------|
| 1.837 s | 0.369s | 

opw-3489413