### PR TITLE
[FIX] web: fix pills resizing in weekly calendar view

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -154,9 +154,10 @@ export class CalendarCommonRenderer extends Component {
             title: record.title,
             start: record.start.toISO(),
             end:
-                ["week", "month"].includes(this.props.model.scale) &&
+                ["week", "month"].includes(this.props.model.scale) && allDay ||
                 (record.isAllDay ||
-                    (allDay && record.end.toMillis() !== record.end.startOf("day").toMillis()))
+                    (allDay && record.end.toMillis() !== record.end.startOf("day").toMillis())
+                )
                     ? record.end.plus({ days: 1 }).toISO()
                     : record.end.toISO(),
             allDay: allDay,

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -8,6 +8,7 @@ import {
     editSelect,
     getFixture,
     makeDeferred,
+    mockTimeout,
     nextTick,
     patchDate,
     patchTimeZone,
@@ -29,6 +30,7 @@ import {
     navigate,
     pickDate,
     resizeEventToTime,
+    resizeEventToDate,
     selectAllDayRange,
     selectDateRange,
     selectTimeRange,
@@ -5545,5 +5547,56 @@ QUnit.module("Views", ({ beforeEach }) => {
         await click(target, ".o_cp_switch_buttons .o_calendar");
 
         assert.ok(document.querySelector(".o_calendar_filter_item[data-value='all'] input").checked, "The value of the 'all' filter should remain the same as it was before re-rendering")
+    });
+
+    QUnit.test(`Resizing Pill of Multiple Days(Allday)`, async (assert) => {
+        const { advanceTime } = mockTimeout();
+        await makeView({
+            type: "calendar",
+            resModel: "event",
+            serverData,
+            arch: `
+                <calendar event_open_popup="1" date_start="start" date_stop="stop" all_day="allday" delete="0" mode="month" >
+                    <field name="stop"/>
+                </calendar>`,
+            mockRPC(route, { args, method }) {
+                if (method === "create") {
+                    assert.deepEqual(
+                        args[0],
+                        [
+                            {
+                                allday: true,
+                                name: "new event",
+                                start: "2016-12-25",
+                                stop: "2016-12-28",
+                            },
+                        ],
+                        "should send the correct data to create events"
+                    );
+                } else if (method === "write") {
+                    assert.deepEqual(args[1], {
+                        allday: true,
+                        start: "2016-12-25",
+                        stop: "2016-12-31",
+                    });
+                }
+            },
+        });
+
+        await selectAllDayRange(target, "2016-12-25", "2016-12-28");
+        await editInput(target, ".o-calendar-quick-create--input", "new event");
+        await click(target, ".o-calendar-quick-create--create-btn");
+        await resizeEventToDate(target, 8, "2016-12-31");
+        await clickEvent(target, 8);
+        await advanceTime(300);
+        assert.strictEqual(
+            target
+                .querySelector(
+                    ".o_cw_popover .o_cw_popover_fields_secondary .list-group-item .o_field_datetime"
+                )
+                .textContent.split(" ")[0],
+            "12/31/2016",
+            "should have correct stop date"
+        );
     });
 });

--- a/addons/web/static/tests/views/calendar/helpers.js
+++ b/addons/web/static/tests/views/calendar/helpers.js
@@ -509,6 +509,37 @@ export async function resizeEventToTime(target, eventId, dateTime) {
     await nextTick();
 }
 
+export async function resizeEventToDate(target, eventId, date) {
+    const event = findEvent(target, eventId);
+    const slot = findAllDaySlot(target, date);
+
+    await scrollTo(event);
+    await triggerEventForCalendar(event, "mouseenter");
+
+    // Find event resizer
+    const resizer = event.querySelector(".fc-end-resizer");
+    resizer.style.display = "block";
+    resizer.style.width = "100%";
+    resizer.style.height = "1em";
+    resizer.style.bottom = "0";
+    const resizerRect = resizer.getBoundingClientRect();
+    const resizerPos = {
+        x: resizerRect.x + resizerRect.width,
+        y: resizerRect.y + resizerRect.height / 2,
+    };
+    await triggerEventForCalendar(resizer, "mousedown", resizerPos);
+    // Find slot position
+    await scrollTo(slot, false);
+    const slotRect = slot.getBoundingClientRect();
+    const toPos = {
+        x: slotRect.x + slotRect.width / 2,
+        y: slotRect.y + slotRect.height / 2,
+    };
+    await triggerEventForCalendar(slot, "mousemove", toPos);
+    await triggerEventForCalendar(slot, "mouseup", toPos);
+    await nextTick();
+}
+
 export async function changeScale(target, scale) {
     await click(target, `.o_view_scale_selector .scale_button_selection`);
     await click(target, `.o_view_scale_selector .o_scale_button_${scale}`);


### PR DESCRIPTION
Steps to reproduce:
- Install planning and switch to calendar view
- try resizing the pill that is already resizable (pills that span for multiple days)

Issue:
pill resizing is not working as expected.

Cause:
the end date wasn't being calculated correctly for this.

Fix:
after this commit, the end date is calculated correctly.

task-3326281
