### PR TITLE
[FIX] website_event_track: handle overflow error for large duration value

### DIFF
--- a/addons/website_event_track/i18n/website_event_track.pot
+++ b/addons/website_event_track/i18n/website_event_track.pot
@@ -2103,6 +2103,12 @@ msgid "Thank you for your proposal."
 msgstr ""
 
 #. module: website_event_track
+#: code:addons/website_event_track/models/event_track.py:0
+#, python-format
+msgid "The entered duration creates a date too far into the future."
+msgstr ""
+
+#. module: website_event_track
 #: model:ir.model.fields,help:website_event_track.field_event_track__website_url
 msgid "The full URL to access the document through the website."
 msgstr ""

--- a/addons/website_event_track/models/event_track.py
+++ b/addons/website_event_track/models/event_track.py
@@ -10,6 +10,7 @@ from odoo.addons.http_routing.models.ir_http import slug
 from odoo.osv import expression
 from odoo.tools.mail import is_html_empty
 from odoo.tools.translate import _, html_translate
+from odoo.exceptions import UserError
 
 
 class Track(models.Model):
@@ -273,8 +274,11 @@ class Track(models.Model):
     def _compute_end_date(self):
         for track in self:
             if track.date:
-                delta = timedelta(minutes=60 * track.duration)
-                track.date_end = track.date + delta
+                try:
+                    delta = timedelta(minutes=60 * track.duration)
+                    track.date_end = track.date + delta
+                except OverflowError:
+                    raise UserError(_("The entered duration creates a date too far into the future."))
             else:
                 track.date_end = False
 


### PR DESCRIPTION
This issue occurs when we enter the large value(1111111111) in the `duration` field.

Steps to produce:
- Install `website_event_track` module.
- Go to Events > Tracks > Create new record.
- Select any `track date` and enter the large duration value(e.g.1111111111)
- Save the record > Error will be generated.

See traceback:
```
OverflowError: date value out of range
  File "odoo/http.py", line 2139, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1715, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1742, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1943, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 467, in call_kw
    model.env.flush_all()
  File "odoo/api.py", line 711, in flush_all
    self._recompute_all()
  File "odoo/api.py", line 707, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "odoo/models.py", line 6466, in _recompute_field
    field.recompute(records)
  File "odoo/fields.py", line 1367, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1340, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1389, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 395, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4553, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/website_event_track/models/event_track.py", line 267, in _compute_end_date
    track.date_end = track.date + delta
```

This issue occurs because here 
https://github.com/odoo/odoo/blob/39fa1f851e53eed633d04145752293fb93cc41f7/addons/website_event_track/models/event_track.py#L277
when calculating the `track end date` based on theprovided duration value,an error is triggered.

sentry-4573940256

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
