### PR TITLE
[FIX] mail: wrong use of group_based_subscription

### DIFF
--- a/addons/mail/static/src/core/common/suggestion_service.js
+++ b/addons/mail/static/src/core/common/suggestion_service.js
@@ -14,7 +14,7 @@ export class SuggestionService {
         this.env = env;
         this.orm = services.orm;
         this.store = services["mail.store"];
-        this.personaService = services['mail.persona'];
+        this.personaService = services["mail.persona"];
     }
 
     getSupportedDelimiters(thread) {
@@ -100,7 +100,7 @@ export class SuggestionService {
             thread &&
             (thread.type === "group" ||
                 thread.type === "chat" ||
-                (thread.type === "channel" && thread.group_based_subscription));
+                (thread.type === "channel" && thread.authorizedGroupFullName));
         if (isNonPublicChannel) {
             // Only return the channel members when in the context of a
             // group restricted channel. Indeed, the message with the mention

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.js
@@ -84,9 +84,9 @@ export class DiscussSidebarCategories extends Component {
     filteredThreads(category) {
         return category.threads.filter((thread) => {
             return (
-                (thread.is_pinned || thread.group_based_subscription) &&
+                (["channel", "group"].includes(thread.type) || thread.is_pinned) &&
                 (!this.state.quickSearchVal ||
-                    cleanTerm(thread.name).includes(cleanTerm(this.state.quickSearchVal)))
+                    cleanTerm(thread.displayName).includes(cleanTerm(this.state.quickSearchVal)))
             );
         });
     }


### PR DESCRIPTION
1. `searchPartnerSuggestions` uses`authorizedGroupFullName` to see if the channel is public or not
2. `filteredThreads` uses channel type check to see if the channel is the allowed types

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
