### PR TITLE
[FIX] pivot: grouping error in sales and pos_order pivot

### DIFF
--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -220,7 +220,7 @@
         <field name="model">pos.order</field>
         <field name="arch" type="xml">
             <pivot string="PoS Orders" sample="1">
-                <field name="date_order" type="row"/>
+                <field name="date_order" interval="month" type="row"/>
                 <field name="margin"/>
                 <field name="margin_percent" invisible="1"/>
                 <field name="amount_total" type="measure"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -59,7 +59,7 @@
         <field name="model">sale.order</field>
         <field name="arch" type="xml">
             <pivot string="Sales Orders" sample="1">
-                <field name="date_order" type="row"/>
+                <field name="date_order" interval="month" type="row"/>
                 <field name="amount_total" type="measure"/>
             </pivot>
         </field>


### PR DESCRIPTION
When opening the pivot view in the sale_order and pos_order, a stop iteration error occurred due to an incorrect groupby name.

This PR resolves the issue by using the correct field name.

TaskId: [3555252](https://www.odoo.com/web#id=3555252&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
