### PR TITLE
[IMP] hr: allow employee public users to update profile picture

### DIFF
--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -334,3 +334,12 @@ class User(models.Model):
             'res_id': employees.id,
             'view_mode': 'form',
         }
+
+    def onchange(self, values, field_names, fields_spec):
+        # Some of the fields are only allowed for groups Employees / Officer
+        # we can avoid building the snapshots for those fields
+        fields_to_read = self._get_employee_fields_to_sync()
+        if any(field in field_names for field in fields_to_read):
+            values = {key: val for key, val in values.items() if key in fields_to_read}
+            fields_spec = {key: val for key, val in fields_spec.items() if key in fields_to_read}
+        return super().onchange(values, field_names, fields_spec)


### PR DESCRIPTION
Current restrictions prevent public users from updating their profile pictures. The issue stems from the onchange method fetching fields that the user group lacks access to. By overriding the onchange method we filter out inaccessible fields before calling the super method. This ensures that public users can update their profile pictures without encountering access errors.

Task-3582195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
