### PR TITLE
[FIX] stock: edit package source location

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -197,6 +197,11 @@ class StockMoveLine(models.Model):
                 res['warning'] = {'title': _('Warning'), 'message': message}
         return res
 
+    @api.onchange('location_id')
+    def _onchange_location(self):
+        if self.package_id and self.package_id.location_id != self.location_id:
+            self.package_id = False
+
     @api.onchange('result_package_id', 'product_id', 'product_uom_id', 'qty_done')
     def _onchange_putaway_location(self):
         default_dest_location = self._get_default_dest_location()


### PR DESCRIPTION
Steps to reproduce:
- Create a stored product
- Update on hand quantity to 30 pacakage P location WH-STOCK
- Create a picking for that product from WH-STOCK to somewhere
- Change source location and validate

Bug:
pacakage is still set which will create a negative quantity for that pacakage in the new location

Fix:
clear the pacakage when changing source location

opw-3546239
