### PR TITLE
[FIX] loyalty: make next order coupon nominative

### DIFF
--- a/addons/loyalty/models/loyalty_program.py
+++ b/addons/loyalty/models/loyalty_program.py
@@ -156,7 +156,7 @@ class LoyaltyProgram(models.Model):
     def _compute_is_nominative(self):
         for program in self:
             program.is_nominative = program.applies_on == 'both' or\
-                (program.program_type == 'ewallet' and program.applies_on == 'future')
+                (program.program_type in ['ewallet', 'next_order_coupons'] and program.applies_on == 'future')
 
     @api.depends('program_type')
     def _compute_is_payment_program(self):


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create a promotion program of type "Next Order Coupons";
- create a sale order that create a coupon for this program;

Issue:
------
The coupon generated is not linked to the partner.

Cause:
------
A partner is linked to the coupon generated if the program is nominative.

Solution:
---------
include the `next_order_coupons` program type
in nominative programs.

opw-3556119