### PR TITLE
[IMP] web: monetary field currency symbol position/display

### DIFF
--- a/addons/web/static/src/views/fields/monetary/monetary_field.js
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.js
@@ -8,16 +8,22 @@ import { useInputField } from "../input_field_hook";
 import { useNumpadDecimal } from "../numpad_decimal_hook";
 import { standardFieldProps } from "../standard_field_props";
 import { session } from "@web/session";
+import { nbsp } from "@web/core/utils/strings";
 
-import { Component } from "@odoo/owl";
+import { Component, onWillUpdateProps, useState } from "@odoo/owl";
 
 export class MonetaryField extends Component {
     setup() {
         useInputField({
-            getValue: () => this.formattedValue,
+            getValue: () => this.getFormattedValue(),
             refName: "numpadDecimal",
             parse: parseMonetary,
         });
+        onWillUpdateProps((nextProps) => {
+            this.state.value = this.getFormattedValue(nextProps);
+        });
+        this.state = useState({ value: this.getFormattedValue() });
+        this.nbsp = nbsp;
         useNumpadDecimal();
     }
 
@@ -50,15 +56,19 @@ export class MonetaryField extends Component {
         return session.currencies[this.currencyId].digits;
     }
 
-    get formattedValue() {
-        if (this.props.inputType === "number" && !this.props.readonly && this.props.value) {
-            return this.props.value;
+    getFormattedValue(props = this.props) {
+        if (props.inputType === "number" && !props.readonly && props.value) {
+            return props.value;
         }
-        return formatMonetary(this.props.value, {
+        return formatMonetary(props.value, {
             digits: this.currencyDigits,
             currencyId: this.currencyId,
-            noSymbol: !this.props.readonly || this.props.hideSymbol,
+            noSymbol: !props.readonly || props.hideSymbol,
         });
+    }
+
+    onInput(ev) {
+        this.state.value = ev.target.value;
     }
 }
 

--- a/addons/web/static/src/views/fields/monetary/monetary_field.xml
+++ b/addons/web/static/src/views/fields/monetary/monetary_field.xml
@@ -2,10 +2,14 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="web.MonetaryField" owl="1">
-        <span t-if="props.readonly" t-esc="formattedValue" />
-        <div class="text-nowrap d-inline-flex w-100 align-items-baseline" t-else="">
-            <span t-if="!props.hideSymbol and currency" t-out="currencySymbol" />
-            <input t-ref="numpadDecimal" t-att-id="props.id" t-att-type="props.inputType" t-att-placeholder="props.placeholder" class="o_input flex-grow-1 flex-shrink-1" autocomplete="off"/>
+        <span t-if="props.readonly" t-esc="getFormattedValue()" />
+        <div class="text-nowrap d-inline-flex w-100 align-items-baseline position-relative me-4" t-else="">
+            <span class="o_input position-absolute pe-none d-flex w-100">
+                <span class="opacity-0 mw-100" t-out="state.value"/>
+                <span t-if="!props.hideSymbol and currency and currency.position === 'after'" t-out="nbsp + currencySymbol"/>
+            </span>
+            <span t-if="!props.hideSymbol and currency and currency.position === 'before'" t-out="currencySymbol + nbsp"/>
+            <input t-ref="numpadDecimal" t-on-input="onInput" t-att-id="props.id" t-att-type="props.inputType" t-att-placeholder="props.placeholder" class="o_input flex-grow-1 flex-shrink-1" autocomplete="off"/>
         </div>
     </t>
 

--- a/addons/web/static/tests/views/fields/monetary_field_tests.js
+++ b/addons/web/static/tests/views/fields/monetary_field_tests.js
@@ -11,6 +11,7 @@ import {
     triggerEvent,
 } from "@web/../tests/helpers/utils";
 import { session } from "@web/session";
+import { nbsp } from "@web/core/utils/strings";
 
 let serverData;
 let target;
@@ -118,8 +119,8 @@ QUnit.module("Fields", (hooks) => {
             "The input should be rendered without the currency symbol."
         );
         assert.strictEqual(
-            target.querySelector(".o_field_widget input").parentNode.childNodes[0].textContent,
-            "$",
+            target.querySelector(".o_field_widget input").parentNode.childNodes[1].textContent,
+            "$" + nbsp,
             "The input should be preceded by a span containing the currency symbol."
         );
 
@@ -166,8 +167,8 @@ QUnit.module("Fields", (hooks) => {
             "The input should be rendered without the currency symbol."
         );
         assert.strictEqual(
-            target.querySelector(".o_field_widget input").parentNode.childNodes[0].textContent,
-            "$",
+            target.querySelector(".o_field_widget input").parentNode.childNodes[1].textContent,
+            "$" + nbsp,
             "The input should be preceded by a span containing the currency symbol."
         );
 
@@ -291,9 +292,10 @@ QUnit.module("Fields", (hooks) => {
             "The input should be rendered without the currency symbol."
         );
         assert.strictEqual(
-            target.querySelector(".o_field_widget input").parentNode.children[0].textContent,
-            "Bs.F",
-            "The input should be preceded by a span containing the currency symbol."
+            target.querySelector(".o_field_widget input").parentNode.childNodes[0].childNodes[1]
+                .textContent,
+            nbsp + "Bs.F",
+            "The input should be superposed with a span containing the currency symbol."
         );
 
         await editInput(target, ".o_field_widget input", "99.111111111");
@@ -352,9 +354,10 @@ QUnit.module("Fields", (hooks) => {
             "The input should be rendered without the currency symbol."
         );
         assert.strictEqual(
-            target.querySelector(".o_field_widget input").parentNode.children[0].textContent,
-            "Bs.F",
-            "The input should be preceded by a span containing the currency symbol."
+            target.querySelector(".o_field_widget input").parentNode.childNodes[0].childNodes[1]
+                .textContent,
+            nbsp + "Bs.F",
+            "The input should be superposed with a span containing the currency symbol."
         );
 
         await editInput(target, ".o_field_widget input", "99.111111111");
@@ -447,8 +450,8 @@ QUnit.module("Fields", (hooks) => {
         );
 
         assert.strictEqual(
-            target.querySelector(".o_field_widget input").parentNode.childNodes[0].textContent,
-            "$",
+            target.querySelector(".o_field_widget input").parentNode.childNodes[1].textContent,
+            "$" + nbsp,
             "The input should be preceded by a span containing the currency symbol."
         );
 
@@ -542,8 +545,8 @@ QUnit.module("Fields", (hooks) => {
         );
 
         assert.strictEqual(
-            target.querySelector(".o_field_widget input").parentNode.childNodes[0].textContent,
-            "$",
+            target.querySelector(".o_field_widget input").parentNode.childNodes[1].textContent,
+            "$" + nbsp,
             "The input should be preceded by a span containing the currency symbol."
         );
 
@@ -592,9 +595,9 @@ QUnit.module("Fields", (hooks) => {
         await click(euroM2OListItem);
 
         assert.strictEqual(
-            target.querySelector(".o_field_monetary div :first-child").textContent +
-                target.querySelector(".o_field_monetary div :last-child").value,
-            "€4.20",
+            target.querySelector(".o_field_monetary input").value +
+                target.querySelector(".o_field_monetary div > span").childNodes[1].textContent,
+            "4.20" + nbsp + "€",
             "The value should be formatted with new currency on blur."
         );
 
@@ -636,9 +639,9 @@ QUnit.module("Fields", (hooks) => {
         await click(euroM2OListItem);
 
         assert.strictEqual(
-            target.querySelector(".o_field_monetary div :first-child").textContent +
-                target.querySelector(".o_field_monetary div :last-child").value,
-            "€4.20",
+            target.querySelector(".o_field_monetary input").value +
+                target.querySelector(".o_field_monetary div > span").childNodes[1].textContent,
+            "4.20" + nbsp + "€",
             "The value should be formatted with new currency on blur."
         );
 
@@ -783,9 +786,10 @@ QUnit.module("Fields", (hooks) => {
             ".o_selected_row .o_field_widget[name=float_field] input",
             "monetary field should have been rendered correctly (without currency)"
         );
-        assert.containsNone(
+        assert.containsN(
             target,
             ".o_selected_row .o_field_widget[name=float_field] span",
+            2,
             "monetary field should have been rendered correctly (without currency)"
         );
 
@@ -799,7 +803,7 @@ QUnit.module("Fields", (hooks) => {
         assert.strictEqual(
             target.querySelector(".o_selected_row .o_field_widget[name=float_field] span")
                 .innerText,
-            "€",
+            nbsp + "€",
             "monetary field should have been re-rendered correctly (with currency)"
         );
         await click(target.querySelector(".o_field_widget[name=float_field] input"));
@@ -817,9 +821,10 @@ QUnit.module("Fields", (hooks) => {
             ".o_selected_row .o_field_widget[name=float_field] input",
             "monetary field should have been re-rendered correctly (without currency)"
         );
-        assert.containsNone(
+        assert.containsN(
             target,
             ".o_selected_row .o_field_widget[name=float_field] span",
+            2,
             "monetary field should have been re-rendered correctly (without currency)"
         );
         await click(target.querySelector(".o_field_widget[name=float_field] input"));
@@ -897,9 +902,9 @@ QUnit.module("Fields", (hooks) => {
             "The input should be rendered without the currency symbol."
         );
         assert.strictEqual(
-            target.querySelector(".o_field_widget[name=float_field] input").parentElement.firstChild
-                .textContent,
-            "$",
+            target.querySelector(".o_field_widget[name=float_field] input").parentElement
+                .childNodes[1].textContent,
+            "$" + nbsp,
             "The input should be preceded by a span containing the currency symbol."
         );
 
@@ -993,8 +998,8 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(target, ".o_form_editable");
         assert.strictEqual(
             target.querySelector(".o_field_widget[name=monetary_field] input").parentElement
-                .firstChild.textContent,
-            "$",
+                .childNodes[1].textContent,
+            "$" + nbsp,
             "The input should be preceded by a span containing the currency symbol."
         );
     });
@@ -1024,8 +1029,8 @@ QUnit.module("Fields", (hooks) => {
         assert.containsOnce(target, ".o_form_editable");
         assert.strictEqual(
             target.querySelector(".o_field_widget[name=monetary_field] input").parentElement
-                .firstChild.textContent,
-            "$",
+                .childNodes[1].textContent,
+            "$" + nbsp,
             "The input should be preceded by a span containing the currency symbol."
         );
     });


### PR DESCRIPTION
This commit improves how currency symbols are displayed in the monetary field by placing the symbol right next to the value inside of the input when the symbol's position is set to be after the value. It doesn't change anything for left-positioned symbols besides adding a space between the symbol and the value.

task-3602826
