### PR TITLE
[FIX] account: make balance zero when it is None

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -583,6 +583,8 @@ class AccountBankStatementLine(models.Model):
             else:
                 new_balance = 0.0
         else:
+            if not isinstance(balance, float):
+                balance = 0.0
             journ_amount_currency = journal_currency.round(balance * rate_comp2journal_curr)
             trans_amount_currency = transaction_currency.round(journ_amount_currency * rate_journal2foreign_curr)
             new_balance = balance


### PR DESCRIPTION
When the cron `_cron_try_auto_reconcile_statement_lines` is executed manually or automatically in the scenario where currency is not same as `journal_currency` and `transaction_currency` then the user will face error.

Error: 
```
TypeError: unsupported operand type(s) for *: 'NoneType' and 'float'
  File "odoo/tools/safe_eval.py", line 365, in safe_eval
    return unsafe_eval(c, globals_dict, locals_dict)
  File "ir.actions.server(566,)", line 1, in <module>
  File "home/odoo/src/enterprise/saas-16.4/account_accountant/models/account_bank_statement.py", line 154, in _cron_try_auto_reconcile_statement_lines
    wizard._action_trigger_matching_rules()
  File "home/odoo/src/enterprise/saas-16.4/sale_account_accountant/models/bank_rec_widget.py", line 15, in _action_trigger_matching_rules
    matching = super()._action_trigger_matching_rules()
  File "home/odoo/src/enterprise/saas-16.4/account_accountant/models/bank_rec_widget.py", line 1079, in _action_trigger_matching_rules
    self._action_select_reconcile_model(reco_model)
  File "home/odoo/src/enterprise/saas-16.4/account_accountant/models/bank_rec_widget.py", line 1398, in _action_select_reconcile_model
    self.line_ids = [
  File "home/odoo/src/enterprise/saas-16.4/account_accountant/models/bank_rec_widget.py", line 1399, in <listcomp>
    Command.create(self._lines_prepare_reco_model_write_off_vals(reco_model, x))
  File "home/odoo/src/enterprise/saas-16.4/account_accountant/models/bank_rec_widget.py", line 843, in _lines_prepare_reco_model_write_off_vals
    ._prepare_counterpart_amounts_using_st_line_rate(self.transaction_currency_id, None, write_off_vals['amount_currency'])['balance']
  File "addons/account/models/account_bank_statement_line.py", line 562, in _prepare_counterpart_amounts_using_st_line_rate
    journ_amount_currency = journal_currency.round(balance * rate_comp2journal_curr)

ValueError: <class 'TypeError'>: "unsupported operand type(s) for *: 'NoneType' and 'float'" while evaluating
'model._cron_try_auto_reconcile_statement_lines(batch_size=100)'
  File "odoo/addons/base/models/ir_cron.py", line 373, in _callback
    self.env['ir.actions.server'].browse(server_action_id).run()
  File "home/odoo/src/custom/trial/saas_trial/models/sentry.py", line 33, in run
    res = super().run()
  File "odoo/addons/base/models/ir_actions.py", line 688, in run
    res = runner(run_self, eval_context=eval_context)
  File "odoo/addons/base/models/ir_actions.py", line 558, in _run_action_code_multi
    safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
  File "odoo/tools/safe_eval.py", line 379, in safe_eval
    raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
```
Balance is None in these scenarios:

- https://github.com/odoo/enterprise/blob/09f84651e5df4df2b18a6af14aab3a19a8f4298b/account_accountant/models/bank_rec_widget.py#L836

- https://github.com/odoo/enterprise/blob/09f84651e5df4df2b18a6af14aab3a19a8f4298b/account_accountant/models/bank_rec_widget.py#L932

Our commit tends to make the balance 0.0 whenever the balance is None or not a float value while calculating `journ_amount_currency`.

sentry-4573049666

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
