### PR TITLE
[FIX] pos_sale, point_of_sale: ensure down payment cancellation reflects in SOL

### DIFF
--- a/addons/point_of_sale/wizard/pos_payment.py
+++ b/addons/point_of_sale/wizard/pos_payment.py
@@ -70,6 +70,10 @@ class PosMakePayment(models.TransientModel):
             order._process_saved_order(False)
             if order.state in {'paid', 'done', 'invoiced'}:
                 order._send_order()
+
+                active_pos_order = self.env["pos.order"].browse(self.env.context.get("active_id"))
+                active_pos_order.lines.sale_order_line_id._compute_name()
+
             return {'type': 'ir.actions.act_window_close'}
 
         return self.launch_payment()

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -71,6 +71,15 @@ class SaleOrderLine(models.Model):
         for sale_line in self:
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids], 0)
 
+    @api.depends('product_id', 'pos_order_line_ids.order_id.refund_orders_count')
+    def _compute_name(self):
+        super()._compute_name()
+        for line in self.filtered(lambda l: l.is_downpayment and not l.display_type):
+            if line.pos_order_line_ids.order_id.filtered(lambda o: o.refund_orders_count or o.account_move.state == 'cancel'):
+                name = line._get_sale_order_line_multiline_description_sale()
+                # Update the name with the Cancelled statement
+                line.name = _("%(line_description)s (Cancelled)", line_description=name)
+
     def _get_sale_order_fields(self):
         return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total"]
 


### PR DESCRIPTION
Before this commit
===================
Previously, when recording a down payment from the Point of Sale (POS), the amount was correctly reflected and visible in the Sale Order line. However, if the down payment was canceled from the POS, the cancellation was not properly reflected in the Sale Order line name(description).

After this commit
===================
With this commit, the issue is addressed, and the cancellation of down payments from the POS is now accurately reflected in the Sale Order line.

task: 3514218
