### PR TITLE
[FIX] mail: improve user mention highlight visibility

### DIFF
--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,5 +1,0 @@
-.o-mail-Message-body {
-    a.o_mail_redirect {
-        --MailRedirect-background: #{$o-component-active-bg};
-    }
-}

--- a/addons/mail/static/src/core/common/message.dark.scss
+++ b/addons/mail/static/src/core/common/message.dark.scss
@@ -1,0 +1,5 @@
+.o-mail-Message-body {
+    a.o_mail_redirect {
+        --MailRedirect-background: #{$o-component-active-bg};
+    }
+}

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -28,14 +28,6 @@
     }
 }
 
-.o-mail-Message-body {
-    a.o_mail_redirect {
-        padding: map-get($spacers, 1);
-        border-radius: $border-radius;
-        background: var(--MailRedirect-background, rgba($o-brand-primary, .2));
-    }
-}
-
 .o-mail-ChatWindow .o-mail-Message:not(.o-cancelSelfAuthored).o-selfAuthored {
     flex-direction: row-reverse;
 

--- a/addons/mail/static/src/core/common/message.scss
+++ b/addons/mail/static/src/core/common/message.scss
@@ -32,7 +32,7 @@
     a.o_mail_redirect {
         padding: map-get($spacers, 1);
         border-radius: $border-radius;
-        background: rgba($primary, .2);
+        background: var(--MailRedirect-background, rgba($o-brand-primary, .2));
     }
 }
 

--- a/addons/mail/static/src/utils/common/format.js
+++ b/addons/mail/static/src/utils/common/format.js
@@ -171,7 +171,7 @@ function generateMentionsLinks(body, { partners = [], threads = [] }) {
         const placeholder = `@-mention-partner-${partner.id}`;
         const text = `@${escape(partner.name)}`;
         mentions.push({
-            class: "o_mail_redirect",
+            class: "o_mail_redirect fw-bolder",
             id: partner.id,
             model: "res.partner",
             placeholder,


### PR DESCRIPTION
This PR fixes an issue about the highlight behind a mentioned
username within the chatter not being that visible.

This issue is especially noticeable in dark mode or when you send
a direct message, since the background is darker.

To fix this issue, we use the `$o-component-active-bg` variable
in addition to the default text color of the link.

task-3582263

## saas-16.4
| | Lightmode | Darkmode |
| ------------- | ------------- | ------------- |
| saas-16.4 - community | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/fff3a733-3215-440b-8530-589fe6218149"> |  |
| saas-16.4 - community (log a note) | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/4b3db1cd-025e-430c-ae62-6d1f33318a80"> |  |
| saas-16.4 - enterprise | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/f3c96230-1ca9-452b-ae36-b874f625de2b"> | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/f4351d0b-b93d-4bda-813d-9395eee94cf7"> |
| saas-16.4 - enterprise (log a note) | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/4a8a0cbf-b906-4bdf-853b-a68c18796a19"> | <img alt="image" src="https://github.com/odoo/odoo/assets/128030743/1e25f87c-20da-4a3c-94bf-52a1e0e626f6"> |

## saas-16.4-fix-mail-redirect-darkmode-color-chgo
| | Lightmode | Darkmode |
| ------------- | ------------- | ------------- |
| saas-16.4-fix-mail-redirect-darkmode-color-chgo - community | ![image](https://github.com/odoo/odoo/assets/128030743/16ada498-1abd-4e14-8de7-ae0eb94a4d1c) |  |
| saas-16.4-fix-mail-redirect-darkmode-color-chgo - community (log a note) | ![image](https://github.com/odoo/odoo/assets/128030743/9bb9b30f-3ede-40ed-a4ec-69e6158da027) |  |
| saas-16.4-fix-mail-redirect-darkmode-color-chgo - enterprise | ![image](https://github.com/odoo/odoo/assets/128030743/a05f25e3-565b-4637-bcea-97bbc9cc6df9) |![image](https://github.com/odoo/odoo/assets/128030743/e3969c96-83e9-4365-b9b3-d3b936ababda) |
| saas-16.4-fix-mail-redirect-darkmode-color-chgo - enterprise (log a note) | ![image](https://github.com/odoo/odoo/assets/128030743/0b994e3c-a286-4ce6-8dbe-6bd890603103) | ![image](https://github.com/odoo/odoo/assets/128030743/4f14527a-ea88-4cab-aa1d-151a9e900e3e) |