### PR TITLE
[FIX] web: form_view > beforeLeave

### DIFF
--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -352,7 +352,8 @@ export class FormController extends Component {
     }
 
     async beforeLeave() {
-        if (this.model.root.dirty) {
+        const dirty = await this.model.root.isDirty();
+        if (dirty) {
             return this.model.root.save({
                 reload: false,
                 onError: this.onSaveError.bind(this),

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -14387,4 +14387,38 @@ QUnit.module("Views", (hooks) => {
             );
         }
     );
+
+    QUnit.test("edit char field and leave without bluring", async function (assert) {
+        serverData.actions[2] = {
+            id: 2,
+            name: "Partners Action 2",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+            view_mode: "list",
+        };
+        serverData.views = {
+            "partner,false,list": `<tree><field name="foo"/></tree>`,
+            "partner,false,form": `<form><field name="foo"/></form>`,
+            "partner,false,search": "<search></search>",
+        };
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, 2);
+        assert.containsOnce(target, ".o_list_view");
+
+        await click(target.querySelector(".o_data_cell"));
+        assert.containsOnce(target, ".o_form_view");
+
+        // update the value but do not blur the input
+        const input = target.querySelector(".o_field_widget[name=foo] input");
+        input.value = "What a Goal !!! JD11";
+
+        // leave the view without clicking out s.t. the input isn't blured (use keynav instead)
+        await triggerHotkey("alt+b"); // alt+b is the hotkey for breadcrumb back
+        assert.containsOnce(target, ".o_list_view");
+        assert.strictEqual(target.querySelector(".o_data_cell").innerText, "What a Goal !!! JD11");
+    });
 });


### PR DESCRIPTION
Before this commit:

Let's modify the value of a field in a form view and do not trigger a
blur event on it. Then exit the view (alt+b). The value was not saved.

After this commit:

The value is now saved because we check if the value has not been
modified using the isDirty() function which checks that there is no
pending promise.

task-3586303
