### PR TITLE
[FIX] account: disallow modifying readonly fields on posted move

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -830,7 +830,9 @@ class AccountBankStatementLine(models.Model):
                 st_line_vals['journal_id'] = journal.id
             if st_line.move_id.partner_id != st_line.partner_id:
                 st_line_vals['partner_id'] = st_line.partner_id.id
+            st_line.move_id.button_draft()
             st_line.move_id.write(st_line_vals)
+            st_line.move_id.action_post()
 
 
 # For optimization purpose, creating the reverse relation of m2o in _inherits saves

--- a/addons/account/tests/test_account_bank_statement.py
+++ b/addons/account/tests/test_account_bank_statement.py
@@ -191,6 +191,7 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
         }])
 
         # Check the account.bank.statement.line is still correct after editing the account.move.
+        statement_line.move_id.button_draft()
         statement_line.move_id.write({'line_ids': [
             (1, liquidity_lines.id, {
                 'debit': expected_liquidity_values.get('debit', 0.0),
@@ -203,6 +204,7 @@ class TestAccountBankStatementLine(AccountTestInvoicingCommon):
                 'amount_currency': expected_counterpart_values.get('amount_currency', 0.0),
             }),
         ]})
+        statement_line.move_id.action_post()
         self.assertRecordValues(statement_line, [{
             'amount': amount,
             'amount_currency': amount_currency,

--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -171,49 +171,9 @@ class TestAccountMove(AccountTestInvoicingCommon):
         # Editing the reference should be allowed.
         self.test_move.ref = 'whatever'
 
-        # Try to edit a line into a locked fiscal year.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (1, lines[2].id, {'debit': lines[2].debit + 100.0}),
-                ],
-            })
-
         # Try to edit the account of a line.
         with self.assertRaises(UserError), self.cr.savepoint():
             self.test_move.line_ids[0].write({'account_id': self.test_move.line_ids[0].account_id.copy().id})
-
-        # Try to edit a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (1, lines[3].id, {'debit': lines[3].debit + 100.0}),
-                ],
-            })
-
-        # Try to add a new tax on a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[2].id, {'tax_ids': [(6, 0, self.company_data['default_tax_purchase'].ids)]}),
-                ],
-            })
-
-        # Try to create a new line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (0, None, {
-                        'name': 'revenue line 1',
-                        'account_id': self.company_data['default_account_revenue'].id,
-                        'debit': 100.0,
-                        'credit': 0.0,
-                    }),
-                ],
-            })
 
         # You can't remove the journal entry from a locked period.
         with self.assertRaises(UserError), self.cr.savepoint():
@@ -260,70 +220,8 @@ class TestAccountMove(AccountTestInvoicingCommon):
         # lines[3] = 'revenue line 2'
         lines = self.test_move.line_ids.sorted('debit')
 
-        # Try to edit a line not affecting the taxes.
-        self.test_move.write({
-            'line_ids': [
-                (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                (1, lines[2].id, {'debit': lines[2].debit + 100.0}),
-            ],
-        })
-
         # Try to edit the account of a line.
         self.test_move.line_ids[0].write({'account_id': self.test_move.line_ids[0].account_id.copy().id})
-
-        # Try to edit a line having some taxes.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (1, lines[3].id, {'debit': lines[3].debit + 100.0}),
-                ],
-            })
-
-        # Try to add a new tax on a line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[2].id, {'tax_ids': [(6, 0, self.company_data['default_tax_purchase'].ids)]}),
-                ],
-            })
-
-        # Try to edit a tax line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (1, lines[1].id, {'debit': lines[1].debit + 100.0}),
-                ],
-            })
-
-        # Try to create a line not affecting the taxes.
-        self.test_move.write({
-            'line_ids': [
-                (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                (0, None, {
-                    'name': 'revenue line 1',
-                    'account_id': self.company_data['default_account_revenue'].id,
-                    'debit': 100.0,
-                    'credit': 0.0,
-                }),
-            ],
-        })
-
-        # Try to create a line affecting the taxes.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            self.test_move.write({
-                'line_ids': [
-                    (1, lines[0].id, {'credit': lines[0].credit + 100.0}),
-                    (0, None, {
-                        'name': 'revenue line 2',
-                        'account_id': self.company_data['default_account_revenue'].id,
-                        'debit': 100.0,
-                        'credit': 0.0,
-                        'tax_ids': [(6, 0, self.company_data['default_tax_sale'].ids)],
-                    }),
-                ],
-            })
 
         # You can't remove the journal entry from a locked period.
         with self.assertRaises(UserError), self.cr.savepoint():
@@ -394,26 +292,20 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
         (lines[0] + lines[2]).reconcile()
 
-        # You can't write something impacting the reconciliation on an already reconciled line.
-        with self.assertRaises(UserError), self.cr.savepoint():
-            draft_moves[0].write({
-                'line_ids': [
-                    (1, lines[1].id, {'credit': lines[1].credit + 100.0}),
-                    (1, lines[2].id, {'debit': lines[2].debit + 100.0}),
-                ]
-            })
-
-        # The write must not raise anything because the rounding of the monetary field should ignore such tiny amount.
-        draft_moves[0].write({
-            'line_ids': [
-                (1, lines[1].id, {'credit': lines[1].credit + 0.0000001}),
-                (1, lines[2].id, {'debit': lines[2].debit + 0.0000001}),
-            ]
-        })
-
         # You can't unlink an already reconciled line.
         with self.assertRaises(UserError), self.cr.savepoint():
             draft_moves.unlink()
+
+    def test_modify_posted_move_readonly_fields(self):
+        self.test_move.action_post()
+
+        readonly_fields = ('invoice_line_ids', 'line_ids', 'invoice_date', 'date', 'partner_id', 'partner_bank_id',
+                           'invoice_payment_term_id', 'currency_id', 'fiscal_position_id', 'auto_post', 'invoice_cash_rounding_id')
+
+        for fname in readonly_fields:
+            with self.assertRaisesRegex(UserError, "This move has been posted. The field you're trying to change is now readonly."), \
+                    self.cr.savepoint():
+                self.test_move.write({fname: False})
 
     def test_add_followers_on_post(self):
         # Add some existing partners, some from another company

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -1831,11 +1831,11 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         })
         pay1_liquidity_line = pay1.line_ids.filtered(lambda x: x.account_id.account_type != 'asset_receivable')
         pay1_rec_line = pay1.line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable')
-        pay1.action_post()
         pay1.write({'line_ids': [
             Command.update(pay1_liquidity_line.id, {'debit': 36511.34}),
             Command.update(pay1_rec_line.id, {'credit': 36511.34}),
         ]})
+        pay1.action_post()
 
         pay2 = self.env['account.payment'].create({
             'partner_type': 'customer',
@@ -2106,11 +2106,11 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         })
         pay1_liquidity_line = pay1.line_ids.filtered(lambda x: x.account_id.account_type != 'asset_receivable')
         pay1_rec_line = pay1.line_ids.filtered(lambda x: x.account_id.account_type == 'asset_receivable')
-        pay1.action_post()
         pay1.write({'line_ids': [
             Command.update(pay1_liquidity_line.id, {'debit': 36511.34}),
             Command.update(pay1_rec_line.id, {'credit': 36511.34}),
         ]})
+        pay1.action_post()
 
         pay2 = self.env['account.payment'].create({
             'partner_type': 'customer',

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -117,6 +117,11 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })
         cls.in_refund_1.action_post()
 
+    def set_move_partner_bank_id(self, move, bank):
+        move.button_draft()
+        move.partner_bank_id = bank
+        move.action_post()
+
     def test_register_payment_single_batch_grouped_keep_open_lower_amount(self):
         ''' Pay 800.0 with 'open' as payment difference handling on two customer invoices (1000 + 2000). '''
         active_ids = (self.out_invoice_1 + self.out_invoice_2).ids
@@ -518,8 +523,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'partner_id': self.partner_a.id,
         })
 
-        self.in_invoice_1.partner_bank_id = bank1
-        self.in_invoice_2.partner_bank_id = bank2
+        self.set_move_partner_bank_id(self.in_invoice_1, bank1)
+        self.set_move_partner_bank_id(self.in_invoice_2, bank2)
 
         active_ids = (self.in_invoice_1 + self.in_invoice_2 + self.in_refund_1).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
@@ -660,8 +665,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         ''' Choose to pay multiple batches, one with two customer invoices (1000 + 2000)
          and one with a vendor bill of 600, by splitting payments.
          '''
-        self.in_invoice_1.partner_bank_id = self.partner_bank_account1
-        self.in_invoice_2.partner_bank_id = self.partner_bank_account2
+        self.set_move_partner_bank_id(self.in_invoice_1, self.partner_bank_account1)
+        self.set_move_partner_bank_id(self.in_invoice_2, self.partner_bank_account2)
 
         active_ids = (self.in_invoice_1 + self.in_invoice_2 + self.in_invoice_3).ids
         payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
@@ -1009,7 +1014,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
     def test_suggested_default_partner_bank_inbound_payment(self):
         """ Test the suggested bank account on the wizard for inbound payment. """
-        self.out_invoice_1.partner_bank_id = False
+        self.set_move_partner_bank_id(self.out_invoice_1, False)
 
         ctx = {'active_model': 'account.move', 'active_ids': self.out_invoice_1.ids}
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
@@ -1019,7 +1024,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'partner_bank_id': False,
         }])
 
-        self.bank_journal_2.bank_account_id = self.out_invoice_1.partner_bank_id = self.comp_bank_account2
+        self.set_move_partner_bank_id(self.out_invoice_1, self.comp_bank_account2)
+        self.bank_journal_2.bank_account_id = self.comp_bank_account2
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
         self.assertRecordValues(wizard, [{
             'journal_id': self.bank_journal_2.id,
@@ -1036,7 +1042,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
     def test_suggested_default_partner_bank_outbound_payment(self):
         """ Test the suggested bank account on the wizard for outbound payment. """
-        self.in_invoice_1.partner_bank_id = False
+        self.set_move_partner_bank_id(self.in_invoice_1, False)
 
         ctx = {'active_model': 'account.move', 'active_ids': self.in_invoice_1.ids}
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
@@ -1046,7 +1052,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'partner_bank_id': self.partner_bank_account1.id,
         }])
 
-        self.in_invoice_1.partner_bank_id = self.partner_bank_account2
+        self.set_move_partner_bank_id(self.in_invoice_1, self.partner_bank_account2)
         wizard = self.env['account.payment.register'].with_context(**ctx).create({})
         self.assertRecordValues(wizard, [{
             'journal_id': self.bank_journal_1.id,
@@ -1063,8 +1069,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
     def test_register_payment_inbound_multiple_bank_account(self):
         """ Pay customer invoices with different bank accounts. """
-        self.out_invoice_1.partner_bank_id = self.comp_bank_account1
-        self.out_invoice_2.partner_bank_id = self.comp_bank_account2
+        self.set_move_partner_bank_id(self.out_invoice_1, self.comp_bank_account1)
+        self.set_move_partner_bank_id(self.out_invoice_2, self.comp_bank_account2)
         self.bank_journal_2.bank_account_id = self.comp_bank_account2
 
         ctx = {'active_model': 'account.move', 'active_ids': (self.out_invoice_1 + self.out_invoice_2).ids}


### PR DESCRIPTION
When an invoice/bill is in a draft state and opened by 2 users,
If one of them posted the invoice, the other user's form are not
up-to-date, resulting in some whacky behavior like modifying 
fields that are supposed to be unmodifiable on a posted move.

This commit adds a check on `account_move.write` function to
prevent this behavior.

task-id: [3536150](https://www.odoo.com/web#id=3536150&cids=1&menu_id=4720&action=333&active_id=967&model=project.task&view_type=form)
