### PR TITLE
[FIX] stock: indivisible quantity on serial tracking

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -230,7 +230,7 @@
                     <field name="state" column_invisible="True"/>
                     <field name="is_locked" column_invisible="True"/>
                     <field name="picking_code" column_invisible="True"/>
-                    <field name="quantity" string="Quantity" readonly="(state == 'done' and is_locked) or (package_level_id and parent.picking_type_entire_packs)" sum="Quantity"/>
+                    <field name="quantity" string="Quantity" readonly="(state == 'done' and is_locked) or (package_level_id and parent.picking_type_entire_packs) or (tracking == 'serial')" sum="Quantity"/>
                     <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"
                         readonly="(package_level_id and parent.picking_type_entire_packs) or (state == 'done' and id)"/>
                 </tree>


### PR DESCRIPTION
Main Changes:
    Enforce the quantity set on a move or move line with serial tracking to be parts of Whole numbers (in the product UoM).
Before:
    It is possible to break a quantity tracked by a serial number
After:
    When the user break a quantity tracked by a serial number, we round this quantity as a Whole number in the respective product UoM

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
