### PR TITLE
[IMP] point_of_sale,pos*: add takeaway button in PoS

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/fiscal_position_button/fiscal_position_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/fiscal_position_button/fiscal_position_button.js
@@ -62,7 +62,7 @@ export class SetFiscalPositionButton extends Component {
 ProductScreen.addControlButton({
     component: SetFiscalPositionButton,
     condition: function () {
-        return this.pos.fiscal_positions.length > 0;
+        return this.pos.fiscal_positions.length > 0 && !this.pos.config.take_away;
     },
     position: ["before", "SetPricelistButton"],
 });

--- a/addons/pos_restaurant/models/pos_config.py
+++ b/addons/pos_restaurant/models/pos_config.py
@@ -16,6 +16,12 @@ class PosConfig(models.Model):
     set_tip_after_payment = fields.Boolean('Set Tip After Payment', help="Adjust the amount authorized by payment terminals to add a tip after the customers left or at the end of the day.")
     module_pos_restaurant = fields.Boolean(default=True)
     module_pos_restaurant_appointment = fields.Boolean("Table Booking")
+    take_away = fields.Boolean("Take Away")
+    take_away_alternative_fp_id = fields.Many2one(
+        'account.fiscal.position',
+        string='Alternative Fiscal Position',
+        help='This is useful for restaurants with onsite and take-away services that imply specific tax rates.',
+    )
 
     def get_tables_order_count_and_printing_changes(self):
         self.ensure_one()

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -16,6 +16,7 @@ class PosOrder(models.Model):
 
     table_id = fields.Many2one('restaurant.table', string='Table', help='The table where this order was served', index='btree_not_null', readonly=True)
     customer_count = fields.Integer(string='Guests', help='The amount of customers that have been served by this order.', readonly=True)
+    take_away = fields.Boolean(string="Take Away", default=False)
 
     @api.model
     def remove_from_ui(self, server_ids):
@@ -81,12 +82,14 @@ class PosOrder(models.Model):
         order_fields = super(PosOrder, self)._order_fields(ui_order)
         order_fields['table_id'] = ui_order.get('table_id', False)
         order_fields['customer_count'] = ui_order.get('customer_count', 0)
+        order_fields['take_away'] = ui_order.get('take_away', False)
         return order_fields
 
     def _export_for_ui(self, order):
         result = super(PosOrder, self)._export_for_ui(order)
         result['table_id'] = order.table_id.id
         result['customer_count'] = order.customer_count
+        result['take_away'] = order.take_away
         return result
 
     @api.model

--- a/addons/pos_restaurant/models/pos_session.py
+++ b/addons/pos_restaurant/models/pos_session.py
@@ -4,7 +4,7 @@
 from odoo import models, Command, api
 from odoo.tools import convert
 from itertools import groupby
-from odoo.osv.expression import AND
+from odoo.osv.expression import AND, OR
 import json
 
 class PosSession(models.Model):
@@ -34,6 +34,14 @@ class PosSession(models.Model):
                 ],
             },
         }
+
+    def _loader_params_account_fiscal_position(self):
+        params = super()._loader_params_account_fiscal_position()
+        params['search_params']['domain'] = OR([
+            params['search_params']['domain'],
+            [('id', '=', self.config_id.take_away_alternative_fp_id.id)]
+        ])
+        return params
 
     def _get_pos_ui_restaurant_floor(self, params):
         floors = self.env['restaurant.floor'].search_read(**params['search_params'])

--- a/addons/pos_restaurant/models/res_config_settings.py
+++ b/addons/pos_restaurant/models/res_config_settings.py
@@ -12,6 +12,8 @@ class ResConfigSettings(models.TransientModel):
     pos_iface_splitbill = fields.Boolean(compute='_compute_pos_module_pos_restaurant', store=True, readonly=False)
     pos_set_tip_after_payment = fields.Boolean(compute='_compute_pos_set_tip_after_payment', store=True, readonly=False)
     pos_module_pos_restaurant_appointment = fields.Boolean(related="pos_config_id.module_pos_restaurant_appointment", readonly=False)
+    pos_take_away = fields.Boolean(related="pos_config_id.take_away", readonly=False)
+    pos_take_away_alternative_fp_id = fields.Many2one(related="pos_config_id.take_away_alternative_fp_id", readonly=False)
 
     @api.depends('pos_module_pos_restaurant', 'pos_config_id')
     def _compute_pos_module_pos_restaurant(self):

--- a/addons/pos_restaurant/static/src/app/control_buttons/take_away_button/take_away_button.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/take_away_button/take_away_button.js
@@ -1,0 +1,41 @@
+/** @odoo-module */
+
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { ProductScreen } from "@point_of_sale/app/screens/product_screen/product_screen";
+import { Component } from "@odoo/owl";
+
+export class TakeAwayButton extends Component {
+    static template = "pos_restaurant.TakeAwayButton";
+
+    setup() {
+        this.pos = usePos();
+    }
+
+    get currentOrder() {
+        return this.pos.get_order();
+    }
+
+    click() {
+        const isTakeAway = !this.currentOrder.take_away;
+        const defaultFp = this.pos.config?.default_fiscal_position_id[0] ?? false;
+        const fiscalPosition = this.pos.fiscal_positions.find(
+            (fiscalPosition) =>
+                fiscalPosition.id ===
+                (isTakeAway ? this.pos.config.take_away_alternative_fp_id[0] : defaultFp)
+        );
+
+        this.currentOrder.take_away = isTakeAway;
+        this.currentOrder.set_fiscal_position(fiscalPosition);
+    }
+}
+
+ProductScreen.addControlButton({
+    component: TakeAwayButton,
+    condition: function () {
+        return (
+            this.pos.config.take_away &&
+            this.pos.config.module_pos_restaurant &&
+            this.pos.config.take_away_alternative_fp_id
+        );
+    },
+});

--- a/addons/pos_restaurant/static/src/app/control_buttons/take_away_button/take_away_button.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/take_away_button/take_away_button.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="pos_restaurant.TakeAwayButton">
+        <span t-attf-class="{{ currentOrder.take_away ? 'btn-primary' : 'btn-light'}} control-button order-split btn rounded-0 fw-bolder" t-on-click="() => this.click()">
+            <i class="fa fa-car me-1"></i>
+            <span> </span>
+            <span>Take-away</span>
+        </span>
+    </t>
+
+</templates>

--- a/addons/pos_restaurant/static/src/overrides/models/models.js
+++ b/addons/pos_restaurant/static/src/overrides/models/models.js
@@ -20,6 +20,7 @@ patch(Order.prototype, {
         if (this.pos.config.module_pos_restaurant) {
             json.table_id = this.tableId;
             json.customer_count = this.customerCount;
+            json.take_away = this.take_away;
         }
 
         return json;
@@ -30,6 +31,7 @@ patch(Order.prototype, {
         if (this.pos.config.module_pos_restaurant) {
             this.tableId = json.table_id;
             this.customerCount = json.customer_count;
+            this.take_away = json.take_away;
         }
     },
     getCustomerCount() {

--- a/addons/pos_restaurant/views/res_config_settings_views.xml
+++ b/addons/pos_restaurant/views/res_config_settings_views.xml
@@ -35,6 +35,16 @@
                         </div>
                     </div>
                 </setting>
+                <setting string="Eat in / Take out" help="Adjust the tax rate based on whether customers are dining in or opting for takeout." invisible="not pos_module_pos_restaurant">
+                    <field name="pos_take_away"/>
+                    <div class="content-group" invisible="not pos_take_away">
+                        <label string="" for="pos_take_away_alternative_fp_id" class="me-2"/>
+                        <field name="pos_take_away_alternative_fp_id" placeholder="Alternative Fiscal Position"/>
+                        <div>
+                            <button name="%(account.action_account_fiscal_position_form)d" icon="oi-arrow-right" type="action" string="Fiscal Positions" class="btn-link"/>
+                        </div>
+                    </div>
+                </setting>
             </block>
             <div id="tip_product" position="after">
                 <div invisible="not pos_module_pos_restaurant or not pos_iface_tipproduct">
@@ -42,6 +52,9 @@
                     <label class="fw-normal" for="pos_set_tip_after_payment" string="Add tip after payment"/>
                 </div>
             </div>
+            <setting id="flexible_taxes" position="attributes">
+                <attribute name="invisible">pos_module_pos_restaurant</attribute>
+            </setting>
         </field>
     </record>
 </odoo>

--- a/addons/pos_self_order/controllers/orders.py
+++ b/addons/pos_self_order/controllers/orders.py
@@ -20,7 +20,7 @@ class PosSelfOrderController(http.Controller):
         order_reference = self._generate_unique_id(pos_session.id, pos_config.id, sequence_number, device_type)
 
         fiscal_position = (
-            pos_config.self_ordering_alternative_fp_id
+            pos_config.take_away_alternative_fp_id
             if is_take_away
             else pos_config.default_fiscal_position_id
         )
@@ -213,8 +213,8 @@ class PosSelfOrderController(http.Controller):
 
         fiscal_pos = pos_config.default_fiscal_position_id
 
-        if take_away and pos_config.self_ordering_alternative_fp_id:
-            fiscal_pos = pos_config.self_ordering_alternative_fp_id
+        if take_away and pos_config.take_away_alternative_fp_id:
+            fiscal_pos = pos_config.take_away_alternative_fp_id
 
         for line in lines:
             if line.get('uuid') in appended_uuid or not line.get('product_id'):

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -36,12 +36,6 @@ class PosConfig(models.Model):
         store=False,
     )
     self_ordering_url = fields.Char(compute="_compute_self_ordering_url")
-    self_ordering_takeaway = fields.Boolean("Takeaway")
-    self_ordering_alternative_fp_id = fields.Many2one(
-        'account.fiscal.position',
-        string='Alternative Fiscal Position',
-        help='This is useful for restaurants with onsite and take-away services that imply specific tax rates.',
-    )
     self_ordering_mode = fields.Selection(
         [("nothing", "Disable"), ("consultation", "QR menu"), ("mobile", "QR menu + Ordering"), ("kiosk", "Kiosk")],
         string="Self Ordering Mode",
@@ -363,7 +357,6 @@ class PosConfig(models.Model):
                 "iface_start_categ_id": self.iface_start_categ_id.id,
                 "iface_tax_included": self.iface_tax_included == "total",
                 "self_ordering_mode": self.self_ordering_mode,
-                "self_ordering_takeaway": self.self_ordering_takeaway,
                 "self_ordering_service_mode": self.self_ordering_service_mode,
                 "self_ordering_default_language_id": default_language[0] if default_language else [],
                 "self_ordering_available_language_ids":  self.self_ordering_available_language_ids.read(["code", "display_name", "iso_code", "flag_image_url"]),
@@ -372,6 +365,7 @@ class PosConfig(models.Model):
                 "self_ordering_pay_after": self.self_ordering_pay_after,
                 "receipt_header": self.receipt_header,
                 "receipt_footer": self.receipt_footer,
+                "take_away": self.take_away,
             },
         }
 

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -43,7 +43,6 @@ class PosOrder(models.Model):
     _inherit = "pos.order"
 
     table_stand_number = fields.Char(string="Table Stand Number")
-    take_away = fields.Boolean(string="Take Away", default=False)
 
     def _compute_tax_details(self):
         self.ensure_one()
@@ -66,17 +65,6 @@ class PosOrder(models.Model):
             merged_tax_details[tax_id]['amount'] += tax_obj['amount']
             merged_tax_details[tax_id]['base'] += tax_obj['base']
         return list(merged_tax_details.values())
-
-    @api.model
-    def create_from_ui(self, orders, draft=False):
-        for order in orders:
-            if order['data'].get('server_id'):
-                server_id = order['data'].get('server_id')
-                old_order = self.env['pos.order'].browse(server_id)
-                if old_order.take_away:
-                    order['data']['take_away'] = old_order.take_away
-
-        return super().create_from_ui(orders, draft)
 
     def _process_saved_order(self, draft):
         res = super()._process_saved_order(draft)

--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -150,13 +150,13 @@ class ProductProduct(models.Model):
         display_price_alternative = price
 
         taxes_default = pos_config.default_fiscal_position_id.map_tax(self.taxes_id)
-        taxes_alternative = pos_config.self_ordering_alternative_fp_id.map_tax(self.taxes_id)
+        taxes_alternative = pos_config.take_away_alternative_fp_id.map_tax(self.taxes_id)
 
         price_unit_default = self._get_price_unit_after_fp(
             price, pos_config.currency_id, pos_config.default_fiscal_position_id
         )
         price_unit_alternative = self._get_price_unit_after_fp(
-            price, pos_config.currency_id, pos_config.self_ordering_alternative_fp_id
+            price, pos_config.currency_id, pos_config.take_away_alternative_fp_id
         )
 
         all_prices_default = taxes_default.compute_all(

--- a/addons/pos_self_order/models/res_config_settings.py
+++ b/addons/pos_self_order/models/res_config_settings.py
@@ -13,10 +13,8 @@ from werkzeug.urls import url_unquote
 class ResConfigSettings(models.TransientModel):
     _inherit = "res.config.settings"
 
-    pos_self_ordering_takeaway = fields.Boolean(related="pos_config_id.self_ordering_takeaway", readonly=False)
     pos_self_ordering_service_mode = fields.Selection(related="pos_config_id.self_ordering_service_mode", readonly=False)
     pos_self_ordering_mode = fields.Selection(related="pos_config_id.self_ordering_mode", readonly=False)
-    pos_self_ordering_alternative_fp_id = fields.Many2one(related="pos_config_id.self_ordering_alternative_fp_id", readonly=False)
     pos_self_ordering_default_language_id = fields.Many2one(related="pos_config_id.self_ordering_default_language_id", readonly=False)
     pos_self_ordering_available_language_ids = fields.Many2many(related="pos_config_id.self_ordering_available_language_ids", readonly=False)
     pos_self_ordering_image_home_ids = fields.Many2many(related="pos_config_id.self_ordering_image_home_ids", readonly=False)

--- a/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
+++ b/addons/pos_self_order/static/src/app/components/attribute_selection/attribute_selection.js
@@ -133,7 +133,7 @@ export class AttributeSelection extends Component {
     }
 
     _getPriceExtra(value) {
-        const isTakeAway = this.selfOrder.take_away;
+        const isTakeAway = this.selfOrder.currentOrder.take_away;
         const priceExtra = isTakeAway
             ? value.price_extra.display_price_default
             : value.price_extra.display_price_alternative;

--- a/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
+++ b/addons/pos_self_order/static/src/app/pages/landing_page/landing_page.js
@@ -100,7 +100,7 @@ export class LandingPage extends Component {
         }
 
         if (
-            this.selfOrder.config.self_ordering_takeaway &&
+            this.selfOrder.config.take_away &&
             this.selfOrder.currentOrder.take_away === null &&
             this.selfOrder.ordering
         ) {

--- a/addons/pos_self_order/tests/test_frontend.py
+++ b/addons/pos_self_order/tests/test_frontend.py
@@ -32,9 +32,9 @@ class TestFrontendMobile(SelfOrderCommonTest):
         })
 
         self.pos_config.write({
+            'take_away': True,
             'self_ordering_mode': 'kiosk',
-            'self_ordering_takeaway': True,
-            'self_ordering_alternative_fp_id': alternative_fp.id,
+            'take_away_alternative_fp_id': alternative_fp.id,
         })
 
         self.pos_config.open_ui()

--- a/addons/pos_self_order/tests/test_self_order_attribute.py
+++ b/addons/pos_self_order/tests/test_self_order_attribute.py
@@ -10,7 +10,7 @@ class TestSelfOrderAttribute(SelfOrderCommonTest):
     def test_self_order_attribute(self):
         self.pos_config.write({
             'self_ordering_default_user_id': self.pos_admin.id,
-            'self_ordering_takeaway': False,
+            'take_away': False,
             'self_ordering_mode': 'mobile',
             'self_ordering_pay_after': 'each',
             'self_ordering_service_mode': 'counter',

--- a/addons/pos_self_order/tests/test_self_order_combo.py
+++ b/addons/pos_self_order/tests/test_self_order_combo.py
@@ -10,7 +10,7 @@ class TestSelfOrderCombo(SelfOrderCommonTest):
     def test_self_order_combo(self):
         self.pos_config.write({
             'self_ordering_default_user_id': self.pos_admin.id,
-            'self_ordering_takeaway': False,
+            'take_away': False,
             'self_ordering_mode': 'mobile',
             'self_ordering_pay_after': 'each',
             'self_ordering_service_mode': 'counter',

--- a/addons/pos_self_order/tests/test_self_order_common.py
+++ b/addons/pos_self_order/tests/test_self_order_common.py
@@ -9,7 +9,7 @@ from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCom
 class TestSelfOrderCommon(SelfOrderCommonTest):
     def test_self_order_common(self):
         self.pos_config.write({
-            'self_ordering_takeaway': True,
+            'take_away': True,
             'self_ordering_mode': 'kiosk',
             'self_ordering_pay_after': 'each',
             'self_ordering_service_mode': 'table',

--- a/addons/pos_self_order/tests/test_self_order_kiosk.py
+++ b/addons/pos_self_order/tests/test_self_order_kiosk.py
@@ -9,7 +9,7 @@ from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCom
 class TestSelfOrderKiosk(SelfOrderCommonTest):
     def test_self_order_kiosk(self):
         self.pos_config.write({
-            'self_ordering_takeaway': True,
+            'take_away': True,
             'self_ordering_mode': 'kiosk',
             'self_ordering_pay_after': 'each',
             'self_ordering_service_mode': 'table',

--- a/addons/pos_self_order/tests/test_self_order_mobile.py
+++ b/addons/pos_self_order/tests/test_self_order_mobile.py
@@ -9,7 +9,7 @@ from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCom
 class TestSelfOrderMobile(SelfOrderCommonTest):
     def test_self_order_mobile(self):
         self.pos_config.write({
-            'self_ordering_takeaway': True,
+            'take_away': True,
             'self_ordering_mode': 'mobile',
             'self_ordering_pay_after': 'each',
             'self_ordering_service_mode': 'table',

--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -59,16 +59,6 @@
                         <field name="pos_self_ordering_image_brand_name" invisible ="1"/>
                         <field name="pos_self_ordering_image_brand" class="w-100" filename="pos_self_ordering_image_brand_name"/>
                     </setting>
-                    <setting string="Eat in / Take out" help="Adjust the tax rate based on whether customers are dining in or opting for takeout." invisible="not pos_self_ordering_mode in ['mobile', 'kiosk']">
-                        <field name="pos_self_ordering_takeaway"/>
-                        <div class="content-group" invisible="not pos_self_ordering_takeaway">
-                            <label string="" for="pos_self_ordering_alternative_fp_id" class="me-2"/>
-                            <field name="pos_self_ordering_alternative_fp_id" placeholder="Alternative Fiscal Position"/>
-                            <div>
-                                <button name="%(account.action_account_fiscal_position_form)d" icon="oi-arrow-right" type="action" string="Fiscal Positions" class="btn-link"/>
-                            </div>
-                        </div>
-                    </setting>
                 </block>
             </block>
 


### PR DESCRIPTION
Previously, the PoS restaurant did not have the option of creating takeaway orders. Self Order added this possibility via a mobile or kiosk but not in the main point-of-sale application.

This functionality has now been added, and it is now possible to activate the takeaway in the pos_config. A button toggling the takeaway will then be present in the PoS interface.
