### PR TITLE
[FIX] web_editor: prevent dirty if no historyStep

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -411,6 +411,9 @@ export class HtmlField extends Component {
         this.Wysiwyg = wysiwygModule.Wysiwyg;
     }
     _isDirty() {
+        if (!this._getCodeViewEl() && !this.wysiwyg?.didUserMakeChanges) {
+            return false;
+        }
         const strippedPropValue = stripHistoryIds(String(this.props.record.data[this.props.name]));
         const strippedEditingValue = stripHistoryIds(this.getEditingValue());
         const domParser = new DOMParser();

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -474,6 +474,10 @@ export class Wysiwyg extends Component {
         this.odooEditor.addEventListener('contentChanged', function () {
             self.$editable.trigger('content_changed');
         });
+        this.odooEditor.addEventListener('historyStep', () => {
+            // Flag to know if the user has made at least one change.
+            this.didUserMakeChanges = true;
+        });
         document.addEventListener("mousemove", this._signalOnline, true);
         document.addEventListener("keydown", this._signalOnline, true);
         document.addEventListener("keyup", this._signalOnline, true);
@@ -3281,11 +3285,13 @@ export class Wysiwyg extends Component {
         if (!this._isCollaborationEnabled(this.options)) {
             this._currentClientId = undefined;
             this.resetValue(value);
+            this.didUserMakeChanges = false;
             return;
         }
         this._currentClientId = this._generateClientId();
         this.odooEditor.collaborationSetClientId(this._currentClientId);
         this.resetValue(value);
+        this.didUserMakeChanges = false;
         this.setupCollaboration(collaborationChannel);
         if (this.options.collaborativeTrigger === 'start') {
             this._joinPeerToPeer();


### PR DESCRIPTION
In some circumstances, the call to HtmlField._isDirty returns true because that method compares the original value with the value of the wysiwyg that could have changed for multiple technical reasons even though the user did not make any change.

To be sure the user has made a change, this commit checks that at least one historyStep was made.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
