### PR TITLE
[FIX] web: Handle undefined in formatFloat

### DIFF
--- a/addons/web/static/src/core/utils/numbers.js
+++ b/addons/web/static/src/core/utils/numbers.js
@@ -189,7 +189,7 @@ export function formatFloat(value, options = {}) {
     } else {
         precision = 2;
     }
-    const formatted = value.toFixed(precision).split(".");
+    const formatted = (value || 0).toFixed(precision).split(".");
     formatted[0] = insertThousandsSep(formatted[0], thousandsSep, grouping);
     if (options.trailingZeros === false && formatted[1]) {
         formatted[1] = formatted[1].replace(/0+$/, "");


### PR DESCRIPTION
This commit addresses an issue introduced by a recent refactor of the formatFloat function (see https://github.com/odoo/odoo/commit/054ca0a19aaf297f420a1b478b93ae26f1b943b8). The refactor changed '(value || 0)' to 'value', which causes issues when the value is undefined. This bug affects several places where formatFloat was assumed to handle undefined values. A notable example is within the point_of_sale module, where creating a contact now raises an error. This fix restores the previous behavior of safely handling undefined values.

opw-3594167

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
