### PR TITLE
[FIX] event_sale: fix pricelist computation in sale order form view

### DIFF
--- a/addons/event_sale/models/sale_order.py
+++ b/addons/event_sale/models/sale_order.py
@@ -161,6 +161,12 @@ class SaleOrderLine(models.Model):
 
     def _get_display_price(self, product):
         if self.event_ticket_id and self.event_id:
-            return self.event_ticket_id.with_context(pricelist=self.order_id.pricelist_id.id, uom=self.product_uom.id).price_reduce
+            return self.event_ticket_id.with_context(
+                pricelist=self.order_id.pricelist_id.id,
+                uom=self.product_uom.id,
+                partner=self.order_id.partner_id,
+                quantity=self.product_uom_qty,
+                date=self.order_id.date_order,
+            ).price_reduce
         else:
             return super()._get_display_price(product)

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -248,7 +248,7 @@ class TestEventSale(TestEventSaleCommon):
             'event_ticket_id': event_ticket.id,
         })
         sol.product_id_change()
-        self.assertEqual(so.amount_total, 660.0, "Ticket is $1000 but the event product is on a pricelist 10 -> 6. So, $600 + a 10% tax.")
+        self.assertAlmostEqual(so.amount_total, 6.6, 2, "Ticket is $1000 but the event product is on a fixed pricelist. So, $6 + a 10% tax.")
 
     @users('user_salesman')
     def test_unlink_so(self):


### PR DESCRIPTION
steps to reproduce:
- Create an event with ticket prices (exemple: 100$)
- Create a pricelist for the event registration product with a fixed price rule (for example: event registration at a price of 40$).
- create a sale order and create a line with "event registration" as a product and select the event

before this commit:
the price on the sale order line is wrong (133$)

after this commit:
the pricelist fixed price is properly taken into account (40$)

Note: the previous test covering this use case was wrong, this commit adapts it

opw-3526626-nda


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
