### PR TITLE
[FIX] stock: unreserve on chained move, forecast report

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -867,6 +867,10 @@ Please change the quantity done or the rounding precision of your unit of measur
         # `write` on `stock.move.line` doesn't call `_recompute_state` (unlike to `unlink`),
         # so it must be called for each move where no move line has been deleted.
         (moves_to_unreserve - moves_not_to_recompute)._recompute_state()
+        if self.env.context.get('unreserve_parent'):
+            moves_orig_to_unreserve = moves_to_unreserve.move_orig_ids.filtered(lambda move: move.reserved_availability)
+            if moves_orig_to_unreserve.picking_id:
+                moves_orig_to_unreserve.picking_id.do_unreserve()
         return True
 
     def _generate_serial_numbers(self, next_serial_count=False):

--- a/addons/stock/static/src/stock_forecasted/forecasted_details.js
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.js
@@ -28,6 +28,7 @@ export class ForecastedDetails extends Component{
             model,
             'do_unreserve',
             [[modelId]],
+            { context: { unreserve_parent: true } },
         );
         this.props.reloadReport();
     }


### PR DESCRIPTION
Use case / Steps to reproduce the issue:
- Enable multi-step routes- on the warehouse routes
- warehouse a) receive goods (1 step)
b) Send goods in output and the deliver (2 steps)
- Create sales order ( 2 deliveries are generated - PICK and OUT )
- Go to product > forecasted > try to unreserve.

The unreserve is only call in the last move of the chain.

Add a context key to unrserve all the parents. It's not the best solution because it unreserve the whole picking and all the parents. So moves that are not related to the current product will be unreserved too.

However, currently it does nothing when you click on it. So it just allow a new usecase for people without removing something.

opw-3589811

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
