### PR TITLE
[FIX] mail: allow to post message on archived records

### DIFF
--- a/addons/mail/controllers/thread.py
+++ b/addons/mail/controllers/thread.py
@@ -93,7 +93,7 @@ class ThreadController(http.Controller):
                 'last_used': datetime.now(),
                 'ids': canned_response_ids,
             })
-        thread = request.env[thread_model].search([("id", "=", thread_id)])
+        thread = request.env[thread_model].with_context(active_test=False).search([("id", "=", thread_id)])
         if not thread:
             raise NotFound()
         if "body" in post_data:


### PR DESCRIPTION
How to reproduce:
- archive any record
- try to "log a note" on that record
- you get a stacktrace due to a "404: Not Found"

Indeed, the controller was checking that the record exists with the active_test
set to True which filter out archived record. This fix is just setting
active_test to False in the controller to avoid the 404 error.

We also add a test to avoid regression on that specific error.

Task-3573336