### PR TITLE
[FIX] mail: reopen discuss app with correct thread

### DIFF
--- a/addons/mail/static/src/models/discuss/discuss.js
+++ b/addons/mail/static/src/models/discuss/discuss.js
@@ -181,14 +181,17 @@ function factory(dependencies) {
             }
             this.threadView.topbar.openInvitePopoverView();
         }
-
+        getThreadIdentifyingDataFromActiveId(activeId) {
+            const [model, id] = typeof this.initActiveId === "number"
+                ? ["mail.channel", this.initActiveId]
+                : this.initActiveId.split("_");
+            return { model, id };
+        }
         /**
          * Opens thread from init active id if the thread exists.
          */
         openInitThread() {
-            const [model, id] = typeof this.initActiveId === 'number'
-                ? ['mail.channel', this.initActiveId]
-                : this.initActiveId.split('_');
+            const { model, id } = this.getThreadIdentifyingDataFromActiveId(this.initActiveId);
             const thread = this.messaging.models['mail.thread'].findFromIdentifyingData({
                 id: model !== 'mail.box' ? Number(id) : id,
                 model,
@@ -221,8 +224,10 @@ function factory(dependencies) {
                 this.env.bus.trigger('do-action', {
                     action: 'mail.action_discuss',
                     options: {
+                        additional_context: {
+                            active_id: this.threadToActiveId(thread),
+                        },
                         name: this.env._t("Discuss"),
-                        active_id: this.threadToActiveId(this),
                         clear_breadcrumbs: false,
                         on_reverse_breadcrumb: () => this.close(), // this is useless, close is called by destroy anyway
                     },

--- a/addons/mail/static/src/widgets/discuss/discuss.js
+++ b/addons/mail/static/src/widgets/discuss/discuss.js
@@ -49,6 +49,18 @@ export const DiscussWidget = AbstractAction.extend({
                 if (!this.discuss.thread) {
                     this.discuss.openInitThread();
                 }
+            } else {
+                const thread = messaging.models["mail.thread"].findFromIdentifyingData(
+                    this.discuss.getThreadIdentifyingDataFromActiveId(initActiveId)
+                );
+                if (thread) {
+                    if (messaging.device.isMobile && thread.channel_type) {
+                        this.discuss.update({ activeMobileNavbarTabId: thread.channel_type });
+                        messaging.chatWindowManager.openThread(thread);
+                    } else {
+                        this.discuss.openThread(thread);
+                    }
+                }
             }
         });
     },


### PR DESCRIPTION
Before this commit, when discuss app was open at least once in a "inbox" then we re-open in a specific thread different from inbox, it was opening the discuss app with Inbox selected instead of the specific thread.

Steps to reproduce:
- Log in as Admin
- Open the Discuss app
- Select "general" as the channel thread
- Copy the URL
- Select "Inbox"
- Open any app (e.g. the "Apps" app)
- Navigate with copied URL in clipboard => Discuss app is open in "Inbox" instead of "general"

This happens because the URL contains an active_id, and the handling of this active_id only works at the 1st opening of Discuss app.

This commit fixes the issue by handling 2nd and more opening of Discuss app as basically a `discuss.openThread()`, which simply opens the thread of given active_id in the Discuss app. In mobile, the conversations are actually open with a chat window, hence the special handling. The discuss app is still open in the appropriate tab, so that back button shows the Discuss app in the correct context.
