### PR TITLE
[FIX] microsoft_calendar: Create event as internal user

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -84,7 +84,8 @@ class Meeting(models.Model):
             partner_included = partner_ids and len(partner_ids) > 0 and sender_user.partner_id.id in partner_ids
             self._check_organizer_validation(sender_user, partner_included)
             # Group new events values by user for later batch creation.
-            vals_by_user[sender_user].append(vals)
+            # Check Internal/External user state to avoid events creation as a portal (no access)
+            vals_by_user[(not sender_user.share and sender_user) or self.env.user].append(vals)
             # Events from a recurrency have their `need_sync_m` attribute set to False.
             if vals.get('recurrence_id') or vals.get('recurrency'):
                 vals['need_sync_m'] = False

--- a/addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py
+++ b/addons/microsoft_calendar/tests/test_sync_microsoft2odoo.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+# This file is outdated and will be removed in the master branch.
 
 from odoo.addons.microsoft_calendar.utils.microsoft_calendar import MicrosoftCalendarService, MicrosoftEvent
 from odoo.exceptions import ValidationError

--- a/addons/microsoft_calendar/tests/test_sync_odoo2microsoft.py
+++ b/addons/microsoft_calendar/tests/test_sync_odoo2microsoft.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+# This file is outdated and will be removed in the master branch.
 
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- On outlook, create an event with an email of a portal user on Odoo
- In Odoo, synchronize the calendar

Current behavior before PR:
- Synchronization of calendar will fail with ACL (Access right) error
- ACL id due to an organizer that is a portal user, no read access to (mail.activity.type)

Desired behavior after PR is merged:
- Calendar is synchronized
- Event with portal organizer will be created by the internal user of sync

opw-3609245

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
