### PR TITLE
[FIX] account_edi_ubl_cii: add a check for item names

### DIFF
--- a/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
+++ b/addons/account_edi_ubl_cii/i18n/account_edi_ubl_cii.pot
@@ -618,6 +618,13 @@ msgstr ""
 
 #. module: account_edi_ubl_cii
 #. odoo-python
+#: code:addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py:0
+#, python-format
+msgid "Every invoice line should have a label."
+msgstr ""
+
+#. module: account_edi_ubl_cii
+#. odoo-python
 #: code:addons/account_edi_ubl_cii/models/account_edi_common.py:0
 #, python-format
 msgid "Export outside the EU"

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -219,7 +219,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'description': description,
 
             # The name of the item.
-            'name': product.name,
+            'name': product.name or line.name,
 
             # Identifier of the product.
             'sellers_item_identification_vals': {'id': product.code},

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -257,6 +257,10 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
             'peppol_endpoint_is_set_supplier':  self._check_required_fields(vals['supplier'], 'peppol_endpoint'),
             'peppol_endpoint_is_set_customer':  self._check_required_fields(vals['customer'], 'peppol_endpoint'),
         })
+        for line_vals in vals['vals']['invoice_line_vals']:
+            constraints.update({
+                f"peppol_line_label_is_set_{line_vals['id']}": self._check_required_fields(line_vals['item_vals'], 'name', _("Every invoice line should have a label.")),
+            })
 
         constraints.update(
             self._invoice_constraints_peppol_en16931_ubl(invoice, vals)


### PR DESCRIPTION
Item names are required on every invoice line. Currently it is possible to send an invoice without item names via peppol from the client side, but the validation on the IAP side fails, resulting in an error that is propagated back to the user. It is faster for the user if we catch such a common error first.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
