### PR TITLE
[15.0][FIX] sale_stock: Consider also non-blocked orders as invoiced

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -458,7 +458,7 @@ class SaleOrderLine(models.Model):
             # but we would like to set its invoice status to 'Fully Invoiced'. The use case is for
             # products sold by weight, where the delivered quantity rarely matches exactly the
             # quantity ordered.
-            if line.order_id.state == 'done'\
+            if line.order_id.state in ('sale', 'done')\
                     and line.invoice_status == 'no'\
                     and line.product_id.type in ['consu', 'product']\
                     and line.product_id.invoice_policy == 'delivery'\


### PR DESCRIPTION
**Steps to reproduce:**

- Keep the configuration "Lock Confirmed Sales" unchecked.
- Create an storable product with "Invoicing policy" = "Delivered quantities".
- Create a sales order to any customer with such product and quantity = 2.
- Confirm the sales order.
- Go to the delivery order, and deliver 1 unit, as your customer says they only wants finally 1 unit.
- When asked for the backorder, say no.
- Invoice the sales order.
- Check the order invoice status.

**Current behavior:** The order puts "Nothing to invoice".

**Expected behavior:** The order puts "Invoiced".

**Explanation:**

There's code for considering this sales order as invoiced, but it's only taken into account sales order in state "done", thus only considering the blocked ones, but the flow without blocking the sales order is perfectly OK (and more as you don't have access to "Block" button) and should be covered as well.

@Tecnativa TT46321