### PR TITLE
[IMP] core: support X-Forwarded-Port http header

### DIFF
--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import json
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 from odoo.http import Request
 from odoo.tests import tagged
@@ -43,7 +43,7 @@ class TestHttpEchoReplyHttpNoDB(TestHttpBase):
     def test_echohttp5_post_csrf(self):
         res = self.nodb_url_open('/test_http/echo-http-csrf?race=Asgard', data={'commander': 'Thor'})
         self.assertEqual(res.status_code, 303)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/web/database/selector')
+        self.assertEqual(urlsplit(res.headers.get('Location', '')).path, '/web/database/selector')
 
     def test_echohttp6_json_over_http(self):
         payload = json.dumps({'commander': 'Thor'})

--- a/odoo/addons/test_http/tests/test_misc.py
+++ b/odoo/addons/test_http/tests/test_misc.py
@@ -4,7 +4,7 @@ import json
 from io import StringIO
 from socket import gethostbyname
 from unittest.mock import patch
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 
 import odoo
 from odoo.http import root, content_disposition
@@ -191,13 +191,13 @@ class TestHttpEnsureDb(TestHttpBase):
         res = self.multidb_url_open('/test_http/ensure_db')
         res.raise_for_status()
         self.assertEqual(res.status_code, 303)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/web/database/selector')
+        self.assertEqual(urlsplit(res.headers.get('Location', '')).path, '/web/database/selector')
 
     def test_ensure_db1_grant_db(self):
         res = self.multidb_url_open('/test_http/ensure_db?db=db0', timeout=10000)
         res.raise_for_status()
         self.assertEqual(res.status_code, 302)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/test_http/ensure_db')
+        self.assertEqual(urlsplit(res.headers.get('Location', '')).path, '/test_http/ensure_db')
         self.assertEqual(odoo.http.root.session_store.get(res.cookies['session_id']).db, 'db0')
 
         # follow the redirection
@@ -224,7 +224,7 @@ class TestHttpEnsureDb(TestHttpBase):
         res = self.multidb_url_open('/test_http/ensure_db?db=db1')
         res.raise_for_status()
         self.assertEqual(res.status_code, 302)
-        self.assertEqual(urlparse(res.headers.get('Location', '')).path, '/test_http/ensure_db')
+        self.assertEqual(urlsplit(res.headers.get('Location', '')).path, '/test_http/ensure_db')
 
         new_session = odoo.http.root.session_store.get(res.cookies['session_id'])
         self.assertNotEqual(session.sid, new_session.sid)

--- a/odoo/addons/test_http/tests/test_session.py
+++ b/odoo/addons/test_http/tests/test_session.py
@@ -3,7 +3,7 @@
 import datetime
 import json
 import pytz
-from urllib.parse import urlparse
+from urllib.parse import urlsplit
 from unittest.mock import patch
 
 import odoo
@@ -63,7 +63,7 @@ class TestHttpSession(TestHttpBase):
         ])
         self.assertFalse(session['db'])
         self.assertEqual(res.status_code, 303)
-        self.assertEqual(urlparse(res.headers['Location']).path, '/web/database/selector')
+        self.assertEqual(urlsplit(res.headers['Location']).path, '/web/database/selector')
 
     def test_session4_web_authenticate_multidb(self):
         self.db_list = [get_db_name(), 'another_database']

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -163,7 +163,7 @@ from werkzeug.exceptions import (HTTPException, BadRequest, Forbidden,
                                  NotFound, InternalServerError)
 try:
     from werkzeug.middleware.proxy_fix import ProxyFix as ProxyFix_
-    ProxyFix = functools.partial(ProxyFix_, x_for=1, x_proto=1, x_host=1)
+    ProxyFix = functools.partial(ProxyFix_, x_for=1, x_proto=1, x_host=1, x_port=1)
 except ImportError:
     from werkzeug.contrib.fixers import ProxyFix
 


### PR DESCRIPTION
Install nginx, setup it to listen on port 8080 instead of default 80
then setup a regular proxy_pass toward a local odoo listening on port
8069 with all the X-Forwarded- headers set:

        listen 8080;
        server_name mycompany.odoo.com;
        proxy_set_header X-Forwarded-Host $host;
        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
        proxy_set_header X-Forwarded-Proto $scheme;
        proxy_set_header X-Forwarded-Port $server_port;
        proxy_set_header X-Real-IP $remote_addr;
        location / {
                proxy_pass http://127.0.0.1:8069;
        }

Inside your browser, access "http://mycompany.odoo.com:8080" you are
wrongly redirected to "http://mycompany.odoo.com:80".

The `X-Forwarded-Port` header wasn't taken into account by Odoo.

Closes: #64643
