### PR TITLE
[IMP] hr_recruitment: add a default recruiter

### DIFF
--- a/addons/hr_recruitment/models/hr_job.py
+++ b/addons/hr_recruitment/models/hr_job.py
@@ -43,7 +43,10 @@ class Job(models.Model):
     manager_id = fields.Many2one(
         'hr.employee', related='department_id.manager_id', string="Department Manager",
         readonly=True, store=True)
-    user_id = fields.Many2one('res.users', "Recruiter", domain="[('share', '=', False), ('company_ids', 'in', company_id)]", tracking=True, help="The Recruiter will be the default value for all Applicants Recruiter's field in this job position. The Recruiter is automatically added to all meetings with the Applicant.")
+    user_id = fields.Many2one('res.users', "Recruiter",
+        domain="[('share', '=', False), ('company_ids', 'in', company_id)]", default=lambda self: self.env.user,
+        tracking=True, help="The Recruiter will be the default value for all Applicants Recruiter's field in this job \
+            position. The Recruiter is automatically added to all meetings with the Applicant.")
     document_ids = fields.One2many('ir.attachment', compute='_compute_document_ids', string="Documents", readonly=True)
     documents_count = fields.Integer(compute='_compute_document_ids', string="Document Count")
     alias_id = fields.Many2one(help="Email alias for this job position. New emails will automatically create new applicants for this job position.")

--- a/addons/hr_recruitment/security/ir.model.access.csv
+++ b/addons/hr_recruitment/security/ir.model.access.csv
@@ -1,5 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_hr_job_interviewer,hr.job.interviewer,hr.model_hr_job,group_hr_recruitment_interviewer,1,0,0,0
+access_hr_job_user,hr.job user,model_hr_job,group_hr_recruitment_user,1,1,1,1
+hr.access_hr_job_user,hr.job user,model_hr_job,hr.group_hr_user,1,0,0,0
 access_hr_applicant_interviewer,hr.applicant.interviewer,model_hr_applicant,group_hr_recruitment_interviewer,1,1,0,0
 access_hr_applicant_user,hr.applicant.user,model_hr_applicant,group_hr_recruitment_user,1,1,1,1
 access_hr_recruitment_stage_interviewer,hr.recruitment.stage.interviewer,model_hr_recruitment_stage,group_hr_recruitment_interviewer,1,0,0,0

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -281,7 +281,7 @@
             <field name="name" position="after">
                 <field name="department_id"/>
                 <field name="no_of_recruitment"/>
-                <field name="application_count" string="Applications"/>
+                <field name="application_count" string="Applications" groups="hr_recruitment.group_hr_recruitment_interviewer"/>
             </field>
             <field name="no_of_employee" position="after">
                 <field name="expected_employees" optional="hide"/>
@@ -292,7 +292,6 @@
                 <field name="alias_name" column_invisible="True"/>
                 <field name="alias_id" invisible="not alias_name" optional="hide"/>
                 <field name="user_id" widget="many2one_avatar_user" optional="hide"/>
-                <field name="no_of_hired_employee" optional="hide"/>
             </field>
         </field>
     </record>

--- a/addons/website_hr_recruitment/security/website_hr_recruitment_security.xml
+++ b/addons/website_hr_recruitment/security/website_hr_recruitment_security.xml
@@ -44,7 +44,7 @@
     </data>
 
 
-    <record id="hr_recruitment.group_hr_recruitment_manager" model="res.groups">
+    <record id="hr_recruitment.group_hr_recruitment_user" model="res.groups">
         <field name="implied_ids" eval="[(4, ref('website.group_website_restricted_editor'))]"/>
     </record>
 </odoo>


### PR DESCRIPTION
This commit adds a default recruiter on the job offer. The purpose is to have a default value on the field because if the user doesn't set a recruiter, the job offer will not notify anyone if someone applies to it and the applicant will receive the default mail response with odoobot as contact.

task-3595474