### PR TITLE
[FIX] hr_recruitment: recruitement_user keeps access when interviewer

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment.py
+++ b/addons/hr_recruitment/models/hr_recruitment.py
@@ -459,7 +459,7 @@ class Applicant(models.Model):
 
     @api.model
     def get_view(self, view_id=None, view_type='form', **options):
-        if view_type == 'form' and self.user_has_groups('hr_recruitment.group_hr_recruitment_interviewer'):
+        if view_type == 'form' and self.user_has_groups('hr_recruitment.group_hr_recruitment_interviewer') and not self.user_has_groups('hr_recruitment.group_hr_recruitment_user'):
             view_id = self.env.ref('hr_recruitment.hr_applicant_view_form_interviewer').id
         return super().get_view(view_id, view_type, **options)
 

--- a/addons/hr_recruitment/models/ir_ui_menu.py
+++ b/addons/hr_recruitment/models/ir_ui_menu.py
@@ -9,6 +9,6 @@ class IrUiMenu(models.Model):
 
     def _load_menus_blacklist(self):
         res = super()._load_menus_blacklist()
-        if self.env.user.has_group('hr_recruitment.group_hr_recruitment_interviewer'):
+        if self.env.user.has_group('hr_recruitment.group_hr_recruitment_interviewer') and not self.env.user.has_group('hr_recruitment.group_hr_recruitment_user'):
             res.append(self.env.ref('hr_recruitment.menu_hr_job_position').id)
         return res


### PR DESCRIPTION
Issue:
======
When a recruitement user has the recruitement interviewer group , will lose the access he has as a user, he will be treated as only interviewer.

Steps to reproduce the error:
=============================
- Added recruitement interviewer access right to admin
- Go back to app page and refresh the page.
- Go to recruitement, you won't see any available jobs
- You can also see the network call has a domain restricting the jobs to only the ones where he is interviewer.

Origin of the iusse:
====================
The recruitement user view was blacklisted for the interviewer user without checking if the user is also a recruitement user.

opw-3599958