### PR TITLE
[FIX] im_livechat: invalid URL Regex in Channel Rules

### DIFF
--- a/addons/im_livechat/i18n/im_livechat.pot
+++ b/addons/im_livechat/i18n/im_livechat.pot
@@ -684,6 +684,12 @@ msgid "Image"
 msgstr ""
 
 #. module: im_livechat
+#: code:addons/im_livechat/models/im_livechat_channel.py:0
+#, python-format
+msgid "Invalid URL Regex: %s"
+msgstr ""
+
+#. module: im_livechat
 #. openerp-web
 #: code:addons/im_livechat/static/src/legacy/public_livechat.js:0
 #, python-format

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -5,6 +5,7 @@ import random
 import re
 
 from odoo import api, Command, fields, models, modules, _
+from odoo.exceptions import ValidationError
 
 
 class ImLivechatChannel(models.Model):
@@ -265,6 +266,12 @@ class ImLivechatChannelRule(models.Model):
         help="The rule will only be applied for these countries. Example: if you select 'Belgium' and 'United States' and that you set the action to 'Hide Button', the chat button will be hidden on the specified URL from the visitors located in these 2 countries. This feature requires GeoIP installed on your server.")
     sequence = fields.Integer('Matching order', default=10,
         help="Given the order to find a matching rule. If 2 rules are matching for the given url/country, the one with the lowest sequence will be chosen.")
+
+    @api.constrains('regex_url')
+    def _check_url_regex(self):
+        for record in self:
+            if record.regex_url and not record.regex_url.startswith("/"):
+                raise ValidationError(_('Invalid URL Regex: %s', record.regex_url))
 
     def match_rule(self, channel_id, url, country_id=False):
         """ determine if a rule of the given channel matches with the given url


### PR DESCRIPTION
If the user adds an invalid value for URL Regex and tries to open the website,
A traceback will appear.

Steps to produce the error:
- Install "website_livechat" > configure website
- Go to 'Live Chat' > Open existing channel > Channel Rules > Add a line >
  Add * in URL Regex > Save
- Now Open the 'Website' > click on 'GO TO WEBSITE'

Traceback:
```
error: nothing to repeat at position 0
  File "odoo/http.py", line 2139, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1715, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1742, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1943, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/im_livechat/controllers/main.py", line 90, in livechat_init
    matching_rule = request.env['im_livechat.channel.rule'].sudo().match_rule(channel_id, url, country_id)
  File "addons/im_livechat/models/im_livechat_channel.py", line 367, in match_rule
    return _match(self.search(domain))
  File "addons/im_livechat/models/im_livechat_channel.py", line 356, in _match
    if re.search(rule.regex_url or '', url or ''):
  File "re.py", line 200, in search
    return _compile(pattern, flags).search(string)
  File "re.py", line 303, in _compile
    p = sre_compile.compile(pattern, flags)
  File "sre_compile.py", line 788, in compile
    p = sre_parse.parse(p, flags)
  File "sre_parse.py", line 955, in parse
    p = _parse_sub(source, state, flags & SRE_FLAG_VERBOSE, 0)
  File "sre_parse.py", line 444, in _parse_sub
    itemsappend(_parse(source, state, verbose, nested + 1,
  File "sre_parse.py", line 669, in _parse
    raise source.error("nothing to repeat",
```

https://github.com/odoo/odoo/blob/52fe645be92bf3c30edbab39bc1dc5a1ac4f1bd0/addons/im_livechat/models/im_livechat_channel.py#L335
Here, when user provides '*' as URL Regex, rule.regex_url will be *,
So when rule.regex_url is searched in the url,
It will lead to the above traceback because there is nothing to search for.

sentry-4586706988

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
