### PR TITLE
[FIX] web: popover clickAway don't preventDefault by default

### DIFF
--- a/addons/web/static/src/core/popover/popover_controller.js
+++ b/addons/web/static/src/core/popover/popover_controller.js
@@ -20,6 +20,7 @@ export class PopoverController extends Component {
         "closeOnClickAway",
         "component",
         "componentProps",
+        "onClickAway?",
         "popoverProps",
         "subPopovers?",
     ];
@@ -55,8 +56,8 @@ export class PopoverController extends Component {
     onClickAway(ev) {
         const target = ev.composedPath()[0];
         if (this.props.closeOnClickAway(target) && !this.isInside(target)) {
+            this.props.onClickAway?.(ev);
             this.props.close();
-            ev.preventDefault();
         }
     }
 

--- a/addons/web/static/src/core/popover/popover_service.js
+++ b/addons/web/static/src/core/popover/popover_service.js
@@ -7,6 +7,7 @@ import { POPOVER_SYMBOL, PopoverController } from "./popover_controller";
 /**
  * @typedef {{
  *   closeOnClickAway?: boolean | (target: HTMLElement) => boolean;
+ *   onClickAway?: (event: Event) => void;
  *   onClose?: () => void;
  *   popoverClass?: string;
  *   animation?: Boolean;
@@ -40,6 +41,7 @@ export const popoverService = {
                     target,
                     close: () => remove(),
                     closeOnClickAway,
+                    onClickAway: options.onClickAway,
                     subPopovers: options[POPOVER_SYMBOL],
                     component,
                     componentProps: markRaw(props),

--- a/addons/web/static/src/views/calendar/hooks.js
+++ b/addons/web/static/src/views/calendar/hooks.js
@@ -16,10 +16,14 @@ import {
     useRef,
 } from "@odoo/owl";
 
-export function useCalendarPopover(component) {
+export function useCalendarPopover(component, options = {}) {
     const owner = useComponent();
     let popoverClass = "";
-    const popoverOptions = { position: "right", onClose: cleanup };
+    const popoverOptions = {
+        position: "right",
+        onClose: cleanup,
+        onClickAway: (ev) => ev.preventDefault(),
+    };
     Object.defineProperty(popoverOptions, "popoverClass", { get: () => popoverClass });
     const popover = usePopover(component, popoverOptions);
     const dialog = useService("dialog");

--- a/addons/web/static/tests/core/popover/popover_service_tests.js
+++ b/addons/web/static/tests/core/popover/popover_service_tests.js
@@ -85,28 +85,22 @@ QUnit.test("close on click away", async (assert) => {
     assert.containsNone(fixture, ".o_popover #comp");
 });
 
-QUnit.test("close on click away should be default prevented", async (assert) => {
+QUnit.test("close on click away should exec onClickAway option", async (assert) => {
     assert.expect(6);
     class Comp extends Component {}
     Comp.template = xml`<div id="comp">in popover</div>`;
 
-    popovers.add(popoverTarget, Comp, {});
+    popovers.add(popoverTarget, Comp, {}, { onClickAway: () => assert.step("onClickAway") });
     await nextTick();
 
     assert.containsOnce(fixture, ".o_popover");
     assert.containsOnce(fixture, ".o_popover #comp");
-    const closeButton = fixture.querySelector("#close");
-    function clickListener(ev) {
-        assert.step(`click-event-${ev.defaultPrevented ? "default-prevented" : ""}`);
-    }
-    closeButton.addEventListener("pointerdown", clickListener);
 
     await click(fixture, "#close");
 
     assert.containsNone(fixture, ".o_popover");
     assert.containsNone(fixture, ".o_popover #comp");
-    assert.verifySteps(["click-event-default-prevented"]);
-    closeButton.removeEventListener("pointerdown", clickListener);
+    assert.verifySteps(["onClickAway"]);
 });
 
 QUnit.test("close on 'Escape' keydown", async (assert) => {


### PR DESCRIPTION
Since commit 3d218e10f8911f14e87981a91f0345ca630e29d5, clicking outside a popover closes the popover and performs a preventDefault on the event. As a consequence, changes made in the property definition popover are no longer applied when the popover is closed by clicking outside.

Problem:
The preventDefault has the consequence of cancelling the input change event allowing the change to be applied to the property definition when the popover is closed.

Solution:
Remove the preventDefault by default and only use it in the case of the calendar view, which is the only use case that wants to prevent the click event so as not to open a record creation dialog (see commit 3d218e10f8911f14e87981a91f0345ca630e29d5).

How to reproduce the PropertyField bug:
- Go to a form view with a properties field
- Click on the edit property button
- A popover opens so that you can edit the field definition
- Type a few characters in the label input
- Click outside the popover

Before this commit:
    The value inserted in the popover is ignored

After this commit:
    The value inserted in the popover is applied to the property.

It is not possible to write a test reproducing this native browser behaviour.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
