### PR TITLE
[FIX] purchase_stock: price diff on refund in AVCO/FIFO

### DIFF
--- a/addons/purchase_price_diff/models/account_move_line.py
+++ b/addons/purchase_price_diff/models/account_move_line.py
@@ -7,9 +7,7 @@ class AccountMoveLine(models.Model):
 
     def _get_price_diff_account(self):
         self.ensure_one()
-        if self.product_id.cost_method == 'standard':
-            debit_pdiff_account = self.product_id.property_account_creditor_price_difference \
-                                    or self.product_id.categ_id.property_account_creditor_price_difference_categ
-            debit_pdiff_account = self.move_id.fiscal_position_id.map_account(debit_pdiff_account)
-            return debit_pdiff_account
-        return super()._get_price_diff_account()
+        debit_pdiff_account = self.product_id.property_account_creditor_price_difference \
+                                or self.product_id.categ_id.property_account_creditor_price_difference_categ
+        debit_pdiff_account = self.move_id.fiscal_position_id.map_account(debit_pdiff_account)
+        return debit_pdiff_account

--- a/addons/purchase_price_diff/tests/__init__.py
+++ b/addons/purchase_price_diff/tests/__init__.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import tests
+from . import test_stockvaluation

--- a/addons/purchase_price_diff/tests/test_stockvaluation.py
+++ b/addons/purchase_price_diff/tests/test_stockvaluation.py
@@ -1,0 +1,186 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime, timedelta
+from unittest.mock import patch
+from freezegun import freeze_time
+
+from odoo.addons.account.models.account_move import AccountMove
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo import models, fields
+from odoo.tests.common import Form, tagged
+from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
+
+@tagged('post_install', '-at_install')
+class TestStockValuation(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.supplier_location = cls.env.ref('stock.stock_location_suppliers')
+        cls.stock_location = cls.env.ref('stock.stock_location_stock')
+        cls.partner_id = cls.env['res.partner'].create({'name': 'Wood Corner Partner'})
+        cls.product1 = cls.env['product.product'].create({'name': 'Large Desk'})
+
+        cls.cat = cls.env['product.category'].create({
+            'name': 'cat',
+        })
+        cls.product1 = cls.env['product.product'].create({
+            'name': 'product1',
+            'type': 'product',
+            'categ_id': cls.cat.id,
+        })
+
+        Account = cls.env['account.account']
+        cls.usd_currency = cls.env.ref('base.USD')
+        cls.eur_currency = cls.env.ref('base.EUR')
+        cls.usd_currency.active = True
+        cls.eur_currency.active = True
+
+        cls.stock_input_account = Account.create({
+            'name': 'Stock Input',
+            'code': 'StockIn',
+            'account_type': 'asset_current',
+            'reconcile': True,
+        })
+        cls.stock_output_account = Account.create({
+            'name': 'Stock Output',
+            'code': 'StockOut',
+            'account_type': 'asset_current',
+            'reconcile': True,
+        })
+        cls.stock_valuation_account = Account.create({
+            'name': 'Stock Valuation',
+            'code': 'StockValuation',
+            'account_type': 'asset_current',
+        })
+        cls.price_diff_account = Account.create({
+            'name': 'price diff account',
+            'code': 'priceDiffAccount',
+            'account_type': 'asset_current',
+        })
+        cls.stock_journal = cls.env['account.journal'].create({
+            'name': 'Stock Journal',
+            'code': 'STJTEST',
+            'type': 'general',
+        })
+        cls.product1.categ_id.write({
+            'property_stock_account_input_categ_id': cls.stock_input_account.id,
+            'property_stock_account_output_categ_id': cls.stock_output_account.id,
+            'property_stock_valuation_account_id': cls.stock_valuation_account.id,
+            'property_stock_journal': cls.stock_journal.id,
+            'property_account_creditor_price_difference_categ': cls.product1.product_tmpl_id.get_product_accounts()['expense'],
+            'property_valuation': 'real_time',
+        })
+        old_action_post = AccountMove.action_post
+        old_create = models.BaseModel.create
+
+        def new_action_post(self):
+            """ Force the creation of tracking values. """
+            res = old_action_post(self)
+            if self:
+                cls.env.flush_all()
+                cls.cr.flush()
+            return res
+
+        def new_create(self, vals_list):
+            cls.cr._now = datetime.now()
+            return old_create(self, vals_list)
+
+        post_patch = patch('odoo.addons.account.models.account_move.AccountMove.action_post', new_action_post)
+        create_patch = patch('odoo.models.BaseModel.create', new_create)
+        cls.startClassPatcher(post_patch)
+        cls.startClassPatcher(create_patch)
+
+    def test_fifo_anglosaxon_return_pdiff(self):
+        self.env.cr.now = fields.Datetime.now
+        self.env.company.anglo_saxon_accounting = True
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+        self.product1.property_account_creditor_price_difference = self.price_diff_account
+
+        # Receive 10@10 ; create the vendor bill
+        po1 = self.env['purchase.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product1.name,
+                    'product_id': self.product1.id,
+                    'product_qty': 10.0,
+                    'product_uom': self.product1.uom_po_id.id,
+                    'price_unit': 10.0,
+                    'date_planned': datetime.today().strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+                }),
+            ],
+        })
+        po1.button_confirm()
+        receipt_po1 = po1.picking_ids[0]
+        receipt_po1.move_ids.quantity_done = 10
+        receipt_po1.button_validate()
+
+        move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
+        move_form.invoice_date = move_form.date
+        move_form.partner_id = self.partner_id
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-po1.id)
+        invoice_po1 = move_form.save()
+        invoice_po1.action_post()
+
+        # Receive 10@20 ; create the vendor bill
+        po2 = self.env['purchase.order'].create({
+            'partner_id': self.partner_id.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product1.name,
+                    'product_id': self.product1.id,
+                    'product_qty': 10.0,
+                    'product_uom': self.product1.uom_po_id.id,
+                    'price_unit': 20.0,
+                    'date_planned': datetime.today().strftime(DEFAULT_SERVER_DATETIME_FORMAT),
+                }),
+            ],
+        })
+        po2.button_confirm()
+        receipt_po2 = po2.picking_ids[0]
+        receipt_po2.move_ids.quantity_done = 10
+        receipt_po2.button_validate()
+
+        move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))
+        move_form.invoice_date = move_form.date
+        move_form.partner_id = self.partner_id
+        move_form.purchase_vendor_bill_id = self.env['purchase.bill.union'].browse(-po2.id)
+        invoice_po2 = move_form.save()
+        invoice_po2.action_post()
+
+        # valuation of product1 should be 300
+        self.assertEqual(self.product1.value_svl, 300)
+
+        # return the second po
+        with freeze_time(fields.date.today() + timedelta(days=1)):
+            stock_return_picking_form = Form(self.env['stock.return.picking']
+                .with_context(active_ids=receipt_po2.ids, active_id=receipt_po2.ids[0],
+                active_model='stock.picking'))
+            stock_return_picking = stock_return_picking_form.save()
+            stock_return_picking.product_return_moves.quantity = 10
+            stock_return_picking_action = stock_return_picking.create_returns()
+            return_pick = self.env['stock.picking'].browse(stock_return_picking_action['res_id'])
+            return_pick.move_ids[0].move_line_ids[0].qty_done = 10
+            return_pick.button_validate()
+
+            # valuation of product1 should be 200 as the first items will be sent out
+            self.assertEqual(self.product1.value_svl, 200)
+
+        with freeze_time(fields.date.today() + timedelta(days=2)):
+            # create a credit note for po2
+            move_form = Form(self.env['account.move'].with_context(default_move_type='in_refund'))
+            move_form.invoice_date = move_form.date
+            move_form.partner_id = self.partner_id
+            move_form._view['modifiers']['purchase_id']['invisible'] = False
+            move_form.purchase_id = po2
+            with move_form.invoice_line_ids.edit(0) as line_form:
+                line_form.quantity = 10
+            creditnote_po2 = move_form.save()
+            creditnote_po2.action_post()
+
+        # check the anglo saxon entries
+        price_diff_entry = self.env['account.move.line'].search([('account_id', '=', self.price_diff_account.id)])
+        self.assertEqual(price_diff_entry.credit, 100)

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -31,8 +31,8 @@ class AccountMove(models.Model):
         '''
         lines_vals_list = []
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
-
         for move in self:
+
             if move.move_type not in ('in_invoice', 'in_refund', 'in_receipt') or not move.company_id.anglo_saxon_accounting:
                 continue
 
@@ -40,9 +40,10 @@ class AccountMove(models.Model):
             for line in move.invoice_line_ids:
                 # Filter out lines being not eligible for price difference.
                 # Moreover, this function is used for standard cost method only.
-                if line.product_id.type != 'product' or line.product_id.valuation != 'real_time' or line.product_id.cost_method != 'standard':
+                if line.product_id.type != 'product' or line.product_id.valuation != 'real_time':
                     continue
-
+                if line.product_id.cost_method != 'standard':
+                    continue
                 # Retrieve accounts needed to generate the price difference.
                 debit_expense_account = line._get_price_diff_account()
                 if not debit_expense_account:
@@ -54,38 +55,22 @@ class AccountMove(models.Model):
                     ('product_qty', '!=', 0.0),
                 ]) if line.purchase_line_id else self.env['stock.move']
 
-                if line.product_id.cost_method != 'standard' and line.purchase_line_id:
-                    if move.move_type == 'in_refund':
-                        valuation_stock_moves = valuation_stock_moves.filtered(lambda stock_move: stock_move._is_out())
-                    else:
-                        valuation_stock_moves = valuation_stock_moves.filtered(lambda stock_move: stock_move._is_in())
-
-                    if not valuation_stock_moves:
-                        continue
-
-                    valuation_price_unit_total, valuation_total_qty = valuation_stock_moves._get_valuation_price_and_qty(line, move.currency_id)
-                    valuation_price_unit = valuation_price_unit_total / valuation_total_qty
-                    valuation_price_unit = line.product_id.uom_id._compute_price(valuation_price_unit, line.product_uom_id)
-                else:
-                    # Valuation_price unit is always expressed in invoice currency, so that it can always be computed with the good rate
-                    price_unit = line.product_id.uom_id._compute_price(line.product_id.standard_price, line.product_uom_id)
-                    price_unit = -price_unit if line.move_id.move_type == 'in_refund' else price_unit
-                    valuation_date = valuation_stock_moves and max(valuation_stock_moves.mapped('date')) or move.date
-                    valuation_price_unit = line.company_currency_id._convert(
-                        price_unit, move.currency_id,
-                        move.company_id, valuation_date, round=False
-                    )
-
+                # Valuation_price unit is always expressed in invoice currency, so that it can always be computed with the good rate
+                price_unit = line.product_id.uom_id._compute_price(line.product_id.standard_price, line.product_uom_id)
+                price_unit = -price_unit if line.move_id.move_type == 'in_refund' else price_unit
+                valuation_date = valuation_stock_moves and max(valuation_stock_moves.mapped('date')) or move.date
+                valuation_price_unit = line.company_currency_id._convert(
+                    price_unit, move.currency_id,
+                    move.company_id, valuation_date, round=False
+                )
 
                 price_unit = line._get_gross_unit_price()
+                if line.move_id.move_type == 'in_refund':
+                    price_unit = -price_unit
 
                 price_unit_val_dif = price_unit - valuation_price_unit
-                # If there are some valued moves, we only consider their quantity already used
-                if line.product_id.cost_method == 'standard':
-                    relevant_qty = line.quantity
-                else:
-                    relevant_qty = line._get_out_and_not_invoiced_qty(valuation_stock_moves)
-                price_subtotal = relevant_qty * price_unit_val_dif
+                price_subtotal = line.quantity * price_unit_val_dif
+                relevant_qty = line.quantity
 
                 # We consider there is a price difference if the subtotal is not zero. In case a
                 # discount has been applied, we can't round the price unit anymore, and hence we


### PR DESCRIPTION
The price diff account has been removed in 16.0 and reintroduced later for standard auto valuation. However during the initial process we removed the price diff functionality for return and refund from supplier in avco/fifo and we would expect the user to empty himself the interim account.

As we went back on the price diff account, we should also reintroduce the 15.0 features for the case describe upper.

opw-3574711
