### PR TITLE
FIX] mass_mailing: discard button remains

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2386,13 +2386,13 @@ const Wysiwyg = Widget.extend({
             this._shouldDelayBlur = false;
         }
     },
-    _onBlur: function () {
+    _onBlur: function (action) {
         if (this._shouldDelayBlur) {
             this._pendingBlur = true;
         } else {
             // todo: to remove when removing the legacy field_html
             this.trigger_up('wysiwyg_blur');
-            this.options.onWysiwygBlur && this.options.onWysiwygBlur();
+            this.options.onWysiwygBlur && this.options.onWysiwygBlur(action);
         }
     },
     _onScroll: function(ev) {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg_iframe.js
@@ -195,7 +195,16 @@ Wysiwyg.include({
         if (!this.options.inIframe) {
             this._super.apply(this, arguments);
         } else {
-            this.$iframe[0].contentWindow.addEventListener('blur', this._onBlur);
+            let action = undefined;
+            const actionButtons = Array.from(document.querySelectorAll('.o_form_button_save, .o_form_button_cancel'));
+            actionButtons.forEach(btn => {
+                btn.addEventListener('mousedown', (ev) => {
+                    action = ev.currentTarget.dataset.tooltip;
+                });
+            });
+            this.$iframe[0].contentWindow.addEventListener('blur', () => {
+                this._onBlur(action);
+            });
         }
     },
 


### PR DESCRIPTION
Before this commit:

After making some changes in mass_mailing when discard button is clicked, this discard reappears.

After this commit:

Now, after making changes when we click on discard button, the button disappears

task-3324903