### PR TITLE
[REF] web: getEvalContext don't exist anymore

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -170,10 +170,7 @@ export class Many2OneField extends Component {
     }
     get context() {
         const { context, record } = this.props;
-        const evalContext = record.getEvalContext
-            ? record.getEvalContext(false)
-            : record.evalContext;
-        return makeContext([context], evalContext);
+        return makeContext([context], record.evalContext);
     }
     get classFromDecoration() {
         const evalContext = this.props.record.evalContextWithVirtualIds;
@@ -365,8 +362,9 @@ export const many2OneField = {
     ],
     supportedTypes: ["many2one"],
     extractProps({ attrs, context, decorations, options, string }, dynamicInfo) {
-        const canCreate =
-            options.no_create ? false : attrs.can_create && evaluateBooleanExpr(attrs.can_create);
+        const canCreate = options.no_create
+            ? false
+            : attrs.can_create && evaluateBooleanExpr(attrs.can_create);
         return {
             placeholder: attrs.placeholder,
             canOpen: !options.no_open,


### PR DESCRIPTION
Since the new RelationalModel (PR: odoo/odoo#114024), getEvalContext no longer exists. In this commit, we will therefore replace the uses of getEvalContext with evalContext.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
