### PR TITLE
[IMP] mail: sort attachments on basis of type in discuss and chatter.

### DIFF
--- a/addons/mail/static/src/core/common/attachment_list.js
+++ b/addons/mail/static/src/core/common/attachment_list.js
@@ -17,7 +17,13 @@ import { url } from "@web/core/utils/urls";
  * @extends {Component<Props, Env>}
  */
 export class AttachmentList extends Component {
-    static props = ["attachments", "unlinkAttachment", "imagesHeight", "messageSearch?"];
+    static props = [
+        "attachments",
+        "unlinkAttachment",
+        "imagesHeight",
+        "maxWidth?",
+        "messageSearch?",
+    ];
     static template = "mail.AttachmentList";
 
     setup() {

--- a/addons/mail/static/src/core/common/attachment_list.xml
+++ b/addons/mail/static/src/core/common/attachment_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentList">
-        <div class="o-mail-AttachmentList overflow-y-auto d-flex flex-column mt-1"
+        <div class="o-mail-AttachmentList d-flex flex-column mt-1"
             t-att-class="{
                 'o-inComposer': env.inComposer,
                 'o-inChatWindow': env.inChatWindow,
@@ -24,11 +24,11 @@
                     t-on-click="() => this.fileViewer.open(attachment, props.attachments)"
                 >
                     <img
-                        class="img img-fluid my-0 mx-auto o-viewable"
+                        class="img img-fluid my-0 o-viewable"
                         t-att-class="{ 'opacity-25': attachment.uploading }"
                         t-att-src="getImageUrl(attachment)"
                         t-att-alt="attachment.name"
-                        t-attf-style="max-width: min(100%, {{ imagesWidth }}px); max-height: {{ props.imagesHeight }}px;"
+                        t-attf-style="max-width: min(100%, {{ props.maxWidth ? props.maxWidth : imagesWidth }}px); max-height: {{ props.imagesHeight }}px;"
                         t-on-load="onImageLoaded"
                     />
                     <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">

--- a/addons/mail/static/src/core/common/link_preview.js
+++ b/addons/mail/static/src/core/common/link_preview.js
@@ -14,7 +14,7 @@ import { useService } from "@web/core/utils/hooks";
  */
 export class LinkPreview extends Component {
     static template = "mail.LinkPreview";
-    static props = ["linkPreview", "deletable"];
+    static props = ["linkPreview", "deletable", "asAttachment?"];
     static components = {};
 
     setup() {

--- a/addons/mail/static/src/core/common/link_preview.scss
+++ b/addons/mail/static/src/core/common/link_preview.scss
@@ -70,3 +70,16 @@
         display: block;
     }
 }
+
+.o-mail-Attachement-LinkPreviewImage img {
+    max-height: $o-mail-LinkPreview-height;
+}
+
+.o-mail-ImageLinkPreviewCard {
+    max-height: 5em;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 4;
+    -webkit-box-orient: vertical;
+    text-overflow: ellipsis;
+}

--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -9,17 +9,25 @@
             <t t-call="mail.LinkPreviewVideo"/>
         </t>
         <t t-if="props.linkPreview.isImage">
-            <t t-call="mail.LinkPreviewImage"/>
+            <t t-if="props.asAttachment" t-call="mail.LinkPreviewImage">
+                <t t-set="className" t-value="'o-mail-Attachement-LinkPreviewImage'"/>
+            </t>
+            <t t-else="" t-call="mail.LinkPreviewImage"/>
         </t>
     </t>
 
     <t t-name="mail.LinkPreviewCard">
         <div class="o-mail-LinkPreviewCard card position-relative w-100 mb-2 rounded bg-view shadow-sm overflow-hidden" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
             <div class="row g-0 flex-row-reverse h-100">
-                <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !props.linkPreview.og_description }">
+                <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !props.linkPreview.og_description and !props.asAttachment }">
                     <div class="p-3">
                         <h6 class="card-title mb-0 me-2" t-attf-class="{{ props.linkPreview.og_description ? 'text-truncate' : 'overflow-hidden' }}">
-                            <a t-att-href="props.linkPreview.source_url" target="_blank" t-out="props.linkPreview.og_title"/>
+                            <t t-if="props.linkPreview.og_title">
+                                <a t-att-href="props.linkPreview.source_url" target="_blank" t-out="props.linkPreview.og_title"/>
+                            </t>
+                            <t t-else="">
+                                <a class="o-mail-ImageLinkPreviewCard" t-att-href="props.linkPreview.source_url" target="_blank" t-out="props.linkPreview.source_url"/>
+                            </t>
                         </h6>
                         <span t-if="props.linkPreview.og_site_name" t-out="props.linkPreview.og_site_name"/>
                         <p t-if="props.linkPreview.og_description" class="o-mail-LinkPreviewCard-description card-text mb-0 mt-2 text-muted small overflow-hidden" t-out="props.linkPreview.og_description"/>
@@ -42,9 +50,14 @@
 
     <t t-name="mail.LinkPreviewImage">
         <div class="o-mail-LinkPreviewImage position-relative mb-2" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
-            <a t-if="props.linkPreview.imageUrl" t-att-href="props.linkPreview.imageUrl" target="_blank">
-                <img class="h-auto w-auto rounded" t-att-src="props.linkPreview.imageUrl" t-on-load="onImageLoaded"/>
-            </a>
+            <t t-if="props.asAttachment">
+                <t t-call="mail.LinkPreviewCard" />
+            </t>
+            <t t-else="">
+                <a t-if="props.linkPreview.imageUrl" t-att-href="props.linkPreview.imageUrl" target="_blank">
+                    <img class="h-auto w-auto rounded" t-att-src="props.linkPreview.imageUrl" t-on-load="onImageLoaded"/>
+                </a>
+            </t>
             <t t-if="props.deletable" t-call="mail.LinkPreview.aside">
                 <t t-set="className" t-value="'btn btn-sm btn-dark mt-2 me-2 rounded opacity-75 opacity-100-hover'"/>
             </t>

--- a/addons/mail/static/src/core/common/link_preview.xml
+++ b/addons/mail/static/src/core/common/link_preview.xml
@@ -9,10 +9,9 @@
             <t t-call="mail.LinkPreviewVideo"/>
         </t>
         <t t-if="props.linkPreview.isImage">
-            <t t-if="props.asAttachment" t-call="mail.LinkPreviewImage">
-                <t t-set="className" t-value="'o-mail-Attachement-LinkPreviewImage'"/>
+            <t t-call="mail.LinkPreviewImage">
+                <t t-set="className" t-value="'o-mail-Attachement-LinkPreviewImage' ? this.props.asAttachment : ''" />
             </t>
-            <t t-else="" t-call="mail.LinkPreviewImage"/>
         </t>
     </t>
 
@@ -22,12 +21,7 @@
                 <div class="col min-w-0" t-att-class="{ 'd-flex align-items-center': !props.linkPreview.og_description and !props.asAttachment }">
                     <div class="p-3">
                         <h6 class="card-title mb-0 me-2" t-attf-class="{{ props.linkPreview.og_description ? 'text-truncate' : 'overflow-hidden' }}">
-                            <t t-if="props.linkPreview.og_title">
-                                <a t-att-href="props.linkPreview.source_url" target="_blank" t-out="props.linkPreview.og_title"/>
-                            </t>
-                            <t t-else="">
-                                <a class="o-mail-ImageLinkPreviewCard" t-att-href="props.linkPreview.source_url" target="_blank" t-out="props.linkPreview.source_url"/>
-                            </t>
+                            <a t-att-class="!props.linkPreview.og_title ? 'o-mail-ImageLinkPreviewCard' : ''" t-att-href="props.linkPreview.source_url" target="_blank" t-out="props.linkPreview.og_title || props.linkPreview.source_url"/>
                         </h6>
                         <span t-if="props.linkPreview.og_site_name" t-out="props.linkPreview.og_site_name"/>
                         <p t-if="props.linkPreview.og_description" class="o-mail-LinkPreviewCard-description card-text mb-0 mt-2 text-muted small overflow-hidden" t-out="props.linkPreview.og_description"/>
@@ -50,14 +44,10 @@
 
     <t t-name="mail.LinkPreviewImage">
         <div class="o-mail-LinkPreviewImage position-relative mb-2" t-att-class="{ 'me-2': env.inChatter }" t-attf-class="{{ className }}">
-            <t t-if="props.asAttachment">
-                <t t-call="mail.LinkPreviewCard" />
-            </t>
-            <t t-else="">
-                <a t-if="props.linkPreview.imageUrl" t-att-href="props.linkPreview.imageUrl" target="_blank">
-                    <img class="h-auto w-auto rounded" t-att-src="props.linkPreview.imageUrl" t-on-load="onImageLoaded"/>
-                </a>
-            </t>
+            <t t-if="props.asAttachment" t-call="mail.LinkPreviewCard" />
+            <a t-elif="props.linkPreview.imageUrl" t-att-href="props.linkPreview.imageUrl" target="_blank">
+                <img class="h-auto w-auto rounded" t-att-src="props.linkPreview.imageUrl" t-on-load="onImageLoaded"/>
+            </a>
             <t t-if="props.deletable" t-call="mail.LinkPreview.aside">
                 <t t-set="className" t-value="'btn btn-sm btn-dark mt-2 me-2 rounded opacity-75 opacity-100-hover'"/>
             </t>

--- a/addons/mail/static/src/core/common/link_preview_list.js
+++ b/addons/mail/static/src/core/common/link_preview_list.js
@@ -12,9 +12,10 @@ import { Component } from "@odoo/owl";
  */
 export class LinkPreviewList extends Component {
     static template = "mail.LinkPreviewList";
-    static props = ["linkPreviews", "deletable?"];
+    static props = ["linkPreviews", "deletable?", "asAttachment?"];
     static defaultProps = {
         deletable: false,
+        asAttachment: false,
     };
     static components = { LinkPreview };
 }

--- a/addons/mail/static/src/core/common/link_preview_list.xml
+++ b/addons/mail/static/src/core/common/link_preview_list.xml
@@ -4,7 +4,7 @@
         <div class="o-mail-LinkPreviewList d-flex flex-column mt-2" t-att-class="{ 'me-2 pe-4': env.inChatWindow and !env.alignedRight, 'ms-2 ps-4': env.inChatWindow and env.alignedRight }">
             <div class="d-flex flex-grow-1 flex-wrap">
                 <t t-foreach="props.linkPreviews" t-as="linkPreview" t-key="linkPreview.id">
-                   <LinkPreview linkPreview="linkPreview" deletable="props.deletable"/>
+                   <LinkPreview linkPreview="linkPreview" deletable="props.deletable" asAttachment="props.asAttachment"/>
                 </t>
             </div>
         </div>

--- a/addons/mail/static/src/core/common/link_preview_model.js
+++ b/addons/mail/static/src/core/common/link_preview_model.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { Record } from "@mail/core/common/record";
+import { deserializeDateTime } from "@web/core/l10n/dates";
 
 export class LinkPreview extends Record {
     static id = "id";
@@ -47,6 +48,15 @@ export class LinkPreview extends Record {
 
     get isCard() {
         return !this.isImage && !this.isVideo;
+    }
+
+    get monthYear() {
+        const message = this.message ?? this._store.Message.get(this.message_id);
+        if (!message) {
+            return undefined;
+        }
+        const datetime = deserializeDateTime(message.create_date);
+        return `${datetime.monthLong}, ${datetime.year}`;
     }
 }
 

--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { AttachmentList } from "@mail/core/common/attachment_list";
+import { AttachmentPanel } from "@mail/discuss/core/common/attachment_panel";
 import { useAttachmentUploader } from "@mail/core/common/attachment_uploader_hook";
 import { Composer } from "@mail/core/common/composer";
 import { useDropzone } from "@mail/core/common/dropzone_hook";
@@ -12,8 +13,6 @@ import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { RecipientList } from "./recipient_list";
 import { FollowerList } from "./follower_list";
 import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
-import { LinkPreview } from "@mail/core/common/link_preview";
-import { AttachmentPanel } from "@mail/discuss/core/common/attachment_panel";
 
 import {
     Component,
@@ -46,6 +45,7 @@ export class Chatter extends Component {
     static template = "mail.Chatter";
     static components = {
         AttachmentList,
+        AttachmentPanel,
         Dropdown,
         Thread,
         Composer,
@@ -54,8 +54,6 @@ export class Chatter extends Component {
         FollowerList,
         SuggestedRecipientsList,
         SearchMessagesPanel,
-        LinkPreview,
-        AttachmentPanel,
     };
     static props = [
         "close?",
@@ -425,16 +423,10 @@ export class Chatter extends Component {
 
     get attachmentCount() {
         const { thread } = this.state;
-        const mediaAttachments =
-            thread?.attachments.filter((attachment) => attachment.isMedia)?.length || 0;
-        const linkPreviews =
-            thread?.messages.reduce(
-                (count, message) => count + (message.linkPreviews?.length > 0 ? 1 : 0),
-                0
-            ) || 0;
-        const fileAttachments =
-            thread?.attachments.filter((attachment) => !attachment.isMedia)?.length || 0;
-
-        return mediaAttachments + linkPreviews + fileAttachments;
+        return (
+            (thread?.attachments.length || 0) +
+            (thread?.messages.reduce((count, message) => count + message.linkPreviews?.length, 0) ||
+                0)
+        );
     }
 }

--- a/addons/mail/static/src/core/web/chatter.js
+++ b/addons/mail/static/src/core/web/chatter.js
@@ -12,6 +12,8 @@ import { isDragSourceExternalFile } from "@mail/utils/common/misc";
 import { RecipientList } from "./recipient_list";
 import { FollowerList } from "./follower_list";
 import { SearchMessagesPanel } from "@mail/core/common/search_messages_panel";
+import { LinkPreview } from "@mail/core/common/link_preview";
+import { AttachmentPanel } from "@mail/discuss/core/common/attachment_panel";
 
 import {
     Component,
@@ -52,6 +54,8 @@ export class Chatter extends Component {
         FollowerList,
         SuggestedRecipientsList,
         SearchMessagesPanel,
+        LinkPreview,
+        AttachmentPanel,
     };
     static props = [
         "close?",
@@ -379,7 +383,7 @@ export class Chatter extends Component {
     }
 
     onClickAddAttachments() {
-        if (this.attachments.length === 0) {
+        if (this.attachmentCount === 0) {
             return;
         }
         this.state.isAttachmentBoxOpened = !this.state.isAttachmentBoxOpened;
@@ -417,5 +421,20 @@ export class Chatter extends Component {
             return this.recipientsPopover.close();
         }
         this.recipientsPopover.open(ev.target, { thread: this.state.thread });
+    }
+
+    get attachmentCount() {
+        const { thread } = this.state;
+        const mediaAttachments =
+            thread?.attachments.filter((attachment) => attachment.isMedia)?.length || 0;
+        const linkPreviews =
+            thread?.messages.reduce(
+                (count, message) => count + (message.linkPreviews?.length > 0 ? 1 : 0),
+                0
+            ) || 0;
+        const fileAttachments =
+            thread?.attachments.filter((attachment) => !attachment.isMedia)?.length || 0;
+
+        return mediaAttachments + linkPreviews + fileAttachments;
     }
 }

--- a/addons/mail/static/src/core/web/chatter.scss
+++ b/addons/mail/static/src/core/web/chatter.scss
@@ -54,3 +54,7 @@
 .o-mail-Chatter button.o-active {
     color: $o-action !important;
 }
+
+.o-mail-ActionPanel-header {
+    z-index: $o-mail-NavigableList-zIndex - 3 !important;
+}

--- a/addons/mail/static/src/core/web/chatter.xml
+++ b/addons/mail/static/src/core/web/chatter.xml
@@ -29,7 +29,7 @@
                     <button class="btn btn-link text-action" t-att-class="{ 'o-active': state.isSearchOpen }" aria-label="Search Messages" title="Search Messages" t-on-click="onClickSearch">
                         <i class="oi oi-search" role="img"/>
                     </button>
-                    <FileUploader t-if="attachments.length === 0" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
+                    <FileUploader t-if="this.attachmentCount === 0" fileUploadClass="'o-mail-Chatter-fileUploader'" multiUpload="true" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                         <t t-set-slot="toggler">
                             <t t-call="mail.Chatter.attachFiles"/>
                         </t>
@@ -97,20 +97,9 @@
                 <t t-if="props.hasActivities and activities.length and !state.isSearchOpen">
                     <t t-call="mail.ActivityList"/>
                 </t>
-                <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative" t-ref="attachment-box">
-                    <div class="d-flex align-items-center">
-                        <hr class="flex-grow-1"/>
-                        <span class="p-3 fw-bold">
-                            Files
-                        </span>
-                        <hr class="flex-grow-1"/>
-                    </div>
+                <div t-if="state.isAttachmentBoxOpened" class="o-mail-AttachmentBox position-relative py-1 px-3" t-ref="attachment-box">
                     <div class="d-flex flex-column">
-                        <AttachmentList
-                            attachments="attachments"
-                            unlinkAttachment.bind="unlinkAttachment"
-                            imagesHeight="100"
-                        />
+                        <AttachmentPanel thread="this.state.thread" />
                         <FileUploader multiUpload="true" fileUploadClass="'o-mail-Chatter-fileUploader'" onUploaded.bind="onUploaded" onClick="(ev) => this.onClickAttachFile(ev)">
                             <t t-set-slot="toggler">
                                 <button class="btn btn-link" type="button" t-att-disabled="!state.thread.hasWriteAccess">
@@ -152,7 +141,7 @@
 <t t-name="mail.Chatter.attachFiles">
     <button class="o-mail-Chatter-attachFiles btn btn-link text-action px-1 d-flex align-items-center" aria-label="Attach files" t-att-class="{ 'my-2': !props.compactHeight }" t-on-click="onClickAddAttachments" t-att-disabled="state.isSearchOpen">
         <i class="fa fa-paperclip fa-lg me-1"/>
-        <span t-if="attachments.length > 0" t-esc="attachments.length"/>
+        <span t-if="attachmentCount" t-esc="attachmentCount"/>
         <i t-if="!state.thread.areAttachmentsLoaded and state.thread.isLoadingAttachments and state.showAttachmentLoading" class="fa fa-circle-o-notch fa-spin" aria-label="Attachment counter loading..."/>
     </button>
 </t>

--- a/addons/mail/static/src/discuss/core/common/action_panel.js
+++ b/addons/mail/static/src/discuss/core/common/action_panel.js
@@ -13,5 +13,6 @@ export class ActionPanel extends Component {
     static props = {
         title: { type: String, optional: true },
         slots: { type: Object, optional: true },
+        asAttachment: { type: Boolean, optional: true },
     };
 }

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -8,9 +8,12 @@
                     <i class="oi oi-arrow-left"/>
                 </button>
                 <div class="d-flex align-items-center fw-bolder w-100">
-                    <hr class="ms-3 flex-grow-1"/>
+                    <t t-if="props.asAttachment">
+                        <hr class="ms-3 flex-grow-1"/>
                         <p t-if="props.title" class="fs-6 fw-bold text-uppercase m-0 text-700 px-3" t-esc="props.title"/>
-                    <hr class="me-3 flex-grow-1"/>
+                        <hr class="me-3 flex-grow-1"/>
+                    </t>
+                    <p t-elif="props.title" class="fs-6 fw-bold text-uppercase m-0 text-700 flex-grow-1" t-esc="props.title"/>
                 </div>
             </div>
             <t t-slot="default"/>

--- a/addons/mail/static/src/discuss/core/common/action_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/action_panel.xml
@@ -7,7 +7,11 @@
                 <button t-if="env.closeActionPanel" class="o-mail-ActionPanel-backButton btn opacity-75 opacity-100-hover ps-0 py-0 fs-5" title="Close panel" t-on-click.stop="env.closeActionPanel">
                     <i class="oi oi-arrow-left"/>
                 </button>
-                <p t-if="props.title" class="fs-6 fw-bold text-uppercase m-0 text-700 flex-grow-1" t-esc="props.title"/>
+                <div class="d-flex align-items-center fw-bolder w-100">
+                    <hr class="ms-3 flex-grow-1"/>
+                        <p t-if="props.title" class="fs-6 fw-bold text-uppercase m-0 text-700 px-3" t-esc="props.title"/>
+                    <hr class="me-3 flex-grow-1"/>
+                </div>
             </div>
             <t t-slot="default"/>
         </div>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.scss
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.scss
@@ -1,0 +1,3 @@
+.o-mail-AttachmentPanelCategory-title.o-selected{
+    border-bottom: 2px solid var(--primary);
+}

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.xml
@@ -11,16 +11,51 @@
                     <t t-else="">File upload is disabled for external users</t>
                 </label>
             </div>
-            <div class="flex-grow-1" t-att-class="{
-                'd-flex justify-content-center align-items-center': props.thread.attachments.length === 0,
-            }">
-                <p t-if="props.thread.attachments.length === 0" class="text-center fst-italic text-500">
-                    <t t-if="props.thread.type === 'channel'">This channel doesn't have any attachments.</t>
-                    <t t-else="">This conversation doesn't have any attachments.</t>
-                </p>
-                <div t-else="" t-foreach="attachmentsByDate" t-as="dateDay" t-key="dateDay" class="d-flex flex-column">
-                    <DateSection date="dateDay" className="'my-1'"/>
-                    <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+            <div class="d-flex flex-column flex-grow-1">
+                <div class=".o-mail-AttachmentpanelCategory d-flex flex-row justify-content-around" t-on-click="(ev) => this.state.current = ev.target.dataset.tab">
+                    <span class="o-mail-AttachmentPanelCategory-title o-mail-Attachment-media text-center w-100 cursor-pointer" t-att-class="this.state.current === 'media' ? 'o-selected' : '' " data-tab="media" data-title="media">
+                        Media
+                    </span>
+                    <span class="o-mail-AttachmentPanelCategory-title o-mail-Attachment-link text-center w-100 cursor-pointer" t-att-class="this.state.current === 'links' ? 'o-selected' : '' " data-tab="links" data-title="link">
+                        Links
+                    </span>
+                    <span class="o-mail-AttachmentPanelCategory-title o-mail-Attachment-file text-center w-100 cursor-pointer" t-att-class="this.state.current === 'files' ? 'o-selected' : '' " data-tab="files" data-title="file">
+                        Files
+                    </span>
+                </div>
+                <div class="o-mail-attachmentPanel-Media" t-if="state.current === 'media'">
+                    <p t-if="Object.keys(this.mediaAttachmentsByDate).length === 0" class="text-center fst-italic text-500 mt-4">
+                        <t t-if="props.thread.type === 'channel'">This channel doesn't have any media attachments.</t>
+                        <t t-else="" >This conversation doesn't have any media attachments.</t>
+                    </p>
+                    <div t-foreach="mediaAttachmentsByDate" t-as="dateDay" t-key="dateDay">
+                        <DateSection date="dateDay" className="'my-1'"/>
+                        <AttachmentList imagesHeight="100" maxWidth="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                    </div>
+                </div>
+                <div class="o-mail-attachmentPanel-Link" t-elif="state.current === 'links'">
+                    <p t-if="Object.keys(this.linkAttachmentsByDate).length === 0" class="text-center fst-italic text-500 mt-4">
+                        <t t-if="props.thread.type === 'channel'">This channel doesn't have any links.</t>
+                        <t t-else="">This conversation doesn't have any links.</t>
+                    </p>
+                    <div t-foreach="linkAttachmentsByDate" t-as="links" t-key="link">
+                        <DateSection date="links" className="'my-1'"/>
+                        <div class="o-mail-linkAttachment d-flex flex-wrap">
+                            <t t-foreach="links_value" t-as="links" t-key="links.id">
+                                <LinkPreview linkPreview="links" deletable="false" asAttachment="true"/>
+                            </t>
+                        </div>
+                    </div>
+                </div>
+                <div class="o-mail-attachmentPanel-File" t-elif="state.current === 'files'">
+                    <p t-if="Object.keys(this.filesAttachmentsByDate).length === 0" class="text-center fst-italic text-500 mt-4">
+                        <t t-if="props.thread.type === 'channel'">This channel doesn't have any file attachments.</t>
+                        <t t-else="">This conversation doesn't have any file attachments.</t>
+                    </p>
+                   <div t-foreach="filesAttachmentsByDate" t-as="dateDay" t-key="dateDay">
+                        <DateSection date="dateDay" className="'my-1'"/>
+                        <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                    </div>
                 </div>
             </div>
             <span t-ref="load-older"/>

--- a/addons/mail/static/src/discuss/core/common/attachment_panel.xml
+++ b/addons/mail/static/src/discuss/core/common/attachment_panel.xml
@@ -3,7 +3,7 @@
 
     <t t-name="mail.AttachmentPanel">
         <t t-set="title">Attachments</t>
-        <ActionPanel title="title">
+        <ActionPanel title="title" asAttachment="true">
             <div t-if="hasToggleAllowPublicUpload" class="form-check form-switch">
                 <label class="form-check-label">
                     <input t-on-change="toggleAllowPublicUpload" class="form-check-input" type="checkbox" role="switch" t-att-checked="props.thread.allow_public_upload"/>
@@ -12,49 +12,25 @@
                 </label>
             </div>
             <div class="d-flex flex-column flex-grow-1">
-                <div class=".o-mail-AttachmentpanelCategory d-flex flex-row justify-content-around" t-on-click="(ev) => this.state.current = ev.target.dataset.tab">
-                    <span class="o-mail-AttachmentPanelCategory-title o-mail-Attachment-media text-center w-100 cursor-pointer" t-att-class="this.state.current === 'media' ? 'o-selected' : '' " data-tab="media" data-title="media">
-                        Media
-                    </span>
-                    <span class="o-mail-AttachmentPanelCategory-title o-mail-Attachment-link text-center w-100 cursor-pointer" t-att-class="this.state.current === 'links' ? 'o-selected' : '' " data-tab="links" data-title="link">
-                        Links
-                    </span>
-                    <span class="o-mail-AttachmentPanelCategory-title o-mail-Attachment-file text-center w-100 cursor-pointer" t-att-class="this.state.current === 'files' ? 'o-selected' : '' " data-tab="files" data-title="file">
-                        Files
-                    </span>
+                <div class="o-mail-AttachmentpanelCategory d-flex flex-row justify-content-around" t-on-click="(ev) => this.state.current = ev.target.dataset.tab">
+                    <t t-foreach="this.attachmentCategories" t-as="category" t-key="category[0]">
+                        <span class="o-mail-AttachmentPanelCategory-title text-center w-100 cursor-pointer"
+                            t-att-class="this.state.current === category[0] ? 'o-selected' : ''"
+                            t-attf-class='o-mail-Attachment-{{ category[0] }}'
+                            t-att-data-tab="category[0]">
+                            <t t-out="category[1]"/>
+                        </span>
+                    </t>
                 </div>
-                <div class="o-mail-attachmentPanel-Media" t-if="state.current === 'media'">
-                    <p t-if="Object.keys(this.mediaAttachmentsByDate).length === 0" class="text-center fst-italic text-500 mt-4">
-                        <t t-if="props.thread.type === 'channel'">This channel doesn't have any media attachments.</t>
-                        <t t-else="" >This conversation doesn't have any media attachments.</t>
+                <div t-attf-class="'o-mail-attachmentPanel-{{ this.state.current }}'">
+                    <p t-if="Object.keys(attachmentsByDate).length === 0" class="text-center fst-italic text-500 mt-4">
+                        <t t-if="props.thread.type === 'channel'">This channel doesn't have any <t t-out="this.state.current"/> attachments.</t>
+                        <t t-else="">This conversation doesn't have any <t t-out="this.state.current"/> attachments.</t>
                     </p>
-                    <div t-foreach="mediaAttachmentsByDate" t-as="dateDay" t-key="dateDay">
-                        <DateSection date="dateDay" className="'my-1'"/>
-                        <AttachmentList imagesHeight="100" maxWidth="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
-                    </div>
-                </div>
-                <div class="o-mail-attachmentPanel-Link" t-elif="state.current === 'links'">
-                    <p t-if="Object.keys(this.linkAttachmentsByDate).length === 0" class="text-center fst-italic text-500 mt-4">
-                        <t t-if="props.thread.type === 'channel'">This channel doesn't have any links.</t>
-                        <t t-else="">This conversation doesn't have any links.</t>
-                    </p>
-                    <div t-foreach="linkAttachmentsByDate" t-as="links" t-key="link">
-                        <DateSection date="links" className="'my-1'"/>
-                        <div class="o-mail-linkAttachment d-flex flex-wrap">
-                            <t t-foreach="links_value" t-as="links" t-key="links.id">
-                                <LinkPreview linkPreview="links" deletable="false" asAttachment="true"/>
-                            </t>
-                        </div>
-                    </div>
-                </div>
-                <div class="o-mail-attachmentPanel-File" t-elif="state.current === 'files'">
-                    <p t-if="Object.keys(this.filesAttachmentsByDate).length === 0" class="text-center fst-italic text-500 mt-4">
-                        <t t-if="props.thread.type === 'channel'">This channel doesn't have any file attachments.</t>
-                        <t t-else="">This conversation doesn't have any file attachments.</t>
-                    </p>
-                   <div t-foreach="filesAttachmentsByDate" t-as="dateDay" t-key="dateDay">
-                        <DateSection date="dateDay" className="'my-1'"/>
-                        <AttachmentList imagesHeight="100" attachments="dateDay_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
+                    <div t-foreach="this.attachmentsByDate" t-as="attachments" t-key="attachments">
+                        <DateSection date="attachments" className="'my-1'"/>
+                        <LinkPreviewList t-if="this.state.current === 'link'" linkPreviews="attachments_value" deletable="false" asAttachment="true"/>
+                        <AttachmentList t-else="" imagesHeight="100" maxWidth="100" attachments="attachments_value" unlinkAttachment="(attachment) => this.attachmentUploadService.unlink(attachment)"/>
                     </div>
                 </div>
             </div>

--- a/addons/mail/static/tests/discuss/core/attachment_panel_tests.js
+++ b/addons/mail/static/tests/discuss/core/attachment_panel_tests.js
@@ -15,15 +15,17 @@ QUnit.test("Empty attachment panel", async () => {
     await openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Show Attachments']");
     await contains(".o-mail-ActionPanel", {
-        contains: ["p", { text: "This channel doesn't have any media attachments." }],
+        text: "This channel doesn't have any media attachments.",
     });
+
     await click(".o-mail-Attachment-link");
     await contains(".o-mail-ActionPanel", {
-        contains: ["p", { text: "This channel doesn't have any links." }],
+        text: "This channel doesn't have any link attachments.",
     });
+
     await click(".o-mail-Attachment-file");
     await contains(".o-mail-ActionPanel", {
-        contains: ["p", { text: "This channel doesn't have any file attachments." }],
+        text: "This channel doesn't have any file attachments.",
     });
 });
 

--- a/addons/mail/static/tests/discuss/core/attachment_panel_tests.js
+++ b/addons/mail/static/tests/discuss/core/attachment_panel_tests.js
@@ -14,8 +14,16 @@ QUnit.test("Empty attachment panel", async () => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Show Attachments']");
-    await contains(".o-mail-Discuss-inspector", {
-        text: "This channel doesn't have any attachments.",
+    await contains(".o-mail-ActionPanel", {
+        contains: ["p", { text: "This channel doesn't have any media attachments." }],
+    });
+    await click(".o-mail-Attachment-link");
+    await contains(".o-mail-ActionPanel", {
+        contains: ["p", { text: "This channel doesn't have any links." }],
+    });
+    await click(".o-mail-Attachment-file");
+    await contains(".o-mail-ActionPanel", {
+        contains: ["p", { text: "This channel doesn't have any file attachments." }],
     });
 });
 
@@ -39,6 +47,7 @@ QUnit.test("Attachment panel sort by date", async () => {
     const { openDiscuss } = await start();
     await openDiscuss(channelId);
     await click(".o-mail-Discuss-header button[title='Show Attachments']");
+    await click(".o-mail-Attachment-file");
     await contains(".o-mail-AttachmentList", {
         text: "file2.pdf",
         after: [".o-mail-DateSection", { text: "September, 2023" }],

--- a/addons/mail/static/tests/web/attachment_box_tests.js
+++ b/addons/mail/static/tests/web/attachment_box_tests.js
@@ -45,6 +45,7 @@ QUnit.test("base non-empty rendering", async () => {
     await contains(".o-mail-AttachmentBox");
     await contains("button", { text: "Attach files" });
     await contains(".o-mail-Chatter input[type='file']");
+    await click(".o-mail-Attachment-file");
     await contains(".o-mail-AttachmentList");
 });
 
@@ -73,9 +74,9 @@ QUnit.test("remove attachment should ask for confirmation", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
+    await click(".o-mail-Attachment-file");
     await contains(".o-mail-AttachmentCard");
     await contains("button[title='Remove']");
-
     await click("button[title='Remove']");
     await contains(".modal-body", { text: 'Do you really want to delete "Blah.txt"?' });
 
@@ -115,6 +116,7 @@ QUnit.test("view attachments", async () => {
         res_model: "res.partner",
         views: [[false, "form"]],
     });
+    await click(".o-mail-Attachment-file");
     await click('.o-mail-AttachmentCard[aria-label="Blah.txt"] .o-mail-AttachmentCard-image');
     await contains(".o-FileViewer");
     await contains(".o-FileViewer-header", { text: "Blah.txt" });
@@ -208,6 +210,7 @@ QUnit.test("attachment box should order attachments from newest to oldest", asyn
     });
     await contains(".o-mail-Chatter [aria-label='Attach files']", { text: "3" });
     await click(".o-mail-Chatter [aria-label='Attach files']"); // open attachment box
+    await click(".o-mail-Attachment-file");
     await contains(":nth-child(1 of .o-mail-AttachmentCard)", { text: "C.txt" });
     await contains(":nth-child(2 of .o-mail-AttachmentCard)", { text: "B.txt" });
     await contains(":nth-child(3 of .o-mail-AttachmentCard)", { text: "A.txt" });

--- a/addons/mail/static/tests/web/attachment_box_tests.js
+++ b/addons/mail/static/tests/web/attachment_box_tests.js
@@ -77,6 +77,7 @@ QUnit.test("remove attachment should ask for confirmation", async () => {
     await click(".o-mail-Attachment-file");
     await contains(".o-mail-AttachmentCard");
     await contains("button[title='Remove']");
+
     await click("button[title='Remove']");
     await contains(".modal-body", { text: 'Do you really want to delete "Blah.txt"?' });
 

--- a/addons/mail/static/tests/web/chatter_tests.js
+++ b/addons/mail/static/tests/web/chatter_tests.js
@@ -213,6 +213,7 @@ QUnit.test("chatter: drop attachments", async () => {
     await contains(".o-mail-Dropzone");
     await contains(".o-mail-AttachmentCard", { count: 0 });
     await dropFiles(".o-mail-Dropzone", files);
+    await click(".o-mail-Attachment-file");
     await contains(".o-mail-AttachmentCard", { count: 2 });
     const extraFiles = [
         await createFile({

--- a/addons/web/static/src/core/file_viewer/file_model.js
+++ b/addons/web/static/src/core/file_viewer/file_model.js
@@ -96,6 +96,10 @@ export const FileModelMixin = T => class extends T {
         );
     }
 
+    get isMedia() {
+        return this.isImage || this.isVideo || this.isVoice;
+    }
+
     /**
      * @returns {Object}
      */


### PR DESCRIPTION
Before this PR:
The attachements that we displayed in the attachmentPanel were not sorted on the 
basis of type, there were displayed just in the order in which they were inserted.

Desired behaviour after this PR:
1. The attachments in the attachment panel are now sorted in three different tab, 
    namely 'Media', 'Links', 'Files'. Each attachment gets stored in its respective tab.
3. Consider linkPreviews as attachement and store all the linkPreviews in the tab 'Links'

task-3485793
