### PR TITLE
[FIX] mrp_account:  take int values of analyticdistribution when creating work center

### DIFF
--- a/addons/mrp_account/models/mrp_workcenter.py
+++ b/addons/mrp_account/models/mrp_workcenter.py
@@ -13,7 +13,7 @@ class MrpWorkcenter(models.Model):
     @api.depends('analytic_distribution')
     def _compute_costs_hour_account_ids(self):
         for record in self:
-            record.costs_hour_account_ids = list(map(int, record.analytic_distribution.keys())) if record.analytic_distribution else []
+            record.costs_hour_account_ids = list(map(int, (key for key in record.analytic_distribution.keys() if key.isdigit()))) if record.analytic_distribution else []
 
     @api.constrains('analytic_distribution')
     def _check_analytic(self):


### PR DESCRIPTION
This traceback arises when the user tries to create a new work center with 
`analytic distribution` values

To reproduce this issue:

1. Install `mrp_account`
2. Open `settings>User&company>groups`
3. Search `Analytic distribution` and give permissions to the current user
4. Open `manufacturing/configuration/work centers`
5. Create a new record and give values to `Analytic Distribution`
6. Try to save the record

Error:
```
ValueError: invalid literal for int() with base 10: '14,4'
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 467, in call_kw
    model.env.flush_all()
  File "odoo/api.py", line 712, in flush_all
    self._recompute_all()
  File "odoo/api.py", line 708, in _recompute_all
    self[field.model_name]._recompute_field(field)
  File "odoo/models.py", line 6825, in _recompute_field
    field.recompute(records)
  File "odoo/fields.py", line 1365, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1338, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1387, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4848, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/mrp_account/models/mrp_workcenter.py", line 16, in _compute_costs_hour_account_ids
    record.costs_hour_account_ids = list(map(int, record.analytic_distribution.keys())) if record.analytic_distribution else []

```

When the user tries to create a record on workcenter with analytic distribution values.
A value error is occuring, because of getting a string value instead of integer during int conversion.

Which leads to the traceback from here

https://github.com/odoo/odoo/blob/2eb769efff0b7b6ddd78376af9cb674a9168572b/addons/mrp_account/models/mrp_workcenter.py#L13-L16

After applying this commit will resolve the issue getting an int value instead of string during int conversion.

sentry-4667862674







