### PR TITLE
[FIX] stock: schedule and deadline date lead time issue

### DIFF
--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -249,10 +249,11 @@ class PurchaseOrderLine(models.Model):
            :return: desired Schedule Date for the PO line
         """
         date_order = po.date_order if po else self.order_id.date_order
+        delay = (seller.delay or 0) + (self.order_id.company_id.po_lead or 0)
         if date_order:
-            return date_order + relativedelta(days=seller.delay if seller else 0)
+            return date_order + relativedelta(days=delay)
         else:
-            return datetime.today() + relativedelta(days=seller.delay if seller else 0)
+            return datetime.today() + relativedelta(days=delay)
 
     @api.depends('product_id', 'order_id.partner_id')
     def _compute_analytic_distribution(self):

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -273,6 +273,7 @@ class StockRule(models.Model):
         params origins: procuremets origins to write on the PO
         """
         purchase_date = min([value.get('date_order') or fields.Datetime.from_string(value['date_planned']) - relativedelta(days=int(value['supplier'].delay)) for value in values])
+        purchase_date = purchase_date - relativedelta(days=self.company_id.po_lead)
 
         # Since the procurements are grouped if they share the same domain for
         # PO but the PO does not exist. In this case it will create the PO from

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -4,6 +4,7 @@
 
 from collections import defaultdict
 from datetime import timedelta
+from dateutil.relativedelta import relativedelta
 from operator import itemgetter
 from re import findall as regex_findall
 
@@ -1420,6 +1421,8 @@ Please change the quantity done or the rounding precision of your unit of measur
         }
 
     def _get_mto_procurement_date(self):
+        if self.rule_id.action == 'pull_push':
+            return self.date - relativedelta(days=self.rule_id.delay or 0)
         return self.date
 
     def _prepare_move_line_vals(self, quantity=None, reserved_quant=None):

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -299,6 +299,9 @@ class StockRule(models.Model):
             fields.Datetime.from_string(values['date_planned']) - relativedelta(days=self.delay or 0)
         )
         date_deadline = values.get('date_deadline') and (fields.Datetime.to_datetime(values['date_deadline']) - relativedelta(days=self.delay or 0)) or False
+        if self.action == 'pull_push':
+            date_scheduled = values.get('date_planned')
+            date_deadline = values.get('date_deadline') or False
         partner = self.partner_address_id or (values.get('group_id', False) and values['group_id'].partner_id)
         if partner:
             product_id = product_id.with_context(lang=partner.lang or self.env.user.lang)
@@ -378,6 +381,13 @@ class StockRule(models.Model):
         if global_visibility_days:
             delay_description.append((_('Global Visibility Days'), _('+ %d day(s)', int(global_visibility_days))))
         return delays, delay_description
+
+    def delay_deadline(self):
+        delay = sum(self.filtered(lambda r: r.action in ['pull', 'pull_push']).mapped('delay'))
+        global_visibility_days = self.env['ir.config_parameter'].sudo().get_param('stock.visibility_days')
+        if global_visibility_days:
+            delay += int(global_visibility_days)
+        return delay
 
 
 class ProcurementGroup(models.Model):

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -103,6 +103,7 @@ class ProductReplenish(models.TransientModel):
     def _prepare_orderpoint_values(self):
         values = {
             'location_id': self.warehouse_id.lot_stock_id.id,
+            'date_planned': self.date_planned,
             'product_id': self.product_id.id,
             'qty_to_order': self.quantity,
         }


### PR DESCRIPTION
Before this commit:
===================
- The schedule and deadline dates for purchase orders (PO) and pickings were
  incorrect and calculated based on today's date, regardless of whether we
  scheduled them for a future date when replenishing from a product.

- Lead times (including security purchase lead time, rule lead time, and seller
  delay) for PO and pickings were not calculated correctly.

After this commit:
==================
- Schedule and deadline dates will be calculated based on the given date when
  replenishing from a product.
- Lead times will be calculated accordingly.

task - 3493271