### PR TITLE
[17.0][FIX] db.py: auto_install module not installable

### DIFF
--- a/odoo/modules/db.py
+++ b/odoo/modules/db.py
@@ -84,7 +84,7 @@ def initialize(cr):
         cr.execute("""
         SELECT m.name FROM ir_module_module m
         WHERE m.auto_install
-        AND state != 'to install'
+        AND state not in ('to install', 'uninstallable')
         AND NOT EXISTS (
             SELECT 1 FROM ir_module_module_dependency d
             JOIN ir_module_module mdep ON (d.name = mdep.name)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Do not try install auto installable modules that are not installable

Current behavior before PR:
If you have an auto_installable module (auto_install = True) that is not installable (installable = False) odoo is trying to install it and displaying warnings on the log

Desired behavior after PR is merged:
Avoid trying to install modules that are auto_install = True and installable = False




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
