### PR TITLE
[IMP] *_payment_*,website_*: move transaction state messages to payment method

### DIFF
--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -119,8 +119,8 @@
         <xpath expr="//a[hasclass('close')]" position="after">
             <t t-if="success == 'pay_invoice'">
                 <t t-set="tx_sudo" t-value="invoice.get_portal_last_transaction()"/>
-                <span t-if="tx_sudo.provider_id.sudo().done_msg" t-out="tx_sudo.provider_id.sudo().done_msg"/>
-                <div t-if="tx_sudo.provider_id.sudo().pending_msg and tx_sudo.provider_code == 'custom' and invoice.ref">
+                <span t-if="tx_sudo.payment_method_id.sudo().done_msg" t-out="tx_sudo.payment_method_id.sudo().done_msg"/>
+                <div t-if="tx_sudo.payment_method_id.sudo().pending_msg and tx_sudo.provider_code == 'custom' and invoice.ref">
                     <b>Communication: </b><span t-out='invoice.ref'/>
                 </div>
             </t>

--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -2759,6 +2759,9 @@
                          ref('base.EUR'),
                      ])]"
         />
+        <field name="pending_msg" type="html">
+            <p>Please make a unique payment transfer to confirm the SEPA mandate.</p>
+        </field>
     </record>
 
     <record id="payment_method_shopback" model="payment.method">

--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -84,6 +84,29 @@ class PaymentMethod(models.Model):
              "to customers.",
     )
 
+    # Message fields
+    pre_msg = fields.Html(
+        string="Help Message", help="The message displayed to explain and help the payment process",
+        translate=True)
+    pending_msg = fields.Html(
+        string="Pending Message",
+        help="The message displayed if the order pending after the payment process",
+        default=lambda self: _(
+            "Your payment has been successfully processed but is waiting for approval."
+        ), translate=True)
+    auth_msg = fields.Html(
+        string="Authorize Message", help="The message displayed if payment is authorized",
+        default=lambda self: _("Your payment has been authorized."), translate=True)
+    done_msg = fields.Html(
+        string="Done Message",
+        help="The message displayed if the order is successfully done after the payment process",
+        default=lambda self: _("Your payment has been successfully processed."),
+        translate=True)
+    cancel_msg = fields.Html(
+        string="Cancelled Message",
+        help="The message displayed if the order is cancelled during the payment process",
+        default=lambda self: _("Your payment has been cancelled."), translate=True)
+
     #=== COMPUTE METHODS ===#
 
     def _compute_is_primary(self):

--- a/addons/payment/models/payment_provider.py
+++ b/addons/payment/models/payment_provider.py
@@ -124,29 +124,6 @@ class PaymentProvider(models.Model):
         currency_field='main_currency_id',
     )
 
-    # Message fields
-    pre_msg = fields.Html(
-        string="Help Message", help="The message displayed to explain and help the payment process",
-        translate=True)
-    pending_msg = fields.Html(
-        string="Pending Message",
-        help="The message displayed if the order pending after the payment process",
-        default=lambda self: _(
-            "Your payment has been successfully processed but is waiting for approval."
-        ), translate=True)
-    auth_msg = fields.Html(
-        string="Authorize Message", help="The message displayed if payment is authorized",
-        default=lambda self: _("Your payment has been authorized."), translate=True)
-    done_msg = fields.Html(
-        string="Done Message",
-        help="The message displayed if the order is successfully done after the payment process",
-        default=lambda self: _("Your payment has been successfully processed."),
-        translate=True)
-    cancel_msg = fields.Html(
-        string="Cancelled Message",
-        help="The message displayed if the order is cancelled during the payment process",
-        default=lambda self: _("Your payment has been cancelled."), translate=True)
-
     # Feature support fields
     support_tokenization = fields.Boolean(
         string="Tokenization Supported", compute='_compute_feature_support_fields'
@@ -181,11 +158,6 @@ class PaymentProvider(models.Model):
     show_credentials_page = fields.Boolean(compute='_compute_view_configuration_fields')
     show_allow_tokenization = fields.Boolean(compute='_compute_view_configuration_fields')
     show_allow_express_checkout = fields.Boolean(compute='_compute_view_configuration_fields')
-    show_pre_msg = fields.Boolean(compute='_compute_view_configuration_fields')
-    show_pending_msg = fields.Boolean(compute='_compute_view_configuration_fields')
-    show_auth_msg = fields.Boolean(compute='_compute_view_configuration_fields')
-    show_done_msg = fields.Boolean(compute='_compute_view_configuration_fields')
-    show_cancel_msg = fields.Boolean(compute='_compute_view_configuration_fields')
     require_currency = fields.Boolean(compute='_compute_view_configuration_fields')
 
     #=== COMPUTE METHODS ===#
@@ -233,11 +205,6 @@ class PaymentProvider(models.Model):
         - `show_credentials_page`: Whether the "Credentials" notebook page should be shown.
         - `show_allow_tokenization`: Whether the `allow_tokenization` field should be shown.
         - `show_allow_express_checkout`: Whether the `allow_express_checkout` field should be shown.
-        - `show_pre_msg`: Whether the `pre_msg` field should be shown.
-        - `show_pending_msg`: Whether the `pending_msg` field should be shown.
-        - `show_auth_msg`: Whether the `auth_msg` field should be shown.
-        - `show_done_msg`: Whether the `done_msg` field should be shown.
-        - `show_cancel_msg`: Whether the `cancel_msg` field should be shown.
         - `require_currency`: Whether the `available_currency_ids` field shoud be required.
 
         For a provider to hide specific elements of the form view, it must override this method and
@@ -250,11 +217,6 @@ class PaymentProvider(models.Model):
             'show_credentials_page': True,
             'show_allow_tokenization': True,
             'show_allow_express_checkout': True,
-            'show_pre_msg': True,
-            'show_pending_msg': True,
-            'show_auth_msg': True,
-            'show_done_msg': True,
-            'show_cancel_msg': True,
             'require_currency': False,
         })
 

--- a/addons/payment/models/payment_transaction.py
+++ b/addons/payment/models/payment_transaction.py
@@ -941,11 +941,11 @@ class PaymentTransaction(models.Model):
 
         display_message = None
         if self.state == 'pending':
-            display_message = self.provider_id.pending_msg
+            display_message = self.payment_method_id.pending_msg
         elif self.state == 'done':
-            display_message = self.provider_id.done_msg
+            display_message = self.payment_method_id.done_msg
         elif self.state == 'cancel':
-            display_message = self.provider_id.cancel_msg
+            display_message = self.payment_method_id.cancel_msg
         post_processing_values = {
             'provider_code': self.provider_code,
             'provider_name': self.provider_id.name,

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -316,10 +316,10 @@
                 </div>
             </div>
             <!-- === Help message === -->
-            <div t-if="not is_html_empty(provider_sudo.pre_msg)"
+            <div t-if="not is_html_empty(pm_sudo.pre_msg)"
                  class="w-100 mb-0 ms-4 small text-600"
             >
-                <t t-out="provider_sudo.pre_msg"/>
+                <t t-out="pm_sudo.pre_msg"/>
             </div>
         </div>
         <!-- === Inline form === -->

--- a/addons/payment/views/payment_method_views.xml
+++ b/addons/payment/views/payment_method_views.xml
@@ -14,6 +14,7 @@
                     </div>
                     <group>
                         <field name="code" readonly="id" groups="base.group_no_one"/>
+                        <field name="code" invisible="True" groups="!base.group_no_one"/>
                         <field name="primary_payment_method_id" invisible="is_primary"/>
                         <field name="active" widget="boolean_toggle"/>
                         <label for="supported_country_ids"/>
@@ -77,6 +78,15 @@
                                        string="Supported by"
                                        widget="many2many_tags"
                                 />
+                            </group>
+                        </page>
+                        <page string="Messages" name="messages">
+                            <group>
+                                <field name="pre_msg"/>
+                                <field name="pending_msg"/>
+                                <field name="auth_msg"/>
+                                <field name="done_msg"/>
+                                <field name="cancel_msg"/>
                             </group>
                         </page>
                     </notebook>

--- a/addons/payment/views/payment_provider_views.xml
+++ b/addons/payment/views/payment_provider_views.xml
@@ -18,11 +18,6 @@
                 <field name="show_credentials_page" invisible="1"/>
                 <field name="show_allow_express_checkout" invisible="1"/>
                 <field name="show_allow_tokenization" invisible="1"/>
-                <field name="show_pre_msg" invisible="1"/>
-                <field name="show_pending_msg" invisible="1"/>
-                <field name="show_auth_msg" invisible="1"/>
-                <field name="show_done_msg" invisible="1"/>
-                <field name="show_cancel_msg" invisible="1"/>
                 <field name="require_currency" invisible="1"/>
                 <field name="code" invisible="1"/>
                 <sheet>
@@ -115,17 +110,6 @@
                                            options="{'no_create': True}"/>
                                 </group>
                                 <group string="Payment Followup" name="payment_followup" invisible="1"/>
-                            </group>
-                        </page>
-                        <page string="Messages"
-                            name="messages"
-                            invisible="module_id and module_state != 'installed'">
-                            <group>
-                                <field name="pre_msg" invisible="not show_pre_msg"/>
-                                <field name="pending_msg" invisible="not show_pending_msg"/>
-                                <field name="auth_msg" invisible="not support_manual_capture or not show_auth_msg"/>
-                                <field name="done_msg" invisible="not show_done_msg"/>
-                                <field name="cancel_msg" invisible="not show_cancel_msg"/>
                             </group>
                         </page>
                     </notebook>

--- a/addons/payment/views/portal_templates.xml
+++ b/addons/payment/views/portal_templates.xml
@@ -281,20 +281,20 @@
         </t>
         <t t-elif="tx.state == 'pending'">
             <t t-set="alert_style">warning</t>
-            <t t-set="status_message" t-value="tx.provider_id.sudo().pending_msg"/>
+            <t t-set="status_message" t-value="tx.payment_method_id.sudo().pending_msg"/>
         </t>
         <t t-elif="tx.state == 'authorized'">
             <t t-set="alert_style">success</t>
-            <t t-set="status_message" t-value="tx.provider_id.sudo().auth_msg"/>
+            <t t-set="status_message" t-value="tx.payment_method_id.sudo().auth_msg"/>
         </t>
         <t t-elif="tx.state == 'done'">
             <t t-set="alert_style">success</t>
             <t t-set="status_heading" t-value="'Thank you!'"/>
-            <t t-set="status_message" t-value="tx.provider_id.sudo().done_msg"/>
+            <t t-set="status_message" t-value="tx.payment_method_id.sudo().done_msg"/>
         </t>
         <t t-elif="tx.state == 'cancel'">
             <t t-set="alert_style">danger</t>
-            <t t-set="status_message" t-value="tx.provider_id.sudo().cancel_msg"/>
+            <t t-set="status_message" t-value="tx.payment_method_id.sudo().cancel_msg"/>
         </t>
         <t t-elif="tx.state == 'error'">
             <t t-set="alert_style">danger</t>

--- a/addons/payment_custom/__manifest__.py
+++ b/addons/payment_custom/__manifest__.py
@@ -10,6 +10,7 @@
     'data': [
         'views/payment_custom_templates.xml',
         'views/payment_provider_views.xml',
+        'views/payment_method_views.xml',
 
         'data/payment_method_data.xml',
         'data/payment_provider_data.xml',  # Depends on `payment_method_wire_transfer`.

--- a/addons/payment_custom/data/payment_method_data.xml
+++ b/addons/payment_custom/data/payment_method_data.xml
@@ -9,6 +9,12 @@
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
         <field name="support_refund"></field>
+        <!-- Clear the default value before recomputing the pending_msg -->
+        <field name="pending_msg" eval="False"/>
     </record>
+
+    <function model="payment.method"
+              name="_transfer_ensure_pending_msg_is_set"
+              eval="[[ref('payment_method_wire_transfer')]]"/>
 
 </odoo>

--- a/addons/payment_custom/data/payment_provider_data.xml
+++ b/addons/payment_custom/data/payment_provider_data.xml
@@ -4,8 +4,6 @@
     <record id="payment.payment_provider_transfer" model="payment.provider">
         <field name="code">custom</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
-        <!-- Clear the default value before recomputing the pending_msg -->
-        <field name="pending_msg" eval="False"/>
         <field name="custom_mode">wire_transfer</field>
         <field name="payment_method_ids"
                eval="[Command.set([
@@ -13,9 +11,5 @@
                      ])]"
         />
     </record>
-
-    <function model="payment.provider"
-              name="_transfer_ensure_pending_msg_is_set"
-              eval="[[ref('payment.payment_provider_transfer')]]"/>
 
 </odoo>

--- a/addons/payment_custom/models/__init__.py
+++ b/addons/payment_custom/models/__init__.py
@@ -1,4 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import payment_method
 from . import payment_provider
 from . import payment_transaction

--- a/addons/payment_custom/models/payment_method.py
+++ b/addons/payment_custom/models/payment_method.py
@@ -1,0 +1,39 @@
+from odoo import _, api, models
+
+
+class PaymentMethod(models.Model):
+    _inherit = 'payment.method'
+
+    @api.model_create_multi
+    def create(self, values_list):
+        methods = super().create(values_list)
+        methods.filtered(lambda m: m.code == 'wire_transfer').pending_msg = None
+        return methods
+
+    def action_recompute_pending_msg(self):
+        """ Recompute the pending message to include the existing bank accounts. """
+        account_payment_module = self.env['ir.module.module']._get('account_payment')
+        if account_payment_module.state == 'installed':
+            for method in self.filtered(lambda m: m.code == 'wire_transfer'):
+                company_ids = method.provider_ids.mapped('company_id.id')
+                accounts = self.env['account.journal']
+                if len(set(company_ids)) == 1:
+                    accounts = self.env['account.journal'].search([
+                        *self.env['account.journal']._check_company_domain(company_ids[0]),
+                        ('type', '=', 'bank'),
+                    ]).bank_account_id
+                account_names = "".join(f"<li><pre>{account.display_name}</pre></li>" for account in accounts)
+                method.pending_msg = f'<div>' \
+                                     f'<h5>{_("Please use the following transfer details")}</h5>' \
+                                     f'<p><br></p>' \
+                                     f'<h6>{_("Bank Account") if len(accounts) == 1 else _("Bank Accounts")}</h6>' \
+                                     f'<ul>{account_names}</ul>' \
+                                     f'<p><br></p>' \
+                                     f'</div>'
+
+    def _transfer_ensure_pending_msg_is_set(self):
+        transfer_methods_without_msg = self.filtered(
+            lambda m: m.code == 'wire_transfer' and not m.pending_msg
+        )
+        if transfer_methods_without_msg:
+            transfer_methods_without_msg.action_recompute_pending_msg()

--- a/addons/payment_custom/models/payment_provider.py
+++ b/addons/payment_custom/models/payment_provider.py
@@ -23,12 +23,6 @@ class PaymentProvider(models.Model):
     qr_code = fields.Boolean(
         string="Enable QR Codes", help="Enable the use of QR-codes when paying by wire transfer.")
 
-    @api.model_create_multi
-    def create(self, values_list):
-        providers = super().create(values_list)
-        providers.filtered(lambda p: p.custom_mode == 'wire_transfer').pending_msg = None
-        return providers
-
     @api.depends('code')
     def _compute_view_configuration_fields(self):
         """ Override of payment to hide the credentials page.
@@ -38,39 +32,10 @@ class PaymentProvider(models.Model):
         super()._compute_view_configuration_fields()
         self.filtered(lambda p: p.code == 'custom').update({
             'show_credentials_page': False,
-            'show_pre_msg': False,
-            'show_done_msg': False,
-            'show_cancel_msg': False,
         })
-
-    def action_recompute_pending_msg(self):
-        """ Recompute the pending message to include the existing bank accounts. """
-        account_payment_module = self.env['ir.module.module']._get('account_payment')
-        if account_payment_module.state == 'installed':
-            for provider in self.filtered(lambda p: p.custom_mode == 'wire_transfer'):
-                company_id = provider.company_id.id
-                accounts = self.env['account.journal'].search([
-                    *self.env['account.journal']._check_company_domain(company_id),
-                    ('type', '=', 'bank'),
-                ]).bank_account_id
-                account_names = "".join(f"<li><pre>{account.display_name}</pre></li>" for account in accounts)
-                provider.pending_msg = f'<div>' \
-                    f'<h5>{_("Please use the following transfer details")}</h5>' \
-                    f'<p><br></p>' \
-                    f'<h6>{_("Bank Account") if len(accounts) == 1 else _("Bank Accounts")}</h6>' \
-                    f'<ul>{account_names}</ul>'\
-                    f'<p><br></p>' \
-                    f'</div>'
 
     def _get_removal_values(self):
         """ Override of `payment` to nullify the `custom_mode` field. """
         res = super()._get_removal_values()
         res['custom_mode'] = None
         return res
-
-    def _transfer_ensure_pending_msg_is_set(self):
-        transfer_providers_without_msg = self.filtered(
-            lambda p: p.custom_mode == 'wire_transfer' and not p.pending_msg
-        )
-        if transfer_providers_without_msg:
-            transfer_providers_without_msg.action_recompute_pending_msg()

--- a/addons/payment_custom/views/payment_method_views.xml
+++ b/addons/payment_custom/views/payment_method_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="payment_method_form" model="ir.ui.view">
+        <field name="name">payment.method.form.inherit.custom</field>
+        <field name="model">payment.method</field>
+        <field name="inherit_id" ref="payment.payment_method_form"/>
+        <field name="arch" type="xml">
+            <field name="pending_msg" position="after">
+                <div class="o_row" colspan="2" invisible="code != 'wire_transfer'">
+                    <button string=" Reload Pending Message"
+                            type="object"
+                            name="action_recompute_pending_msg"
+                            class="oe_link ms-0 ps-0"
+                            icon="fa-refresh"/>
+                </div>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/addons/payment_custom/views/payment_provider_views.xml
+++ b/addons/payment_custom/views/payment_provider_views.xml
@@ -15,17 +15,6 @@
             <group name="payment_followup" position="attributes">
                 <attribute name="invisible">code == 'custom'</attribute>
             </group>
-            <field name="pending_msg" position="after">
-                <div class="o_row" colspan="2"
-                     invisible="custom_mode != 'wire_transfer'">
-                    <button string=" Reload Pending Message"
-                            type="object"
-                            name="action_recompute_pending_msg"
-                            class="oe_link ms-0 ps-0"
-                            icon="fa-refresh"
-                            />
-              </div>
-            </field>
         </field>
     </record>
 

--- a/addons/website_event_booth_exhibitor/tests/test_wevent_booth_exhibitor.py
+++ b/addons/website_event_booth_exhibitor/tests/test_wevent_booth_exhibitor.py
@@ -19,7 +19,6 @@ class TestWEventBoothExhibitorCommon(HttpCaseWithUserDemo, HttpCaseWithUserPorta
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.env.ref('base.user_admin').write({
             'name': 'Mitchell Admin',

--- a/addons/website_event_sale/tests/test_frontend_buy_tickets.py
+++ b/addons/website_event_sale/tests/test_frontend_buy_tickets.py
@@ -96,7 +96,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.start_tour("/", 'event_buy_tickets', login="admin")
 
@@ -109,7 +108,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         #  Ensure the use of USD (company currency)
         self.env['product.pricelist'].create({'name': "Public Pricelist"})
@@ -125,7 +123,6 @@ class TestUi(HttpCaseWithUserDemo, TestWebsiteEventSaleCommon):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         self.start_tour("/", 'event_buy_last_ticket')
 

--- a/addons/website_sale/tests/test_delivery_ui.py
+++ b/addons/website_sale/tests/test_delivery_ui.py
@@ -15,7 +15,6 @@ class TestUi(odoo.tests.HttpCase):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
 
         # Avoid Shipping/Billing address page
         self.env.ref('base.partner_admin').write({

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -87,7 +87,6 @@ class TestUi(HttpCaseWithUserDemo):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
         self.start_tour("/", 'shop_buy_product', login="admin")
 
     def test_03_demo_checkout(self):
@@ -99,7 +98,6 @@ class TestUi(HttpCaseWithUserDemo):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
         self.start_tour("/", 'shop_buy_product', login="demo")
 
     def test_04_admin_website_sale_tour(self):
@@ -111,7 +109,6 @@ class TestUi(HttpCaseWithUserDemo):
             'state': 'enabled',
             'is_published': True,
         })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
         self.env.company.country_id = self.env.ref('base.us')
         tax_group = self.env['account.tax.group'].create({'name': 'Tax 15%'})
         tax = self.env['account.tax'].create({

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2471,20 +2471,20 @@
                         <i class="fa fa-pencil"></i>
                     </a>
                     <t t-if="tx_sudo.state == 'pending'">
-                        <t t-out="tx_sudo.provider_id.sudo().pending_msg"/>
+                        <t t-out="tx_sudo.payment_method_id.sudo().pending_msg"/>
                     </t>
                     <t t-if="tx_sudo.state == 'done'">
-                        <span t-if='tx_sudo.provider_id.sudo().done_msg' t-out="tx_sudo.provider_id.sudo().done_msg"/>
+                        <span t-if='tx_sudo.payment_method_id.sudo().done_msg' t-out="tx_sudo.payment_method_id.sudo().done_msg"/>
                     </t>
                     <t t-if="tx_sudo.state == 'done' and order.amount_total != tx_sudo.amount">
                         <span>Unfortunately your order can not be confirmed as the amount of your payment does not match the amount of your cart.
                         Please contact the responsible of the shop for more information.</span>
                     </t>
                     <t t-if="tx_sudo.state == 'cancel'">
-                        <t t-out="tx_sudo.provider_id.sudo().cancel_msg"/>
+                        <t t-out="tx_sudo.payment_method_id.sudo().cancel_msg"/>
                     </t>
                     <t t-if="tx_sudo.state == 'authorized'">
-                        <t t-if="tx_sudo.provider_id.sudo().auth_msg" t-out="tx_sudo.provider_id.sudo().auth_msg"/>
+                        <t t-if="tx_sudo.payment_method_id.sudo().auth_msg" t-out="tx_sudo.payment_method_id.sudo().auth_msg"/>
                         <span t-else="">Your payment has been authorized.</span>
                     </t>
                     <t t-if="tx_sudo.state == 'error'">

--- a/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
+++ b/addons/website_sale_loyalty/tests/test_shop_sale_coupon.py
@@ -28,17 +28,6 @@ class WebsiteSaleLoyaltyTestUi(TestSaleProductAttributeValueCommon, HttpCase):
         cls.env.ref('website.default_website').company_id = cls.env.company
 
     def test_01_admin_shop_sale_loyalty_tour(self):
-        if self.env['ir.module.module']._get('payment_custom').state != 'installed':
-            self.skipTest("Transfer provider is not installed")
-
-        transfer_provider = self.env.ref('payment.payment_provider_transfer')
-        transfer_provider.sudo().write({
-            'state': 'enabled',
-            'is_published': True,
-            'company_id': self.env.company.id,
-        })
-        transfer_provider._transfer_ensure_pending_msg_is_set()
-
         # pre enable "Show # found" option to avoid race condition...
         public_category = self.env['product.public.category'].create({'name': 'Public Category'})
 

--- a/addons/website_sale_picking/data/payment_method_data.xml
+++ b/addons/website_sale_picking/data/payment_method_data.xml
@@ -9,6 +9,9 @@
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
         <field name="support_refund"></field>
+        <field name="pending_msg" type="html">
+            <p><i>Your order has been saved.</i> Please come to the store to pay for your products.</p>
+        </field>
     </record>
 
 </odoo>

--- a/addons/website_sale_picking/data/payment_provider_data.xml
+++ b/addons/website_sale_picking/data/payment_provider_data.xml
@@ -14,11 +14,6 @@
         />
         <field name="image_128" type="base64" file="website_sale_picking/static/description/icon.png"/>
         <field name="redirect_form_view_id" ref="payment_custom.redirect_form"/>
-        <field name="pending_msg" type="html">
-            <p>
-                <i>Your order has been saved.</i> Please come to the store to pay for your products
-            </p>
-        </field>
     </record>
 
 </odoo>

--- a/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
+++ b/addons/website_sale_picking/static/tests/tours/onsite_payment_tour.js
@@ -20,7 +20,7 @@ registry.category("web_tour.tours").add('onsite_payment_tour', {
         wTourUtils.clickOnElement('pay button', 'button[name="o_payment_submit_button"]:visible:not(:disabled)'),
         {
             content: "Check if the payment is successful",
-            trigger: 'p:contains(Your order has been saved. Please come to the store to pay for your products)',
+            trigger: 'p:contains(Your order has been saved. Please come to the store to pay for your products.)',
         },
 
         // Test multi products (Either physical or not)
@@ -37,7 +37,7 @@ registry.category("web_tour.tours").add('onsite_payment_tour', {
         wTourUtils.clickOnElement('Pay button', 'button[name="o_payment_submit_button"]:visible:not(:disabled)'),
         {
             content: "Check if the payment is successful",
-            trigger: 'p:contains(Your order has been saved. Please come to the store to pay for your products)',
+            trigger: 'p:contains(Your order has been saved. Please come to the store to pay for your products.)',
         },
 
         // Test without any physical product (option pay on site should not appear)


### PR DESCRIPTION
The job of transaction state messages is to show a message on top of paid documents on the portal. For example, if a confirmed transaction is linked to a sales order, the following message is shown at the top of the page: "Your payment has been successfully processed, thank you!".

Currently, these messages are configurable per provider, but it's unlikely that one will want Stripe to display something different than Adyen for a given transaction state. However, we definitively want to display a different message depending on the transaction's payment method. For example, wire transfer payments use the `pending_msg` field to display the payment instructions; payment methods like Karna are asynchronous by design, and we'll want to display the appropriate message regardless of the provider used to process the payment; etc. This will also allow modules like `payment_custom` to work with a single provider and multiple payment methods rather than multiple providers and one payment method each.

task-2941756