### PR TITLE
[IMP] account_peppol: add warnings about missing data on invoices

### DIFF
--- a/addons/account_peppol/models/account_move.py
+++ b/addons/account_peppol/models/account_move.py
@@ -24,6 +24,11 @@ class AccountMove(models.Model):
         copy=False,
     )
     peppol_is_demo_uuid = fields.Boolean(compute="_compute_peppol_is_demo_uuid")
+    peppol_warning = fields.Html(
+        string='Peppol warning',
+        compute='_compute_peppol_warning',
+        copy=False,
+    )
 
     @api.model
     def fields_get(self, allfields=None, attributes=None):
@@ -46,6 +51,10 @@ class AccountMove(models.Model):
         self.peppol_move_state = 'canceled'
         self.send_and_print_values = False
 
+    # -------------------------------------------------------------------------
+    # COMPUTE METHODS
+    # -------------------------------------------------------------------------
+
     @api.depends('peppol_message_uuid')
     def _compute_peppol_is_demo_uuid(self):
         for move in self:
@@ -63,3 +72,31 @@ class AccountMove(models.Model):
                 move.peppol_move_state = 'ready'
             else:
                 move.peppol_move_state = move.peppol_move_state
+
+    @api.depends('invoice_line_ids.tax_ids', 'invoice_line_ids.product_id', 'partner_id.peppol_eas', 'partner_id.peppol_endpoint')
+    def _compute_peppol_warning(self):
+        for move in self:
+            if any([move.company_id.account_peppol_proxy_state != 'active',
+                    move.peppol_move_state in ('skipped', 'canceled', 'done'),
+                    move.partner_id.ubl_cii_format in (False, 'facturx'),
+                    move.move_type not in ('out_invoice', 'out_refund'),
+                    not move.restrict_mode_hash_table,
+                ]):
+                move.peppol_warning = None
+                continue
+
+            required_checks = {
+                'partner_eas_endpoint_missing': [False, _("The partner is missing Peppol EAS code or Peppol Endpoint.")],
+                'product_missing': [False, _("Each Peppol invoice line should have a corresponding product.")],
+                'not_one_tax': [False, _("Each Peppol invoice line should have one and only one corresponding tax.")],
+            }
+            if not move.partner_id.peppol_eas or not move.partner_id.peppol_endpoint:
+                required_checks['partner_eas_endpoint_missing'][0] = True
+            for line in move.invoice_line_ids:
+                if not line.product_id:
+                    required_checks['product_missing'][0] = True
+                if not line.tax_ids or len(line.tax_ids) > 1:
+                    required_checks['not_one_tax'][0] = True
+
+            move.peppol_warning = ("").join(
+                f'<div>{check_val[1]}</div>' for check_val in required_checks.values() if check_val[0])

--- a/addons/account_peppol/views/account_move_views.xml
+++ b/addons/account_peppol/views/account_move_views.xml
@@ -13,6 +13,11 @@
                         string="Cancel PEPPOL"
                         invisible="peppol_move_state != 'to_send' or state == 'draft'"/>
             </header>
+            <header position="after">
+                <div class="alert alert-info mb-0" role="alert" invisible="not peppol_warning">
+                    <field name="peppol_warning" nolabel="1"/>
+                </div>
+            </header>
 
             <xpath expr="//div[@name='journal_div']" position="after">
                 <label for="peppol_move_state"


### PR DESCRIPTION
The invoice lines and the partner need to be configured correctly to generate a valid UBL file. This commit adds a warning banner for when:
- 1+ invoice lines don't have a product
- 1+ invoice lines have no tax
- 1+ invoice lines have more than 1 tax
- partner has no EAS or Endpoint set

and the journal has a lock on posted entries with hash.

task-3594007




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
