### PR TITLE
[FIX] purchase : Tax excluded spanish translation

### DIFF
--- a/addons/purchase/i18n/es.po
+++ b/addons/purchase/i18n/es.po
@@ -2793,7 +2793,7 @@ msgstr "Método de redondeo del cálculo de impuestos"
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form
 msgid "Tax excl."
-msgstr "Impuestos incluidos"
+msgstr "Impuestos no incluidos"
 
 #. module: purchase
 #: model_terms:ir.ui.view,arch_db:purchase.purchase_order_form


### PR DESCRIPTION
[FIX] purchase : Tax excluded spanish translation

Current behavior before PR:
There were two columns named "Impuestos incluidos" which is translated into taxes included where one of them is actually referring to Tax excluded amount

Desired behavior after PR is merged:
Translation has been corrected

opw-3471103