### PR TITLE
[FIX] hr_recruitment: Auto-add Applicants as Followers in Chatter

### DIFF
--- a/addons/hr_recruitment/tests/test_recruitment_process.py
+++ b/addons/hr_recruitment/tests/test_recruitment_process.py
@@ -88,7 +88,7 @@ class TestRecruitmentProcess(TestHrCommon):
             }
         )
         application = self.env["hr.applicant"].create(
-            {"name": "Test Job Application for Notification", "job_id": job.id}
+            {"name": "Test Job Application for Notification", "job_id": job.id, "partner_name": "applicant 1"}
         )
         new_application_message = application.message_ids.filtered(
             lambda m: m.subtype_id == new_application_mt


### PR DESCRIPTION
**Issue:**
Job applicants were not automatically added as followers to their own application records upon applying

**Steps To reproduce:**
1. Submit job application.
2. Observe applicant not added as a follower in chatter.

**Solution:**
- Enhanced the create function in hr_recruitment to check if applicants are partners.
- If not already partners, applicants are created as partners.
- All new partners (applicants) are then automatically added as followers to the application chatter.

opw-3572351


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
