### PR TITLE
[FIX] point_of_sale: should not load default pricelist

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1665,10 +1665,13 @@ class PosSession(models.Model):
         for tax in loaded_data['taxes_by_id'].values():
             tax['children_tax_ids'] = [loaded_data['taxes_by_id'][id] for id in tax['children_tax_ids']]
 
-        for pricelist in loaded_data['product.pricelist']:
-            if pricelist['id'] == self.config_id.pricelist_id.id:
-                loaded_data['default_pricelist'] = pricelist
-                break
+        if self.config_id.use_pricelist:
+            default_pricelist = next(
+                (pl for pl in loaded_data['product.pricelist'] if pl['id'] == self.config_id.pricelist_id.id),
+                False
+            )
+            if default_pricelist:
+                loaded_data['default_pricelist'] = default_pricelist
 
         fiscal_position_by_id = {fpt['id']: fpt for fpt in self._get_pos_ui_account_fiscal_position_tax(
             self._loader_params_account_fiscal_position_tax())}

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -262,8 +262,7 @@ class ResConfigSettings(models.TransientModel):
                 ('currency_id', '=', currency_id),
             ])
             if not res_config.pos_use_pricelist:
-                res_config.pos_available_pricelist_ids = pricelists_in_current_currency[:1]
-                res_config.pos_pricelist_id = pricelists_in_current_currency[:1]
+                res_config.pos_pricelist_id = False
             else:
                 if any([p.currency_id.id != currency_id for p in res_config.pos_available_pricelist_ids]):
                     res_config.pos_available_pricelist_ids = pricelists_in_current_currency

--- a/addons/point_of_sale/tests/test_point_of_sale_flow.py
+++ b/addons/point_of_sale/tests/test_point_of_sale_flow.py
@@ -1798,3 +1798,18 @@ class TestPointOfSaleFlow(TestPointOfSaleCommon):
 
         moves = self.env['account.move'].search([('ref', '=', f'pos_order_{order.id}')])
         self.assertEqual(len(moves), 2)
+
+    def test_no_default_pricelist(self):
+        """Should not have default_pricelist if use_pricelist is false."""
+
+        pricelist = self.env['product.pricelist'].create({
+            'name': 'Test Pricelist',
+        })
+        self.pos_config.write({
+            'pricelist_id': pricelist.id,
+            'use_pricelist': False,
+        })
+        self.pos_config.open_ui()
+        loaded_data = self.pos_config.current_session_id.load_pos_data()
+
+        self.assertFalse(loaded_data.get('default_pricelist', False))


### PR DESCRIPTION
Pricelist is no longer required. Because of that, pos no longer need to implicitly load a default pricelist when "Flexible Pricelists" (use_pricelist) flag is active. Therefore, when deactivating the option, we clear the value of pos.config.pricelist_id.

We also make sure that during loading of data when opening a session, default_pricelist is not set if use_pricelist is false.

Also note that we are not clearing available_pricelist_ids because of some limitation in the synchronization between res.config.settings and pos.config. It's okay to keep the links because it won't be loaded when use_pricelist is false. Also, it's nice to see it filled when reactivating the flag.

