### PR TITLE
[FIX] mass_mailing: added _get_translation_frontend_modules_name

### DIFF
--- a/addons/mass_mailing/models/__init__.py
+++ b/addons/mass_mailing/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_http
 from . import ir_mail_server
 from . import ir_model
 from . import link_tracker

--- a/addons/mass_mailing/models/ir_http.py
+++ b/addons/mass_mailing/models/ir_http.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = "ir.http"
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ["mass_mailing"]


### PR DESCRIPTION
    [FIX] mass_mailing: added _get_translation_frontend_modules_name
    
    Before: When a user receive a mass_mailing and click on the
    unsubscribe button, he arrives on the unsubscribe webpage where
    the first sentence stay in english whatever the website language
    
    Step to reproduce:
    - Create a db with the email marketing and web module
    - Create a mailing list with at least one recipient
    - Send the mailing (catch the email with an email catcher, ex: mailhog)
    - Click on the unsubscribe button
    
    Now: The first sentence is in the website language




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
