### PR TITLE
[FIX] l10n_ch: QR Code title on invoice overlap

### DIFF
--- a/addons/l10n_ch/static/src/scss/report_swissqr.scss
+++ b/addons/l10n_ch/static/src/scss/report_swissqr.scss
@@ -29,7 +29,7 @@ body.l10n_ch_qr{
     font-weight: bold;
     height: 7mm * $l10n-ch-qr-ratio;
     padding: 15px;
-    padding-top: 150px;
+    padding-top: 220px;
     h1{
         padding-left:20mm;
         white-space:nowrap;


### PR DESCRIPTION
Before: Invoice with QR code, the second page has the title "QR Bill for invoice ..." that overlap the company information header

Step to reproduce:
- Make sure to have l10n_ch (Switzerland) installed
- Have QR Codes activated in Settings
- Create an Invoice for customer
- Customer has to be located in Switzerland. On the Customer form, in the Accounting tab, make sure Electronic Invoicing format is set
 to Peppol BIS Billing 3.0 and Peppol-e address to Switzerland
 VAT number
- Make sure all banks are set as well
- For Configure Document Layout: Make sure layout is set to DIN5008 and paper format is  European A4 for DIN5008 Type A
- Print Invoice. On the QR Code page, the header and the title will be overlapping

Now: "QR Bill for invoice ..." no more overlapping with header

opw-3590095

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
