### PR TITLE
[IMP] l10n_it_edi: enable change edi_mode

### DIFF
--- a/addons/l10n_it_edi/models/res_company.py
+++ b/addons/l10n_it_edi/models/res_company.py
@@ -114,4 +114,5 @@ class ResCompany(models.Model):
     @api.depends("account_edi_proxy_client_ids")
     def _compute_l10n_it_edi_proxy_user_id(self):
         for company in self:
-            company.l10n_it_edi_proxy_user_id = company.account_edi_proxy_client_ids.filtered(lambda x: x.proxy_type == 'l10n_it_edi')
+            company.l10n_it_edi_proxy_user_id = company.account_edi_proxy_client_ids.filtered(
+               lambda x: x.proxy_type == 'l10n_it_edi' and x.active)

--- a/addons/l10n_it_edi/models/res_config_settings.py
+++ b/addons/l10n_it_edi/models/res_config_settings.py
@@ -1,90 +1,48 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, fields, _
-from odoo.exceptions import UserError
+from odoo import api, models, fields
 
 class ResConfigSettings(models.TransientModel):
     _inherit = 'res.config.settings'
 
-    is_edi_proxy_active = fields.Boolean(compute='_compute_is_edi_proxy_active')
-    l10n_it_edi_proxy_current_state = fields.Char(compute='_compute_l10n_it_edi_proxy_current_state')
-    l10n_it_edi_register = fields.Boolean(compute='_compute_l10n_it_edi_register', inverse='_set_l10n_it_edi_register_demo_mode')
-    l10n_it_edi_demo_mode = fields.Selection(
+    l10n_it_edi_register = fields.Boolean(
+        compute='_compute_l10n_it_edi_register',
+        inverse='_set_l10n_it_edi_register_mode')
+    l10n_it_edi_mode = fields.Selection(
         [('demo', 'Demo'),
          ('test', 'Test (experimental)'),
          ('prod', 'Official')],
-        compute='_compute_l10n_it_edi_demo_mode',
-        inverse='_set_l10n_it_edi_register_demo_mode',
+        compute='_compute_l10n_it_edi_mode',
+        inverse='_set_l10n_it_edi_register_mode',
         readonly=False)
 
-    def _create_proxy_user(self, company_id, edi_mode):
-        self.env['account_edi_proxy_client.user']._register_proxy_user(company_id, 'l10n_it_edi', edi_mode)
-
-    def button_create_proxy_user(self):
-        self._create_proxy_user(self.company_id, self.l10n_it_edi_demo_mode)
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_l10n_it_edi_demo_mode(self):
+    @api.depends('company_id.l10n_it_edi_proxy_user_id')
+    def _compute_l10n_it_edi_mode(self):
         for config in self:
-            edi_user = self.env['account_edi_proxy_client.user'].search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-            config.l10n_it_edi_demo_mode = edi_user.edi_mode or 'demo'
+            config.l10n_it_edi_mode = config.company_id.l10n_it_edi_proxy_user_id.edi_mode
 
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_is_edi_proxy_active(self):
-        for config in self:
-            config.is_edi_proxy_active = config.company_id.account_edi_proxy_client_ids
-
-    @api.depends('company_id.account_edi_proxy_client_ids', 'company_id.account_edi_proxy_client_ids.active')
-    def _compute_l10n_it_edi_proxy_current_state(self):
-        for config in self:
-            proxy_user = config.company_id.account_edi_proxy_client_ids.search([
-                ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
-
-            config.l10n_it_edi_proxy_current_state = 'inactive' if not proxy_user else 'demo' if proxy_user.id_client[:4] == 'demo' else 'active'
-
-    @api.depends('company_id')
+    @api.depends('company_id.l10n_it_edi_proxy_user_id')
     def _compute_l10n_it_edi_register(self):
         """Needed because it expects a compute"""
-        self.l10n_it_edi_register = False
-
-    def _set_l10n_it_edi_register_demo_mode(self):
         for config in self:
+            config.l10n_it_edi_register = bool(config.company_id.l10n_it_edi_proxy_user_id)
 
-            proxy_user = self.env['account_edi_proxy_client.user'].search([
+    def button_create_proxy_user(self):
+        self.env['account_edi_proxy_client.user']._register_proxy_user(self.company_id, 'l10n_it_edi', self.l10n_it_edi_mode)
+
+    def _set_l10n_it_edi_register_mode(self):
+        for config in self.filtered(lambda x: x.l10n_it_edi_register):
+
+            # Disable all users
+            ProxyUser = config.env['account_edi_proxy_client.user']
+            proxy_users = ProxyUser.sudo().with_context(active_test=False).search([
                 ('company_id', '=', config.company_id.id),
-                ('proxy_type', '=', 'l10n_it_edi'),
-            ], limit=1)
+                ('proxy_type', '=', 'l10n_it_edi')])
+            proxy_users.active = False
 
-            real_proxy_users = self.env['account_edi_proxy_client.user'].sudo().search([
-                ('company_id', '=', config.company_id.id),
-                ('id_client', 'not like', 'demo'),
-            ])
-
-            # Update the config as per the selected radio button
-            previous_demo_state = proxy_user.edi_mode
-            edi_mode = config.l10n_it_edi_demo_mode
-
-            # If the user is trying to change from a state in which they have a registered official or testing proxy client
-            # to another state, we should stop them
-            if real_proxy_users and previous_demo_state != edi_mode:
-                raise UserError(_("The company has already registered with the service as 'Test' or 'Official', it cannot change."))
-
-            if config.l10n_it_edi_register:
-                # There should only be one user at a time, if there are no users, register one
-                if not proxy_user:
-                    self._create_proxy_user(config.company_id, edi_mode)
-                    return
-
-                # If there is a demo user, and we are transitioning from demo to test or production, we should
-                # delete all demo users and then create the new user.
-                elif proxy_user.id_client[:4] == 'demo' and edi_mode != 'demo':
-                    self.env['account_edi_proxy_client.user'].search([
-                        ('company_id', '=', config.company_id.id),
-                        ('id_client', '=like', 'demo%'),
-                    ]).sudo().unlink()
-                    self._create_proxy_user(config.company_id, edi_mode)
+            # Create or enable selected user
+            new_edi_mode = config.l10n_it_edi_mode
+            if selected_proxy_user := proxy_users.filtered(lambda x: x.edi_mode == new_edi_mode):
+                selected_proxy_user.active = True
+            else:
+                config.env['account_edi_proxy_client.user']._register_proxy_user(config.company_id, 'l10n_it_edi', new_edi_mode)

--- a/addons/l10n_it_edi/views/res_config_settings_views.xml
+++ b/addons/l10n_it_edi/views/res_config_settings_views.xml
@@ -10,22 +10,18 @@
                 <block title="Electronic Document Invoicing" invisible="country_code != 'IT'" id='account_edi'>
                     <setting>
                         <div class="group-content">
-                            <field name="l10n_it_edi_proxy_current_state" invisible="1"/>
                             <span class="o_form_label">
                                 Fattura Elettronica mode
                             </span>
                             <span class="fa fa-lg fa-building-o" title="Values set here are company-specific."/>
                             <div class="text-muted">
                                 In demo mode Odoo will just simulate the sending of invoices to the government.<br/>
-                                In test mode (experimental) Odoo will send the invoices to a non-production service.
-                                Saving this change will direct all companies on this database to this use this configuration.
-                                Once registered for testing or official, the mode cannot be changed.
+                                In test (experimental) mode Odoo will send the invoices to a non-production service.<br/>
+                                In official mode sent invoices will be considered fiscally relevant by the Tax Agency.
                             </div>
-                            <field name="l10n_it_edi_demo_mode"
-                                    widget="radio"
-                                    options="{'horizontal': true}"/>
+                            <field name="l10n_it_edi_mode" widget="radio" options="{'horizontal': true}"/>
                         </div>
-                        <div class="mt8 content-group" invisible="l10n_it_edi_proxy_current_state == 'active' or l10n_it_edi_proxy_current_state == 'demo' and l10n_it_edi_demo_mode == 'demo'">
+                        <div class="mt8 content-group" invisible="l10n_it_edi_register">
                             <span class="o_form_label">Allow Odoo to process invoices</span>
                             <div class="text-muted">
                                 By checking this box, I accept that Odoo may process my invoices.
@@ -33,13 +29,9 @@
                             <div class="content-group">
                                 <field name="l10n_it_edi_register"/>
                             </div>
-
                         </div>
-                        <div class="text-success mt8" invisible="l10n_it_edi_proxy_current_state in ['inactive', 'demo']">
-                            An Official or Test service has been registered.
-                        </div>
-                        <div class="text-success mt8" invisible="l10n_it_edi_proxy_current_state != 'demo' or l10n_it_edi_demo_mode != 'demo'">
-                            A Demo service is in use.
+                        <div class="text-success mt8" invisible="not l10n_it_edi_register">
+                            Fattura Elettronica has been registered.
                         </div>
                     </setting>
                 </block>


### PR DESCRIPTION
We have many requests to change the edi_mode from `test` to `prod`.
It's part of the expected flow to test the EDI flow and then switch to production.

Ticket links: 
https://www.odoo.com/web#id=3050134&model=project.task
https://www.odoo.com/web#id=3187331&model=project.task

opw-3050134
opw-3187331