### PR TITLE
[FIX] account: same amount percentage of child taxes, difference in amount

### DIFF
--- a/addons/account/tests/test_tax.py
+++ b/addons/account/tests/test_tax.py
@@ -220,12 +220,12 @@ class TestTax(TestTaxCommon):
         res = self.group_tax_percent.with_context({'force_price_include':True}).compute_all(100.0)
         self._check_compute_all_results(
             100,    # 'total_included'
-            83.33,    # 'total_excluded'
+            83.33 + 0.01,    # 'total_excluded' + 0.01 round off
             [
                 # base , amount     | seq | amount | incl | incl_base
                 # ---------------------------------------------------
                 (83.33, 8.33),    # |  1  |    10% |      |
-                (83.33, 8.34),    # |  2  |    10% |      |
+                (83.33, 8.33),    # |  2  |    10% |      |
                 # ---------------------------------------------------
             ],
             res


### PR DESCRIPTION

Before PR:
===
Any tax, having group of included taxes with the same amount percentage, in some cases the amount of included taxes is not same.

After PR:
===
Any tax, having group of included taxes with the same amount percentage, the amount of child taxes is now the same.

task id:3410529
