### PR TITLE
[FIX] website: prevent error while submit the contact form

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -69,15 +69,16 @@ class WebsiteForm(http.Controller):
                 # in case of an email, we want to send it immediately instead of waiting
                 # for the email queue to process
                 if model_name == 'mail.mail':
-                    form_has_email_cc = {'email_cc', 'email_bcc'} & kwargs.keys() or \
-                        'email_cc' in kwargs["website_form_signature"]
-                    # remove the email_cc information from the signature
-                    kwargs["website_form_signature"] = kwargs["website_form_signature"].split(':')[0]
-                    if kwargs.get("email_to"):
-                        value = kwargs['email_to'] + (':email_cc' if form_has_email_cc else '')
-                        hash_value = hmac(model_record.env, 'website_form_signature', value)
-                        if not consteq(kwargs["website_form_signature"], hash_value):
-                            raise AccessDenied('invalid website_form_signature')
+                    if "website_form_signature" in kwargs:
+                        form_has_email_cc = {'email_cc', 'email_bcc'} & kwargs.keys() or \
+                            'email_cc' in kwargs["website_form_signature"]
+                        # remove the email_cc information from the signature
+                        kwargs["website_form_signature"] = kwargs["website_form_signature"].split(':')[0]
+                        if kwargs.get("email_to"):
+                            value = kwargs['email_to'] + (':email_cc' if form_has_email_cc else '')
+                            hash_value = hmac(model_record.env, 'website_form_signature', value)
+                            if not consteq(kwargs["website_form_signature"], hash_value):
+                                raise AccessDenied('invalid website_form_signature')
                     request.env[model_name].sudo().browse(id_record).send()
 
         # Some fields have additional SQL constraints that we can't check generically


### PR DESCRIPTION
Currently the error occurs when user submit their contact form.

Steps to reproduce:
- Install 'Website' module.
- Go to Website > Contact Us > click on Edit.
- Select contact us form > STYLE (sidebar)
- In the 'Form' section remove whatever is written on the 'Recipient Email' field.
- Then save it .
- Open contact us page, fill details and click on the 'Submit' button.
- The error is generated in the log.

Traceback on sentry:

```KeyError: 'website_form_signature'
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1873, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website/controllers/form.py", line 47, in website_form
    return self._handle_website_form(model_name, **kwargs)
  File "addons/website/controllers/form.py", line 78, in _handle_website_form
    'email_cc' in kwargs["website_form_signature"]
```

This is because the 'website_form_signature' is added from [1], but due to condition at [2] it is not executed in  [1] as result the key was not added in form.

This commit solves this issue by adding the condition which validate the 'website_form_signature' if it available in kwargs.

[1]-https://github.com/odoo/odoo/blob/550727ccabe5ad2b2cc6c2979147139b45587da7/addons/website/tools.py#L226 [2]-https://github.com/odoo/odoo/blob/550727ccabe5ad2b2cc6c2979147139b45587da7/addons/website/tools.py#L217

sentry-4633940473




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
