### PR TITLE
[FIX] stock: parent location dropdown size

### DIFF
--- a/addons/stock/static/src/scss/many2one.scss
+++ b/addons/stock/static/src/scss/many2one.scss
@@ -1,0 +1,3 @@
+.o-autocomplete--dropdown-menu {
+    font-size: $font-size-base;
+}


### PR DESCRIPTION
As the parent location in the location form is in an h2 tag, the dropdown was also using the h2 font size.
It should not

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
