### PR TITLE
[IMP] hr_contract: employee info update after contract start date

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -232,6 +232,17 @@ class Contract(models.Model):
     def _assign_open_contract(self):
         for contract in self:
             contract.employee_id.sudo().write({'contract_id': contract.id})
+            contract_start_message = "The new contract starts today"
+            if contract.job_id:
+                contract_start_message = _(
+                    "The new contract starts today, the job position has been updated accordingly to %s.") % contract.job_id.name
+                contract.employee_id.sudo().write({
+                    'job_id': contract.job_id,
+                    'department_id': contract.department_id.id,
+                })
+            else:
+                contract_start_message = _("The new contract starts today.")
+            contract.employee_id.message_post(body=contract_start_message)
 
     @api.depends('wage')
     def _compute_contract_wage(self):


### PR DESCRIPTION
Ensure the employee's title, department and job position are updated on their profile only when the respective contract starts. If the employee has already a job title, it will only change if the offer related to new contract has a different job title.

Task-3035630

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
