### PR TITLE
[FIX] mail: center avatar with composer with a single line

### DIFF
--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -14,7 +14,7 @@
                     'p-3': normal,
                     'o-hasSelfAvatar px-3': !env.inChatWindow and thread,
                 }" t-attf-class="{{ props.className }}">
-            <div class="o-mail-Composer-sidebarMain flex-shrink-0" t-if="!compact and props.sidebar">
+            <div class="o-mail-Composer-sidebarMain flex-shrink-0 pt-1" t-if="!compact and props.sidebar">
                 <img class="o-mail-Composer-avatar o_avatar rounded" t-att-src="threadService.avatarUrl(store.self, props.composer.thread)" alt="Avatar of user"/>
             </div>
             <div class="o-mail-Composer-coreHeader text-truncate small p-2" t-if="props.composer.thread and props.messageToReplyTo?.thread === props.composer.thread">


### PR DESCRIPTION
Before this commit, the avatar next to composer in Discuss app had the top aligned with the top of the text input of composer. The avatar is smaller than the input, and the text in the input is centered, so the alignment looks off.

This commit fixes the issue by offseting the avatar so that when the composer has only 1 line, the avatar is vertically centered with the input.

Note that this alignment should be fixed, i.e. if the input field has more than 1 line, we want to keep the avatar in the same place, hence why the avatar is just statically offset.

Before
![before](https://github.com/odoo/odoo/assets/6569390/64f5bac2-5517-4737-92f2-d0427efe43d9)

After
![after](https://github.com/odoo/odoo/assets/6569390/4a125a99-a4e1-4cb8-9697-3c152f516134)

Rules
![rules](https://github.com/odoo/odoo/assets/6569390/462d4716-0002-4b68-a205-b864550d4de6)
