### PR TITLE
[IMP] partner_autocomplete: improve vat number matching

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -6,6 +6,8 @@ import json
 import logging
 import requests
 
+from stdnum.eu.vat import check_vies
+
 from odoo import api, fields, models, tools, _
 
 _logger = logging.getLogger(__name__)
@@ -130,6 +132,28 @@ class ResPartner(models.Model):
         if vies_vat_data:
             return [self._format_data_company(vies_vat_data)]
         else:
+            vies_result = None
+            try:
+                vies_result = check_vies(vat)
+            except Exception:
+                _logger.exception("Failed VIES VAT check.")
+            if vies_result:
+                name = vies_result['name']
+                if vies_result['valid'] and name != '---':
+                    address = list(filter(bool, vies_result['address'].split('\n')))
+                    street = address[0]
+                    zip_city = address[-1].split(' ', 1) if len(address) > 1 else [None, None]
+                    street2 = address[1] if len(address) > 2 else None
+                    return [self._iap_replace_location_codes({
+                        'name': name,
+                        'vat': vat,
+                        'street': street,
+                        'street2': street2,
+                        'city': zip_city[1],
+                        'zip': zip_city[0],
+                        'country_code': vies_result['countryCode'],
+                        'skip_enrich': True,
+                    })]
             return []
 
     @api.model

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
@@ -116,7 +116,7 @@ var PartnerAutocompleteMixin = {
         var self = this;
 
         var removeUselessFields = function (company) {
-            var fields = 'label,description,domain,logo,legal_name,ignored,email'.split(',');
+            var fields = 'label,description,domain,logo,legal_name,ignored,email,skip_enrich'.split(',');
             fields.forEach(function (field) {
                 delete company[field];
             });
@@ -129,7 +129,7 @@ var PartnerAutocompleteMixin = {
 
         return new Promise(function (resolve) {
             // Fetch additional company info via Autocomplete Enrichment API
-            var enrichPromise = self._enrichCompany(company);
+            var enrichPromise = !company.skip_enrich ? self._enrichCompany(company) : false;
 
             // Get logo
             var logoPromise = company.logo ? self._getCompanyLogo(company.logo) : false;


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
The first search request for a VAT number will always fail, because we need to find an active link to a directory company before we return the company information

Current behavior before PR:
Data is returned for a VAT number search only if
we already have an active link to a directory company

Desired behavior after PR is merged:
If no directory company was found, fill in company with result from viesvat

task-3548046

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
