### PR TITLE
[FIX] website: remove writing ability

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -239,7 +239,7 @@
                     <!-- Header -->
                     <header t-attf-class="card-header overflow-hidden bg-secondary p-0 border-0 rounded-0 #{opt_events_list_columns and 'col-12' or 'col-4 col-lg-3'} #{(not opt_events_list_cards) and 'shadow-sm'}">
                         <!-- Image + Link -->
-                        <div class="d-block h-100 w-100">
+                        <div class="d-block h-100 w-100 o_not_editable">
                             <t t-call="website.record_cover">
                                 <t t-set="_record" t-value="event"/>
                                 <!-- Short Date -->


### PR DESCRIPTION
Commit fixes the issue that allows people
to write on cards (event card, appointment cards, etc) The class `o_editable` is automatically added to the card styles. In order to fix this I decided to add `o_not_editable` to the card styles, so that it prevents adding `o_editable`.

task-3481761

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
