### PR TITLE
[FIX] payment,website_sale{_loyalty}: fix enable payment requirements

### DIFF
--- a/addons/payment/static/src/js/payment_form_mixin.js
+++ b/addons/payment/static/src/js/payment_form_mixin.js
@@ -29,9 +29,6 @@ odoo.define('payment.payment_form_mixin', require => {
             } else {
                 this._setPaymentFlow(); // Initialize the payment flow to let providers overwrite it
             }
-            // When a module wants to activate the button,
-            // it must test its conditions and then call this bus.
-            core.bus.on('enableButton', this, this._enableButton);
         },
 
         //--------------------------------------------------------------------------

--- a/addons/website_sale_loyalty/static/src/js/website_sale_loyalty_delivery.js
+++ b/addons/website_sale_loyalty/static/src/js/website_sale_loyalty_delivery.js
@@ -3,6 +3,7 @@
 import PublicWidget from 'web.public.widget';
 import { patch } from 'web.utils';
 import core from 'web.core';
+import 'website_sale_delivery.checkout';
 
 const _t = core._t;
 
@@ -14,7 +15,7 @@ patch(PublicWidget.registry.websiteSaleDelivery, 'addons/website_sale_loyalty_de
     /**
      * @override
      */
-     _handleCarrierUpdateResult: async function (carrierInput) {
+    _handleCarrierUpdateResult: async function (carrierInput) {
         await this._super.apply(this, arguments);
         if (this.result.new_amount_order_discounted) {
             // Update discount of the order


### PR DESCRIPTION
### Main Issue(s) :
When a delivery method is poorly configured (e.g. missing data), a customer should not be able to pay and confirm a purchase order as the company miss information to properly deliver him the product.

### Steps to reproduce :
- Backend :
    - Properly configure a delivery carrier with pickup point(s)
    - Configure a payment provider
- Website :
    - Add a Product to the cart
    - Go to the checkout Form
    - Choose the configure delivery method but do not choose a pickup point (Button is disabled)
    - Choose a payment method
When we choose a payment method, the "Pay Now" button is enabled even if the delivery method is misconfigured

### Main change(s) :
Separate the payment related logics from the delivery scope on the website to ensure coherent logic on each side

### Before :
On the website checkout form, the "Pay Now" button can be enabled from multiple sources through a bus event. This mechanism allow one widget to bypass other widgets conditions, such leading to false-positive "Pay Now" button activation.

### After :
The faulty bus is removed, while the (only) widget relying on it is redesigned to restrain his scope of action while handling "payment activation" succesfully.

opw-3569497

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
