### PR TITLE
[wip] base: remove the 'force_email' from the context in the views

### DIFF
--- a/addons/account/wizard/account_move_send_views.xml
+++ b/addons/account/wizard/account_move_send_views.xml
@@ -62,7 +62,8 @@
                             <field name="mail_partner_ids"
                                    widget="many2many_tags_email"
                                    placeholder="Add contacts to notify..."
-                                   context="{'force_email': True, 'show_email': True}"/>
+                                   options="{'no_quick_create': True}"
+                                   context="{'form_view_ref': 'base.view_partner_simple_form'}"/>
                         </div>
                         <field name="mail_subject"
                                placeholder="Subject..."

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -232,7 +232,8 @@
                             <div class="d-flex align-items-baseline" colspan="2">
                                 <field name="partner_ids" widget="many2manyattendee"
                                     placeholder="Select attendees..."
-                                    context="{'force_email':True}"
+                                    options="{'no_quick_create': True}"
+                                    context="{'form_view_ref': 'base.view_partner_simple_form'}"
                                     domain="[('type','!=','private')]"
                                     class="oe_inline"
                                     readonly="not user_can_edit"
@@ -311,7 +312,8 @@
                         <field name="allday"/>
                         <field name="partner_ids" widget="many2manyattendee"
                             placeholder="Add attendees..."
-                            context="{'force_email':True}"
+                            options="{'no_quick_create': True}"
+                            context="{'form_view_ref': 'base.view_partner_simple_form'}"
                             class="oe_inline"
                         />
                         <label for="videocall_location" class="opacity-100"/>

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -38,8 +38,7 @@
                         <label for="partner_ids" string="Recipients" invisible="composition_mode != 'comment' or subtype_is_log"/>
                         <div groups="base.group_user" invisible="composition_mode != 'comment' or subtype_is_log">
                             <span name="document_followers_text" invisible="not model or composition_mode == 'mass_mail'">Followers of the document and</span>
-                            <field name="partner_ids" widget="many2many_tags_email" placeholder="Add contacts to notify..."
-                                context="{'force_email':True, 'show_email':True}"/>
+                            <field name="partner_ids" widget="many2many_tags_email" placeholder="Add contacts to notify..." options="{'no_quick_create': True}" context="{'form_view_ref': 'base.view_partner_simple_form'}"/>
                         </div>
                         <field name="subject" placeholder="Welcome to MyCompany!" required="True"/>
                     </group>

--- a/addons/mail/wizard/mail_wizard_invite_views.xml
+++ b/addons/mail/wizard/mail_wizard_invite_views.xml
@@ -13,7 +13,8 @@
                         <field name="res_id" invisible="1"/>
                         <field name="partner_ids" widget="many2many_tags_email"
                                 placeholder="Add contacts to notify..."
-                                context="{'force_email':True, 'show_email':True}"/>
+                                options="{'no_quick_create': True}"
+                                context="{'form_view_ref': 'base.view_partner_simple_form'}"/>
                         <field name="notify"/>
                         <field name="message" invisible="not notify"
                                options="{'style-inline': true, 'no-attachment': true}"

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -25,7 +25,8 @@
                         <label for="partner_ids" string="Invite People" invisible="access_mode == 'read'"/>
                         <label for="partner_ids" invisible="access_mode == 'edit'"/>
                     </div>
-                    <field name="partner_ids" widget="many2many_tags_email" options="{'no_quick_create': True}" placeholder="Add contacts to share the project..." nolabel="1" context="{'show_email': True, 'force_email':True}" class="mb-4"/>
+                    <field name="partner_ids" widget="many2many_tags_email" options="{'no_quick_create': True}" placeholder="Add contacts to share the project..." nolabel="1"
+                           context="{'form_view_ref': 'base.view_partner_simple_form'}" class="mb-4"/>
                 </group>
                 <field name="note" placeholder="Add a note" nolabel="1"/>
                 <footer>

--- a/addons/sale/wizard/sale_order_cancel_views.xml
+++ b/addons/sale/wizard/sale_order_cancel_views.xml
@@ -24,9 +24,9 @@
                     <group col="2">
                         <field name="recipient_ids"
                                widget="many2many_tags_email"
-                               context="{'force_email': True,
-                                         'show_email': True,
-                                         'no_create_edit': True}"/>
+                               options="{'no_quick_create': True}"
+                               context="{'form_view_ref': 'base.view_partner_simple_form'}"
+                        />
                     </group>
                     <group col="2">
                         <field name="subject" placeholder="Subject"/>

--- a/addons/survey/wizard/survey_invite_views.xml
+++ b/addons/survey/wizard/survey_invite_views.xml
@@ -26,7 +26,8 @@
                             <field name="partner_ids"
                                 widget="many2many_tags_email"
                                 placeholder="Add existing contacts..."
-                                context="{'force_email':True, 'show_email':True, 'no_create_edit': True}"
+                                options="{'no_quick_create': True}"
+                                context="{'form_view_ref': 'base.view_partner_simple_form'}"
                                 required="True"
                                 invisible="not send_email"/>
                             <field name="emails"

--- a/addons/website_slides/wizard/slide_channel_invite_views.xml
+++ b/addons/website_slides/wizard/slide_channel_invite_views.xml
@@ -24,7 +24,7 @@
                                     widget="many2many_tags_email"
                                     placeholder="Add contacts..."
                                     required="send_email"
-                                    context="{'force_email':True, 'show_email':True, 'no_create_edit': True, 'no_quick_create': True}"/>
+                                    options="{'no_quick_create': True, 'no_create_edit': True}"/>
                             </group>
                             <group col="2" invisible="not send_email">
                                 <field name="lang" invisible="1"/>

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -428,8 +428,6 @@ class Partner(models.Model):
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):
-        if (not view_id) and (view_type == 'form') and self._context.get('force_email'):
-            view_id = self.env.ref('base.view_partner_simple_form').id
         arch, view = super()._get_view(view_id, view_type, **options)
         if vat_label := self.env.company.country_id.vat_label:
             for node in arch.iterfind(".//field[@name='vat']"):

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -113,7 +113,7 @@
                     <group>
                         <field name="function" placeholder="e.g. Sales Director" invisible="is_company"/>
                         <field name="user_ids" invisible="1"/>
-                        <field name="email" widget="email" context="{'gravatar_image': True}" required="context.get('force_email', False) or user_ids"/>
+                        <field name="email" widget="email" context="{'gravatar_image': True}" required="True"/>
                         <field name="phone" widget="phone" options="{'enable_sms': false}"/>
                         <field name="mobile" widget="phone" options="{'enable_sms': false}"/>
                     </group>


### PR DESCRIPTION
https://github.com/odoo/odoo/commit/ba1a5509fa49fd846739252d16083dd8cb334b53#diff-36973ac6e1f20b32a00fbcdc1f811c923bbb44ca15a0e068018e904ff565644fR97 
The PR above added some constraints on what can be used on the context of views. The key word 'force-email' is no longer relevant and will be removed from the context before reaching the next view/python code.

This commit's purpose is to remove the force_email that were forgotten. In order to still open the simplified partner form view, the ref of the view is given in the context instead.

task - 3538000
https://www.odoo.com/web#id=3538000&menu_id=4720&cids=1&action=333&active_id=4105&model=project.task&view_type=form





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
