### PR TITLE
[FIX] core: relevant error when duplicate groupby spec

### DIFF
--- a/odoo/addons/test_read_group/tests/test_private_read_group.py
+++ b/odoo/addons/test_read_group/tests/test_private_read_group.py
@@ -326,6 +326,10 @@ class TestPrivateReadGroup(common.TransactionCase):
         with self.assertRaises(ValueError):
             Model._read_group([], ['"date:week'])
 
+        with self.assertRaises(ValueError) as error:
+            Model._read_group([], ['date:month', 'date:month'])
+        self.assertEqual(str(error.exception), "The groupby=['date:month', 'date:month'] param contains duplication of 'date:month'")
+
         # Test malformed aggregate clause
         with self.assertRaises(ValueError):
             Model._read_group([], aggregates=['value'])  # No aggregate

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1863,6 +1863,8 @@ class BaseModel(metaclass=MetaModel):
 
         groupby_terms: dict[str, SQL] = {}
         for spec in groupby:
+            if spec in groupby_terms:
+                raise ValueError(f"The {groupby=!r} param contains duplication of {spec!r}")
             groupby_terms[spec], fnames_used = self._read_group_groupby(spec, query)
             fnames_to_flush.update(fnames_used)
 


### PR DESCRIPTION
[FIX] core: relevant error when duplicate groupby spec
Since https://github.com/odoo/odoo/pull/103510/files#diff-7144f88ea32f36feb17ce1b8dda7dee1631f5ada34075414587df3948c6b3d1bR1863,
`groupby` of `_read_group` doesn't handle no-unique groupby_spec
(`groupby=['date:month', 'date:month]`). This is because the
`groupby_terms` deduplicate the `groupby` by its dict nature.

We cannot easily fix this in `_read_group`, instead we raise a
corresponding error. The `read_group` (public method) can already
handle duplicate groupby specifications, unless when one of then is
implicit and the other one is explicit as
`groupby=['date', 'date:month]`. This was rarely requested from the
pivot view and fixed in https://github.com/odoo/odoo/pull/143792