### PR TITLE
[FIX] web: fix crash on remove filter in pivot

### DIFF
--- a/addons/web/static/src/views/pivot/pivot_model.js
+++ b/addons/web/static/src/views/pivot/pivot_model.js
@@ -1311,11 +1311,13 @@ export class PivotModel extends Model {
             subGroupMeasurements: subGroupMeasurements,
         });
 
-        const subTreeKeys = tree.sortedKeys || [...tree.directSubTrees.keys()];
-        subTreeKeys.forEach((subTreeKey) => {
-            const subTree = tree.directSubTrees.get(subTreeKey);
-            rows = rows.concat(this._getTableRows(subTree, columns));
-        });
+        if (!isLeaf) {
+            const subTreeKeys = tree.sortedKeys || [...tree.directSubTrees.keys()];
+            subTreeKeys.forEach((subTreeKey) => {
+                const subTree = tree.directSubTrees.get(subTreeKey);
+                rows = rows.concat(this._getTableRows(subTree, columns));
+            });
+        }
 
         return rows;
     }

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -5679,4 +5679,49 @@ QUnit.module("Views", (hooks) => {
             );
         }
     );
+
+    QUnit.test("leaf row with subTreeKeys", async function (assert) {
+        const pivot = await makeView({
+            type: "pivot",
+            resModel: "partner",
+            serverData,
+            arch: `<pivot/>`,
+            searchViewArch: `
+                <search>
+                    <filter name="my_filter" string="My Filter" domain="[('product_id', '=', 37)]"/>
+                </search>
+            `,
+        });
+
+        // Add filter
+        await toggleFilterMenu(pivot);
+        await toggleMenuItem(pivot, "My Filter");
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll(".o_value")].map((el) => el.textContent),
+            ["1"]
+        );
+
+        await click(pivot.el, "tbody .o_pivot_header_cell_closed");
+        await click(pivot.el.querySelectorAll("tbody .o_group_by_menu .o_menu_item")[0]); // select "Company Type"
+        await click(pivot.el, "tbody .o_pivot_header_cell_closed");
+        await click(pivot.el.querySelectorAll("tbody .o_group_by_menu .o_menu_item")[4]); // select "Product"
+
+        // Toggle column order
+        await click(pivot.el, ".o_pivot_measure_row");
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll(".o_value")].map((el) => el.textContent),
+            ["1", "1", "1"]
+        );
+
+        // Remove filter
+        await toggleFilterMenu(pivot);
+        await toggleMenuItem(pivot, "My Filter");
+
+        assert.deepEqual(
+            [...pivot.el.querySelectorAll(".o_value")].map((el) => el.textContent),
+            ["4", "2", "1", "1", "2"]
+        );
+    });
 });


### PR DESCRIPTION
What are the steps to reproduce your issue?
1) Open Sale > Report
2) Filter for product
3) On the left column make breadown first by product template, than by product 4) Sort the columns
5) Clear the product filter and enter a new product

What is the current behavior that you observe?
Error message comes, see attached screenshot

What would be your expected behavior in this case? No error message

opw-3584675