### PR TITLE
[FIX] sale_project: Take SOLs into account for stat button

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -324,7 +324,7 @@ class Project(models.Model):
         )
 
         SaleOrderLine = self.env['sale.order.line']
-        sale_order_line_domain = [('order_id', 'any', [('analytic_account_id', 'in', self.analytic_account_id.ids)])]
+        sale_order_line_domain = ['|', ('order_id', 'any', [('analytic_account_id', 'in', self.analytic_account_id.ids)]), ('order_id', '=', self.sale_order_id.id)]
         sale_order_line_query = SaleOrderLine._where_calc(sale_order_line_domain)
         sale_order_line_sql = sale_order_line_query.select(
             f'{SaleOrderLine._table}.project_id AS id',


### PR DESCRIPTION
In the project update view, the sale order items stat button does not display the right count of item. This is because sale order lines are not taken into account for the stat button

To reproduce:
- Install sale_project
- Create a billable project with a customer
- Open the project update view and add some sol.
- The stat button count should display `1` and when opened, it should only display the `project.project.sale_line_id`

task-3573591

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
