### PR TITLE
[IMP] web: move no-content helper to renderer

### DIFF
--- a/addons/web/static/src/views/graph/graph_controller.xml
+++ b/addons/web/static/src/views/graph/graph_controller.xml
@@ -62,16 +62,10 @@
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
-                <t t-if="model.data">
-                    <t t-if="!model.hasData() or model.useSampleModel and props.info.noContentHelp" t-call="web.ActionHelper">
-                        <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
-                    </t>
-                    <t t-component="props.Renderer" model="model" buttonTemplate="props.buttonTemplate" />
-                </t>
-                <t t-else="" t-call="web.NoContentHelper">
-                    <t t-set="title">Invalid data</t>
-                    <t t-set="description">Pie chart cannot mix positive and negative numbers. Try to change your domain to only display positive results</t>
-                </t>
+                <t t-component="props.Renderer"
+                    model="model"
+                    noContentHelp="props.info.noContentHelp"
+                    buttonTemplate="props.buttonTemplate"/>
             </Layout>
         </div>
     </t>

--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -759,8 +759,21 @@ export class GraphRenderer extends Component {
         const { cumulated } = this.model.metaData;
         this.model.updateMetaData({ cumulated: !cumulated });
     }
+
+    /**
+     * @returns {boolean}
+     */
+    get showNoContentHelper() {
+        return this.props.noContentHelp && (
+            !this.model.hasData() || this.model.useSampleModel
+        );
+    }
 }
 
 GraphRenderer.template = "web.GraphRenderer";
 GraphRenderer.components = { Dropdown, DropdownItem };
-GraphRenderer.props = ["class?", "model", "buttonTemplate"];
+GraphRenderer.props = [
+    "model",
+    "noContentHelp?",
+    "buttonTemplate"
+];

--- a/addons/web/static/src/views/graph/graph_renderer.xml
+++ b/addons/web/static/src/views/graph/graph_renderer.xml
@@ -28,13 +28,24 @@
     </t>
 
     <t t-name="web.GraphRenderer">
-        <div t-att-class="'o_graph_renderer o_renderer h-100 d-flex flex-column border-top ' + props.class" t-ref="root">
-            <div class="d-flex gap-1 mt-2 mx-3 mb-3">
-                <t t-call="{{ props.buttonTemplate }}"/>
-            </div>
-            <div class="o_graph_canvas_container flex-grow-1 position-relative" t-ref="container">
-                <canvas t-ref="canvas" />
-            </div>
+        <div t-ref="root" class="o_graph_renderer o_renderer h-100 d-flex flex-column border-top" t-att-class="{
+            o_empty: showNoContentHelper,
+        }">
+            <t t-if="model.data">
+                <div class="d-flex gap-1 mt-2 mx-3 mb-3">
+                    <t t-call="{{ props.buttonTemplate }}"/>
+                </div>
+                <div class="o_graph_canvas_container flex-grow-1 position-relative" t-ref="container">
+                    <canvas t-ref="canvas" />
+                </div>
+                <t t-if="showNoContentHelper" t-call="web.ActionHelper">
+                    <t t-set="noContentHelp" t-value="props.noContentHelp"/>
+                </t>
+            </t>
+            <t t-else="" t-call="web.NoContentHelper">
+                <t t-set="title">Invalid data</t>
+                <t t-set="description">Pie chart cannot mix positive and negative numbers. Try to change your domain to only display positive results</t>
+            </t>
         </div>
     </t>
 

--- a/addons/web/static/src/views/kanban/kanban_renderer.xml
+++ b/addons/web/static/src/views/kanban/kanban_renderer.xml
@@ -2,10 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanRenderer">
-        <div class="o_kanban_renderer o_renderer d-flex"
-            t-attf-class="{{ props.list.isGrouped ? 'o_kanban_grouped align-content-stretch' : 'o_kanban_ungrouped align-content-start flex-wrap justify-content-start' }}"
-            t-ref="root"
-        >
+        <div t-ref="root" class="o_kanban_renderer o_renderer d-flex" t-att-class="{
+            'o_kanban_grouped align-content-stretch': props.list.isGrouped,
+            'o_kanban_ungrouped align-content-start flex-wrap justify-content-start': !props.list.isGrouped,
+            'o_empty': showNoContentHelper,
+        }">
             <t t-foreach="getGroupsOrRecords()" t-as="groupOrRecord" t-key="groupOrRecord.key">
                 <t t-if="groupOrRecord.group">
                     <t t-set="group" t-value="groupOrRecord.group" />

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -2,14 +2,9 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ListRenderer">
-        <div
-            class="o_list_renderer o_renderer table-responsive"
-            tabindex="-1"
-            t-ref="root"
-        >
-            <t t-if="showNoContentHelper" t-call="web.ActionHelper">
-                <t t-set="noContentHelp" t-value="props.noContentHelp"/>
-            </t>
+        <div t-ref="root" tabindex="-1" class="o_list_renderer o_renderer table-responsive" t-att-class="{
+            o_empty: showNoContentHelper,
+        }">
             <table t-attf-class="o_list_table table table-sm table-hover position-relative mb-0 {{props.list.isGrouped ? 'o_list_table_grouped' : 'o_list_table_ungrouped table-striped'}}" t-ref="table">
                 <thead>
                     <tr>
@@ -93,6 +88,9 @@
                     </tr>
                 </tfoot>
             </table>
+            <t t-if="showNoContentHelper" t-call="web.ActionHelper">
+                <t t-set="noContentHelp" t-value="props.noContentHelp"/>
+            </t>
         </div>
     </t>
 

--- a/addons/web/static/src/views/pivot/pivot_controller.xml
+++ b/addons/web/static/src/views/pivot/pivot_controller.xml
@@ -30,19 +30,9 @@
                 <t t-set-slot="control-panel-navigation-additional">
                     <t t-component="searchBarToggler.component" t-props="searchBarToggler.props"/>
                 </t>
-                <t t-set="displayNoContent" t-value="
-                    props.info.noContentHelp !== false and (
-                        !(model.hasData() and model.metaData.activeMeasures.length) or
-                        model.useSampleModel
-                    )"
-                />
-                <t t-if="displayNoContent">
-                    <t t-if="props.info.noContentHelp" t-call="web.ActionHelper">
-                        <t t-set="noContentHelp" t-value="props.info.noContentHelp"/>
-                    </t>
-                    <t t-else="" t-call="web.NoContentHelper"/>
-                </t>
-                <t t-component="props.Renderer" model="model"/>
+                <t t-component="props.Renderer"
+                    model="model"
+                    noContentHelp="props.info.noContentHelp"/>
             </Layout>
         </div>
     </t>

--- a/addons/web/static/src/views/pivot/pivot_renderer.js
+++ b/addons/web/static/src/views/pivot/pivot_renderer.js
@@ -238,7 +238,19 @@ export class PivotRenderer extends Component {
         };
         this.openView(this.model.getGroupDomain(group), this.views, context);
     }
+
+    /**
+     * @returns {boolean}
+     */
+    get showNoContentHelper() {
+        return this.props.noContentHelp && (
+            !(this.model.hasData() && this.model.metaData.activeMeasures.length) || this.model.useSampleModel
+        );
+    }
 }
 PivotRenderer.template = "web.PivotRenderer";
 PivotRenderer.components = { Dropdown, DropdownItem, CheckBox, PivotGroupByMenu };
-PivotRenderer.props = ["model"];
+PivotRenderer.props = [
+    "model",
+    "noContentHelp?",
+];

--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -2,54 +2,64 @@
 <templates xml:space="preserve">
 
     <t t-name="web.PivotRenderer">
-        <t t-call="web.PivotView.Buttons"/>
-        <div t-if="model.hasData() and model.metaData.activeMeasures.length" class="o_pivot table-responsive mx-3">
-            <table
-                class="table-hover table table-sm table-bordered table-borderless"
-                t-att-class="{ o_enable_linking: !model.metaData.disableLinking }"
-                t-ref="table"
-            >
-                <thead>
-                    <tr t-foreach="table.headers" t-as="row" t-key="'header_' + row_index" class="border-top-0">
-                        <t t-foreach="row" t-as="cell" t-key="'header_row_' + cell_index">
-                            <t t-if="cell.measure" t-call="web.PivotMeasure"/>
-                            <t t-elif="cell.isLeaf !== undefined" t-call="web.PivotHeader">
-                                <t t-set="isXAxis" t-value="true"/>
-                                <t t-set="isInHead" t-value="true"/>
-                            </t>
-                            <th t-else="" t-att-colspan="cell.width" t-att-rowspan="cell.height" class="border-0 bg-100 fw-normal" t-att-class="{ 'border-0': cell_index != 0 }"/>
-                        </t>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr t-foreach="table.rows" t-as="row" t-key="'row_' + row_index">
-                        <t t-call="web.PivotHeader">
-                            <t t-set="isXAxis" t-value="false"/>
-                            <t t-set="cell" t-value="row"/>
-                        </t>
-                        <t t-foreach="row.subGroupMeasurements" t-as="cell" t-key="'row_cell_' + cell_index">
-                            <td class="o_pivot_cell_value bg-100" t-att-class="{
-                                    o_empty: cell.value === undefined,
-                                    'cursor-pointer': cell.value !== undefined,
-                                    'fw-bold': cell.isBold,
-                                }" t-on-click="() => this.onOpenView(cell)"
-                                   t-on-mouseover="onMouseEnter" t-on-mouseout="onMouseLeave">
-                                <t t-if="cell.value !== undefined">
-                                    <div t-if="cell.originIndexes.length > 1" class="o_variation" t-att-class="{
-                                             'o_positive text-success': cell.value &gt; 0,
-                                             'o_negative text-danger': cell.value &lt; 0,
-                                             o_null: cell.value === 0,
-                                        }" t-esc="getFormattedVariation(cell)"/>
-                                    <div t-elif="model.metaData.measures[cell.measure].type === 'boolean'" class="o_value">
-                                        <CheckBox disabled="true" value="cell.value" />
-                                    </div>
-                                    <div t-else="1" class="o_value" t-esc="getFormattedValue(cell)"/>
+        <div class="o_pivot_renderer o_renderer" t-att-class="{
+            o_empty: showNoContentHelper,
+        }">
+            <t t-call="web.PivotView.Buttons"/>
+            <div t-if="model.hasData() and model.metaData.activeMeasures.length" class="o_pivot table-responsive mx-3">
+                <table
+                    class="table-hover table table-sm table-bordered table-borderless"
+                    t-att-class="{ o_enable_linking: !model.metaData.disableLinking }"
+                    t-ref="table"
+                >
+                    <thead>
+                        <tr t-foreach="table.headers" t-as="row" t-key="'header_' + row_index" class="border-top-0">
+                            <t t-foreach="row" t-as="cell" t-key="'header_row_' + cell_index">
+                                <t t-if="cell.measure" t-call="web.PivotMeasure"/>
+                                <t t-elif="cell.isLeaf !== undefined" t-call="web.PivotHeader">
+                                    <t t-set="isXAxis" t-value="true"/>
+                                    <t t-set="isInHead" t-value="true"/>
                                 </t>
-                            </td>
-                        </t>
-                    </tr>
-                </tbody>
-            </table>
+                                <th t-else="" t-att-colspan="cell.width" t-att-rowspan="cell.height" class="border-0 bg-100 fw-normal" t-att-class="{ 'border-0': cell_index != 0 }"/>
+                            </t>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr t-foreach="table.rows" t-as="row" t-key="'row_' + row_index">
+                            <t t-call="web.PivotHeader">
+                                <t t-set="isXAxis" t-value="false"/>
+                                <t t-set="cell" t-value="row"/>
+                            </t>
+                            <t t-foreach="row.subGroupMeasurements" t-as="cell" t-key="'row_cell_' + cell_index">
+                                <td class="o_pivot_cell_value bg-100" t-att-class="{
+                                        o_empty: cell.value === undefined,
+                                        'cursor-pointer': cell.value !== undefined,
+                                        'fw-bold': cell.isBold,
+                                    }" t-on-click="() => this.onOpenView(cell)"
+                                    t-on-mouseover="onMouseEnter" t-on-mouseout="onMouseLeave">
+                                    <t t-if="cell.value !== undefined">
+                                        <div t-if="cell.originIndexes.length > 1" class="o_variation" t-att-class="{
+                                                'o_positive text-success': cell.value &gt; 0,
+                                                'o_negative text-danger': cell.value &lt; 0,
+                                                o_null: cell.value === 0,
+                                            }" t-esc="getFormattedVariation(cell)"/>
+                                        <div t-elif="model.metaData.measures[cell.measure].type === 'boolean'" class="o_value">
+                                            <CheckBox disabled="true" value="cell.value" />
+                                        </div>
+                                        <div t-else="1" class="o_value" t-esc="getFormattedValue(cell)"/>
+                                    </t>
+                                </td>
+                            </t>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+            <t t-if="showNoContentHelper">
+                <t t-if="props.noContentHelp" t-call="web.ActionHelper">
+                    <t t-set="noContentHelp" t-value="props.noContentHelp"/>
+                </t>
+                <t t-else="" t-call="web.NoContentHelper"/>
+            </t>
         </div>
     </t>
 

--- a/addons/web/static/src/views/view.scss
+++ b/addons/web/static/src/views/view.scss
@@ -20,6 +20,7 @@
 .o_view_nocontent {
     @include o-position-absolute(0, 0, 0, 0);
     pointer-events: none;
+    overflow: auto;
     z-index: var(--o-view-nocontent-zindex, 1);
     display: flex;
     align-items: center;

--- a/addons/web/static/src/webclient/webclient_layout.scss
+++ b/addons/web/static/src/webclient/webclient_layout.scss
@@ -77,6 +77,9 @@ html {
         height: 100%;
         direction: ltr;
       }
+      .o_renderer.o_empty {
+        overflow: hidden;
+      }
     }
   }
 


### PR DESCRIPTION
This PR will move the no-content helper from the view controllers to the view renderers and add a `o_empty` class on the renderer container when the no-content helper is shown allowing people to define new css rules.

task-3381729

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
