### PR TITLE
[FIX] account: alert spacing above the sheet

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -629,7 +629,7 @@
                                 attrs="{'invisible' : [('to_check', '=', False)]}" data-hotkey="k" />
                         <field name="state" widget="statusbar" statusbar_visible="draft,posted"/>
                     </header>
-                    <div class="alert alert-warning mb-0" role="alert"
+                    <div class="alert alert-warning mb-2" role="alert"
                          attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('duplicated_ref_ids', '=', [])]}">
                         Warning: this bill might be a duplicate of
                         <button name="open_duplicated_ref_bill_view"
@@ -638,17 +638,17 @@
                                 class="btn btn-link p-0"
                         />
                     </div>
-                    <div class="alert alert-info mb-0" role="alert" attrs="{'invisible': [('is_being_sent', '=', False)]}">
+                    <div class="alert alert-info mb-2" role="alert" attrs="{'invisible': [('is_being_sent', '=', False)]}">
                         This invoice is being sent in the background.
                     </div>
                     <!-- Invoice outstanding credits -->
                     <div groups="account.group_account_invoice,account.group_account_readonly"
-                         class="alert alert-warning mb-0" role="alert"
+                         class="alert alert-warning mb-2" role="alert"
                          attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('tax_lock_date_message', '=', False)]}">
                         <field name="tax_lock_date_message" nolabel="1"/>
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
-                         class="alert alert-info mb-0" role="alert"
+                         class="alert alert-info mb-2" role="alert"
                          attrs="{'invisible': ['|', '|', ('move_type', 'not in', ('out_invoice', 'out_receipt')), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> for this customer. You can allocate them to mark this invoice as paid.
                     </div>
@@ -658,34 +658,34 @@
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> for this vendor. You can allocate them to mark this bill as paid.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
-                         class="alert alert-info mb-0" role="alert"
+                         class="alert alert-info mb-2" role="alert"
                          attrs="{'invisible': ['|', '|', ('move_type', '!=', 'out_refund'), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> for this customer. You can allocate them to mark this credit note as paid.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
-                         class="alert alert-info mb-0" role="alert"
+                         class="alert alert-info mb-2" role="alert"
                          attrs="{'invisible': ['|', '|', ('move_type', '!=', 'in_refund'), ('invoice_has_outstanding', '=', False), ('payment_state', 'not in', ('not_paid', 'partial'))]}">
                         You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> for this vendor. You can allocate them to mark this credit note as paid.
                     </div>
-                    <div class="alert alert-info mb-0" role="alert"
+                    <div class="alert alert-info mb-2" role="alert"
                          attrs="{'invisible': ['|', ('state', '!=', 'draft'), ('auto_post', '!=', 'at_date')]}">
                         This move is configured to be posted automatically at the accounting date: <field name="date" readonly="1"/>.
                     </div>
-                    <div class="alert alert-info mb-0" role="alert"
+                    <div class="alert alert-info mb-2" role="alert"
                          attrs="{'invisible': ['|', '|', ('state', '!=', 'draft'), ('auto_post', '=', 'no'), ('auto_post', '=', 'at_date')]}">
                          <field name="auto_post" readonly="1"/> auto-posting enabled. Next accounting date: <field name="date" readonly="1"/>.<span attrs="{'invisible': [('auto_post_until', '=', False)]}"> The recurrence will end on <field name="auto_post_until" readonly="1"/> (included).</span>
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
-                         class="alert alert-warning mb-0" role="alert"
+                         class="alert alert-warning mb-2" role="alert"
                          attrs="{'invisible': [('partner_credit_warning', '=', '')]}">
                         <field name="partner_credit_warning"/>
                     </div>
                     <!-- Currency consistency -->
-                    <div class="alert alert-warning mb-0" role="alert"
+                    <div class="alert alert-warning mb-2" role="alert"
                          attrs="{'invisible': ['|', ('display_inactive_currency_warning', '=', False), ('move_type', 'not in', ('in_invoice', 'in_refund', 'in_receipt'))]}">
                         In order to validate this bill, you must <button class="oe_link" type="object" name="action_activate_currency" style="padding: 0; vertical-align: baseline;">activate the currency of the bill</button>. The journal entries need to be computed by Odoo before being posted in your company's currency.
                     </div>
-                    <div class="alert alert-warning mb-0" role="alert"
+                    <div class="alert alert-warning mb-2" role="alert"
                          attrs="{'invisible': ['|', ('display_inactive_currency_warning', '=', False), ('move_type', 'not in', ('out_invoice', 'out_refund', 'out_receipt'))]}">
                         In order to validate this invoice, you must <button class="oe_link" type="object" name="action_activate_currency" style="padding: 0; vertical-align: baseline;">activate the currency of the invoice</button>. The journal entries need to be computed by Odoo before being posted in your company's currency.
                     </div>


### PR DESCRIPTION
The alerts above the sheet when viewing an invoice in the form view are missing some margins.

This fix applies a `mb-2` on these alerts to even the spacing between the statusbar and the sheet.

task-3577058

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
