### PR TITLE
[FIX] mass_mailing: filter active subscriber on unsubscribe button

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -39,7 +39,7 @@ class MassMailController(http.Controller):
                 mailing.update_opt_out(email, mailing.contact_list_ids.ids, True)
 
                 contacts = request.env['mailing.contact'].sudo().search([('email_normalized', '=', tools.email_normalize(email))])
-                subscription_list_ids = contacts.mapped('subscription_list_ids').filtered('active')
+                subscription_list_ids = contacts.mapped('subscription_list_ids').filtered('list_id.active')
                 # In many user are found : if user is opt_out on the list with contact_id 1 but not with contact_id 2,
                 # assume that the user is not opt_out on both
                 # TODO DBE Fixme : Optimise the following to get real opt_out and opt_in


### PR DESCRIPTION
This issue occurs when a user sends a customer an email, and then the customer clicks the `unsubscribe` button from template,at that time the error will generated.  

step to reproduce-
- Install the Email Marketing and add Outgoing Mail Server.
- Open the Email Marketing.
- Create Mailing List e.g. 'Test' and add contact with email.
- Create new mailing.
- Select mailing list 'Test'
- Select any one template  / send it.
- Now , open email of that you add mailing contact.
- Then click on Unsubscribe button
- The error will be generated.

sentry traceback-
```
KeyError: 'active'
  File "odoo/http.py", line 2139, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1715, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1742, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1856, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/mass_mailing/controllers/main.py", line 39, in mailing_unsubscribe
    subscription_list_ids = contacts.mapped('subscription_list_ids').filtered('active')
  File "odoo/models.py", line 5723, in filtered
    return self.browse([rec.id for rec in self if func(rec)])
  File "odoo/models.py", line 5723, in <listcomp>
    return self.browse([rec.id for rec in self if func(rec)])
  File "odoo/models.py", line 5722, in <lambda>
    func = lambda rec: any(rec.mapped(name))
  File "odoo/models.py", line 5700, in mapped
    recs = recs._fields[name].mapped(recs)
```

This is because PR https://github.com/odoo/odoo/pull/138875 added the `active` key in filter, but it is not present in the contact subscription.

This commit fixes the above issue by using the key 'list_id.active' because the active field belongs to the mailing list, not the contact subscription.

sentry-4587714148