### PR TITLE
[FIX] website_slides: take into account reply-to of email template

### DIFF
--- a/addons/website_slides/wizard/slide_channel_invite.py
+++ b/addons/website_slides/wizard/slide_channel_invite.py
@@ -97,6 +97,11 @@ class SlideChannelInvite(models.TransientModel):
             'recipient_ids': [(4, slide_channel_partner.partner_id.id)]
         }
 
+        # if user wants to override FROM by configuring the email template
+        # take it into account
+        if self.template_id.email_from and self.template_id.email_from != self.env.user.email_formatted:
+            mail_values['email_from'] = self.template_id.email_from
+
         # optional support of notif_layout in context
         notif_layout = self.env.context.get('notif_layout', self.env.context.get('custom_layout'))
         if notif_layout:


### PR DESCRIPTION
# Context:
The current logic will not look at the `email_from` field of the email templates used for invites/communication in the context of eLearning courses.

This means that the email of the user initiating the invite action will be used as `From` and `Reply-to` in the email being sent out.

Some users might want the option to define a specific email address to contact their antendees(example `training@companydomain.com`). It also opens up the possibility to use a specific outgoing email server with a `from_filter` configured for this purpose.

# How to reproduce the behavior:
1) Setup a standard database with demo data and eLearning(`website_slides`) installed
2) Go to eLearning and choose a course with `enroll = 'invite'` 
3) Invite a user that has at least a portal access (demo user for example). We assume that the current user uses `user@companydomain.com`.
4) With the wizard open, use the popup button for the email template and configure it to use a specific from (example `training@companydomain.com`) 5) Send out the email and verify it's email headers

Email headers will be

Before this change:
From: `"User" <user@companydomain.com>`
Reply-To: `"User" <user@companydomain.com>`

After this change:
From: `training@companydomain.com`
Reply-To: `training@companydomain.com`
(Reply-To will become catchall address if ICP `mail.catchall.domain` is set, output being `mail.catchall.domain`@`mail.catchall.domain`)

## Info to take into account:
* The model `slide.channel.partner` does not have a dedicated chatter/thread. So there is not default email alias that routes the replies. This means the customer has to handle the replies either on the custom `From` email address, or when the reply-to is the catchall, the sender will get a bounce email inviting them to contact the default info email address of the company.

opw-3604174


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
