### PR TITLE
[FIX] project: project tree view addable without stage access

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -148,6 +148,7 @@ class Base(models.AbstractModel):
                 if 'context' in field_spec:
                     co_records = co_records.with_context(**field_spec['context'])
 
+                #checkout this vvv
                 if 'fields' in field_spec:
                     if field_spec.get('limit') is not None:
                         limit = field_spec['limit']


### PR DESCRIPTION
Steps to reproduce:

- Install Studio, CRM and Projects.
- Go to a lead and open the studio edit for it.
- Now try to ad a new many2many field as "Project".

We will receive an access error related to the "stage_id" field which will not be available for all the users unles we activate it in the project module, but by adding the groups to the field itself we can make it so it will ignore it when no it doesn't have the proper rights.

note: for the existing databases we might need to clear the cache in order to make it work.

opw-3603635
