### PR TITLE
[FIX] hr_timesheet: hide WIP Report in timesheet print action

### DIFF
--- a/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_controller.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_controller.js
@@ -1,0 +1,17 @@
+/** @odoo-module */
+
+import { ListController } from "@web/views/list/list_controller";
+
+export class TimesheetListController extends ListController {
+
+    get actionMenuItems() {
+        const actionMenus = super.actionMenuItems;
+        // hack so we don't show WIP print report timesheet app
+        const { print, action } = actionMenus;
+        return {
+            action: action,
+            print: print.filter((a) => a.name !== this.env._t("WIP report")),
+        };
+    }
+
+}

--- a/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_view.js
+++ b/addons/hr_timesheet/static/src/views/timesheet_list/timesheet_list_view.js
@@ -1,0 +1,12 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+import { TimesheetListController } from "./timesheet_list_controller";
+import { listView } from "@web/views/list/list_view";
+
+export const timesheetListView = {
+    ...listView,
+    Controller: TimesheetListController,
+};
+
+registry.category("views").add("timesheet_list", timesheetListView);

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -5,7 +5,8 @@
             <field name="name">account.analytic.line.tree.hr_timesheet</field>
             <field name="model">account.analytic.line</field>
             <field name="arch" type="xml">
-                <tree editable="bottom" string="Timesheet Activities" sample="1" decoration-muted="readonly_timesheet == True">
+                <tree editable="bottom" string="Timesheet Activities" sample="1" decoration-muted="readonly_timesheet == True"
+                    js_class="timesheet_list">
                     <field name="readonly_timesheet" invisible="1"/>
                     <field name="date" attrs="{'readonly': [('readonly_timesheet', '=', True)]}"/>
                     <field name="employee_id" invisible="1" attrs="{'readonly': [('readonly_timesheet', '=', True)]}"/>


### PR DESCRIPTION
Steps:
-----
   - mrp_account installed
   - Got to timesheet > my timesheet list view
   - Select multi timesheet
   - Click on print action
   - Print WIP report
   - 
Issue:
----
   When mrp_account is installed, the WIP report is shown in the print action
   of the timesheet.throw the traceback  when we print the WIP report.

Fixed:
----
  We have removed the WIP report from the timeheet app as it is not relevant
   for the timesheet app.

Technical:
----
 There is no bridge module between mrp_account and timesheet so we done
   in hr_timesheet module.

task-3465424
