### PR TITLE
[FIX] mass_mailing: Enable users to unsubscribe properly

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -12,7 +12,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 class MassMailController(http.Controller):
 
     def _valid_unsubscribe_token(self, mailing_id, res_id, email, token):
-        if not (mailing_id and res_id and email and token):
+        if not (mailing_id and res_id is not None and email and token):
             return False
         mailing = request.env['mailing.mailing'].sudo().browse(mailing_id)
         return consteq(mailing._unsubscribe_token(res_id, email), token)


### PR DESCRIPTION
### Steps
- Create a new Marketing Campaign.
- Add a new mailing list with one user.
- Select the template where there an unsubscribe button to be sent.
- Test the campaign with the user's email in the created mailing list.
- On the received mail, click on 'unsubscribe'.

### Issue
A traceback of denied access.

### Reason
In ``_valid_unsubscribe_token()``, ``res_id`` can be ``0`` so the condition ``not (mailing_id and res_id is not None and email and token):`` will most be true and raise the Error.

opw-3568781