### PR TITLE
[FIX] hr_gamification: allow granting badges to user without employee

### DIFF
--- a/addons/hr_gamification/models/gamification.py
+++ b/addons/hr_gamification/models/gamification.py
@@ -14,7 +14,7 @@ class GamificationBadgeUser(models.Model):
     @api.constrains('employee_id')
     def _check_employee_related_user(self):
         for badge_user in self:
-            if badge_user.employee_id not in badge_user.user_id.\
+            if badge_user.employee_id and badge_user.employee_id not in badge_user.user_id.\
                 with_context(allowed_company_ids=self.env.user.company_ids.ids).employee_ids:
                 raise ValidationError(_('The selected employee does not correspond to the selected user.'))
 

--- a/addons/hr_gamification/wizard/gamification_badge_user_wizard.py
+++ b/addons/hr_gamification/wizard/gamification_badge_user_wizard.py
@@ -8,18 +8,14 @@ from odoo.exceptions import UserError, AccessError
 class GamificationBadgeUserWizard(models.TransientModel):
     _inherit = 'gamification.badge.user.wizard'
 
-    employee_id = fields.Many2one('hr.employee', string='Employee', required=True)
-    user_id = fields.Many2one('res.users', string='User', related='employee_id.user_id',
-        store=False, readonly=True, compute_sudo=True)
+    employee_id = fields.Many2one('hr.employee', string='Employee', required=False)
+    user_id = fields.Many2one('res.users', string='User', compute='_compute_user_id',
+        store=True, readonly=False, compute_sudo=True)
 
     def action_grant_badge(self):
         """Wizard action for sending a badge to a chosen employee"""
-        if not self.user_id:
-            raise UserError(_('You can send badges only to employees linked to a user.'))
-
         if self.env.uid == self.user_id.id:
             raise UserError(_('You can not send a badge to yourself.'))
-
         values = {
             'user_id': self.user_id.id,
             'sender_id': self.env.uid,
@@ -29,3 +25,8 @@ class GamificationBadgeUserWizard(models.TransientModel):
         }
 
         return self.env['gamification.badge.user'].create(values)._send_badge()
+
+    @api.depends('employee_id')
+    def _compute_user_id(self):
+        for wizard in self:
+            wizard.user_id = wizard.employee_id.user_id

--- a/addons/hr_gamification/wizard/gamification_badge_user_wizard_views.xml
+++ b/addons/hr_gamification/wizard/gamification_badge_user_wizard_views.xml
@@ -7,11 +7,9 @@
             <field name="inherit_id" ref="gamification.view_badge_wizard_grant" />
             <field name="arch" type="xml">
                 <data>
-                    <field name="user_id" position="attributes">
-                        <attribute name="invisible">True</attribute>
-                    </field>
+                    <!--remove in master-->
                     <xpath expr="//field[@name='user_id']" position="after">
-                        <field name="employee_id" nolabel="1" domain="[('user_id', '!=', False),('user_id', '!=', uid)]" />
+                        <field name="employee_id" nolabel="1" invisible="1" domain="[('user_id', '!=', False),('user_id', '!=', uid)]" />
                     </xpath>
                 </data>
             </field>


### PR DESCRIPTION
When hr_gamification is installed, it's not possible to grant badges to users that don't have associated employees.

Expected behavior: we should be able to grant badges to any users.

This is because user_id was related field with employee_id. We remove that dependency.

task - 3593382
