### PR TITLE
[FIX] hr_holidays : Delete time off on second approval

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -955,12 +955,12 @@ class HolidaysRequest(models.Model):
         now = fields.Datetime.now()
 
         if not self.user_has_groups('hr_holidays.group_hr_holidays_user'):
-            if any(hol.state not in ['draft', 'confirm'] for hol in self):
+            if any(hol.state not in ['draft', 'confirm', 'validate1'] for hol in self):
                 raise UserError(error_message % state_description_values.get(self[:1].state))
             if any(hol.date_from < now for hol in self):
                 raise UserError(_('You cannot delete a time off which is in the past'))
         else:
-            for holiday in self.filtered(lambda holiday: holiday.state not in ['draft', 'cancel', 'confirm']):
+            for holiday in self.filtered(lambda holiday: holiday.state not in ['draft', 'cancel', 'confirm', 'validate1']):
                 raise UserError(error_message % (state_description_values.get(holiday.state),))
 
     def unlink(self):


### PR DESCRIPTION
[FIX] hr_holidays : Delete time off on second approval

Steps to reproduce:
	1- Install Time off app
	2- Create a new time off with two approvals
	3- Confirm the first approval
	4- Delete the time off where its state is 'Second Approval'
	
Current behavior before PR:
The employee can't delete his requested time off if its state is 'Second Approval'

Desired behavior after PR is merged:
The employee can delete his requested time unless it is full approved

opw-3419085