### PR TITLE
[IMP] web: post revamp calendar improvements 

### DIFF
--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -30,9 +30,12 @@
             --o-bg-opacity: 1;
         }
 
-        &.o_attendee_status_tentative,
-        &.o_attendee_status_alone,
         &.o_attendee_status_needsAction {
+            --o-bg-opacity: 0;
+        }
+
+        &.o_attendee_status_tentative,
+        &.o_attendee_status_alone {
             --o-bg-opacity: .5;
         }
 

--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -24,7 +24,7 @@
     }
 }
 
-.o_calendar_renderer .o_event {
+.o_event {
     &:not(.o_event_dot) {
         &.o_attendee_status_active {
             --o-bg-opacity: 1;
@@ -38,6 +38,7 @@
 
         &.o_attendee_status_declined {
             --o-bg-opacity: 0;
+            text-decoration: line-through;
         }
     }
 

--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -26,13 +26,11 @@
 
 .o_calendar_renderer .fc-event {
     &:not(.o_event_dot) {
-        --o-overlay-opacity: .5;
-
         &.o_attendee_status_active {
             --o-bg-opacity: 1;
         }
 
-        &.o_attendee_status_tentative, &.o_event_hatched {
+        &.o_attendee_status_tentative {
             --o-bg-opacity: .5;
         }
 
@@ -45,7 +43,7 @@
             --o-bg-opacity: 0;
         }
 
-        &.o_attendee_status_tentative, &.o_event_hatched {
+        &.o_attendee_status_tentative {
             .fc-bg {
                 background: repeating-linear-gradient(
                     45deg,
@@ -59,26 +57,8 @@
     }
 
     &.o_event_dot {
-        --o-overlay-opacity: .25;
-
-        display: flex;
-        align-items: center;
-        gap: map-get($spacers, 1 );
-        border: none;
-        background-color: rgba(var(--o-event-bg--subtle-rgb), var(--o-bg-opacity));
-
-        &:before {
-            z-index: 2;
-            display: inline-block;
-            font-family: Fontawesome;
-            color: var(--o-event-bg, #{$info});
-            content: '\f111'; // fa-circle
-        }
-
-        &.o_attendee_status_needsAction, &.o_event_hatched {
-            &:before {
-                content: "\f1db"; // fa-circle-thin
-            }
+        &.o_attendee_status_needsAction:before {
+            content: "\f1db"; // fa-circle-thin
         }
 
         &.o_attendee_status_tentative:before {
@@ -92,27 +72,11 @@
         &.o_attendee_status_alone {
             content: "\f06a"; // fa-exclamation-circle
         }
-
-        &:hover {
-            --o-bg-opacity: 1;
-        }
     }
 
-    &.o_attendee_status_declined, &.o_event_striked {
+    &.o_attendee_status_declined {
         .fc-content {
             text-decoration: line-through;
         }
-    }
-}
-
-@for $-i from 1 through length($o-colors-complete) {
-    $-color: nth($o-colors-complete, $-i);
-    $-color-subtle: mix($o-white, $-color, 85%);
-
-    .o_calendar_renderer .fc-event.o_calendar_color_#{$-i - 1} {
-        --o-event-bg: #{$-color};
-        --o-event-bg-rgb: #{to-rgb($-color)};
-        --o-event-bg--subtle: #{$-color-subtle};
-        --o-event-bg--subtle-rgb: #{to-rgb($-color-subtle)};
     }
 }

--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -24,16 +24,13 @@
     }
 }
 
-.o_calendar_renderer .fc-event {
+.o_calendar_renderer .o_event {
     &:not(.o_event_dot) {
         &.o_attendee_status_active {
             --o-bg-opacity: 1;
         }
 
-        &.o_attendee_status_tentative {
-            --o-bg-opacity: .5;
-        }
-
+        &.o_attendee_status_tentative,
         &.o_attendee_status_alone,
         &.o_attendee_status_needsAction {
             --o-bg-opacity: .5;
@@ -42,41 +39,23 @@
         &.o_attendee_status_declined {
             --o-bg-opacity: 0;
         }
-
-        &.o_attendee_status_tentative {
-            .fc-bg {
-                background: repeating-linear-gradient(
-                    45deg,
-                    RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .3),
-                    RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .3) 10px,
-                    RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .6) 10px,
-                    RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .6) 20px
-                ) !important;
-            }
-        }
     }
 
     &.o_event_dot {
-        &.o_attendee_status_needsAction:before {
-            content: "\f1db"; // fa-circle-thin
+        &.o_attendee_status_needsAction {
+            --o-event-dot-icon: '\f1db'; // fa-circle-thin
         }
 
-        &.o_attendee_status_tentative:before {
-            content: "\f059"; // fa-question-circle
+        &.o_attendee_status_tentative {
+            --o-event-dot-icon: '\f059'; // fa-question-circle
         }
 
-        &.o_attendee_status_declined:before {
-            content: "\f05e"; // fa-ban
+        &.o_attendee_status_declined {
+            --o-event-dot-icon: '\f05e'; // fa-ban
         }
 
         &.o_attendee_status_alone {
-            content: "\f06a"; // fa-exclamation-circle
-        }
-    }
-
-    &.o_attendee_status_declined {
-        .fc-content {
-            text-decoration: line-through;
+            --o-event-dot-icon: '\f06a'; // fa-exclamation-circle
         }
     }
 }

--- a/addons/hr_holidays/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_renderer.scss
@@ -4,19 +4,30 @@
     flex-basis: fit-content;
 
     .o_calendar_renderer {
-        @for $size from 1 through length($o-colors) {
-            .o_calendar_widget {
-                .hr_mandatory_day_top_#{$size - 1}:not(.fc-disabled-day) {
+        .o_calendar_widget {
+            @for $size from 1 through length($o-colors) {
+                .hr_mandatory_day_top_#{$size - 1}:not(.fc-disabled-day):not(:hover):not(.fc-today) {
                     .fc-day-number {
                         color: nth($o-colors, $size) !important;
-                        font-weight: 600;
                     }
                 }
             }
-        }
 
-        .fc-bgevent {
-            border-radius: 25px;
+
+            [class*='hr_mandatory_day'] {
+
+                .fc-day-number {
+                    font-weight: 600;
+                }
+
+                &.fc-today .fc-day-number {
+                    text-decoration: underline;
+                }
+            }
+
+            .fc-bgevent {
+                border-radius: 25px;
+            }
         }
     }
 }

--- a/addons/hr_homeworking/static/src/calendar/common/calender_common_renderer.xml
+++ b/addons/hr_homeworking/static/src/calendar/common/calender_common_renderer.xml
@@ -9,7 +9,7 @@
                         <i class="o_homework_content d-flex align-items-center justify-content-center flex-wrap border border-1 rounded-circle me-0" t-att-class="`fa ${iconStr} wl_color_${record.colorIndex}`" t-att-data-id="record.id"/>
                     </div>
                 </t>
-                <span class="fw-bolder" t-esc="records[0].title"/>
+                <span class="text-900 fw-bolder" t-esc="records[0].title"/>
             </div>
         </t>
         <t t-else="">

--- a/addons/hr_homeworking/static/src/calendar/common/popover/calendar_common_popover.xml
+++ b/addons/hr_homeworking/static/src/calendar/common/popover/calendar_common_popover.xml
@@ -2,31 +2,35 @@
 <templates>
     <t t-name="homework.AttendeeCalendarCommonPopover">
         <t t-if="isWorkLocationEvent()">
-        <Record resModel="'hr.employee.location'" fieldNames="fieldNames" fields="fields" activeFields="fields" values="values" mode="'readonly'" t-slot-scope="slot">
-            <div class="card-header d-flex justify-content-between py-2 pe-2">
-                <span class="popover-header border-0">
-                    <t t-if="slot.record.data.work_location_type === 'office'">
-                        <i class="fa fa-fw fa-building me-2" role="img" t-att-class="`wl_color_${props.record.colorIndex}`"/>
-                    </t>
-                    <t t-elif="slot.record.data.work_location_type === 'home'">
-                        <i class="fa fa-fw fa-home me-2" role="img" />
-                    </t>
-                    <t t-else="">
-                    <i class="fa fa-fw fa-map-marker me-2" t-att-class="`wl_color_${props.record.colorIndex}`" role="img"/>
-                    </t>
-                    <t t-esc="props.record.title"/>
-                </span>
-                <span class="o_cw_popover_close ms-4 mt-2 me-2" t-on-click.stop="() => props.close()">
-                    <i class="fc-close fc-icon fc-icon-x" />
-                </span>
-            </div>
-            <div class="o_cw_body">
-                <t t-call="{{ constructor.subTemplates.body }}" />
-                <div class="card-footer border-top d-flex gap-1" t-att-class="{ 'o_footer_shrink': !hasFooter }">
-                    <t t-call="{{ constructor.subTemplates.footer }}" />
-                </div>
-            </div>
-        </Record>
+            <Record resModel="'hr.employee.location'" fieldNames="fieldNames" fields="fields" activeFields="fields" values="values" mode="'readonly'" t-slot-scope="slot">
+                <t t-if="env.isSmall">
+                    <Dialog title="props.record.title" contentClass="'o_calendar_color_'+ props.record.colorIndex">
+                        <t t-call="{{ constructor.subTemplates.body }}" />
+                        <t t-set-slot="footer">
+                            <t t-call="calendar.AttendeeCalendarCommonPopover.footer" />
+                        </t>
+                    </Dialog>
+                </t>
+                <t t-else="">
+                    <div class="card-header d-flex justify-content-between py-2 pe-2">
+                        <span class="popover-header border-0">
+                            <i t-if="slot.record.data.work_location_type === 'office'" class="fa fa-fw fa-building me-2" role="img" t-att-class="`wl_color_${props.record.colorIndex}`"/>
+                            <i t-elif="slot.record.data.work_location_type === 'home'" class="fa fa-fw fa-home me-2" role="img" />
+                            <i t-else="" class="fa fa-fw fa-map-marker me-2" t-att-class="`wl_color_${props.record.colorIndex}`" role="img"/>
+                            <t t-esc="props.record.title"/>
+                        </span>
+                        <span class="o_cw_popover_close ms-4 mt-2 me-2" t-on-click.stop="() => props.close()">
+                            <i class="fc-close fc-icon fc-icon-x" />
+                        </span>
+                    </div>
+                    <div class="o_cw_body">
+                        <t t-call="{{ constructor.subTemplates.body }}" />
+                        <div class="card-footer d-flex gap-1 border-top" t-att-class="{ 'o_footer_shrink': !hasFooter }">
+                            <t t-call="{{ constructor.subTemplates.footer }}" />
+                        </div>
+                    </div>
+                </t>
+            </Record>
         </t>
         <t t-else="">
             <t t-call="web.CalendarCommonPopover" />

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.xml
@@ -16,7 +16,7 @@
     </t>
 
     <t t-name="web.CalendarCommonRendererHeader">
-        <span class="o_cw_day_name" t-esc="scale == 'day' ? weekdayLong : weekdayShort "/> <span t-if="scale != 'month'" class="fc-day-number o_cw_day_number" t-esc="day"/>
+        <span class="o_cw_day_name" t-esc="scale == 'day' ? weekdayLong : weekdayShort "/> <span t-if="scale != 'month'" class="fc-day-number o_cw_day_number position-relative z-index-1" t-esc="day"/>
     </t>
 
 </templates>

--- a/addons/web/static/src/views/calendar/calendar_controller.scss
+++ b/addons/web/static/src/views/calendar/calendar_controller.scss
@@ -2,16 +2,6 @@
 $o-cw-color-today-accent: $o-danger;
 $o-cw-filter-avatar-size: 20px;
 
-// Animations
-@keyframes backgroundfade {
-    from {
-        background-color: rgba($info, 0.5);
-    }
-    to {
-        background-color: rgba($info, 0.1);
-    }
-}
-
 .o_calendar_container {
     grid-template-columns: auto minmax(auto, 210px);
 
@@ -62,28 +52,6 @@ $o-cw-filter-avatar-size: 20px;
         // sync buttons are only displayed on calendar.event views
         .o_calendar_sync {
             padding-bottom: 0.5em;
-        }
-    }
-
-    .o_calendar_filter {
-
-        .o_calendar_filter_items_checkall,
-        .o_calendar_filter_item {
-
-            button.o_remove {
-                transform: translate(100%, -50%);
-            }
-
-            &:hover {
-                button.o_remove {
-                    transform: translate(0%, -50%);
-                }
-            }
-        }
-
-        .o_field_many2one {
-            margin-top: 1rem;
-            width: 100%;
         }
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_controller.xml
+++ b/addons/web/static/src/views/calendar/calendar_controller.xml
@@ -34,13 +34,13 @@
                         </div>
                         <ViewScaleSelector scales="scales" currentScale="model.scale" isWeekendVisible="state.isWeekendVisible" setScale.bind="setScale" toggleWeekendVisibility.bind="toggleWeekendVisibility"/>
                         <button
-                            class="btn btn-secondary o_calendar_button_today order-2 order-lg-0 ms-auto ms-lg-0"
+                            class="btn btn-secondary o_calendar_button_today order-2 order-lg-0"
                             t-att-class="env.isSmall ? 'btn-sm btn-light' : 'btn-secondary'"
                             t-on-click.stop="() => this.setDate('today')"
                         >   <span t-if="env.isSmall" class="position-relative pt-1"><t t-esc="today"/><i class="fa fa-calendar-o position-absolute top-50 start-50 translate-middle fs-1"></i></span>
                             <t t-else="">Today</t>
                         </button>
-                        <h5 class="d-inline-flex ms-lg-2 mb-0">
+                        <h5 class="d-inline-flex ms-md-1 mb-0 me-auto">
                             <t t-if="model.meta.scale === 'year'">
                                 <t t-esc="currentYear"/>
                             </t>
@@ -48,13 +48,13 @@
                                 <t t-esc="currentMonth"/>
                             </t>
                             <t t-elif="model.meta.scale === 'week'">
-                                <t t-esc="weekHeader"/> <span t-if="model.meta.scale === 'week'" class="badge bg-100 rounded px-1 ms-1">Week <t t-esc="currentWeek"/></span>
+                                <t t-esc="weekHeader"/> <span t-if="model.meta.scale === 'week'" class="badge align-self-center flex-shrink-0 bg-100 rounded px-1 ms-1">Week <t t-esc="currentWeek"/></span>
                             </t>
                             <t t-else="">
                                 <t t-esc="dayHeader" />
                             </t>
                         </h5>
-                        <button class="btn btn-light d-none d-md-block order-4 oi oi-panel-right ms-lg-auto collapsed lh-base" t-on-click="toggleSideBar"/>
+                        <button class="btn btn-light d-none d-md-block order-last oi oi-panel-right collapsed lh-base" t-on-click="toggleSideBar"/>
                     </div>
                     <MobileFilterPanel t-if="env.isSmall" t-props="mobileFilterPanelProps" />
                     <t t-if="showCalendar" t-component="props.Renderer" t-props="rendererProps" />

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -9,6 +9,14 @@
         border-top: 1px solid var(--o-cw-border-color);
     }
 
+    .fc-bg .fc-day {
+        background-color: rgba(var(--o-cw-day-bg, initial), var(--o-bg-opacity, .5));
+
+        &.fc-today:not(.o_calendar_disabled) {
+            --o-cw-day-bg: #{$o-view-background-color};
+        }
+    }
+
     .o_event {
         // `web/lib/fullcalendar/core/main.css` gives events with links and draggable events a hand mouse pointer,
         // but doesn't take into account that events have popovers.
@@ -22,100 +30,6 @@
 
         &, &:hover {
             color: $body-color;
-        }
-
-        &:not(.o_event_dot) {
-            --o-overlay-opacity: .5;
-
-            border-color: var(--o-event-bg--subtle, #{$info});
-
-            &:hover .fc-bg {
-                --o-bg-opacity: 1;
-            }
-
-            &:not(.fc-dragging).o_cw_custom_highlight {
-                box-shadow: 0px 8px 8px -7px rgba(0, 0, 0, 0.2);
-                z-index: 2; // for the shadow to go over the events below
-            }
-
-            &.o_event_hatched, &.o_attendee_status_tentative {
-                --o-bg-opacity: .5;
-
-                &.fc-bgevent, .fc-bg {
-                    background: repeating-linear-gradient(
-                        45deg,
-                        RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .3),
-                        RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .3) 10px,
-                        RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .6) 10px,
-                        RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .6) 20px
-                    ) !important;
-                }
-            }
-
-            &.fc-bgevent, .fc-bg {
-                background-color: var(--o-event-bg--subtle, #{$info});
-                opacity: var(--o-bg-opacity, .5);
-            }
-
-            &.fc-bgevent {
-                border-radius: $border-radius;
-
-                &.o_event_striked {
-                    background: linear-gradient(
-                        transparent 0 45%,
-                        var(--o-event-bg, #{$info}) 45% 55%,
-                        transparent 55% 100%);
-                }
-            }
-        }
-
-        &.o_event_dot {
-            --o-overlay-opacity: .25;
-
-            display: flex;
-            align-items: center;
-            gap: map-get($spacers, 1 );
-            border: none;
-            padding: 0 map-get($spacers, 1);
-            background-color: rgba(var(--o-event-bg--subtle-rgb), var(--o-bg-opacity));
-
-            @include media-breakpoint-down(md) {
-                margin: 0;
-            }
-
-            @include media-breakpoint-up(md) {
-                padding: 0 map-get($spacers, 1);
-            }
-
-            &:before {
-                content: var(--o-event-dot-icon, '\f111'); // fa-circle
-                z-index: 2;
-                display: inline-block;
-                font-family: Fontawesome;
-                color: var(--o-event-bg, #{$info});
-
-                @include media-breakpoint-down(md) {
-                    font-size: $o-font-size-base-smaller / 2;
-                }
-            }
-
-            &:hover {
-                --o-bg-opacity: .5;
-            }
-
-            &.o_event_hatched {
-                --o-event-dot-icon: '\f1db'; // fa-circle-thin
-            }
-
-            &.o_event_striked {
-                --o-event-dot-icon: '\f1db'; // fa-circle-thin
-            }
-        }
-
-        &.o_event_striked, &.o_attendee_status_declined {
-            .fc-content {
-                text-decoration: line-through;
-            }
         }
 
         &.fc-mirror, &.fc-dragging {
@@ -141,6 +55,11 @@
             display: block;
             z-index: 3;
             background-color: rgba($o-view-background-color, var(--o-overlay-opacity));
+        }
+
+        &:not(.o_event_dot):not(.fc-dragging).o_cw_custom_highlight {
+            box-shadow: 0px 8px 8px -7px rgba(0, 0, 0, 0.2);
+            z-index: 2; // for the shadow to go over the events below
         }
 
         .fc-bg {
@@ -280,6 +199,7 @@
 
                 &.fc-today {
                     color: $primary;
+
                     .o_cw_day_number {
                         color: $o-view-background-color;
 
@@ -657,6 +577,107 @@
     }
 }
 
+//=== Event colors and styles ===//
+// Defined outside `.o_calendar_renderer` for popovers
+
+.o_event {
+
+    &, &:hover {
+        color: $body-color;
+    }
+
+    &:not(.o_event_dot) {
+        --o-overlay-opacity: .5;
+
+        border-color: var(--o-event-bg--subtle, #{$info});
+
+        &:hover {
+            --o-bg-opacity: .75;
+        }
+
+        &:not(.fc-dragging).o_cw_custom_highlight {
+            box-shadow: 0px 8px 2px -7px rgba(0, 0, 0, 0.5);
+            z-index: 2; // for the shadow to go over the events below
+        }
+
+        &.o_event_hatched, &.o_attendee_status_tentative {
+            &.fc-bgevent, .fc-bg {
+                background: repeating-linear-gradient(
+                    45deg,
+                    RGBA(var(--o-event-bg--subtle-rgb, #{to-rgb($info)}), .5),
+                    RGBA(var(--o-event-bg--subtle-rgb, #{to-rgb($info)}), .5) 10px,
+                    RGBA(var(--o-event-bg--subtle-rgb, #{to-rgb($info)}), 1) 10px,
+                    RGBA(var(--o-event-bg--subtle-rgb, #{to-rgb($info)}), 1) 20px
+                ) !important;
+            }
+        }
+
+        .fc-bg, &.fc-bgevent {
+            background-color: rgba(var(--o-event-bg--subtle-rgb, #{to-rgb($info)}), var(--o-bg-opacity, 1));
+        }
+
+        &.fc-bgevent.o_event_striked {
+            background: linear-gradient(
+                transparent 0 45%,
+                var(--o-event-bg, #{$info}) 45% 55%,
+                transparent 55% 100%);
+        }
+    }
+
+    &.o_event_dot {
+        --o-overlay-opacity: .25;
+
+        display: flex;
+        align-items: center;
+        gap: 3px;
+        border: none;
+        padding: 0 map-get($spacers, 1);
+        background-color: rgba(var(--o-event-bg--subtle-rgb), var(--o-bg-opacity));
+
+        @include media-breakpoint-down(md) {
+            margin: 0;
+        }
+
+        @include media-breakpoint-up(md) {
+            padding: 0 map-get($spacers, 1);
+        }
+
+        &:before {
+            content: var(--o-event-dot-icon, '\f111'); // fa-circle
+            z-index: 2;
+            display: inline-block;
+            font-family: Fontawesome;
+            color: var(--o-event-bg, #{$info});
+
+            @include media-breakpoint-down(md) {
+                font-size: $o-font-size-base-smaller / 2;
+            }
+        }
+
+        &:hover {
+            --o-bg-opacity: .5;
+        }
+
+        &.o_event_hatched {
+            --o-event-dot-icon: '\f1db'; // fa-circle-thin
+        }
+
+        &.o_event_striked {
+            --o-event-dot-icon: '\f1db'; // fa-circle-thin
+        }
+    }
+
+    &.fc-bgevent {
+        border-radius: $border-radius;
+        opacity: 1;
+    }
+
+    &.o_event_striked {
+        .fc-content {
+            text-decoration: line-through;
+        }
+    }
+}
 
 // ===============  Generate color classes ===============
 @for $-i from 1 through length($o-colors-complete) {
@@ -664,11 +685,13 @@
     $-color-subtle: mix($o-white, $-color, 55%);
     $-filter-border-color: shade-color($-color, 20%);
 
-    .o_calendar_renderer .o_event.o_calendar_color_#{$-i - 1} {
-        --o-event-bg: #{$-color};
-        --o-event-bg-rgb: #{to-rgb($-color)};
-        --o-event-bg--subtle: #{$-color-subtle};
-        --o-event-bg--subtle-rgb: #{to-rgb($-color-subtle)};
+    .o_calendar_renderer, .o_cw_popover {
+        .o_event.o_calendar_color_#{$-i - 1} {
+            --o-event-bg: #{$-color};
+            --o-event-bg-rgb: #{to-rgb($-color)};
+            --o-event-bg--subtle: #{$-color-subtle};
+            --o-event-bg--subtle-rgb: #{to-rgb($-color-subtle)};
+        }
     }
 
     .o_cw_filter_color_#{$-i - 1} {

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -30,6 +30,59 @@
             }
         }
 
+        &:not(.o_event_dot) {
+            --o-overlay-opacity: .5;
+
+            &.o_event_hatched {
+                --o-bg-opacity: .5;
+
+                .fc-bg {
+                    background: repeating-linear-gradient(
+                        45deg,
+                        RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .3),
+                        RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .3) 10px,
+                        RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .6) 10px,
+                        RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .6) 20px
+                    ) !important;
+                }
+            }
+
+        }
+
+        &.o_event_dot {
+            --o-overlay-opacity: .25;
+
+            display: flex;
+            align-items: center;
+            gap: map-get($spacers, 1 );
+            border: none;
+            background-color: rgba(var(--o-event-bg--subtle-rgb), var(--o-bg-opacity));
+
+            &:before {
+                z-index: 2;
+                display: inline-block;
+                font-family: Fontawesome;
+                color: var(--o-event-bg, #{$info});
+                content: '\f111'; // fa-circle
+            }
+
+            &:hover {
+                --o-bg-opacity: 1;
+            }
+
+            &.o_event_hatched {
+                &:before {
+                    content: "\f1db"; // fa-circle-thin
+                }
+            }
+        }
+
+        &.o_event_striked {
+            .fc-content {
+                text-decoration: line-through;
+            }
+        }
+
         &.fc-mirror, &.fc-dragging {
             --o-bg-opacity: .25;
             border-color: rgba($o-action, .5);
@@ -587,33 +640,26 @@
 
 
 // ===============  Generate color classes ===============
-@for $i from 1 through length($o-colors-complete) {
-    $color: nth($o-colors-complete, $i);
-    $color-subtle: mix($o-white, $color, 55%);
+@for $-i from 1 through length($o-colors-complete) {
+    $-color: nth($o-colors-complete, $-i);
+    $-color-subtle: mix($o-white, $-color, 55%);
 
     .o_calendar_renderer .fc-view {
-        .o_calendar_color_#{$i - 1} {
+        .o_calendar_color_#{$-i - 1} {
             &.fc-bgevent, &:not(.o_event_dot) .fc-bg {
-                background-color: $color-subtle;
+                background-color: $-color-subtle;
             }
 
-            &.fc-event:not(.o_event_dot):not(.fc-dragging) {
-                color: color-contrast($color-subtle);
-                border-color: tint-color($color, 50%);
-            }
-        }
-    }
+            &.fc-event {
+                --o-event-bg: #{$-color};
+                --o-event-bg-rgb: #{to-rgb($-color)};
+                --o-event-bg--subtle: #{$-color-subtle};
+                --o-event-bg--subtle-rgb: #{to-rgb($-color-subtle)};
 
-    .o_cw_filter_color_#{$i - 1} {
-        &.form-check:hover .o_cw_filter_input_bg:not(.no_filter_color) {
-            border-color: shade-color($color, 20%);
-        }
-
-        .o_cw_filter_input_bg {
-            border-color: $color;
-
-            &:checked {
-                background-color: $color;
+                &:not(.o_event_dot):not(.fc-dragging) {
+                    color: color-contrast($-color-subtle);
+                    border-color: tint-color($-color, 50%);
+                }
             }
         }
     }

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -9,34 +9,39 @@
         border-top: 1px solid var(--o-cw-border-color);
     }
 
-    .fc-event {
+    .o_event {
         // `web/lib/fullcalendar/core/main.css` gives events with links and draggable events a hand mouse pointer,
         // but doesn't take into account that events have popovers.
         cursor: pointer;
-        color: $body-color;
         background-color: $o-view-background-color;
-        transition: right .3s, left .3s;
         overflow: hidden;
 
         @include media-breakpoint-down (md) {
             line-height: 1.2;
         }
 
-        &:hover {
+        &, &:hover {
             color: $body-color;
-
-            &:not(.o_event_dot) .fc-bg {
-                --o-bg-opacity: .35;
-            }
         }
 
         &:not(.o_event_dot) {
             --o-overlay-opacity: .5;
 
-            &.o_event_hatched {
+            border-color: var(--o-event-bg--subtle, #{$info});
+
+            &:hover .fc-bg {
+                --o-bg-opacity: 1;
+            }
+
+            &:not(.fc-dragging).o_cw_custom_highlight {
+                box-shadow: 0px 8px 8px -7px rgba(0, 0, 0, 0.2);
+                z-index: 2; // for the shadow to go over the events below
+            }
+
+            &.o_event_hatched, &.o_attendee_status_tentative {
                 --o-bg-opacity: .5;
 
-                .fc-bg {
+                &.fc-bgevent, .fc-bg {
                     background: repeating-linear-gradient(
                         45deg,
                         RGBA(var(--o-event-bg-rgb, #{to-rgb($info)}), .3),
@@ -47,6 +52,21 @@
                 }
             }
 
+            &.fc-bgevent, .fc-bg {
+                background-color: var(--o-event-bg--subtle, #{$info});
+                opacity: var(--o-bg-opacity, .5);
+            }
+
+            &.fc-bgevent {
+                border-radius: $border-radius;
+
+                &.o_event_striked {
+                    background: linear-gradient(
+                        transparent 0 45%,
+                        var(--o-event-bg, #{$info}) 45% 55%,
+                        transparent 55% 100%);
+                }
+            }
         }
 
         &.o_event_dot {
@@ -56,28 +76,43 @@
             align-items: center;
             gap: map-get($spacers, 1 );
             border: none;
+            padding: 0 map-get($spacers, 1);
             background-color: rgba(var(--o-event-bg--subtle-rgb), var(--o-bg-opacity));
 
+            @include media-breakpoint-down(md) {
+                margin: 0;
+            }
+
+            @include media-breakpoint-up(md) {
+                padding: 0 map-get($spacers, 1);
+            }
+
             &:before {
+                content: var(--o-event-dot-icon, '\f111'); // fa-circle
                 z-index: 2;
                 display: inline-block;
                 font-family: Fontawesome;
                 color: var(--o-event-bg, #{$info});
-                content: '\f111'; // fa-circle
+
+                @include media-breakpoint-down(md) {
+                    font-size: $o-font-size-base-smaller / 2;
+                }
             }
 
             &:hover {
-                --o-bg-opacity: 1;
+                --o-bg-opacity: .5;
             }
 
             &.o_event_hatched {
-                &:before {
-                    content: "\f1db"; // fa-circle-thin
-                }
+                --o-event-dot-icon: '\f1db'; // fa-circle-thin
+            }
+
+            &.o_event_striked {
+                --o-event-dot-icon: '\f1db'; // fa-circle-thin
             }
         }
 
-        &.o_event_striked {
+        &.o_event_striked, &.o_attendee_status_declined {
             .fc-content {
                 text-decoration: line-through;
             }
@@ -92,6 +127,10 @@
             }
         }
 
+        &:not(.fc-mirror):not(.fc-dragging) {
+            transition: right .3s, left .3s;
+        }
+
         &.fc-mirror {
             background-color: rgba($o-action, var(--o-bg-opacity));
         }
@@ -104,26 +143,8 @@
             background-color: rgba($o-view-background-color, var(--o-overlay-opacity));
         }
 
-        &:not(.o_event_dot):not(.fc-dragging).o_cw_custom_highlight {
-            box-shadow: 0px 8px 8px -7px rgba(0, 0, 0, 0.2);
-            z-index: 2; // for the shadow to go over the events below
-        }
-
         .fc-bg {
             transition: $transition-base;
-        }
-
-        .fc-content {
-            > .o_event_title {
-                @include media-breakpoint-down(lg){
-                    text-overflow: unset;
-                    white-space: break-spaces;
-
-                    > span {
-                        word-break: break-word;
-                    }
-                }
-            }
         }
     }
 
@@ -196,7 +217,7 @@
         }
 
         .o_calendar_disabled {
-            background-color: rgba($gray-200, .5);
+            --o-cw-day-bg: #{to-rgb($gray-200)};
         }
 
         // ======  Specific agenda types ======
@@ -260,7 +281,6 @@
                 &.fc-today {
                     color: $primary;
                     .o_cw_day_number {
-                        position:relative;
                         color: $o-view-background-color;
 
                         &:before {
@@ -272,7 +292,6 @@
                             border-radius: $border-radius-pill;
                             background: $primary;
                             aspect-ratio: 1;
-                            color: $o-view-background-color;
                         }
                     }
                 }
@@ -343,15 +362,9 @@
                 box-shadow: inset 0 1px 0 var(--o-cw-border-color);
             }
 
-            .fc-day.fc-widget-content.fc-today:not(.o_calendar_disabled) {
-                background: $o-view-background-color;
-            }
-
             .fc-event {
-                --o-bg-opacity: .25;
-
                 // Prevent events with similar color to visually overlap each other
-                &:not(.o_event_allday):not(.o_homework_event) {
+                &:not(.o_event_allday):not(.o_homework_event):not(.o_cw_custom_highlight) {
                     box-shadow: 0 0 0 1px $o-view-background-color;
                 }
 
@@ -368,6 +381,17 @@
                     @include media-breakpoint-up(md) {
                         margin-top: 0;
                         margin-bottom: 0;
+                    }
+
+                    > .o_event_title {
+                        @include media-breakpoint-down(lg){
+                            text-overflow: unset;
+                            white-space: break-spaces;
+
+                            > span {
+                                word-break: break-word;
+                            }
+                        }
                     }
                 }
             }
@@ -468,10 +492,6 @@
                 border-left: none;
             }
 
-            .fc-bg .fc-today:not(.o_calendar_disabled) {
-                background: none;
-            }
-
             .fc-more-cell {
                 > div,
                 .fc-more {
@@ -482,11 +502,15 @@
             .fc-event {
                 padding: 0 map-get($spacers, 1);
                 @include media-breakpoint-up(lg) {
-                    margin: 0 3px 2px;
+                    margin-bottom: 2px;
+
+                    &:not(.o_event_dot) {
+                        margin-left: 3px;
+                        margin-right: 3px;
+                    }
                 }
 
                 .fc-content {
-                    display: flex;
                     justify-content: start;
                     flex-direction: row;
                     max-height: 1.2em;
@@ -594,6 +618,10 @@
                         text-align: center;
                         cursor: pointer;
                     }
+
+                    .o_event.fc-bgevent:not(.o_event_dot) {
+                        --o-bg-opacity: .5;
+                    }
                 }
             }
         }
@@ -629,38 +657,22 @@
     }
 }
 
-.o_calendar_renderer .fc-view {
-    .fc-event:not(.o_event_dot):not(.fc-dragging) {
-        &.o_cw_custom_highlight, &.o_calendar_popover_open {
-            box-shadow: 0px 8px 2px -7px rgba(0, 0, 0, 0.5);
-            z-index: 2; // for the shadow to go over the events below
-        }
-    }
-}
-
 
 // ===============  Generate color classes ===============
 @for $-i from 1 through length($o-colors-complete) {
     $-color: nth($o-colors-complete, $-i);
     $-color-subtle: mix($o-white, $-color, 55%);
+    $-filter-border-color: shade-color($-color, 20%);
 
-    .o_calendar_renderer .fc-view {
-        .o_calendar_color_#{$-i - 1} {
-            &.fc-bgevent, &:not(.o_event_dot) .fc-bg {
-                background-color: $-color-subtle;
-            }
+    .o_calendar_renderer .o_event.o_calendar_color_#{$-i - 1} {
+        --o-event-bg: #{$-color};
+        --o-event-bg-rgb: #{to-rgb($-color)};
+        --o-event-bg--subtle: #{$-color-subtle};
+        --o-event-bg--subtle-rgb: #{to-rgb($-color-subtle)};
+    }
 
-            &.fc-event {
-                --o-event-bg: #{$-color};
-                --o-event-bg-rgb: #{to-rgb($-color)};
-                --o-event-bg--subtle: #{$-color-subtle};
-                --o-event-bg--subtle-rgb: #{to-rgb($-color-subtle)};
-
-                &:not(.o_event_dot):not(.fc-dragging) {
-                    color: color-contrast($-color-subtle);
-                    border-color: tint-color($-color, 50%);
-                }
-            }
-        }
+    .o_cw_filter_color_#{$-i - 1} {
+        --o-cw-filter-border: #{$-filter-border-color};
+        --o-cw-filter-bg: #{$-color};
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_popover.scss
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_popover.scss
@@ -1,42 +1,30 @@
-.o_cw_popover_link {
+.o_cw_popover .o_cw_popover_link.o_event.fc-bgevent {
+    &:hover {
+        --o-bg-opacity: .75;
+    }
+
     margin-top: 2px;
+    outline-color: var(--o-event-bg--subtle);
+    padding: 0 map-get($spacers, 1);
 
-    &[class*="o_calendar_color_"] {
-        --o-bg-opacity: 1;
-
-        border-radius: $border-radius;
-        border-color: var(--o-cw-popover-color, #{$info});
-        padding: 0 map-get($spacers, 1);
-        background: RGBA(var(--o-cw-popover-color--subtle, #{to-rgb($info)}), var(--o-bg-opacity));
-        font-weight: $font-weight-normal;
+    &.o_event_hatched, &.o_attendee_status_tentative {
+        --o-event-bg-rgb: var(--o-event-bg--subtle-rgb);
 
         &:hover {
-            --o-bg-opacity: .5 !important;
-        }
-
-        &.o_event_dot {
-            --o-bg-opacity: 0;
-
-            &:before {
-                margin-right: map-get($spacers, 1);
-                font-family: FontAwesome;
-                font-size: $o-font-size-base-smaller;
-                color: var(--o-cw-popover-color, #{$info});
-                content: '\f111';
-            }
-
+            opacity: .75;
         }
     }
 
-    @for $i from 1 through length($o-colors-complete) {
-        $color: nth($o-colors-complete, $i);
-        $color-subtle: mix($o-white, $color, 55%);
+    &:not(.o_event_dot) {
+        border: 1px solid var(--o-event-bg--subtle);
+    }
 
-        &.o_calendar_color_#{$i - 1} {
-            --o-cw-popover-color: #{$color};
-            --o-cw-popover-color--subtle: #{$color-subtle};
+    &.o_event_dot {
+        --o-bg-opacity: 0;
+        outline-color: transparent;
 
-            color: color-contrast($color-subtle);
+        &:hover {
+            --o-bg-opacity: .5;
         }
     }
 }

--- a/addons/web/static/src/views/calendar/calendar_year/calendar_year_popover.xml
+++ b/addons/web/static/src/views/calendar/calendar_year/calendar_year_popover.xml
@@ -57,7 +57,7 @@
             href="#"
             t-on-click.prevent="() => this.onRecordClick(record)"
             t-attf-style="{{ getRecordStyle(record) }}"
-            t-attf-class="o_cw_popover_link d-flex align-items-center gap-1 {{ getRecordClass(record) }} {{record.startHour ? 'o_event_dot' : 'o_event_allday'}}"
+            t-attf-class="o_cw_popover_link o_event fc-bgevent d-flex align-items-center gap-1 {{ getRecordClass(record) }} {{record.startHour ? 'o_event_dot' : 'o_event_allday'}} {{record.isHatched ? 'o_event_hatched' : record.isStriked ? 'o_event_striked' : '' }}"
             t-att-data-id="record.id"
             t-att-data-title="record.title"
         >

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.scss
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.scss
@@ -19,4 +19,22 @@
             }
         }
     }
+
+    @for $-i from 1 through length($o-colors-complete) {
+        $-color: nth($o-colors-complete, $i);
+
+        .o_cw_filter_color_#{$i - 1} {
+            &.form-check:hover .o_cw_filter_input_bg:not(.no_filter_color) {
+                border-color: shade-color($-color, 20%);
+            }
+
+            .o_cw_filter_input_bg {
+                border-color: $-color;
+
+                &:checked {
+                    background-color: $-color;
+                }
+            }
+        }
+    }
 }

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.scss
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.scss
@@ -10,31 +10,44 @@
         max-height: 100%; // max-height is required to properly trigger transition
         overflow: auto;
     }
+
     .o_calendar_filter_item {
+        &.form-check:hover .o_cw_filter_input_bg:not(.no_filter_color) {
+            border-color: var(--o-cw-filter-border, $o-white);
+        }
+
         &.no_filter_color, &.o_cw_filter_color_false, &:not([class*='o_cw_filter_color']) {
             input, input:hover {
                 border-color: $light;
                 background-color: transparent !important;
                 filter: invert(1) grayscale(1);
+                box-shadow: none;
+            }
+        }
+
+        &, & ~ .o_calendar_filter_items_checkall {
+            button.o_remove {
+                transform: translate(100%, -50%);
+            }
+
+            &:hover {
+                button.o_remove {
+                    transform: translate(0%, -50%);
+                }
+            }
+        }
+
+        .o_cw_filter_input_bg {
+            border-color: var(--o-cw-filter-bg);
+
+            &:checked {
+                background-color: var(--o-cw-filter-bg);
             }
         }
     }
 
-    @for $-i from 1 through length($o-colors-complete) {
-        $-color: nth($o-colors-complete, $i);
-
-        .o_cw_filter_color_#{$i - 1} {
-            &.form-check:hover .o_cw_filter_input_bg:not(.no_filter_color) {
-                border-color: shade-color($-color, 20%);
-            }
-
-            .o_cw_filter_input_bg {
-                border-color: $-color;
-
-                &:checked {
-                    background-color: $-color;
-                }
-            }
-        }
+    .o_field_many2one {
+        margin-top: 1rem;
+        width: 100%;
     }
 }

--- a/addons/web/static/src/views/calendar/mobile_filter_panel/calendar_mobile_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/mobile_filter_panel/calendar_mobile_filter_panel.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.CalendarMobileFilterPanel">
-        <div class="o_other_calendar_panel d-flex align-items-center" t-on-click="props.toggleSideBar">
+        <div t-if="props.model.filterSections.length gt 0" class="o_other_calendar_panel d-flex align-items-center" t-on-click="props.toggleSideBar">
             <div class="o_filter me-auto d-flex overflow-auto">
                 <t t-foreach="props.model.filterSections" t-as="section" t-key="section.fieldName">
                     <t t-if="section.filters.length gt 0">


### PR DESCRIPTION
This PR fixes issues after the revamp in PR https://github.com/odoo/odoo/pull/138670

The first fix was to move some of the SCSS in the `calendar` module into the `web` module. Because some modules such as `planning` don't require `calendar`, if it isn't installed, `planning` would not have the styling and colors of the events. By moving things around, this makes for a major part of the diff in this PR.

Some event styles were also not being applied in the Year view. This is because we moved all the styles for event styling inside the `.fc-event` selector, but the Year view doesn't have this class on its events, instead we changed it to the `o_event` class which is in every view.

This PR includes other improvements such as making the events' colors stand out more in Year view, making "mandatory days" more readable, and improving the calendar header's layout. 

Entreprise PR https://github.com/odoo/enterprise/pull/50251

task-3575827

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
