### PR TITLE
[FIX] mass_mailing : Mailing list name

### DIFF
--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -117,7 +117,7 @@ class MassMailingList(models.Model):
         return super(MassMailingList, self).write(vals)
 
     def name_get(self):
-        return [(list.id, "%s (%s)" % (list.name, list.contact_count)) for list in self]
+        return [(list.id, list.name) for list in self]
 
     def copy(self, default=None):
         self.ensure_one()


### PR DESCRIPTION
[FIX] mass_mailing : Mailing list name

Steps to reproduce:
	1- Install Email Marketing and Website apps
	2- Go to website and create a 'subscribe to newsletter' form
	3- Check the names of the mailing lists shown in the 'subscribe to' field

Current behavior before PR:
the mailing list name that appears in many views like the 'subscribe to newsletter' form is the name concatenated with the number of contacts in that list

Desired behavior after PR is merged:
The name is now shown as the name only without any other variables concatenated with it

opw-3574794