### PR TITLE
[IMP] account: Splitting Amount to settle menu

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -335,7 +335,7 @@
                                         <t t-out="dashboard.number_waiting"/> Unpaid Invoices
                                     </a>
                                     <a type="object" name="open_action" t-if="journal_type == 'purchase'"
-                                    context="{'action_name': 'action_open_payment_items', 'search_default_purchases': '1'}">
+                                    context="{'action_name': 'action_open_purchase_payment_items', 'search_default_purchases': '1'}">
                                         <t t-out="dashboard.number_waiting"/> Bills to Pay
                                     </a>
                                 </div>
@@ -349,7 +349,7 @@
                                         <span><t t-out="dashboard.number_late"/> Late Invoices</span>
                                     </a>
                                     <a type="object" t-if="journal_type == 'purchase'" name="open_action"
-                                    context="{'action_name': 'action_open_payment_items', 'search_default_purchases': '1', 'search_default_late': '1'}">
+                                    context="{'action_name': 'action_open_purchase_payment_items', 'search_default_purchases': '1', 'search_default_late': '1'}">
                                         <span><t t-out="dashboard.number_late"/> Late Bills</span>
                                     </a>
                                 </div>

--- a/addons/account/views/account_menuitem.xml
+++ b/addons/account/views/account_menuitem.xml
@@ -11,6 +11,7 @@
             <menuitem id="menu_action_move_out_invoice_type" action="action_move_out_invoice_type" sequence="1"/>
             <menuitem id="menu_action_move_out_refund_type" action="action_move_out_refund_type" sequence="2"/>
             <menuitem id="menu_action_move_out_receipt_type" action="action_move_out_receipt_type" groups="account.group_sale_receipts" sequence="3"/>
+            <menuitem id="menu_action_open_sale_payment_items" action="action_open_sale_payment_items" sequence="10"/>
             <menuitem id="menu_action_account_payments_receivable" name="Payments" action="action_account_payments" sequence="15"/>
             <menuitem id="product_product_menu_sellable" name="Products" action="product_product_action_sellable" sequence="100"/>
             <menuitem id="menu_account_customer" name="Customers" action="res_partner_action_customer" sequence="110"/>
@@ -19,7 +20,7 @@
             <menuitem id="menu_action_move_in_invoice_type" action="action_move_in_invoice_type" sequence="1"/>
             <menuitem id="menu_action_move_in_refund_type" action="action_move_in_refund_type" sequence="2"/>
             <menuitem id="menu_action_move_in_receipt_type" action="action_move_in_receipt_type" groups="account.group_purchase_receipts" sequence="3"/>
-            <menuitem id="menu_action_open_payment_items" action="action_open_payment_items" sequence="10"/>
+            <menuitem id="menu_action_open_purchase_payment_items" action="action_open_purchase_payment_items" sequence="10"/>
             <menuitem id="menu_action_account_payments_payable" name="Payments" action="action_account_payments_payable" sequence="20"/>
             <menuitem id="menu_account_supplier_accounts" name="Bank Accounts" action="action_account_supplier_accounts" sequence="80"/>
             <menuitem id="product_product_menu_purchasable" name="Products" action="product_product_action_purchasable" sequence="100"/>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1689,19 +1689,36 @@
             </field>
         </record>
 
-        <record id="action_open_payment_items" model="ir.actions.act_window">
+        <record id="action_open_sale_payment_items" model="ir.actions.act_window">
             <field name="name">Amounts to Settle</field>
             <field name="res_model">account.move.line</field>
             <field name="view_mode">tree</field>
             <field name="view_id" ref="view_move_line_payment_tree"/>
             <field name="search_view_id" ref="view_account_move_line_payment_filter"/>
             <field name="context">{'search_default_group_by_partner':1, 'expand':1}</field>
-            <field name="domain">[('parent_state', '=', 'posted'), ('amount_residual', '!=', 0), ('account_id.reconcile', '=', True)]</field>
+            <field name="domain">[('parent_state', '=', 'posted'), ('amount_residual', '&lt;', 0), ('account_id.reconcile', '=', True), ('journal_id.type', '=', 'sale')]</field>
             <field name="help" type="html">
                 <p class="o_view_nocontent_smiling_face">
                     Amounts to settle
                 </p><p>
-                    Cool, it looks like you don't have anything to pay either for vendor bills or for customer credit notes.
+                    Cool, it looks like you don't have any customer credit notes to pay.
+                </p>
+            </field>
+        </record>
+
+        <record id="action_open_purchase_payment_items" model="ir.actions.act_window">
+            <field name="name">Amounts to Settle</field>
+            <field name="res_model">account.move.line</field>
+            <field name="view_mode">tree</field>
+            <field name="view_id" ref="view_move_line_payment_tree"/>
+            <field name="search_view_id" ref="view_account_move_line_payment_filter"/>
+            <field name="context">{'search_default_group_by_partner':1, 'expand':1}</field>
+            <field name="domain">[('parent_state', '=', 'posted'), ('amount_residual', '&lt;', 0), ('account_id.reconcile', '=', True), ('journal_id.type', '=', 'purchase')]</field>
+            <field name="help" type="html">
+                <p class="o_view_nocontent_smiling_face">
+                    Amounts to settle
+                </p><p>
+                    Cool, it looks like you don't have any vendor bills to pay.
                 </p>
             </field>
         </record>


### PR DESCRIPTION
Current behavior before PR:
Currently, the "Amounts to settle" button in the "Vendors" drop-down menu opens a view showing all the account.move.line that are to be reconciled. Also, they should only be shown when their residual is less than zero.

Desired behavior after PR is merged:
This commit makes it now so that when clicking on that button, only the amls linked to a purchase journal are shown and another "Amounts to Settle" button has been added in the "Customers" drop-down menu to show the amls linked to a sale journal

Enterprise:https://github.com/odoo/enterprise/pull/49649

task-3572482

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
