### PR TITLE
[FIX] setup: add scheduled action for HTTPS certificate update

### DIFF
--- a/setup/win32/conf/iot/CheckHTTPSCertificateUpdate.bat
+++ b/setup/win32/conf/iot/CheckHTTPSCertificateUpdate.bat
@@ -1,0 +1,13 @@
+echo Odoo IoT HTTPS Certificate Update Check...
+@echo off
+
+set url=http://localhost:8069/hw_drivers/check_certificate
+set curl_command=curl -s -o nul -w %%{http_code} %url%
+
+for /f %%i in ('%curl_command%') do set http_status=%%i
+
+if %http_status% equ 200 (
+    exit /b 0
+) else (
+    exit /b 1
+)

--- a/setup/win32/setup.nsi
+++ b/setup/win32/setup.nsi
@@ -301,6 +301,15 @@ SectionEnd
 Section $(TITLE_IOT) IOT
     SectionIn 3
     DetailPrint "Configuring TITLE_IOT"
+
+    # Set a folder with specific IoT related files
+    SetOutPath "$INSTDIR\iot"
+    File "conf\iot\CheckHTTPSCertificateUpdate.bat"
+
+    # Create scheduled actions (handled in Windows Task Scheduler)
+    nsExec::Exec 'schtasks /create /sc daily /tn Odoo\CheckHTTPSCertificateUpdate /tr "$INSTDIR\iot\CheckHTTPSCertificateUpdate.bat" /st 02:00'
+
+    # Configuration odoo config for IoT
     WriteIniStr "$INSTDIR\server\odoo.conf" "options" "server_wide_modules" "web,hw_posbox_homepage,hw_drivers"
     WriteIniStr "$INSTDIR\server\odoo.conf" "options" "list_db" "False"
     WriteIniStr "$INSTDIR\server\odoo.conf" "options" "max_cron_threads" "0"
@@ -393,6 +402,7 @@ Section "Uninstall"
     ExecWait '"$0" /S'
     ExecWait '"$INSTDIR\Ghostscript\uninstgs.exe" /S'
 
+    nsExec::Exec "schtasks /delete /tn Odoo\CheckHTTPSCertificateUpdate /f"
     nsExec::Exec "net stop ${SERVICENAME}"
     nsExec::Exec "sc delete ${SERVICENAME}"
     sleep 2
@@ -402,6 +412,7 @@ Section "Uninstall"
     Rmdir /r "$INSTDIR\thirdparty"
     Rmdir /r "$INSTDIR\python"
     Rmdir /r "$INSTDIR\nssm"
+    Rmdir /r "$INSTDIR\iot"
     FindFirst $0 $1 "$INSTDIR\nginx*"
     Rmdir /R "$INSTDIR\$1"
     FindClose $0


### PR DESCRIPTION
Context:
When an HTTPS certificate is delivered, it is valid for ~1 month. To avoid missing the certificate, a script is automatically ran daily to check if a new HTTPS certificate is necessary.

On the IoT box, it is added in the native Unix system with this file: https://github.com/odoo/odoo/blob/16.0/addons/point_of_sale/tools/posbox/overwrite_after_init/etc/cron.daily/odoo

However, prior to this commit, there is nothing equivalent for windows

Note: the HTTPS certificate check is also done automatically when accessing the homepage.

Before this commit:
After an HTTPS certificate delivery, if we let the IoT server running non-stop (and without accessing the homepage). The HTTPS will expire without any automatic renew.

After this commit:
A windows native "Scheduler Task" is created on installation to check daily for HTTPS certificate update.
We use the same logic that the one of the IoT box with a call to the public URL to check for the update.
The script will also return a code that can be seen in the "Task Scheduler" Windows app in the "Last Run Result" column
![image](https://github.com/odoo/odoo/assets/60775325/ce1dc000-aac9-43f7-88e0-bc74904095e2)


opw-3617687