### PR TITLE
[FIX] stock: make show_reserved invisible

### DIFF
--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -104,7 +104,7 @@
                                     <field name="default_location_return_id" invisible="code not in ['incoming', 'outgoing', 'internal']" groups="stock.group_stock_multi_locations"/>
                                     <field name="create_backorder"/>
                                     <field name="show_operations" invisible="not show_picking_type"/>
-                                    <field name="show_reserved" invisible="code != 'incoming'"/>
+                                    <field name="show_reserved" invisible="1"/>
                                 </group>
                             </group>
                             <group name="second">


### PR DESCRIPTION
The field is now readonly and computed, so there's no reason to show it. 
It's still present since it is used in at least one xpath.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
