### PR TITLE
[FIX] base: avoid conflict during populate

### DIFF
--- a/odoo/addons/base/populate/res_company.py
+++ b/odoo/addons/base/populate/res_company.py
@@ -17,10 +17,12 @@ class Partner(models.Model):
     }
 
     def _populate_factories(self):
+        last_id = self.env["res.company"].search([], order="id desc", limit=1).id
+
         # remaining: paperformat_id, parent_id, partner_id, favicon, font, report_header, external_report_layout_id, report_footer
         ref = self.env.ref
         def get_name(values=None, counter=0, **kwargs):
-            return 'company_%s_%s' % (counter, self.env['res.currency'].browse(values['currency_id']).name)
+            return 'company_%s_%s' % (last_id + counter + 1, self.env['res.currency'].browse(values['currency_id']).name)
         return [
             ('name', populate.constant('company_{counter}')),
             ('sequence', populate.randint(0, 100)),

--- a/odoo/addons/base/populate/res_user.py
+++ b/odoo/addons/base/populate/res_user.py
@@ -16,6 +16,8 @@ class Users(models.Model):
     _populate_dependencies = ["res.partner"]
 
     def _populate_factories(self):
+        last_id = self.env["res.users"].search([], order="id desc", limit=1).id
+
         partner_ids = list(self.env.registry.populated_models["res.partner"])
 
         def get_partner_id(random=None, **kwargs):
@@ -23,10 +25,17 @@ class Users(models.Model):
             partner_ids.remove(partner_id)
             return partner_id
 
+        def compute_login(values=None, counter=0, **kwargs):
+            return f'user_login_{last_id + counter + 1}'
+
+        def compute_name(values=None, counter=0, **kwargs):
+            return f'user_{last_id + counter + 1}'
+
         return [
             ("active", populate.cartesian([True, False], [0.9, 0.1])),
             ("partner_id", populate.compute(get_partner_id)),
-            ("login", populate.constant("user_login_{counter}")),
+            ('login', populate.compute(compute_login)),
+            ('name', populate.compute(compute_name)),
         ]
 
     def _populate(self, scale):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
partial backport of c5f8cb4f90c8cc903d0261f2c6978c8e297d4282 to avoid same errors

Current behavior before PR:
during populate on runbot:
`ERROR: duplicate key value violates unique constraint "res_company_name_uniq" DETAIL:  Key (name)=(company_0_EUR) already exists`

Desired behavior after PR is merged:
no more errors



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
