### PR TITLE
[FIX] sale_loyalty: restrict ewallet

### DIFF
--- a/addons/sale_loyalty/i18n/sale_loyalty.pot
+++ b/addons/sale_loyalty/i18n/sale_loyalty.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 16.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-02-02 10:34+0000\n"
-"PO-Revision-Date: 2023-02-02 10:34+0000\n"
+"POT-Creation-Date: 2023-11-28 14:03+0000\n"
+"PO-Revision-Date: 2023-11-28 14:03+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -457,6 +457,13 @@ msgstr ""
 #: code:addons/sale_loyalty/models/sale_order.py:0
 #, python-format
 msgid "This coupon is expired."
+msgstr ""
+
+#. module: sale_loyalty
+#. odoo-python
+#: code:addons/sale_loyalty/models/sale_order.py:0
+#, python-format
+msgid "This program cannot be applied with code."
 msgstr ""
 
 #. module: sale_loyalty

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -633,7 +633,7 @@ class SaleOrder(models.Model):
         if self._allow_nominative_programs():
             ewallet_coupons = self.env['loyalty.card'].search(
                 [('id', 'not in', self.applied_coupon_ids.ids), ('partner_id', '=', self.partner_id.id),
-                ('points', '>', 0), ('program_id.program_type', '=', 'ewallet')])
+                 ('points', '>', 0), ('program_id.program_type', '=', 'ewallet')])
             if ewallet_coupons:
                 self.applied_coupon_ids += ewallet_coupons
         # Programs that are applied to the order and count points
@@ -996,6 +996,8 @@ class SaleOrder(models.Model):
         elif (program.limit_usage and program.total_order_count >= program.max_usage) or\
             (program.date_to and program.date_to < fields.Date.context_today(self)):
             return {'error': _('This code is expired (%s).', code)}
+        elif program.program_type in ('loyalty', 'ewallet'):
+            return {'error': _("This program cannot be applied with code.")}
 
         # Rule will count the next time the points are updated
         if rule:

--- a/addons/sale_loyalty_delivery/tests/test_free_shipping_reward.py
+++ b/addons/sale_loyalty_delivery/tests/test_free_shipping_reward.py
@@ -315,9 +315,9 @@ class TestSaleCouponProgramRules(TestSaleCouponCommon):
         claimable_rewards = order._get_claimable_rewards()
         self.assertEqual(len(claimable_rewards), 1)
         # Try to apply the loyalty card to the sale order
-        self._apply_promo_code(order, loyalty_card.code)
+        self.assertTrue(self._claim_reward(order, loyalty_program))
         # Check if there is an error in the sequence
-        # via `_apply_program_reward` in `apply_promo_code` method
+        # via `_apply_program_reward` in `_claim_reward` method
 
     def test_nothing_delivered_nothing_to_invoice(self):
         program = self.env['loyalty.program'].create({


### PR DESCRIPTION
Users could use all ewallets as long as they had codes. Ewallet usage got restricted to people in the same company.

task-3540370

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
