### PR TITLE
[FIX] website_sale: show pickup locations if case of 1 shipping method

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale/static/src/js/website_sale_delivery.js
@@ -275,6 +275,10 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
         }
     },
 
+    _arePickupLocationsDisplayed: function (ev) {
+        return !ev.currentTarget.closest('.o_delivery_carrier_select').querySelector(".o_order_location").parentElement.classList.contains("d-none");
+    },
+
     //--------------------------------------------------------------------------
     // Handlers
     //--------------------------------------------------------------------------
@@ -302,7 +306,7 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
      */
     _onClickShowLocations: async function (ev) {
         // This checks if there is a pick up point already select with that carrier
-        if (!ev.currentTarget.closest('.o_delivery_carrier_select').querySelector(".o_order_location").parentElement.classList.contains("d-none")) {
+        if (this._arePickupLocationsDisplayed(ev)) {
             return;
         }
         const showPickupLocations = ev.currentTarget.closest('.o_delivery_carrier_select').querySelector('.o_show_pickup_locations');
@@ -354,7 +358,7 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
         const radio = ev.currentTarget.closest('.o_delivery_carrier_select').querySelector(
             'input[type="radio"]'
         );
-        if (radio.checked) {
+        if (radio.checked && this._arePickupLocationsDisplayed(ev)) {
             return;
         }
 


### PR DESCRIPTION
Issue:
======
When we have 1 delivery method enabled that have pickup locations, it will be selected by default and the pickup locations will never be displayed.

Steps to reproduce the issue:
=============================
- Set up pickup locations carried for sendcloud (like mondial relay)
- Go through the website with just that shipping method available and add a product to cart valid with the configuration of sendcloud.
- Go to checkoutout you will get the shipping method selected but no pick up options

Origin of the issue:
====================
If the delivery method is already selected it will skip showing pickup locations.

Solutions:
==========
Now there is another check to make sure that it will be skipped only when the pick up locations are displayed.

opw-3569497

