### PR TITLE
[FIX] survey: enable submit when empty required depending questions are not triggered

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -221,11 +221,10 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
                             if (!treatedQuestionIds.includes(questionId)) {
                                 var dependingQuestion = $('.js_question-wrapper#' + questionId);
                                 dependingQuestion.removeClass('d-none');
-
-                                // Add answer to selected answer
-                                self.selectedAnswers.push(parseInt($target.val()));
                             }
                         });
+                        // Add answer to selected answer
+                        self.selectedAnswers.push(parseInt($target.val()));
                     }
                 }
             }


### PR DESCRIPTION
### Steps
- Create a survey with all questions on the same page.
- The 1st question must be multiple choice(only one answer)(eg. yes or no) and mandatory.
- The 2nd a one line text mandatory with conditional display on question 1, yes answer.
- The 3rd same as the 2nd.
- Start the survey test, click on 'yes' so the next questions are displayed.
- Without submitting click on 'no'.
- Try to submit the form.

### Issue
Nothing happens.

### Reason
When an answer that triggers other questions is choose it's added to ``self.selectedAnswers`` <number_of_questions_triggered> times but must be added just once.


opw-3574744