### PR TITLE
[FIX] web: correct z-index css for no content

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -23,7 +23,7 @@
     --KanbanColumn__highlight-background: #{rgba($o-info, 0.05)};
     --KanbanColumn__highlight-border: #{$o-info};
 
-    --o-view-nocontent-zindex: 1;
+    --o-view-nocontent-zindex: -1;
     // ----------------------------------------------------------------------------
 
     .dropdown,


### PR DESCRIPTION
Version:
--------
V16.0 only

Steps to reproduce:
-------------------
- go to the kanban view;
- group projects;
- search for a particular project;
- click on the dropdown button to get the project settings;

Issue:
------
It is difficult to click on "Settings" for the part that hovers the right-hand column.

Cause:
------
Since commit [^1], the `z-index` of the column for group creation has been set to `2`.
In the documentation [^2], the following rule creates a new Stacking Context:

> Element with a position value absolute or relative and z-index value other than auto.

Even if the `z-index` of the kanban card is `1000` we are still below a `z-index` of `2` of a higher Stacking Context.

Solution:
---------
Force the `z-index` to `-1` to obtain `0` according to the rule:
```css
z-index: calc(var(--o-view-nocontent-zindex) + 1);
```
We won't create a new Stacking Context and the kanban card will be above the column.

[^1]: e95e2a23bc168815a27a9c64e4ff9394de468ada
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_positioned_layout/Understanding_z-index/Stacking_context

opw-3510640