### PR TITLE
[FIX] pos_l10n_es: allow not invoicing

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/l10n_es_pos/static/src/overrides/components/payment_screen/payment_screen.js
@@ -8,14 +8,10 @@ patch(PaymentScreen.prototype, {
             return await super.validateOrder(...arguments);
         }
         const order = this.currentOrder;
-        this.currentOrder.to_invoice = true;
+        order.is_l10n_es_simplified_invoice = order.canBeSimplifiedInvoiced() && !order.to_invoice;
+        order.to_invoice = true;
         const simplified_partner =
             this.pos.db.partner_by_id[this.pos.config.simplified_partner_id[0]];
-        if (order.canBeSimplifiedInvoiced()) {
-            order.is_l10n_es_simplified_invoice ??= true;
-        } else {
-            order.is_l10n_es_simplified_invoice = false;
-        }
         order.partner ||= simplified_partner;
         if (!order.is_l10n_es_simplified_invoice && order.partner.id === simplified_partner.id) {
             order.partner = null;


### PR DESCRIPTION
Steps to reproduce:

1. Open a pos configured with a spanish localization;
2. Make an order that is less then 400 euros;
3. Click on invoice;
4. Click on invoice again such that it is toggled off.
5. Observe that validating the order brings the popup to select a partner

The issue is that toggling the invoice off doesn't actually work correctly.

Task: 3597292






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
