### PR TITLE
[IMP] website_event_track: collapse tracks and agenda

### DIFF
--- a/addons/website_event_track/static/src/scss/event_track_templates.scss
+++ b/addons/website_event_track/static/src/scss/event_track_templates.scss
@@ -149,14 +149,3 @@
         }
     }
 }
-
-/*
- * EVENT TOOL: DATE
- */
-.o_wevent_event {
-    .o_we_track_day_header {
-        a.collapsed {
-            transform: rotate(-90deg);
-        }
-    }
-}

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -73,85 +73,92 @@
 
 <!-- Agenda Main Display -->
 <template id="agenda_main" name="Tracks: Main Display">
-    <section t-foreach="days" t-as="day" class="col-12">
-        <!-- DAY HEADER -->
-        <div class="o_we_track_day_header d-flex justify-content-between align-items-center w-100">
-            <div class="d-flex flex-column flex-grow-1">
-                <span class="m-0 fw-bold" t-out="day" t-options="{'widget': 'date', 'format': 'EEEE '}"/>
-                <div class="d-flex align-items-center justify-content-start">
-                    <span class="h3 mb-0 fw-bold" t-out="day" t-options="{'widget': 'date', 'format': 'dd MMMM YYYY'}"/>
-                    <span class="small ms-2 fw-light">(<t t-out="event.date_tz"/>)</span>
+    <div class="accordion accordion-flush">
+        <section t-foreach="days" t-as="day" class="accordion-item">
+            <!-- DAY HEADER -->
+            <div class="o_we_track_day_header accordion-header" t-attf-id="collapse_agenda_heading_{{day}}">
+                <button class="accordion-button collapsed px-0 shadow-none" aria-expanded="true" type="button" data-bs-toggle="collapse" t-attf-data-bs-target="#collapse_agenda_{{day}}"  t-attf-aria-controls="collapse_agenda_{{day}}">
+                    <div class="d-flex flex-column flex-grow-1">
+                        <strong t-out="day" t-options="{'widget': 'date', 'format': 'EEEE '}"/>
+                        <div class="d-flex align-items-center justify-content-start">
+                            <span class="h3 my-0 fw-bold" t-out="day" t-options="{'widget': 'date', 'format': 'dd MMMM'}"/>
+                            <span class="d-none d-md-block h3 my-0 ms-2 fw-bold" t-out="day" t-options="{'widget': 'date', 'format': 'YYYY'}"/>
+                            <span class="d-none d-md-block ms-2 fw-light small">(<t t-out="event.date_tz"/>)</span>
+                        </div>
+                    </div>
+                    <small class="align-self-end my-auto me-3 text-muted"><t t-out="tracks_by_days[day]"/> tracks</small>
+                </button>
+            </div>
+
+            <t t-set="locations" t-value="locations_by_days[day]"/>
+            <!-- Day Agenda -->
+            <div t-attf-id="collapse_agenda_{{day}}" t-attf-class="accordion-collapse collapse show">
+                <div class="o_we_online_agenda accordion-body p-0">
+                    <table t-attf-id="o_we_table_search_{{day}}" class="table table-sm h-100 border-0">
+                        <!--Header-->
+                        <tr>
+                            <th class="border-0"/>
+                            <t t-foreach="locations" t-as="location">
+                                <th t-if="location" class="active text-center">
+                                    <span t-out="location and location.name or 'Unknown'"/>
+                                </th>
+                            </t>
+                        </tr>
+
+                        <!-- Time Slots -->
+                        <t t-set="used_cells" t-value="[]"/>
+                        <t t-foreach="time_slots[day]" t-as="time_slot">
+                            <t t-set="is_round_hour" t-value="time_slot == time_slot.replace(minute=0)"/>
+                            <t t-set="is_half_hour" t-value="time_slot == time_slot.replace(minute=30)"/>
+
+                            <tr t-att-class="'%s' % ('active' if is_round_hour else '')">
+                                <td class="active">
+                                    <b class="rounded px-2 bg-white" t-if="is_round_hour" t-out="time_slots[day][time_slot]['formatted_time']"/>
+                                </td>
+
+                                <t t-foreach="locations" t-as="location">
+                                    <t t-set="tracks" t-value="time_slots[day][time_slot].get(location, {})"/>
+                                    <t t-if="tracks">
+                                        <t t-foreach="tracks" t-as="track">
+                                            <t t-set="_classes"
+                                               t-value="'text-center %s %s %s' % (
+                                                    'event_color_%s' % (track.color or 0),
+                                                    'event_track h-100' if track else '',
+                                                    'o_location_size_%d' % len(locations),
+                                               )"/>
+                                            <t t-if="track.location_id and track.location_id == location">
+                                                <td t-att-rowspan="tracks[track]['rowspan']"
+                                                    t-att-class="_classes">
+                                                    <t t-call="website_event_track.agenda_main_track"/>
+                                                </td>
+                                            </t>
+                                            <t t-else="">
+                                                <td t-att-colspan="len(locations)-1"
+                                                    t-att-rowspan="tracks[track]['rowspan']"
+                                                    t-att-class="_classes">
+                                                    <t t-call="website_event_track.agenda_main_track"/>
+                                                </td>
+                                            </t>
+                                            <t t-set="used_cells" t-value="used_cells + tracks[track]['occupied_cells']"/>
+                                        </t>
+                                    </t>
+                                    <t t-elif="location and (time_slot, location) not in used_cells">
+                                        <td t-att-rowspan="1"
+                                            t-att-class="'o_location_size_%s %s' % (len(locations),
+                                                'o_we_agenda_time_slot_half' if is_half_hour else
+                                                'o_we_agenda_time_slot_main' if is_round_hour else
+                                                ''
+                                            )"><div/>
+                                        </td>
+                                    </t>
+                                </t>
+                            </tr>
+                        </t>
+                    </table>
                 </div>
             </div>
-            <small class="float-end text-muted align-self-end"><t t-out="tracks_by_days[day]"/> tracks</small>
-        </div>
-        <hr class="mt-2 mb-2"/>
-
-        <t t-set="locations" t-value="locations_by_days[day]"/>
-        <!-- Day Agenda -->
-        <div class="o_we_online_agenda">
-        <table id="table_search" class="table table-sm border-0 h-100">
-            <!--Header-->
-            <tr>
-                <th class="border-0 position-sticky"/>
-                <t t-foreach="locations" t-as="location">
-                    <th t-if="location" class="active text-center">
-                        <span t-out="location and location.name or 'Unknown'"/>
-                    </th>
-                </t>
-            </tr>
-
-            <!-- Time Slots -->
-            <t t-set="used_cells" t-value="[]"/>
-            <t t-foreach="time_slots[day]" t-as="time_slot">
-                <t t-set="is_round_hour" t-value="time_slot == time_slot.replace(minute=0)"/>
-                <t t-set="is_half_hour" t-value="time_slot == time_slot.replace(minute=30)"/>
-
-                <tr t-att-class="'%s' % ('active' if is_round_hour else '')">
-                    <td class="active">
-                        <b t-if="is_round_hour" t-out="time_slots[day][time_slot]['formatted_time']"/>
-                    </td>
-
-                    <t t-foreach="locations" t-as="location">
-                        <t t-set="tracks" t-value="time_slots[day][time_slot].get(location, {})"/>
-                        <t t-if="tracks">
-                            <t t-foreach="tracks" t-as="track">
-                                <t t-set="_classes"
-                                    t-value="'text-center %s %s %s' % (
-                                        'event_color_%s' % (track.color or 0),
-                                        'event_track h-100' if track else '',
-                                        'o_location_size_%d' % len(locations),
-                                    )"/>
-                                <t t-if="track.location_id and track.location_id == location">
-                                    <td t-att-rowspan="tracks[track]['rowspan']"
-                                        t-att-class="_classes">
-                                        <t t-call="website_event_track.agenda_main_track"/>
-                                    </td>
-                                </t>
-                                <t t-else="">
-                                    <td t-att-colspan="len(locations)-1"
-                                        t-att-rowspan="tracks[track]['rowspan']"
-                                        t-att-class="_classes">
-                                        <t t-call="website_event_track.agenda_main_track"/>
-                                    </td>
-                                </t>
-                                <t t-set="used_cells" t-value="used_cells + tracks[track]['occupied_cells']"/>
-                            </t>
-                        </t>
-                        <t t-elif="location and (time_slot, location) not in used_cells">
-                            <td t-att-rowspan="1"
-                                t-att-class="'o_location_size_%s %s' % (len(locations),
-                                    'o_we_agenda_time_slot_half' if is_half_hour else
-                                    'o_we_agenda_time_slot_main' if is_round_hour else
-                                    ''
-                                )"><div/></td>
-                        </t>
-                    </t>
-                </tr>
-            </t>
-        </table>
-        </div>
-    </section>
+        </section>
+    </div>
 </template>
 
 <template id="agenda_main_track" name="Track Agenda: Track">

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -77,7 +77,7 @@
         <section t-foreach="days" t-as="day" class="accordion-item">
             <!-- DAY HEADER -->
             <div class="o_we_track_day_header accordion-header" t-attf-id="collapse_agenda_heading_{{day}}">
-                <button class="accordion-button collapsed px-0 shadow-none" aria-expanded="true" type="button" data-bs-toggle="collapse" t-attf-data-bs-target="#collapse_agenda_{{day}}"  t-attf-aria-controls="collapse_agenda_{{day}}">
+                <button t-attf-class="accordion-button {{'collapsed' if default_collapse_by_days[day] else ''}} px-0 shadow-none" t-att-aria-expanded="default_collapse_by_days[day] and 'false' or 'true'" type="button" data-bs-toggle="collapse" t-attf-data-bs-target="#collapse_agenda_{{day}}" t-attf-aria-controls="collapse_agenda_{{day}}">
                     <div class="d-flex flex-column flex-grow-1">
                         <strong t-out="day" t-options="{'widget': 'date', 'format': 'EEEE '}"/>
                         <div class="d-flex align-items-center justify-content-start">
@@ -92,7 +92,7 @@
 
             <t t-set="locations" t-value="locations_by_days[day]"/>
             <!-- Day Agenda -->
-            <div t-attf-id="collapse_agenda_{{day}}" t-attf-class="accordion-collapse collapse show">
+            <div t-attf-id="collapse_agenda_{{day}}" t-attf-class="accordion-collapse collapse {{'show' if not default_collapse_by_days[day] else ''}}">
                 <div class="o_we_online_agenda accordion-body p-0">
                     <table t-attf-id="o_we_table_search_{{day}}" class="table table-sm h-100 border-0">
                         <!--Header-->
@@ -115,7 +115,6 @@
                                 <td class="active">
                                     <b class="rounded px-2 bg-white" t-if="is_round_hour" t-out="time_slots[day][time_slot]['formatted_time']"/>
                                 </td>
-
                                 <t t-foreach="locations" t-as="location">
                                     <t t-set="tracks" t-value="time_slots[day][time_slot].get(location, {})"/>
                                     <t t-if="tracks">

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -238,97 +238,93 @@
                 <t t-set="tracks_date" t-value="tracks_info['date']"/>
                 <t t-set="tracks_header_name" t-value="tracks_info['name']"/>
                 <t t-set="tracks" t-value="tracks_info['tracks']"/>
-                <!-- DAY HEADER -->
-                <div t-attf-class="o_we_track_day_header d-flex align-items-center py-3">
-                    <div class="d-flex flex-grow-1 flex-column" t-if="tracks_date">
-                        <span class="m-0 fw-bold" t-out="tracks_date"
-                            t-options="{'widget': 'date', 'format': 'EEEE '}"/>
-                        <div class="d-flex align-items-center justify-content-start">
-                            <span class="h3 mb-0 fw-bold" t-out="tracks_date"
-                                t-options="{'widget': 'date', 'format': 'dd MMMM YYYY'}"/>
-                                <span class="small ms-2 fw-light">(<t t-out="event.date_tz"/>)</span>
+                <div class="o_we_track_day_header accordion accordion-flush" id="accordion_tracks">
+                    <div class="accordion-item border-0">
+                        <div class="accordion-header" t-attf-id="collapse_session_list_heading_{{tracks_info_index}}">
+                            <button t-attf-class="accordion-button px-0 shadow-none {{'collapsed' if tracks_info['default_collapsed'] else ''}}" type="button" data-bs-toggle="collapse" t-attf-data-bs-target="#collapse_session_list_{{tracks_info_index}}" t-att-aria-expanded="'false' if tracks_info['default_collapsed'] else 'true'" t-attf-aria-controls="collapse_session_list_{{tracks_info_index}}">
+                                <div class="d-flex flex-grow-1 flex-column" t-if="tracks_date">
+                                    <span class="m-0 fw-bold" t-out="tracks_date"
+                                          t-options="{'widget': 'date', 'format': 'EEEE '}"/>
+                                    <div class="d-flex align-items-center justify-content-start">
+                                        <span class="h3 my-0 fw-bold" t-out="tracks_date"
+                                              t-options="{'widget': 'date', 'format': 'dd MMMM YYYY'}"/>
+                                        <span class="ms-2 fw-light small">(<t t-out="event.date_tz"/>)</span>
+                                    </div>
+                                </div>
+                                <div class="d-flex flex-grow-1" t-elif="tracks_header_name">
+                                    <span class="h1 m-0 fw-bold"
+                                          t-out="tracks_header_name"/>
+                                </div>
+                            </button>
                         </div>
-                    </div>
-                    <div class="d-flex flex-grow-1" t-elif="tracks_header_name">
-                        <span class="h1 m-0 fw-bold"
-                            t-out="tracks_header_name"/>
-                    </div>
-                    <a t-attf-class="my-auto align-self-start text-black {{ 'collapsed' if tracks_info['default_collapsed'] else '' }}"
-                        t-attf-href="#collapse_session_list_{{ tracks_info_index }}"
-                        t-attf-aria-controls="collapse_session_list_{{ tracks_info_index }}"
-                        t-att-aria-expanded="'false' if tracks_info['default_collapsed'] else 'true'"
-                        data-bs-toggle="collapse">
-                        <i class="oi oi-chevron-down"/>
-                    </a>
-                    <hr class="mt-2 mb-2"/>
-                </div>
-                <!-- DAY TRACKS LIST -->
-                <div t-attf-class="collapse {{ '' if tracks_info['default_collapsed'] else 'show' }}"
-                    t-attf-id="collapse_session_list_{{ tracks_info_index }}">
-                    <div t-foreach="tracks" t-as="track"
-                        t-att-class="'o_wesession_list_item p-3 event_color_%d' % (track.color)">
-                        <div class="row g-0">
-                            <div class="col-12 d-flex justify-content-between">
-                                <!-- Hour: Live > Remaining > Hour: desktop only -->
-                                <div t-if="tracks_date and today_tz &lt;= tracks_date"
-                                    >
-                                    <span t-if="track.is_track_live and not track.is_track_done"
-                                        class="badge text-bg-danger">Live</span>
-                                    <span t-elif="not track.is_track_done and track.is_track_soon">
-                                        <span t-out="track.track_start_remaining"
-                                            t-options="{'widget': 'duration', 'digital': False, 'format': 'narrow',
-                                                        'add_direction': True, 'unit': 'second', 'round': 'minute'}"/>
-                                    </span>
-                                    <span t-elif="not track.is_track_done and not track.is_track_soon"
-                                        t-out="track.date"
-                                        t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short', 'tz_name': event.date_tz}"/>
-                                    <span t-else="" class="badge text-bg-info">Finished</span>
-                                </div>
-                                <!-- reminder -->
-                                <div t-if="not event.is_done and (not track.date or today_tz &lt;= tracks_date) and option_track_wishlist"
-                                    class="d-none d-md-block py-1">
-                                    <t t-call="website_event_track.track_widget_reminder">
-                                        <t t-set="reminder_small" t-value="False"/>
-                                        <t t-set="reminder_light" t-value="False"/>
-                                    </t>
-                                </div>
-                            </div>
-                            <!-- Main column: name, speaker -->
-                            <div class="col-12">
-                                <span class="h5 mb0">
-                                    <a t-if="track.website_published or is_event_user"
-                                        class="me-2"
-                                        t-att-href="track.website_url">
-                                        <span t-field="track.name"/>
-                                    </a>
-                                    <t t-else="">
-                                        <span class="me-2" t-field="track.name"/>
-                                    </t>
-                                    <span t-if="not track.website_published and is_event_user"
-                                        class="badge text-bg-danger o_wevent_online_badge_unpublished">
-                                        Unpublished
-                                    </span>
-                                </span>
-                            </div>
-                            
-                            <div class="col-12 d-flex justify-content-between align-items-end">
-                                <div class="d-flex align-items-center w-100 gap-2 text-muted">
-                                    <span class="text-muted" t-out="track.partner_tag_line"/>
-                                    <t t-if="tracks_date and today_tz &lt;= tracks_date">
-                                        <t t-if="track.duration and not track.is_track_done and not track.is_track_done">
-                                            <span class="d-none d-md-block">&amp;bull;</span>
-                                            <span class="d-none d-md-block"
-                                                t-out="track.duration"
-                                                t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'hour', 'round': 'minute'}"/>
-                                        </t>
-                                    </t>
-                                </div>
-                                <!-- Aside column: tags -->
-                                <div class="d-none d-md-flex justify-content-end align-items-center w-auto gap-2">
-                                    <!-- Tags: desktop only -->
-                                    <t t-foreach="track.tag_ids" t-as="tag">
-                                        <t t-if="tag.color" t-call="website_event_track.track_tag_badge_link"/>
-                                    </t>
+                        <div t-attf-id="collapse_session_list_{{tracks_info_index}}" t-attf-class="accordion-collapse collapse {{ '' if tracks_info['default_collapsed'] else 'show' }}">
+                            <div class="accordion-body px-0">
+                                <div t-foreach="tracks" t-as="track"
+                                     t-att-class="'o_wesession_list_item p-3 event_color_%d' % (track.color)">
+                                    <div class="row g-0">
+                                        <div class="col-12 d-flex justify-content-between">
+                                            <!-- Hour: Live > Remaining > Hour: desktop only -->
+                                            <div t-if="tracks_date and today_tz &lt;= tracks_date" >
+                                                <span t-if="track.is_track_live and not track.is_track_done"
+                                                      class="badge text-bg-danger">Live</span>
+                                                <span t-elif="not track.is_track_done and track.is_track_soon">
+                                                    <span t-out="track.track_start_remaining"
+                                                          t-options="{'widget': 'duration', 'digital': False, 'format': 'narrow',
+                                                                    'add_direction': True, 'unit': 'second', 'round': 'minute'}"/>
+                                                </span>
+                                                <span t-elif="not track.is_track_done and not track.is_track_soon"
+                                                      t-out="track.date"
+                                                      t-options="{'widget': 'datetime', 'time_only': True, 'format': 'short', 'tz_name': event.date_tz}"/>
+                                                <span t-else="" class="badge text-bg-info">Finished</span>
+                                            </div>
+                                            <!-- reminder -->
+                                            <div t-if="not event.is_done and (not track.date or today_tz &lt;= tracks_date) and option_track_wishlist"
+                                                 class="d-none d-md-block py-1">
+                                                <t t-call="website_event_track.track_widget_reminder">
+                                                    <t t-set="reminder_small" t-value="False"/>
+                                                    <t t-set="reminder_light" t-value="False"/>
+                                                </t>
+                                            </div>
+                                        </div>
+                                        <!-- Main column: name, speaker -->
+                                        <div class="col-12">
+                                            <span class="h5 mb0">
+                                                <a t-if="track.website_published or is_event_user"
+                                                   class="me-2"
+                                                   t-att-href="track.website_url">
+                                                    <span t-field="track.name"/>
+                                                </a>
+                                                <t t-else="">
+                                                    <span class="me-2" t-field="track.name"/>
+                                                </t>
+                                                <span t-if="not track.website_published and is_event_user"
+                                                      class="badge text-bg-danger o_wevent_online_badge_unpublished">
+                                                    Unpublished
+                                                </span>
+                                            </span>
+                                        </div>
+                                                
+                                        <div class="col-12 d-flex justify-content-between align-items-end">
+                                            <div class="d-flex align-items-center w-100 gap-2 text-muted">
+                                                <span class="text-muted" t-out="track.partner_tag_line"/>
+                                                <t t-if="tracks_date and today_tz &lt;= tracks_date">
+                                                    <t t-if="track.duration and not track.is_track_done and not track.is_track_done">
+                                                        <span class="d-none d-md-block">&amp;bull;</span>
+                                                        <span class="d-none d-md-block"
+                                                              t-out="track.duration"
+                                                              t-options="{'widget': 'duration', 'digital': False, 'format': 'short', 'unit': 'hour', 'round': 'minute'}"/>
+                                                    </t>
+                                                </t>
+                                            </div>
+                                            <!-- Aside column: tags -->
+                                            <div class="d-none d-md-flex justify-content-end align-items-center w-auto gap-2">
+                                                <!-- Tags: desktop only -->
+                                                <t t-foreach="track.tag_ids" t-as="tag">
+                                                    <t t-if="tag.color" t-call="website_event_track.track_tag_badge_link"/>
+                                                </t>
+                                            </div>
+                                        </div>
+                                    </div>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Prior to this PR, usability in the `tracks view` and in the `agenda view` was not good. 
To collapse the tracks, you had to click on the arrow (and only there)
There was no collapsing possible in the `agenda view`

task-3599197

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
