### PR TITLE
[FIX] purchase: Prepare move line from POL using commercial partner

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1347,7 +1347,7 @@ class PurchaseOrderLine(models.Model):
             'move_id': move.id,
             'currency_id': currency and currency.id or False,
             'date_maturity': move.invoice_date_due,
-            'partner_id': move.partner_id.id,
+            'partner_id': move.commercial_partner_id.id,
         })
         return res
 


### PR DESCRIPTION
When using the vendor bill autocomplete feature, the vendor bill move lines are prepared using the values fetched from the purchase order. However, it uses the vendor bill's partner_id instead of commercial_partner_id and causes a mismatch in the partner_id column of line_ids.

It is overwritten with the proper commercial_partner_id when the vendor bill gets posted, but duplicate tax lines are not consolidated.

Now it uses commercial_partner_id from the beginning, saving the headache of duplicate taxes on accounting reports.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
