### PR TITLE
[FIX] web: Popover target prop validation

### DIFF
--- a/addons/web/static/src/core/popover/popover.js
+++ b/addons/web/static/src/core/popover/popover.js
@@ -143,10 +143,16 @@ Popover.props = {
     },
     target: {
         validate: (target) => {
-            // target may be inside an iframe, so get the Element constructor
-            // to test against from its owner document's default view
-            const Element = target?.ownerDocument?.defaultView.Element;
-            return Boolean(Element) && target instanceof Element;
+            // target may have been created by either the top window's document
+            // or the one of an iframe.
+            let prototype = Object.getPrototypeOf(target);
+            while (prototype) {
+                if (prototype.constructor?.name === "Element") {
+                    return true;
+                }
+                prototype = Object.getPrototypeOf(prototype);
+            }
+            return false;
         },
     },
     slots: {


### PR DESCRIPTION
Before this commit, the validation of the Popover component's `target` prop would fail if the target was part of an iframe document but had been created by the top window's document.

After that [1] replaced the Bootstrap tooltip by our own Tooltip component (making use of the popover service, which in turn uses the Popover component), this led to tracebacks is mass_mailing when editing mailings that had images inserted via the "/image" command, or even images part of themes like the "Welcome Message" (id="default") one.

This commit makes such prop validation more flexible and agonistic to which document created the target element.

[1]: https://github.com/odoo/odoo/commit/08cd27cc8ad78d2ee9ffe80ddb9e1cc50a557ee2
