### PR TITLE
[FIX] sale_pdf_quote_builder: restrict user to upload corrupt pdf

### DIFF
--- a/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
+++ b/addons/sale_pdf_quote_builder/i18n/sale_pdf_quote_builder.pot
@@ -154,6 +154,13 @@ msgid ""
 msgstr ""
 
 #. module: sale_pdf_quote_builder
+#. odoo-python
+#: code:addons/sale_pdf_quote_builder/models/sale_order_template.py:0
+#, python-format
+msgid "The uploaded file is not a valid PDF. Please upload a valid PDF file."
+msgstr ""
+
+#. module: sale_pdf_quote_builder
 #: model:ir.model.fields,field_description:sale_pdf_quote_builder.field_product_document__attached_on
 msgid "Visible at"
 msgstr ""

--- a/addons/sale_pdf_quote_builder/models/sale_order_template.py
+++ b/addons/sale_pdf_quote_builder/models/sale_order_template.py
@@ -1,7 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
-from odoo import fields, models
-
+import io
+from odoo import api, fields, models, _
+import base64
+from odoo.exceptions import ValidationError
+from PyPDF2 import PdfFileReader
+try:
+    from PyPDF2.errors import PdfReadError
+except ImportError:
+    from PyPDF2.utils import PdfReadError
 
 class SaleOrderTemplate(models.Model):
     _inherit = 'sale.order.template'
@@ -12,3 +18,13 @@ class SaleOrderTemplate(models.Model):
     sale_footer = fields.Binary(
         string="Footer pages", default=lambda self: self.env.company.sale_footer)
     sale_footer_name = fields.Char(default=lambda self: self.env.company.sale_footer_name)
+
+    @api.constrains('sale_header', 'sale_footer')
+    def _check_valid_header_and_footer(self):
+        try:
+            if self.sale_header:
+                PdfFileReader(io.BytesIO(base64.b64decode(self.sale_header)), strict=False, overwriteWarnings=False)
+            if self.sale_footer:
+                PdfFileReader(io.BytesIO(base64.b64decode(self.sale_footer)), strict=False, overwriteWarnings=False)
+        except PdfReadError:
+            raise ValidationError(_("The uploaded file is not a valid PDF. Please upload a valid PDF file."))


### PR DESCRIPTION
When the header and footer pages of Quotation template contains corrupted pdf then while previewing the quotation if the user clicks on view details or clicks on action quote pdf then the user will face error.

Steps to produce:
- Sales > Configuration > Sale Orders > Quotation Templates.
- Create a new Quotation Template > Fill the necessary details.
- In PDF Quote Builder > Header Pages > Add a pdf which is corrupted, or does not have EOF.
- Create a new quotation, add the newly created quotation template.
- Save the details and preview the quotation.
- In the preview of quotaion click on `View Details` button.
- or after saving the details open the tree view of quotations
  select the quotation in which you kept newly created quotation
  template and then click on print then `PDF Quote`.

Error:
```
PdfReadError: EOF marker not found
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1873, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/sale/controllers/portal.py", line 128, in portal_order_page
    return self._show_report(
  File "addons/portal/controllers/portal.py", line 491, in _show_report
    report = getattr(ReportAction, method_name)(report_ref, list(model.ids), data={'report_type': report_type})[0]
  File "addons/account/models/ir_actions_report.py", line 58, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "odoo/addons/base/models/ir_actions_report.py", line 839, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "addons/sale_pdf_quote_builder/models/ir_actions_report.py", line 44, in _render_qweb_pdf_prepare_streams
    header_stream = pdf.fill_form_fields_pdf(header_stream, so_form_fields)
  File "odoo/tools/pdf.py", line 104, in fill_form_fields_pdf
    reader = PdfFileReader(io.BytesIO(document), strict=False)
  File "odoo/tools/pdf.py", line 221, in <lambda>
    old_init(self, stream=stream, strict=strict, warndest=None, overwriteWarnings=False)
  File "PyPDF2/pdf.py", line 1084, in __init__
    self.read(stream)
  File "PyPDF2/pdf.py", line 1696, in read
    raise utils.PdfReadError("EOF marker not found")
   ```

This commit does not allow user to upload corrupted pdf as header and footer pages of Quotation templates.

sentry-4621647394

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
