### PR TITLE
[FIX] microsoft_calendar: events duplicated reinstalling Outlook Calendar

### DIFF
--- a/addons/microsoft_calendar/tests/test_microsoft_event.py
+++ b/addons/microsoft_calendar/tests/test_microsoft_event.py
@@ -280,11 +280,14 @@ class TestMicrosoftEvent(TestCommon):
     def test_ignore_not_found_items(self):
 
         # arrange
+        start_date = datetime(2023, 11, 27, 17, 25)
         events = MicrosoftEvent([{
             "type": "singleInstance",
             "_odoo_id": False,
             "iCalUId": "UNKNOWN_EVENT",
             "id": "UNKNOWN_EVENT",
+            'start': {'dateTime': (start_date).isoformat(), 'timeZone': 'UTC'},
+            'end': {'dateTime': (start_date + relativedelta(minutes=30)).isoformat(), 'timeZone': 'UTC'},
         }])
 
         # act


### PR DESCRIPTION
Work in progress 👷

When reinstalling the Outlook Calendar app and activating the sync again leads to duplicated events. This happens due to the loss of 'microsoft_id' field when uninstalling Outlook. This way, when the app is reinstalled and the sync is activated, all events in Outlook (without 'microsoft_id') are recreated on Outlook side and spam attendees.