### PR TITLE
[FIX] stock_account: accurate distribution of added value in revaluation

### DIFF
--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation.py
@@ -92,14 +92,16 @@ class StockValuationLayerRevaluation(models.TransientModel):
             'quantity': 0,
         }
 
-        remaining_qty = sum(remaining_svls.mapped('remaining_qty'))
+        total_remaining_qty = sum(remaining_svls.mapped('remaining_qty'))
+        total_remaining_unit_cost = sum(svl.remaining_value / svl.remaining_qty for svl in remaining_svls)
+        remaining_qty = total_remaining_qty
         remaining_value = self.added_value
-        remaining_value_unit_cost = self.currency_id.round(remaining_value / remaining_qty)
         for svl in remaining_svls:
             if float_is_zero(svl.remaining_qty - remaining_qty, precision_rounding=self.product_id.uom_id.rounding):
                 taken_remaining_value = remaining_value
             else:
-                taken_remaining_value = remaining_value_unit_cost * svl.remaining_qty
+                new_unit_cost = (svl.remaining_value / svl.remaining_qty) / total_remaining_unit_cost
+                taken_remaining_value = self.currency_id.round(new_unit_cost * self.added_value)
             if float_compare(svl.remaining_value + taken_remaining_value, 0, precision_rounding=self.product_id.uom_id.rounding) < 0:
                 raise UserError(_('The value of a stock valuation layer cannot be negative. Landed cost could be use to correct a specific transfer.'))
 
@@ -109,9 +111,14 @@ class StockValuationLayerRevaluation(models.TransientModel):
 
         revaluation_svl = self.env['stock.valuation.layer'].create(revaluation_svl_vals)
 
-        # Update the stardard price in case of AVCO
-        if product_id.categ_id.property_cost_method in ('average', 'fifo'):
+        # Update the standard price
+        cost_method = product_id.categ_id.property_cost_method
+        if cost_method == 'average':
             product_id.with_context(disable_auto_svl=True).standard_price += self.added_value / self.current_quantity_svl
+        elif cost_method == 'fifo' and len(remaining_svls) > 0:
+            # In FIFO, the standard_price is taken from the oldest svl with remaining quantity
+            unit_cost = self.currency_id.round(remaining_svls[0].remaining_value / remaining_svls[0].remaining_qty)
+            product_id.with_context(disable_auto_svl=True).standard_price = unit_cost
 
         # If the Inventory Valuation of the product category is automated, create related account move.
         if self.property_valuation != 'real_time':


### PR DESCRIPTION
It's not always possible to revalue a FIFO product to 0.

## Steps to reproduce:
1. Create a FIFO automated product
2. Purchase 5 units @ 5€
3. Purchase 5 units @ 10€
4. Create a revaluation layer of -75€
5. “The value of a stock valuation layer cannot be negative.”

## Before this commit:
When creating a revaluation layer for a product, the added value is distributed evenly among the layers, based on their remaining quantity. With this implementation, it's not possible to revalue a FIFO product with varying unit costs on multiple layers.

## After this commit:
The added value is distributed evenly among the layers based on their unit cost, rather than their remaining quantity. This prevents the taken value from exceeding the remaining value.

Additionally, the standard_price in FIFO is computed from the oldest layer with remaining quantity.

opw-3535616
