### PR TITLE
[16.0][FIX] web: Widget selection_badge does not allow to uncheck the badge

### DIFF
--- a/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
+++ b/addons/web/static/src/views/fields/badge_selection/badge_selection_field.js
@@ -55,7 +55,11 @@ export class BadgeSelectionField extends Component {
                 }
                 break;
             case "selection":
-                this.props.update(value);
+                if (value === this.props.value) {
+                    this.props.update(false);
+                } else {
+                    this.props.update(value);
+                }
                 break;
         }
     }

--- a/addons/web/static/tests/views/fields/badge_selection_field_tests.js
+++ b/addons/web/static/tests/views/fields/badge_selection_field_tests.js
@@ -148,4 +148,40 @@ QUnit.module("Fields", (hooks) => {
             );
         }
     );
+
+    QUnit.test(
+        "BadgeSelectionField widget on a selection unchecking selected value",
+        async function (assert) {
+            await makeView({
+                serverData,
+                type: "form",
+                resModel: "partner",
+                arch: '<form><field name="color" widget="selection_badge"/></form>',
+            });
+
+            assert.containsOnce(
+                target,
+                "div.o_field_selection_badge",
+                "should have rendered outer div"
+            );
+            assert.containsN(target, "span.o_selection_badge", 2, "should have 2 possible choices");
+            assert.strictEqual(
+                target.querySelector("span.o_selection_badge").textContent,
+                "Red",
+                "one of them should be Red"
+            );
+
+            // click again on red option
+            await click(target.querySelector("span.o_selection_badge.active"));
+
+            await click(target.querySelector(".o_form_button_save"));
+
+            var newRecord = _.last(serverData.models.partner.records);
+            assert.strictEqual(
+                newRecord.color,
+                false,
+                "the new value should be false as we have selected same value as default"
+            );
+        }
+    );
 });


### PR DESCRIPTION
As the selection badge is not checking if a badge is selected to set the value, when clicking to a badge that is selected yet, is updating the value to itself, so the value does not change.
![badge not working](https://github.com/odoo/odoo/assets/35952655/a9bad8fe-9e5d-42d0-90ac-30e175a999c4)

By checking if the badge is trying to assign the same value, we can set the badge to false.
![badge working](https://github.com/odoo/odoo/assets/35952655/1b55e7e2-bd25-4210-ac25-146c8decbc18)

cc @Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
