### PR TITLE
[FIX] l10n_lt: change default digits for Lithuania

### DIFF
--- a/addons/l10n_lt/models/template_lt.py
+++ b/addons/l10n_lt/models/template_lt.py
@@ -16,7 +16,7 @@ class AccountChartTemplate(models.AbstractModel):
             'property_stock_account_input_categ_id': 'account_account_template_2045',
             'property_stock_account_output_categ_id': 'account_account_template_2045',
             'property_stock_valuation_account_id': 'account_account_template_2040',
-            'code_digits': '1',
+            'code_digits': '6',
             'use_anglo_saxon': True,
         }
 


### PR DESCRIPTION
The digits of the accounts of Lithuania's COA go up to 6. 
It's currently defined to 1, which makes no sense. 
We will change it to 6.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
