### PR TITLE
[IMP] pos_self_order: change idle timer in kiosk mode

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -220,10 +220,10 @@ export class SelfOrder extends Reactive {
         window.addEventListener("click", (event) => {
             this.idleTimout && clearTimeout(this.idleTimout);
             this.idleTimout = setTimeout(() => {
-                if (this.router.activeSlot !== "payment") {
+                if (this.router.activeSlot !== "payment" && this.router.activeSlot !== "default") {
                     this.router.navigate("default");
                 }
-            }, 5 * 1000 * 60);
+            }, 40 * 1000);
         });
     }
 


### PR DESCRIPTION
Before, the timer was 5 minutes before returning the kiosk to the home page if nobody used it.

Now the timer is 40 seconds.