### PR TITLE
[FIX] web_editor: add and update link test cases

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -6,9 +6,7 @@ import {
     childNodeIndex,
     closestBlock,
     closestElement,
-    closestPath,
     DIRECTIONS,
-    findNode,
     getCursors,
     getDeepRange,
     getInSelection,
@@ -16,7 +14,6 @@ import {
     getSelectedNodes,
     getTraversedNodes,
     insertAndSelectZws,
-    insertText,
     isBlock,
     isColorGradient,
     isSelectionFormat,
@@ -439,27 +436,6 @@ export const editorCommands = {
     justifyFull: editor => align(editor, 'justify'),
 
     // Link
-    createLink: (editor, link, content) => {
-        const sel = editor.document.getSelection();
-        if (content && !sel.isCollapsed) {
-            editor.deleteRange(sel);
-        }
-        if (sel.isCollapsed) {
-            insertText(sel, content || 'link');
-        }
-        const currentLink = closestElement(sel.focusNode, 'a');
-        link = link || prompt('URL or Email', (currentLink && currentLink.href) || 'http://');
-        const res = editor.document.execCommand('createLink', false, link);
-        if (res) {
-            setSelection(sel.anchorNode, sel.anchorOffset, sel.focusNode, sel.focusOffset);
-            const node = findNode(closestPath(sel.focusNode), node => node.tagName === 'A');
-            for (const [param, value] of Object.entries(editor.options.defaultLinkAttributes)) {
-                node.setAttribute(param, `${value}`);
-            }
-            const pos = [node.parentElement, childNodeIndex(node) + 1];
-            setSelection(...pos, ...pos, false);
-        }
-    },
     unlink: editor => {
         const sel = editor.document.getSelection();
         const isCollapsed = sel.isCollapsed;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/link.test.js
@@ -6,14 +6,11 @@ import {
     click,
     deleteBackward,
     insertText,
-    insertParagraphBreak,
     insertLineBreak,
     testEditor,
-    createLink,
     undo
 } from '../utils.js';
 
-const convertToLink = createLink;
 const unlink = async function (editor) {
     editor.execCommand('unlink');
 };
@@ -146,131 +143,6 @@ describe('Link', () => {
         testUrlRegex(`www.google.com/a!b/c?d,e,f#g!i`, { expectedUrl: 'www.google.com/a!b/c?d,e,f#g!i' });
         testUrlRegex(`www.google.com/a%b%c`, { expectedUrl: 'www.google.com/a%b%c' });
         testUrlRegex(`http://google.com?a.b.c&d!e#e'f`, { expectedUrl: "http://google.com?a.b.c&d!e#e'f" });
-    });
-    describe('insert Link', () => {
-        describe('range collapsed', () => {
-            it('should insert a link and preserve spacing', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a [] c</p>',
-                    stepFunction: createLink,
-                    // Two consecutive spaces like one so `a [] c` is
-                    // effectively the same as `a []c`.
-                    contentAfter: '<p>a <a href="#">link</a>[]c</p>',
-                });
-            });
-            it('should insert a link and write a character after the link', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[]c</p>',
-                    stepFunction: async editor => {
-                        await createLink(editor);
-                        await insertText(editor, 'b');
-                    },
-                    contentAfter: '<p>a<a href="#">link</a>b[]c</p>',
-                });
-            });
-            it('should write two characters after the link', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[]d</p>',
-                    stepFunction: async editor => {
-                        await createLink(editor);
-                        await insertText(editor, 'b');
-                        await insertText(editor, 'c');
-                    },
-                    contentAfter: '<p>a<a href="#">link</a>bc[]d</p>',
-                });
-            });
-            it('should insert a link and write a character after the link then create a new <p>', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[]c</p>',
-                    stepFunction: async editor => {
-                        await createLink(editor);
-                        await insertText(editor, 'b');
-                        await insertParagraphBreak(editor);
-                    },
-                    contentAfter: '<p>a<a href="#">link</a>b</p><p>[]c</p>',
-                });
-            });
-            it('should insert a link and write a character, a new <p> and another character', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[]d</p>',
-                    stepFunction: async editor => {
-                        await createLink(editor);
-                        await insertText(editor, 'b');
-                        await insertParagraphBreak(editor);
-                        await insertText(editor, 'c');
-                    },
-                    contentAfter: '<p>a<a href="#">link</a>b</p><p>c[]d</p>',
-                });
-            });
-            it('should insert a link and write a character at the end of the link then insert a <br>', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[]c</p>',
-                    stepFunction: async editor => {
-                        await createLink(editor);
-                        await insertText(editor, 'b');
-                        await insertLineBreak(editor);
-                    },
-                    // Writing at the end of a link writes outside the link.
-                    contentAfter: '<p>a<a href="#">link</a>b<br>[]c</p>',
-                });
-            });
-            it('should insert a link and write a character insert a <br> and another character', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[]d</p>',
-                    stepFunction: async editor => {
-                        await createLink(editor);
-                        await insertText(editor, 'b');
-                        await insertLineBreak(editor);
-                        await insertText(editor, 'c');
-                    },
-                    // Writing at the end of a link writes outside the link.
-                    contentAfter: '<p>a<a href="#">link</a>b<br>c[]d</p>',
-                });
-            });
-            it('should insert a <br> inside a link', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p><a href="#">a[]b</a></p>',
-                    stepFunction: async editor => {
-                        await insertLineBreak(editor);
-                    },
-                    contentAfter: '<p><a href="#">a<br>[]b</a></p>',
-                });
-            });
-        });
-        describe('range not collapsed', () => {
-            // This succeeds, but why would the cursor stay inside the link
-            // if the next text insert should be outside of the link (see next test)
-            it('should set the link on two existing characters and loose range', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[bc]d</p>',
-                    stepFunction: async editor => {
-                        await convertToLink(editor);
-                    },
-                    contentAfter: '<p>a<a href="#">bc</a>[]d</p>',
-                });
-            });
-            it('should set the link on two existing characters, lose range and add a character', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[bc]e</p>',
-                    stepFunction: async editor => {
-                        await convertToLink(editor);
-                        await insertText(editor, 'd');
-                    },
-                    contentAfter: '<p>a<a href="#">bc</a>d[]e</p>',
-                });
-            });
-            // This fails, but why would the cursor stay inside the link
-            // if the next text insert should be outside of the link (see previous test)
-            it('should replace selection by a link', async () => {
-                await testEditor(BasicEditor, {
-                    contentBefore: '<p>a[bc]d</p>',
-                    stepFunction: async editor => {
-                        await createLink(editor, '#');
-                    },
-                    contentAfter: '<p>a<a href="#">#</a>[]d</p>',
-                });
-            });
-        });
     });
     describe('edit link label', () => {
         describe('range collapsed', () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/utils.js
@@ -551,10 +551,6 @@ export async function toggleBold() {
     return new Promise(resolve => setTimeout(() => resolve(), 200));
 }
 
-export async function createLink(editor, content) {
-    editor.execCommand('createLink', '#', content);
-}
-
 export async function insertText(editor, text) {
     // Create and dispatch events to mock text insertion. Unfortunatly, the
     // events will be flagged `isTrusted: false` by the browser, requiring

--- a/addons/web_editor/static/tests/link_tests.js
+++ b/addons/web_editor/static/tests/link_tests.js
@@ -1,0 +1,446 @@
+/** @odoo-module **/
+import { setSelection } from "@web_editor/js/editor/odoo-editor/src/utils/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+import { patchWithCleanup, nextTick, triggerHotkey } from "@web/../tests/helpers/utils";
+import { Wysiwyg } from "@web_editor/js/wysiwyg/wysiwyg";
+import {
+    triggerEvent,
+    insertText,
+    insertParagraphBreak,
+} from "@web_editor/js/editor/odoo-editor/test/utils";
+
+function onMount() {
+    const editor = wysiwyg.odooEditor;
+    const editable = editor.editable;
+    editor.testMode = true;
+    return { editor, editable };
+}
+
+function inputText(selector, content) {
+    const selectorElement = document.querySelector(selector);
+    selectorElement.focus();
+    for (const char of content) {
+        selectorElement.dispatchEvent(new window.KeyboardEvent("keydown", { key: char }));
+        document.execCommand("insertText", false, char);
+        selectorElement.dispatchEvent(new window.KeyboardEvent("keyup", { key: char }));
+    }
+}
+
+let serverData;
+let wysiwyg;
+
+QUnit.module(
+    "Link Creation",
+    {
+        before: function () {
+            serverData = {
+                models: {
+                    note: {
+                        fields: {
+                            body: {
+                                string: "Editor",
+                                type: "html",
+                            },
+                        },
+                        records: [
+                            {
+                                id: 1,
+                                display_name: "first record",
+                                body: "<p><br></p>",
+                            },
+                        ],
+                    },
+                },
+            };
+        },
+        beforeEach: async function () {
+            setupViewRegistries();
+            patchWithCleanup(Wysiwyg.prototype, {
+                init() {
+                    super.init(...arguments);
+                    wysiwyg = this;
+                },
+            });
+            await makeView({
+                type: "form",
+                serverData,
+                resModel: "note",
+                arch:
+                    "<form>" +
+                    '<field name="body" widget="html" style="height: 100px"/>' +
+                    "</form>",
+                resId: 1,
+            });
+        },
+    },
+    function () {
+        QUnit.module("HotKeys");
+
+        QUnit.test("should be able to create link with ctrl+k and typing Create link in command palette search", async function (assert) {
+            const { editor, editable } = onMount();
+            const node = editable.querySelector("p");
+            setSelection(node, 0);
+            // Open command palette
+            await triggerHotkey("control+k");
+            // Search Create link from command palette
+            inputText(".o_command_palette_search input", "Create link");
+            await nextTick();
+            await triggerHotkey("Enter");
+            // Insert link url
+            inputText('input[id="o_link_dialog_url_input"]', "#");
+            // Click on Insert button
+            editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                `<p><a href="#" target="_blank">#</a><br></p>`
+            );
+        });
+
+        QUnit.test("should be able to create link with ctrl+k and ctrl+k", async function (assert) {
+            const { editor, editable } = onMount();
+            const node = editable.querySelector("p");
+            setSelection(node, 0);
+            // Open command palette
+            await triggerHotkey("control+k");
+            // Hot key for Create link
+            await triggerHotkey("control+k")
+            // Insert link url
+            inputText('input[id="o_link_dialog_url_input"]', "#");
+            // Click on Insert button
+            editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                `<p><a href="#" target="_blank">#</a><br></p>`
+            );
+        });
+
+        QUnit.test(
+            "should be able to create link with ctrl+k , and should make link on two existing characters",
+            async function (assert) {
+                const { editor, editable } = onMount();
+                const node = editable.querySelector("p");
+                setSelection(node, 0);
+                insertText(editor, "Hello");
+                setSelection(node, 1, node, 3);
+                // Open command palette
+                await triggerHotkey("control+k");
+                // Hot key for Create link
+                await triggerHotkey("control+k")
+                // Insert link url
+                inputText('input[id="o_link_dialog_url_input"]', "#");
+                // Click on Insert button
+                editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+                await nextTick();
+                assert.strictEqual(
+                    editable.innerHTML,
+                    `<p>H<a href="#" target="_blank">el</a>lo</p>`
+                );
+            }
+        );
+
+
+        QUnit.module("Typing based");
+
+        QUnit.test("typing valid URL + space should convert to link", async function (assert) {
+                const { editor, editable } = onMount();
+                const node = editable.querySelector("p");
+                setSelection(node, 0);
+                inputText(".odoo-editor-editable p", "http://google.co.in");
+                insertText(editor, " ");
+                editor.clean();
+                assert.strictEqual(
+                    editable.innerHTML,
+                    `<p><a href="http://google.co.in">http://google.co.in</a> </p>`
+                );
+            }
+        );
+
+        QUnit.test("typing invalid URL + space should not convert to link", async function (assert) {
+            const { editor, editable } = onMount();
+            const node = editable.querySelector("p");
+            setSelection(node, 0);
+            inputText(".odoo-editor-editable p", "www.odoo");
+            insertText(editor, " ");
+            editor.clean();
+            assert.strictEqual(editable.innerHTML, "<p>www.odoo </p>");
+        });
+
+
+        QUnit.module("Toolbar based");
+
+        QUnit.test("should convert all selected text to link", async function (assert) {
+            const { editor, editable } = onMount();
+            const node = editable.querySelector("p");
+            setSelection(node, 0);
+            insertText(editor, "Hello");
+            setSelection(node, 0, node, 5);
+            await nextTick();
+            // Click on link button from floating toolbar
+            editor.document.querySelector("#toolbar .fa-link").click();
+            await nextTick();
+            // Insert link url
+            inputText('input[id="o_link_dialog_url_input"]', "#");
+            // Click on Insert button
+            editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                `<p><a href="#" target="_blank">Hello</a></p>`
+            );
+        });
+
+        QUnit.test("should set the link on two existing characters", async function (assert) {
+            const { editor, editable } = onMount();
+            const node = editable.querySelector("p");
+            setSelection(node, 0);
+            insertText(editor, "Hello");
+            setSelection(node, 1, node, 3);
+            // Click on link button from floating toolbar
+            editor.document.querySelector("#toolbar .fa-link").click();
+            await nextTick();
+            // Insert link url
+            inputText('input[id="o_link_dialog_url_input"]', "#");
+            // Click on Insert button
+            editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                `<p>H<a href="#" target="_blank">el</a>lo</p>`
+            );
+        });
+
+
+        QUnit.module("PowerBox related");
+
+        QUnit.test("Should be able to insert link on empty p", async function (assert) {
+            const { editor, editable } = onMount();
+            const node = editable.querySelector("p");
+            setSelection(node, 0);
+            triggerEvent(node, "input", { data: "/" });
+            // Click on link button from powerbox
+            editor.document.querySelector(".oe-powerbox-commandWrapper .fa-link").click();
+            await nextTick();
+            // Insert link url
+            inputText('input[id="o_link_dialog_url_input"]', "#");
+            // Click on Insert button
+            editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                `<p><a href="#" target="_blank">#</a><br></p>`
+            );
+        });
+
+        QUnit.test("should insert a link and preserve spacing", async function (assert) {
+            const { editor, editable } = onMount();
+            const node = editable.querySelector("p");
+            setSelection(node, 0);
+            insertText(editor, "ab");
+            setSelection(node.firstChild, 1, node.firstChild, 1);
+            insertText(editor, " ");
+            setSelection(node.firstChild, 2, node.firstChild, 2);
+            insertText(editor, " ");
+            setSelection(node.firstChild, 3, node.firstChild, 3);
+            insertText(editor, " ");
+            setSelection(node.firstChild, 2, node.firstChild, 2);
+            triggerEvent(node, "input", { data: "/" });
+            // Click on link button from powerbox
+            editor.document.querySelector(".oe-powerbox-commandWrapper .fa-link").click();
+            await nextTick();
+            // Insert link label
+            inputText('input[id="o_link_dialog_label_input"]', "link");
+            // Insert link url
+            inputText('input[id="o_link_dialog_url_input"]', "#");
+            // Click on Insert button
+            editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                `<p>a <a href="#" target="_blank">link</a>&nbsp;&nbsp;b</p>`
+            );
+        });
+
+        QUnit.test(
+            "should insert a link and write a character after the link is created",
+            async function (assert) {
+                const { editor, editable } = onMount();
+                const node = editable.querySelector("p");
+                setSelection(node, 0);
+                insertText(editor, "ab");
+                setSelection(node.firstChild, 1);
+                triggerEvent(node, "input", { data: "/" });
+                // Click on link button from powerbox
+                editor.document.querySelector(".oe-powerbox-commandWrapper .fa-link").click();
+                await nextTick();
+                // Insert link url
+                inputText('input[id="o_link_dialog_url_input"]', "#");
+                // Click on Insert button
+                editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+                await nextTick();
+                editor.document.getSelection().collapseToEnd();
+                insertText(editor, "D");
+                editor.clean();
+                assert.strictEqual(
+                    editable.innerHTML,
+                    `<p>a<a href="#" target="_blank">#D</a>b</p>`
+                );
+            }
+        );
+
+        QUnit.test(
+            "should insert a link and write 2 character after the link is created",
+            async function (assert) {
+                const { editor, editable } = onMount();
+                const node = editable.querySelector("p");
+                setSelection(node, 0);
+                insertText(editor, "ab");
+                setSelection(node.firstChild, 1);
+                triggerEvent(node, "input", { data: "/" });
+                // Click on link button from powerbox
+                editor.document.querySelector(".oe-powerbox-commandWrapper .fa-link").click();
+                await nextTick();
+                await triggerHotkey("Enter");
+                // Insert link url
+                inputText('input[id="o_link_dialog_url_input"]', "#");
+                // Click on Insert button
+                editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+                await nextTick();
+                editor.document.getSelection().collapseToEnd();
+                insertText(editor, "E");
+                insertText(editor, "D");
+                editor.clean();
+                assert.strictEqual(
+                    editable.innerHTML,
+                    `<p>a<a href="#" target="_blank">#ED</a>b</p>`
+                );
+            }
+        );
+
+        QUnit.test(
+            "should insert a link and write a character after the link then create a new <p>",
+            async function (assert) {
+                const { editor, editable } = onMount();
+                const node = editable.querySelector("p");
+                setSelection(node, 0);
+                insertText(editor, "ab");
+                triggerEvent(node, "input", { data: "/" });
+                // Click on link button from powerbox
+                editor.document.querySelector(".oe-powerbox-commandWrapper .fa-link").click();
+                await nextTick();
+                await triggerHotkey("Enter");
+                // Insert link label
+                inputText('input[id="o_link_dialog_label_input"]', "link");
+                // Insert link url
+                inputText('input[id="o_link_dialog_url_input"]', "#");
+                // Click on Insert button
+                editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+                await nextTick();
+                editor.document.getSelection().collapseToEnd();
+                insertText(editor, "E");
+                await insertParagraphBreak(editor);
+                editor.clean();
+                assert.strictEqual(
+                    editable.innerHTML,
+                    `<p>ab<a href="#" target="_blank">linkE</a></p><p><br></p>`
+                );
+            }
+        );
+
+        QUnit.test(
+            "should insert a link, write a character, a new <p>, and another character",
+            async function (assert) {
+                const { editor, editable } = onMount();
+                const node = editable.querySelector("p");
+                setSelection(node, 0);
+                insertText(editor, "ab");
+                setSelection(node.firstChild, 1);
+                triggerEvent(node, "input", { data: "/" });
+                // Click on link button from powerbox
+                editor.document.querySelector(".oe-powerbox-commandWrapper .fa-link").click();
+                await nextTick();
+                await triggerHotkey("Enter");
+                // Insert link label
+                inputText('input[id="o_link_dialog_label_input"]', "link");
+                // Insert link url
+                inputText('input[id="o_link_dialog_url_input"]', "#");
+                // Click on Insert button
+                editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+                await nextTick();
+                editor.document.getSelection().collapseToEnd();
+                insertText(editor, "E");
+                await insertParagraphBreak(editor);
+                insertText(editor, "D");
+                editor.clean();
+                assert.strictEqual(
+                    editable.innerHTML,
+                    `<p>a<a href="#" target="_blank">linkE</a></p><p>Db</p>`
+                );
+            }
+        );
+
+        QUnit.test(
+            "should insert a link and write a character at the end of the link then insert a <br>",
+            async function (assert) {
+                const { editor, editable } = onMount();
+                const node = editable.querySelector("p");
+                setSelection(node, 0);
+                insertText(editor, "ab");
+                setSelection(node.firstChild, 1);
+                triggerEvent(node, "input", { data: "/" });
+                // Click on link button from powerbox
+                editor.document.querySelector(".oe-powerbox-commandWrapper .fa-link").click();
+                await nextTick();
+                await triggerHotkey("Enter");
+                // Insert link label
+                inputText('input[id="o_link_dialog_label_input"]', "link");
+                // Insert link url
+                inputText('input[id="o_link_dialog_url_input"]', "#");
+                // Click on Insert button
+                editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+                await nextTick();
+                editor.document.getSelection().collapseToEnd();
+                insertText(editor, "E");
+                triggerEvent(node, "keydown", { key: "Enter", shiftKey: true });
+                editor.clean();
+                assert.strictEqual(
+                    editable.innerHTML,
+                    `<p>a<a href="#" target="_blank">linkE<br></a>b</p>`
+                );
+            }
+        );
+
+        QUnit.test(
+            "should insert a link and write a character insert a <br> and another character",
+            async function (assert) {
+                const { editor, editable } = onMount();
+                const node = editable.querySelector("p");
+                setSelection(node, 0);
+                insertText(editor, "ab");
+                setSelection(node.firstChild, 1);
+                triggerEvent(node, "input", { data: "/" });
+                // Click on link button from powerbox
+                editor.document.querySelector(".oe-powerbox-commandWrapper .fa-link").click();
+                await nextTick();
+                await triggerHotkey("Enter");
+                // Insert link label
+                inputText('input[id="o_link_dialog_label_input"]', "link");
+                // Insert link url
+                inputText('input[id="o_link_dialog_url_input"]', "#");
+                // Click on Insert button
+                editor.document.querySelector(".o_dialog footer button.btn-primary").click();
+                await nextTick();
+                editor.document.getSelection().collapseToEnd();
+                insertText(editor, "E");
+                triggerEvent(node, "keydown", { key: "Enter", shiftKey: true });
+                insertText(editor, "D");
+                editor.clean();
+                assert.strictEqual(
+                    editable.innerHTML,
+                    `<p>a<a href="#" target="_blank">linkE<br>D</a>b</p>`
+                );
+            }
+        );
+    }
+);


### PR DESCRIPTION
Specification:

-The tests are not testing the actual OdooEditor behavior, but the `editorCommands.createLink()` function (which is not used anywhere). -CreateLink method was a dead code.
-No test cases were there for dialog box based link creation.

Cases Covered:

-typing url + space
-powerbox
-selecting text and link button on the toolbar

task-3087957
