### PR TITLE
[FIX] account: payment register wizard in company currency

### DIFF
--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1101,7 +1101,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         invoice.action_post()
 
         # Payment of 600 USD (equivalent to 1200 Gol in 2017).
-        # 600.0 USD should be computed correctly to fully paid the invoices.
+        # 600.0 USD are needed in 2017 to fully pay the invoice, but the wizard default value should still be 
+        # the old 400 USD. Remaining 200 USD will come with the exchange difference.
         wizard = self.env['account.payment.register']\
             .with_context(active_model='account.move', active_ids=invoice.ids)\
             .create({
@@ -1110,7 +1111,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             })
 
         self.assertRecordValues(wizard, [{
-            'amount': 600.0,
+            'amount': 400.0,
             'payment_difference': 0.0,
             'currency_id': self.company_data['currency'].id,
         }])

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -484,12 +484,7 @@ class AccountPaymentRegister(models.TransientModel):
             return self._get_total_amount_using_same_currency(batch_result, early_payment_discount=early_payment_discount)
         elif self.source_currency_id != comp_curr and self.currency_id == comp_curr:
             # Foreign currency on source line but the company currency one on the opposite line.
-            return self.source_currency_id._convert(
-                self.source_amount_currency,
-                comp_curr,
-                self.company_id,
-                self.payment_date,
-            ), False
+            return self.source_amount, False
         elif self.source_currency_id == comp_curr and self.currency_id != comp_curr:
             # Company currency on source line but a foreign currency one on the opposite line.
             residual_amount = 0.0


### PR DESCRIPTION
in case you wanna register a payment in company currency for an invoice in foreign currency, there's no point in converting the residual amount in foreign currency into the company currency: the residual amount in company currency is already known. That's a useless extra step and it can introduce rounding errors as stated in the below use case.

failing use case:
1) make an invoice in foreign currency with a lot of lines, until you can witness than the receivable/payable balance isn't anymore the exact conversion of the invoice total in company currency (because of the sum of roundings). 
2) Then try to register a payment in company currency and the proposed amount should be exactly the one on the receivable/payable line(s) but it's not and you'll get a small rounding issue, provoking havoc in the reconciliation

opw-ticket 3471723

Note that a test was wrongly checking the default amount in company currency of the register payment wizard was the conversion of residual currency amount at payment date. But that made no sense.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
