### PR TITLE
[IMP] fields: make `search` methods usable for related fields

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -615,8 +615,8 @@ class Field(MetaField('DummyField', (object,), {})):
         self.compute = self._compute_related
         if self.inherited or not (self.readonly or field.readonly):
             self.inverse = self._inverse_related
-        if field._description_searchable:
-            # allow searching on self only if the related field is searchable
+        if field._description_searchable and not self.search:
+            # use default search if field is searchable & no method is provided
             self.search = self._search_related
 
         # A readonly related field without an inverse method should not have a


### PR DESCRIPTION
Check whether a search method is provided to avoid overwriting it for related fields.


