### PR TITLE
[FIX] resource: calculate duration of overlapping work intervals

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -633,13 +633,15 @@ class ResourceCalendar(models.Model):
         from_datetime, dummy = make_aware(from_datetime)
         to_datetime, dummy = make_aware(to_datetime)
 
+        day_total = self._get_resources_day_total(from_datetime, to_datetime)[False]
+
         # actual hours per day
         if compute_leaves:
             intervals = self._work_intervals_batch(from_datetime, to_datetime, domain=domain)[False]
         else:
             intervals = self._attendance_intervals_batch(from_datetime, to_datetime, domain=domain)[False]
 
-        return self._get_attendance_intervals_days_data(intervals)
+        return self._get_days_data(intervals, day_total)
 
     def plan_hours(self, hours, day_dt, compute_leaves=False, domain=None, resource=None):
         """

--- a/addons/resource/tests/__init__.py
+++ b/addons/resource/tests/__init__.py
@@ -1,4 +1,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 # -*- coding: utf-8 -*-
 
-from . import test_utils
+from . import test_resource_calendar, test_utils

--- a/addons/resource/tests/test_resource_calendar.py
+++ b/addons/resource/tests/test_resource_calendar.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import tagged, common
+from datetime import datetime, date
+
+@tagged('post_install', '-at_install')
+class TestResourceCalender(common.TransactionCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.resource_calendar = cls.env['resource.calendar'].create({
+            'name': 'resource calendar',
+            'tz': 'UTC',
+        })
+
+        monday_morning_attendance = cls.env['resource.calendar.attendance'].create({
+            'name': 'Monday Morning',
+            'dayofweek': '0',
+            'hour_from': 8.0,
+            'hour_to': 12.0,
+            'day_period': 'morning',
+            'calendar_id': cls.resource_calendar.id,
+        })
+        monday_afternoon_attendance = cls.env['resource.calendar.attendance'].create({
+            'name': 'Monday Afternoon',
+            'dayofweek': '0',
+            'hour_from': 12.0,
+            'hour_to': 16.0,
+            'day_period': 'afternoon',
+            'calendar_id': cls.resource_calendar.id,
+        })
+
+        tuesday_morning_attendance = cls.resource_calendar.env['resource.calendar.attendance'].create({
+            'name': 'Tuesday Morning',
+            'dayofweek': '1',
+            'date_from': date(2023, 1, 3),
+            'date_to': date(2023, 1, 3),
+            'hour_from': 8.0,
+            'hour_to': 16.0,
+            'day_period': 'morning',
+            'calendar_id': cls.resource_calendar.id,
+        })
+
+        cls.resource_calendar.attendance_ids = [monday_morning_attendance.id, monday_afternoon_attendance.id, tuesday_morning_attendance.id]
+
+    def test_get_work_duration_data(self):
+        # test
+        from_datetime = datetime(2023, 1, 2, 0, 0)
+        to_datetime = datetime(2023, 1, 4, 0, 0)
+        actual = self.resource_calendar.get_work_duration_data(
+            from_datetime, to_datetime, compute_leaves=True, domain=None
+        )
+
+        # assert
+        expected = {'days': 2.0, 'hours': 16.0}
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
### Steps to reproduce:
1. install **Time Off** module
2. Go to the **Employees** app
3. In the menu above, go to **Configuration > Working** Schedules
4. Click on **Standard 40 hours/week**
5. Delete **Monday Lunch** work interval
6. Change the **work from** property of the **Monday Afternoon** to **12:00** so it overlaps with the **Monday Morning** interval
7. Go to the **Time Off** app
8. An Error is raised!

### Investigation:
- When two work intervals overlap they are being merged together https://github.com/odoo/odoo/blob/1229c13c12eedc71aa49dc14fa51059de01885d0/addons/resource/models/resource_calendar.py#L358 That corrupt the metadata of the newly created interval as each one has a different name, day period and more importantly id.
- These intervals' metadata are then used to calculate the duration of each but as they are corrupted, an error arises https://github.com/odoo/odoo/blob/1229c13c12eedc71aa49dc14fa51059de01885d0/addons/resource/models/resource_calendar.py#L491

### Solution:
Following the same approach in version 16.4 by not extracting the `day_duration` from the metadata of the intervals when calculating the duration but rather interfering them.

opw-3588805
