### PR TITLE
[FIX] mrp: raise exception if expected duration value is overflowed

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -4970,6 +4970,14 @@ msgid ""
 msgstr ""
 
 #. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/mrp_production.py:0
+#, python-format
+msgid "The entered expected duration creates a date too far into the future."
+msgstr ""
+
+#. module: mrp
+#. odoo-python
 #: code:addons/mrp/models/stock_orderpoint.py:0
 #, python-format
 msgid "The following replenishment order has been generated"

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -701,7 +701,10 @@ class MrpProduction(models.Model):
             date_finished = production.date_start + relativedelta(days=days_delay)
             if date_finished == production.date_start:
                 workorder_expected_duration = sum(self.workorder_ids.mapped('duration_expected'))
-                date_finished = date_finished + relativedelta(minutes=workorder_expected_duration or 60)
+                try:
+                    date_finished = date_finished + relativedelta(minutes=workorder_expected_duration or 60)
+                except OverflowError:
+                    raise UserError(_("The entered expected duration creates a date too far into the future."))
             production.date_finished = date_finished
 
     @api.depends('company_id', 'bom_id', 'product_id', 'product_qty', 'product_uom_id', 'location_src_id', 'date_start')


### PR DESCRIPTION
This issue occurs when the user enters the large value `(1111111111)` 
in the `duration_expected` field, while creating a `Manufacturing Order` record.

To reproduce this issue:

1) Install `mrp`
2) Open `Manufacturing/Operations/ Manufacturing Orders` 
3) Create a new `Manufacture Order` record.
4) Select any product and add a line in `Work Oders` 
5) Enter the larger duration value in `duration_expected` like `(e.g.11111111111)`.

Error: https://pastebin.com/Qwp7u5VR

This issue occurring from here

https://github.com/odoo/odoo/blob/4cb1f8a01bf54503d1bf46697ed837655e826269/addons/mrp/models/mrp_production.py#L704

When calculating the `date_finished` based on the provided `expected duration` value, an error is triggered.

sentry-4595180557

