### PR TITLE
[FIX] web: account for floating-points errors in formatFloat

### DIFF
--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -20,3 +20,54 @@ export function computeVariation(value, comparisonValue) {
     }
     return (value - comparisonValue) / Math.abs(comparisonValue);
 }
+
+/**
+ * performs a half up rounding with arbitrary precision, correcting for float loss of precision
+ * See the corresponding float_round() in server/tools/float_utils.py for more info
+ *
+ * @param {number} value the value to be rounded
+ * @param {number} precision a precision parameter. eg: 0.01 rounds to two digits.
+ */
+export function roundPrecision(value, precision) {
+    if (!value) {
+        return 0;
+    } else if (!precision || precision < 0) {
+        precision = 1;
+    }
+    let normalizedValue = value / precision;
+    const epsilonMagnitude = Math.log2(Math.abs(normalizedValue));
+    const epsilon = Math.pow(2, epsilonMagnitude - 52);
+    normalizedValue += normalizedValue >= 0 ? epsilon : -epsilon;
+
+    /**
+     * Javascript performs strictly the round half up method, which is asymmetric. However, in
+     * Python, the method is symmetric. For example:
+     * - In JS, Math.round(-0.5) is equal to -0.
+     * - In Python, round(-0.5) is equal to -1.
+     * We want to keep the Python behavior for consistency.
+     */
+    const sign = normalizedValue < 0 ? -1.0 : 1.0;
+    const roundedValue = sign * Math.round(Math.abs(normalizedValue));
+    return roundedValue * precision;
+}
+
+export function roundDecimals(value, decimals) {
+    /**
+     * The following decimals introduce numerical errors:
+     * Math.pow(10, -4) = 0.00009999999999999999
+     * Math.pow(10, -5) = 0.000009999999999999999
+     *
+     * Such errors will propagate in roundPrecision and lead to inconsistencies between Python
+     * and JavaScript. To avoid this, we parse the scientific notation.
+     */
+    return roundPrecision(value, parseFloat("1e" + -decimals));
+}
+
+/**
+ * @param {number} value
+ * @param {integer} decimals
+ * @returns {boolean}
+ */
+export function floatIsZero(value, decimals) {
+    return roundDecimals(value, decimals) === 0;
+}

--- a/addons/web/static/src/fields/formatters.js
+++ b/addons/web/static/src/fields/formatters.js
@@ -6,6 +6,8 @@ import { _lt } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { intersperse } from "@web/core/utils/strings";
 import { session } from "@web/session";
+import { roundDecimals } from "@web/core/utils/numbers";
+
 
 // -----------------------------------------------------------------------------
 // Helpers
@@ -128,7 +130,7 @@ export function formatFloat(value, options = {}) {
     } else {
         precision = 2;
     }
-    const formatted = (value || 0).toFixed(precision || 2).split(".");
+    const formatted = roundDecimals(value, precision).toFixed(precision || 2).split(".");
     formatted[0] = insertThousandsSep(formatted[0], thousandsSep, grouping);
     if (options.noTrailingZeros) {
         formatted[1] = formatted[1].replace(/0+$/, "");

--- a/addons/web/static/tests/core/utils/numbers_tests.js
+++ b/addons/web/static/tests/core/utils/numbers_tests.js
@@ -1,0 +1,139 @@
+/** @odoo-module **/
+
+import { roundPrecision, roundDecimals, floatIsZero } from "@web/core/utils/numbers";
+
+QUnit.module("utils", () => {
+    QUnit.module("numbers");
+
+    QUnit.test("roundPrecision", function (assert) {
+        assert.expect(26);
+
+        assert.strictEqual(String(roundPrecision(1.0, 1)), "1");
+        assert.strictEqual(String(roundPrecision(1.0, 0.1)), "1");
+        assert.strictEqual(String(roundPrecision(1.0, 0.01)), "1");
+        assert.strictEqual(String(roundPrecision(1.0, 0.001)), "1");
+        assert.strictEqual(String(roundPrecision(1.0, 0.0001)), "1");
+        assert.strictEqual(String(roundPrecision(1.0, 0.00001)), "1");
+        assert.strictEqual(String(roundPrecision(1.0, 0.000001)), "1");
+        assert.strictEqual(String(roundPrecision(1.0, 0.0000001)), "1");
+        assert.strictEqual(String(roundPrecision(1.0, 0.00000001)), "1");
+        assert.strictEqual(String(roundPrecision(0.5, 1)), "1");
+        assert.strictEqual(String(roundPrecision(-0.5, 1)), "-1");
+        assert.strictEqual(String(roundPrecision(2.6745, 0.001)), "2.6750000000000003");
+        assert.strictEqual(String(roundPrecision(-2.6745, 0.001)), "-2.6750000000000003");
+        assert.strictEqual(String(roundPrecision(2.6744, 0.001)), "2.674");
+        assert.strictEqual(String(roundPrecision(-2.6744, 0.001)), "-2.674");
+        assert.strictEqual(String(roundPrecision(0.0004, 0.001)), "0");
+        assert.strictEqual(String(roundPrecision(-0.0004, 0.001)), "0");
+        assert.strictEqual(String(roundPrecision(357.4555, 0.001)), "357.456");
+        assert.strictEqual(String(roundPrecision(-357.4555, 0.001)), "-357.456");
+        assert.strictEqual(String(roundPrecision(457.4554, 0.001)), "457.455");
+        assert.strictEqual(String(roundPrecision(-457.4554, 0.001)), "-457.455");
+        assert.strictEqual(String(roundPrecision(-457.4554, 0.05)), "-457.45000000000005");
+        assert.strictEqual(String(roundPrecision(457.444, 0.5)), "457.5");
+        assert.strictEqual(String(roundPrecision(457.3, 5)), "455");
+        assert.strictEqual(String(roundPrecision(457.5, 5)), "460");
+        assert.strictEqual(String(roundPrecision(457.1, 3)), "456");
+    });
+
+    QUnit.test("roundDecimals", function (assert) {
+        assert.expect(21);
+
+        assert.strictEqual(String(roundDecimals(1.0, 0)), "1");
+        assert.strictEqual(String(roundDecimals(1.0, 1)), "1");
+        assert.strictEqual(String(roundDecimals(1.0, 2)), "1");
+        assert.strictEqual(String(roundDecimals(1.0, 3)), "1");
+        assert.strictEqual(String(roundDecimals(1.0, 4)), "1");
+        assert.strictEqual(String(roundDecimals(1.0, 5)), "1");
+        assert.strictEqual(String(roundDecimals(1.0, 6)), "1");
+        assert.strictEqual(String(roundDecimals(1.0, 7)), "1");
+        assert.strictEqual(String(roundDecimals(1.0, 8)), "1");
+        assert.strictEqual(String(roundDecimals(0.5, 0)), "1");
+        assert.strictEqual(String(roundDecimals(-0.5, 0)), "-1");
+        assert.strictEqual(String(roundDecimals(2.6745, 3)), "2.6750000000000003");
+        assert.strictEqual(String(roundDecimals(-2.6745, 3)), "-2.6750000000000003");
+        assert.strictEqual(String(roundDecimals(2.6744, 3)), "2.674");
+        assert.strictEqual(String(roundDecimals(-2.6744, 3)), "-2.674");
+        assert.strictEqual(String(roundDecimals(0.0004, 3)), "0");
+        assert.strictEqual(String(roundDecimals(-0.0004, 3)), "0");
+        assert.strictEqual(String(roundDecimals(357.4555, 3)), "357.456");
+        assert.strictEqual(String(roundDecimals(-357.4555, 3)), "-357.456");
+        assert.strictEqual(String(roundDecimals(457.4554, 3)), "457.455");
+        assert.strictEqual(String(roundDecimals(-457.4554, 3)), "-457.455");
+    });
+
+    QUnit.test("floatIsZero", function (assert) {
+        assert.strictEqual(floatIsZero(1, 0), false);
+        assert.strictEqual(floatIsZero(0.9999, 0), false);
+        assert.strictEqual(floatIsZero(0.50001, 0), false);
+        assert.strictEqual(floatIsZero(0.5, 0), false);
+        assert.strictEqual(floatIsZero(0.49999, 0), true);
+        assert.strictEqual(floatIsZero(0, 0), true);
+        assert.strictEqual(floatIsZero(0.49999, 0), true);
+        assert.strictEqual(floatIsZero(-0.50001, 0), false);
+        assert.strictEqual(floatIsZero(-0.5, 0), false);
+        assert.strictEqual(floatIsZero(-0.9999, 0), false);
+        assert.strictEqual(floatIsZero(-1, 0), false);
+
+        assert.strictEqual(floatIsZero(0.1, 1), false);
+        assert.strictEqual(floatIsZero(0.099999, 1), false);
+        assert.strictEqual(floatIsZero(0.050001, 1), false);
+        assert.strictEqual(floatIsZero(0.05, 1), false);
+        assert.strictEqual(floatIsZero(0.049999, 1), true);
+        assert.strictEqual(floatIsZero(0, 1), true);
+        assert.strictEqual(floatIsZero(-0.049999, 1), true);
+        assert.strictEqual(floatIsZero(-0.05, 1), false);
+        assert.strictEqual(floatIsZero(-0.050001, 1), false);
+        assert.strictEqual(floatIsZero(-0.099999, 1), false);
+        assert.strictEqual(floatIsZero(-0.1, 1), false);
+
+        assert.strictEqual(floatIsZero(0.01, 2), false);
+        assert.strictEqual(floatIsZero(0.0099999, 2), false);
+        assert.strictEqual(floatIsZero(0.005, 2), false);
+        assert.strictEqual(floatIsZero(0.0050001, 2), false);
+        assert.strictEqual(floatIsZero(0.0049999, 2), true);
+        assert.strictEqual(floatIsZero(0, 2), true);
+        assert.strictEqual(floatIsZero(-0.0049999, 2), true);
+        assert.strictEqual(floatIsZero(-0.0050001, 2), false);
+        assert.strictEqual(floatIsZero(-0.005, 2), false);
+        assert.strictEqual(floatIsZero(-0.0099999, 2), false);
+        assert.strictEqual(floatIsZero(-0.01, 2), false);
+
+        // 4 and 5 decimal places are mentioned as special cases in `roundDecimals` method.
+        assert.strictEqual(floatIsZero(0.0001, 4), false);
+        assert.strictEqual(floatIsZero(0.000099999, 4), false);
+        assert.strictEqual(floatIsZero(0.00005, 4), false);
+        assert.strictEqual(floatIsZero(0.000050001, 4), false);
+        assert.strictEqual(floatIsZero(0.000049999, 4), true);
+        assert.strictEqual(floatIsZero(0, 4), true);
+        assert.strictEqual(floatIsZero(-0.000049999, 4), true);
+        assert.strictEqual(floatIsZero(-0.000050001, 4), false);
+        assert.strictEqual(floatIsZero(-0.00005, 4), false);
+        assert.strictEqual(floatIsZero(-0.000099999, 4), false);
+        assert.strictEqual(floatIsZero(-0.0001, 4), false);
+
+        assert.strictEqual(floatIsZero(0.00001, 5), false);
+        assert.strictEqual(floatIsZero(0.0000099999, 5), false);
+        assert.strictEqual(floatIsZero(0.000005, 5), false);
+        assert.strictEqual(floatIsZero(0.0000050001, 5), false);
+        assert.strictEqual(floatIsZero(0.0000049999, 5), true);
+        assert.strictEqual(floatIsZero(0, 5), true);
+        assert.strictEqual(floatIsZero(-0.0000049999, 5), true);
+        assert.strictEqual(floatIsZero(-0.0000050001, 5), false);
+        assert.strictEqual(floatIsZero(-0.000005, 5), false);
+        assert.strictEqual(floatIsZero(-0.0000099999, 5), false);
+        assert.strictEqual(floatIsZero(-0.00001, 5), false);
+
+        assert.strictEqual(floatIsZero(0.0000001, 7), false);
+        assert.strictEqual(floatIsZero(0.000000099999, 7), false);
+        assert.strictEqual(floatIsZero(0.00000005, 7), false);
+        assert.strictEqual(floatIsZero(0.000000050001, 7), false);
+        assert.strictEqual(floatIsZero(0.000000049999, 7), true);
+        assert.strictEqual(floatIsZero(0, 7), true);
+        assert.strictEqual(floatIsZero(-0.000000049999, 7), true);
+        assert.strictEqual(floatIsZero(-0.000000050001, 7), false);
+        assert.strictEqual(floatIsZero(-0.00000005, 7), false);
+        assert.strictEqual(floatIsZero(-0.000000099999, 7), false);
+        assert.strictEqual(floatIsZero(-0.0000001, 7), false);
+    });
+});

--- a/addons/web/static/tests/fields/formatters_tests.js
+++ b/addons/web/static/tests/fields/formatters_tests.js
@@ -32,6 +32,7 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(formatFloat(1500, { thousandsSep: "" }), "1500.00");
         assert.strictEqual(formatFloat(-1.01), "-1.01");
         assert.strictEqual(formatFloat(-0.01), "-0.01");
+        assert.strictEqual(formatFloat(52.205), "52.21");
 
         assert.strictEqual(formatFloat(38.0001, { noTrailingZeros: true }), "38");
         assert.strictEqual(formatFloat(38.1, { noTrailingZeros: true }), "38.1");


### PR DESCRIPTION
### Steps to reproduce

* ensure the Product Price decimal precision is set to 2
* create an invoice and add a line with a price 52.205

You should see that the price is rounded to 52.20, which is not what we expect. Rounding is done correctly on the backend (subtotal is correctly set to 52.21)

### Cause

This is a floating-point issue, `52.205` cannot be represented. Instead, you get `52.2049999999999982947`, which rounds to `52.20`

### Fix

The fix simply implements the same behavior as [`float_round`](https://github.com/odoo/odoo/blob/da812d914ef960bcc601508c9051e0525e5ab3e7/odoo/tools/float_utils.py#L72-L75), by adjusting the value to round with a small number that's proportional to the rounding precision.

Partial backport of 8d50daeefa4a208ca1d85a3da5c213f363be5dcd

opw-3228043
