### PR TITLE
[FIX] web: kanban cards border issues

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -482,7 +482,7 @@
         .o_kanban_record {
             width: 100%;
 
-            & + .o_kanban_record:not(.o_dragged) .oe_kanban_card {
+            & + .o_kanban_record:not(.o_dragged) > div:not(.o_dropdown_kanban) {
                 border-top: none;
             }
         }
@@ -636,8 +636,12 @@
             margin: calc(var(--KanbanRecord-margin-v) * 0.5) var(--KanbanRecord-margin-h);
 
             @include media-breakpoint-down(md) {
-                margin: 0 0 #{-$border-width};
+                margin: 0 0;
                 flex-basis: 100%;
+
+                & + .o_kanban_record > div:not(.o_dropdown_kanban) {
+                    border-top: none;
+                }
             }
 
             &.o_kanban_ghost {


### PR DESCRIPTION
In commit d8fcc218bc70caff4f4368309d7aa3be8b8ddaa5 we introduced a fix to the focus state of the kanban card. This fix did not account for the ungrouped Kanbancard which are listed next to eachother < md screens.

This commit also changes the `.oe_kanban_card` selector to the same selector that defines the borders. This avoid unconsistency if the `oe_kanban_card` class is omitted.

task-3580229

Closes: https://github.com/odoo/enterprise/pull/50010

| Ungrouped cards < md | Double border due to selecting oe_kanban_card |
| -- | -- | 
| ![image](https://github.com/odoo/odoo/assets/118886338/8b0204cd-0367-4461-9605-40edb79c1dc8) | ![image](https://github.com/odoo/odoo/assets/118886338/53a4f182-d4b7-482f-b975-c5bfa9182f6d)| 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
