### PR TITLE
WIP [IMP] stock, sale_stock: improvements for sale_stock_renting

### DIFF
--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -46,7 +46,7 @@ class StockMove(models.Model):
         return self.sale_line_id.order_id or res
 
     def _get_sale_order_lines(self):
-        """ Return all possible sale order lines for one or multiple stock moves. """
+        """ Return all possible sale order lines for one stock move. """
         def _get_origin_moves(move):
             origin_moves = move.move_orig_ids
             if origin_moves:
@@ -59,6 +59,7 @@ class StockMove(models.Model):
                 destination_moves += _get_destination_moves(destination_moves)
             return destination_moves
 
+        self.ensure_one()
         return (self + _get_origin_moves(self) + _get_destination_moves(self)).sale_line_id
 
     def _assign_picking_post_process(self, new=False):


### PR DESCRIPTION
_get_sale_order_lines() should only be used for a single move. 
force_qty repurposed as a dictionnary for sale_stock_renting. Kept the behavior for the quantity part and added a flow for lot_ids


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
