### PR TITLE
[FIX] web_editor: mass mailing linktool input not focusable, fixed style

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -730,7 +730,7 @@ export class OdooEditor extends EventTarget {
             if (fontSizeInput && ev.target.closest('#font-size .dropdown-toggle')) {
                 // If the click opened the font size dropdown, select the input content.
                 fontSizeInput.select();
-            } else if (!this.isSelectionInEditable()) {
+            } else if (!this.isSelectionInEditable() && !this.isSelectionInMassMailingToolbar()) {
                 // Otherwise, if we lost the selection in the editable, restore it.
                 this.historyResetLatestComputedSelection(true);
             }
@@ -4121,6 +4121,20 @@ export class OdooEditor extends EventTarget {
             const focusElement = closestElement(selection.focusNode);
             return anchorElement && anchorElement.isContentEditable && focusElement && focusElement.isContentEditable &&
                 this.editable.contains(selection.anchorNode) && this.editable.contains(selection.focusNode);
+        } else {
+            return false;
+        }
+    }
+    /**
+     * Returns true if the current selection is inside the toolbar of massmailing.
+     *
+     * @param {Object} [selection]
+     * @returns {boolean}
+     */
+    isSelectionInMassMailingToolbar(selection) {
+        selection = selection || this.document.getSelection();
+        if (selection && selection.anchorNode && selection.focusNode && this.toolbar.ownerDocument && this.document === this.toolbar.ownerDocument) {
+            return this.toolbar.contains(selection.anchorNode) && this.toolbar.contains(selection.focusNode);
         } else {
             return false;
         }

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link_tools.js
@@ -159,7 +159,7 @@ export class LinkTools extends Link {
         super._setSelectOptionFromLink(...arguments);
         const link = this.$link[0];
         const customStyleProps = ['color', 'background-color', 'background-image', 'border-width', 'border-style', 'border-color'];
-        const shapeClasses = ['btn-outline-primary', 'btn-outline-secondary', 'btn-fill-primary', 'btn-fill-secondary', 'rounded-circle', 'flat'];
+        const shapeClasses = ['btn-outline-primary', 'btn-outline-secondary', 'btn-fill-primary', 'btn-fill-secondary', 'flat'];
         if (customStyleProps.some(s => link.style[s]) || shapeClasses.some(c => link.classList.contains(c))) {
             // Force custom style if style or shape exists on the link.
             const customOption = this.$el[0].querySelector('[name="link_style_color"] we-button[data-value="custom"]');


### PR DESCRIPTION
Reproduction:

1. In mass mailing, using the template with button
2. Click on the button and edit it using link tool
3. When clicking in the URL input and the label input, the focus is always reset to the button
4. The style of the link is always custom

Fix: Use isSelectionInBlockRoot to include when selection is in the linktool; Remove the rounded-circle from the shape classes because it is also set for default styles like primary button and secondary button so it’s not accurate for customized style

task-3508580

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
