### PR TITLE
[FIX] hr_homeworking: set font color to dark instead of white

### DIFF
--- a/addons/hr_homeworking/static/src/calendar/common/calender_common_renderer.xml
+++ b/addons/hr_homeworking/static/src/calendar/common/calender_common_renderer.xml
@@ -9,7 +9,7 @@
                         <i class="o_homework_content d-flex align-items-center justify-content-center flex-wrap border border-1 rounded-circle me-0" t-att-class="`fa ${iconStr} wl_color_${record.colorIndex}`" t-att-data-id="record.id"/>
                     </div>
                 </t>
-                <span class="fw-bolder" t-esc="records[0].title"/>
+                <span class="text-900 fw-bolder" t-esc="records[0].title"/>
             </div>
         </t>
         <t t-else="">


### PR DESCRIPTION
The text in the homeworking label inherits the color of `.fc-event`  which is set by the Fullcalendar library. 
This causes the text to be white on a white background.

task-3617332
part of task-3575827

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
