### PR TITLE
[FIX] resource: fixed singleton for calendar attendance

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -488,7 +488,7 @@ class ResourceCalendar(models.Model):
             # take durations in days proportionally to what is left of the interval.
             interval_hours = (stop - start).total_seconds() / 3600
             day_hours[start.date()] += interval_hours
-            day_days[start.date()] += meta.duration_days * interval_hours / meta.duration_hours
+            day_days[start.date()] += sum(meta.mapped('duration_days')) * interval_hours / sum(meta.mapped('duration_hours'))
 
         return {
             # Round the number of days to the closest 16th of a day.


### PR DESCRIPTION
when it tried to compute duration of `intervals
from this function `_get_attendance_intervals_days_data` we got multiple `resource.calendar.attendance` record and we directly use
` meta.duration_days * interval_hours / meta.duration_hours` so we got traceback.
Error generated during upgraded database.

```
select hour_from,hour_to, resource_id from resource_calendar_attendance where calendar_id = 1 and id in (7,8);
 hour_from | hour_to | resource_id
-----------+---------+-------------
        13 |      17 |
         9 |      13 |
(2 rows)

  File "/home/odoo/src/odoo/17.0/addons/hr_holidays/models/hr_leave.py", line 556, in _get_duration
    work_days_data = self.employee_id._get_work_days_data_batch(self.date_from, self.date_to, domain=domain, calendar=resource_calendar)[self.employee_id.id]
  File "/home/odoo/src/odoo/17.0/addons/resource/models/resource_mixin.py", line 116, in _get_work_days_data_batch
    result[calendar_resource.id] = calendar._get_attendance_intervals_days_data(intervals[calendar_resource.id])
  File "/home/odoo/src/odoo/17.0/addons/resource/models/resource_calendar.py", line 502, in _get_attendance_intervals_days_data
    day_days[start.date()] += meta.duration_days * interval_hours / meta.duration_hours
  File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1146, in __get__
    record.ensure_one()
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 5819, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
ValueError: Expected singleton: resource.calendar.attendance(7, 8)
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
