### PR TITLE
[FIX] project: the calculation of the 'remaining hours' measure correct

### DIFF
--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -17,7 +17,7 @@ class ReportProjectTaskUser(models.Model):
         select_to_append = """,
                 (t.effective_hours * 100) / NULLIF(t.planned_hours, 0) as progress,
                 t.effective_hours as hours_effective,
-                t.planned_hours - t.effective_hours - t.subtask_effective_hours as remaining_hours,
+                NULLIF(t.remaining_hours, 0) as remaining_hours,
                 NULLIF(t.planned_hours, 0) as hours_planned,
                 t.overtime as overtime
         """

--- a/addons/project/report/project_report.py
+++ b/addons/project/report/project_report.py
@@ -141,6 +141,7 @@ class ReportProjectTaskUser(models.Model):
     def _where(self):
         return """
                 t.project_id IS NOT NULL
+                AND t.parent_id IS NULL
         """
 
     def init(self):


### PR DESCRIPTION
Steps to reproduce:
- Navigate to the 'project' module.
- Go to the 'reporting' section and access 'tasks analysis'.

Issue:
- The calculation of the 'remaining hours' measure within the tasks analysis appears to be inaccurate.

Solution:
- Rectify the calculation method for the 'remaining hours' measure in the tasks analysis of project reporting to ensure accurate and reliable results.

task-3576701

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
