### PR TITLE
[FIX] partner_autocomplete : Suggestions available in tax field for GST

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_core.js
@@ -36,8 +36,7 @@ export function usePartnerAutocomplete() {
         return checkVATNumber(sanitizeVAT(value));
     }
 
-    async function checkGSTNumber(value) {
-        // Lazyload jsvat only if the component is being used.
+    function isGSTNumber(value) {
         // Check if the input is a valid GST number.
         let isGST = false;
         if (value && value.length === 15) {
@@ -55,10 +54,16 @@ export function usePartnerAutocomplete() {
         return isGST;
     }
 
+    async function isTAXNumber(value) {
+        const isVAT = await isVATNumber(value);
+        const isGST = isGSTNumber(value);
+        return isVAT || isGST;
+    }
+
     async function autocomplete(value) {
         value = value.trim();
 
-        const isVAT = await isVATNumber(value) || await checkGSTNumber(value);
+        const isVAT = await isTAXNumber(value);
         let odooSuggestions = [];
         let clearbitSuggestions = [];
         return new Promise((resolve, reject) => {
@@ -185,6 +190,15 @@ export function usePartnerAutocomplete() {
                     }
                     else {
                         notification.add(company_data.error_message);
+                    }
+                    if (company_data.city !== undefined) {
+                        company.city = company_data.city;
+                    }
+                    if (company_data.street !== undefined) {
+                        company.street = company_data.street;
+                    }
+                    if (company_data.zip !== undefined) {
+                        company.zip = company_data.zip;
                     }
                     company_data = company;
                 }
@@ -328,5 +342,5 @@ export function usePartnerAutocomplete() {
             notification.add(title);
         }
     }
-    return { autocomplete, getCreateData, isVATNumber };
+    return { autocomplete, getCreateData, isTAXNumber };
 }

--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -21,7 +21,7 @@ export class PartnerAutoCompleteCharField extends CharField {
 
     async validateSearchTerm(request) {
         if (this.props.name == 'vat') {
-            return this.partner_autocomplete.isVATNumber(request);
+            return this.partner_autocomplete.isTAXNumber(request);
         }
         else {
             return request && request.length > 2;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
It was not possible to obtain suggestions by entering a GST in the Tax ID field when creating a contact.

Current behavior before PR:
When a GST number is entered in the Tax ID field of the contact creation form, nothing happens. 

Desired behavior after PR is merged:
Suggestions can now be accessed by entering a GST number in the Tax ID field of the contact form.
Also, add the option of allowing completion even with an 'insufficient credit' error.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
