### PR TITLE
[FIX] lunch: fix no content smiling face visibility

### DIFF
--- a/addons/lunch/static/src/components/lunch_dashboard.xml
+++ b/addons/lunch/static/src/components/lunch_dashboard.xml
@@ -72,7 +72,7 @@
     <t t-name="lunch.LunchDashboardOrder" owl="1">
         <LunchAlerts alerts="state.infos.alerts"/>
 
-        <div class="o_lunch_banner container-fluid p-4 bg-view">
+        <div class="o_lunch_banner container-fluid p-4 border-bottom bg-view order-lg-first">
             <div class="row h-100">
                 <div class="col-12 col-md-4">
                     <div class="row h-100 align-content-center">
@@ -126,7 +126,7 @@
             <t t-call="lunch.LunchDashboardOrder"/>
         </t>
         <t t-else="">
-            <details class="fixed-bottom bg-view p-2" t-att-open="state.mobileOpen">
+            <details class="bg-view p-2" t-att-open="state.mobileOpen">
                 <summary class="btn btn-primary w-100" t-on-click="() => state.mobileOpen = !state.mobileOpen">
                     <i class="fa fa-fw fa-shopping-cart"/>
                     Your Cart (<LunchCurrency currency="currency" amount="state.infos.total || 0"/>)

--- a/addons/lunch/static/src/views/kanban.xml
+++ b/addons/lunch/static/src/views/kanban.xml
@@ -1,12 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="lunch.KanbanRenderer" owl="1">
-        <div class="o_lunch_content d-flex flex-column h-100">
+        <div class="o_lunch_content d-flex flex-column h-lg-100">
+        <t t-call="web.KanbanRenderer"/>
             <LunchDashboard openOrderLine.bind="openOrderLine"/>
-
-            <div class="overflow-auto border-top">
-                <t t-call="web.KanbanRenderer"/>
-            </div>
         </div>
     </t>
 </templates>


### PR DESCRIPTION
This PR fixes an issue about the smiling face not being visible when there is no content in this view.

Prior to this commit, the kanban renderer was called within a `div` tag, which generated rendering issue in some cases.

To fix this issue, we remove the extra div and set a border-bottom to the element placed above.

task-3584240