### PR TITLE
[IMP] product_expiry: always show expiration date & warn by color

### DIFF
--- a/addons/product_expiry/views/stock_move_views.xml
+++ b/addons/product_expiry/views/stock_move_views.xml
@@ -17,16 +17,10 @@
         <field name="model">stock.move.line</field>
         <field name="inherit_id" ref="stock.view_stock_move_line_operation_tree"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='lot_id']" position="after">
-                <field name="is_expired" column_invisible="True"/>
-                <button class="fa fa-exclamation-triangle text-danger"
-                    title="This lot is expired." string="This lot is expired"
-                    disabled="1"
-                    invisible="not is_expired"/>
-            </xpath>
             <xpath expr="//field[@name='lot_name']" position="after" >
+                <field name="is_expired" column_invisible="True"/>
                 <field name="picking_type_use_existing_lots" column_invisible="True"/>
-                <field name="expiration_date" force_save="1" column_invisible="not parent.use_expiration_date or parent.picking_code != 'incoming'" readonly="picking_type_use_existing_lots"/>
+                <field name="expiration_date" force_save="1" column_invisible="not parent.use_expiration_date or parent.picking_code != 'incoming'" readonly="picking_type_use_existing_lots" decoration-danger="is_expired"/>
             </xpath>
         </field>
     </record>
@@ -37,15 +31,9 @@
         <field name="inherit_id" ref="stock.view_stock_move_line_detailed_operation_tree"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='lot_name']" position="after">
-                <field name="picking_type_use_existing_lots" column_invisible="True"/>
-                <field name="expiration_date" force_save="1" column_invisible="context.get('picking_code') != 'incoming'" readonly="picking_type_use_existing_lots"/>
-            </xpath>
-            <xpath expr="//field[@name='lot_id']" position="after">
                 <field name="is_expired" column_invisible="True"/>
-                <button class="fa fa-exclamation-triangle text-danger"
-                    title="This lot is expired." string="This lot is expired"
-                    disabled="1"
-                    invisible="not is_expired"/>
+                <field name="picking_type_use_existing_lots" column_invisible="True"/>
+                <field name="expiration_date" force_save="1" column_invisible="context.get('picking_code') != 'incoming'" readonly="picking_type_use_existing_lots" decoration-danger="is_expired"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
 # Main changes:
Always show the expiration date on the move lines of concerned products.

 # Before:
Show a warning when the expiration date has been reached.

 # After:
Show the expiration date of the product if it has one. Rather than showing an alert if the expiration date has been reached, set the text-danger bootstrap class on the expiration date.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
