### PR TITLE
[FIX] core: do not check version on uninstallable modules

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -345,10 +345,11 @@ def load_manifest(module, mod_path=None):
     elif manifest['auto_install']:
         manifest['auto_install'] = set(manifest['depends'])
 
-    try:
-        manifest['version'] = adapt_version(manifest['version'])
-    except ValueError as e:
-        raise ValueError(f"Module {module}: invalid manifest") from e
+    if manifest.get('installable', True):
+        try:
+            manifest['version'] = adapt_version(manifest['version'])
+        except ValueError as e:
+            raise ValueError(f"Module {module}: invalid manifest") from e
     manifest['addons_path'] = normpath(opj(mod_path, os.pardir))
 
     return manifest


### PR DESCRIPTION

Description of the issue/feature this PR addresses:
If we have a module with instalalble = False on the manifest and an older version, for eg "16.0.1.0.0", odoo server can't start due to version check

Current behavior before PR:
Can't start odoo server if there are modules with "instalalble = False" and version info with different major version included, for eg "16.0.1.0.0"

Desired behavior after PR is merged:
Odoo server starting ok



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
