### PR TITLE
[FIX] web: Remove archive action if view is not editable.

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_view.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_view.js
@@ -49,7 +49,7 @@ var BasicView = AbstractView.extend({
         this.rendererParams.viewEditable = this.controllerParams.activeActions.edit;
 
         this.controllerParams.confirmOnDelete = true;
-        this.controllerParams.archiveEnabled = 'active' in this.fields || 'x_active' in this.fields;
+        this.controllerParams.archiveEnabled = ('active' in this.fields || 'x_active' in this.fields) && this.controllerParams.activeActions.edit;
         this.controllerParams.hasButtons =
                 'action_buttons' in params ? params.action_buttons : true;
         this.controllerParams.viewId = viewInfo.view_id;


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

Even if a view is not editable, the Archive action button is still available. 

Issue has been seen as far back as v11:
https://gist.github.com/goliveirab/a3dafb432338d7250d32e548151bfd9c

### Current behavior before PR:

If the user selects the Archive action, the operation fails with an access error, i.e.
> You are not allowed to modify Contacts (res.partner) records.

### Desired behavior after PR is merged:

The Archive action is hidden when the view is not editable.

<img width="728" alt="Screenshot 2023-11-28 at 12 28 37 PM" src="https://github.com/odoo/odoo/assets/495315/ed5283ec-ae4c-401f-b100-117932a4647b">

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
