### PR TITLE
[FIX] stock: incorrect difference when grouping quants

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -126,10 +126,13 @@ class StockQuant(models.Model):
         for quant in quants:
             quant.inventory_date = date_by_location[quant.location_id]
 
-    @api.depends('inventory_quantity')
+    @api.depends('inventory_quantity', 'inventory_quantity_set')
     def _compute_inventory_diff_quantity(self):
-        for quant in self:
+        has_inventory = self.filtered(lambda q: q.inventory_quantity_set or q.inventory_quantity)
+        for quant in has_inventory:
             quant.inventory_diff_quantity = quant.inventory_quantity - quant.quantity
+
+        (self - has_inventory).inventory_diff_quantity = 0
 
     @api.depends('inventory_quantity')
     def _compute_inventory_quantity_set(self):
@@ -327,6 +330,8 @@ class StockQuant(models.Model):
         return action
 
     def action_apply_inventory(self):
+        # Compute `inventory_diff_quantity` if quantity was not set manually
+        self.filtered(lambda quant: not quant.inventory_quantity_set).inventory_quantity_set = True
         products_tracked_without_lot = []
         for quant in self:
             rounding = quant.product_uom_id.rounding
@@ -636,7 +641,6 @@ class StockQuant(models.Model):
         for quant in self:
             quant.inventory_date = date_by_location[quant.location_id]
         self.write({'inventory_quantity': 0, 'user_id': False})
-        self.write({'inventory_diff_quantity': 0})
 
     @api.model
     def _update_available_quantity(self, product_id, location_id, quantity, lot_id=None, package_id=None, owner_id=None, in_date=None):

--- a/addons/stock/tests/test_quant.py
+++ b/addons/stock/tests/test_quant.py
@@ -751,6 +751,13 @@ class StockQuant(TransactionCase):
         quant = self.gather_relevant(self.product, self.stock_subloc2)
         self.assertFalse(quant.inventory_quantity_set)
 
+        res = self.env['stock.quant'].read_group(
+            [("product_id", "=", self.product.id)],
+            ["inventory_diff_quantity:sum"],
+            ["location_id"],
+        )
+        self.assertEqual(sum(r["inventory_diff_quantity"] for r in res), 0)
+
     def test_unpack_and_quants_merging(self):
         """
         When unpacking a package, if there are already some quantities of the


### PR DESCRIPTION
## Steps to reproduce:
1. Create a new product
2. Purchase the product (3 qty)
3. Validate the PO & receive the products
4. Go to the product's quantity on hands
5. Group by location

The “Difference” field is -3 but should not display anything.

## Before this commit:
The field “Difference” is hidden when the inventory has not been counted manually; however, when grouping the quants, the difference is incorrectly displayed.

## After this commit:
The difference is only computed for quants that have been counted manually, and therefore displays the correct total when grouping the quants.

opw-3564822
