### PR TITLE
[IMP] account: Uncheck Customer Addresses in demo data

### DIFF
--- a/addons/website_sale/data/demo.xml
+++ b/addons/website_sale/data/demo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<odoo noupdate="1">
-
+<odoo>
+    <data noupdate="1">
         <record model="website" id="website.website2">
             <field name="salesteam_id" ref="sales_team.salesteam_website_sales"/>
         </record>
@@ -755,5 +755,10 @@
             <field name="create_uid" ref="base.user_demo"/>
             <field name="user_id" ref="base.user_demo"/>
         </record>
-
+    </data>
+    <data>
+        <record id="demo_res_config_settings" model="res.config.settings">
+            <field name="group_sale_delivery_address" eval="False"/>
+        </record>
+    </data>
 </odoo>


### PR DESCRIPTION
Addresses the issue where the Customer Addresses option in the Accounting settings complicates the user interface in demo mode. By unchecking this option in the demo data, the UI is simplified.

task-3599641



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
