### PR TITLE
[FIX] stock_account: _run_fifo_vacuum rounding

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -433,7 +433,7 @@ class ProductProduct(models.Model):
                     break
 
             # Get the estimated value we will correct.
-            remaining_value_before_vacuum = svl_to_vacuum.unit_cost * qty_taken_on_candidates
+            remaining_value_before_vacuum = svl_to_vacuum.value * qty_taken_on_candidates / svl_to_vacuum.quantity
             new_remaining_qty = svl_to_vacuum.remaining_qty + qty_taken_on_candidates
             corrected_value = remaining_value_before_vacuum - tmp_value
             svl_to_vacuum.write({

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -798,6 +798,23 @@ class TestStockValuationFIFO(TestStockValuationCommon):
         finally:
             self.env.user.company_id = old_company
 
+    def test_update_available_quantity_vacuum(self):
+        """ edit product price precision and update on hand quantity
+        """
+        self.env['decimal.precision'].search([('name', '=', 'Product Price')]).digits = 6
+        self.product1.write({"standard_price": 0.0123})
+        self.env['stock.quant'].create({
+            'product_id': self.product1.id,
+            'inventory_quantity': -2000,
+            'location_id': self.stock_location.id
+        }).action_apply_inventory()
+        self.env['stock.quant'].create({
+            'product_id': self.product1.id,
+            'inventory_quantity': 2000,
+            'location_id': self.stock_location.id
+        }).action_apply_inventory()
+        self.assertEqual(self.product1.value_svl, 0.0)
+
 class TestStockValuationChangeCostMethod(TestStockValuationCommon):
     def test_standard_to_fifo_1(self):
         """ The accounting impact of this cost method change is neutral.


### PR DESCRIPTION
Steps to reproduce:
- Increase product price precision to 6 in Decimal accuracy
- Create a stored product with FIFO valuation and cost=0.0123$
- Update on hand quantity to -2000 than back to 0

Bug:
an extra valuation layer is created by _run_fifo_vacuum since it is using the original SVL unit cost which was rounded to the currency precision

Fix:
use Value/quantity instead of unit cost to avoid the rounding issue

opw-3493669

