### PR TITLE
[FIX] base: handle type error without currency_id

### DIFF
--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -246,6 +246,8 @@ class Currency(models.Model):
 
     @api.model
     def _get_conversion_rate(self, from_currency, to_currency, company, date):
+        from_currency = from_currency or self.env.company.currency_id
+        to_currency = to_currency or self.env.company.currency_id
         currency_rates = (from_currency + to_currency)._get_rates(company, date)
         res = currency_rates.get(to_currency.id) / currency_rates.get(from_currency.id)
         return res


### PR DESCRIPTION
While the user creates an expense record and sets the currency to null, a traceback will be generated.

Steps to reproduce:
- Install hr_expense module.
- Settings > Users & Companies > Groups
- Search the "Multi Currencies" groups and add it to the user's access rights.
- Go to the Expenses menu, create a new record, and set the currency to null.
- After that, a traceback will be generated.

Traceback:
```
KeyError: <NewId 0x7f832c362920>
  File "odoo/api.py", line 965, in get
    cache_value = field_cache[record._ids[0]]
CacheMiss: 'hr.expense(<NewId 0x7f832c362920>,).currency_rate'
  File "odoo/fields.py", line 1160, in __get__
    value = env.cache.get(record, self)
  File "odoo/api.py", line 972, in get
    raise CacheMiss(record, field)
TypeError: unsupported operand type(s) for /: 'float' and 'NoneType'
  File "odoo/http.py", line 2139, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1715, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1742, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1943, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 191, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 717, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 30, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 26, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "odoo/models.py", line 6781, in onchange
    todo = [
  File "odoo/models.py", line 6784, in <listcomp>
    if name not in done and snapshot0.has_changed(name)
  File "odoo/models.py", line 6584, in has_changed
    return self[name] != record[name]
  File "odoo/models.py", line 6211, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1157, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1367, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1340, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1389, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 395, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4553, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/hr_expense/models/hr_expense.py", line 342, in _compute_unit_amount
    expense.unit_amount = expense.company_currency_id.round(expense.total_amount_company / (expense.quantity or 1))
  File "odoo/fields.py", line 1157, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1367, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1340, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1389, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 395, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4553, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/hr_expense/models/hr_expense.py", line 253, in _compute_total_amount_company
    price_unit=expense.total_amount * expense.currency_rate,
  File "odoo/fields.py", line 1211, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1389, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 395, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4553, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/hr_expense/models/hr_expense.py", line 165, in _compute_currency_rate
    expense.currency_rate = self.env['res.currency']._get_conversion_rate(
  File "odoo/addons/base/models/res_currency.py", line 250, in _get_conversion_rate
    res = currency_rates.get(to_currency.id) / currency_rates.get(from_currency.id)
```

After applying this commit, it will resolve an issue calculating a currency rate.

code reference:
https://github.com/odoo/odoo/blob/62d9221cf937c9ba9685364aa590e26dae9bc666/addons/hr_expense/models/hr_expense.py#L165
https://github.com/odoo/odoo/blob/62d9221cf937c9ba9685364aa590e26dae9bc666/odoo/addons/base/models/res_currency.py#L250

sentry-4576282327