### PR TITLE
[FIX] base: Monetary fields exports behave like Float fields

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1643,6 +1643,11 @@ class Monetary(Field):
     def convert_to_write(self, value, record):
         return value
 
+    def convert_to_export(self, value, record):
+        if value or value == 0.0:
+            return value
+        return ''
+
 
 class _String(Field):
     """ Abstract class for string fields. """


### PR DESCRIPTION
New PR targetting 16.0 created from https://github.com/odoo/odoo/pull/56358

Float and Monetary fields behave differently when we use the export button (either xlsx or csv)
When a Float is null, it is exported as 0.0.
When a Float is equal to 0.0, it is exported as 0.0.
When a Monetary is null, it is exported as "" (blank).
When a Monetary is equal to 0.0, it is exported as "" (blank).

Since Monetary is just an encapsulation of a float, there's no reason for them to behave differently.

This fix ensures Monetary have the same behaviour as Float, namely:
When a Monetary is null, it is exported as 0.0.
When a Monetary is equal to 0.0, it is exported as 0.0.

Description of the issue/feature this PR addresses:

This PR ains at fixing this issue: https://github.com/odoo/odoo/issues/56351

Current behavior before PR:

Float and Monetary fields behave differently when we export them.
When a Float is null, it is exported as 0.0.
When a Float is equal to 0.0, it is exported as 0.0.
When a Monetary is null, it is exported as "" (blank).
When a Monetary is equal to 0.0, it is exported as "" (blank).

Desired behavior after PR is merged:

Float and Monetary behave identically:
When a Float is null, it is exported as 0.0.
When a Float is equal to 0.0, it is exported as 0.0.
When a Monetary is null, it is exported as 0.0.
When a Monetary is equal to 0.0, it is exported as 0.0.

--
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)