### PR TITLE
[FIX] account: fix value assignment to wrong field in payment term lines.

### DIFF
--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -296,7 +296,7 @@ class AccountPaymentTermLine(models.Model):
     def _compute_value_amount(self):
         for line in self:
             if line.value == 'fixed':
-                line.amount = 0
+                line.value_amount = 0
             else:
                 amount = 0
                 for i in line.payment_id.line_ids.filtered(lambda r: r.value == 'percent'):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Fix the wrong field assignment in the function of field "Due" from the payment term lines.

**Impacted versions**
* 17.0

Desired behaviour after PR is merged:
After this PR merge, System will assign value to the right field.

Fixed Issue [#141837](https://github.com/odoo/odoo/issues/141837)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
