### PR TITLE
[FIX] web_editor: mobile odoo enter after enter clears content

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2664,7 +2664,7 @@ export class OdooEditor extends EventTarget {
             } else {
                 this.historyStep();
             }
-        } else if (ev.inputType === 'insertCompositionText') {
+        } else if (['insertText', 'insertCompositionText'].includes(ev.inputType)) {
             this._fromCompositionText = true;
         }
     }


### PR DESCRIPTION
Reproduction:

1. On mobile app, open note, write something, type "enter"
2.  the line is removed

Fix: add a case of inputText for mobile input to make sure the history step is correctly set up

Related commit: https://github.com/odoo/odoo/commit/53b4afe747ab6ec2cfc889867e86fb8bc0ac3408

task-3573657





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
