### PR TITLE
[FIX] web_editor: traceback when creating a link in dev mode

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_dialog.js
@@ -10,6 +10,7 @@ export class LinkDialog extends Link {
     static props = {
         ...Link.props,
         focusField: { type: String, optional: true },
+        close: { type: Function },
         onClose: { type: Function },
         onSave: { type: Function },
     };


### PR DESCRIPTION
Reproduction:

1. Activate the dev mode
2. Create a link
3. Traceback

Fix: declare the close function, the close function is needed as the
dialog_service adds close as a prop here: https://github.com/odoo/odoo/blob/b02d7fe6c4eaee09066cf58d0e9bad91e3a3234d/addons/web/static/src/core/dialog/dialog_service.js#L70

task-3572349



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
