### PR TITLE
[IMP] {website_}mass_mailing: split contact name into first and last name

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -769,9 +769,10 @@ class MassMailing(models.Model):
     def action_view_mailing_contacts(self):
         """Show the mailing contacts who are in a mailing list selected for this mailing."""
         self.ensure_one()
-        action = self.env['ir.actions.actions']._for_xml_id('mass_mailing.action_view_mass_mailing_contacts')
+        action = self.env['mailing.contact'].action_view_mailing_contacts()
         if self.contact_list_ids:
             action['context'] = {
+                'name_is_split': action['context']['name_is_split'],
                 'default_mailing_list_ids': self.contact_list_ids[0].ids,
                 'default_subscription_ids': [(0, 0, {'list_id': self.contact_list_ids[0].id})],
             }

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -171,9 +171,9 @@ class MassMailingList(models.Model):
         return action
 
     def action_view_contacts(self):
-        action = self.env["ir.actions.actions"]._for_xml_id("mass_mailing.action_view_mass_mailing_contacts")
+        action = self.env['mailing.contact'].action_view_mailing_contacts()
         action['domain'] = [('list_ids', 'in', self.ids)]
-        action['context'] = {'default_list_ids': self.ids}
+        action['context'] = {'name_is_split': action['context']['name_is_split'], 'default_list_ids': self.ids}
         return action
 
     def action_view_contacts_email(self):
@@ -188,21 +188,36 @@ class MassMailingList(models.Model):
         return action
 
     def action_view_contacts_opt_out(self):
-        action = self.env["ir.actions.actions"]._for_xml_id('mass_mailing.action_view_mass_mailing_contacts')
+        action = self.env['mailing.contact'].action_view_mailing_contacts()
         action['domain'] = [('list_ids', 'in', self.id)]
-        action['context'] = {'default_list_ids': self.ids, 'create': False, 'search_default_filter_opt_out': 1}
+        action['context'] = {
+            'name_is_split': action['context']['name_is_split'],
+            'default_list_ids': self.ids,
+            'create': False,
+            'search_default_filter_opt_out': 1,
+        }
         return action
 
     def action_view_contacts_blacklisted(self):
-        action = self.env["ir.actions.actions"]._for_xml_id('mass_mailing.action_view_mass_mailing_contacts')
+        action = self.env['mailing.contact'].action_view_mailing_contacts()
         action['domain'] = [('list_ids', 'in', self.id)]
-        action['context'] = {'default_list_ids': self.ids, 'create': False, 'search_default_filter_blacklisted': 1}
+        action['context'] = {
+            'name_is_split': action['context']['name_is_split'],
+            'default_list_ids': self.ids,
+            'create': False,
+            'search_default_filter_blacklisted': 1,
+        }
         return action
 
     def action_view_contacts_bouncing(self):
-        action = self.env["ir.actions.actions"]._for_xml_id('mass_mailing.action_view_mass_mailing_contacts')
+        action = self.env['mailing.contact'].action_view_mailing_contacts()
         action['domain'] = [('list_ids', 'in', self.id)]
-        action['context'] = {'default_list_ids': self.ids, 'create': False, 'search_default_filter_bounce': 1}
+        action['context'] = {
+            'name_is_split': action['context']['name_is_split'],
+            'default_list_ids': self.ids,
+            'create': False,
+            'search_default_filter_bounce': 1,
+        }
         return action
 
     def action_merge(self, src_lists, archive):

--- a/addons/mass_mailing/models/res_config_settings.py
+++ b/addons/mass_mailing/models/res_config_settings.py
@@ -26,6 +26,10 @@ class ResConfigSettings(models.TransientModel):
         string='24H Stat Mailing Reports',
         config_parameter='mass_mailing.mass_mailing_reports',
         help='Check how well your mailing is doing a day after it has been sent.')
+    mass_mailing_split_contact_name = fields.Boolean(
+        string='Split First and Last Name',
+        config_parameter='mass_mailing.split_contact_name',
+        help='Separate Mailing Contact Names into two fields')
 
     @api.onchange('mass_mailing_outgoing_mail_server')
     def _onchange_mass_mailing_outgoing_mail_server(self):

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -49,7 +49,9 @@
                 </header>
                 <field name="create_date" optional="show"/>
                 <field name="title_id" optional="hide"/>
-                <field name="name" readonly="1"/>
+                <field name="name" readonly="1" column_invisible="context.get('name_is_split')"/>
+                <field name="first_name" readonly="1" column_invisible="not context.get('name_is_split')"/>
+                <field name="last_name" readonly="1" column_invisible="not context.get('name_is_split')"/>
                 <field name="company_name"/>
                 <field name="email" readonly="1"/>
                 <field name="is_blacklisted" string="Email Blacklisted"/>
@@ -114,16 +116,26 @@
         <field name="arch" type="xml">
             <form string="Mailing List Contacts">
                 <field name="id" invisible="1"/>
+                <field name="name_is_split" invisible="1"/>
                 <sheet>
                     <div class="oe_title">
                         <label for="name" string="Contact Name"/>
                         <h1>
-                            <field class="text-break" name="name" placeholder="e.g. John Smith"/>
+                            <field class="text-break" name="name" placeholder="e.g. John Smith"
+                                   readonly="name_is_split" invisible="name_is_split and not name"/>
+                            <!-- simulate the placeholder on the readonly field -->
+                            <span class="oe_grey" invisible="not name_is_split or name">e.g. "John Smith"</span>
                         </h1>
-                        <div>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags" style="width: 100%"/>
-                        </div>
                     </div>
+                    <!-- Separate group in order to have the correct tabindex -->
+                    <group invisible="not name_is_split">
+                        <group>
+                            <field name="first_name" placeholder="e.g. &quot;John&quot;"/>
+                        </group>
+                        <group>
+                            <field name="last_name" placeholder="e.g. &quot;Smith&quot;"/>
+                        </group>
+                    </group>
                     <group>
                         <group>
                             <label for="email" class="oe_inline"/>
@@ -142,6 +154,7 @@
                         <group>
                             <field name="create_date" readonly="1" invisible="not id"/>
                             <field name="message_bounce" readonly="1" invisible="not id"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags" style="width: 100%"/>
                         </group>
                     </group>
                     <field name="subscription_ids">
@@ -196,5 +209,13 @@
                 Mailing contacts allow you to separate your marketing audience from your business contact directory.
             </p>
         </field>
+    </record>
+
+    <record model="ir.actions.server" id="action_view_mass_mailing_contacts_with_config">
+        <field name="name">Mailing List Contacts</field>
+        <field name="model_id" ref="model_mailing_contact"/>
+        <field name="state">code</field>
+        <field name="binding_view_types">tree,kanban,form,graph,pivot</field>
+        <field name="code">action = env['mailing.contact'].action_view_mailing_contacts()</field>
     </record>
 </odoo>

--- a/addons/mass_mailing/views/mailing_menus.xml
+++ b/addons/mass_mailing/views/mailing_menus.xml
@@ -28,7 +28,7 @@
               id="menu_email_mass_mailing_contacts"
               parent="mass_mailing_mailing_list_menu"
               sequence="2"
-              action="action_view_mass_mailing_contacts"/>
+              action="action_view_mass_mailing_contacts_with_config"/>
 
     <!-- Campaigns -->
     <menuitem name="Campaigns"

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -12,6 +12,15 @@
                             <setting title="This tool is advised if your marketing campaign is composed of several emails." help="Manage mass mailing campaigns">
                                 <field name="group_mass_mailing_campaign"/>
                             </setting>
+                            <setting name="contact_naming" title="Contact Naming" help="Separate Mailing Contact Names into two fields">
+                                <field name="mass_mailing_split_contact_name"/>
+                            </setting>
+                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page. The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to blacklist themselves">
+                                <field name="show_blacklist_buttons"/>
+                            </setting>
+                            <setting name="mass_mailing_reports_setting_container" title="Send a report to the mailing responsible one day after the mailing has been sent." help="Check how well your mailing is doing a day after it has been sent">
+                                <field name="mass_mailing_reports"/>
+                            </setting>
                             <setting name="dedicated_server_setting_container" title="Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails." help="Pick a dedicated outgoing mail server for your mass mailings">
                                 <field name="mass_mailing_outgoing_mail_server"/>
                                 <div class="content-group" invisible="not mass_mailing_outgoing_mail_server">
@@ -23,12 +32,6 @@
                                         <button type="action" name="base.action_ir_mail_server_list" string="Configure Outgoing Mail Servers" icon="oi-arrow-right" class="oe_link"/>
                                     </div>
                                 </div>
-                            </setting>
-                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page. The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to blacklist themselves">
-                                <field name="show_blacklist_buttons"/>
-                            </setting>
-                            <setting name="mass_mailing_reports_setting_container" title="Send a report to the mailing responsible one day after the mailing has been sent." help="Check how well your mailing is doing a day after it has been sent">
-                                <field name="mass_mailing_reports"/>
                             </setting>
                         </block>
                     </app>

--- a/addons/website_mass_mailing/data/ir_model_data.xml
+++ b/addons/website_mass_mailing/data/ir_model_data.xml
@@ -11,6 +11,8 @@
             <value>mailing.contact</value>
             <value eval="[
                 'name',
+                'first_name',
+                'last_name',
                 'company_name',
                 'title_id',
                 'email',

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -59,7 +59,27 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
             <form id="newsletter_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required"
                   data-mark="*" data-model_name="mailing.contact" data-success-mode="message" hide-change-model="true">
                 <div class="s_website_form_rows row s_col_no_bgcolor">
-                    <div class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
+                    <t t-if="request.env['mailing.contact']._get_name_is_split()">
+                        <div class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub1a">
+                                    <span class="s_website_form_label_content">Name</span>
+                                    <span class="s_website_form_mark"> *</span>
+                                </label>
+                                <div class="col-sm row">
+                                    <div class="col-sm-6">
+                                        <input id="mailing_sub1a" type="text" class="form-control s_website_form_input"
+                                               name="first_name" placeholder="First Name" required="1"/>
+                                    </div>
+                                    <div class="col-sm-6">
+                                        <input id="mailing_sub1b" type="text" class="form-control s_website_form_input"
+                                               name="last_name" placeholder="Last Name" required="1"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                    <div t-else="" class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub1">
                                 <span class="s_website_form_label_content">Your Name</span>


### PR DESCRIPTION
[IMP] {website_}mass_mailing: split contact name into first and last name

Add an option that allows to fill the contact name by providing a first and a
last name instead of a single name. This option is not set by default.

If the option is enabled, the name will automatically be filled when filling
the first and the last name (as first name followed by last name).
In the front-end, inserting the form subscription of the newsletter block,
insert a form with a first name and last name field instead of a single name
field. Unfortunately, when changing the option, it won't update the
subscription form automatically (it must be done manually).

A small inconvenient is that when updating first or last name, it will update
the name so that the other part of the name is lost. To mitigate that problem,
we have enabled the tracking on "name" so that any change on that field is
logged in the chatter.

If the option is not enabled, only names can be filled. First and last name
will remain empty. Enabling the option won't convert name to first and last
name; that works should be done manually (maybe using an export and an import).

When not enabled, we make the first and last name fields not searchable so that
they don't appears in custom filters or dynamic placeholder.

Notes:
- the first and last name are not alligned with the rest of the form because we
have set them in a different group to force the correct tabindex.
- the columns of the mailing contact list view change depending of the system
parameter mass_mailing.split_contact_name. If it is true, the "name" column is
replaced by a first and a last name column. Technically, it has been
implemented through a context variable (name_is_split) as it is not possible to
use the system parameter directly.

Task-3597124