### PR TITLE
[FIX] mrp: odoo error when print work order

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -2374,6 +2374,13 @@ msgid ""
 msgstr ""
 
 #. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/mrp_workorder.py:0
+#, python-format
+msgid "Invalid Barcode Format, following characters are not supported: %s"
+msgstr ""
+
+#. module: mrp
 #: model:ir.actions.act_window,name:mrp.action_mrp_production_moves
 msgid "Inventory Moves"
 msgstr ""


### PR DESCRIPTION
Problem
-------
- active work orders, create 1 work orders has name as 'Working é', go to Manufacturing -> Operations -> Work Orders -> print work orders => odoo error

Reason
------
- name 'Working é' has 'é' invalid Barcode Format, 'é' are not supported

Oddo error 

> RPC_ERROR
> Odoo Server Error
> Traceback (most recent call last):
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_actions_report.py", line 571, in barcode
>     barcode = createBarcodeDrawing(barcode_type, value=value, format='png', **kwargs)
>   File "/home/locvan/python/python3.10-venv/odoo16/lib/python3.10/site-packages/reportlab/graphics/barcode/__init__.py", line 116, in createBarcodeDrawing
>     raise ValueError("Illegal barcode with value '%s' in code '%s'" % (options.get('value',None), codeName))
> ValueError: Illegal barcode with value 'hoạt động 1' in code 'Code128'
> 
> During handling of the above exception, another exception occurred:
> 
> Traceback (most recent call last):
>   File "<786>", line 335, in template_786
>   File "<786>", line 317, in template_786_content
>   File "<786>", line 299, in template_786_t_call_0
>   File "<786>", line 47, in template_786_t_call_1
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_qweb.py", line 2383, in _get_field
>     content = converter.record_to_html(record, field_name, field_options)
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_qweb_fields.py", line 121, in record_to_html
>     return False if value is False else self.value_to_html(value, options=options)
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_qweb_fields.py", line 704, in value_to_html
>     barcode = self.env['ir.actions.report'].barcode(
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_actions_report.py", line 584, in barcode
>     raise ValueError("Cannot convert into barcode.")
> ValueError: Cannot convert into barcode.
> 
> The above exception was the direct cause of the following exception:
> 
> Traceback (most recent call last):
>   File "/home/locvan/git/odoo16/addons/web/controllers/report.py", line 113, in report_download
>     response = self.report_routes(reportname, docids=docids, converter=converter, context=context)
>   File "/home/locvan/git/odoo16/odoo/http.py", line 697, in route_wrapper
>     result = endpoint(self, *args, **params_ok)
>   File "/home/locvan/git/odoo16/addons/web/controllers/report.py", line 42, in report_routes
>     pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
>   File "/home/locvan/git/odoo16/addons/account/models/ir_actions_report.py", line 58, in _render_qweb_pdf
>     return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_actions_report.py", line 819, in _render_qweb_pdf
>     collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
>   File "/home/locvan/git/odoo16/addons/account_edi_ubl_cii/models/ir_actions_report.py", line 58, in _render_qweb_pdf_prepare_streams
>     collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
>   File "/home/locvan/git/odoo16/addons/account_edi/models/ir_actions_report.py", line 14, in _render_qweb_pdf_prepare_streams
>     collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
>   File "/home/locvan/git/odoo16/addons/account/models/ir_actions_report.py", line 20, in _render_qweb_pdf_prepare_streams
>     return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_actions_report.py", line 708, in _render_qweb_pdf_prepare_streams
>     html = self.with_context(**additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_actions_report.py", line 896, in _render_qweb_html
>     return self._render_template(report.report_name, data), 'html'
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_actions_report.py", line 623, in _render_template
>     return view_obj._render_template(template, values).encode()
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_ui_view.py", line 2125, in _render_template
>     return self.env['ir.qweb']._render(template, values)
>   File "/home/locvan/git/odoo16/odoo/tools/profiler.py", line 292, in _tracked_method_render
>     return method_render(self, template, values, **options)
>   File "/home/locvan/git/odoo16/odoo/addons/base/models/ir_qweb.py", line 581, in _render
>     result = ''.join(rendering)
>   File "<786>", line 341, in template_786
> odoo.addons.base.models.ir_qweb.QWebException: Error while render the template
> ValueError: Cannot convert into barcode.
> Template: mrp.report_mrp_workorder
> Path: /t/t/t/t/div/div[2]/div[2]/span/div
> Node: <div t-field="o.name" t-options="{\'widget\': \'barcode\', \'width\': 600, \'height\': 100, \'img_style\': \'width:350px;height:60px\'}"/>
> 
> The above server error caused the following client error:
> RPC_ERROR: Odoo Server Error
>     at makeErrorFromResponse (http://localhost:8016/web/assets/255-3a327b5/web.assets_backend.min.js:988:163)
>     at decoder.onload (http://localhost:8016/web/assets/255-3a327b5/web.assets_backend.min.js:975:7)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
