### PR TITLE
[FIX] web_editor: properly ignore drag on non-draggable snippets

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3077,6 +3077,7 @@ var SnippetsMenu = Widget.extend({
             return false;
         };
 
+        // GREP: SNIPPETS_DRAGGABLE
         this.$snippets = $scroll.find('.o_panel_body').children()
             .addClass('oe_snippet')
             .each((i, el) => {
@@ -3393,13 +3394,20 @@ var SnippetsMenu = Widget.extend({
         if (!$scrollingElement[0] || $scrollingElement.find('body.o_in_iframe').length) {
             $scrollingElement = $(this.ownerDocument).find('.o_editable');
         }
+        // GREP: SNIPPETS_DRAGGABLE
+        // This is done because the current system does not take a list of
+        // elements, and instead just a CSS selector string, while the old
+        // system did take a list. In the future, either the new system should
+        // take a list of elements, or we should better handle the snippets
+        // that are not draggable.
+        this.$snippets.addClass("o_we_draggable");
 
         const dragAndDropOptions = this.options.getDragAndDropOptions({
             el: this.$el[0],
-            elements: ".oe_snippet",
+            elements: ".oe_snippet.o_we_draggable",
             scrollingElement: $scrollingElement[0],
             handle: '.oe_snippet_thumbnail:not(.o_we_already_dragging)',
-            cancel: '.oe_snippet.o_disabled',
+            ignore: '.oe_snippet.o_disabled',
             dropzones: () => {
                 return $dropZones.toArray();
             },

--- a/addons/website/static/tests/tours/installable_snippet_not_draggable.js
+++ b/addons/website/static/tests/tours/installable_snippet_not_draggable.js
@@ -1,0 +1,19 @@
+/** @odoo-module **/
+import wTourUtils from "@website/js/tours/tour_utils";
+
+wTourUtils.registerWebsitePreviewTour("installable_snippet_not_draggable", {
+    url: "/",
+    test: true,
+    edition: true,
+}, () => [
+    wTourUtils.dragNDrop({ name: "Fake Snippet" }),
+    {
+        content: "Check that the snippet is not in the page",
+        trigger: "iframe body",
+        run: ({ tip_widget }) => {
+            if (tip_widget.$anchor[0].querySelector("[data-name='Fake Snippet']")) {
+                throw new Error("The snippet should not be in the page");
+            }
+        }
+    }
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -617,3 +617,21 @@ class TestUi(odoo.tests.HttpCase):
             self.env['website'].with_context(website_id=website.id).viewref(key).active = active
 
         self.start_tour('/', 'website_no_dirty_lazy_image', login='admin')
+
+    def test_installable_snippet_not_draggable(self):
+        # Create a fake installable snippet
+        website_snippets = self.env.ref('website.snippets')
+        self.env['ir.ui.view'].create({
+            'name': 'Fake Snippet',
+            'type': 'qweb',
+            # Use a pre-compiled line, as QWeb compilation will ignore a
+            # non existent module.
+            'arch': """
+                <xpath expr="//div[@id='snippet_effect']/div[hasclass('o_panel_body')]" position="inside">
+                    <div name="Fake Snippet" data-oe-type="snippet" data-module-id="999999" data-oe-thumbnail="/website/static/src/img/snippets_thumbs/s_donation.svg"><section/></div>
+                </xpath>
+            """,
+            'inherit_id': website_snippets.id,
+            'key': 'website.fake_external_snippet'
+        })
+        self.start_tour('/', 'installable_snippet_not_draggable', login='admin')


### PR DESCRIPTION
In [commit 1], jQueryUI was replaced by in house drag and drop and while doing so, replaced a jQuery array of snippets as the draggable elements by a selector `oe_snippet` on the `SnippetsMenu` HTML element. This lead to installable snippets being draggable even though they should not.

More so, it seems like the "cancel" option of jQueryUI was not adapted to "ignore" of the new API.

This commit fixes both and uses ignore to ignore installable snippets.

Steps to reproduce:
 - Have a DB with installable modules
 - Start a website page edition
 - Drag an installable Snippet => It should not be draggable

[commit 1]: https://github.com/odoo/odoo/commit/7594d71ca8610d5947e80f325ccb57abc23c2c76

task-3600773
