### PR TITLE
[FIX] base_vat: VIES check should not be blocking

### DIFF
--- a/addons/base_vat/i18n/base_vat.pot
+++ b/addons/base_vat/i18n/base_vat.pot
@@ -81,6 +81,13 @@ msgid ""
 msgstr ""
 
 #. module: base_vat
+#. odoo-python
+#: code:addons/base_vat/models/res_partner.py:0
+#, python-format
+msgid "The VAT number %s failed the VIES VAT validation check."
+msgstr ""
+
+#. module: base_vat
 #: code:addons/base_vat/models/account_fiscal_position.py:0
 #, python-format
 msgid ""

--- a/addons/base_vat/views/res_partner_views.xml
+++ b/addons/base_vat/views/res_partner_views.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <data>
         <record id="view_partner_form" model="ir.ui.view">
-            <field name="name">res.partner.vat.inherit</field>
             <field name="model">res.partner</field>
-            <field name="inherit_id" ref="base.view_partner_form"/>
+            <field name="name">view.partner.base.vat.form</field>
+            <field name="inherit_id" ref="base.view_partner_form" />
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='vat']" position="attributes">
-                    <attribute name="string">VAT</attribute>
-                </xpath>
-                <xpath expr="//span[hasclass('o_vat_label')]" position="replace">
-                    <span class="o_vat_label">VAT</span>
+                <xpath expr="//div[hasclass('alert')]" position="after">
+                    <div class="alert alert-warning oe_edit_only" role="alert" attrs="{'invisible': [('vies_failed_message', '=', False)]}">
+                        <field name="vies_failed_message" nolabel="1" readonly="1"/>
+                    </div>
                 </xpath>
             </field>
         </record>
+    </data>
 </odoo>

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -25298,8 +25298,9 @@ msgstr ""
 #: model:ir.model.fields,help:base.field_res_partner__vat
 #: model:ir.model.fields,help:base.field_res_users__vat
 msgid ""
-"The Tax Identification Number. Complete it if the contact is subjected to "
-"government taxes. Used in some legal statements."
+"The Tax Identification Number. Values here will be validated based on the "
+"country format. You can use '/' to indicate that the partner is not subject "
+"to tax."
 msgstr ""
 
 #. module: base

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -174,7 +174,7 @@ class Partner(models.Model):
     tz_offset = fields.Char(compute='_compute_tz_offset', string='Timezone offset', invisible=True)
     user_id = fields.Many2one('res.users', string='Salesperson',
       help='The internal user in charge of this contact.')
-    vat = fields.Char(string='Tax ID', index=True, help="The Tax Identification Number. Complete it if the contact is subjected to government taxes. Used in some legal statements.")
+    vat = fields.Char(string='Tax ID', index=True, help="The Tax Identification Number. Values here will be validated based on the country format. You can use '/' to indicate that the partner is not subject to tax.")
     same_vat_partner_id = fields.Many2one('res.partner', string='Partner with same Tax ID', compute='_compute_same_vat_partner_id', store=False)
     bank_ids = fields.One2many('res.partner.bank', 'partner_id', string='Banks')
     website = fields.Char('Website Link')


### PR DESCRIPTION
Backport of fix in 16.0:
6785804a0d431f1c69ae479ea9c2f613a65d05cc

Commit message:
> To that end, we will now do the VIES and regular VAT
> check separately.
> The VAT check stays as a constrains, while the VIES
> check will now be done in an onchange and simply
> display a warning if it fails.
>
> We will also now allow VAT with a single character to
> ignore the checks. This will allow users to better
> distinguish partners for which they didn't enter VAT
> against partners which are not subject to VAT by setting
> the later's VAT to '/' or any other characters.

opw-3549022
