### PR TITLE
[IMP] account: set default Cash rounding method

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -537,6 +537,7 @@ class AccountMove(models.Model):
     invoice_cash_rounding_id = fields.Many2one(
         comodel_name='account.cash.rounding',
         string='Cash Rounding Method',
+        default=lambda self: self.company_id.account_cash_rounding_id,
         help='Defines the smallest coinage of the currency that can be used to pay by cash.',
     )
     send_and_print_values = fields.Json(copy=False)

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -71,6 +71,7 @@ class ResCompany(models.Model):
     transfer_account_code_prefix = fields.Char(string='Prefix of the transfer accounts')
     account_sale_tax_id = fields.Many2one('account.tax', string="Default Sale Tax", check_company=True)
     account_purchase_tax_id = fields.Many2one('account.tax', string="Default Purchase Tax", check_company=True)
+    account_cash_rounding_id = fields.Many2one('account.cash.rounding', string="Default Cash Rounding", check_company=True, help="Default Cash Rounding Method for Invoices and Bills")
     tax_calculation_rounding_method = fields.Selection([
         ('round_per_line', 'Round per Line'),
         ('round_globally', 'Round Globally'),

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -49,6 +49,13 @@ class ResConfigSettings(models.TransientModel):
         readonly=False,
         check_company=True,
     )
+    cash_rounding_id = fields.Many2one(
+        comodel_name='account.cash.rounding',
+        string='Default Cash Rounding',
+        related='company_id.account_cash_rounding_id',
+        readonly=False,
+        check_company=True,
+    )
     tax_calculation_rounding_method = fields.Selection(
         related='company_id.tax_calculation_rounding_method', string='Tax calculation rounding method', readonly=False)
     account_journal_suspense_account_id = fields.Many2one(

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -138,6 +138,9 @@
                                 documentation="/applications/finance/accounting/receivables/customer_invoices/cash_rounding.html">
                                 <field name="group_cash_rounding"/>
                                 <div class="mt8">
+                                    <field name="cash_rounding_id" invisible="not group_cash_rounding" placeholder="Default Method"/>
+                                </div>
+                                <div class="mt8">
                                     <button name="%(account.rounding_list_action)d" icon="oi-arrow-right"
                                             type="action" string="Cash Roundings" class="btn-link"
                                             invisible="not group_cash_rounding"/>

--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -32,6 +32,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'data/l10n_in.port.code.csv',
         'data/res_country_state_data.xml',
         'data/uom_data.xml',
+        'data/account_cash_rounding.xml',
         'views/account_invoice_views.xml',
         'views/account_journal_views.xml',
         'views/res_config_settings_views.xml',

--- a/addons/l10n_in/data/account_cash_rounding.xml
+++ b/addons/l10n_in/data/account_cash_rounding.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="cash_rounding_in_half_up" model="account.cash.rounding">
+        <field name="name">Half Up</field>
+        <field name="rounding">1</field>
+        <field name="strategy">add_invoice_line</field>
+        <field name="rounding_method">HALF-UP</field>
+    </record>
+</odoo>

--- a/addons/l10n_in/data/template/account.account-in.csv
+++ b/addons/l10n_in/data/template/account.account-in.csv
@@ -67,6 +67,8 @@
 "p2123","Closing Stock","2123","expense","","False"
 "p2131","Loss on Sale of Assets","2131","expense","","False"
 "p2132","Write Off Expense","2132","expense","","False"
+"p213201","Round off Expense","213201","expense","","False"
+"p213202","Round off Income","213202","income","","False"
 "p11244","TDS Deducted","11244","liability_current","","False"
 "p11245","TCS Collected","11245","liability_current","","False"
 "p10055","CESS Receivable","10055","asset_current","l10n_in.cess_tag_account","False"

--- a/addons/l10n_in/models/template_in.py
+++ b/addons/l10n_in/models/template_in.py
@@ -36,5 +36,13 @@ class AccountChartTemplate(models.AbstractModel):
                 'fiscalyear_last_month': '3',
                 'account_sale_tax_id': 'igst_sale_18',
                 'account_purchase_tax_id': 'igst_purchase_18',
+                'account_cash_rounding_id': self.env.ref('l10n_in.cash_rounding_in_half_up'),
             },
         }
+
+    def _post_load_data(self, template_code, company, template_data):
+        self.env.ref('l10n_in.cash_rounding_in_half_up').write({
+            'profit_account_id': self.env.ref('account.%s_p213202'%(self.env.company.id), raise_if_not_found=False),
+            'loss_account_id': self.env.ref('account.%s_p213201'%(self.env.company.id), raise_if_not_found=False)
+        })
+        return super()._post_load_data(template_code, company, template_data)


### PR DESCRIPTION
Introduced a configurable default setting for Cash Rounding Method in invoice and bills creation.
Specifically, set the default Cash Rounding Method to HALF-UP for Indian company contexts.

Task: 3614520
