### PR TITLE
[FIX] web: add vertical align to buttons in list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -106,6 +106,7 @@
             }
             &.o_list_button {
                 white-space: nowrap;
+                vertical-align: middle;
                 > button {
                     padding: 0 5px;
                     &:not(:last-child) {
@@ -156,6 +157,7 @@
 
         .o_list_record_remove, .o_handle_cell {
             width: 1px;  // to prevent the column to expand
+            vertical-align: middle;
         }
 
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Following the changes in 902fcba, it added a new vertical alignment for elements in a list view.
The issue is that since `o_list_button` are excluded from the new rules, when we have a line thicker than one line, the buttons won't be aligned with the other fields anymore.
Same issue with `o_list_record_remove` and `o_handle_cell` that won't be aligned with the other fields either.

Example in the Purchase app
Current behavior before PR:
![image](https://github.com/odoo/odoo/assets/18055894/4aed65e6-8097-450a-8daa-629cd1a97002)

Desired behavior after PR is merged:
![image](https://github.com/odoo/odoo/assets/18055894/1d8569ab-5172-4e17-9d62-8211905085ff)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
