### PR TITLE
[FIX] account: add computed non-stored field to speedup reconciliation

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -45,7 +45,7 @@ class AccountBankStatementLine(models.Model):
         comodel_name='account.move',
         auto_join=True,
         string='Journal Entry', required=True, readonly=True, ondelete='cascade',
-        check_company=True)
+        check_company=True, index='btree')
     statement_id = fields.Many2one(
         comodel_name='account.bank.statement',
         string='Statement',

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -16,7 +16,7 @@ class AccountPayment(models.Model):
     move_id = fields.Many2one(
         comodel_name='account.move',
         string='Journal Entry', required=True, readonly=True, ondelete='cascade',
-        check_company=True)
+        check_company=True, index='btree')
 
     is_reconciled = fields.Boolean(string="Is Reconciled", store=True,
         compute='_compute_reconciliation_status')

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -271,7 +271,7 @@ class AccountPayment(models.Model):
             }
 
         # Decode the reconciliation to keep only invoices.
-        term_lines = self.line_ids.filtered(lambda line: line.account_id.account_type in ('asset_receivable', 'liability_payable'))
+        term_lines = self.receivable_payable_line_ids
         invoices = (term_lines.matched_debit_ids.debit_move_id.move_id + term_lines.matched_credit_ids.credit_move_id.move_id)\
             .filtered(lambda x: x.is_outbound() or x.move_type == 'in_receipt')
         invoices = invoices.sorted(lambda x: x.invoice_date_due or x.date)


### PR DESCRIPTION
Add a computed non-stored field to get the line_ids whose account is either 'liability_payable' or 'asset_receivable'. The result
is stored in the field_cache for the current Transaction, avoiding a possible O(n²) loop when coming from bank_reconcile_widget. This can happen when a given user tries to reconcile a bank_statement_line with a
batch payment containing lots of lines. Because of the call to `_get_reconciled_invoices` in the 
account_edi/account_move:reconcile override, `get_reconciled_amls` is called for each line in the
batch payment. Filtered will therefore be call on move.line_ids for each line, leading to an O(n²) loop, with n the size
of move.line_ids. `self.line_ids` can be big in this context because of this line https://github.com/odoo/enterprise/blob/450499ee6834572859abba807231e3df758c9bdc/account_accountant/models/bank_rec_widget.py#L1804.

Also, add missing b-tree indexes on move_id in account_payment and account_bank_statement_line. This speeds up
queries produced when reconciling batch payments in the bank_rec_widget

#### speedup
Customer database with 4000 bank.statement.lines, 29 batch.payments, 150 000 account.moves, 1.2M account.move.lines,
130 000 payments. Customer is trying to reconcile a single bank statement line with a batch payment of 3633 payments.

##### Speedscope

- [arxi_reconcile_batch_payments_before_pr.json](https://github.com/odoo/odoo/files/13476643/arxi_reconcile_batch_payments_before_pr.json)
- [arxi_reconcile_batch_payments_after_pr.json](https://github.com/odoo/odoo/files/13476650/arxi_reconcile_batch_payments_after_pr.json)

##### Flamegraph
Before
![account_batch_payment_reconcile_before_pr](https://github.com/odoo/odoo/assets/9673274/2b4092c0-8853-4fa5-aad0-3aefd3e69593)
After
![account_batch_payment_reconcile_after_pr](https://github.com/odoo/odoo/assets/9673274/ad58c77f-b548-4096-b12b-358afd8e0696)

##### Pgbadger slowest queries

![arxi_slowest](https://github.com/odoo/odoo/assets/9673274/3a789b8e-2657-4b66-83da-d84f2933696d)

The `_get_reconciled_amls` bottleneck is coming from the overriding of `reconcile` in account_edi to retrieve documents
that need to be updated post reconciliation. It would be possible to add a check and skip this step if the lines we are trying to reconcile do not have any document_ids nor are applicable to any edi_format. This would achieve the same speedup but would limit the optimization to batch payments without documents.

**ENT PR**: odoo/enterprise#51607

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
