### PR TITLE
[FIX]mass_mailing: prevent traceback mail body empty while sending

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1034,10 +1034,12 @@ class MassMailing(models.Model):
             if not res_ids:
                 raise UserError(_('There are no recipients selected.'))
 
+            body_html_default = f"""<p><br><p>"""
+
             composer_values = {
                 'author_id': author_id,
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
-                'body': mailing._prepend_preview(mailing.body_html, mailing.preview),
+                'body': mailing._prepend_preview(mailing.body_html or body_html_default, mailing.preview),
                 'subject': mailing.subject,
                 'model': mailing.mailing_model_real,
                 'email_from': mailing.email_from,


### PR DESCRIPTION
When a user creates a mailing, adds the Preview Text of the email content, and then sends or schedules that mailing without selecting a template from the mail body, at that time the error will be generated in the backend.

step to reproduce-
- install the `Email Marketing`
- open `Email Marketing` > click new mail.
- go to the `settings` note page
- enter the string of preview text of email content.
- not select any template from the mail body -click on the send button.
- the error will be generated.

```
TypeError: expected string or bytes-like object
  File "odoo/tools/safe_eval.py", line 365, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(527,)", line 1, in <module>
  File "addons/mass_mailing/models/mailing.py", line 1125, in _process_mass_mailing_queue
    mass_mailing.action_send_mail()
  File "addons/mass_mailing/models/mailing.py", line 1064, in action_send_mail
    'body': mailing._prepend_preview(mailing.body_html, mailing.preview),
  File "addons/mail/models/mail_render_mixin.py", line 203, in _prepend_preview
    return tools.prepend_html_content(html, html_preview)
  File "odoo/tools/mail.py", line 494, in prepend_html_content
    body_match = re.search(r'<body[^>]*>', html_body) or re.search(r'<html[^>]*>', html_body)
  File "re.py", line 200, in search
    return _compile(pattern, flags).search(string)
ValueError: <class 'TypeError'>: "expected string or bytes-like object" while evaluating
'model._process_mass_mailing_queue()'
  File "odoo/addons/base/models/ir_cron.py", line 373, in _callback
    self.env['ir.actions.server'].browse(server_action_id).run()
  File "home/odoo/src/custom/trial/saas_trial/models/sentry.py", line 33, in run
    res = super().run()
  File "odoo/addons/base/models/ir_actions.py", line 688, in run
    res = runner(run_self, eval_context=eval_context)
  File "addons/website/models/ir_actions_server.py", line 61, in _run_action_code_multi
    res = super(ServerAction, self)._run_action_code_multi(eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 558, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "odoo/tools/safe_eval.py", line 379, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```

If the user has not chosen a template from the mail body after this commit, then there should be no tracebacks in the backend.

sentry-4551336791
