### PR TITLE
[FIX] portal: display avatar in row

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -415,6 +415,11 @@ form label {
     object-fit: cover;
 }
 
+.row > .o_portal_contact_img {
+    padding-left: 0;
+    padding-right: 0;
+}
+
 .o_portal_sidebar {
     #sidebar_content.card {
         border-left: 0;


### PR DESCRIPTION
    Before: Avatar icon doesn't show up in task's portal list view
    
    Step to reproduce (runbot 16):
    - Install Project and 'portal' module
    - Create a task, set Joel Willis as customer and assign either Mitchell Admin or Marc Demo
    - Log in as portal
        Click on "Tasks"
        You should see a list view, with a column for assignees,
        with the inspector you can see the avatar icon is not displayed
    
    Now: Avatar icon is correctly displayed
    
    opw-3592972


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
