### PR TITLE
[IMP] l10n_in: add signature in invoices

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -255,7 +255,7 @@
                                         </div>
                                     </t>
                                 </div>
-                                <div class="mb-3" t-if="o.move_type in ('out_invoice', 'in_refund') and o.payment_reference">
+                                <div class="mb-3" t-if="o.move_type in ('out_invoice', 'in_refund') and o.payment_reference" id="payment_communication">
                                     <p name="payment_communication">
                                         Payment Communication: <span class="fw-bold" t-field="o.payment_reference">INV/2023/00001</span>
                                     </p>

--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -33,6 +33,8 @@ class AccountMove(models.Model):
     l10n_in_reseller_partner_id = fields.Many2one('res.partner', 'Reseller', domain=[('vat', '!=', False)], help="Only Registered Reseller")
     l10n_in_journal_type = fields.Selection(string="Journal Type", related='journal_id.type')
 
+    l10n_in_user_posting_move = fields.Many2one("res.users", "User who confirmed the invoice")
+
     @api.depends('partner_id')
     def _compute_l10n_in_gst_treatment(self):
         indian_invoice = self.filtered(lambda m: m.country_code == 'IN')
@@ -81,6 +83,8 @@ class AccountMove(models.Model):
         gst_treatment_name_mapping = {k: v for k, v in
                              self._fields['l10n_in_gst_treatment']._description_selection(self.env)}
         for move in posted.filtered(lambda m: m.country_code == 'IN'):
+            # Keep track of the person confirming the invoice in order to add their signature
+            move.l10n_in_user_posting_move = move.write_uid
             if not move.company_id.state_id:
                 msg = _("Your company %s needs to have a correct address in order to validate this invoice.\n"
                 "Set the address of your company (Don't forget the State field)", move.company_id.name)

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -6,6 +6,7 @@ class ResCompany(models.Model):
 
     l10n_in_upi_id = fields.Char(string="UPI Id")
     l10n_in_active_audit_trail = fields.Boolean(string="Audit Trail", default=False, help="Once you activate audit trail it can't be deactivated.")
+    l10n_in_display_sign_on_invoice = fields.Boolean(string="Authorised Signature on Invoice")
 
     def write(self, vals):
         if 'l10n_in_active_audit_trail' in vals:

--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -10,3 +10,4 @@ class ResConfigSettings(models.TransientModel):
     group_l10n_in_reseller = fields.Boolean(implied_group='l10n_in.group_l10n_in_reseller', string="Manage Reseller(E-Commerce)")
     module_l10n_in_edi = fields.Boolean('Indian Electronic Invoicing')
     module_l10n_in_edi_ewaybill = fields.Boolean('Indian Electronic Waybill')
+    l10n_in_display_sign_on_invoice = fields.Boolean(string="Authorised Signature on Invoice", related="company_id.l10n_in_display_sign_on_invoice", readonly=False)

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -58,6 +58,18 @@
             </h2>
         </xpath>
 
-    </template>
+        <xpath expr="//div[@id='right-elements']" position="inside">
+            <div class="row">
+                <div class="col-6">
+                    <div t-if="o.move_type == 'out_invoice' and o.state != 'draft' and o.company_id.l10n_in_display_sign_on_invoice and not is_html_empty(o.invoice_user_id.signature)" t-out="o.l10n_in_user_posting_move.signature"/>
+                </div>
+            </div>
+        </xpath>
 
+        <xpath expr="//div[hasclass('clearfix')]" position="after">
+            <xpath expr="//div[@name='comment']" position="move"/>
+            <xpath expr="//div[@id='payment_communication']" position="move"/>
+        </xpath>
+
+    </template>
 </odoo>

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -15,6 +15,9 @@
                 <setting help="Connect to NIC (National Informatics Center) to submit e-waybill on posting." name="electronic_waybill_in" invisible="country_code != 'IN'" documentation="/applications/finance/accounting/fiscal_localizations/localizations/india.html#indian-e-waybill">
                     <field name="module_l10n_in_edi_ewaybill" class="oe_inline" widget="upgrade_boolean"/>
                 </setting>
+                <setting help="To enhance authenticity, add the signature of the individual who posted the invoice." name="l10n_in_display_sign_on_invoice_boolean" invisible="country_code != 'IN'">
+                    <field name="l10n_in_display_sign_on_invoice" class="oe_inline"/>
+                </setting>
             </block>
             <xpath expr="//app[@name='account']" position="inside">
                 <div id="india_integration_section" invisible="1">


### PR DESCRIPTION
[IMP] l10n_in: add signature in invoices
In India, most of the invoices have a sign field added to them.

-  Added a field in res_config to (de)activate the usage of a signature on invoices
-  Added this field to invoices by using the user's signature.
-  Moved payment communication and terms and condition below said signature to align with the common usage.

task-3552682