### PR TITLE
[FIX] mrp: ui improvement

### DIFF
--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.js
@@ -21,7 +21,7 @@ export class BomOverviewComponent extends Component {
         this.state = useState({
             showOptions: {
                 uom: false,
-                availabilities: true,
+                availabilities: false || this.props.action.context.activate_availabilities,
                 costs: true,
                 operations: true,
                 leadTimes: true,

--- a/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
+++ b/addons/mrp/static/src/mrp_forecasted/forecasted_buttons.js
@@ -18,6 +18,7 @@ patch(ForecastedButtons.prototype, {
             additionalContext: {
                 active_id: this.bomId,
                 active_product_id: this.productId,
+                activate_availabilities : true,
             },
         });
     }

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -72,8 +72,8 @@
                     <field name="reservation_state" optional="hide" decoration-danger="reservation_state == 'confirmed'" decoration-success="reservation_state == 'assigned'"/>
                     <field name="product_qty" sum="Total Qty" string="Quantity" readonly="1" optional="show"/>
                     <field name="product_uom_id" string="UoM" readonly="1" options="{'no_open':True,'no_create':True}" groups="uom.group_uom" optional="show"/>
-                    <field name="duration_expected" invisible="duration_expected == 0" groups="mrp.group_mrp_routings" widget="float_time" sum="Total expected duration" optional="show"/>
-                    <field name="duration" invisible="duration == 0" groups="mrp.group_mrp_routings" widget="float_time" sum="Total real duration" optional="show"/>
+                    <field name="duration_expected" invisible="duration_expected == 0" groups="mrp.group_mrp_routings" widget="float_time" sum="Total expected duration" optional="hide"/>
+                    <field name="duration" invisible="duration == 0" groups="mrp.group_mrp_routings" widget="float_time" sum="Total real duration" optional="hide"/>
                     <field name="company_id" readonly="1" groups="base.group_multi_company" optional="show"/>
                     <field name="state"
                            decoration-success="state in ('done', 'to_close')"


### PR DESCRIPTION
This commit fixes:
 - hide `read_duration` and `expected_duration` in MO list view.
 - hide `component availability` byt default in bom overview, unless if coming from mrp forecast.

task-3547356

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
