### PR TITLE
[IMP] mass_mailing: improve opt-out reporting menu

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -46,8 +46,8 @@
         'views/mailing_contact_views.xml',
         'views/mailing_list_views.xml',
         'views/mailing_mailing_views.xml',
-        'views/mailing_subscription_views.xml',
         'views/mailing_subscription_optout_views.xml',
+        'views/mailing_subscription_views.xml',
         'views/res_config_settings_views.xml',
         'views/utm_campaign_views.xml',
         'views/mailing_menus.xml',
@@ -132,6 +132,9 @@
             'mass_mailing/static/src/xml/mass_mailing.xml',
             'mass_mailing/static/src/xml/mass_mailing_mobile_preview.xml',
             'mass_mailing/static/src/js/tours/**/*',
+        ],
+        'web.assets_backend_lazy': [
+            'mass_mailing/static/src/views/mass_mailing_subscription_graph_renderer.js',
         ],
         'mass_mailing.assets_mail_themes': [
             'mass_mailing/static/src/scss/themes/**/*',

--- a/addons/mass_mailing/demo/mailing_list_contact.xml
+++ b/addons/mass_mailing/demo/mailing_list_contact.xml
@@ -39,5 +39,10 @@
             <field name="email">franz.faubourg@example.com</field>
             <field name="list_ids" eval="[(5, 0, 0)]"/>
         </record>
+        <record id="mass_mail_contact_7" model="mailing.contact">
+            <field name="name">Gilbert Gilson</field>
+            <field name="email">gilbert.gilson@example.com</field>
+            <field name="list_ids" eval="[(5, 0, 0)]"/>
+        </record>
     </data>
 </odoo>

--- a/addons/mass_mailing/demo/mailing_subscription.xml
+++ b/addons/mass_mailing/demo/mailing_subscription.xml
@@ -18,6 +18,7 @@
             <field name="contact_id" ref="mass_mailing.mass_mail_contact_4"/>
             <field name="list_id" ref="mass_mailing.mailing_list_data"/>
             <field name="opt_out">True</field>
+            <field name="opt_out_reason_id" ref="mass_mailing.mailing_subscription_optout_data_1"/>
         </record>
         <record id="mailing_list_data_sub_contact_5" model="mailing.subscription">
             <field name="contact_id" ref="mass_mailing.mass_mail_contact_5"/>
@@ -27,6 +28,13 @@
             <field name="contact_id" ref="mass_mailing.mass_mail_contact_6"/>
             <field name="list_id" ref="mass_mailing.mailing_list_data"/>
             <field name="opt_out">True</field>
+            <field name="opt_out_reason_id" ref="mass_mailing.mailing_subscription_optout_data_3"/>
+        </record>
+        <record id="mailing_list_data_sub_contact_7" model="mailing.subscription">
+            <field name="contact_id" ref="mass_mailing.mass_mail_contact_7"/>
+            <field name="list_id" ref="mass_mailing.mailing_list_data"/>
+            <field name="opt_out">True</field>
+            <field name="opt_out_reason_id" ref="mass_mailing.mailing_subscription_optout_data_3"/>
         </record>
         <!-- Subscription to 'mailing_list_1' -->
         <record id="mailing_list_1_sub_contact_3" model="mailing.subscription">

--- a/addons/mass_mailing/models/mailing_subscription.py
+++ b/addons/mass_mailing/models/mailing_subscription.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 
 
 class MailingSubscription(models.Model):
@@ -51,3 +51,19 @@ class MailingSubscription(models.Model):
         if vals.get('opt_out_datetime') or vals.get('opt_out_reason_id'):
             vals['opt_out'] = True
         return super().write(vals)
+
+    def open_mailing_contact(self):
+        action = {
+            'name': _('Mailing Contacts'),
+            'type': 'ir.actions.act_window',
+            'view_mode': 'tree,form',
+            'domain': [('id', 'in', self.contact_id.ids)],
+            'res_model': 'mailing.contact',
+        }
+        if len(self) == 1:
+            action.update({
+                'name': _('Mailing Contact'),
+                'view_mode': 'form',
+                'res_id': self.contact_id.id,
+            })
+        return action

--- a/addons/mass_mailing/static/src/views/mass_mailing_subscription_graph_renderer.js
+++ b/addons/mass_mailing/static/src/views/mass_mailing_subscription_graph_renderer.js
@@ -1,0 +1,36 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { GraphRenderer } from "@web/views/graph/graph_renderer";
+import { graphView } from "@web/views/graph/graph_view";
+
+
+export class SubscriptionGraphRenderer extends GraphRenderer {
+    /**
+     * Open the pivot view instead of the list view on graph click.
+     * @override
+     */
+    openView(domain, views, context) {
+        this.actionService.doAction(
+            {
+                context,
+                domain,
+                name: this.model.metaData.title,
+                res_model: this.model.metaData.resModel,
+                target: "current",
+                type: "ir.actions.act_window",
+                views: [[false, "pivot"], [false, "form"]],
+            },
+            {
+                viewType: "pivot",
+            }
+        );
+    }
+}
+
+export const subscriptionGraphView = {
+    ...graphView,
+    Renderer: SubscriptionGraphRenderer,
+};
+
+registry.category("views").add("subscription_graph", subscriptionGraphView);

--- a/addons/mass_mailing/views/mailing_menus.xml
+++ b/addons/mass_mailing/views/mailing_menus.xml
@@ -48,7 +48,7 @@
               sequence="1"
               parent="menu_mass_mailing_report"
               action="mailing_trace_report_action_mail"/>
-    <menuitem name="Optout"
+    <menuitem name="Opt-Out Report"
               id="mailing_menu_report_subscribe_reason"
               sequence="2"
               parent="menu_mass_mailing_report"

--- a/addons/mass_mailing/views/mailing_subscription_optout_views.xml
+++ b/addons/mass_mailing/views/mailing_subscription_optout_views.xml
@@ -20,9 +20,10 @@
         <field name="name">mailing.subscription.optout.view.tree</field>
         <field name="model">mailing.subscription.optout</field>
         <field name="arch" type="xml">
-            <tree>
+            <tree editable="bottom">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
+                <field name="is_feedback" string="Allow Feedback" widget="boolean_toggle"/>
             </tree>
         </field>
     </record>

--- a/addons/mass_mailing/views/mailing_subscription_views.xml
+++ b/addons/mass_mailing/views/mailing_subscription_views.xml
@@ -27,19 +27,41 @@
         </field>
     </record>
 
+    <record id="mailing_subscription_view_graph" model="ir.ui.view">
+        <field name="name">mailing.subscription.view.graph</field>
+        <field name="model">mailing.subscription</field>
+        <field name="arch" type="xml">
+            <graph js_class="subscription_graph" string="Mailing List Subscriptions" type="pie" sample="1">
+                <field name="opt_out_datetime" interval="week"/>
+                <!-- Hide the bounce measure from the measures dropdown -->
+                <field name="message_bounce" type="measure" invisible="1"/>
+            </graph>
+        </field>
+    </record>
+
+    <record id="mailing_subscription_view_pivot" model="ir.ui.view">
+        <field name="name">mailing.subscription.view.pivot</field>
+        <field name="model">mailing.subscription</field>
+        <field name="arch" type="xml">
+            <pivot string="Mailing List Subscriptions" sample="1">
+                <field name="opt_out_datetime" interval="week" type="row"/>
+                <field name="list_id" type="row"/>
+            </pivot>
+        </field>
+    </record>
+
     <record id="mailing_subscription_view_tree" model="ir.ui.view">
         <field name="name">mailing.subscription.view.tree</field>
         <field name="model">mailing.subscription</field>
         <field name="arch" type="xml">
-            <tree string="Mailing List Subscriptions">
-                <field name="contact_id"/>
+            <tree string="Mailing List Subscriptions" create="0" type="object" action="open_mailing_contact">
                 <field name="create_date" string="Subscription Date"/>
-                <field name="list_id"/>
-                <field name="opt_out"/>
-                <field name="opt_out_reason_id"/>
-                <field name="opt_out_datetime" readonly="1"/>
-                <field name="message_bounce" optional="hide"/>
+                <field name="contact_id" string="Mailing Contact"/>
                 <field name="is_blacklisted" optional="hide"/>
+                <field name="list_id"/>
+                <field name="opt_out_datetime" readonly="1"/>
+                <field name="opt_out_reason_id"/>
+                <field name="message_bounce" optional="hide" sum="Total"/>
             </tree>
         </field>
     </record>
@@ -49,32 +71,38 @@
         <field name="model">mailing.subscription</field>
         <field name="arch" type="xml">
            <search string="Mailing List Subscriptions">
-                <field name="contact_id"/>
                 <field name="list_id"/>
-                <field name="opt_out"/>
                 <field name="opt_out_reason_id"/>
+                <field name="contact_id"/>
                 <field name="opt_out_datetime"/>
-                <filter string="Optout" name="filter_optout" domain="[('opt_out', '=', True)]"/>
+                <filter string="Subscription Date" name="filter_create_date" date="create_date" default_period="month"/>
+                <separator/>
+                <filter string="Unsubscription Date" name="filter_opt_out_datetime" date="opt_out_datetime" default_period="month"/>
                 <group expand="0" string="Group By">
+                    <filter string="Unsubscription Date" name="group_by_opt_out_datetime" context="{'group_by': 'opt_out_datetime:week'}"/>
                     <filter string="Mailing List" name="group_by_list_id" context="{'group_by': 'list_id'}"/>
-                    <filter string="Optout Reason" name="group_by_opt_out_reason_id" context="{'group_by': 'opt_out_reason_id'}"/>
+                    <filter string="Reason" name="group_by_opt_out_reason_id" context="{'group_by': 'opt_out_reason_id'}"/>
                 </group>
             </search>
         </field>
     </record>
 
     <record id="mailing_subscription_action_report_optout" model="ir.actions.act_window">
-        <field name="name">Subscriptions</field>
+        <field name="name">Opt-Out Report</field>
         <field name="res_model">mailing.subscription</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">graph,pivot,tree,form</field>
         <field name="context">{
             'search_default_group_by_opt_out_reason_id': 1,
-            'search_default_filter_optout': 1,
         }</field>
-        <field name="domain">[]</field>
+        <field name="domain">[('opt_out', '=', True)]</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No data yet.
+            </p><p>
+                Come back later to discover why contacts unsubscribe.<br/>
+                <a name="%(mass_mailing.mailing_subscription_optout_action)d" type="action" class="text-primary">
+                    <i class="oi oi-arrow-right"/> Configure Opt-out Reasons
+                </a>
             </p>
         </field>
     </record>


### PR DESCRIPTION
Purpose
=======
Provide an overview on unsubscriptions.

Specifications
==============
Improve the opt-out reporting menu:
- Add a graph and pivot view.
- Improve the list view and open mailing contact form on record click.
- Improve the quick search, filters and group bys.
- Set a default group by on Opt-out Reasons.
- Set Reason list view to editable bottom and adding the is_feedback field.
- Set a domain to only show the subscriptions that are opt-out.
- Open pivot view instead of list view on graph click.
- Remove the bounce measure from the graph view measures.
- Update demo date to have some opt-outs with specific reasons.

Technical:
The mailing_subscription_optout_views file needs to be loaded
before the mailing_subscription_views one for the
mailing_subscription_optout_action action to be found.

Task-3604866

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
