### PR TITLE
[FIX] hr_recruitment_survey : ir.rule id conflict with hr_appraisal_s…

### DIFF
--- a/addons/hr_recruitment_survey/security/hr_recruitment_survey_security.xml
+++ b/addons/hr_recruitment_survey/security/hr_recruitment_survey_security.xml
@@ -5,7 +5,7 @@
             <field name="implied_ids" eval="[Command.link(ref('survey.group_survey_user'))]"/>
             <field name="comment">It will also allow to send surveys and see the resume.</field>
         </record>
-        <record id="survey.survey_user_input_rule_survey_user_read" model="ir.rule">
+        <record id="survey.recruitment_survey_user_input_rule_survey_user_read" model="ir.rule">
             <field name="name">Survey user input: officer: read all non private survey answers</field>
             <field name="domain_force">[('applicant_id', '=', False)]</field>
         </record>


### PR DESCRIPTION
…urvey

The ir.rule survey.survey_user_input_rule_survey_user_read is already defined in the hr_recruitment_appraisal module in saas-16.3.  Changing its ID here to avoid conflicts and undetermined behaviour when both modules are installed.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr