### PR TITLE
[FIX] hr_expense: Don't always recompute product cost & taxes

### DIFF
--- a/addons/sale_expense_margin/models/sale_order_line.py
+++ b/addons/sale_expense_margin/models/sale_order_line.py
@@ -13,12 +13,10 @@ class SaleOrderLine(models.Model):
         date_today = fields.Date.context_today(self)
         expense_lines = self.filtered('expense_id')
         for line in expense_lines:
-            if line.expense_id.product_has_cost:
-                product_cost = line.expense_id.untaxed_amount / line.expense_id.quantity
-            else:
-                product_cost = line.expense_id.untaxed_amount
+            expense = line.expense_id
+            product_cost = expense.untaxed_amount / (expense.quantity or 1.0)
 
-            from_currency = line.expense_id.currency_id
+            from_currency = expense.currency_id
             to_currency = line.currency_id or line.order_id.currency_id
 
             if to_currency and product_cost and from_currency != to_currency:

--- a/addons/sale_expense_margin/tests/test_so_expense_purchase_price.py
+++ b/addons/sale_expense_margin/tests/test_so_expense_purchase_price.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 from odoo.tests import tagged
 
@@ -9,19 +9,31 @@ class TestExpenseMargin(TestExpenseCommon):
 
     def test_expense_reinvoice_purchase_price(self):
         # re-invoiceable products
-        product_with_cost = self.product_a
-        product_with_cost.write({'standard_price': 1000, 'expense_policy': 'sales_price'})
-        product_with_no_cost = self.product_b
-        product_with_no_cost.write({'standard_price': 0, 'expense_policy': 'sales_price'})
+        product_with_cost_and_taxes = self.product_a
+        product_with_cost_no_taxes = self.env['product.product'].create({
+            'name': 'product_a',
+            'uom_id': self.env.ref('uom.product_uom_unit').id,
+            'lst_price': 1000.0,
+            'standard_price': 1000.0,
+            'property_account_income_id': self.company_data['default_account_revenue'].id,
+            'property_account_expense_id': self.company_data['default_account_expense'].id,
+            'taxes_id': [],
+            'supplier_taxes_id': [],
+            'can_be_expensed': True,
+            'expense_policy': 'sales_price',
+        })
+        product_with_cost_and_taxes.write({'standard_price': 1000, 'expense_policy': 'sales_price'})
+        product_with_no_cost = self.product_c
+        product_with_no_cost.write({'expense_policy': 'sales_price'})
 
         # create SO line and confirm SO (with only one line)
         sale_order = self.env['sale.order'].with_context(mail_notrack=True, mail_create_nolog=True).create({
             'partner_id': self.partner_a.id,
             'partner_invoice_id': self.partner_a.id,
             'partner_shipping_id': self.partner_a.id,
-            'order_line': [(0, 0, {
-                'name': product_with_cost.name,
-                'product_id': product_with_cost.id,
+            'order_line': [Command.create({
+                'name': product_with_cost_and_taxes.name,
+                'product_id': product_with_cost_and_taxes.id,
                 'product_uom_qty': 2.0,
                 'price_unit': 13.0,
             })],
@@ -36,18 +48,18 @@ class TestExpenseMargin(TestExpenseCommon):
             'accounting_date': '2020-10-12',
             'expense_line_ids': [
                 # expense with zero cost product, with 15% tax
-                (0, 0, {
+                Command.create({
                     'name': 'expense_1',
                     'date': '2020-10-07',
                     'product_id': product_with_no_cost.id,
                     'unit_amount': product_with_no_cost.standard_price,
                     'total_amount': 100,
-                    'tax_ids': [(6, 0, self.company_data['default_tax_purchase'].ids)],
+                    'tax_ids': [Command.set(self.company_data['default_tax_purchase'].ids)],
                     'employee_id': self.expense_employee.id,
                     'sale_order_id': sale_order.id,
                 }),
                 # expense with zero cost product, with no tax
-                (0, 0, {
+                Command.create({
                     'name': 'expense_2',
                     'date': '2020-10-07',
                     'product_id': product_with_no_cost.id,
@@ -58,24 +70,22 @@ class TestExpenseMargin(TestExpenseCommon):
                     'sale_order_id': sale_order.id
                 }),
                 # expense with product with cost (1000), with 15% tax
-                (0, 0, {
+                Command.create({
                     'name': 'expense_3',
                     'date': '2020-10-07',
-                    'product_id': product_with_cost.id,
+                    'product_id': product_with_cost_and_taxes.id,
                     'quantity': 3,
-                    'unit_amount': product_with_cost.standard_price,
-                    'tax_ids': [(6, 0, self.company_data['default_tax_purchase'].ids)],
+                    'unit_amount': product_with_cost_no_taxes.standard_price,
                     'employee_id': self.expense_employee.id,
                     'sale_order_id': sale_order.id
                 }),
                 # expense with product with cost (1000), with no tax
-                (0, 0, {
+                Command.create({
                     'name': 'expense_4',
                     'date': '2020-10-07',
-                    'product_id': product_with_cost.id,
+                    'product_id': product_with_cost_no_taxes.id,
                     'quantity': 5,
-                    'unit_amount': product_with_cost.standard_price,
-                    'tax_ids': False,
+                    'unit_amount': product_with_cost_no_taxes.standard_price,
                     'employee_id': self.expense_employee.id,
                     'sale_order_id': sale_order.id
                 }),


### PR DESCRIPTION
When an expense is submitted and for the steps after, there is no need to recompute the product_cost and the taxes as it may be confusing or generate discrepancies with the account move by changing the totals.

task-3580004

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
