### PR TITLE
[FIX] stock: fix put_in_pack

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1498,8 +1498,7 @@ class Picking(models.Model):
 
             quantity_move_line_ids = self.move_line_ids.filtered(
                 lambda ml:
-                    float_compare(ml.quantity, 0.0, precision_rounding=ml.product_uom_id.rounding) > 0 and
-                    not ml.result_package_id
+                    float_compare(ml.quantity, 0.0, precision_rounding=ml.product_uom_id.rounding) > 0
             )
             move_line_ids = quantity_move_line_ids.filtered(lambda ml: ml.picked)
             if not move_line_ids:


### PR DESCRIPTION
In the barcode app, it was not possible anymore to create multiple packs from one delivery as the function checked if a package had already been created

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
