### PR TITLE
[FIX] stock: Replace generate_serial widget with button

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -171,7 +171,10 @@
                         <group/>
                     </group>
                     <div class="d-flex">
-                        <widget class="btn btn-link btn-group" name="generate_serials" invisible="not display_assign_serial"/>
+                        <!-- The button is done this way to align it with the import widget-->
+                        <div class="btn btn-link btn-group">
+                            <button class="btn btn-link" name="action_assign_serial" type="object">Generate Serials</button>
+                        </div>
                         <widget class="btn btn-link btn-group" name="import_lots" invisible="not display_import_lot"/>
                     </div>
                     <field name="move_line_ids"


### PR DESCRIPTION
Before this commit, In Transfer form,
when you click the burger icon on a stock move and click Generate Serials, it will always generate new lines. Even if lines already exist, which is the case for Serial tracked products. This is a problem with the widget. The `action_assign_serial`
button works well from the tree view and was added in the form instead of the widget.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
