### PR TITLE
[FIX] pos_self_order: receipt payment lines

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -134,6 +134,10 @@ class PosOrder(models.Model):
                 }
                 for line in self.lines
             ],
+            "payment_lines": [{
+                "name": payment.payment_method_id.name,
+                "amount": payment.amount
+            } for payment in self.payment_ids],
             "tax_details": self._compute_tax_details(),
         }
 

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -498,7 +498,7 @@ export class SelfOrder extends Reactive {
             amount_tax: order.amount_tax,
             total_without_tax: order.amount_total - order.amount_tax,
             total_paid: order.amount_paid,
-            paymentlines: [{ name: "Bank", amount: order.amount_total }],
+            paymentlines: order.payment_lines,
             change: 0,
             tax_details: order.tax_details,
             name: order.pos_reference,


### PR DESCRIPTION
Fixes the receipt payment lines name (replacing "Bank" by the payment method name).

task-id: 3572422