### PR TITLE
[IMP] portal: change _search method to support custom search_in

### DIFF
--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -150,7 +150,7 @@ publicWidget.registry.portalSearchPanel = publicWidget.Widget.extend({
      */
     _search: function () {
         var search = new URL(window.location).searchParams;
-        search.set("search_in", this.$('.dropdown-item.active').attr('href').replace('#', ''));
+        search.set("search_in", this.$('.dropdown-item.active').attr('href')?.replace('#', '') || '');
         search.set("search", this.$('input[name="search"]').val());
         window.location.search = search.toString();
     },


### PR DESCRIPTION
The _search method of the portal search panel uses the currently selected dropdown item to retrieve the search criteria ; however, when using a search criteria that is not displayed in the dropdown menu, the replace method causes a traceback, since calling attr on the empty jquery selector object returns undefined.

The _search method was changed to use optional chaining before accessing the replace method, and to replace the search_in value by an empty string in case the result of the expression is undefined.