### PR TITLE
[FIX] website: fixed keyerror configurator_snippets

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -660,7 +660,7 @@ class IrModuleModule(models.Model):
         # Configurator
         # ------------------------------------------------------------
 
-        configurator_snippets = manifest['configurator_snippets']
+        configurator_snippets = manifest.get('configurator_snippets', {})
 
         # Generate general configurator snippet templates
         create_values = []
@@ -686,7 +686,7 @@ class IrModuleModule(models.Model):
         # New page templates
         # ------------------------------------------------------------
 
-        templates = manifest['new_page_templates']
+        templates = manifest.get('new_page_templates', {})
 
         # Generate general new page snippet templates
         create_values = []


### PR DESCRIPTION
when there is module like `theme_common`
got manifest with {} value. so we got error
on this line:
configurator_snippets = manifest['configurator_snippets']

so got traceback KeyError: 'configurator_snippets'

this error reproduced during upgrading database.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
