### PR TITLE
[FIX] spreadsheet: fix css rule

### DIFF
--- a/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.scss
+++ b/addons/spreadsheet/static/src/o_spreadsheet/o_spreadsheet_extended.scss
@@ -15,7 +15,7 @@
         background-origin: content-box;
     }
 
-    .o-sidePanelButtons .o-sidePanelButton {
+    .o-sidePanelButtons .o-button {
         color: #666;
 
         &.o_global_filter_save {


### PR DESCRIPTION
We recently renamed `o-sidePanelButton` to `o-button` in the library but did not change it inside Odoo.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
