### PR TITLE
[FIX] website_forum: fix the invalid URL link

### DIFF
--- a/addons/website_forum/models/forum.py
+++ b/addons/website_forum/models/forum.py
@@ -511,13 +511,14 @@ class Post(models.Model):
         if content and self.env.user.karma < forum.karma_dofollow:
             for match in re.findall(r'<a\s.*href=".*?">', content):
                 match = re.escape(match)  # replace parenthesis or special char in regex
-                content = re.sub(match, match[:3] + 'rel="nofollow" ' + match[3:], content)
+                content = re.sub(match, match[:match.find("ugc") + 3] + ' nofollow' + match[match.find("ugc") + 3:], content)
 
         if self.env.user.karma < forum.karma_editor:
             filter_regexp = r'(<img.*?>)|(<a[^>]*?href[^>]*?>)|(<[a-z|A-Z]+[^>]*style\s*=\s*[\'"][^\'"]*\s*background[^:]*:[^url;]*url)'
             content_match = re.search(filter_regexp, content, re.I)
             if content_match:
                 raise AccessError(_('%d karma required to post an image or link.', forum.karma_editor))
+        content = content.replace('\\', '')
         return content
 
     def _default_website_meta(self):


### PR DESCRIPTION
How to reproduce:
- Login as a portal user, create a new post by adding a URL link
- Post Your Question
- Login as admin to validate the post
- Click on 'To Validate' from the moderation tool
- Click on the mentioned URL

Throws a Traceback and redirects to the about:blank#blocked page.

Technical Reason:
The '_update_content' method performs a regular expression on the link by using the escape method, which is later convert the backslash '\' into '%5C' while html_sanitize.

After this commit:
Clicking on the mentioned link redirects to the correct URL

Task-3472776
