### PR TITLE
[MOV] l10n_account_edi_ubl_cii_tests: test_ubl_cii

### DIFF
--- a/addons/account_edi_ubl_cii/tests/__init__.py
+++ b/addons/account_edi_ubl_cii/tests/__init__.py
@@ -1,4 +1,3 @@
 # -*- coding: utf-8 -*-
 
 from . import test_partner_peppol_fields
-from . import test_ubl_cii

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/__init__.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/__init__.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 
+from . import test_ubl_cii
 from . import test_xml_ubl_be
 from . import test_xml_ubl_de
 from . import test_xml_cii_fr

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_ubl_cii.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_ubl_cii.py
@@ -7,8 +7,8 @@ from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
 
 
-@tagged('post_install', '-at_install')
-class TestAccountEdiUblCii(AccountTestInvoicingCommon):
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestEdiUBLCII(AccountTestInvoicingCommon):
 
     @classmethod
     def setUpClass(cls, chart_template_ref=None):


### PR DESCRIPTION
Correction of the forward PR:
https://github.com/odoo/odoo/pull/142508

All tests concerning the UBL/CII EDIs (e.g. `test_ubl_cii.py`)
should be in the `l10n_account_edi_ubl_cii_tests` module.