### PR TITLE
[FIX] l10n_ar: AFIP responsibility readonly sub companies

### DIFF
--- a/addons/l10n_ar/views/res_company_view.xml
+++ b/addons/l10n_ar/views/res_company_view.xml
@@ -6,7 +6,7 @@
         <field name="model">res.company</field>
         <field name="arch" type="xml">
             <field name="vat" position="after">
-                <field name="l10n_ar_afip_responsibility_type_id" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('country_code', '!=', 'AR')]}"/>
+                <field name="l10n_ar_afip_responsibility_type_id" options="{'no_open': True, 'no_create': True}" attrs="{'invisible': [('country_code', '!=', 'AR')], 'readonly': [('parent_id', '!=', False)]}"/>
                 <label for="l10n_ar_gross_income_number" string="Gross Income" attrs="{'invisible': [('country_code', '!=', 'AR')]}"/>
                 <div attrs="{'invisible': [('country_code', '!=', 'AR')]}" name="gross_income">
                     <field name="l10n_ar_gross_income_type" class="oe_inline"/>


### PR DESCRIPTION
AFIP responsibility should be inherited from parent
company, and user should not be able to change it
afterward. With this commit, we make the field readonly
on form view if there is a parent company.
