### PR TITLE
[FIX] iap: remove IAP neutralization

### DIFF
--- a/addons/partner_autocomplete/data/neutralize.sql
+++ b/addons/partner_autocomplete/data/neutralize.sql
@@ -1,4 +1,0 @@
-INSERT INTO ir_config_parameter (key, value)
-VALUES ('iap.partner_autocomplete.endpoint', 'https://iap-services-test.odoo.com')
-    ON CONFLICT (key) DO
-       UPDATE SET value = 'https://iap-services-test.odoo.com';

--- a/addons/sms/data/neutralize.sql
+++ b/addons/sms/data/neutralize.sql
@@ -1,4 +1,0 @@
-INSERT INTO ir_config_parameter (key, value)
-VALUES ('sms.endpoint', 'https://iap-services-test.odoo.com')
-    ON CONFLICT (key) DO
-       UPDATE SET value = 'https://iap-services-test.odoo.com';

--- a/addons/snailmail/data/neutralize.sql
+++ b/addons/snailmail/data/neutralize.sql
@@ -1,4 +1,0 @@
-INSERT INTO ir_config_parameter (key, value)
-VALUES ('snailmail.endpoint', 'https://iap-services-test.odoo.com')
-    ON CONFLICT (key) DO
-       UPDATE SET value = 'https://iap-services-test.odoo.com';

--- a/addons/website_crm_iap_reveal/data/neutralize.sql
+++ b/addons/website_crm_iap_reveal/data/neutralize.sql
@@ -1,4 +1,0 @@
-INSERT INTO ir_config_parameter (key, value)
-VALUES ('reveal.endpoint', 'https://iap-services-test.odoo.com')
-    ON CONFLICT (key) DO
-       UPDATE SET value = 'https://iap-services-test.odoo.com';


### PR DESCRIPTION
Since commit 550595d, it's no longer necessary to change the endpoint to the IAP services test server.