### PR TITLE
[FIX] point_of_sale: correctly convert html to image

### DIFF
--- a/addons/point_of_sale/static/src/app/printer/base_printer.js
+++ b/addons/point_of_sale/static/src/app/printer/base_printer.js
@@ -72,7 +72,7 @@ export class BasePrinter {
     async htmlToImg(el) {
         const elClone = el.cloneNode(true);
         const receiptContainer = document.querySelector(".pos-receipt-print");
-        receiptContainer.appendChild(elClone);
+        receiptContainer.innerHTML = elClone.outerHTML;
         const receipt = receiptContainer.querySelector(".pos-receipt");
         // Odoo RTL support automatically flip left into right but html2canvas
         // won't work as expected if the receipt is aligned to the right of the


### PR DESCRIPTION
Current behavior:
When you activate automatic receipt printing, and print order changes on a printer. If you directly pay for the order instead of clicking on the order button, the printer will print wrong things.

Steps to reproduce:
- Activate automatic receipt printing
- Add 2 ePos printers
- Link 1 printer to the drink pos category product
- Set 1 printer to print the receipts of the PoS
- Make an order with some drinks (in restaurant mode)
- Directly click on the payment button
- Pay for the order
- The same ticket will be printed on both printers, when it should be one with the drinks and one with the receipt

Note:
This was happening because the function used to transform the html to
image was putting the 2 things to print in the same `pos_receipt_print`
div, and the function was always taking the first one.

opw-3574619
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
