### PR TITLE
[FIX] point_of_sale: exclude internal reference in loaded products

### DIFF
--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -2054,6 +2054,7 @@ class PosSession(models.Model):
         :param custom_search_params: a dictionary containing params of a search_read()
         """
         params = self._loader_params_product_product()
+        self = self.with_context(**params['context'])
         # custom_search_params will take priority
         params['search_params'] = {**params['search_params'], **custom_search_params}
         products = self.env['product.product'].with_context(active_test=False).search_read(**params['search_params'])


### PR DESCRIPTION
Previously, products loaded from the background included the internal reference in their displayed name. This behavior was due to the 'display_default_code' context, which prevents the inclusion of 'default_code' in the product name, not being utilized within the 'get_pos_ui_product_product_by_params' function.

opw-3617195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
