### PR TITLE
[FIX] spreadsheet : Dashboard view for rtl languages

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.scss
+++ b/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.scss
@@ -8,6 +8,11 @@
     .o-selection input {
         display: initial;
     }
+
+    .o-figure-canvas {
+        /*rtl:ignore*/
+        direction: ltr;
+    }
 }
 
 .o-sidePanel .o-sidePanelButtons .o-button {


### PR DESCRIPTION
[FIX] spreadsheet : Dashboard view for rtl languages

Steps to reproduce:
	1- Install any right-to-left language
	2- Open Dashboard application
	3- Check the view of the top canvas
	
Current behavior before PR:
The text in the top canvas in the dashboard app when using a right-to-left language is not shown in a good way

Desired behavior after PR is merged:
The view has been fixed and the text is visible now

opw-3592360