### PR TITLE
[FIX] mail: fix search message panel input behavior

### DIFF
--- a/addons/mail/static/src/core/common/search_messages_panel.xml
+++ b/addons/mail/static/src/core/common/search_messages_panel.xml
@@ -6,10 +6,10 @@
                 <div class="input-group">
                     <div class="o_searchview form-control d-flex align-items-center py-1" role="search" aria-autocomplete="list">
                         <div class="o_searchview_input_container d-flex flex-grow-1 flex-wrap gap-1">
-                            <input type="text" class="o_searchview_input flex-grow-1 w-auto border-0" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
+                            <input type="text" class="o_searchview_input o_input flex-grow-1 w-auto border-0" accesskey="Q" placeholder="Search" t-model="state.searchTerm" t-on-keydown="onKeydownSearch" t-ref="autofocus" role="searchbox"/>
                         </div>
                     </div>
-                    <button class="btn" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-primary' : 'btn-primary'" t-on-click="() => this.search()" aria-label="Search button">
+                    <button class="btn" t-att-class="state.searchedTerm === state.searchTerm ? 'btn-outline-secondary' : 'btn-secondary'" t-on-click="() => this.search()" aria-label="Search button">
                         <i t-if="!messageSearch.searching" class="o_searchview_icon oi oi-search" role="img" aria-label="Search Messages" title="Search Messages"/>
                         <i t-else="" class="fa fa-spin fa-spinner" aria-label="Search in progress" title="Search in progress"/>
                     </button>


### PR DESCRIPTION
This PR fixes issues related to the input located inside the search
messages panel.

Prior to this commit, the input was missing a `o_input` class, which is
used across our input to set a transparent background to it. This is
especially visible in dark mode.

We also adapt the search button, switching its type from `primary` to
`secondary` to emphasize the existing primary button within the form view
and also providing better consistency across other actions within the
chatter.

task-3584006