### PR TITLE
[FIX l10n_eg_edi_eta: fix rounding issue for edi document

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_edi_format.py
+++ b/addons/l10n_eg_edi_eta/models/account_edi_format.py
@@ -249,7 +249,7 @@ class AccountEdiFormat(models.Model):
         for line in invoice.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section')):
             line_tax_details = tax_data.get(line, {})
             price_unit = self._l10n_eg_edi_round(abs((line.balance / line.quantity) / (1 - (line.discount / 100.0)))) if line.quantity and line.discount != 100.0 else line.price_unit
-            price_subtotal_before_discount = self._l10n_eg_edi_round(abs(line.balance / (1 - (line.discount / 100)))) if line.discount != 100.0 else price_unit * line.quantity
+            price_subtotal_before_discount = self._l10n_eg_edi_round(abs(line.balance / (1 - (line.discount / 100)))) if line.discount != 100.0 else self._l10n_eg_edi_round(price_unit * line.quantity)
             discount_amount = self._l10n_eg_edi_round(price_subtotal_before_discount - abs(line.balance))
             item_code = line.product_id.l10n_eg_eta_code or line.product_id.barcode
             lines.append({


### PR DESCRIPTION
Step to reproduce the issue:
1) Install l10n_eg and l10n_eg_edi_eta modules and select the company EG Company 2) Configure all required fields to post an Invoice with an Egyptian company (wrong credentials are ok since the issue can be triggered without really sending the e-invoice) 3) Create an invoice with an invoice line that has a quantity of 12 and a price unit of 12.8 with a 100% discount 4) Post the invoice
5) open the created json document in the 'EDI Documents' tab

Result: The 'salesTotal' field has a value of 153.60000000000002, causing the E-invoice rejection by the authorities
Expected result: 153.6

opw-3569383





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
