### PR TITLE
[FIX] {mass_mailing_,}sms, tools: fix links and characters counts

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -12,6 +12,7 @@ from odoo import tools, models, fields, api, _
 from odoo.exceptions import UserError
 from odoo.osv import expression
 
+LINK_TRACKER_MIN_CODE_LENGTH = 3
 URL_MAX_SIZE = 10 * 1024 * 1024
 
 
@@ -269,7 +270,7 @@ class LinkTrackerCode(models.Model):
 
     @api.model
     def _get_random_code_strings(self, n=1):
-        size = 3
+        size = LINK_TRACKER_MIN_CODE_LENGTH
         while True:
             code_propositions = [
                 ''.join(random.choices(string.ascii_letters + string.digits, k=size))

--- a/addons/mass_mailing_sms/__manifest__.py
+++ b/addons/mass_mailing_sms/__manifest__.py
@@ -28,6 +28,11 @@
         'wizard/sms_composer_views.xml',
         'wizard/mailing_sms_test_views.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'mass_mailing_sms/static/src/js/fields_sms_widget.js',
+        ],
+    },
     'demo': [
         'data/utm_demo.xml',
         'data/mailing_list_demo.xml',

--- a/addons/mass_mailing_sms/i18n/mass_mailing_sms.pot
+++ b/addons/mass_mailing_sms/i18n/mass_mailing_sms.pot
@@ -16,6 +16,29 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: mass_mailing_sms
+#. openerp-web
+#: code:addons/mass_mailing_sms/static/src/js/fields_sms_widget.js:0
+#, python-format
+msgid ""
+"%s characters (including link trackers and opt-out link), fits in %s SMS "
+"(%s) "
+msgstr ""
+
+#. module: mass_mailing_sms
+#. openerp-web
+#: code:addons/mass_mailing_sms/static/src/js/fields_sms_widget.js:0
+#, python-format
+msgid "%s characters (including link trackers), fits in %s SMS (%s) "
+msgstr ""
+
+#. module: mass_mailing_sms
+#. openerp-web
+#: code:addons/mass_mailing_sms/static/src/js/fields_sms_widget.js:0
+#, python-format
+msgid "%s characters (including opt-out link), fits in %s SMS (%s) "
+msgstr ""
+
+#. module: mass_mailing_sms
 #: model_terms:ir.ui.view,arch_db:mass_mailing_sms.mailing_sms_test_view_form
 msgid ""
 "+32 495 85 85 77\n"
@@ -699,6 +722,12 @@ msgstr ""
 #: code:addons/mass_mailing_sms/wizard/sms_composer.py:0
 #, python-format
 msgid "STOP SMS : %s"
+msgstr ""
+
+#. module: mass_mailing_sms
+#: code:addons/mass_mailing_sms/wizard/sms_composer.py:0
+#, python-format
+msgid "STOP SMS : %(unsubscribe_url)s"
 msgstr ""
 
 #. module: mass_mailing_sms

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -3,7 +3,10 @@
 
 import logging
 
+from urllib.parse import urljoin
+
 from odoo import api, fields, models, _
+from odoo.addons.link_tracker.models.link_tracker import LINK_TRACKER_MIN_CODE_LENGTH
 from odoo.exceptions import UserError
 from odoo.osv import expression
 
@@ -29,7 +32,7 @@ class Mailing(models.Model):
     # 'sms_subject' should have the same helper as 'subject' field when 'mass_mailing_sms' installed.
     # otherwise 'sms_subject' will get the old helper from 'mass_mailing' module.
     # overriding 'subject' field helper in this model is not working, since the helper will keep the new value
-    # even when 'mass_mailing_sms' removed (see 'mailing_mailing_view_form_sms' for more details).                    
+    # even when 'mass_mailing_sms' removed (see 'mailing_mailing_view_form_sms' for more details).
     sms_subject = fields.Char('Title', help='For an email, the subject your recipients will see in their inbox.\n'
                               'For an SMS, the internal title of the message.',
                               related='subject', translate=False, readonly=False)
@@ -66,7 +69,7 @@ class Mailing(models.Model):
 
     @api.depends('mailing_trace_ids.failure_type')
     def _compute_sms_has_iap_failure(self):
-        failures = ['sms_acc', 'sms_credit'] 
+        failures = ['sms_acc', 'sms_credit']
         if not self.ids:
             self.sms_has_insufficient_credit = self.sms_has_unregistered_account = False
         else:
@@ -323,6 +326,39 @@ class Mailing(models.Model):
             res[mailing.id] = body
         res.update(super(Mailing, self - sms_mailings).convert_links())
         return res
+
+    def get_sms_link_replacements_placeholders(self):
+        """Get placeholders for replaced links in sms widget for accurate computation of sms counts.
+
+        Reminders and assumptions:
+          * Links wille be transformed to the format "[base_url]/r/[link_tracker_code]/s/[sms_id]".
+          * unsubscribe is formatted as: "\nSTOP SMS : [base_url]/sms/[mailing_id]/[trace_code]".
+
+        :return: Character counts used for links, formatted as `{link: str, unsubscribe: str}`.
+        """
+        if self:
+            self.ensure_one()
+
+        self.check_access_rights('write')
+
+        max_sms = self.env['sms.sms'].sudo().search_read([], ['id'], order='id desc', limit=1)
+        sms_id_length = max(len(str(max_sms[0]['id'])), 5) if max_sms else 5  # Assumes a mailing won't be more than 10⁵ sms at once
+        max_code = self.env['link.tracker.code'].sudo().search_read([], ['code'], order='id DESC', limit=1)
+        code_length = len(max_code[0]['code']) + 1 if max_code else LINK_TRACKER_MIN_CODE_LENGTH
+
+        if self.id:
+            mailing_id_placeholder_length = len(str(self.id))
+        else:
+            max_mailing = self.env['mailing.mailing'].sudo().search_read([], ['id'], order='id DESC', limit=1)
+            mailing_id_placeholder_length = len(str(max_mailing[0]['id'] + 1)) if max_mailing else 1
+        mailing_id_placeholder = 'x' * mailing_id_placeholder_length
+
+        base_url = self.get_base_url()
+        opt_out_url = urljoin(base_url, f"sms/{mailing_id_placeholder}/{'x' * self.env['mailing.trace'].CODE_SIZE}")
+        return {
+            'link': urljoin(base_url, f"r/{'x' * code_length}/s/{'x' * sms_id_length}"),
+            'unsubscribe': f"\n{self.env['sms.composer']._get_unsubscribe_info(opt_out_url)}"
+        }
 
     # ------------------------------------------------------
     # A/B Test Override

--- a/addons/mass_mailing_sms/static/src/js/fields_sms_widget.js
+++ b/addons/mass_mailing_sms/static/src/js/fields_sms_widget.js
@@ -1,0 +1,86 @@
+/** @odoo-module **/
+
+import { _t } from "web.core";
+import SmsWidget from '@sms/js/fields_sms_widget';
+
+const TEXT_URL_REGEX = /https?:\/\/[\w@:%.+&~#=/-]+(?:\?\S+)?/g;  // from tools.mail.TEXT_URL_REGEX
+
+/**
+ * Override to provide extra characters count information to
+ * consider links converted with link_tracker and opt-out
+ * link if the option is selected.
+ */
+SmsWidget.include({
+    events: _.extend({}, SmsWidget.prototype.events || {}, {
+        'focusin': '_onClick',
+    }),
+    /**
+     *@override
+     */
+    willStart: async function () {
+        await this._super.apply(this, arguments);
+        if (this.model === "mailing.mailing" && this.mode === 'edit') {
+            const { unsubscribe, link } = await this._rpc({
+                model: 'mailing.mailing',
+                method: 'get_sms_link_replacements_placeholders',
+                args: [this.res_id]
+            });
+            this.linkReplacementsPlaceholders = { unsubscribe, link };
+            this.noticeLinksReplaced = false;
+        }
+    },
+    /**
+     * Add the characters for opt-out link if enabled.
+     *
+     * @override
+     */
+    _compute: function() {
+        this._super.apply(this, arguments);
+        if (!this.linkReplacementsPlaceholders) {
+            return;
+        }
+        // this is the simplest way to read from another field in a legacy fix.
+        const unsubscribe_el = document.querySelector('div[name="sms_allow_unsubscribe"] input');
+        if (unsubscribe_el && unsubscribe_el.checked) {
+            this.optOutEnabled = true;
+            this.nbrChar += this.linkReplacementsPlaceholders.unsubscribe.length;
+        }
+    },
+    /**
+     * Add the applicable extra characters notice.
+     *
+     * @override
+     */
+    _getNbrCharExplanationTemplate: function () {
+        if (this.optOutEnabled) {
+            return this.noticeLinksReplaced
+                ? _t("%s characters (including link trackers and opt-out link), fits in %s SMS (%s) ")
+                : _t("%s characters (including opt-out link), fits in %s SMS (%s) ");
+        }
+        return this.noticeLinksReplaced
+            ? _t("%s characters (including link trackers), fits in %s SMS (%s) ")
+            : this._super.apply(this, arguments); // Also default when no linkReplacementsPlaceholders
+    },
+    /**
+     * Convert links to link trackers-length replacements.
+     * Works under the assumption that these trackers urls only
+     * contain GSM7 characters.
+     *
+     * @override
+     */
+    _getValueForSmsCounts: function () {
+        const value = this._super.apply(this, arguments);
+        if (this.linkReplacementsPlaceholders) {
+            const replaced = value.replaceAll(TEXT_URL_REGEX, this.linkReplacementsPlaceholders.link);
+            this.noticeLinksReplaced = replaced !== value;
+            return replaced;
+        }
+        return value;
+    },
+    _onClick: function() {
+        this._super.apply(this, arguments);
+        if (this.linkReplacementsPlaceholders) {  // covers mailing and edit mode
+            this._updateSMSInfo();
+        }
+    }
+});

--- a/addons/mass_mailing_sms/tests/test_mailing_internals.py
+++ b/addons/mass_mailing_sms/tests/test_mailing_internals.py
@@ -59,3 +59,32 @@ class TestMassMailValues(MassSMSCommon):
             'contact_list_ids': [(4, self.mailing_list_1.id), (4, self.mailing_list_2.id)]
         })
         self.assertEqual(literal_eval(mailing.mailing_domain), [('list_ids', 'in', (self.mailing_list_1 | self.mailing_list_2).ids)])
+
+    @users('user_marketing')
+    def test_mailing_get_sms_link_replacements_placeholders(self):
+        """Test the extra chars counts for estimating total SMS characters length.
+
+          * links are transformed into "[base_url]/r/[link_tracker_code]/s/[sms_id]".
+          * opt-out link is formatted as "\nSTOP SMS : [base_url]/sms/[mailing_id]/[trace_code]".
+        See `get_sms_link_replacements_placeholders` for safety characters.
+        """
+        mailing = self.env['mailing.mailing'].create({
+            'body_plaintext': 'Coucou hibou',
+            'mailing_model_id': self.env['ir.model']._get('res.partner').id,
+            'mailing_type': 'sms',
+            'name': 'TestMailing',
+            'subject': 'Test',
+        })
+        base_url = self.env['mailing.mailing'].get_base_url()
+
+        expected = {
+            'link': f'{base_url}/r/xxxx/s/xxxxx',
+            'unsubscribe': f"\nSTOP SMS : {base_url}/sms/{'x' * len(str(mailing.id))}/{'x' * self.env['mailing.trace'].CODE_SIZE}",
+        }
+        self.assertDictEqual(mailing.get_sms_link_replacements_placeholders(), expected)
+
+        no_mailing = self.env['mailing.mailing']
+        self.assertDictEqual(no_mailing.get_sms_link_replacements_placeholders(), expected)
+
+        new_mailing = self.env['mailing.mailing'].new()
+        self.assertDictEqual(new_mailing.get_sms_link_replacements_placeholders(), expected)

--- a/addons/mass_mailing_sms/wizard/sms_composer.py
+++ b/addons/mass_mailing_sms/wizard/sms_composer.py
@@ -3,7 +3,7 @@
 
 import werkzeug.urls
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 
 
 class SMSComposer(models.TransientModel):
@@ -24,6 +24,10 @@ class SMSComposer(models.TransientModel):
             '/sms/%s/%s' % (self.mailing_id.id, trace_code)
         )
 
+    @api.model
+    def _get_unsubscribe_info(self, url):
+        return _('STOP SMS : %(unsubscribe_url)s', unsubscribe_url=url)
+
     def _prepare_mass_sms_trace_values(self, record, sms_values):
         trace_code = self.env['mailing.trace']._get_random_code()
         trace_values = {
@@ -42,7 +46,8 @@ class SMSComposer(models.TransientModel):
             trace_values['trace_status'] = 'cancel'
         else:
             if self.mass_sms_allow_unsubscribe:
-                sms_values['body'] = '%s\n%s' % (sms_values['body'] or '', _('STOP SMS : %s', self._get_unsubscribe_url(record.id, trace_code, sms_values['number'])))
+                stop_sms = self._get_unsubscribe_info(self._get_unsubscribe_url(record.id, trace_code, sms_values['number']))
+                sms_values['body'] = '%s\n%s' % (sms_values['body'] or '', stop_sms)
         return trace_values
 
     def _get_optout_record_ids(self, records, recipients_info):

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -5,7 +5,8 @@ import logging
 
 from odoo import api, models, fields
 from odoo.addons.phone_validation.tools import phone_validation
-from odoo.tools import html2plaintext, plaintext2html
+from odoo.addons.sms.tools.sms_tools import sms_content_to_rendered_html
+from odoo.tools import html2plaintext
 
 _logger = logging.getLogger(__name__)
 
@@ -146,6 +147,15 @@ class MailThread(models.AbstractModel):
                 }
         return result
 
+    @api.returns('mail.message', lambda value: value.id)
+    def message_post(self, *args, body='', message_type='notification', **kwargs):
+        # When posting an 'SMS' `message_type`, make sure that the body is used as-is in the sms,
+        # and reformat the message body for the notification (mainly making URLs clickable).
+        if message_type == 'sms':
+            kwargs['sms_content'] = body
+            body = sms_content_to_rendered_html(body)
+        return super().message_post(*args, body=body, message_type=message_type, **kwargs)
+
     def _message_sms_schedule_mass(self, body='', template=False, active_domain=None, **composer_values):
         """ Shortcut method to schedule a mass sms sending on a recordset.
 
@@ -229,7 +239,7 @@ class MailThread(models.AbstractModel):
             subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note')
 
         return self.message_post(
-            body=plaintext2html(html2plaintext(body)), partner_ids=partner_ids or [],  # TDE FIXME: temp fix otherwise crash mail_thread.py
+            body=body, partner_ids=partner_ids or [],  # TDE FIXME: temp fix otherwise crash mail_thread.py
             message_type='sms', subtype_id=subtype_id,
             sms_numbers=sms_numbers, sms_pid_to_number=sms_pid_to_number,
             **kwargs
@@ -241,7 +251,7 @@ class MailThread(models.AbstractModel):
         return recipients_data
 
     def _notify_record_by_sms(self, message, recipients_data, msg_vals=False,
-                              sms_numbers=None, sms_pid_to_number=None,
+                              sms_content=None, sms_numbers=None, sms_pid_to_number=None,
                               check_existing=False, put_in_queue=False, **kwargs):
         """ Notification method: by SMS.
 
@@ -249,10 +259,14 @@ class MailThread(models.AbstractModel):
         :param recipients_data: see ``_notify_thread``;
         :param msg_vals: see ``_notify_thread``;
 
+        :param sms_content: plaintext version of body, mainly to avoid
+          conversion glitches by splitting html and plain text content formatting
+          (e.g.: links, styling.).
+          If not given, `msg_vals`'s `body` is used and converted from html to plaintext;
         :param sms_numbers: additional numbers to notify in addition to partners
           and classic recipients;
         :param pid_to_number: force a number to notify for a given partner ID
-              instead of taking its mobile / phone number;
+          instead of taking its mobile / phone number;
         :param check_existing: check for existing notifications to update based on
           mailed recipient, otherwise create new notifications;
         :param put_in_queue: use cron to send queued SMS instead of sending them
@@ -264,9 +278,9 @@ class MailThread(models.AbstractModel):
         sms_all = self.env['sms.sms'].sudo()
 
         # pre-compute SMS data
-        body = msg_vals['body'] if msg_vals and msg_vals.get('body') else message.body
+        body = sms_content or html2plaintext(msg_vals['body'] if msg_vals and msg_vals.get('body') else message.body)
         sms_base_vals = {
-            'body': html2plaintext(body),
+            'body': body,
             'mail_message_id': message.id,
             'state': 'outgoing',
         }

--- a/addons/sms/static/src/js/fields_sms_widget.js
+++ b/addons/sms/static/src/js/fields_sms_widget.js
@@ -62,11 +62,19 @@ var SmsWidget = FieldTextEmojis.extend({
      * @private
      */
     _compute: function () {
-        var content = this._getValue();
+        const content = this._getValueForSmsCounts();
         this.encoding = this._extractEncoding(content);
         this.nbrChar = content.length;
         this.nbrChar += (content.match(/\n/g) || []).length;
         this.nbrSMS = this._countSMS(this.nbrChar, this.encoding);
+    },
+
+    _getValueForSmsCounts: function () {
+        return this._getValue();
+    },
+
+    _getNbrCharExplanationTemplate: function () {
+        return _t("%s characters, fits in %s SMS (%s) ");
     },
 
     /**
@@ -122,8 +130,8 @@ var SmsWidget = FieldTextEmojis.extend({
      * @private
      */
     _renderSMSInfo: function () {
-        var string = _.str.sprintf(_t('%s characters, fits in %s SMS (%s) '), this.nbrChar, this.nbrSMS, this.encoding);
-        var $span = $('<span>', {
+        const string = _.str.sprintf(this._getNbrCharExplanationTemplate(), this.nbrChar, this.nbrSMS, this.encoding);
+        const $span = $('<span>', {
             'class': 'text-muted o_sms_count',
         });
         $span.text(string);
@@ -134,9 +142,9 @@ var SmsWidget = FieldTextEmojis.extend({
      * Update widget SMS information with re-computed info about length, ...
      * @private
      */
-    _updateSMSInfo: function ()  {
+    _updateSMSInfo: function () {
         this._compute();
-        var string = _.str.sprintf(_t('%s characters, fits in %s SMS (%s) '), this.nbrChar, this.nbrSMS, this.encoding);
+        const string = _.str.sprintf(this._getNbrCharExplanationTemplate(), this.nbrChar, this.nbrSMS, this.encoding);
         this.$('.o_sms_count').text(string);
     },
 

--- a/addons/sms/static/src/js/fields_sms_widget.js
+++ b/addons/sms/static/src/js/fields_sms_widget.js
@@ -44,11 +44,14 @@ var SmsWidget = FieldTextEmojis.extend({
         var def = this._super.apply(this, arguments);
 
         this._compute();
-        $('.o_sms_container').remove();
-        var $sms_container = $('<div class="o_sms_container"/>');
+        const $sms_container = $('<div class="o_sms_container"/>');
+        if (!document.contains($sms_container[0])) {
+            this.$el = this.$el.add($sms_container);
+        } else {
+            $sms_container.empty();
+        }
         $sms_container.append(this._renderSMSInfo());
         $sms_container.append(this._renderIAPButton());
-        this.$el = this.$el.add($sms_container);
 
         return def;
     },

--- a/addons/sms/tests/__init__.py
+++ b/addons/sms/tests/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_sms_composer
 from . import test_sms_template

--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -183,8 +183,9 @@ class SMSCase(MockSMS):
         self.assertEqual(self.env['mail.notification'].search(base_domain), self.env['mail.notification'])
         self.assertEqual(self._sms, [])
 
-    def assertSMSNotification(self, recipients_info, content, messages=None, check_sms=True, sent_unlink=False):
-        """ Check content of notifications.
+    def assertSMSNotification(self, recipients_info, content, messages=None, check_sms=True, sent_unlink=False,
+                              mail_message_values=None):
+        """ Check content of notifications and sms.
 
           :param recipients_info: list[{
             'partner': res.partner record (may be empty),
@@ -192,6 +193,8 @@ class SMSCase(MockSMS):
             'state': ready / sent / exception / canceled (sent by default),
             'failure_type': optional: sms_number_missing / sms_number_format / sms_credit / sms_server
             }, { ... }]
+          :param content: SMS content
+          :param mail_message_values: dictionary of expected mail message fields values
         """
         partners = self.env['res.partner'].concat(*list(p['partner'] for p in recipients_info if p.get('partner')))
         numbers = [p['number'] for p in recipients_info if p.get('number')]
@@ -218,7 +221,8 @@ class SMSCase(MockSMS):
 
             notif = notifications.filtered(lambda n: n.res_partner_id == partner and n.sms_number == number and n.notification_status == state)
             self.assertTrue(notif, 'SMS: not found notification for %s (number: %s, state: %s)' % (partner, number, state))
-
+            for field_name, expected_value in (mail_message_values or {}).items():
+                self.assertEqual(notif.mail_message_id[field_name], expected_value)
             if state not in ('sent', 'ready', 'canceled'):
                 self.assertEqual(notif.failure_type, recipient_info['failure_type'])
             if check_sms:
@@ -237,8 +241,9 @@ class SMSCase(MockSMS):
                     raise NotImplementedError('Not implemented')
 
         if messages is not None:
-            for message in messages:
-                self.assertEqual(content, tools.html2plaintext(message.body).rstrip('\n'))
+            with patch("odoo.tools.mail.tags_to_remove", tools.mail.tags_to_remove + ["a"]):
+                for message in messages:
+                    self.assertEqual(content, tools.html2plaintext(tools.html_sanitize(message.body)).rstrip('\n'))
 
     def assertSMSLogged(self, records, body):
         for record in records:

--- a/addons/sms/tests/test_sms_composer.py
+++ b/addons/sms/tests/test_sms_composer.py
@@ -1,0 +1,106 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from unittest.mock import patch
+
+from odoo.addons.sms.models.mail_thread import MailThread
+from odoo.addons.sms.tests.common import SMSCommon, SMSCase
+from odoo.tests import tagged
+from odoo.tools import html2plaintext, plaintext2html
+
+
+@tagged('at_install')
+class TestSMSComposerComment(SMSCommon, SMSCase):
+    """ Test behaviors that are overridden when other modules
+    are installed (e.g., mass_mailing). In these cases,
+    test_mail_sms or test_mail_full should be used."""
+
+    def test_message_post_sms_vs_notification(self):
+        """Check that the conversion of html to plain text does remove links
+
+        This is necessary when an SMS is sent from message_post with sms type
+        and not from _message_sms. In this case, it can be expected to receive html
+        that should be interpreted as such instead of escaped before being sent.
+
+        Note that as it is not simple nor desirable to inline replace a link such as
+        `<a href="href">Here</a>` to `href` in the sms, we keep the footnote behavior
+        of html2plaintext in this case (see second case tested).
+        """
+        cases = [
+            (
+                'Hello there, check this awesome <b>app</b> I found:<br/>https://odoo.com',  # not a `a` link in source
+                '<p>Hello there, check this awesome &lt;b&gt;app&lt;/b&gt; I found:&lt;br/&gt;<a href="https://odoo.com" target="_blank" rel="noreferrer noopener">https://odoo.com</a></p>',
+                'Hello there, check this awesome <b>app</b> I found:<br/>https://odoo.com'
+            ), (
+                'Hello there, check this awesome <b>app</b> I found:<br/><a href="https://odoo.com">Here</a>',   # a link
+                '<p>Hello there, check this awesome &lt;b&gt;app&lt;/b&gt; I found:&lt;br/&gt;&lt;a href="<a href="https://odoo.com%22&gt;Here&lt;/a&gt;" target="_blank" rel="noreferrer noopener">https://odoo.com"&gt;Here&lt;/a&gt;</a></p>',
+                'Hello there, check this awesome <b>app</b> I found:<br/><a href="https://odoo.com">Here</a>'  # keep all information
+            )
+        ]
+
+        for message_content, expected_notification_content, expected_sms_content in cases:
+            with self.subTest(message_content=message_content):
+                with self.with_user('admin'), self.mockSMSGateway():
+                    message = self.env.user.partner_id.message_post(
+                        body=message_content, message_type='sms', sms_numbers=['+3215228817386'])
+
+                self.assertSMSNotification(
+                    [{'number': '+3215228817386'}], expected_sms_content, message,
+                    mail_message_values={"body": expected_notification_content},
+                )
+
+    def test_message_sms_body_sms_vs_notification(self):
+        """Check that the rendering of the sms notification is identical to the sms.
+
+        The only expected difference is that links are converted to be clickable.
+        The test verifies that MailThread._message_sms() works as expected."""
+        # Cases are formatted as (sms text, expected notification body, old notification body rendering)
+        # The last element is used to show what bug is fixed with this commit from 15.0.
+        # todo: clean in master.
+        cases = [
+            (
+                "Hello there, check this awesome app I found:\nhttps://odoo.com",
+                '<p>Hello there, check this awesome app I found:<br>'
+                '<a href="https://odoo.com" target="_blank" rel="noreferrer noopener">https://odoo.com</a></p>',
+                # same
+                '<p>Hello there, check this awesome app I found:<br/>'
+                '<a href="https://odoo.com" target="_blank" rel="noreferrer noopener">https://odoo.com</a></p>',
+            ), (
+                "Hello there, check this awesome <b>app</b> I found:\nhttps://odoo.com",
+                # b is kept as is in notification, but link is still added as well
+                '<p>Hello there, check this awesome &lt;b&gt;app&lt;/b&gt; I found:<br>'
+                '<a href="https://odoo.com" target="_blank" rel="noreferrer noopener">https://odoo.com</a></p>',
+                # html was interpreted and converted
+                '<p>Hello there, check this awesome *app* I found:<br/>'
+                '<a href="https://odoo.com" target="_blank" rel="noreferrer noopener">https://odoo.com</a></p>',
+            ),
+            (
+                # Here, we check that the sms sent is the sms written.
+                # The only expected difference is that links are converted to be clickable.
+                # Note that we acknowledge the erroneous href created in the notification*
+                # left for later *: todo: fix (probably in master)
+                "Hello there, check this awesome <b>app</b> I found:\n*https://odoo.com*",
+                '<p>Hello there, check this awesome &lt;b&gt;app&lt;/b&gt; I found:<br>'
+                '*<a href="https://odoo.com*" target="_blank" rel="noreferrer noopener">https://odoo.com*</a></p>',
+                '<p>Hello there, check this awesome *app* I found:<br/>'
+                '*<a href="https://odoo.com*" target="_blank" rel="noreferrer noopener">https://odoo.com*</a></p>',
+            ),
+        ]
+
+        for sms_content, expected_notification_content, old_expected_notification_content in cases:
+            with self.subTest(sms_content=sms_content):
+                # compare with old rendering
+                old_notification_content = plaintext2html(html2plaintext(sms_content))
+                self.assertEqual(old_notification_content, old_expected_notification_content, msg=old_notification_content)
+
+                with self.with_user('admin'):
+                    composer = self.env['sms.composer'].with_context(
+                        active_model='res.partner', active_id=self.partner_employee).create({'body': sms_content})
+                    _message_sms_patch = patch.object(
+                        MailThread, '_message_sms', autospec=True, side_effect=MailThread._message_sms)
+                    with self.mockSMSGateway(), _message_sms_patch as _patched_message_sms:
+                        messages = composer._action_send_sms()
+                        _patched_message_sms.assert_called()  # make sure we're testing `_message_sms` too
+                self.assertSMSNotification(
+                    [{'partner': self.partner_employee}], sms_content, messages,
+                    mail_message_values={"body": expected_notification_content},
+                )

--- a/addons/sms/tools/__init__.py
+++ b/addons/sms/tools/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import tools
-from . import wizard
+from . import sms_tools

--- a/addons/sms/tools/sms_tools.py
+++ b/addons/sms/tools/sms_tools.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+
+from odoo.tools import html_escape, html_keep_url
+
+
+def sms_content_to_rendered_html(text):
+    """Transforms plaintext into html making urls clickable and preserving newlines"""
+    text_with_links = html_keep_url(str(html_escape(text)))
+    return re.sub(r'\r?\n|\r', '<br/>', text_with_links)

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -5,8 +5,8 @@ from ast import literal_eval
 
 from odoo import api, fields, models, _
 from odoo.addons.phone_validation.tools import phone_validation
+from odoo.addons.sms.tools.sms_tools import sms_content_to_rendered_html
 from odoo.exceptions import UserError
-from odoo.tools import html2plaintext, plaintext2html
 
 
 class SendSMS(models.TransientModel):
@@ -349,7 +349,7 @@ class SendSMS(models.TransientModel):
     def _prepare_log_body_values(self, sms_records_values):
         result = {}
         for record_id, sms_values in sms_records_values.items():
-            result[record_id] = plaintext2html(html2plaintext(sms_values['body']))
+            result[record_id] = sms_content_to_rendered_html(sms_values['body'])
         return result
 
     def _prepare_mass_log_values(self, records, sms_records_values):

--- a/addons/test_mail_full/tests/test_sms_post.py
+++ b/addons/test_mail_full/tests/test_sms_post.py
@@ -28,9 +28,9 @@ class TestSMSPost(TestMailFullCommon, TestMailFullRecipients):
             test_record = self.env['mail.test.sms'].browse(self.test_record.id)
             messages = test_record._message_sms('<p>Mega SMS<br/>Top moumoutte</p>', partner_ids=self.partner_1.ids)
 
-        self.assertEqual(messages.body, '<p>Mega SMS<br>Top moumoutte</p>')
+        self.assertEqual(messages.body, '<p>&lt;p&gt;Mega SMS&lt;br/&gt;Top moumoutte&lt;/p&gt;</p>')  # html should not be interpreted
         self.assertEqual(messages.subtype_id, self.env.ref('mail.mt_note'))
-        self.assertSMSNotification([{'partner': self.partner_1}], 'Mega SMS\nTop moumoutte', messages)
+        self.assertSMSNotification([{'partner': self.partner_1}], '<p>Mega SMS<br/>Top moumoutte</p>', messages)
 
     def test_message_sms_internals_check_existing(self):
         with self.with_user('employee'), self.mockSMSGateway(sim_error='wrong_number_format'):
@@ -56,9 +56,9 @@ class TestSMSPost(TestMailFullCommon, TestMailFullRecipients):
             test_record = self.env['mail.test.sms'].browse(self.test_record.id)
             messages = test_record._message_sms('<p>Mega SMS<br/>Top moumoutte</p>', subtype_id=self.env.ref('mail.mt_comment').id, partner_ids=self.partner_1.ids)
 
-        self.assertEqual(messages.body, '<p>Mega SMS<br>Top moumoutte</p>')
+        self.assertEqual(messages.body, '<p>&lt;p&gt;Mega SMS&lt;br/&gt;Top moumoutte&lt;/p&gt;</p>')  # html should not be interpreted
         self.assertEqual(messages.subtype_id, self.env.ref('mail.mt_comment'))
-        self.assertSMSNotification([{'partner': self.partner_1}], 'Mega SMS\nTop moumoutte', messages)
+        self.assertSMSNotification([{'partner': self.partner_1}], '<p>Mega SMS<br/>Top moumoutte</p>', messages)
 
     def test_message_sms_internals_pid_to_number(self):
         pid_to_number = {


### PR DESCRIPTION
#### Commit 1
[FIX] sms, tools: prevent adding link references in sms

This fix prevents the conversion of urls into reference footnotes
in sent sms (adding characters and imparing readability) when 
coming from raw text (in opposition to html source).

#### Commit 2
[FIX] mass_mailing_sms: fix characters count with (opt-out) links

Also impacted: sms

When adding opt-out link or any link in the text, the characters
count was incorrect which made SMS campaigns more expensive than
expected when added characters meant more SMS to send for the
message.

#### Commit 3
[FIX] sms: fix disappearing sms counts

To reproduce: 
1. On a contact form view, click the `SMS` to send an SMS to a customer.
2. Enter some characters in the body textarea
3. Click outside the textarea

At this point the count disappears and does not return on re-entering either.

This solves it. (We keep jquery to keep this short and simple, as it will 
be obsolete with OWL in more recent versions anyway).

Task-3502174