### PR TITLE
[FIX] point_of_sale,web,web_editor: fix barcode scanner for employees

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -103,9 +103,9 @@
             'barcodes_gs1_nomenclature/static/src/js/barcode_service.js',
             'web/static/src/legacy/js/core/class.js',
             'web/static/src/views/fields/parsers.js',
-            'web/static/src/webclient/barcode/barcode_scanner.js',
-            'web/static/src/webclient/barcode/ZXingBarcodeDetector.js',
-            'web/static/src/webclient/barcode/crop_overlay.js',
+            'web/static/src/webclient/barcode/**/*',
+            'web/static/src/legacy/xml/base.xml',
+            'web/static/src/legacy/js/core/bus.js',
             # report download utils
             'web/static/src/webclient/actions/reports/utils.js',
             # libs

--- a/addons/web/static/src/webclient/barcode/barcode_scanner.js
+++ b/addons/web/static/src/webclient/barcode/barcode_scanner.js
@@ -201,14 +201,14 @@ export function isBarcodeScannerSupported() {
  *
  * @returns {Promise<string>} resolves when a {qr,bar}code has been detected
  */
-export async function scanBarcode(facingMode = "environment") {
+export async function scanBarcode(facingMode = "environment", env = owl.Component.env) {
     const promise = new Promise((resolve, reject) => {
         bus.on(busOk, null, resolve);
         bus.on(busError, null, reject);
     });
     const appForBarcodeDialog = new App(BarcodeDialog, {
-        env: owl.Component.env,
-        dev: owl.Component.env.isDebug(),
+        env: env,
+        dev: "isDebug" in env ? env.isDebug() : env.debug,
         templates,
         translatableAttributes: ["data-tooltip"],
         translateFn: _t,


### PR DESCRIPTION
Current behavior:
When you activate multiple employees per session in PoS, and assign a barcode to each employee, when you start the PoS you should be able to scan the barcode of the employee to login. But it doesn't work. The barcode scanner dialog is not working properly

Steps to reproduce:
- activate multiple employees per session in PoS
- assign a barcode to each employee
- start the PoS

opw-3539047
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
