### PR TITLE
[FIX] account: fix tax_string compute functions

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -64,7 +64,7 @@ class ProductTemplate(models.Model):
     @api.depends('taxes_id', 'list_price')
     def _compute_tax_string(self):
         for record in self:
-            record.tax_string = record._construct_tax_string(record.list_price)
+            record.tax_string = record._construct_tax_string(record.list_price) if record.id else ''
 
     def _construct_tax_string(self, price):
         currency = self.currency_id
@@ -190,4 +190,4 @@ class ProductProduct(models.Model):
     @api.depends('lst_price', 'product_tmpl_id', 'taxes_id')
     def _compute_tax_string(self):
         for record in self:
-            record.tax_string = record.product_tmpl_id._construct_tax_string(record.lst_price)
+            record.tax_string = record.product_tmpl_id._construct_tax_string(record.lst_price) if record.id else ''


### PR DESCRIPTION
Fix tax_string compute functions in product.template and product.product

Description of the issue/feature this PR addresses:

Compute function does not take into consideration if record was created yet

Current behavior before PR:

Error in creating product.product or product.template

Desired behavior after PR is merged:

creating product.product or product.template smoothly with no errors

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
