### PR TITLE
[FIX] l10n_es_edi_sii: ImporteTotal should apply the reverse charge

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -363,14 +363,9 @@ class AccountEdiFormat(models.Model):
                             "\n".join(invoice.line_ids.tax_ids.mapped('name'))
                         ))
 
-                    invoice_node['ImporteTotal'] = round(sign * (
-                        tax_details_info_service_vals['tax_details']['base_amount']
-                        + tax_details_info_service_vals['tax_details']['tax_amount']
-                        - tax_details_info_service_vals['tax_amount_retention']
-                        + tax_details_info_consu_vals['tax_details']['base_amount']
-                        + tax_details_info_consu_vals['tax_details']['tax_amount']
-                        - tax_details_info_consu_vals['tax_amount_retention']
-                    ), 2)
+                    invoice_node['ImporteTotal'] = round(invoice.amount_total_signed
+                                                         + sign * tax_details_info_service_vals['tax_amount_retention']
+                                                         + sign * tax_details_info_consu_vals['tax_amount_retention'], 2)
 
             else:
                 # Vendor bills
@@ -390,14 +385,17 @@ class AccountEdiFormat(models.Model):
                 if tax_details_info_other_vals['tax_details_info']:
                     invoice_node['DesgloseFactura']['DesgloseIVA'] = tax_details_info_other_vals['tax_details_info']
 
-                invoice_node['ImporteTotal'] = round(sign * (
-                    tax_details_info_isp_vals['tax_details']['base_amount']
-                    + tax_details_info_isp_vals['tax_details']['tax_amount']
-                    - tax_details_info_isp_vals['tax_amount_retention']
-                    + tax_details_info_other_vals['tax_details']['base_amount']
-                    + tax_details_info_other_vals['tax_details']['tax_amount']
-                    - tax_details_info_other_vals['tax_amount_retention']
-                ), 2)
+                if invoice._l10n_es_is_dua():
+                    invoice_node['ImporteTotal'] = round(sign * (
+                            tax_details_info_isp_vals['tax_details']['base_amount']
+                            + tax_details_info_isp_vals['tax_details']['tax_amount']
+                            + tax_details_info_other_vals['tax_details']['base_amount']
+                            + tax_details_info_other_vals['tax_details']['tax_amount']
+                    ), 2)
+                else:
+                    invoice_node['ImporteTotal'] = round(-invoice.amount_total_signed
+                                                         - sign * tax_details_info_isp_vals['tax_amount_retention']
+                                                         - sign * tax_details_info_other_vals['tax_amount_retention'], 2)
 
                 invoice_node['CuotaDeducible'] = round(sign * (
                     tax_details_info_isp_vals['tax_amount_deductible']

--- a/addons/l10n_es_edi_sii/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_sii/tests/test_edi_xml.py
@@ -783,7 +783,7 @@ class TestEdiXmls(TestEsEdiCommon):
                     'Contraparte': {'NombreRazon': 'partner_b', 'NIF': 'F35999705'},
                     'DescripcionOperacion': 'manual',
                     'ClaveRegimenEspecialOTrascendencia': '01',
-                    'ImporteTotal': 121.0,
+                    'ImporteTotal': 100.0,
                     'FechaRegContable': '02-01-2019',
                     'DesgloseFactura': {
                         'InversionSujetoPasivo': {


### PR DESCRIPTION
When a line with a factor_percent of -100 is applied in the tax, it should be subtracted from the ImporteTotal.

This way, we might think that the total of the invoice should do, but we need the amount before application of the withholdings.

And in the case of DUA it should be the sum of base and tax.

task 3603788

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
