### PR TITLE
[FIX] sale_project: use hours as default uom for products on the fly

### DIFF
--- a/addons/sale_project/views/sale_order_line_views.xml
+++ b/addons/sale_project/views/sale_order_line_views.xml
@@ -28,6 +28,7 @@
                 <attribute name="context">{
                     'default_detailed_type': 'service',
                     'default_service_policy': 'ordered_prepaid',
+                    'default_uom_id': %(uom.product_uom_hour)d,
                 }</attribute>
             </field>
         </field>


### PR DESCRIPTION
When creating a SOL on the fly, it's also possible to create a product on the fly for that SOL. In that case, its default UOM should be hours instead of units.

Task-3380927