### PR TITLE
[FIX] website_slides_survey: display correct icon for certification

### DIFF
--- a/addons/website_slides_survey/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_lesson.xml
@@ -42,5 +42,11 @@
                 </a>
             </xpath>
         </template>
+
+        <template id="slide_aside_training_category_inherit_survey" inherit_id="website_slides.slide_aside_training_category">
+            <xpath expr="//t[@t-set='slide_icon'][last()]" position="before">
+                <t t-set="slide_icon" t-elif="aside_slide.slide_type == 'certification'" t-value="'fa-trophy'"/>
+            </xpath>
+        </template>
     </data>
 </odoo>

--- a/addons/website_slides_survey/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides_survey/views/website_slides_templates_lesson_fullscreen.xml
@@ -7,6 +7,9 @@
             <attribute name="t-att-data-is-member">slide.channel_id.is_member</attribute>
             <attribute name="t-att-data-can-upload">channel.can_upload</attribute>
         </xpath>
+        <xpath expr="//t[@t-set='slide_icon'][last()]" position="before">
+            <t t-set="slide_icon" t-elif="slide.slide_type == 'certification'" t-value="'fa-trophy'"/>
+        </xpath>
     </template>
 
 </data></odoo>


### PR DESCRIPTION
Steps to reproduce
===================
1. Open any course with certification.
2. Preview certification content. The icon for certification is not displayed correctly.

Technical
==========
The commit https://github.com/odoo/odoo/commit/091eaa3cd2cb42eeccaaf905e04139f9fd98d365 altered the way icons are displayed for all content on the template. However, for certification content, it is not handled and shows the default icon 'fa-file-o'.

After this PR
=================
The certification icon is displayed correctly.

Task-3551242