### PR TITLE
[IMP] mail: do not wait for init_messaging at webclient startup

### DIFF
--- a/addons/mail/static/src/core/common/chat_window_container.js
+++ b/addons/mail/static/src/core/common/chat_window_container.js
@@ -7,15 +7,7 @@ import {
     CHAT_WINDOW_WIDTH,
 } from "@mail/core/common/chat_window_service";
 
-import {
-    Component,
-    onWillStart,
-    useExternalListener,
-    useState,
-    onMounted,
-    useRef,
-    useEffect,
-} from "@odoo/owl";
+import { Component, useExternalListener, useState, onMounted, useRef, useEffect } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
 import { Dropdown } from "@web/core/dropdown/dropdown";
@@ -48,9 +40,8 @@ export class ChatWindowContainer extends Component {
         this.hiddenMenuRef = useRef("hiddenMenu");
         useEffect(
             () => this.setHiddenMenuOffset(),
-            () => [this.chatWindowService.hidden]
+            () => [this.chatWindowService.hidden, this.store.isMessagingReady]
         );
-        onWillStart(() => this.messaging.isReady);
         onMounted(() => this.setHiddenMenuOffset());
 
         this.onResize();

--- a/addons/mail/static/src/core/common/chat_window_container.xml
+++ b/addons/mail/static/src/core/common/chat_window_container.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.ChatWindowContainer">
-    <div class="o-mail-ChatWindowContainer" t-if="!store.discuss.isActive or ui.isSmall">
+    <div class="o-mail-ChatWindowContainer" t-if="store.isMessagingReady and (!store.discuss.isActive or ui.isSmall)">
         <div t-if="chatWindowService.hidden.length > 0 and !ui.isSmall" t-ref="hiddenMenu" class="o-mail-ChatWindow-hiddenMenuContainer position-fixed bottom-0">
             <t t-call="mail.ChatWindowHiddenMenu"/>
         </div>


### PR DESCRIPTION
The messaging service starts synchronously and exposes a promise isReady that is resolved when the call to init_messaging is done. This is good as this call thus doesn't slow down the services startup and thus the webclient mount.

Unfortunately, the ChatWindowContainer, which is a main component, i.e. a child of the WebClient, waits for that promise in its onWillStart. As a consequence, the webclient can't be mounted until the rpc returns, which can take a while (in odoo.com, this rpc lasts ~500ms).

The chat windows being "peripherical components", there's no reason to block the whole application for them. Instead, the webclient can be mounted, and when they are ready, the chat windows can be rendered. This is what this commit does.

closes odoo/odoo#139750

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
