### PR TITLE
[IMP] project: make parent_id field optionally visible in list view for all

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -782,7 +782,7 @@
                     <field name="recurrence_id" column_invisible="True" />
                 </list>
                 <xpath expr="//field[@name='partner_id']" position="after">
-                    <field name="parent_id" optional="hide" context="{'search_view_ref': 'project.view_task_search_form', 'search_default_project_id': project_id}" groups="base.group_no_one"/>
+                    <field name="parent_id" optional="hide" context="{'search_view_ref': 'project.view_task_search_form', 'search_default_project_id': project_id}"/>
                 </xpath>
                 <xpath expr="//field[@name='stage_id']" position="after">
                     <field name="personal_stage_type_id" string="Personal Stage" optional="hide"/>


### PR DESCRIPTION
Current behavior before PR:
- The parent_id field was only displayed in the project task list view when the
  developer mode was enabled.

Desired behavior after PR is merged:
- The parent_id field can now be optionally displayed in the project task list
  view for all users.


task-3612810

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
