### PR TITLE
[FIX] base: customize csv export delimiter

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1852,7 +1852,8 @@ class CSVExport(ExportFormat, http.Controller):
 
     def from_data(self, fields, rows):
         fp = io.BytesIO()
-        writer = pycompat.csv_writer(fp, quoting=1)
+        delimiter = request.env['ir.config_parameter'].sudo().get_param('base_import.csv_internal_sep') or ','
+        writer = pycompat.csv_writer(fp, quoting=1, delimiter=delimiter)
 
         writer.writerow(fields)
 

--- a/odoo/addons/base/data/ir_config_parameter_data.xml
+++ b/odoo/addons/base/data/ir_config_parameter_data.xml
@@ -19,5 +19,11 @@
             <field name="value">notifications</field>
         </record>
 
+        <!-- CSV Delimeter/separator -->
+        <record id="csv_import_export_separator" model="ir.config_parameter">
+            <field name="key">base_import.csv_internal_sep</field>
+            <field name="value">,</field>
+        </record>
+
     </data>
 </odoo>


### PR DESCRIPTION
The issue:
the delimiter is hardcoded when you export something as CSV

The fix:
Making the delimiter modifiable

opw-3277005