### PR TITLE
[FIX] portal, sale_stock: fix layout issues

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -282,7 +282,7 @@
 
     <template id="portal_record_sidebar" name="My Portal Record Sidebar">
         <div t-attf-class="#{classes}">
-            <div class="o_portal_sidebar_content sticky-lg-top d-lg-inline-block mb-4 mb-lg-0 p-3 p-lg-0" id="sidebar_content">
+            <div class="o_portal_sidebar_content sticky-lg-top d-lg-inline-block mb-4 mb-lg-0 mt-lg-n5 p-3 p-lg-0 pt-lg-5" id="sidebar_content">
                 <div t-if="title" class="position-relative d-flex align-items-center justify-content-md-center justify-content-lg-between flex-wrap gap-2">
                     <t t-out="title"/>
                 </div>

--- a/addons/sale_stock/views/sale_stock_portal_template.xml
+++ b/addons/sale_stock/views/sale_stock_portal_template.xml
@@ -27,7 +27,7 @@
                         <t t-set="delivery_report_url"
                            t-value="'/my/picking/pdf/%s?%s' % (picking.id, keep_query())"/>
                         <div name="delivery_order"
-                            class="d-flex flex-wrap align-items-center">
+                            class="d-flex flex-column flex-wrap align-items-start">
                             <div name="delivery_details">
                                 <a t-att-href="delivery_report_url">
                                     <span t-esc="picking.name"/>


### PR DESCRIPTION
This commit aims to fix two issues within portal :

- The sticky sidebar is hidden on scroll due to the lack of spacing ;

- The delivery orders informations layout is not optimal.

To fix these issues, we modified two things in the layout :

- We add a padding and margin to our sidebar, preventing it from being hidden when scrolling.

- We change the flex properties applied to the sale_stock information.

task-3586254