### PR TITLE
[FIX] l10n_eg_edi_eta: round Egyptian companies currency rates

### DIFF
--- a/addons/l10n_eg_edi_eta/models/res_currency_rate.py
+++ b/addons/l10n_eg_edi_eta/models/res_currency_rate.py
@@ -3,6 +3,7 @@
 
 
 from odoo import models, api, _
+from odoo.tools import float_round
 
 
 class ResCurrencyRate(models.Model):
@@ -22,3 +23,27 @@ class ResCurrencyRate(models.Model):
                 }
             }
         return super()._onchange_rate_warning()
+
+    def _sanitize_vals(self, vals):
+        vals = super()._sanitize_vals(vals)
+
+        # Continue only if fiscal country is Egypt
+        company = self.env['res.company'].browse(vals.get('company_id')) or self.env.company
+        if company.account_fiscal_country_id.code != 'EG':
+            return vals
+
+        last_rate = self.env['res.currency.rate']._get_last_rates_for_companies(company)
+        inverse_company_rate = None
+
+        # Calculate inverse_company_rate based on the available key
+        if 'inverse_company_rate' in vals:
+            inverse_company_rate = vals.pop('inverse_company_rate')
+        elif 'company_rate' in vals:
+            inverse_company_rate = 1 / vals.pop('company_rate')
+        elif 'rate' in vals:
+            inverse_company_rate = last_rate[company] / vals.pop('rate')
+
+        if inverse_company_rate is not None:
+            vals['rate'] = last_rate[company] / float_round(inverse_company_rate, precision_digits=5)
+
+        return vals


### PR DESCRIPTION
### Summary

The Egyptian ETA requires exchange rates to be sent with a decimal precision of 5. Currently, the rounding of the rate is done right when the EDI document is generated,  but all the internal calculations are done with the full rate. This difference creates inconsistencies in the values that are sent to the Egyptian ETA.

### Steps to reproduce

* Install `l10n_eg_edi_eta` module and select the company EG Company
* Configure all required fields to post an Invoice with an Egyptian company (wrong credentials are ok, since the issue can be triggered without really sending the e-invoice)
* activate a second currency (ex: USD) and add a new rate such that `1 USD = 30.903316 EGP`
* Create and confirm an invoice in USD for $200000
* open the created JSON document in the 'EDI Documents' tab

Here, we will have an amount of `6180663.2` and an amount in currency of `200000.0`. When you round the rate to 5 decimals, you get `30.90332`. However, you will find an inconsistency when trying to use that rounded rate to check the amounts above:
`6180663.2 / 30.90332 = 199999.97 != 200000`

### Cause

Currently, there's a warning to alert users editing exchange rates that these rates should not exceed five decimal places. However, since it's just a warning (nothing is actually enforced), it completely gets bypassed in the case where the user is using automatic currency rates.

### Fix

When the Egyptian EDI is installed, ensure that Egyptian companies' rates are rounded to 5 decimals.

opw-3570816