### PR TITLE
[FIX] project : hide stage column

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -201,7 +201,7 @@
                                     <field name="portal_user_names" string="Assignees" optional="show"/>
                                     <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" decoration-danger="date_deadline &lt; current_date" optional="show"/>
                                     <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" optional="hide"/>
-                                    <field name="stage_id" optional="show"/>
+                                    <field name="stage_id" column_invisible="True"/>
                                     <button name="action_open_task" type="object" title="View Task" string="View Task" class="btn btn-link float-end"
                                             context="{'form_view_ref': 'project.project_sharing_project_task_view_form', 'search_view_ref': 'project.project_sharing_project_task_view_search'}"
                                             invisible="project_id or project_id != id"/>


### PR DESCRIPTION
When creating a sub-task from a task form view, it should not be possible to choose the stage of the subtask from the parent's view as It should heritate from it.

taskid:3551354

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
