### PR TITLE
[IMP] account: send and print opens partner dialog

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -695,7 +695,7 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
         self.partner_a.email = None
         self.partner_b.email = None
         wizard = self.create_send_and_print(invoice1 + invoice2)
-        self.assertFalse(wizard.send_mail_warning_message)
+        self.assertTrue(wizard.send_mail_warning_message)
         self.assertRecordValues(wizard, [{
             'send_mail_readonly': True,
             'checkbox_send_mail': False,

--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -257,11 +257,16 @@ class AccountMoveSend(models.TransientModel):
             invoices_without_mail_data = wizard.move_ids.filtered(lambda x: not x.partner_id.email)
             wizard.send_mail_readonly = invoices_without_mail_data == wizard.move_ids
 
-            if wizard.mode == 'invoice_multi' and wizard.checkbox_send_mail and invoices_without_mail_data:
+            if invoices_without_mail_data:
                 wizard.send_mail_warning_message = _(
                     "The partners on the following invoices have no email address, "
-                    "so those invoices will not be sent: %s",
-                    ", ".join(invoices_without_mail_data.mapped('name')))
+                    "so those invoices will not be sent: %s"
+                ) % ", ".join(sorted(invoices_without_mail_data.mapped('name')))
+
+    @api.depends('move_ids')
+    def _compute_checkbox_send_mail(self):
+        for wizard in self:
+            wizard.checkbox_send_mail = wizard.company_id.invoice_is_email and not wizard.send_mail_readonly
 
     @api.depends('mail_template_id')
     def _compute_mail_lang(self):
@@ -333,6 +338,31 @@ class AccountMoveSend(models.TransientModel):
     # -------------------------------------------------------------------------
 
     @api.model
+    def action_open_partners_without_email(self, wizard_ids=None):
+        if not wizard_ids:
+            return
+        partners = self.env['res.partner']
+        for wizard in self.browse(wizard_ids):
+            partners |= wizard.move_ids.mapped("partner_id").filtered(lambda x: not x.email)
+        if len(partners) == 1:
+            return {
+                'type': 'ir.actions.act_window',
+                'res_model': 'res.partner',
+                'view_mode': 'form',
+                'target': 'current',
+                'res_id': partners.id
+            }
+        else:
+            return {
+                'type': 'ir.actions.act_window',
+                'name': _('Partners without email'),
+                'view_mode': 'tree,form',
+                'res_model': 'res.partner',
+                'context': {'create': False, 'delete': False},
+                'domain': [('id', 'in', partners.ids)],
+                'target': 'current',
+            }
+
     def _need_invoice_document(self, invoice):
         """ Determine if we need to generate the documents for the invoice passed as parameter.
         :param invoice:         An account.move record.

--- a/addons/account/wizard/account_move_send_views.xml
+++ b/addons/account/wizard/account_move_send_views.xml
@@ -7,24 +7,27 @@
         <field name="groups_id" eval="[Command.link(ref('base.group_user'))]"/>
         <field name="arch" type="xml">
             <form js_class="account_move_send_form">
+
                 <!-- Invisible fields -->
                 <field name="company_id" invisible="1"/>
                 <field name="move_ids" invisible="1"/>
                 <field name="mode" invisible="1"/>
-
                 <field name="enable_download" invisible="1"/>
                 <field name="enable_send_mail" invisible="1"/>
                 <field name="send_mail_readonly" invisible="1"/>
                 <field name="display_mail_composer" invisible="1"/>
                 <field name="mail_lang" invisible="1"/>
-                <field name="mail_partner_ids" widget="many2many_tags_email" class="d-none" context="{'force_email': True}"/>
 
                 <!-- Warnings -->
                 <div name="warnings">
                     <div class="alert alert-warning"
                         role="alert"
                         invisible="not send_mail_warning_message">
-                        <field name="send_mail_warning_message"/>
+                        <field name="send_mail_warning_message" class="d-inline me-2"/>
+                        <button name="action_open_partners_without_email"
+                                type="object"
+                                class="btn-secondary"
+                                string="See Partners"/>
                     </div>
                 </div>
 


### PR DESCRIPTION
When you open a Send and Print dialog, if the partner had no email, then the form to edit the partne appears.
We're removing this behaviour and let the user decide if he wants to check the partners or not.

![image](https://github.com/odoo/odoo/assets/1665365/bf15d438-2593-4813-a587-0d110ae9805d)