### PR TITLE
[IMP] purchase, account, sale: add account.order(.line).mixin

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -75,6 +75,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'data/account_reports_data.xml',
         'views/uom_uom_views.xml',
         'views/product_views.xml',
+        'wizard/account_advance_payments_views.xml',
         'views/tests_shared_js_python.xml',
         'views/base_document_layout_views.xml',
         'views/report_templates.xml'

--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -6,6 +6,8 @@ from . import ir_http
 from . import res_partner_bank
 from . import account_account_tag
 from . import account_account
+from . import account_order_line_mixin
+from . import account_order_mixin
 from . import account_journal
 from . import account_tax
 from . import account_reconcile_model

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4570,7 +4570,7 @@ class AccountMove(models.Model):
                 for l in dpl.invoice_lines
                 if l.move_id.state == 'posted' and l.move_id not in real_invoices  # don't recompute with the final invoice
             )
-            dpl.tax_id = dpl.invoice_lines.tax_ids
+            dpl.tax_ids = dpl.invoice_lines.tax_ids
         return res
 
     def js_assign_outstanding_line(self, line_id):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2916,7 +2916,7 @@ class AccountMove(models.Model):
                 .filtered(
                     lambda line:
                         line.is_downpayment
-                        and line.invoice_lines <= self.mapped('line_ids')  # See https://github.com/odoo/odoo/pull/52648
+                        and line.account_move_line_ids <= self.mapped('line_ids')  # See https://github.com/odoo/odoo/pull/52648
                 )
         )
         self = self.with_context(skip_invoice_sync=True, dynamic_unlink=True)  # no need to sync to delete everything
@@ -4563,14 +4563,14 @@ class AccountMove(models.Model):
         dp_lines._compute_name()  # Update the description of DP lines (Draft -> Posted)
         downpayment_lines = dp_lines.filtered(lambda ol: not ol.order_id._is_locked())
         other_order_lines = downpayment_lines.order_id.order_line - downpayment_lines
-        real_invoices = set(other_order_lines.invoice_lines.move_id)
+        real_invoices = set(other_order_lines.account_move_line_ids.move_id)
         for dpl in downpayment_lines:
             dpl.price_unit = sum(
                 l.price_unit if l.move_id.move_type in ('out_invoice', 'in_invoice') else -l.price_unit
-                for l in dpl.invoice_lines
+                for l in dpl.account_move_line_ids
                 if l.move_id.state == 'posted' and l.move_id not in real_invoices  # don't recompute with the final invoice
             )
-            dpl.tax_ids = dpl.invoice_lines.tax_ids
+            dpl.tax_ids = dpl.account_move_line_ids.tax_ids
         return res
 
     def js_assign_outstanding_line(self, line_id):

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -418,6 +418,7 @@ class AccountMoveLine(models.Model):
              "associated partner",
     )
     is_refund = fields.Boolean(compute='_compute_is_refund')
+    is_downpayment = fields.Boolean()
 
     _sql_constraints = [
         (
@@ -1185,6 +1186,9 @@ class AccountMoveLine(models.Model):
             'target': 'new',
             'type': 'ir.actions.act_window',
         }
+
+    def _get_order_lines(self):
+        return self.env['account.order.line.mixin']
 
     # -------------------------------------------------------------------------
     # INVERSE METHODS

--- a/addons/account/models/account_order_line_mixin.py
+++ b/addons/account/models/account_order_line_mixin.py
@@ -1,0 +1,140 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _, api
+from odoo.tools import format_date
+
+
+class AccountOrderLineMixin(models.AbstractModel):
+    # This mixin contains the shared logic between sale order lines and purchase order lines (ex. taxes, down payments, ...)
+    _name = 'account.order.line.mixin'
+    _description = 'Account Order Line Mixin'
+
+    is_downpayment = fields.Boolean(
+        string="Is a down payment",
+        help="Down payments are made when creating account moves from an order. They are not copied when duplicating an order."
+    )
+
+    invoice_lines = fields.One2many('account.move.line')  # To override
+    display_type = fields.Selection(
+        [('line_section', "Section"), ('line_note', "Note")],
+        help="Technical field for UX purpose.",
+    )
+    product_id = fields.Many2one('product.product', 'Product', change_default=True, index='btree_not_null')
+    name = fields.Text(string='Description', compute='_compute_name', required=True, store=True, readonly=False, precompute=True)
+    order_id = fields.Many2one('account.order.mixin')
+    qty_to_invoice = fields.Float('Quantity to Invoice', compute='_compute_qty_to_invoice', digits='Product Unit of Measure', store=True)
+    price_unit = fields.Float("Unit Price", digits='Product Price', compute='_compute_price_unit', required=True, readonly=False, store=True)
+    tax_id = fields.Many2many('account.tax', string="Taxes", check_company=True, context={'active_test': False})
+    product_uom = fields.Many2one('uom.uom', "Unit of Measure", domain="[('category_id', '=', product_uom_category_id)]")
+    discount = fields.Float("Discount (%)", digits='Discount', compute='_compute_discount', store=True, readonly=False, precompute=True)
+    currency_id = fields.Many2one(related='order_id.currency_id', store=True, string='Currency', readonly=True, precompute=True)
+    price_subtotal = fields.Monetary(compute='_compute_amount', string='Subtotal', store=True)
+    price_total = fields.Monetary(compute='_compute_amount', string='Total', store=True)
+    price_tax = fields.Float(compute='_compute_amount', string='Tax', store=True)
+
+    def _has_valid_qty_to_invoice(self, final=False):
+        """
+        Returns whether this account order line has a valid quantity for creating an invoice line from it.
+        Used in account order to decide whether to create an invoice line for this entry.
+        """
+        raise NotImplementedError  # To override
+
+    def _prepare_invoice_line(self, move=False, **optional_values):
+        """
+        Returns a dictionary of values to be used for creating the invoice line from this account order line.
+        Used in account order to create the invoice lines.
+        """
+        self.ensure_one()
+        return {
+            'display_type': self.display_type or 'product',
+            'product_id': self.product_id.id,
+            'product_uom_id': self.product_uom.id,
+            'quantity': self.qty_to_invoice,
+            'discount': self.discount,
+            'is_downpayment': self.is_downpayment,
+        }
+
+    def _get_invoice_lines(self):
+        self.ensure_one()
+        if self._context.get('accrual_entry_date'):
+            return self.invoice_lines.filtered(
+                lambda l: l.move_id.invoice_date and l.move_id.invoice_date <= self._context['accrual_entry_date']
+            )
+        else:
+            return self.invoice_lines
+
+    def _get_downpayment_state(self):
+        self.ensure_one()
+
+        if self.display_type:
+            return None
+
+        invoice_lines = self._get_invoice_lines()
+        if all(line.parent_state == 'draft' for line in invoice_lines):
+            return 'draft'
+        if all(line.parent_state == 'cancel' for line in invoice_lines):
+            return 'cancel'
+
+        return None
+
+    def _compute_name(self):
+        for line in self:
+            if line.is_downpayment:
+                lang = line.order_id._get_lang()
+                if lang != self.env.lang:
+                    line = line.with_context(lang=lang)
+
+                line.name = line._get_downpayment_description()
+
+    @api.depends('price_unit', 'tax_ids', 'discount')
+    def _compute_amount(self):
+        for line in self:
+            tax_results = self.env['account.tax']._compute_taxes(
+                [line._convert_to_tax_base_line_dict()],
+                line.company_id,
+            )
+            totals = next(iter(tax_results['totals'].values()))
+            amount_untaxed = totals['amount_untaxed']
+            amount_tax = totals['amount_tax']
+
+            line.update({
+                'price_subtotal': amount_untaxed,
+                'price_tax': amount_tax,
+                'price_total': amount_untaxed + amount_tax,
+            })
+
+    def _compute_price_unit(self):
+        pass  # To override
+
+    def _compute_discount(self):
+        pass  # To override
+
+    def _compute_qty_to_invoice(self):
+        pass  # To override
+
+    def _get_downpayment_description(self):
+        self.ensure_one()
+        if self.display_type:
+            return _("Down Payments")
+
+        dp_state = self._get_downpayment_state()
+        name = _("Down Payment")
+        if dp_state == 'draft':
+            name = _(
+                "Down Payment: %(date)s (Draft)",
+                date=format_date(self.env, self.create_date.date()),
+            )
+        elif dp_state == 'cancel':
+            name = _("Down Payment (Cancelled)")
+        else:
+            invoice = self._get_invoice_lines().filtered(
+                lambda aml: aml.quantity >= 0
+            ).move_id.filtered(lambda move: move.move_type in ['out_invoice', 'in_invoice'])
+            if len(invoice) == 1 and invoice.payment_reference and invoice.invoice_date:
+                name = _(
+                    "Down Payment (ref: %(reference)s on %(date)s)",
+                    reference=invoice.payment_reference,
+                    date=format_date(self.env, invoice.invoice_date),
+                )
+
+        return name

--- a/addons/account/models/account_order_line_mixin.py
+++ b/addons/account/models/account_order_line_mixin.py
@@ -14,7 +14,7 @@ class AccountOrderLineMixin(models.AbstractModel):
         help="Down payments are made when creating account moves from an order. They are not copied when duplicating an order."
     )
 
-    invoice_lines = fields.One2many('account.move.line')  # To override
+    account_move_line_ids = fields.One2many('account.move.line')  # To override
     display_type = fields.Selection(
         [('line_section', "Section"), ('line_note', "Note")],
         help="Technical field for UX purpose.",
@@ -57,11 +57,11 @@ class AccountOrderLineMixin(models.AbstractModel):
     def _get_invoice_lines(self):
         self.ensure_one()
         if self._context.get('accrual_entry_date'):
-            return self.invoice_lines.filtered(
+            return self.account_move_line_ids.filtered(
                 lambda l: l.move_id.invoice_date and l.move_id.invoice_date <= self._context['accrual_entry_date']
             )
         else:
-            return self.invoice_lines
+            return self.account_move_line_ids
 
     def _get_downpayment_state(self):
         self.ensure_one()

--- a/addons/account/models/account_order_line_mixin.py
+++ b/addons/account/models/account_order_line_mixin.py
@@ -24,7 +24,7 @@ class AccountOrderLineMixin(models.AbstractModel):
     order_id = fields.Many2one('account.order.mixin')
     qty_to_invoice = fields.Float('Quantity to Invoice', compute='_compute_qty_to_invoice', digits='Product Unit of Measure', store=True)
     price_unit = fields.Float("Unit Price", digits='Product Price', compute='_compute_price_unit', required=True, readonly=False, store=True)
-    tax_id = fields.Many2many('account.tax', string="Taxes", check_company=True, context={'active_test': False})
+    tax_ids = fields.Many2many('account.tax', string="Taxes", check_company=True, context={'active_test': False})
     product_uom = fields.Many2one('uom.uom', "Unit of Measure", domain="[('category_id', '=', product_uom_category_id)]")
     discount = fields.Float("Discount (%)", digits='Discount', compute='_compute_discount', store=True, readonly=False, precompute=True)
     currency_id = fields.Many2one(related='order_id.currency_id', store=True, string='Currency', readonly=True, precompute=True)

--- a/addons/account/models/account_order_mixin.py
+++ b/addons/account/models/account_order_mixin.py
@@ -111,7 +111,7 @@ class AccountOrderMixin(models.AbstractModel):
         """
         raise NotImplementedError  # To override
 
-    def _prepare_invoice(self):
+    def _prepare_account_move_values(self):
         """
         Prepare the dict of values to create the new invoice for this order.
         Used when generating the invoice from this account order.
@@ -217,7 +217,7 @@ class AccountOrderMixin(models.AbstractModel):
             if not any(not line.display_type for line in invoiceable_lines):
                 continue
 
-            invoice_vals = order._prepare_invoice()
+            invoice_vals = order._prepare_account_move_values()
             invoice_line_vals = []
             down_payment_section_added = False
             for line in invoiceable_lines:

--- a/addons/account/models/account_order_mixin.py
+++ b/addons/account/models/account_order_mixin.py
@@ -1,0 +1,243 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command, _, api, fields, models
+from odoo.tools import float_is_zero
+
+
+class AccountOrderMixin(models.AbstractModel):
+    # This mixin contains the shared logic between sale orders and purchase orders (ex. taxes, down payments, ...)
+    _name = 'account.order.mixin'
+    _description = 'Account Order Mixin'
+
+    amount_to_invoice = fields.Monetary("Amount to invoice", compute='_compute_amount_to_invoice')
+    amount_invoiced = fields.Monetary("Amount already invoiced", compute='_compute_amount_invoiced')
+
+    # To override
+    company_id = fields.Many2one('res.company', 'Company', required=True, index=True, default=lambda self: self.env.company)
+    currency_id = fields.Many2one('res.currency', 'Currency', required=True, default=lambda self: self.env.company.currency_id.id)
+    fiscal_position_id = fields.Many2one('account.fiscal.position', string='Fiscal Position', check_company=True)
+    partner_id = fields.Many2one('res.partner', required=True, change_default=True, tracking=True, index=True, domain="[('company_id', 'in', (False, company_id))]")
+
+    amount_untaxed = fields.Monetary(string='Untaxed Amount', store=True, compute='_compute_amounts')
+    amount_tax = fields.Monetary(string="Taxes", store=True, compute='_compute_amounts')
+    amount_total = fields.Monetary(string='Total', store=True, compute='_compute_amounts')
+
+    invoice_ids = fields.Many2many('account.move')
+    order_line = fields.One2many('account.order.line.mixin')
+
+    invoice_status = fields.Selection([], compute='_compute_invoice_status', store=True)
+    name = fields.Char(string="Order Reference", required=True, copy=False, readonly=False, index='trigram', default=lambda self: _('New'))
+    payment_term_id = fields.Many2one('account.payment.term', 'Payment Terms', check_company=True)
+
+    @api.depends('invoice_ids.state', 'currency_id', 'amount_total')
+    def _compute_amount_to_invoice(self):
+        pass  # To override
+
+    @api.depends('amount_total', 'amount_to_invoice')
+    def _compute_amount_invoiced(self):
+        for order in self:
+            order.amount_invoiced = order.amount_total - order.amount_to_invoice
+
+    @api.depends('order_line.price_subtotal', 'order_line.price_tax', 'order_line.price_total')
+    def _compute_amounts(self):
+        """Compute the total amounts of the order."""
+        for order in self:
+            order_lines = order.order_line.filtered(lambda l: not l.display_type)
+
+            if order.company_id.tax_calculation_rounding_method == 'round_globally':
+                tax_results = self.env['account.tax']._compute_taxes(
+                    [
+                        line._convert_to_tax_base_line_dict()
+                        for line in order_lines
+                    ],
+                    order.company_id,
+                )
+                totals = tax_results['totals']
+                amount_untaxed = totals.get(order.currency_id, {}).get('amount_untaxed', 0.0)
+                amount_tax = totals.get(order.currency_id, {}).get('amount_tax', 0.0)
+            else:
+                amount_untaxed = sum(order_lines.mapped('price_subtotal'))
+                amount_tax = sum(order_lines.mapped('price_tax'))
+
+            order.amount_untaxed = amount_untaxed
+            order.amount_tax = amount_tax
+            order.amount_total = order.amount_untaxed + order.amount_tax
+
+    def _compute_invoice_status(self):
+        pass  # To override
+
+    def _get_copiable_order_lines(self):
+        """Returns the order lines that can be copied to a new order."""
+        return self.order_line.filtered(lambda l: not l.is_downpayment)
+
+    def copy_data(self, default=None):
+        default = default or {}
+        default_has_no_order_line = 'order_line' not in default
+        default.setdefault('order_line', [])
+        vals_list = super().copy_data(default=default)
+        if default_has_no_order_line:
+            for order, vals in zip(self, vals_list):
+                vals['order_line'] = [
+                    Command.create(line_vals)
+                    for line_vals in order._get_copiable_order_lines().copy_data()
+                ]
+        return vals_list
+
+    def action_view_invoice(self, invoices=False):
+        """
+        Returns the action to view the provided invoices.
+        Used to display the created invoices after creation.
+        """
+        raise NotImplementedError  # To override
+
+    def _get_order_direction(self):
+        """
+        Returns the sign (1 or -1) to indicate whether the order is related to selling or buying (respectively)
+        to multiply with when calculating the amount to invoice and creating the invoice lines.
+        """
+        raise NotImplementedError  # To override
+
+    def _is_locked(self):
+        """
+        Returns whether the order is locked.
+        Used to decide which down payment lines to update the status of when posting a linked down payment invoice.
+        """
+        raise NotImplementedError  # To override
+
+    def _create_new_order_line(self, values):
+        """
+        Returns the results of a call to create() on the subrecord (sale.order.line or purchase.order.line).
+        Used to create the order lines of the correct type.
+        """
+        raise NotImplementedError  # To override
+
+    def _prepare_invoice(self):
+        """
+        Prepare the dict of values to create the new invoice for this order.
+        Used when generating the invoice from this account order.
+        """
+        self.ensure_one()
+        return {
+            'currency_id': self.currency_id.id,
+            'invoice_origin': self.name,
+            'invoice_payment_term_id': self.payment_term_id.id,
+            'invoice_line_ids': [],
+            'company_id': self.company_id.id,
+        }
+
+    def _create_invoices(self, grouped=False, final=False, date=None):
+        """
+        Create the invoices for this account order.
+        """
+        raise NotImplementedError  # To override
+
+    def _get_lang(self):
+        self.ensure_one()
+
+        if self.partner_id.lang and not self.partner_id.is_public:
+            return self.partner_id.lang
+
+        return self.env.lang
+
+    def _get_invoiceable_lines(self, final=False):
+        """Return the invoiceable lines for order `self`."""
+
+        # Keep down payment lines separately, to put them together
+        # at the end of the invoice, in a specific dedicated section.
+        down_payment_lines = []
+        invoiceable_lines = []
+        pending_section = None
+        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+
+        for line in self.order_line:
+            if line.display_type == 'line_section':
+                # Only invoice the section if one of its lines is invoiceable
+                pending_section = line
+                continue
+            if line.display_type != 'line_note' and float_is_zero(line.qty_to_invoice, precision_digits=precision):
+                continue
+            if line._has_valid_qty_to_invoice(final) or line.display_type == 'line_note':
+                if line.is_downpayment:
+                    down_payment_lines.append(line)
+                    continue
+                if pending_section:
+                    invoiceable_lines.append(pending_section)
+                    pending_section = None
+                invoiceable_lines.append(line)
+
+        return invoiceable_lines + down_payment_lines
+
+    def _prepare_down_payment_section_line(self, **optional_values):
+        """ Prepare the values to create a new down payment section.
+
+        :param dict optional_values: any parameter that should be added to the returned down payment section
+        :return: `account.move.line` creation values
+        :rtype: dict
+        """
+        self.ensure_one()
+        # Edit the context to properly translate the section heading (https://github.com/odoo/odoo/commit/964d35207717af9e7bf42e6f9293249cb6e48991)
+        context = {'lang': self.partner_id.lang}
+        down_payments_section_line = {
+            'display_type': 'line_section',
+            'name': _("Down Payments"),
+            'product_id': False,
+            'product_uom_id': False,
+            'quantity': 0,
+            'discount': 0,
+            'price_unit': 0,
+            'account_id': False,
+            **optional_values
+        }
+        del context
+        return down_payments_section_line
+
+    def _get_order_lines_to_report(self):
+        down_payment_lines = self.order_line.filtered(
+            lambda line:
+                line.is_downpayment
+                and not line.display_type
+                and not line._get_downpayment_state()
+        )
+
+        return self.order_line.filtered(
+            lambda line:
+                not line.is_downpayment
+                or (line.display_type and down_payment_lines)
+                or line in down_payment_lines
+        )
+
+    def _generate_invoice_values(self, final=False):
+        invoice_vals_list = []
+        sequence = 0
+        for order in self:
+            order = order.with_company(order.company_id).with_context(lang=order._get_lang())
+
+            invoiceable_lines = order._get_invoiceable_lines(final)
+
+            if not any(not line.display_type for line in invoiceable_lines):
+                continue
+
+            invoice_vals = order._prepare_invoice()
+            invoice_line_vals = []
+            down_payment_section_added = False
+            for line in invoiceable_lines:
+                if not down_payment_section_added and line.is_downpayment:
+                    # Create a dedicated section for the down payments
+                    # (put at the end of the invoiceable_lines, except for the initial down payment invoice itself)
+                    invoice_line_vals.append(
+                        Command.create(
+                            order._prepare_down_payment_section_line(sequence=sequence)
+                        ),
+                    )
+                    down_payment_section_added = True
+                    sequence += 1
+                invoice_line_vals.append(
+                    Command.create(
+                        line._prepare_invoice_line(sequence=sequence)
+                    ),
+                )
+                sequence += 1
+
+            invoice_vals['invoice_line_ids'] += invoice_line_vals
+            invoice_vals_list.append(invoice_vals)
+        return invoice_vals_list

--- a/addons/account/models/account_order_mixin.py
+++ b/addons/account/models/account_order_mixin.py
@@ -22,14 +22,14 @@ class AccountOrderMixin(models.AbstractModel):
     amount_tax = fields.Monetary(string="Taxes", store=True, compute='_compute_amounts')
     amount_total = fields.Monetary(string='Total', store=True, compute='_compute_amounts')
 
-    invoice_ids = fields.Many2many('account.move')
+    account_move_ids = fields.Many2many('account.move')
     order_line = fields.One2many('account.order.line.mixin')
 
     invoice_status = fields.Selection([], compute='_compute_invoice_status', store=True)
     name = fields.Char(string="Order Reference", required=True, copy=False, readonly=False, index='trigram', default=lambda self: _('New'))
     payment_term_id = fields.Many2one('account.payment.term', 'Payment Terms', check_company=True)
 
-    @api.depends('invoice_ids.state', 'currency_id', 'amount_total')
+    @api.depends('account_move_ids.state', 'currency_id', 'amount_total')
     def _compute_amount_to_invoice(self):
         pass  # To override
 

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1052,6 +1052,7 @@
                                         <field name="product_id"
                                                optional="show"
                                                widget="product_label_section_and_note_field"
+                                               readonly="is_downpayment"
                                                domain="
                                                     context.get('default_move_type') in ('out_invoice', 'out_refund', 'out_receipt')
                                                     and [('sale_ok', '=', True)]

--- a/addons/account/wizard/__init__.py
+++ b/addons/account/wizard/__init__.py
@@ -12,3 +12,4 @@ from . import base_document_layout
 from . import account_payment_register
 from . import accrued_orders
 from . import base_partner_merge
+from . import account_advance_payment

--- a/addons/account/wizard/account_advance_payment.py
+++ b/addons/account/wizard/account_advance_payment.py
@@ -288,13 +288,13 @@ class AdvancePaymentWizard(models.AbstractModel):
         downpayment_line_map = {}
         for tax_id, analytic_distribution, price_subtotal, account in down_payment_values:
             grouping_key = frozendict({
-                self._taxes_field_name(): tuple(sorted(tax_id.ids)),
+                'tax_ids': tuple(sorted(tax_id.ids)),
                 'analytic_distribution': analytic_distribution,
                 'account_id': account,
             })
             downpayment_line_map.setdefault(grouping_key, {
                 **base_downpayment_lines_values,
-                self._taxes_field_name(): grouping_key[self._taxes_field_name()],
+                'tax_ids': grouping_key['tax_ids'],
                 'analytic_distribution': grouping_key['analytic_distribution'],
                 'product_uom_qty': 0.0,
                 'price_unit': 0.0,

--- a/addons/account/wizard/account_advance_payment.py
+++ b/addons/account/wizard/account_advance_payment.py
@@ -318,7 +318,7 @@ class AdvancePaymentWizard(models.AbstractModel):
     def _prepare_down_payment_invoice_values(self, order, dp_lines, accounts):
         self.ensure_one()
         return {
-            **order._prepare_invoice(),
+            **order._prepare_account_move_values(),
             'invoice_line_ids': [Command.create(
                 line._prepare_invoice_line(
                     name=self._get_down_payment_description(order),

--- a/addons/account/wizard/account_advance_payment.py
+++ b/addons/account/wizard/account_advance_payment.py
@@ -1,0 +1,339 @@
+#  Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models, fields, api, _, Command
+from odoo.exceptions import UserError
+from odoo.tools import frozendict, float_compare
+
+
+class AdvancePaymentWizard(models.AbstractModel):
+    _name = 'account.advance.payment.wizard'
+    _description = "Advance Payment Account Move"
+
+    advance_payment_method = fields.Selection(
+        selection=[
+            ('delivered', "Regular invoice/bill"),
+            ('percentage', "Down payment (percentage)"),
+            ('fixed', "Down payment (fixed amount)"),
+        ],
+        string="Create Invoice",
+        default='delivered',
+        required=True,
+        help="A standard invoice is issued with all the order lines ready for invoicing, "
+             "according to their invoicing policy (based on ordered or delivered quantity).",
+    )
+    count = fields.Integer(string="Order Count", compute='_compute_count')
+    order_ids = fields.Many2many('account.order.mixin', default=lambda self: self.env.context.get('active_ids'))
+
+    # Down Payment logic
+    has_down_payments = fields.Boolean(string="Has down payments", compute="_compute_has_down_payments")
+
+    # New Down Payment
+    amount = fields.Float(
+        string="Down Payment",
+        help="The percentage of amount to be invoiced in advance.",
+    )
+    fixed_amount = fields.Monetary(
+        string="Down Payment Amount (Fixed)",
+        help="The fixed amount to be invoiced in advance.",
+    )
+    currency_id = fields.Many2one(
+        comodel_name='res.currency',
+        compute='_compute_currency_id',
+        store=True,
+    )
+    company_id = fields.Many2one(
+        comodel_name='res.company',
+        compute='_compute_company_id',
+        store=True,
+    )
+    amount_invoiced = fields.Monetary(
+        string="Already invoiced",
+        compute="_compute_invoice_amounts",
+        help="Only confirmed down payments and invoiced amounts are considered.",
+    )
+    amount_to_invoice = fields.Monetary(
+        string="Amount to invoice",
+        compute="_compute_invoice_amounts",
+    )
+
+    # UI
+    display_draft_invoice_warning = fields.Boolean(compute="_compute_display_draft_invoice_warning")
+    display_invoice_amount_warning = fields.Boolean(compute="_compute_display_invoice_amount_warning")
+
+    # === HOOKS ===#
+    def _needs_to_group_on_invoice(self):
+        """
+        Returns whether to create one invoice for all orders related to the same partner and invoicing address.
+        Used for setting the grouped parameter on invoice creation.
+        """
+        return False
+
+    def _get_payment_term_account_type(self):
+        """
+        Returns a string with the account_type to filter the account move lines on the created invoice.
+        Used to check the rounding on the invoice lines after down payment invoice creation.
+        """
+        raise NotImplementedError  # To override
+
+    def _get_product_account_internal_group(self):
+        """
+        Returns the account category (expense or income) to use for getting the correct account from the product.
+        Used when creating the down payment lines.
+        """
+        raise NotImplementedError  # To override
+
+    # === COMPUTE METHODS ===#
+
+    @api.depends('order_ids')
+    def _compute_count(self):
+        for wizard in self:
+            wizard.count = len(wizard.order_ids)
+
+    @api.depends('order_ids')
+    def _compute_has_down_payments(self):
+        for wizard in self:
+            wizard.has_down_payments = any(
+                wizard.order_ids.order_line.mapped('is_downpayment')
+            )
+
+    # next computed fields are only used for down payments invoices and therefore should only
+    # have a value when 1 unique order is invoiced through the wizard
+    # =============
+
+    @api.depends('order_ids')
+    def _compute_currency_id(self):
+        self.currency_id = False
+        for wizard in self:
+            if wizard.count == 1:
+                wizard.currency_id = wizard.order_ids.currency_id
+
+    @api.depends('order_ids')
+    def _compute_company_id(self):
+        self.company_id = False
+        for wizard in self:
+            if wizard.count == 1:
+                wizard.company_id = wizard.order_ids.company_id
+
+    # =============
+
+    @api.depends('amount', 'fixed_amount', 'advance_payment_method', 'amount_to_invoice')
+    def _compute_display_invoice_amount_warning(self):
+        for wizard in self:
+            invoice_amount = wizard.fixed_amount
+            if wizard.advance_payment_method == 'percentage':
+                invoice_amount = wizard.amount / 100 * sum(wizard.order_ids.mapped('amount_total'))
+            wizard.display_invoice_amount_warning = invoice_amount > wizard.amount_to_invoice
+
+    @api.depends('order_ids')
+    def _compute_display_draft_invoice_warning(self):
+        for wizard in self:
+            wizard.display_draft_invoice_warning = any(invoice.state == 'draft' for invoice in wizard.order_ids.invoice_ids)
+
+    @api.depends('order_ids')
+    def _compute_invoice_amounts(self):
+        for wizard in self:
+            # _origin -> See https://github.com/odoo/odoo/pull/133836
+            wizard.amount_invoiced = sum(wizard.order_ids._origin.mapped('amount_invoiced'))
+            wizard.amount_to_invoice = sum(wizard.order_ids._origin.mapped('amount_to_invoice'))
+
+    # === CONSTRAINT METHODS ===#
+
+    def _check_amount_is_positive(self):
+        for wizard in self:
+            if (wizard.advance_payment_method == 'percentage' and float_compare(wizard.amount, 0, precision_rounding=wizard.currency_id.rounding) <= 0) \
+                    or (wizard.advance_payment_method == 'fixed' and float_compare(wizard.fixed_amount, 0, precision_rounding=wizard.currency_id.rounding) <= 0):
+                raise UserError(_('The value of a down payment amount must be positive.'))
+
+    # === ACTION METHODS ===#
+
+    def create_invoices(self):
+        self._check_amount_is_positive()
+        invoices = self._create_invoices(self.order_ids)
+        return self.order_ids.action_view_invoice(invoices=invoices)
+
+    def view_draft_invoices(self):
+        return {
+            'name': _('Draft Invoices'),
+            'type': 'ir.actions.act_window',
+            'view_mode': 'tree',
+            'views': [(False, 'list'), (False, 'form')],
+            'res_model': 'account.move',
+            'domain': [('state', '=', 'draft')],  # To override
+        }
+
+    def _create_invoices(self, orders):
+        if self.advance_payment_method == 'delivered':
+            return orders._create_invoices(final=True, grouped=self._needs_to_group_on_invoice())
+
+        return self._create_down_payment_invoice()
+
+    def _create_down_payment_invoice(self):
+        self.order_ids.ensure_one()
+        self_c = self.with_company(self.company_id)
+        order = self_c.order_ids
+
+        # Create down payment section if necessary
+        if not any(line.display_type and line.is_downpayment for line in order.order_line):
+            self_c.order_ids.with_context(no_log_for_new_lines=True)._create_new_order_line(
+                self_c._prepare_down_payment_section_values(order)
+            )
+
+        values, accounts = self_c._prepare_down_payment_lines_values(order)
+        down_payment_lines = self_c.order_ids.with_context(no_log_for_new_lines=True)._create_new_order_line(values)
+
+        invoice = self_c.env['account.move'].sudo().create(
+            self_c._prepare_down_payment_invoice_values(order, down_payment_lines, accounts)
+        )
+
+        # Ensure the invoice total is exactly the expected fixed amount.
+        if self_c.advance_payment_method == 'fixed':
+            delta_amount = (invoice.amount_total - self_c.fixed_amount) * (-1 if invoice.is_inbound() else 1) * self_c.order_ids._get_order_direction()
+            if not order.currency_id.is_zero(delta_amount):
+                receivable_line = invoice.line_ids.filtered(lambda aml: aml.account_id.account_type == self_c._get_payment_term_account_type())[:1]
+                product_lines = invoice.line_ids.filtered(lambda aml: aml.display_type == 'product')
+                tax_lines = invoice.line_ids.filtered(lambda aml: aml.tax_line_id.amount_type not in (False, 'fixed'))
+
+                if product_lines and tax_lines and receivable_line:
+                    line_commands = [Command.update(receivable_line.id, {
+                        'amount_currency': receivable_line.amount_currency + delta_amount,
+                    })]
+                    delta_sign = 1 if delta_amount > 0 else -1
+                    for lines, attr, sign in (
+                        (product_lines, 'price_total', -1),
+                        (tax_lines, 'amount_currency', 1),
+                    ):
+                        remaining = delta_amount
+                        for line in lines:
+                            if order.currency_id.compare_amounts(remaining, 0) != delta_sign:
+                                break
+                            amt = delta_sign * max(
+                                order.currency_id.rounding,
+                                abs(order.currency_id.round(remaining / len(lines))),
+                            )
+                            remaining -= amt
+                            line_commands.append(Command.update(line.id, {attr: line[attr] + amt * sign}))
+                    invoice.line_ids = line_commands
+
+        # Unsudo the invoice after creation if not already sudoed
+        invoice = invoice.sudo(self_c.env.su)
+
+        return invoice
+
+    def _prepare_down_payment_section_values(self, order):
+        return {
+            'product_uom_qty': 0.0,
+            'order_id': order.id,
+            'display_type': 'line_section',
+            'is_downpayment': True,
+            'sequence': order.order_line and order.order_line[-1].sequence + 1 or 10,
+        }
+
+    def _prepare_down_payment_lines_values(self, order):
+        """ Create one down payment line per tax or unique taxes combination and per account.
+            Apply the tax(es) to their respective lines.
+
+            :param order: Order for which the down payment lines are created.
+            :return:      An array of dicts with the down payment lines values.
+        """
+        self.ensure_one()
+
+        if self.advance_payment_method == 'percentage':
+            ratio = self.amount / 100
+        else:
+            ratio = self.fixed_amount / order.amount_total if order.amount_total else 1
+
+        order_lines = order.order_line.filtered(lambda l: not l.display_type and not l.is_downpayment)
+        base_downpayment_lines_values = self._prepare_base_downpayment_line_values(order)
+
+        tax_base_line_dicts = [
+            line._convert_to_tax_base_line_dict(
+                analytic_distribution=line.analytic_distribution,
+                handle_price_include=False
+            )
+            for line in order_lines
+        ]
+        computed_taxes = self.env['account.tax']._compute_taxes(tax_base_line_dicts, self.company_id)
+        down_payment_values = []
+        for line, tax_repartition in computed_taxes['base_lines_to_update']:
+            account = line['product'].product_tmpl_id.get_product_accounts(
+                fiscal_pos=order.fiscal_position_id
+            ).get(self._get_product_account_internal_group())
+            taxes = line['taxes'].flatten_taxes_hierarchy()
+            fixed_taxes = taxes.filtered(lambda tax: tax.amount_type == 'fixed')
+            down_payment_values.append([
+                taxes - fixed_taxes,
+                line['analytic_distribution'],
+                tax_repartition['price_subtotal'],
+                account,
+            ])
+            for fixed_tax in fixed_taxes:
+                # Fixed taxes cannot be set as taxes on down payments as they always amounts to 100%
+                # of the tax amount. Therefore fixed taxes are removed and are replace by a new line
+                # with appropriate amount, and non fixed taxes if the fixed tax affected the base of
+                # any other non fixed tax.
+                if fixed_tax.price_include:
+                    continue
+
+                if fixed_tax.include_base_amount:
+                    pct_tax = taxes[list(taxes).index(fixed_tax) + 1:]\
+                        .filtered(lambda t: t.is_base_affected and t.amount_type != 'fixed')
+                else:
+                    pct_tax = self.env['account.tax']
+                down_payment_values.append([
+                    pct_tax,
+                    line['analytic_distribution'],
+                    line['quantity'] * fixed_tax.amount,
+                    account,
+                ])
+
+        downpayment_line_map = {}
+        for tax_id, analytic_distribution, price_subtotal, account in down_payment_values:
+            grouping_key = frozendict({
+                self._taxes_field_name(): tuple(sorted(tax_id.ids)),
+                'analytic_distribution': analytic_distribution,
+                'account_id': account,
+            })
+            downpayment_line_map.setdefault(grouping_key, {
+                **base_downpayment_lines_values,
+                self._taxes_field_name(): grouping_key[self._taxes_field_name()],
+                'analytic_distribution': grouping_key['analytic_distribution'],
+                'product_uom_qty': 0.0,
+                'price_unit': 0.0,
+            })
+            downpayment_line_map[grouping_key]['price_unit'] += price_subtotal
+        for key in downpayment_line_map:
+            downpayment_line_map[key]['price_unit'] = order.currency_id.round(downpayment_line_map[key]['price_unit'] * ratio)
+
+        return list(downpayment_line_map.values()), [key['account_id'] for key in downpayment_line_map]
+
+    def _prepare_base_downpayment_line_values(self, order):
+        self.ensure_one()
+        return {
+            'product_uom_qty': 0.0,
+            'order_id': order.id,
+            'discount': 0.0,
+            'is_downpayment': True,
+            'sequence': order.order_line and order.order_line[-1].sequence + 1 or 10,
+        }
+
+    def _prepare_down_payment_invoice_values(self, order, dp_lines, accounts):
+        self.ensure_one()
+        return {
+            **order._prepare_invoice(),
+            'invoice_line_ids': [Command.create(
+                line._prepare_invoice_line(
+                    name=self._get_down_payment_description(order),
+                    quantity=1.0,
+                    **({'account_id': account.id} if account else {})
+                )
+            ) for line, account in zip(dp_lines, accounts)],
+        }
+
+    def _get_down_payment_description(self, order):
+        self.ensure_one()
+        context = {'lang': order.partner_id.lang}
+        if self.advance_payment_method == 'percentage':
+            name = _("Down payment of %(amount)s%%", amount=self.amount)
+        else:
+            name = _("Down Payment")
+        del context
+        return name

--- a/addons/account/wizard/account_advance_payment.py
+++ b/addons/account/wizard/account_advance_payment.py
@@ -126,7 +126,7 @@ class AdvancePaymentWizard(models.AbstractModel):
     @api.depends('order_ids')
     def _compute_display_draft_invoice_warning(self):
         for wizard in self:
-            wizard.display_draft_invoice_warning = any(invoice.state == 'draft' for invoice in wizard.order_ids.invoice_ids)
+            wizard.display_draft_invoice_warning = any(invoice.state == 'draft' for invoice in wizard.order_ids.account_move_ids)
 
     @api.depends('order_ids')
     def _compute_invoice_amounts(self):

--- a/addons/account/wizard/account_advance_payments_views.xml
+++ b/addons/account/wizard/account_advance_payments_views.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_account_advance_payment" model="ir.ui.view">
+        <field name="model">account.advance.payment.wizard</field>
+        <field name="arch" type="xml">
+            <form>
+                <field name="display_draft_invoice_warning" invisible="1"/>
+                <field name="has_down_payments" invisible="1"/>
+                <div class="alert alert-warning py-1" role="alert" invisible="not display_draft_invoice_warning">
+                    <a name="view_draft_invoices" type="object"></a>
+                    <p invisible="advance_payment_method != 'delivered'" name="deduct_draft"></p>
+                </div>
+                <group>
+                    <field name="order_ids" invisible="1"/>
+                    <field name="count" invisible="count == 1"/>
+                    <field name="advance_payment_method" class="oe_inline"
+                        widget="radio"
+                        invisible="count &gt; 1"/>
+                </group>
+                <group name="down_payment_specification"
+                    invisible="advance_payment_method not in ('fixed', 'percentage')">
+                    <field name="company_id" invisible="1"/>
+                    <label for="amount"/>
+                    <div id="payment_method_details">
+                        <field name="currency_id" invisible="1"/>
+                        <field name="display_invoice_amount_warning" invisible="1"/>
+                        <field name="fixed_amount"
+                            invisible="advance_payment_method != 'fixed'"
+                            required="advance_payment_method == 'fixed'"
+                            class="oe_inline"/>
+                        <field name="amount"
+                            invisible="advance_payment_method != 'percentage'"
+                            required="advance_payment_method == 'percentage'"
+                            class="oe_inline"/>
+                        <span invisible="advance_payment_method != 'percentage'"
+                            class="oe_inline">% </span>
+                        <span invisible="not display_invoice_amount_warning"
+                              class="oe_inline text-danger"
+                              name="amount_warning"
+                              title="title">
+                            <i class="fa fa-warning"/>
+                        </span>
+                    </div>
+                </group>
+                <group invisible="not has_down_payments and not amount_invoiced">
+                    <field name="amount_invoiced"/>
+                    <field name="amount_to_invoice"/>
+                </group>
+                <footer>
+                    <button name="create_invoices"
+                            type="object"
+                            id="create_invoice_open"
+                            string="Create Draft"
+                            class="btn-primary"
+                            data-hotkey="q"/>
+                    <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
+                </footer>
+            </form>
+        </field>
+    </record>
+</odoo>

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -181,7 +181,7 @@ class AccruedExpenseRevenue(models.TransientModel):
                         account = self._get_computed_account(order, order_line.product_id, is_purchase)
                         amount_currency = order_line.currency_id.round(order_line.qty_to_invoice * order_line.price_unit)
                         amount = order.currency_id._convert(amount_currency, self.company_id.currency_id, self.company_id)
-                        fnames = ['qty_to_invoice', 'qty_received', 'qty_invoiced', 'invoice_lines']
+                        fnames = ['qty_to_invoice', 'qty_received', 'qty_invoiced', 'account_move_line_ids']
                         label = _(
                             '%(order)s - %(order_line)s; %(quantity_billed)s Billed, %(quantity_received)s Received at %(unit_price)s each',
                             order=order.name,
@@ -194,7 +194,7 @@ class AccruedExpenseRevenue(models.TransientModel):
                         account = self._get_computed_account(order, order_line.product_id, is_purchase)
                         amount_currency = order_line.untaxed_amount_to_invoice
                         amount = order.currency_id._convert(amount_currency, self.company_id.currency_id, self.company_id)
-                        fnames = ['qty_to_invoice', 'untaxed_amount_to_invoice', 'qty_invoiced', 'qty_delivered', 'invoice_lines']
+                        fnames = ['qty_to_invoice', 'untaxed_amount_to_invoice', 'qty_invoiced', 'qty_delivered', 'account_move_line_ids']
                         label = _(
                             '%(order)s - %(order_line)s; %(quantity_invoiced)s Invoiced, %(quantity_delivered)s Delivered at %(unit_price)s each',
                             order=order.name,

--- a/addons/account_payment/tests/test_payment_flows.py
+++ b/addons/account_payment/tests/test_payment_flows.py
@@ -40,7 +40,7 @@ class TestFlows(AccountPaymentCommon, PaymentHttpCommon):
             )
         tx_sudo = self._get_tx(processing_values['reference'])
         # Note: strangely, the check
-        # self.assertEqual(tx_sudo.invoice_ids, invoice)
+        # self.assertEqual(tx_sudo.account_move_ids, invoice)
         # doesn't work, and cache invalidation doesn't work either.
         self.invoice.invalidate_recordset(['transaction_ids'])
         self.assertEqual(self.invoice.transaction_ids, tx_sudo)

--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -219,7 +219,7 @@ class SaleOrder(models.Model):
             'product_uom_qty': 1,
             'product_uom': carrier.product_id.uom_id.id,
             'product_id': carrier.product_id.id,
-            'tax_id': [(6, 0, taxes_ids)],
+            'tax_ids': [(6, 0, taxes_ids)],
             'is_delivery': True,
         }
         if carrier.free_over and self.currency_id.is_zero(price_unit) :

--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -424,7 +424,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
         delivery_line = sale_order.order_line.filtered(lambda l: l.is_delivery)
 
         # delivery line should have taxes from the branch company
-        self.assertRecordValues(delivery_line, [{'product_id': delivery_product.id, 'tax_id': tax_b.ids}])
+        self.assertRecordValues(delivery_line, [{'product_id': delivery_product.id, 'tax_ids': tax_b.ids}])
 
         # update delivery product by setting only the tax from parent company
         delivery_product.write({'taxes_id': [Command.set((tax_a).ids)]})
@@ -438,7 +438,7 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
         delivery_line = sale_order.order_line.filtered(lambda l: l.is_delivery)
 
         # delivery line should have taxes from the parent company as there is no tax from the branch company
-        self.assertRecordValues(delivery_line, [{'product_id': delivery_product.id, 'tax_id': tax_a.ids}])
+        self.assertRecordValues(delivery_line, [{'product_id': delivery_product.id, 'tax_ids': tax_a.ids}])
 
     def test_update_weight_in_shipping_when_change_quantity(self):
         product_test = self.env['product.product'].create({

--- a/addons/event_booth_sale/tests/test_event_booth_sale.py
+++ b/addons/event_booth_sale/tests/test_event_booth_sale.py
@@ -186,7 +186,7 @@ class TestEventBoothSaleInvoice(AccountTestInvoicingCommon, TestEventBoothSaleWD
 
         # Create and check that the invoice was created
         invoice = sale_order._create_invoices()
-        self.assertEqual(len(sale_order.invoice_ids), 1, "Invoice not created.")
+        self.assertEqual(len(sale_order.account_move_ids), 1, "Invoice not created.")
 
         # Confirm the invoice and check SO invoice status
         invoice.action_post()

--- a/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
+++ b/addons/l10n_be_pos_sale/tests/test_l10n_be_pos_sale.py
@@ -31,7 +31,7 @@ class TestPoSSaleL10NBe(TestPointOfSaleHttpCommon):
                 'product_uom_qty': 10,
                 'product_uom': self.product_a.uom_id.id,
                 'price_unit': 10,
-                'tax_id': False,
+                'tax_ids': False,
             })],
         })
 

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -187,13 +187,13 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
             'fixed_amount': 6350.0,
         })
         downpayment_1.create_invoices()
-        advance_invoice = sale_order.invoice_ids
+        advance_invoice = sale_order.account_move_ids
 
         downpayment_2 = self.env['sale.advance.payment.inv'].with_context(context).create({
             'advance_payment_method': 'delivered',
         })
         downpayment_2.create_invoices()
-        final_invoice = sale_order.invoice_ids - advance_invoice
+        final_invoice = sale_order.account_move_ids - advance_invoice
 
         return advance_invoice, final_invoice
 

--- a/addons/l10n_hu_edi/tests/common.py
+++ b/addons/l10n_hu_edi/tests/common.py
@@ -169,7 +169,7 @@ class L10nHuEdiTestCommon(AccountTestInvoicingCommon):
                     'product_id': self.product_a.id,
                     'product_uom_qty': 1,
                     'price_unit': 10000.0,
-                    'tax_id': [Command.set(self.tax_vat.ids)],
+                    'tax_ids': [Command.set(self.tax_vat.ids)],
                 })
             ]
         })

--- a/addons/l10n_in_purchase/views/report_purchase_order.xml
+++ b/addons/l10n_in_purchase/views/report_purchase_order.xml
@@ -2,7 +2,7 @@
 <odoo>
 
     <template id="gst_report_purchaseorder_document_inherit" inherit_id="purchase.report_purchaseorder_document">
-        <xpath expr="//t[@t-foreach='o.order_line']//td[@id='product']" position="replace">
+        <xpath expr="//t[@t-foreach='lines_to_report']//td[@id='product']" position="replace">
             <td>
                 <span t-field="line.name"/>
                 <t t-if="line.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'">
@@ -16,7 +16,7 @@
     </template>
 
     <template id="gst_report_purchasequotation_document_inherit" inherit_id="purchase.report_purchasequotation_document">
-        <xpath expr="//t[@t-foreach='o.order_line']//td[@id='product']" position="replace">
+        <xpath expr="//t[@t-foreach='lines_to_report']//td[@id='product']" position="replace">
             <td>
                 <span t-field="order_line.name"/>
                 <t t-if="order_line.product_id.l10n_in_hsn_code and o.company_id.account_fiscal_country_id.code == 'IN'">

--- a/addons/l10n_in_purchase_stock/models/stock_move.py
+++ b/addons/l10n_in_purchase_stock/models/stock_move.py
@@ -19,6 +19,6 @@ class StockMove(models.Model):
         if line_id := self.purchase_line_id:
             return {
                 'is_from_order': True,
-                'taxes': line_id.taxes_id
+                'taxes': line_id.tax_ids
             }
         return super()._l10n_in_get_product_tax()

--- a/addons/l10n_in_sale/models/sale_order.py
+++ b/addons/l10n_in_sale/models/sale_order.py
@@ -33,8 +33,8 @@ class SaleOrder(models.Model):
                     l10n_in_gst_treatment = order.partner_id.vat and 'regular' or 'consumer'
                 order.l10n_in_gst_treatment = l10n_in_gst_treatment
 
-    def _prepare_invoice(self):
-        invoice_vals = super(SaleOrder, self)._prepare_invoice()
+    def _prepare_account_move_values(self):
+        invoice_vals = super()._prepare_account_move_values()
         if self.country_code == 'IN':
             invoice_vals['l10n_in_reseller_partner_id'] = self.l10n_in_reseller_partner_id.id
             invoice_vals['l10n_in_gst_treatment'] = self.l10n_in_gst_treatment

--- a/addons/l10n_in_sale/wizard/sale_make_invoice_advance.py
+++ b/addons/l10n_in_sale/wizard/sale_make_invoice_advance.py
@@ -7,8 +7,8 @@ from odoo import models
 class SaleAdvancePaymentInv(models.TransientModel):
     _inherit = "sale.advance.payment.inv"
 
-    def _prepare_invoice_values(self, order, so_line, accounts):
-        res = super()._prepare_invoice_values(order, so_line, accounts)
+    def _prepare_down_payment_invoice_values(self, order, so_line, accounts):
+        res = super()._prepare_down_payment_invoice_values(order, so_line, accounts)
         if order.country_code == 'IN':
             res['l10n_in_gst_treatment'] = order.l10n_in_gst_treatment
         if order.l10n_in_reseller_partner_id:

--- a/addons/l10n_in_sale_stock/models/stock_move.py
+++ b/addons/l10n_in_sale_stock/models/stock_move.py
@@ -19,6 +19,6 @@ class StockMove(models.Model):
         if line_id := self.sale_line_id:
             return {
                 'is_from_order': True,
-                'taxes': line_id.tax_id,
+                'taxes': line_id.tax_ids,
             }
         return super()._l10n_in_get_product_tax()

--- a/addons/l10n_it_edi_doi/models/sale_order.py
+++ b/addons/l10n_it_edi_doi/models/sale_order.py
@@ -118,13 +118,13 @@ class SaleOrder(models.Model):
             if declaration_fiscal_position and order.l10n_it_edi_doi_id:
                 order.fiscal_position_id = declaration_fiscal_position
 
-    def _prepare_invoice(self):
+    def _prepare_account_move_values(self):
         """
         Prepare the dict of values to create the new invoice for a sales order. This method may be
         overridden to implement custom invoice generation (making sure to call super() to establish
         a clean extension chain).
         """
-        vals = super()._prepare_invoice()
+        vals = super()._prepare_account_move_values()
         declaration = self.l10n_it_edi_doi_id
         if declaration:
             date = fields.Date.context_today(self)

--- a/addons/l10n_it_edi_doi/models/sale_order.py
+++ b/addons/l10n_it_edi_doi/models/sale_order.py
@@ -163,12 +163,12 @@ class SaleOrder(models.Model):
             if not declaration_of_intent_tax:
                 continue
             declaration_tax_lines = order.order_line.filtered(
-                lambda line: declaration_of_intent_tax in line.tax_id
+                lambda line: declaration_of_intent_tax in line.tax_ids
             )
             if declaration_tax_lines and not order.l10n_it_edi_doi_id:
                 errors.append(_('Given the tax %s is applied, there should be a Declaration of Intent selected.',
                                 declaration_of_intent_tax.name))
-            if any(line.tax_id != declaration_of_intent_tax for line in declaration_tax_lines):
+            if any(line.tax_ids != declaration_of_intent_tax for line in declaration_tax_lines):
                 errors.append(_('A line using tax %s should not contain any other taxes',
                                 declaration_of_intent_tax.name))
         if errors:
@@ -240,7 +240,7 @@ class SaleOrder(models.Model):
             order_lines = order.order_line.filtered(
                 # The declaration tax cannot be used with other taxes on a single line
                 # (checked in `action_confirm`)
-                lambda line: line.tax_id.ids == tax.ids
+                lambda line: line.tax_ids.ids == tax.ids
             )
             order_not_yet_invoiced = 0
             for line in order_lines:

--- a/addons/l10n_it_edi_doi/models/sale_order_line.py
+++ b/addons/l10n_it_edi_doi/models/sale_order_line.py
@@ -13,7 +13,7 @@ class SaleOrderLine(models.Model):
         store=True,
     )
 
-    @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity')
+    @api.depends('account_move_line_ids.move_id.state', 'account_move_line_ids.quantity')
     def _compute_qty_invoiced_posted(self):
         """
         This method is almost identical to '_compute_qty_invoiced()'. The only difference lies in the fact that

--- a/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
+++ b/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
@@ -93,7 +93,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                 'product_id': self.product_1.id,
                 'price_unit': 1000.0,  # == declaration.threshold
                 'product_uom_qty': 2,
-                'tax_id': [Command.set(declaration_tax.ids)],
+                'tax_ids': [Command.set(declaration_tax.ids)],
             }),
         ])
 
@@ -217,13 +217,13 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 1000.0,  # == declaration.threshold
-                'tax_id': [Command.set(declaration_tax.ids)],
+                'tax_ids': [Command.set(declaration_tax.ids)],
             }),
             Command.create({
                 'name': 'not a declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 2000.0,  # > declaration.threshold; not counted
-                'tax_id': False,
+                'tax_ids': False,
             }),
         ])
 
@@ -313,13 +313,13 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 2000.0,  # > declaration.threshold
-                'tax_id': [Command.set(declaration_tax.ids)],
+                'tax_ids': [Command.set(declaration_tax.ids)],
             }),
             Command.create({
                 'name': 'not a declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 2000.0,  # > declaration.threshold; not counted
-                'tax_id': False,
+                'tax_ids': False,
             }),
         ])
         independent_order.action_confirm()
@@ -334,13 +334,13 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                 'name': 'declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 1000.0,  # == declaration.threshold
-                'tax_id': [Command.set(declaration_tax.ids)],
+                'tax_ids': [Command.set(declaration_tax.ids)],
             }),
             Command.create({
                 'name': 'not a declaration line',
                 'product_id': self.product_1.id,
                 'price_unit': 2000.0,  # > declaration.threshold; not counted
-                'tax_id': False,
+                'tax_ids': False,
             }),
         ])
         order.action_confirm()
@@ -448,7 +448,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                     'product_id': self.product_1.id,
                     'product_uom_qty': 2,
                     'price_unit': 2000.0,  # > declaration.threshold
-                    'tax_id': [Command.set(declaration_tax.ids)],
+                    'tax_ids': [Command.set(declaration_tax.ids)],
                 }),
             ]) for dummy in range(3)
         ])

--- a/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
+++ b/addons/l10n_it_edi_doi/tests/test_amounts_and_warnings.py
@@ -361,7 +361,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
                    'amount': 50,
                }).create_invoices()
 
-        invoice = order.invoice_ids[0]
+        invoice = order.account_move_ids[0]
 
         # The invoice just moves amount from `not_invoiced_yet` to `invoiced`.
         # It does not lower the remaining ammount.
@@ -385,7 +385,7 @@ class TestItEdiDoiRemaining(TestItEdiDoi):
             'remaining': -3000.0,
         }])
 
-        invoice2 = order.invoice_ids[1]
+        invoice2 = order.account_move_ids[1]
         invoice2.action_post()
         self.assertEqual(
             invoice2.l10n_it_edi_doi_warning,

--- a/addons/l10n_it_stock_ddt/models/account_invoice.py
+++ b/addons/l10n_it_stock_ddt/models/account_invoice.py
@@ -53,7 +53,7 @@ class AccountMove(models.Model):
                 if done_moves_related and line_count not in invoice_line_pickings.get(done_moves_related.picking_id, []):
                     invoice_line_pickings.setdefault(done_moves_related.picking_id, []).append(line_count)
             else:
-                total_invoices = done_moves_related.mapped('sale_line_id.invoice_lines').filtered(
+                total_invoices = done_moves_related.mapped('sale_line_id.account_move_line_ids').filtered(
                     lambda l: l.move_id.state == 'posted' and l.move_id.move_type == 'out_invoice').sorted(lambda l: (l.move_id.invoice_date, l.move_id.id))
                 total_invs = [(i.product_uom_id._compute_quantity(i.quantity, i.product_id.uom_id), i) for i in total_invoices]
                 inv = total_invs.pop(0)

--- a/addons/l10n_it_stock_ddt/tests/test_ddt.py
+++ b/addons/l10n_it_stock_ddt/tests/test_ddt.py
@@ -51,7 +51,7 @@ class TestDDT(TestSaleCommon):
                                    'product_uom_qty': 5,
                                    'product_uom': p.uom_id.id,
                                    'price_unit': p.list_price,
-                                   'tax_id': self.company_data['default_tax_sale']})
+                                   'tax_ids': self.company_data['default_tax_sale']})
                            for p in (
                     self.company_data['product_order_no'],
                     self.company_data['product_service_delivery'],
@@ -112,7 +112,7 @@ class TestDDT(TestSaleCommon):
                                    'product_uom_qty': 3,
                                    'product_uom': self.product_a.uom_id.id,
                                    'price_unit': self.product_a.list_price,
-                                   'tax_id': self.company_data['default_tax_sale']
+                                    'tax_ids': self.company_data['default_tax_sale']
                                    }
                             )],
             'pricelist_id': self.company_data['default_pricelist'].id,

--- a/addons/l10n_it_stock_ddt/tests/test_edi.py
+++ b/addons/l10n_it_stock_ddt/tests/test_edi.py
@@ -109,7 +109,7 @@ class TestItEdiDDT(TestItEdi):
                         'product_uom_qty': 5,
                         'product_uom': product.uom_id.id,
                         'price_unit': product.list_price,
-                        'tax_id': self.tax_22
+                        'tax_ids': self.tax_22
                     }) for product in self.products
                 ],
                 'pricelist_id': self.default_pricelist.id,

--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -318,7 +318,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
             to be included in the UBL
         """
         if not line.move_id._is_downpayment() and line.sale_line_ids and all(sale_line.is_downpayment for sale_line in line.sale_line_ids):
-            prepayment_move_id = line.sale_line_ids.invoice_lines.move_id.filtered(lambda m: m._is_downpayment())
+            prepayment_move_id = line.sale_line_ids.account_move_line_ids.move_id.filtered(lambda m: m._is_downpayment())
             return {
                 'prepayment_id': prepayment_move_id.name,
                 'issue_date': fields.Datetime.context_timestamp(self.with_context(tz='Asia/Riyadh'),

--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -63,7 +63,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
                 'name': self.product_a.name,
                 'product_qty': 2.0,
                 'price_unit': 100,
-                'taxes_id': False,
+                'tax_ids': False,
             })],
         })
         po.button_confirm()

--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -66,7 +66,7 @@ class PosOrder(models.Model):
                     'product_id': line.product_id.id,
                     'price_unit': line.price_unit,
                     'product_uom_qty': 0,
-                    'tax_id': [(6, 0, line.tax_ids.ids)],
+                    'tax_ids': [(6, 0, line.tax_ids.ids)],
                     'is_downpayment': True,
                     'discount': line.discount,
                     'sequence': sale_lines and sale_lines[-1].sequence + 2 or 10,
@@ -92,7 +92,7 @@ class PosOrder(models.Model):
                 so_line_stock_move_ids = so_line.move_ids.group_id.stock_move_ids
                 for stock_move in so_line.move_ids:
                     picking = stock_move.picking_id
-                    if not picking.state in ['waiting', 'confirmed', 'assigned']:
+                    if picking.state not in ['waiting', 'confirmed', 'assigned']:
                         continue
                     new_qty = so_line.product_uom_qty - so_line.qty_delivered
                     if float_compare(new_qty, 0, precision_rounding=stock_move.product_uom.rounding) <= 0:

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -62,7 +62,7 @@ class SaleOrderLine(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return ['discount', 'display_name', 'price_total', 'price_unit', 'product_id', 'product_uom_qty', 'qty_delivered',
-            'qty_invoiced', 'qty_to_invoice', 'display_type', 'name', 'tax_id']
+            'qty_invoiced', 'qty_to_invoice', 'display_type', 'name', 'tax_ids']
 
     @api.depends('pos_order_line_ids.qty')
     def _compute_qty_delivered(self):
@@ -77,7 +77,7 @@ class SaleOrderLine(models.Model):
             sale_line.qty_invoiced += sum([self._convert_qty(sale_line, pos_line.qty, 'p2s') for pos_line in sale_line.pos_order_line_ids], 0)
 
     def _get_sale_order_fields(self):
-        return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_id", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total"]
+        return ["product_id", "display_name", "price_unit", "product_uom_qty", "tax_ids", "qty_delivered", "qty_invoiced", "discount", "qty_to_invoice", "price_total"]
 
     def read_converted(self):
         field_names = self._get_sale_order_fields()

--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -42,10 +42,12 @@ class SaleOrder(models.Model):
             'domain': [('id', 'in', linked_orders.ids)],
         }
 
-    @api.depends('order_line', 'amount_total', 'order_line.invoice_lines.parent_state', 'order_line.invoice_lines.price_total', 'order_line.pos_order_line_ids')
+    @api.depends('order_line', 'amount_total', 'order_line.account_move_line_ids.parent_state',
+                 'order_line.account_move_line_ids.price_total', 'order_line.pos_order_line_ids')
     def _compute_amount_unpaid(self):
         for sale_order in self:
-            total_invoice_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('invoice_lines').filtered(lambda l: l.parent_state != 'cancel').mapped('price_total'))
+            total_invoice_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped(
+                'account_move_line_ids').filtered(lambda l: l.parent_state != 'cancel').mapped('price_total'))
             total_pos_paid = sum(sale_order.order_line.filtered(lambda l: not l.display_type).mapped('pos_order_line_ids.price_subtotal_incl'))
             sale_order.amount_unpaid = sale_order.amount_total - (total_invoice_paid + total_pos_paid)
 

--- a/addons/pos_sale/static/src/overrides/models/pos_store.js
+++ b/addons/pos_sale/static/src/overrides/models/pos_store.js
@@ -101,9 +101,9 @@ patch(PosStore.prototype, {
                 qty: line.product_uom_qty,
                 price_unit: line.price_unit,
                 tax_ids:
-                    orderFiscalPos || !line.tax_id
+                    orderFiscalPos || !line.tax_ids
                         ? undefined
-                        : line.tax_id.map((t) => ["link", t]),
+                        : line.tax_ids.map((t) => ["link", t]),
                 sale_order_origin_id: sale_order,
                 sale_order_line_id: line,
                 customer_note: line.customer_note,

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -584,7 +584,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
                 'analytic_distribution': {self.analytic_account.id: 100},
                 'product_id': self.product_order.id,
                 'product_qty': 2,  # plural value to check if the price is multiplied more than once
-                'taxes_id': [included_tax.id],  # set the included tax
+                'tax_ids': [included_tax.id],  # set the included tax
                 'price_unit': self.product_order.standard_price,
                 'currency_id': self.env.company.currency_id.id,
             })],

--- a/addons/project_purchase/tests/test_project_profitability.py
+++ b/addons/project_purchase/tests/test_project_profitability.py
@@ -202,7 +202,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
         )
         # Create a vendor bill linked to the PO
         purchase_order.action_create_invoice()
-        self.assertEqual(purchase_order.invoice_ids.state, 'draft')
+        self.assertEqual(purchase_order.account_move_ids.state, 'draft')
         # now the bill has been created and set to draft so the section "purchase_order" should appear, its costs should be accounted in the "to bill" part
         # of the purchase_order section, but should touch in the other_purchase_costs
         self.assertDictEqual(
@@ -232,10 +232,10 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             },
         )
         # Post the vendor bill linked to the PO
-        purchase_bill = purchase_order.invoice_ids
+        purchase_bill = purchase_order.account_move_ids
         purchase_bill.invoice_date = datetime.today()
         purchase_bill.action_post()
-        self.assertEqual(purchase_order.invoice_ids.state, 'posted')
+        self.assertEqual(purchase_order.account_move_ids.state, 'posted')
         # now the bill has been posted so the costs of the section "purchase_order" should be accounted in the "billed" part
         # and the total should be updated accordingly
         self.assertDictEqual(
@@ -538,7 +538,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
 
     def _create_invoice_for_po(self, purchase_order):
         purchase_order.action_create_invoice()
-        purchase_bill = purchase_order.invoice_ids  # get the bill from the purchase
+        purchase_bill = purchase_order.account_move_ids  # get the bill from the purchase
         purchase_bill.invoice_date = datetime.today()
         purchase_bill.action_post()
 
@@ -608,7 +608,7 @@ class TestProjectPurchaseProfitability(TestProjectProfitabilityCommon, TestPurch
             },
         )
 
-        purchase_bill = purchase_order.invoice_ids  # get the bill from the purchase
+        purchase_bill = purchase_order.account_move_ids  # get the bill from the purchase
         purchase_bill.invoice_date = datetime.today()
         purchase_bill.action_post()
         # same here, taxes should not be calculated in the profitability

--- a/addons/purchase/__init__.py
+++ b/addons/purchase/__init__.py
@@ -5,3 +5,4 @@ from . import controllers
 from . import models
 from . import report
 from . import populate
+from . import wizard

--- a/addons/purchase/__manifest__.py
+++ b/addons/purchase/__manifest__.py
@@ -17,6 +17,7 @@
         'data/purchase_data.xml',
         'data/ir_cron_data.xml',
         'report/purchase_reports.xml',
+        'wizard/purchase_make_bill_advance_views.xml',
         'views/purchase_views.xml',
         'views/res_config_settings_views.xml',
         'views/product_views.xml',

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -51,7 +51,7 @@ class AccountMove(models.Model):
             return
 
         # Copy data from PO
-        invoice_vals = self.purchase_id.with_company(self.purchase_id.company_id)._prepare_invoice()
+        invoice_vals = self.purchase_id.with_company(self.purchase_id.company_id)._prepare_account_move_values()
         has_invoice_lines = bool(self.invoice_line_ids.filtered(lambda x: x.display_type not in ('line_note', 'line_section')))
         new_currency_id = self.currency_id if has_invoice_lines else invoice_vals.get('currency_id')
         del invoice_vals['ref'], invoice_vals['payment_reference']

--- a/addons/purchase/models/account_invoice.py
+++ b/addons/purchase/models/account_invoice.py
@@ -65,7 +65,7 @@ class AccountMove(models.Model):
         po_lines = self.purchase_id.order_line - self.invoice_line_ids.mapped('purchase_line_id')
         for line in po_lines.filtered(lambda l: not l.display_type):
             self.invoice_line_ids += self.env['account.move.line'].new(
-                line._prepare_account_move_line(self)
+                line._prepare_invoice_line(self)
             )
 
         # Compute invoice_origin.
@@ -480,3 +480,6 @@ class AccountMoveLine(models.Model):
         # OVERRIDE to copy the 'purchase_line_id' field as well.
         super(AccountMoveLine, self)._copy_data_extend_business_fields(values)
         values['purchase_line_id'] = self.purchase_line_id.id
+
+    def _get_order_lines(self):
+        return self.purchase_line_id or super()._get_order_lines()

--- a/addons/purchase/models/account_tax.py
+++ b/addons/purchase/models/account_tax.py
@@ -13,7 +13,7 @@ class AccountTax(models.Model):
         taxes_to_compute -= used_taxes
 
         if taxes_to_compute:
-            self.env['purchase.order.line'].flush_model(['taxes_id'])
+            self.env['purchase.order.line'].flush_model(['tax_ids'])
             self.env.cr.execute("""
                 SELECT id
                 FROM account_tax

--- a/addons/purchase/models/analytic_account.py
+++ b/addons/purchase/models/analytic_account.py
@@ -13,13 +13,13 @@ class AccountAnalyticAccount(models.Model):
     def _compute_purchase_order_count(self):
         for account in self:
             account.purchase_order_count = self.env['purchase.order'].search_count([
-                ('order_line.invoice_lines.analytic_line_ids.account_id', '=', account.id)
+                ('order_line.account_move_line_ids.analytic_line_ids.account_id', '=', account.id)
             ])
 
     def action_view_purchase_orders(self):
         self.ensure_one()
         purchase_orders = self.env['purchase.order'].search([
-            ('order_line.invoice_lines.analytic_line_ids.account_id', '=', self.id)
+            ('order_line.account_move_line_ids.analytic_line_ids.account_id', '=', self.id)
         ])
         result = {
             "type": "ir.actions.act_window",

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -218,16 +218,16 @@ class PurchaseOrder(models.Model):
                     float_is_zero(line.qty_to_invoice, precision_digits=precision)
                     for line in order.order_line.filtered(lambda l: not l.display_type)
                 )
-                and order.order_line.invoice_lines.filtered(lambda aml: not aml.is_downpayment)
+                and order.order_line.account_move_line_ids.filtered(lambda aml: not aml.is_downpayment)
             ):
                 order.invoice_status = 'invoiced'
             else:
                 order.invoice_status = 'no'
 
-    @api.depends('order_line.invoice_lines.move_id')
+    @api.depends('order_line.account_move_line_ids.move_id')
     def _compute_invoice(self):
         for order in self:
-            invoices = order.mapped('order_line.invoice_lines.move_id')
+            invoices = order.mapped('order_line.account_move_line_ids.move_id')
             order.invoice_ids = invoices
             order.invoice_count = len(invoices)
 

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -618,7 +618,7 @@ class PurchaseOrder(models.Model):
             return moves
         return self.action_view_invoice(moves)
 
-    def _prepare_invoice(self):
+    def _prepare_account_move_values(self):
         """Prepare the dict of values to create the new invoice for a purchase order.
         """
         self.ensure_one()
@@ -627,7 +627,7 @@ class PurchaseOrder(models.Model):
         partner_invoice = self.env['res.partner'].browse(self.partner_id.address_get(['invoice'])['invoice'])
         partner_bank_id = self.partner_id.commercial_partner_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
 
-        invoice_vals = super()._prepare_invoice()
+        invoice_vals = super()._prepare_account_move_values()
         invoice_vals.update({
             'ref': self.partner_ref or '',
             'move_type': move_type,

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -51,7 +51,7 @@ class PurchaseOrder(models.Model):
     notes = fields.Html('Terms and Conditions')
 
     invoice_count = fields.Integer(compute="_compute_invoice", string='Bill Count', copy=False, default=0, store=True)
-    invoice_ids = fields.Many2many('account.move', compute="_compute_invoice", string='Bills', copy=False, store=True)
+    account_move_ids = fields.Many2many(compute="_compute_invoice", string='Bills', copy=False, store=True)
     invoice_status = fields.Selection(selection_add=[
         ('no', 'Nothing to Bill'),
         ('to invoice', 'Waiting Bills'),
@@ -228,7 +228,7 @@ class PurchaseOrder(models.Model):
     def _compute_invoice(self):
         for order in self:
             invoices = order.mapped('order_line.account_move_line_ids.move_id')
-            order.invoice_ids = invoices
+            order.account_move_ids = invoices
             order.invoice_count = len(invoices)
 
     @api.onchange('date_planned')
@@ -504,7 +504,7 @@ class PurchaseOrder(models.Model):
 
     def button_cancel(self):
         for order in self:
-            for inv in order.invoice_ids:
+            for inv in order.account_move_ids:
                 if inv and inv.state not in ('cancel', 'draft'):
                     raise UserError(_("Unable to cancel this purchase order. You must first cancel the related vendor bills."))
 
@@ -645,8 +645,8 @@ class PurchaseOrder(models.Model):
         immediately.
         """
         if not invoices:
-            self.invalidate_model(['invoice_ids'])
-            invoices = self.invoice_ids
+            self.invalidate_model(['account_move_ids'])
+            invoices = self.account_move_ids
 
         result = self.env['ir.actions.act_window']._for_xml_id('account.action_move_in_invoice_type')
         # choose the view_mode accordingly

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -17,68 +17,11 @@ from odoo.exceptions import UserError, ValidationError
 
 class PurchaseOrder(models.Model):
     _name = "purchase.order"
-    _inherit = ['portal.mixin', 'product.catalog.mixin', 'mail.thread', 'mail.activity.mixin']
+    _inherit = ['portal.mixin', 'product.catalog.mixin', 'mail.thread', 'mail.activity.mixin', 'account.order.mixin']
     _description = "Purchase Order"
     _rec_names_search = ['name', 'partner_ref']
     _order = 'priority desc, id desc'
 
-    @api.depends('order_line.price_total', 'currency_id')
-    def _amount_all(self):
-        for order in self:
-            order_lines = order.order_line.filtered(lambda x: not x.display_type)
-
-            if order.company_id.tax_calculation_rounding_method == 'round_globally':
-                tax_results = self.env['account.tax']._compute_taxes(
-                    [
-                        line._convert_to_tax_base_line_dict()
-                        for line in order_lines
-                    ],
-                    order.company_id,
-                )
-                totals = tax_results['totals']
-                amount_untaxed = totals.get(order.currency_id, {}).get('amount_untaxed', 0.0)
-                amount_tax = totals.get(order.currency_id, {}).get('amount_tax', 0.0)
-            else:
-                amount_untaxed = sum(order_lines.mapped('price_subtotal'))
-                amount_tax = sum(order_lines.mapped('price_tax'))
-
-            order.amount_untaxed = amount_untaxed
-            order.amount_tax = amount_tax
-            order.amount_total = order.amount_untaxed + order.amount_tax
-            order.amount_total_cc = order.amount_total / order.currency_rate
-
-    @api.depends('state', 'order_line.qty_to_invoice')
-    def _get_invoiced(self):
-        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
-        for order in self:
-            if order.state not in ('purchase', 'done'):
-                order.invoice_status = 'no'
-                continue
-
-            if any(
-                not float_is_zero(line.qty_to_invoice, precision_digits=precision)
-                for line in order.order_line.filtered(lambda l: not l.display_type)
-            ):
-                order.invoice_status = 'to invoice'
-            elif (
-                all(
-                    float_is_zero(line.qty_to_invoice, precision_digits=precision)
-                    for line in order.order_line.filtered(lambda l: not l.display_type)
-                )
-                and order.invoice_ids
-            ):
-                order.invoice_status = 'invoiced'
-            else:
-                order.invoice_status = 'no'
-
-    @api.depends('order_line.invoice_lines.move_id')
-    def _compute_invoice(self):
-        for order in self:
-            invoices = order.mapped('order_line.invoice_lines.move_id')
-            order.invoice_ids = invoices
-            order.invoice_count = len(invoices)
-
-    name = fields.Char('Order Reference', required=True, index='trigram', copy=False, default='New')
     priority = fields.Selection(
         [('0', 'Normal'), ('1', 'Urgent')], 'Priority', default='0', index=True)
     origin = fields.Char('Source Document', copy=False,
@@ -92,12 +35,10 @@ class PurchaseOrder(models.Model):
     date_order = fields.Datetime('Order Deadline', required=True, index=True, copy=False, default=fields.Datetime.now,
         help="Depicts the date within which the Quotation should be confirmed and converted into a purchase order.")
     date_approve = fields.Datetime('Confirmation Date', readonly=True, index=True, copy=False)
-    partner_id = fields.Many2one('res.partner', string='Vendor', required=True, change_default=True, tracking=True, check_company=True, help="You can find a vendor by its Name, TIN, Email or Internal Reference.")
+    partner_id = fields.Many2one(string='Vendor', help="You can find a vendor by their Name, TIN, Email, or Internal Reference.")
     dest_address_id = fields.Many2one('res.partner', check_company=True, string='Dropship Address',
         help="Put an address if you want to deliver directly from the vendor to the customer. "
              "Otherwise, keep empty to deliver to your own company.")
-    currency_id = fields.Many2one('res.currency', 'Currency', required=True,
-        default=lambda self: self.env.company.currency_id.id)
     state = fields.Selection([
         ('draft', 'RFQ'),
         ('sent', 'RFQ Sent'),
@@ -106,28 +47,27 @@ class PurchaseOrder(models.Model):
         ('done', 'Locked'),
         ('cancel', 'Cancelled')
     ], string='Status', readonly=True, index=True, copy=False, default='draft', tracking=True)
-    order_line = fields.One2many('purchase.order.line', 'order_id', string='Order Lines', copy=True)
+    order_line = fields.One2many('purchase.order.line', 'order_id', string='Order Lines')
     notes = fields.Html('Terms and Conditions')
 
     invoice_count = fields.Integer(compute="_compute_invoice", string='Bill Count', copy=False, default=0, store=True)
     invoice_ids = fields.Many2many('account.move', compute="_compute_invoice", string='Bills', copy=False, store=True)
-    invoice_status = fields.Selection([
+    invoice_status = fields.Selection(selection_add=[
         ('no', 'Nothing to Bill'),
         ('to invoice', 'Waiting Bills'),
         ('invoiced', 'Fully Billed'),
-    ], string='Billing Status', compute='_get_invoiced', store=True, readonly=True, copy=False, default='no')
+    ], string='Billing Status', readonly=True, copy=False, default='no')
     date_planned = fields.Datetime(
         string='Expected Arrival', index=True, copy=False, compute='_compute_date_planned', store=True, readonly=False,
         help="Delivery date promised by vendor. This date is used to determine expected arrival of products.")
     date_calendar_start = fields.Datetime(compute='_compute_date_calendar_start', readonly=True, store=True)
 
-    amount_untaxed = fields.Monetary(string='Untaxed Amount', store=True, readonly=True, compute='_amount_all', tracking=True)
+    amount_untaxed = fields.Monetary(readonly=True, tracking=True)
     tax_totals = fields.Binary(compute='_compute_tax_totals', exportable=False)
-    amount_tax = fields.Monetary(string='Taxes', store=True, readonly=True, compute='_amount_all')
-    amount_total = fields.Monetary(string='Total', store=True, readonly=True, compute='_amount_all')
-    amount_total_cc = fields.Monetary(string="Company Total", store=True, readonly=True, compute="_amount_all", currency_field="company_currency_id")
+    amount_total_cc = fields.Monetary(string="Company Total", store=True, readonly=True, compute="_compute_amounts", currency_field="company_currency_id")
+    amount_to_invoice = fields.Monetary("Amount to be billed")  # Only override the string
+    amount_invoiced = fields.Monetary("Amount already billed")  # Only override the string
 
-    fiscal_position_id = fields.Many2one('account.fiscal.position', string='Fiscal Position', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     tax_country_id = fields.Many2one(
         comodel_name='res.country',
         compute='_compute_tax_country_id',
@@ -137,14 +77,12 @@ class PurchaseOrder(models.Model):
     tax_calculation_rounding_method = fields.Selection(
         related='company_id.tax_calculation_rounding_method',
         string='Tax calculation rounding method', readonly=True)
-    payment_term_id = fields.Many2one('account.payment.term', 'Payment Terms', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
     incoterm_id = fields.Many2one('account.incoterms', 'Incoterm', help="International Commercial Terms are a series of predefined commercial terms used in international transactions.")
 
     product_id = fields.Many2one('product.product', related='order_line.product_id', string='Product')
     user_id = fields.Many2one(
         'res.users', string='Buyer', index=True, tracking=True,
         default=lambda self: self.env.user, check_company=True)
-    company_id = fields.Many2one('res.company', 'Company', required=True, index=True, default=lambda self: self.env.company.id)
     company_currency_id = fields.Many2one(related="company_id.currency_id", string="Company Currency")
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', string="Country code")
     currency_rate = fields.Float("Currency Rate", compute='_compute_currency_rate', compute_sudo=True, store=True, readonly=True, help='Ratio between the purchase order currency and the company currency')
@@ -234,6 +172,64 @@ class PurchaseOrder(models.Model):
                 record.tax_country_id = record.fiscal_position_id.country_id
             else:
                 record.tax_country_id = record.company_id.account_fiscal_country_id
+
+    @api.depends('currency_rate')
+    def _compute_amounts(self):
+        super()._compute_amounts()
+        for order in self:
+            order.amount_total_cc = order.amount_total / order.currency_rate
+
+    def _compute_amount_to_invoice(self):
+        super()._compute_amount_to_invoice()
+        for order in self:
+            # If the invoice status is 'Fully Invoiced' force the amount to invoice to equal zero and return early.
+            if order.invoice_status == 'invoiced':
+                order.amount_to_invoice = 0.0
+                continue
+            order.amount_to_invoice = order.amount_total
+            for account_move in order.account_move_ids:
+                if account_move.state != 'posted':
+                    continue
+                amount_total = sum(account_move.line_ids.filtered(lambda x: order == x.purchase_order_id).mapped('price_total'))
+                invoice_amount_currency = account_move.currency_id._convert(
+                    amount_total * account_move.direction_sign * order._get_order_direction(),
+                    order.currency_id,
+                    account_move.company_id,
+                    account_move.date,
+                )
+                order.amount_to_invoice -= invoice_amount_currency
+
+    @api.depends('state', 'order_line.qty_to_invoice')
+    def _compute_invoice_status(self):
+        super()._compute_invoice_status()
+        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+        for order in self:
+            if order.state not in ('purchase', 'done'):
+                order.invoice_status = 'no'
+                continue
+
+            if any(
+                not float_is_zero(line.qty_to_invoice, precision_digits=precision) and not line.is_downpayment
+                for line in order.order_line.filtered(lambda l: not l.display_type)
+            ):
+                order.invoice_status = 'to invoice'
+            elif (
+                all(
+                    float_is_zero(line.qty_to_invoice, precision_digits=precision)
+                    for line in order.order_line.filtered(lambda l: not l.display_type)
+                )
+                and order.order_line.invoice_lines.filtered(lambda aml: not aml.is_downpayment)
+            ):
+                order.invoice_status = 'invoiced'
+            else:
+                order.invoice_status = 'no'
+
+    @api.depends('order_line.invoice_lines.move_id')
+    def _compute_invoice(self):
+        for order in self:
+            invoices = order.mapped('order_line.invoice_lines.move_id')
+            order.invoice_ids = invoices
+            order.invoice_count = len(invoices)
 
     @api.onchange('date_planned')
     def onchange_date_planned(self):
@@ -564,42 +560,24 @@ class PurchaseOrder(models.Model):
                 # supplier info should be added regardless of the user access rights
                 line.product_id.product_tmpl_id.sudo().write(vals)
 
-    def action_create_invoice(self):
+    def action_create_invoice(self, skip_dialog_check=False):
         """Create the invoice associated to the PO.
         """
-        precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+
+        if self.env.user.has_group('purchase.group_down_payment') and not skip_dialog_check:
+            return {
+                'name': _('Create bills'),
+                'type': 'ir.actions.act_window',
+                'view_mode': 'form',
+                'res_model': 'purchase.advance.payment.wizard',
+                'target': 'new',
+            }
 
         # 1) Prepare invoice vals and clean-up the section lines
-        invoice_vals_list = []
-        sequence = 10
-        for order in self:
-            if order.invoice_status != 'to invoice':
-                continue
-
-            order = order.with_company(order.company_id)
-            pending_section = None
-            # Invoice values.
-            invoice_vals = order._prepare_invoice()
-            # Invoice line values (keep only necessary sections).
-            for line in order.order_line:
-                if line.display_type == 'line_section':
-                    pending_section = line
-                    continue
-                if not float_is_zero(line.qty_to_invoice, precision_digits=precision):
-                    if pending_section:
-                        line_vals = pending_section._prepare_account_move_line()
-                        line_vals.update({'sequence': sequence})
-                        invoice_vals['invoice_line_ids'].append((0, 0, line_vals))
-                        sequence += 1
-                        pending_section = None
-                    line_vals = line._prepare_account_move_line()
-                    line_vals.update({'sequence': sequence})
-                    invoice_vals['invoice_line_ids'].append((0, 0, line_vals))
-                    sequence += 1
-            invoice_vals_list.append(invoice_vals)
+        invoice_vals_list = self._generate_invoice_values()
 
         if not invoice_vals_list:
-            raise UserError(_('There is no invoiceable line. If a product has a control policy based on received quantity, please make sure that a quantity has been received.'))
+            raise UserError(_('There are no invoiceable lines. If a product has a control policy based on received quantity, please make sure that a quantity has been received.'))
 
         # 2) group by (company_id, partner_id, currency_id) for batch creation
         new_invoice_vals_list = []
@@ -635,6 +613,9 @@ class PurchaseOrder(models.Model):
         # is actually negative or not
         moves.filtered(lambda m: m.currency_id.round(m.amount_total) < 0).action_switch_move_type()
 
+        # If coming from the down payment wizard we just return the raw moves
+        if skip_dialog_check:
+            return moves
         return self.action_view_invoice(moves)
 
     def _prepare_invoice(self):
@@ -646,20 +627,16 @@ class PurchaseOrder(models.Model):
         partner_invoice = self.env['res.partner'].browse(self.partner_id.address_get(['invoice'])['invoice'])
         partner_bank_id = self.partner_id.commercial_partner_id.bank_ids.filtered_domain(['|', ('company_id', '=', False), ('company_id', '=', self.company_id.id)])[:1]
 
-        invoice_vals = {
+        invoice_vals = super()._prepare_invoice()
+        invoice_vals.update({
             'ref': self.partner_ref or '',
             'move_type': move_type,
             'narration': self.notes,
-            'currency_id': self.currency_id.id,
             'partner_id': partner_invoice.id,
             'fiscal_position_id': (self.fiscal_position_id or self.fiscal_position_id._get_fiscal_position(partner_invoice)).id,
             'payment_reference': self.partner_ref or '',
             'partner_bank_id': partner_bank_id.id,
-            'invoice_origin': self.name,
-            'invoice_payment_term_id': self.payment_term_id.id,
-            'invoice_line_ids': [],
-            'company_id': self.company_id.id,
-        }
+        })
         return invoice_vals
 
     def action_view_invoice(self, invoices=False):
@@ -1090,3 +1067,15 @@ class PurchaseOrder(models.Model):
 
     def _get_edi_builders(self):
         return []
+
+    def _create_new_order_line(self, values):
+        return self.env['purchase.order.line'].create(values)
+
+    def _is_locked(self):
+        return self.state == 'done'
+
+    def _create_invoices(self, grouped=False, final=False, date=None):
+        return self.action_create_invoice(True)
+
+    def _get_order_direction(self):
+        return 1

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -153,7 +153,7 @@ class PurchaseOrder(models.Model):
             order.reminder_date_before_receipt = order.partner_id.with_company(order.company_id).reminder_date_before_receipt
 
     @api.depends_context('lang')
-    @api.depends('order_line.taxes_id', 'order_line.price_subtotal', 'amount_total', 'amount_untaxed')
+    @api.depends('order_line.tax_ids', 'order_line.price_subtotal', 'amount_total', 'amount_untaxed')
     def _compute_tax_totals(self):
         for order in self:
             order_lines = order.order_line.filtered(lambda x: not x.display_type)

--- a/addons/purchase/models/res_config_settings.py
+++ b/addons/purchase/models/res_config_settings.py
@@ -32,6 +32,8 @@ class ResConfigSettings(models.TransientModel):
     group_send_reminder = fields.Boolean("Receipt Reminder", implied_group='purchase.group_send_reminder', default=True,
         help="Allow automatically send email to remind your vendor the receipt date")
 
+    group_down_payment = fields.Boolean("Down Payments", implied_group="purchase.group_down_payment", help="Allow creating vendor bills for down payments on purchase orders")
+
     @api.onchange('use_po_lead')
     def _onchange_use_po_lead(self):
         if not self.use_po_lead:

--- a/addons/purchase/populate/purchase.py
+++ b/addons/purchase/populate/purchase.py
@@ -85,7 +85,7 @@ class PurchaseOrderLine(models.Model):
             ('name', populate.constant("PO-line-{counter}")),
             ('product_id', populate.randomize(product_ids)),
             ('product_uom', populate.compute(get_product_uom)),
-            ('taxes_id', populate.constant(False)),  # to avoid slow _prepare_add_missing_fields
+            ('tax_ids', populate.constant(False)),  # to avoid slow _prepare_add_missing_fields
             ('date_planned', populate.compute(get_date_planned)),
             ('product_qty', populate.randint(1, 10)),
             ('price_unit', populate.randint(10, 100)),

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -69,7 +69,7 @@
                                 <td id="product">
                                     <span t-field="line.name"/>
                                 </td>
-                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.taxes_id])"/>
+                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_ids])"/>
                                 <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>

--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -60,7 +60,8 @@
                 </thead>
                 <tbody>
                     <t t-set="current_subtotal" t-value="0"/>
-                    <t t-foreach="o.order_line" t-as="line">
+                    <t t-set="lines_to_report" t-value="o._get_order_lines_to_report()"/>
+                    <t t-foreach="lines_to_report" t-as="line">
                         <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
 
                         <tr t-att-class="'bg-200 fw-bold o_line_section' if line.display_type == 'line_section' else 'fst-italic o_line_note' if line.display_type == 'line_note' else ''">
@@ -76,16 +77,18 @@
                                     <span t-field="line.date_planned"/>
                                 </td>
                                 <td class="text-end">
-                                    <span t-field="line.product_qty"/>
-                                    <span t-field="line.product_uom.name" groups="uom.group_uom"/>
-                                    <span t-if="line.product_packaging_id">
+                                    <t t-if="not line.is_downpayment">
+                                        <span t-field="line.product_qty"/>
+                                        <span t-field="line.product_uom.name" groups="uom.group_uom"/>
+                                        <span t-if="line.product_packaging_id">
                                         (<span t-field="line.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="line.product_packaging_id"/>)
-                                    </span>
+                                        </span>
+                                    </t>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_unit"/>
                                 </td>
-                                <td class="text-end">
+                                <td t-if="not line.is_downpayment" class="text-end">
                                     <span t-field="line.price_subtotal"
                                         t-options='{"widget": "monetary", "display_currency": o.currency_id}'/>
                                 </td>
@@ -103,7 +106,7 @@
                                 </td>
                             </t>
                         </tr>
-                        <t t-if="current_section and (line_last or o.order_line[line_index+1].display_type == 'line_section')">
+                        <t t-if="current_section and (line_last or lines_to_report[line_index+1].display_type == 'line_section') and not line.is_downpayment">
                             <tr class="is-subtotal text-end">
                                 <td colspan="99" id="subtotal">
                                     <strong class="mr16">Subtotal</strong>

--- a/addons/purchase/report/purchase_quotation_templates.xml
+++ b/addons/purchase/report/purchase_quotation_templates.xml
@@ -29,7 +29,8 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <t t-foreach="o.order_line" t-as="order_line">
+                    <t t-set="lines_to_report" t-value="o._get_order_lines_to_report()"/>
+                    <t t-foreach="lines_to_report" t-as="order_line">
                         <tr t-att-class="'bg-200 fw-bold o_line_section' if order_line.display_type == 'line_section' else 'fst-italic o_line_note' if order_line.display_type == 'line_note' else ''">
                             <t t-if="not order_line.display_type">
                                 <td id="product">

--- a/addons/purchase/security/ir.model.access.csv
+++ b/addons/purchase/security/ir.model.access.csv
@@ -37,3 +37,4 @@ access_account_account_purchase_manager,account.account purchase manager,account
 access_purchase_bill_union,access_purchase_bill_union,model_purchase_bill_union,purchase.group_purchase_user,1,0,0,0
 access_report_purchase_order,purchase.stock.report,model_purchase_report,purchase.group_purchase_manager,1,0,0,0
 access_report_purchase_order_user,purchase.stock.report user,model_purchase_report,purchase.group_purchase_user,1,0,0,0
+access_purchase_advance_payment_wizard,access.purchase.advance.payment.wizard,model_purchase_advance_payment_wizard,purchase.group_purchase_user,1,1,1,0

--- a/addons/purchase/security/purchase_security.xml
+++ b/addons/purchase/security/purchase_security.xml
@@ -30,6 +30,11 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
+    <record id="group_down_payment" model="res.groups">
+        <field name="name">Allow creating vendor bills for down payments on purchase orders</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
+
 </data>
 <data noupdate="1">
     <record model="res.groups" id="base.group_user">

--- a/addons/purchase/tests/__init__.py
+++ b/addons/purchase/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_access_rights
 from . import test_accrued_purchase_orders
 from . import test_purchase_tax_totals
 from . import test_purchase_dashboard
+from . import test_purchase_downpayment

--- a/addons/purchase/tests/test_access_rights.py
+++ b/addons/purchase/tests/test_access_rights.py
@@ -63,7 +63,7 @@ class TestPurchaseInvoice(AccountTestInvoicingCommon):
 
         purchase_order.order_line.qty_received = 4
         purchase_order.action_create_invoice()
-        invoice = purchase_order.invoice_ids
+        invoice = purchase_order.account_move_ids
         with self.assertRaises(AccessError):
             invoice.action_post()
 
@@ -88,7 +88,7 @@ class TestPurchaseInvoice(AccountTestInvoicingCommon):
 
         purchase_order_user2.order_line.qty_received = 4
         purchase_order_user2.action_create_invoice()
-        vendor_bill_user2 = purchase_order_user2.invoice_ids
+        vendor_bill_user2 = purchase_order_user2.account_move_ids
 
         # open purchase_order_user2 and vendor_bill_user2 with `self.purchase_user`
         purchase_order_user1 = Form(purchase_order_user2.with_user(self.purchase_user))

--- a/addons/purchase/tests/test_accrued_purchase_orders.py
+++ b/addons/purchase/tests/test_accrued_purchase_orders.py
@@ -38,7 +38,7 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
                     'product_qty': 10.0,
                     'product_uom': cls.product_a.uom_id.id,
                     'price_unit': cls.product_a.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                     'analytic_distribution': {
                         cls.analytic_account_a.id : 80.0,
                         cls.analytic_account_b.id : 20.0,
@@ -50,7 +50,7 @@ class TestAccruedPurchaseOrders(AccountTestInvoicingCommon):
                     'product_qty': 10.0,
                     'product_uom': cls.product_b.uom_id.id,
                     'price_unit': cls.product_b.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                     'analytic_distribution': {
                         cls.analytic_account_b.id : 100.0,
                     },

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -725,8 +725,8 @@ class TestPurchase(AccountTestInvoicingCommon):
             line.product_id = product_no_tax
         po = po_form.save()
         self.assertRecordValues(po.order_line, [
-            {'product_id': product_all_taxes.id, 'taxes_id': tax_xx.ids},
-            {'product_id': product_no_xx_tax.id, 'taxes_id': tax_x.ids},
-            {'product_id': product_no_branch_tax.id, 'taxes_id': (tax_a + tax_b).ids},
-            {'product_id': product_no_tax.id, 'taxes_id': []},
+            {'product_id': product_all_taxes.id, 'tax_ids': tax_xx.ids},
+            {'product_id': product_no_xx_tax.id, 'tax_ids': tax_x.ids},
+            {'product_id': product_no_branch_tax.id, 'tax_ids': (tax_a + tax_b).ids},
+            {'product_id': product_no_tax.id, 'tax_ids': []},
         ])

--- a/addons/purchase/tests/test_purchase_downpayment.py
+++ b/addons/purchase/tests/test_purchase_downpayment.py
@@ -34,7 +34,7 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
             'product_uom': cls.product_order.uom_id.id,
             'price_unit': 100,
             'order_id': cls.purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         cls.pol_serv_deliver = cls.env['purchase.order.line'].create({
             'name': cls.service_deliver.name,
@@ -43,7 +43,7 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
             'product_uom': cls.service_deliver.uom_id.id,
             'price_unit': 100,
             'order_id': cls.purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         cls.pol_serv_order = cls.env['purchase.order.line'].create({
             'name': cls.service_order.name,
@@ -52,7 +52,7 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
             'product_uom': cls.service_order.uom_id.id,
             'price_unit': 100,
             'order_id': cls.purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         cls.pol_product_deliver = cls.env['purchase.order.line'].create({
             'name': cls.product_deliver.name,
@@ -61,7 +61,7 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
             'product_uom': cls.product_deliver.uom_id.id,
             'price_unit': 100,
             'order_id': cls.purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
 
         cls.expense_account = cls.company_data['default_account_expense']
@@ -359,9 +359,9 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
         expense_acc_2 = self.expense_account.copy()
         self.purchase_order.order_line[1].product_id.product_tmpl_id.property_account_expense_id = expense_acc_2
 
-        self.purchase_order.order_line[0].taxes_id = self.tax_15 + self.tax_10
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
-        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
+        self.purchase_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(self.purchase_order)
         invoice = self.purchase_order.invoice_ids
         down_pay_amt = -self.purchase_order.amount_total / 2
@@ -384,9 +384,9 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
 
     def test_tax_breakdown_other_currency(self):
         self.purchase_order.currency_id = self.other_currency  # rate = 2.0
-        self.purchase_order.order_line[0].taxes_id = self.tax_15 + self.tax_10
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
-        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
+        self.purchase_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(self.purchase_order)
         invoice = self.purchase_order.invoice_ids
         down_pay_amt = -self.purchase_order.amount_total / 2
@@ -407,9 +407,9 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_fixed_payment_method(self):
-        self.purchase_order.order_line[0].taxes_id = self.tax_15 + self.tax_10
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
-        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
+        self.purchase_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(self.purchase_order, method='fixed', amount=222.5)
         invoice = self.purchase_order.invoice_ids
         down_pay_amt = -222.5
@@ -430,10 +430,10 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_fixed_payment_method_with_taxes_on_all_lines(self):
-        self.purchase_order.order_line[0].taxes_id = self.tax_15
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
-        self.purchase_order.order_line[2].taxes_id = self.tax_10
-        self.purchase_order.order_line[3].taxes_id = self.tax_10
+        self.purchase_order.order_line[0].tax_ids = self.tax_15
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
+        self.purchase_order.order_line[2].tax_ids = self.tax_10
+        self.purchase_order.order_line[3].tax_ids = self.tax_10
         self.make_downpayment(self.purchase_order, method='fixed', amount=222.5)
         invoice = self.purchase_order.invoice_ids
         down_pay_amt = -222.5
@@ -454,9 +454,9 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
 
     def test_tax_price_include_breakdown(self):
         tax_10_incl = self.create_tax(10, {'price_include': True})
-        self.purchase_order.order_line[0].taxes_id = tax_10_incl + self.tax_10
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
-        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[0].tax_ids = tax_10_incl + self.tax_10
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
+        self.purchase_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(self.purchase_order)
         invoice = self.purchase_order.invoice_ids
         down_pay_amt = -self.purchase_order.amount_total / 2
@@ -479,9 +479,9 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
     def test_tax_price_include_include_base_amount_breakdown(self):
         tax_10_pi_ba = self.create_tax(10, {'price_include': True, 'include_base_amount': True})
         self.tax_10.sequence = 2
-        self.purchase_order.order_line[0].taxes_id = tax_10_pi_ba + self.tax_10
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
-        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[0].tax_ids = tax_10_pi_ba + self.tax_10
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
+        self.purchase_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(self.purchase_order)
         invoice = self.purchase_order.invoice_ids
         down_pay_amt = -self.purchase_order.amount_total / 2
@@ -502,10 +502,10 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_with_discount(self):
-        self.purchase_order.order_line[0].taxes_id = self.tax_10
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[0].tax_ids = self.tax_10
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
         self.purchase_order.order_line[1].discount = 25.0
-        self.purchase_order.order_line[2].taxes_id = self.tax_15
+        self.purchase_order.order_line[2].tax_ids = self.tax_15
         self.make_downpayment(self.purchase_order)
         invoice = self.purchase_order.invoice_ids
         down_pay_amt = -self.purchase_order.amount_total / 2
@@ -528,10 +528,10 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
     def test_tax_price_include_include_base_amount_breakdown_with_discount(self):
         tax_10_pi_ba = self.create_tax(10, {'price_include': True, 'include_base_amount': True})
         self.tax_10.sequence = 2
-        self.purchase_order.order_line[0].taxes_id = tax_10_pi_ba + self.tax_10
+        self.purchase_order.order_line[0].tax_ids = tax_10_pi_ba + self.tax_10
         self.purchase_order.order_line[0].discount = 25.0
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
-        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
+        self.purchase_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(self.purchase_order)
         invoice = self.purchase_order.invoice_ids
         down_pay_amt = -self.purchase_order.amount_total / 2
@@ -569,9 +569,9 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
             'children_tax_ids': [Command.set((tax_10_fix_c + tax_10_a).ids)],
             'type_tax_use': 'purchase',
         })
-        self.purchase_order.order_line[0].taxes_id = tax_group_1
-        self.purchase_order.order_line[1].taxes_id = tax_group_2
-        self.purchase_order.order_line[2].taxes_id = tax_10_a
+        self.purchase_order.order_line[0].tax_ids = tax_group_1
+        self.purchase_order.order_line[1].tax_ids = tax_group_2
+        self.purchase_order.order_line[2].tax_ids = tax_10_a
         self.make_downpayment(self.purchase_order)
 
         # Line 1: 200 + 80 = 284
@@ -602,11 +602,11 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
         analytic_plan = self.env['account.analytic.plan'].create({'name': 'Plan Test'})
         an_acc_01 = str(self.env['account.analytic.account'].create({'name': 'Account 01', 'plan_id': analytic_plan.id}).id)
         an_acc_02 = str(self.env['account.analytic.account'].create({'name': 'Account 02', 'plan_id': analytic_plan.id}).id)
-        self.purchase_order.order_line[0].taxes_id = self.tax_15 + self.tax_10
+        self.purchase_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
         self.purchase_order.order_line[0].analytic_distribution = {an_acc_01: 100}
-        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[1].tax_ids = self.tax_10
         self.purchase_order.order_line[1].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
-        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].tax_ids = self.tax_10
         self.purchase_order.order_line[2].analytic_distribution = {an_acc_01: 100}
         self.make_downpayment(self.purchase_order)
         invoice = self.purchase_order.invoice_ids
@@ -650,10 +650,10 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
             'children_tax_ids': [Command.set((tax_10_fix_c + tax_10_a).ids)],
             'type_tax_use': 'purchase',
         })
-        self.purchase_order.order_line[0].taxes_id = tax_group_1
+        self.purchase_order.order_line[0].tax_ids = tax_group_1
         self.purchase_order.order_line[0].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
-        self.purchase_order.order_line[1].taxes_id = tax_group_2
-        self.purchase_order.order_line[2].taxes_id = tax_10_a
+        self.purchase_order.order_line[1].tax_ids = tax_group_2
+        self.purchase_order.order_line[2].tax_ids = tax_10_a
         self.make_downpayment(self.purchase_order)
 
         # Line 1: 200 + 80 = 284

--- a/addons/purchase/tests/test_purchase_downpayment.py
+++ b/addons/purchase/tests/test_purchase_downpayment.py
@@ -1,0 +1,696 @@
+#  Part of Odoo. See LICENSE file for full copyright and licensing details.
+import datetime
+import uuid
+
+from odoo import Command
+from odoo.addons.purchase.tests.test_purchase_invoice import TestPurchaseToInvoiceCommon
+from odoo.tests import tagged, Form
+
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.company_data_2 = cls.setup_other_company()
+        cls.other_currency = cls.setup_other_currency('EUR')
+        cls.env.user.groups_id += cls.env.ref('purchase.group_down_payment')
+
+        PurchaseOrder = cls.env['purchase.order'].with_context(tracking_disable=True)
+
+        cls.tax_account = cls.env['account.account'].search([('account_type', '=', 'asset_current')], limit=1)
+        cls.tax_10 = cls.create_tax(10)
+        cls.tax_15 = cls.create_tax(15)
+
+        # create a generic Purchase Order with all classical products and empty pricelist
+        cls.purchase_order = PurchaseOrder.create({
+            'partner_id': cls.partner_a.id,
+        })
+        cls.pol_product_order = cls.env['purchase.order.line'].create({
+            'name': cls.product_order.name,
+            'product_id': cls.product_order.id,
+            'product_qty': 2,
+            'product_uom': cls.product_order.uom_id.id,
+            'price_unit': 100,
+            'order_id': cls.purchase_order.id,
+            'taxes_id': False,
+        })
+        cls.pol_serv_deliver = cls.env['purchase.order.line'].create({
+            'name': cls.service_deliver.name,
+            'product_id': cls.service_deliver.id,
+            'product_qty': 2,
+            'product_uom': cls.service_deliver.uom_id.id,
+            'price_unit': 100,
+            'order_id': cls.purchase_order.id,
+            'taxes_id': False,
+        })
+        cls.pol_serv_order = cls.env['purchase.order.line'].create({
+            'name': cls.service_order.name,
+            'product_id': cls.service_order.id,
+            'product_qty': 2,
+            'product_uom': cls.service_order.uom_id.id,
+            'price_unit': 100,
+            'order_id': cls.purchase_order.id,
+            'taxes_id': False,
+        })
+        cls.pol_product_deliver = cls.env['purchase.order.line'].create({
+            'name': cls.product_deliver.name,
+            'product_id': cls.product_deliver.id,
+            'product_qty': 2,
+            'product_uom': cls.product_deliver.uom_id.id,
+            'price_unit': 100,
+            'order_id': cls.purchase_order.id,
+            'taxes_id': False,
+        })
+
+        cls.expense_account = cls.company_data['default_account_expense']
+        cls.payable_account = cls.company_data['default_account_payable']
+
+    @classmethod
+    def create_tax(cls, amount, values=None):
+        vals = {
+            'name': f'Tax {amount} {uuid.uuid4()}',
+            'amount_type': 'percent',
+            'amount': amount,
+            'type_tax_use': 'purchase',
+            'repartition_line_ids': [
+                Command.create({'document_type': 'invoice', 'repartition_type': 'base'}),
+                Command.create({'document_type': 'invoice', 'repartition_type': 'tax', 'account_id': cls.tax_account.id}),
+                Command.create({'document_type': 'refund', 'repartition_type': 'base'}),
+                Command.create({'document_type': 'refund', 'repartition_type': 'tax', 'account_id': cls.tax_account.id}),
+            ]
+        }
+        if values:
+            vals.update(values)
+        return cls.env['account.tax'].create(vals)
+
+    @classmethod
+    def make_downpayment(cls, purchase_order, method='percentage', amount=50.0):
+        cls.env['purchase.advance.payment.wizard'].with_context({
+            'active_model': 'purchase.order',
+            'active_ids': [purchase_order.id],
+            'active_id': purchase_order.id,
+            'default_journal_id': cls.company_data['default_journal_purchase'].id,
+        }).create({
+            'advance_payment_method': method,
+            'amount' if method == 'percentage' else 'fixed_amount': amount,
+        }).create_invoices()
+        purchase_order.button_confirm()
+
+    def _assert_invoice_lines_values(self, lines, expected):
+        return self.assertRecordValues(lines, [dict(zip(expected[0], x)) for x in expected[1:]])
+
+    def test_downpayment_fixed_tax_incl(self):
+        """
+            Check if DP PO line is created and the total amount of the final invoice is equal to the POs total amount.
+        """
+        self.purchase_order.button_confirm()
+        self.assertEqual(len(self.purchase_order.invoice_ids), 0, "No invoices should have been made yet")
+        self.make_downpayment(self.purchase_order, method='fixed')
+        self.make_downpayment(self.purchase_order, method='fixed')
+        self.assertEqual(len(self.purchase_order.invoice_ids), 2, 'Invoice should be created for the PO')
+        downpayment_line = self.purchase_order.order_line.filtered(lambda l: l.is_downpayment and not l.display_type)
+        self.assertEqual(len(downpayment_line), 2, '2 PO lines for downpayments should be created in PO')
+
+        # Update received quantity of PO lines
+        self.pol_serv_deliver.qty_received = 2
+        self.pol_product_deliver.qty_received = 2
+
+        # Final invoice
+        self.make_downpayment(self.purchase_order, method='delivered')
+
+        self.assertEqual(len(self.purchase_order.invoice_ids), 3, 'Invoice should be created for the PO')
+        invoice = max(self.purchase_order.invoice_ids)
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))),
+                         len(self.purchase_order.order_line.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), 'All lines should be invoiced')
+        self.assertEqual(len(invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
+        self.assertEqual(invoice.amount_total, self.purchase_order.amount_total - sum(downpayment_line.mapped('price_unit')), 'Downpayment should be applied')
+
+    def test_downpayment_validation(self):
+        """
+            Check if invoice from DP can be validated.
+        """
+        self.env.company.po_lock = 'lock'
+        self.purchase_order.button_confirm()
+        self.assertEqual(len(self.purchase_order.invoice_ids), 0, "No invoices should have been made yet")
+        self.make_downpayment(self.purchase_order, amount=10)
+        self.assertEqual(len(self.purchase_order.invoice_ids), 1, 'Invoice should be created for the PO')
+
+        # Update delivered quantity of PO lines
+        self.pol_serv_deliver.qty_received = 2
+        self.pol_product_deliver.qty_received = 2
+
+        self.purchase_order.invoice_ids.invoice_date = datetime.datetime.today()
+        self.purchase_order.invoice_ids.action_post()
+
+    def test_downpayment_line_remains_on_PO(self):
+        """
+           Check DP PO line is created and remains unchanged even if everything is invoiced
+        """
+        # Single line PO
+        self.pol_serv_deliver.unlink()
+        self.pol_serv_order.unlink()
+        self.pol_product_deliver.unlink()
+        self.pol_product_order.product_qty = 5
+
+        self.purchase_order.button_confirm()
+
+        # Update delivered quantity of PO line
+        self.pol_product_order.qty_received = 5
+
+        self.make_downpayment(self.purchase_order, method='fixed')
+        self.make_downpayment(self.purchase_order, method='delivered')
+
+        downpayment_line = self.purchase_order.order_line.filtered(lambda l: l.is_downpayment and not l.display_type)
+        self.assertEqual(downpayment_line[0].price_unit, 50, 'The down payment unit price should not change on PO')
+        self.purchase_order.invoice_ids.invoice_date = datetime.datetime.today()
+        self.purchase_order.invoice_ids.action_post()
+        self.assertEqual(downpayment_line[0].price_unit, 50, 'The down payment unit price should not change on PO')
+
+    def test_downpayment_fixed_amount_with_zero_total_amount(self):
+        """
+            Check that DP should be zero if the total PO amount is zero.
+        """
+        # PO with one line and amount total is zero
+        self.pol_serv_deliver.unlink()
+        self.pol_serv_order.unlink()
+        self.pol_product_deliver.unlink()
+        self.pol_product_order.product_qty = 5
+        self.pol_product_order.price_unit = 0
+
+        self.purchase_order.button_confirm()
+        self.purchase_order.order_line.qty_received = 5
+        self.make_downpayment(self.purchase_order, method='fixed')
+        self.assertEqual(self.purchase_order.order_line[2].price_unit, 0.0, 'The down payment amount should be 0.0')
+
+    def test_downpayment_percentage_tax_incl(self):
+        """
+            Test invoice with a percentage downpayment and an included tax.
+            Check that the total amount of the invoice is correct and equal to the PO total amount.
+        """
+        self.purchase_order.button_confirm()
+        self.make_downpayment(self.purchase_order)
+
+        self.assertEqual(len(self.purchase_order.invoice_ids), 1, 'Invoice should be created for the PO')
+        downpayment_line = self.purchase_order.order_line.filtered(lambda l: l.is_downpayment and not l.display_type)
+        self.assertEqual(len(downpayment_line), 1, 'PO line downpayment should be created on PO')
+        self.assertEqual(downpayment_line.price_unit, self.purchase_order.amount_total / 2, 'Downpayment line on the PO should have the correct amount')
+
+        invoice = self.purchase_order.invoice_ids[0]
+        downpayment_aml = invoice.line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))[0]
+        self.assertEqual(downpayment_aml.price_total, self.purchase_order.amount_total / 2, 'Downpayment should have the correct tax included amount on the downpayment invoice')
+        self.assertEqual(downpayment_aml.price_unit, self.purchase_order.amount_total / 2, 'Downpayment should have the correct unit price on the downpayment invoice')
+        self.purchase_order.invoice_ids.invoice_date = datetime.datetime.today()
+        self.purchase_order.invoice_ids.action_post()
+        self.assertEqual(downpayment_line.price_unit, self.purchase_order.amount_total / 2, 'Downpayment line on the PO should have the correct amount after posting the downpayment invoice')
+
+    def test_downpayment_invoice_and_partial_credit_note(self):
+        """
+            Test for correct behavior in the following flow:
+            1. Create and post a down payment on a PO.
+            2. Create and post a (partial) credit note for this down payment invoice
+            The down payment line on the PO should have its amount reduced by the amount that was credited.
+        """
+        self.purchase_order.button_confirm()
+
+        self.make_downpayment(self.purchase_order, method='fixed', amount=100)
+
+        # Ensure the downpayment line on the purchase order is correctly set to 100
+        downpayment_line = self.purchase_order.order_line.filtered(lambda l: l.is_downpayment and not l.display_type)
+        self.assertEqual(downpayment_line.price_unit, 100)
+
+        # post the downpayment invoice and ensure the downpayment_line amount is still 100
+        self.purchase_order.invoice_ids.invoice_date = datetime.datetime.today()
+        self.purchase_order.invoice_ids.action_post()
+        self.assertEqual(downpayment_line.price_unit, 100)
+
+        # Create a credit note for a part of the downpayment invoice and post it
+        po_invoice = max(self.purchase_order.invoice_ids)
+        credit_note_wizard = self.env['account.move.reversal'].with_context(
+            {'active_ids': [po_invoice.id], 'active_id': po_invoice.id, 'active_model': 'account.move'}).create({
+            'reason': 'no reason',
+            'journal_id': po_invoice.journal_id.id,
+            'date': '2020-02-01',
+        })
+        reversal_action = credit_note_wizard.refund_moves()
+        reverse_move = self.env['account.move'].browse(reversal_action['res_id'])
+        with Form(reverse_move) as form_reverse:
+            with form_reverse.invoice_line_ids.edit(0) as line_form:
+                line_form.price_unit = 20.0
+        reverse_move.action_post()
+        self.assertEqual(downpayment_line.price_unit, 80,
+                         "The downpayment line amount should be equal to the sum of the invoice and credit note amount")
+
+    def test_multi_company_invoice(self):
+        """
+            Checks that the company of the invoices generated in a multi-company environment using the
+           'purchase.advance.payment.wizard' wizard matches the company of the PO and not with the current company.
+        """
+        po_company_id = self.purchase_order.company_id.id
+        yet_another_company_id = self.company_data_2['company'].id
+        po_for_downpayment = self.purchase_order.copy()
+
+        context = {
+            'active_model': 'purchase.order',
+            'active_ids': [self.purchase_order.id],
+            'active_id': self.purchase_order.id,
+            'default_journal_id': self.company_data['default_journal_purchase'].id,
+            'allowed_company_ids': [yet_another_company_id, self.env.company.id],
+            'company_id': yet_another_company_id,
+        }
+        context_for_downpayment = context.copy()
+        context_for_downpayment.update(active_ids=[po_for_downpayment.id], active_id=po_for_downpayment.id)
+
+        # Make sure the invoice is not created with a journal in the context
+        # Because it makes the test always succeed (by using the journal company instead of the env company)
+        no_journal_ctxt = dict(context)
+        no_journal_ctxt.pop('default_journal_id', None)
+        no_journal_ctxt.pop('journal_id', None)
+
+        self.purchase_order.with_context(context).button_confirm()
+        payment = self.env['purchase.advance.payment.wizard'].with_context(no_journal_ctxt).create({
+            'advance_payment_method': 'percentage',
+            'amount': 50,
+        })
+        payment.create_invoices()
+        self.assertEqual(self.purchase_order.invoice_ids[0].company_id.id, po_company_id, "The company of the invoice should be the same as the one from the PO")
+
+        po_for_downpayment.with_context(context_for_downpayment).button_confirm()
+        downpayment = self.env['purchase.advance.payment.wizard'].with_context(context_for_downpayment).create({
+            'advance_payment_method': 'fixed',
+            'fixed_amount': 50,
+        })
+        downpayment.create_invoices()
+        self.assertEqual(po_for_downpayment.invoice_ids[0].company_id.id, po_company_id, "The company of the downpayment invoice should be the same as the one from the PO")
+
+    def test_refund_invoice_with_downpayment(self):
+        """
+            Check that refunding invoices for POs with downpayments works as expected for the following flow:
+            1. We create and post a down payment on a PO.
+            2. We create and post a final invoice for the remaining amount to be paid on the PO.
+            3. We create and post a credit note for the final invoice.
+        """
+        self.pol_serv_deliver.unlink()
+        self.pol_serv_order.unlink()
+        self.pol_product_deliver.unlink()
+        self.pol_product_order.product_qty = 5
+        self.pol_product_order.price_unit = 235
+
+        self.assertRecordValues(self.pol_product_order, [{
+            'price_unit': 235.0,
+            'discount': 0.0,
+            'product_qty': 5.0,
+            'qty_to_invoice': 0.0,
+        }])
+        self.assertEqual(self.purchase_order.invoice_status, 'no')
+        self.purchase_order.button_confirm()
+
+        self.assertEqual(self.pol_product_order.qty_to_invoice, 5.0)
+        self.assertEqual(self.purchase_order.invoice_status, 'to invoice')
+
+        self.make_downpayment(self.purchase_order)
+        # order_line[1] is the down payment section
+        pol_downpayment = self.purchase_order.order_line[2]
+        dp_invoice = self.purchase_order.invoice_ids[0]
+        dp_invoice.invoice_date = datetime.datetime.today()
+        self.purchase_order.invoice_ids.invoice_date = datetime.datetime.today()
+        self.purchase_order.invoice_ids.action_post()
+
+        self.assertRecordValues(pol_downpayment, [{
+            'price_unit': 587.5,
+            'discount': 0.0,
+            'product_qty': 0.0,
+            'qty_invoiced': 1.0,
+            'qty_to_invoice': -1.0,
+        }])
+        self.assertEqual(self.purchase_order.invoice_status, 'to invoice')
+
+        self.make_downpayment(self.purchase_order, method='delivered')
+
+        po_invoice = max(self.purchase_order.invoice_ids)
+        self.assertEqual(len(po_invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))),
+                         len(self.purchase_order.order_line.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), 'All lines should be invoiced')
+        self.assertEqual(len(po_invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
+        self.assertEqual(po_invoice.amount_total, self.purchase_order.amount_total - pol_downpayment.price_unit, 'Downpayment should be applied')
+        po_invoice.invoice_date = datetime.datetime.today()
+        po_invoice.action_post()
+
+        credit_note_wizard = self.env['account.move.reversal'].with_context({'active_ids': [po_invoice.id], 'active_id': po_invoice.id, 'active_model': 'account.move'}).create({
+            'reason': 'reason test refund with downpayment',
+            'journal_id': po_invoice.journal_id.id,
+        })
+        credit_note_wizard.refund_moves()
+        invoice_refund = self.purchase_order.invoice_ids.sorted(key=lambda inv: inv.id, reverse=False)[-1]
+        invoice_refund.invoice_date = datetime.datetime.today()
+        invoice_refund.action_post()
+
+        self.assertEqual(self.pol_product_order.qty_to_invoice, 5.0, "The refund should make it so the quantity to invoice is the ordered quantity")
+        self.assertEqual(self.pol_product_order.qty_invoiced, 0.0, "The qty invoiced should be zero since the refund cancels the previously invoiced amount")
+        self.assertEqual(len(self.pol_product_order.invoice_lines), 2, "The product line is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
+        self.assertEqual(pol_downpayment.qty_invoiced, 1.0, "The qty invoiced should remain 1 since the refund was only for the ordered product, not the downpayment")
+        self.assertEqual(pol_downpayment.qty_to_invoice, -1.0, "Downpayment was invoiced separately and should still count as invoiced after refund of the product line. Since the ordered qty is 0 for down payments, this means -1 is remaining to invoice.")
+        self.assertEqual(len(pol_downpayment.invoice_lines), 3, "The down payment line is invoiced, so it should be linked to 3 invoice lines (downpayment invoice, partial invoice and refund)")
+
+    def test_tax_and_account_breakdown(self):
+        """
+            Test to check if down payments are properly broken down per tax.
+        """
+        expense_acc_2 = self.expense_account.copy()
+        self.purchase_order.order_line[1].product_id.product_tmpl_id.property_account_expense_id = expense_acc_2
+
+        self.purchase_order.order_line[0].taxes_id = self.tax_15 + self.tax_10
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.make_downpayment(self.purchase_order)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -self.purchase_order.amount_total / 2
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                      'balance',     'price_total'],
+            # base lines
+            [self.expense_account.id,    (self.tax_15 + self.tax_10).ids, 100,          125],
+            [expense_acc_2.id,           self.tax_10.ids,                 100,          110],
+            [self.expense_account.id,    self.tax_10.ids,                 100,          110],
+            [self.expense_account.id,    self.env['account.tax'],         100,          100],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'],         30,           0],
+            [self.tax_account.id,        self.env['account.tax'],         15,           0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'],         down_pay_amt, 0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_breakdown_other_currency(self):
+        self.purchase_order.currency_id = self.other_currency  # rate = 2.0
+        self.purchase_order.order_line[0].taxes_id = self.tax_15 + self.tax_10
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.make_downpayment(self.purchase_order)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -self.purchase_order.amount_total / 2
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                      'balance',           'price_total'],
+            # base lines
+            [self.expense_account.id,    (self.tax_15 + self.tax_10).ids, 50,                 125],
+            [self.expense_account.id,    self.tax_10.ids,                 100,                220],
+            [self.expense_account.id,    self.env['account.tax'],         50,                 100],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'],         15,                 0],
+            [self.tax_account.id,        self.env['account.tax'],         7.5,                0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'],         down_pay_amt / 2.0, 0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_breakdown_fixed_payment_method(self):
+        self.purchase_order.order_line[0].taxes_id = self.tax_15 + self.tax_10
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.make_downpayment(self.purchase_order, method='fixed', amount=222.5)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -222.5
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                      'balance',     'price_total'],
+            # base lines
+            [self.expense_account.id,    (self.tax_15 + self.tax_10).ids, 50,           62.5],
+            [self.expense_account.id,    self.tax_10.ids,                 100,          110],
+            [self.expense_account.id,    self.env['account.tax'],         50,           50],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'],         15,           0],
+            [self.tax_account.id,        self.env['account.tax'],         7.5,          0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'],         down_pay_amt, 0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_breakdown_fixed_payment_method_with_taxes_on_all_lines(self):
+        self.purchase_order.order_line[0].taxes_id = self.tax_15
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[3].taxes_id = self.tax_10
+        self.make_downpayment(self.purchase_order, method='fixed', amount=222.5)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -222.5
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',              'balance',     'price_total'],
+            # base lines
+            [self.expense_account.id,    self.tax_15.ids,         50,           57.5],
+            [self.expense_account.id,    self.tax_10.ids,         150,          165],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'], 7.5,          0],
+            [self.tax_account.id,        self.env['account.tax'], 15,           0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'], down_pay_amt, 0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_price_include_breakdown(self):
+        tax_10_incl = self.create_tax(10, {'price_include': True})
+        self.purchase_order.order_line[0].taxes_id = tax_10_incl + self.tax_10
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.make_downpayment(self.purchase_order)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -self.purchase_order.amount_total / 2
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                       'balance',    'price_total'],
+            # base lines
+            [self.expense_account.id,    (tax_10_incl + self.tax_10).ids,  90.91,       109.09],
+            [self.expense_account.id,    self.tax_10.ids,                  200,         220],
+            [self.expense_account.id,    self.env['account.tax'],          100,         100],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'],          29.09,       0],
+            [self.tax_account.id,        self.env['account.tax'],          9.09,        0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'],          down_pay_amt, 0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_price_include_include_base_amount_breakdown(self):
+        tax_10_pi_ba = self.create_tax(10, {'price_include': True, 'include_base_amount': True})
+        self.tax_10.sequence = 2
+        self.purchase_order.order_line[0].taxes_id = tax_10_pi_ba + self.tax_10
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.make_downpayment(self.purchase_order)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -self.purchase_order.amount_total / 2
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                       'balance',     'price_total'],
+            # base lines
+            [self.expense_account.id,    (tax_10_pi_ba + self.tax_10).ids, 90.91,        110],
+            [self.expense_account.id,    self.tax_10.ids,                  200,          220],
+            [self.expense_account.id,    self.env['account.tax'],          100,          100],
+            # taxes
+            [self.tax_account.id,        self.tax_10.ids,                  9.09,         0],
+            [self.tax_account.id,        self.env['account.tax'],          30,           0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'],          down_pay_amt, 0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_breakdown_with_discount(self):
+        self.purchase_order.order_line[0].taxes_id = self.tax_10
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[1].discount = 25.0
+        self.purchase_order.order_line[2].taxes_id = self.tax_15
+        self.make_downpayment(self.purchase_order)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -self.purchase_order.amount_total / 2
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',               'balance',    'price_total'],
+            # base lines
+            [self.expense_account.id,    self.tax_10.ids,         175,          192.5],
+            [self.expense_account.id,    self.tax_15.ids,         100,          115],
+            [self.expense_account.id,    self.env['account.tax'], 100,          100],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'], 17.5,         0],
+            [self.tax_account.id,        self.env['account.tax'], 15,           0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'], down_pay_amt, 0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_price_include_include_base_amount_breakdown_with_discount(self):
+        tax_10_pi_ba = self.create_tax(10, {'price_include': True, 'include_base_amount': True})
+        self.tax_10.sequence = 2
+        self.purchase_order.order_line[0].taxes_id = tax_10_pi_ba + self.tax_10
+        self.purchase_order.order_line[0].discount = 25.0
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.make_downpayment(self.purchase_order)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -self.purchase_order.amount_total / 2
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                       'balance',     'price_total'],
+            # base lines
+            [self.expense_account.id,    (tax_10_pi_ba + self.tax_10).ids, 68.18,        82.5],
+            [self.expense_account.id,    self.tax_10.ids,                  200,          220],
+            [self.expense_account.id,    self.env['account.tax'],          100,          100],
+            # taxes
+            [self.tax_account.id,        self.tax_10.ids,                  6.82,         0],
+            [self.tax_account.id,        self.env['account.tax'],          27.5,         0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'],          down_pay_amt, 0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_fixed_amount_breakdown(self):
+        tax_10_fix_a = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True})
+        tax_10_fix_b = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True})
+        tax_10_fix_c = self.create_tax(10, {'amount_type': 'fixed'})
+        tax_10_a = self.tax_10
+        tax_10_b = self.create_tax(10)
+        tax_group_1 = self.env['account.tax'].create({
+            'name': "Tax Group",
+            'amount_type': 'group',
+            'children_tax_ids': [Command.set((tax_10_fix_a + tax_10_a + tax_10_fix_b + tax_10_b).ids)],
+            'type_tax_use': 'purchase',
+        })
+        tax_group_2 = self.env['account.tax'].create({
+            'name': "Tax Group 2",
+            'amount_type': 'group',
+            'children_tax_ids': [Command.set((tax_10_fix_c + tax_10_a).ids)],
+            'type_tax_use': 'purchase',
+        })
+        self.purchase_order.order_line[0].taxes_id = tax_group_1
+        self.purchase_order.order_line[1].taxes_id = tax_group_2
+        self.purchase_order.order_line[2].taxes_id = tax_10_a
+        self.make_downpayment(self.purchase_order)
+
+        # Line 1: 200 + 80 = 284
+        # Line 2: 200 + 40 = 240
+        # Line 3: 200 + 20 = 220
+        # Line 4: 200
+        # Total: 944
+
+        invoice = self.purchase_order.invoice_ids
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                 'balance',    'price_total'],
+            # base lines
+            [self.expense_account.id,    (tax_10_a + tax_10_b).ids, 110,          132],
+            [self.expense_account.id,    tax_10_b.ids,              10,           11],
+            [self.expense_account.id,    tax_10_a.ids,              200,          220],
+            [self.expense_account.id,    self.env['account.tax'],   110,          110],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'],   31,           0],
+            [self.tax_account.id,        self.env['account.tax'],   12,           0],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'], -473,         0],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_analytic_distribution(self):
+        analytic_plan = self.env['account.analytic.plan'].create({'name': 'Plan Test'})
+        an_acc_01 = str(self.env['account.analytic.account'].create({'name': 'Account 01', 'plan_id': analytic_plan.id}).id)
+        an_acc_02 = str(self.env['account.analytic.account'].create({'name': 'Account 02', 'plan_id': analytic_plan.id}).id)
+        self.purchase_order.order_line[0].taxes_id = self.tax_15 + self.tax_10
+        self.purchase_order.order_line[0].analytic_distribution = {an_acc_01: 100}
+        self.purchase_order.order_line[1].taxes_id = self.tax_10
+        self.purchase_order.order_line[1].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
+        self.purchase_order.order_line[2].taxes_id = self.tax_10
+        self.purchase_order.order_line[2].analytic_distribution = {an_acc_01: 100}
+        self.make_downpayment(self.purchase_order)
+        invoice = self.purchase_order.invoice_ids
+        down_pay_amt = -self.purchase_order.amount_total / 2
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                      'balance',     'price_total', 'analytic_distribution'],
+            # base lines
+            [self.expense_account.id,    (self.tax_15 + self.tax_10).ids, 100,          125,           {an_acc_01: 100}],
+            [self.expense_account.id,    self.tax_10.ids,                 100,          110,           {an_acc_01: 50, an_acc_02: 50}],
+            [self.expense_account.id,    self.tax_10.ids,                 100,          110,           {an_acc_01: 100}],
+            [self.expense_account.id,    self.env['account.tax'],         100,          100, False],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'],         30,           0, False],
+            [self.tax_account.id,        self.env['account.tax'],         15,           0, False],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'],         down_pay_amt, 0, False],
+        ]
+
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_tax_fixed_amount_analytic_distribution(self):
+        analytic_plan = self.env['account.analytic.plan'].create({'name': 'Plan Test'})
+        an_acc_01 = str(self.env['account.analytic.account'].create({'name': 'Account 01', 'plan_id': analytic_plan.id}).id)
+        an_acc_02 = str(self.env['account.analytic.account'].create({'name': 'Account 02', 'plan_id': analytic_plan.id}).id)
+        tax_10_fix_a = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True})
+        tax_10_fix_b = self.create_tax(10, {'amount_type': 'fixed', 'include_base_amount': True})
+        tax_10_fix_c = self.create_tax(10, {'amount_type': 'fixed'})
+        tax_10_a = self.tax_10
+        tax_10_b = self.create_tax(10)
+        tax_group_1 = self.env['account.tax'].create({
+            'name': "Tax Group",
+            'amount_type': 'group',
+            'children_tax_ids': [Command.set((tax_10_fix_a + tax_10_a + tax_10_fix_b + tax_10_b).ids)],
+            'type_tax_use': 'purchase',
+        })
+        tax_group_2 = self.env['account.tax'].create({
+            'name': "Tax Group 2",
+            'amount_type': 'group',
+            'children_tax_ids': [Command.set((tax_10_fix_c + tax_10_a).ids)],
+            'type_tax_use': 'purchase',
+        })
+        self.purchase_order.order_line[0].taxes_id = tax_group_1
+        self.purchase_order.order_line[0].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
+        self.purchase_order.order_line[1].taxes_id = tax_group_2
+        self.purchase_order.order_line[2].taxes_id = tax_10_a
+        self.make_downpayment(self.purchase_order)
+
+        # Line 1: 200 + 80 = 284
+        # Line 2: 200 + 40 = 240
+        # Line 3: 200 + 20 = 220
+        # Line 4: 200
+        # Total: 944
+
+        invoice = self.purchase_order.invoice_ids
+        # pylint: disable=C0326
+        expected = [
+            # keys
+            ['account_id',               'tax_ids',                 'balance',    'price_total', 'analytic_distribution'],
+            # base lines
+            [self.expense_account.id,    (tax_10_a + tax_10_b).ids, 110,          132,            {an_acc_01: 50, an_acc_02: 50}],
+            [self.expense_account.id,    tax_10_b.ids,              10,           11,             {an_acc_01: 50, an_acc_02: 50}],
+            [self.expense_account.id,    tax_10_a.ids,              200,          220, False],
+            [self.expense_account.id,    self.env['account.tax'],   110,          110, False],
+            # taxes
+            [self.tax_account.id,        self.env['account.tax'],   31,           0, False],
+            [self.tax_account.id,        self.env['account.tax'],   12,           0, False],
+            # receivable
+            [self.payable_account.id,    self.env['account.tax'], -473,          0, False],
+        ]
+        self._assert_invoice_lines_values(invoice.line_ids, expected)
+
+    def test_downpayment_line_name(self):
+        """ Test downpayment's PO line name is updated when invoice is posted. """
+        self.make_downpayment(self.purchase_order, method='fixed')
+        dp_line = self.purchase_order.order_line.filtered(
+            lambda pol: pol.is_downpayment and not pol.display_type
+        )
+        dp_line.name = 'whatever'
+        self.purchase_order.invoice_ids.invoice_date = datetime.datetime.today()
+        self.purchase_order.invoice_ids.action_post()
+
+        self.assertNotEqual(
+            dp_line.name, 'whatever',
+            "DP line's description should be recomputed when the linked invoice is posted",
+        )

--- a/addons/purchase/tests/test_purchase_downpayment.py
+++ b/addons/purchase/tests/test_purchase_downpayment.py
@@ -347,10 +347,10 @@ class TestPurchaseDownpayment(TestPurchaseToInvoiceCommon):
 
         self.assertEqual(self.pol_product_order.qty_to_invoice, 5.0, "The refund should make it so the quantity to invoice is the ordered quantity")
         self.assertEqual(self.pol_product_order.qty_invoiced, 0.0, "The qty invoiced should be zero since the refund cancels the previously invoiced amount")
-        self.assertEqual(len(self.pol_product_order.invoice_lines), 2, "The product line is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
+        self.assertEqual(len(self.pol_product_order.account_move_line_ids), 2, "The product line is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
         self.assertEqual(pol_downpayment.qty_invoiced, 1.0, "The qty invoiced should remain 1 since the refund was only for the ordered product, not the downpayment")
         self.assertEqual(pol_downpayment.qty_to_invoice, -1.0, "Downpayment was invoiced separately and should still count as invoiced after refund of the product line. Since the ordered qty is 0 for down payments, this means -1 is remaining to invoice.")
-        self.assertEqual(len(pol_downpayment.invoice_lines), 3, "The down payment line is invoiced, so it should be linked to 3 invoice lines (downpayment invoice, partial invoice and refund)")
+        self.assertEqual(len(pol_downpayment.account_move_line_ids), 3, "The down payment line is invoiced, so it should be linked to 3 invoice lines (downpayment invoice, partial invoice and refund)")
 
     def test_tax_and_account_breakdown(self):
         """

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -477,7 +477,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
         po.button_confirm()
         po.order_line.qty_received = 1
         po.action_create_invoice()
-        self.assertRecordValues(po.invoice_ids.invoice_line_ids,
+        self.assertRecordValues(po.account_move_ids.invoice_line_ids,
                                 [{'analytic_distribution': analytic_distribution_model.analytic_distribution}])
 
     def test_sequence_invoice_lines_from_multiple_purchases(self):
@@ -579,7 +579,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
         line.qty_received = 10
         purchase_order.action_create_invoice()
 
-        invoice = purchase_order.invoice_ids
+        invoice = purchase_order.account_move_ids
         invoice.invoice_date = invoice.date
         invoice.action_post()
 
@@ -715,7 +715,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             [], invoice.partner_id.id, invoice.amount_total)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
         self.assertEqual(invoice.amount_total, po.amount_total)
 
     def test_total_match_via_po_reference(self):
@@ -725,7 +725,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
         self.assertEqual(invoice.amount_total, po.amount_total)
 
     def test_subset_total_match_from_ocr(self):
@@ -736,7 +736,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=True)
         additional_unmatch_po_line = po.order_line.filtered(lambda l: l.product_id == self.service_order)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
         self.assertTrue(additional_unmatch_po_line.id in invoice.line_ids.purchase_line_id.ids)
         self.assertTrue(invoice.line_ids.filtered(lambda l: l.purchase_line_id == additional_unmatch_po_line).quantity == 0)
 
@@ -749,7 +749,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
         invoice_lines = invoice.line_ids.filtered(lambda l: l.price_unit)
         self.assertEqual(len(invoice_lines), 2)
         for line in invoice_lines:
@@ -765,7 +765,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
         invoice_lines = invoice.line_ids.filtered(lambda l: l.price_unit)
         self.assertEqual(len(invoice_lines), 2)
         for line in po.order_line:
@@ -780,7 +780,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
         invoice_lines = invoice.line_ids.filtered(lambda l: l.price_unit)
         self.assertEqual(len(invoice_lines), 1)
         for line in invoice_lines:
@@ -795,7 +795,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
         invoice_lines = invoice.line_ids.filtered(lambda l: l.price_unit)
         self.assertEqual(len(invoice_lines), 1)
         for line in invoice_lines:
@@ -810,7 +810,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
         invoice_lines = invoice.line_ids.filtered(lambda l: l.price_unit)
         self.assertEqual(len(invoice_lines), 2)
         for line in invoice_lines:
@@ -827,7 +827,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=True)
 
-        self.assertTrue(invoice.id in po.invoice_ids.ids)
+        self.assertTrue(invoice.id in po.account_move_ids.ids)
 
     def test_no_match_same_reference(self):
         po = self.init_purchase(confirm=True, products=[self.product_order, self.service_order])
@@ -836,7 +836,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['my_match_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
 
-        self.assertTrue(invoice.id not in po.invoice_ids.ids)
+        self.assertTrue(invoice.id not in po.account_move_ids.ids)
 
     def test_no_match(self):
         po = self.init_purchase(confirm=True, products=[self.product_order, self.service_order])
@@ -845,7 +845,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         invoice._find_and_set_purchase_orders(
             ['other_reference'], invoice.partner_id.id, invoice.amount_total, from_ocr=False)
 
-        self.assertTrue(invoice.id not in po.invoice_ids.ids)
+        self.assertTrue(invoice.id not in po.account_move_ids.ids)
 
     def test_onchange_partner_currency(self):
         """
@@ -1022,7 +1022,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
         # creating bill from PO
         po1.order_line.qty_received = 1
         po1.action_create_invoice()
-        invoice1 = po1.invoice_ids
+        invoice1 = po1.account_move_ids
         self.assertFalse(invoice1.invoice_user_id)
         # creating bill with Auto_complete feature
         move_form = Form(self.env['account.move'].with_context(default_move_type='in_invoice'))

--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -128,7 +128,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom': self.product_deliver.uom_id.id,
             'price_unit': self.product_deliver.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_serv_deliver = PurchaseOrderLine.create({
             'name': self.service_deliver.name,
@@ -137,7 +137,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom': self.service_deliver.uom_id.id,
             'price_unit': self.service_deliver.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         purchase_order.button_confirm()
 
@@ -172,7 +172,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom': self.product_order.uom_id.id,
             'price_unit': self.product_order.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_serv_order = PurchaseOrderLine.create({
             'name': self.service_order.name,
@@ -181,7 +181,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom': self.service_order.uom_id.id,
             'price_unit': self.service_order.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         purchase_order.button_confirm()
 
@@ -216,7 +216,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom': self.product_deliver.uom_id.id,
             'price_unit': self.product_deliver.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_serv_deliver = PurchaseOrderLine.create({
             'name': self.service_deliver.name,
@@ -225,7 +225,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom': self.service_deliver.uom_id.id,
             'price_unit': self.service_deliver.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         purchase_order.button_confirm()
 
@@ -261,7 +261,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom': self.product_order.uom_id.id,
             'price_unit': self.product_order.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         pol_serv_order = PurchaseOrderLine.create({
             'name': self.service_order.name,
@@ -270,7 +270,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
             'product_uom': self.service_order.uom_id.id,
             'price_unit': self.service_order.list_price,
             'order_id': purchase_order.id,
-            'taxes_id': False,
+            'tax_ids': False,
         })
         purchase_order.button_confirm()
 
@@ -314,7 +314,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                 'product_uom': self.product_order.uom_id.id,
                 'price_unit': 1000,
                 'order_id': po.id,
-                'taxes_id': False,
+                'tax_ids': False,
             })
             po.button_confirm()
             pol_prod_order.write({'qty_received': 1})
@@ -356,7 +356,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                 'product_qty': 12,
                 'product_uom': self.product_a.uom_id.id,
                 'price_unit': 0.001,
-                'taxes_id': False,
+                'tax_ids': False,
             })]
         })
         po.button_confirm()
@@ -493,7 +493,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                     'product_qty': 10.0,
                     'product_uom': self.product_order.uom_id.id,
                     'price_unit': self.product_order.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                     'sequence': sequence_number,
                 }) for sequence_number in range(10, 13)]
             purchase_order = self.env['purchase.order'].with_context(tracking_disable=True).create({
@@ -527,7 +527,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                     'product_qty': 10.0,
                     'product_uom': self.product_order.uom_id.id,
                     'price_unit': self.product_order.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                     'sequence': sequence_number,
                 }) for sequence_number in range(10, 13)]
             purchase_order = self.env['purchase.order'].with_context(tracking_disable=True).create({
@@ -569,7 +569,7 @@ class TestPurchaseToInvoice(TestPurchaseToInvoiceCommon):
                     'product_qty': 20.0,
                     'product_uom': self.product_deliver.uom_id.id,
                     'price_unit': self.product_deliver.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -961,7 +961,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
                         'product_id': self.product_order.id,
                         'product_qty': 1.0,
                         'price_unit': self.product_order.list_price,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                 ]
             } for partner_ref in ('PO-001', False)
@@ -1012,7 +1012,7 @@ class TestInvoicePurchaseMatch(TestPurchaseToInvoiceCommon):
                     'product_id': self.product_order.id,
                     'product_qty': 1.0,
                     'price_unit': self.product_order.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })

--- a/addons/purchase/tests/test_purchase_order_report.py
+++ b/addons/purchase/tests/test_purchase_order_report.py
@@ -28,7 +28,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
                     'product_uom': uom_dozen.id,
                     'price_unit': 100.0,
                     'date_planned': datetime.today(),
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
                 (0, 0, {
                     'name': self.product_b.name,
@@ -37,7 +37,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
                     'product_uom': uom_dozen.id,
                     'price_unit': 200.0,
                     'date_planned': datetime.today(),
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -138,7 +138,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
                     'product_qty': 0.0,
                     'product_uom': False,
                     'price_unit': 0.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
                 (0, 0, {
                     'name': 'This is a section',
@@ -147,7 +147,7 @@ class TestPurchaseOrderReport(AccountTestInvoicingCommon):
                     'product_qty': 0.0,
                     'product_uom': False,
                     'price_unit': 0.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })

--- a/addons/purchase/tests/test_purchase_tax_totals.py
+++ b/addons/purchase/tests/test_purchase_tax_totals.py
@@ -76,7 +76,7 @@ class PurchaseTestTaxTotals(TestTaxTotals):
         po.order_line.qty_received = 1
         po.action_create_invoice()
 
-        invoice = po.invoice_ids
+        invoice = po.account_move_ids
         invoice.invoice_date = '2020-01-01'
         invoice.action_post()
 

--- a/addons/purchase/tests/test_purchase_tax_totals.py
+++ b/addons/purchase/tests/test_purchase_tax_totals.py
@@ -28,7 +28,7 @@ class PurchaseTestTaxTotals(TestTaxTotals):
                 'product_qty': 1,
                 'product_uom': self.po_product.uom_po_id.id,
                 'price_unit': amount,
-                'taxes_id': [(6, 0, taxes.ids)],
+                'tax_ids': [(6, 0, taxes.ids)],
             })
         for amount, taxes in lines_data]
 
@@ -54,7 +54,7 @@ class PurchaseTestTaxTotals(TestTaxTotals):
                     'product_id': self.po_product.id,
                     'product_qty': 1.0,
                     'price_unit': 100.0,
-                    'taxes_id': [Command.set(tax_purchase.ids)],
+                    'tax_ids': [Command.set(tax_purchase.ids)],
                 }),
             ],
         })

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -349,7 +349,7 @@
                                         />
                                     </td>
                                     <td t-if="not update_dates and order.state in ['purchase', 'done']" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
-                                        <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.taxes_id))"/>
+                                        <span t-out="', '.join(map(lambda t: (t.description or t.name), line.tax_ids))"/>
                                     </td>
                                     <td class="text-end" t-if="not update_dates and order.state in ['purchase', 'done'] and not line.is_downpayment">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -263,7 +263,7 @@
                   </div>
               </div>
 
-              <t t-set="invoices" t-value="[i for i in order.invoice_ids if i.state not in ['draft', 'cancel']]"/>
+              <t t-set="invoices" t-value="[i for i in order.account_move_ids if i.state not in ['draft', 'cancel']]"/>
               <div t-if="invoices" class="row">
                   <div class="col">
                       <strong class="d-block mb-1">Invoices</strong>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -309,8 +309,9 @@
                     <tbody class="purchase_tbody">
 
                           <t t-set="current_subtotal" t-value="0"/>
+                          <t t-set="lines_to_report" t-value="order._get_order_lines_to_report()"/>
 
-                          <t t-foreach="order.order_line" t-as="line">
+                          <t t-foreach="lines_to_report" t-as="line">
 
                               <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal"/>
 
@@ -350,7 +351,7 @@
                                     <td t-if="not update_dates and order.state in ['purchase', 'done']" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                         <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.taxes_id))"/>
                                     </td>
-                                    <td class="text-end" t-if="not update_dates and order.state in ['purchase', 'done']">
+                                    <td class="text-end" t-if="not update_dates and order.state in ['purchase', 'done'] and not line.is_downpayment">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>
                                     </td>
                                 </t>
@@ -368,7 +369,7 @@
                                 </t>
                             </tr>
 
-                            <t t-if="current_section and (line_last or order.order_line[line_index+1].display_type == 'line_section') and order.state in ['purchase', 'done']">
+                            <t t-if="current_section and (line_last or lines_to_report[line_index+1].display_type == 'line_section') and order.state in ['purchase', 'done'] and not line.is_downpayment">
                                 <tr class="is-subtotal text-end">
                                     <td colspan="99">
                                         <strong class="mr16">Subtotal</strong>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -228,7 +228,7 @@
                                     <field name="product_type" column_invisible="True"/>
                                     <field name="product_uom" column_invisible="True" groups="!uom.group_uom"/>
                                     <field name="product_uom_category_id" column_invisible="True"/>
-                                    <field name="invoice_lines" column_invisible="True"/>
+                                    <field name="account_move_line_ids" column_invisible="True"/>
                                     <field name="is_downpayment" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
                                     <field
@@ -306,7 +306,7 @@
                                                     <field name="name"/>
                                                 </page>
                                                 <page string="Invoices and Incoming Shipments" name="invoices_incoming_shiptments">
-                                                    <field name="invoice_lines"/>
+                                                    <field name="account_move_line_ids"/>
                                                 </page>
                                             </notebook>
                                             </group>
@@ -787,7 +787,7 @@
                         </group>
                         <field name="name"/>
                         <separator string="Manual Invoices"/>
-                        <field name="invoice_lines"/>
+                        <field name="account_move_line_ids"/>
                     </sheet>
                 </form>
             </field>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -229,6 +229,7 @@
                                     <field name="product_uom" column_invisible="True" groups="!uom.group_uom"/>
                                     <field name="product_uom_category_id" column_invisible="True"/>
                                     <field name="invoice_lines" column_invisible="True"/>
+                                    <field name="is_downpayment" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
                                     <field
                                         name="product_id"
@@ -237,15 +238,15 @@
                                         context="{'partner_id':parent.partner_id, 'quantity':product_qty, 'company_id': parent.company_id}"
                                         force_save="1" domain="[('purchase_ok', '=', True)]"/>
                                     <field name="name" widget="section_and_note_text" optional="show"/>
-                                    <field name="date_planned" optional="hide" required="not display_type" force_save="1"/>
+                                    <field name="date_planned" optional="hide" required="not display_type" force_save="1" readonly="is_downpayment"/>
                                     <field name="analytic_distribution" widget="analytic_distribution"
                                            optional="hide"
                                            groups="analytic.group_analytic_accounting"
                                            options="{'product_field': 'product_id', 'business_domain': 'purchase_order', 'amount_field': 'price_subtotal'}"/>
-                                    <field name="product_qty"/>
+                                    <field name="product_qty" readonly="is_downpayment"/>
                                     <field name="qty_received_manual" column_invisible="True"/>
                                     <field name="qty_received_method" column_invisible="True"/>
-                                    <field name="qty_received" string="Received" column_invisible="parent.state not in ('purchase', 'done')" readonly="qty_received_method != 'manual'" optional="show"/>
+                                    <field name="qty_received" string="Received" column_invisible="parent.state not in ('purchase', 'done')" readonly="qty_received_method != 'manual' or is_downpayment" optional="show"/>
                                     <field name="qty_invoiced" string="Billed" column_invisible="parent.state not in ('purchase', 'done')" optional="show"/>
                                     <field name="product_uom" string="UoM" groups="uom.group_uom"
                                         readonly="state in ('purchase', 'done', 'cancel')"
@@ -256,12 +257,13 @@
                                     <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" optional="show"/>
                                     <field name="price_unit" readonly="qty_invoiced != 0"/>
                                     <button name="action_purchase_history" type="object" icon="fa-history" title="Purchase History" invisible="not id"/>
-                                    <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show"/>
-                                    <field name="discount" string="Disc.%" readonly="qty_invoiced != 0" optional="hide"/>
-                                    <field name="price_subtotal" string="Tax excl."/>
+                                    <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show" readonly="is_downpayment"/>
+                                    <field name="discount" string="Disc.%" readonly="qty_invoiced != 0 or is_downpayment" optional="hide"/>
+                                    <field name="price_subtotal" string="Tax excl." invisible="is_downpayment"/>
                                     <field name="price_total"
                                            string="Tax incl."
                                            column_invisible="parent.tax_calculation_rounding_method == 'round_globally'"
+                                           invisible="is_downpayment"
                                            optional="hide"/>
                                 </tree>
                                 <form string="Purchase Order Line">

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -156,7 +156,7 @@
                             class="oe_stat_button"
                             icon="fa-pencil-square-o" invisible="invoice_count == 0 or state in ('draft', 'sent', 'to approve')">
                             <field name="invoice_count" widget="statinfo" string="Vendor Bills"/>
-                            <field name='invoice_ids' invisible="1"/>
+                            <field name='account_move_ids' invisible="1"/>
                         </button>
                     </div>
                     <div class="oe_title">

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -257,7 +257,7 @@
                                     <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" optional="show"/>
                                     <field name="price_unit" readonly="qty_invoiced != 0"/>
                                     <button name="action_purchase_history" type="object" icon="fa-history" title="Purchase History" invisible="not id"/>
-                                    <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show" readonly="is_downpayment"/>
+                                    <field name="tax_ids" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id), ('active', '=', True)]" context="{'default_type_tax_use': 'purchase', 'search_view_ref': 'account.account_tax_view_search'}" options="{'no_create': True}" optional="show" readonly="is_downpayment"/>
                                     <field name="discount" string="Disc.%" readonly="qty_invoiced != 0 or is_downpayment" optional="hide"/>
                                     <field name="price_subtotal" string="Tax excl." invisible="is_downpayment"/>
                                     <field name="price_total"
@@ -292,7 +292,7 @@
                                                 <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" />
                                                 <field name="price_unit"/>
                                                 <field name="discount"/>
-                                                <field name="taxes_id" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]" options="{'no_create': True}"/>
+                                                <field name="tax_ids" widget="many2many_tags" domain="[('type_tax_use', '=', 'purchase'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]" options="{'no_create': True}"/>
                                             </group>
                                             <group>
                                                 <field name="date_planned" required="not display_type"/>
@@ -326,7 +326,7 @@
                                      <field name="price_unit"/>
                                      <field name="discount"/>
                                      <field name="display_type"/>
-                                     <field name="taxes_id"/>
+                                     <field name="tax_ids"/>
                                      <field name="tax_calculation_rounding_method"/>
                                      <templates>
                                          <t t-name="kanban-box">
@@ -776,8 +776,8 @@
                                 <field name="price_unit"/>
                             </group>
                             <group>
-                                <field name="taxes_id" widget="many2many_tags"
-                                    domain="[('type_tax_use', '=', 'purchase')]"/>
+                                <field name="tax_ids" widget="many2many_tags"
+                                       domain="[('type_tax_use', '=', 'purchase')]"/>
                                 <field name="date_planned" readonly="1"/>
                                 <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                                 <field name="analytic_distribution" widget="analytic_distribution"

--- a/addons/purchase/views/res_config_settings_views.xml
+++ b/addons/purchase/views/res_config_settings_views.xml
@@ -45,6 +45,9 @@
                         <setting id="three_way_matching" title="If enabled, activates 3-way matching on vendor bills : the items must be received in order to pay the invoice." documentation="/applications/inventory_and_mrp/purchase/manage_deals/control_bills.html" help="Make sure you only pay bills for which you received the goods you ordered">
                             <field name="module_account_3way_match" string="3-way matching" widget="upgrade_boolean"/>
                         </setting>
+                        <setting id="down_payments" help="Allow creating vendor bills for down payments on purchase orders">
+                            <field name="group_down_payment"/>
+                        </setting>
                     </block>
                     <block title="Products" name="matrix_setting_container">
                         <setting id="variant_options" help="Purchase variants of a product using attributes (size, color, etc.)" documentation="/applications/sales/sales/products_prices/products/variants.html">

--- a/addons/purchase/wizard/__init__.py
+++ b/addons/purchase/wizard/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import purchase_make_bill_advance

--- a/addons/purchase/wizard/purchase_make_bill_advance.py
+++ b/addons/purchase/wizard/purchase_make_bill_advance.py
@@ -1,0 +1,46 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models, _, SUPERUSER_ID
+
+
+class PurchaseAdvancePaymentWizard(models.TransientModel):
+    _name = 'purchase.advance.payment.wizard'
+    _description = "Purchase Advance Payment Bill"
+    _inherit = ["account.advance.payment.wizard"]
+
+    advance_payment_method = fields.Selection(
+        string="Create Bill",
+        help="A standard vendor bill is created with all the order lines ready for billing, "
+             "according to their bill policy (based on ordered or received quantity).",
+    )
+
+    amount = fields.Float(help="The percentage of amount billed in advance.")
+    fixed_amount = fields.Monetary(help="The fixed amount billed in advance.")
+
+    amount_to_invoice = fields.Monetary(string="Amount to be billed", help="The amount to be billed = Purchase Order Total - Amount already billed.")
+    amount_invoiced = fields.Monetary(string="Amount already billed")
+    order_ids = fields.Many2many('purchase.order')
+
+    def view_draft_invoices(self):
+        res = super().view_draft_invoices()
+        res['name'] = _('Draft Bills')
+        res['domain'].append(('line_ids.purchase_order_id.id', 'in', self.order_ids.ids))
+        return res
+
+    def _get_payment_term_account_type(self):
+        return 'liability_payable'
+
+    def _get_product_account_internal_group(self):
+        return 'expense'
+
+    def _taxes_field_name(self):
+        return 'taxes_id'
+
+    def _create_down_payment_invoice(self):
+        invoice = super()._create_down_payment_invoice()
+        poster = self.env.user._is_internal() and self.env.user.id or SUPERUSER_ID
+        title = _("Down payment vendor bill")
+        self.order_ids.with_user(poster).message_post(
+            body=_("%s has been created", invoice._get_html_link(title=title)),
+        )
+        return invoice

--- a/addons/purchase/wizard/purchase_make_bill_advance.py
+++ b/addons/purchase/wizard/purchase_make_bill_advance.py
@@ -33,9 +33,6 @@ class PurchaseAdvancePaymentWizard(models.TransientModel):
     def _get_product_account_internal_group(self):
         return 'expense'
 
-    def _taxes_field_name(self):
-        return 'taxes_id'
-
     def _create_down_payment_invoice(self):
         invoice = super()._create_down_payment_invoice()
         poster = self.env.user._is_internal() and self.env.user.id or SUPERUSER_ID

--- a/addons/purchase/wizard/purchase_make_bill_advance_views.xml
+++ b/addons/purchase/wizard/purchase_make_bill_advance_views.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_purchase_advance_payment_wizard" model="ir.ui.view">
+        <field name="inherit_id" ref="account.view_account_advance_payment"/>
+        <field name="model">purchase.advance.payment.wizard</field>
+        <field name="mode">primary</field>
+        <field name="name">Create Bills</field>
+        <field name="arch" type="xml">
+            <form position="attributes">
+                <attribute name="string">Bill Purchase Order</attribute>
+            </form>
+            <a name="view_draft_invoices" position="inside">There are existing Draft Bills for this Purchase Order.</a>
+            <p name="deduct_draft" position="inside">
+                The new bill will deduct draft bills linked to this purchase order.
+            </p>
+            <span name="amount_warning" position="attributes">
+                <attribute name="title">The Down Payment is greater than the amount remaining to be billed.</attribute>
+            </span>
+        </field>
+    </record>
+</odoo>

--- a/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
+++ b/addons/purchase_edi_ubl_bis3/models/purchase_edi_xml_ubl_bis3.py
@@ -86,9 +86,9 @@ class PurchaseEdiXmlUBLBIS3(models.AbstractModel):
         }
 
     def _get_tax_category_vals(self, order, order_line):
-        if not order_line.taxes_id:
+        if not order_line.tax_ids:
             return None
-        tax = order_line.taxes_id[0]
+        tax = order_line.tax_ids[0]
         tax_unece_codes = self.env['account.edi.common'].get_tax_unece_codes_order(order, tax)
         return {
             'id': tax_unece_codes.get('tax_category_code'),

--- a/addons/purchase_mrp/report/mrp_report_mo_overview.py
+++ b/addons/purchase_mrp/report/mrp_report_mo_overview.py
@@ -33,7 +33,7 @@ class ReportMoOverview(models.AbstractModel):
 
     def _format_extra_replenishment(self, po_line, quantity, production_id=False):
         po = po_line.order_id
-        price = po_line.taxes_id.with_context(round=False).compute_all(
+        price = po_line.tax_ids.with_context(round=False).compute_all(
             po_line.price_unit, currency=po.currency_id, quantity=quantity, product=po_line.product_id, partner=po.partner_id
         )['total_void']
         return {
@@ -81,7 +81,7 @@ class ReportMoOverview(models.AbstractModel):
         if move_in and move_in.purchase_line_id:
             po_line = move_in.purchase_line_id
             po = po_line.order_id
-            price = po_line.taxes_id.with_context(round=False).compute_all(
+            price = po_line.tax_ids.with_context(round=False).compute_all(
                 po_line.price_unit, currency=po.currency_id, quantity=uom_id._compute_quantity(quantity, move_in.purchase_line_id.product_uom),
                 product=po_line.product_id, partner=po.partner_id
             )['total_void']

--- a/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
+++ b/addons/purchase_mrp/tests/test_anglo_saxon_valuation.py
@@ -134,7 +134,7 @@ class TestAngloSaxonValuationPurchaseMRP(AccountTestInvoicingCommon):
         with po_form.order_line.new() as pol_form:
             pol_form.product_id = kit
             pol_form.price_unit = 100
-            pol_form.taxes_id.clear()
+            pol_form.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
 

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -1103,7 +1103,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             pol_form.product_qty = 30
             pol_form.product_uom = self.uom_kg
             pol_form.price_unit = 90000
-            pol_form.taxes_id.clear()
+            pol_form.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
 

--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -272,7 +272,7 @@ class PurchaseRequisitionLine(models.Model):
             'product_uom': self.product_id.uom_po_id.id,
             'product_qty': product_qty,
             'price_unit': price_unit,
-            'taxes_id': [(6, 0, taxes_ids)],
+            'tax_ids': [(6, 0, taxes_ids)],
             'date_planned': date_planned,
             'analytic_distribution': self.analytic_distribution,
         }

--- a/addons/purchase_requisition/tests/test_purchase_requisition.py
+++ b/addons/purchase_requisition/tests/test_purchase_requisition.py
@@ -529,4 +529,4 @@ class TestPurchaseRequisition(TestPurchaseRequisitionCommon):
         alt_po_wizard = alt_po_wizard_form.save()
         alt_po_id = alt_po_wizard.action_create_alternative()['res_id']
         alt_po = self.env['purchase.order'].browse(alt_po_id)
-        self.assertEqual(orig_po.order_line.taxes_id, alt_po.order_line.taxes_id)
+        self.assertEqual(orig_po.order_line.tax_ids, alt_po.order_line.tax_ids)

--- a/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
+++ b/addons/purchase_requisition/wizard/purchase_requisition_create_alternative.py
@@ -80,7 +80,10 @@ class PurchaseRequisitionCreateAlternative(models.TransientModel):
             'origin': self.origin_po_id.origin,
         }
         if self.copy_products and self.origin_po_id:
-            vals['order_line'] = [Command.create(self._get_alternative_line_value(line)) for line in self.origin_po_id.order_line]
+            vals['order_line'] = [
+                Command.create(self._get_alternative_line_value(line))
+                for line in self.origin_po_id.order_line if not line.is_downpayment
+            ]
         return vals
 
     @api.model

--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -21,7 +21,7 @@ class AccountMoveLine(models.Model):
             return 0
         aml_qty = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
         invoiced_qty = sum(line.product_uom_id._compute_quantity(line.quantity, line.product_id.uom_id)
-                           for line in self.purchase_line_id.invoice_lines - self)
+                           for line in self.purchase_line_id.account_move_line_ids - self)
         layers = in_moves.stock_valuation_layer_ids
         layers_qty = sum(layers.mapped('quantity'))
         out_qty = layers_qty - sum(layers.mapped('remaining_qty'))
@@ -66,7 +66,7 @@ class AccountMoveLine(models.Model):
         # we use this to get an order between posted AML and layers
         history = [(layer.create_date, False, layer) for layer in layers]
         am_state_field = self.env['ir.model.fields'].search([('model', '=', 'account.move'), ('name', '=', 'state')], limit=1)
-        for aml in po_line.invoice_lines:
+        for aml in po_line.account_move_line_ids:
             move = aml.move_id
             if move.state != 'posted':
                 continue

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -188,8 +188,8 @@ class PurchaseOrder(models.Model):
             result['res_id'] = pickings.id
         return result
 
-    def _prepare_invoice(self):
-        invoice_vals = super()._prepare_invoice()
+    def _prepare_account_move_values(self):
+        invoice_vals = super()._prepare_account_move_values()
         invoice_vals['invoice_incoterm_id'] = self.incoterm_id.id
         return invoice_vals
 

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -166,10 +166,10 @@ class PurchaseOrderLine(models.Model):
                     raise UserError(_('You cannot decrease the ordered quantity below the received quantity.\n'
                                       'Create a return first.'))
 
-                if float_compare(line.product_qty, line.qty_invoiced, precision_rounding=rounding) < 0 and line.invoice_lines:
+                if float_compare(line.product_qty, line.qty_invoiced, precision_rounding=rounding) < 0 and line.account_move_line_ids:
                     # If the quantity is now below the invoiced quantity, create an activity on the vendor bill
                     # inviting the user to create a refund.
-                    line.invoice_lines[0].move_id.activity_schedule(
+                    line.account_move_line_ids[0].move_id.activity_schedule(
                         'mail.mail_activity_data_warning',
                         note=_('The quantities on your purchase order indicate less than billed. You should ask for a refund.'))
 
@@ -261,7 +261,7 @@ class PurchaseOrderLine(models.Model):
     def _check_orderpoint_picking_type(self):
         warehouse_loc = self.order_id.picking_type_id.warehouse_id.view_location_id
         dest_loc = self.move_dest_ids.location_id or self.orderpoint_id.location_id
-        if warehouse_loc and dest_loc and dest_loc.warehouse_id and not warehouse_loc.parent_path in dest_loc[0].parent_path:
+        if warehouse_loc and dest_loc and dest_loc.warehouse_id and warehouse_loc.parent_path not in dest_loc[0].parent_path:
             raise UserError(_('The warehouse of operation type (%(operation_type)s) is inconsistent with location (%(location)s) of reordering rule (%(reordering_rule)s) for product %(product)s. Change the operation type or cancel the request for quotation.',
                               product=self.product_id.display_name, operation_type=self.order_id.picking_type_id.display_name, location=self.orderpoint_id.location_id.display_name, reordering_rule=self.orderpoint_id.display_name))
 

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -195,9 +195,9 @@ class PurchaseOrderLine(models.Model):
         order = self.order_id
         price_unit = self.price_unit
         price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
-        if self.taxes_id:
+        if self.tax_ids:
             qty = self.product_qty or 1
-            price_unit = self.taxes_id.with_context(round=False).compute_all(
+            price_unit = self.tax_ids.with_context(round=False).compute_all(
                 price_unit, currency=self.order_id.currency_id, quantity=qty, product=self.product_id, partner=self.order_id.partner_id
             )['total_void']
             price_unit = price_unit / qty

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -52,7 +52,7 @@ class StockMove(models.Model):
             received_qty -= self.product_uom._compute_quantity(self.quantity, line.product_uom, rounding_method='HALF-UP')
         if line.product_id.purchase_method == 'purchase' and float_compare(line.qty_invoiced, received_qty, precision_rounding=line.product_uom.rounding) > 0:
             move_layer = line.move_ids.sudo().stock_valuation_layer_ids
-            invoiced_layer = line.sudo().invoice_lines.stock_valuation_layer_ids
+            invoiced_layer = line.sudo().account_move_line_ids.stock_valuation_layer_ids
             # value on valuation layer is in company's currency, while value on invoice line is in order's currency
             receipt_value = 0
             if move_layer:
@@ -63,7 +63,7 @@ class StockMove(models.Model):
                     l.value, order.currency_id, order.company_id, l.create_date, round=False)))
             total_invoiced_value = 0
             invoiced_qty = 0
-            for invoice_line in line.sudo().invoice_lines:
+            for invoice_line in line.sudo().account_move_line_ids:
                 if invoice_line.move_id.state != 'posted':
                     continue
                 # Adjust unit price to account for discounts before adding taxes.
@@ -253,7 +253,7 @@ class StockMove(models.Model):
     def _get_all_related_aml(self):
         # The back and for between account_move and account_move_line is necessary to catch the
         # additional lines from a cogs correction
-        return super()._get_all_related_aml() | self.purchase_line_id.invoice_lines.move_id.line_ids.filtered(
+        return super()._get_all_related_aml() | self.purchase_line_id.account_move_line_ids.move_id.line_ids.filtered(
             lambda aml: aml.product_id == self.purchase_line_id.product_id)
 
     def _get_all_related_sm(self, product):

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -218,7 +218,7 @@ class StockMove(models.Model):
         """ Overridden to return the vendor bills related to this stock move.
         """
         rslt = super(StockMove, self)._get_related_invoices()
-        rslt += self.mapped('picking_id.purchase_id.invoice_ids').filtered(lambda x: x.state == 'posted')
+        rslt += self.mapped('picking_id.purchase_id.account_move_ids').filtered(lambda x: x.state == 'posted')
         return rslt
 
     def _get_source_document(self):

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -249,7 +249,7 @@ class StockRule(models.Model):
             date=line.order_id.date_order and line.order_id.date_order.date(),
             uom_id=product_id.uom_po_id)
 
-        price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.taxes_id, company_id) if seller else 0.0
+        price_unit = self.env['account.tax']._fix_tax_included_price_company(seller.price, line.product_id.supplier_taxes_id, line.tax_ids, company_id) if seller else 0.0
         if price_unit and seller and line.order_id.currency_id and seller.currency_id != line.order_id.currency_id:
             price_unit = seller.currency_id._convert(
                 price_unit, line.order_id.currency_id, line.order_id.company_id, fields.Date.today())

--- a/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/purchase_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -46,7 +46,7 @@ class TestValuationReconciliation(ValuationReconciliationTestCommon):
                         'product_uom': product.uom_po_id.id,
                         'price_unit': price_unit,
                         'date_planned': date,
-                        'taxes_id': [(6, 0, product.supplier_taxes_id.ids)] if set_tax else False,
+                        'tax_ids': [(6, 0, product.supplier_taxes_id.ids)] if set_tax else False,
                     })],
                 'date_order': date,
             })

--- a/addons/purchase_stock/tests/test_average_price.py
+++ b/addons/purchase_stock/tests/test_average_price.py
@@ -149,7 +149,7 @@ class TestAveragePrice(ValuationReconciliationTestCommon):
 
         purchase_order.button_confirm()
         purchase_order.action_create_invoice()
-        bill = purchase_order.invoice_ids[0]
+        bill = purchase_order.account_move_ids[0]
 
         bill.invoice_date = time.strftime('%Y-%m-%d')
         bill.invoice_line_ids[0].quantity = 1.0
@@ -186,14 +186,14 @@ class TestAveragePrice(ValuationReconciliationTestCommon):
 
         purchase_order.button_confirm()
         purchase_order.action_create_invoice()
-        bill = purchase_order.invoice_ids[0]
+        bill = purchase_order.account_move_ids[0]
 
         bill.invoice_date = time.strftime('%Y-%m-%d')
         bill.invoice_line_ids[0].price_unit = 100.0
         bill.button_cancel()
 
         purchase_order.action_create_invoice()
-        bill = purchase_order.invoice_ids[1]
+        bill = purchase_order.account_move_ids[1]
 
         bill.invoice_date = time.strftime('%Y-%m-%d')
         bill.invoice_line_ids[0].price_unit = 300.0
@@ -232,7 +232,7 @@ class TestAveragePrice(ValuationReconciliationTestCommon):
 
         purchase_order.button_confirm()
         purchase_order.action_create_invoice()
-        bill = purchase_order.invoice_ids[0]
+        bill = purchase_order.account_move_ids[0]
 
         bill.invoice_date = time.strftime('%Y-%m-%d')
         bill.action_post()

--- a/addons/purchase_stock/tests/test_fifo_price.py
+++ b/addons/purchase_stock/tests/test_fifo_price.py
@@ -343,7 +343,7 @@ class TestFifoPrice(ValuationReconciliationTestCommon):
                 'product_uom': super_product.uom_id.id,
                 'price_unit': super_product.standard_price,
                 'date_planned': time.strftime('%Y-%m-%d'),
-                'taxes_id': [(4, tax.id)],
+                'tax_ids': [(4, tax.id)],
             })],
         })
 

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -229,10 +229,10 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         # Modify after invoicing
         po1.action_create_invoice()
         self.assertEqual(po1.order_line.qty_invoiced, 15)
-        self.assertFalse(po1.invoice_ids.activity_ids)
+        self.assertFalse(po1.account_move_ids.activity_ids)
         po1.order_line.product_qty = 14.99
         self.assertTrue(
-            po1.invoice_ids.activity_ids,
+            po1.account_move_ids.activity_ids,
             "Lowering product qty below invoiced qty should schedule an activity",
         )
 

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -419,7 +419,7 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
                 'product_qty': 7,
                 'product_uom': super_product.uom_id.id,
                 'price_unit': super_product.standard_price,
-                'taxes_id': [(4, tax.id)],
+                'tax_ids': [(4, tax.id)],
             })],
         })
 

--- a/addons/purchase_stock/tests/test_purchase_stock_accrued_entries.py
+++ b/addons/purchase_stock/tests/test_purchase_stock_accrued_entries.py
@@ -30,7 +30,7 @@ class TestAccruedPurchaseStock(AccountTestInvoicingCommon):
                     'product_qty': 10.0,
                     'product_uom': product.uom_id.id,
                     'price_unit': product.list_price,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })

--- a/addons/purchase_stock/tests/test_reordering_rule.py
+++ b/addons/purchase_stock/tests/test_reordering_rule.py
@@ -1124,4 +1124,4 @@ class TestReorderingRule(TransactionCase):
         po_line = self.env['purchase.order.line'].search([('product_id', '=', product.id)])
         self.assertEqual(len(po_line), 1, 'There should be only one PO line')
         self.assertEqual(po_line.product_qty, 10, 'The PO line quantity should be 10')
-        self.assertTrue(po_line.taxes_id)
+        self.assertTrue(po_line.tax_ids)

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -829,7 +829,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         receipt.move_ids.picked = True
         receipt.button_validate()
 
-        product_aml = po.invoice_ids.line_ids.filtered('product_id')
+        product_aml = po.account_move_ids.line_ids.filtered('product_id')
         self.assertEqual(receipt.move_ids.stock_valuation_layer_ids.value, 100)
         self.assertTrue(product_aml.reconciled)
         self.assertTrue(product_aml.full_reconcile_id)
@@ -2225,7 +2225,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
             self.assertEqual(self.product1.stock_valuation_layer_ids.mapped('value'), expected_svl_values, 'Err while invoicing %s @ %s' % (qty, price))
             self.assertEqual(self.product1.stock_valuation_layer_ids.mapped('remaining_value'), expected_svl_remaining_values, 'Err while invoicing %s @ %s' % (qty, price))
 
-        bill01, bill02, _bill03, bill04, bill05 = po.invoice_ids.sorted('id')
+        bill01, bill02, _bill03, bill04, bill05 = po.account_move_ids.sorted('id')
 
         self._refund(bill01, 1.0)
         expected_svl_values += [-2.0]
@@ -3044,7 +3044,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         delivery.button_validate()
 
         po.action_create_invoice()
-        bill = po.invoice_ids
+        bill = po.account_move_ids
         bill.invoice_date = bill_date
         bill.action_post()
 
@@ -3140,9 +3140,9 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
 
         # Make sure the Vendor Bill has been created,
         # and confirm it at an earlier date (to generate the exchange difference).
-        self.assertEqual(len(purchase_order.invoice_ids), 1)
+        self.assertEqual(len(purchase_order.account_move_ids), 1)
 
-        vendor_bill = purchase_order.invoice_ids
+        vendor_bill = purchase_order.account_move_ids
         vendor_bill.invoice_date = fields.Date.from_string('2023-11-01')
         vendor_bill.action_post()
 

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -663,7 +663,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                 (0, 0, {
                     'name': self.product1.name,
                     'product_id': self.product1.id,
-                    'taxes_id': [(4, tax_with_no_account.id)],
+                    'tax_ids': [(4, tax_with_no_account.id)],
                     'product_qty': 10.0,
                     'product_uom': self.product1.uom_po_id.id,
                     'price_unit': 10.0,
@@ -960,7 +960,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 1.0,
                     'product_uom': self.product1.uom_po_id.id,
                     'price_unit': 105.0,  # 50$
-                    'taxes_id': [(4, tax.id)],
+                    'tax_ids': [(4, tax.id)],
                     'date_planned': date_po,
                 }),
             ],
@@ -1046,7 +1046,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 1.0,
                     'product_uom': self.product1.uom_po_id.id,
                     'price_unit': 100.0,  # 50$
-                    'taxes_id': [(4, tax_without_account.id)],
+                    'tax_ids': [(4, tax_without_account.id)],
                 }),
             ],
         })
@@ -2749,7 +2749,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 1.0,
                     'product_uom': self.product1.uom_po_id.id,
                     'price_unit': 100.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -2946,7 +2946,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                     'product_qty': 1.0,
                     'product_uom': self.product1.uom_po_id.id,
                     'price_unit': 100.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
             ],
         })
@@ -3012,7 +3012,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                         'product_id': self.product1.id,
                         'product_qty': 1.0,
                         'price_unit': purchase_price,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                 ]
             })
@@ -3205,7 +3205,7 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
                         'product_qty': 1.0,
                         'product_uom': self.product1.uom_po_id.id,
                         'price_unit': 1000.0,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                 ],
             })

--- a/addons/purchase_stock/views/purchase_views.xml
+++ b/addons/purchase_stock/views/purchase_views.xml
@@ -49,7 +49,7 @@
             <xpath expr="//div[@name='reminder']" position="after">
                 <field name="effective_date" invisible="not effective_date"/>
             </xpath>
-            <xpath expr="//field[@name='order_line']/form//field[@name='invoice_lines']" position="after">
+            <xpath expr="//field[@name='order_line']/form//field[@name='account_move_line_ids']" position="after">
                 <field name="move_ids"/>
             </xpath>
             <field name="invoice_status" position="before">
@@ -82,7 +82,7 @@
         <field name="model">purchase.order.line</field>
         <field name="inherit_id" ref="purchase.purchase_order_line_form2"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='invoice_lines']" position="after">
+            <xpath expr="//field[@name='account_move_line_ids']" position="after">
                 <separator string="Stock Moves"/>
                 <field name="move_ids"/>
             </xpath>

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -183,7 +183,7 @@ class AccountMoveLine(models.Model):
             'name': self.name,
             'sequence': last_sequence,
             'price_unit': price,
-            'tax_id': [x.id for x in taxes],
+            'tax_ids': [x.id for x in taxes],
             'discount': 0.0,
             'product_id': self.product_id.id,
             'product_uom': self.product_uom_id.id,

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -9,7 +9,6 @@ from odoo.tools import float_compare, float_is_zero
 class AccountMoveLine(models.Model):
     _inherit = 'account.move.line'
 
-    is_downpayment = fields.Boolean()
     sale_line_ids = fields.Many2many(
         'sale.order.line',
         'sale_order_line_invoice_rel',
@@ -227,3 +226,6 @@ class AccountMoveLine(models.Model):
     def _get_downpayment_lines(self):
         # OVERRIDE
         return self.sale_line_ids.filtered('is_downpayment').invoice_lines.filtered(lambda line: line.move_id._is_downpayment())
+
+    def _get_order_lines(self):
+        return self.sale_line_ids or super()._get_order_lines()

--- a/addons/sale/models/account_move_line.py
+++ b/addons/sale/models/account_move_line.py
@@ -225,7 +225,7 @@ class AccountMoveLine(models.Model):
 
     def _get_downpayment_lines(self):
         # OVERRIDE
-        return self.sale_line_ids.filtered('is_downpayment').invoice_lines.filtered(lambda line: line.move_id._is_downpayment())
+        return self.sale_line_ids.filtered('is_downpayment').account_move_line_ids.filtered(lambda line: line.move_id._is_downpayment())
 
     def _get_order_lines(self):
         return self.sale_line_ids or super()._get_order_lines()

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -637,7 +637,7 @@ class SaleOrder(models.Model):
                 )
 
     @api.depends_context('lang')
-    @api.depends('order_line.tax_id', 'order_line.price_unit', 'amount_total', 'amount_untaxed', 'currency_id')
+    @api.depends('order_line.tax_ids', 'order_line.price_unit', 'amount_total', 'amount_untaxed', 'currency_id')
     def _compute_tax_totals(self):
         for order in self:
             order_lines = order.order_line.filtered(lambda x: not x.display_type)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1147,13 +1147,13 @@ class SaleOrder(models.Model):
 
     # INVOICING #
 
-    def _prepare_invoice(self):
+    def _prepare_account_move_values(self):
         """
         Prepare the dict of values to create the new invoice for a sales order. This method may be
         overridden to implement custom invoice generation (making sure to call super() to establish
         a clean extension chain).
         """
-        values = super()._prepare_invoice()
+        values = super()._prepare_account_move_values()
 
         txs_to_be_linked = self.transaction_ids.filtered(
             lambda tx: (

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -32,7 +32,14 @@ SALE_ORDER_STATE = [
 
 class SaleOrder(models.Model):
     _name = 'sale.order'
-    _inherit = ['portal.mixin', 'product.catalog.mixin', 'mail.thread', 'mail.activity.mixin', 'utm.mixin']
+    _inherit = [
+        'portal.mixin',
+        'product.catalog.mixin',
+        'mail.thread',
+        'mail.activity.mixin',
+        'utm.mixin',
+        'account.order.mixin'
+    ]
     _description = "Sales Order"
     _order = 'date_order desc, id desc'
     _check_company_auto = True
@@ -51,22 +58,7 @@ class SaleOrder(models.Model):
 
     #=== FIELDS ===#
 
-    name = fields.Char(
-        string="Order Reference",
-        required=True, copy=False, readonly=False,
-        index='trigram',
-        default=lambda self: _('New'))
-
-    company_id = fields.Many2one(
-        comodel_name='res.company',
-        required=True, index=True,
-        default=lambda self: self.env.company)
-    partner_id = fields.Many2one(
-        comodel_name='res.partner',
-        string="Customer",
-        required=True, change_default=True, index=True,
-        tracking=1,
-        check_company=True)
+    partner_id = fields.Many2one(string="Customer")
     state = fields.Selection(
         selection=SALE_ORDER_STATE,
         string="Status",
@@ -155,19 +147,15 @@ class SaleOrder(models.Model):
         index='btree_not_null')
 
     fiscal_position_id = fields.Many2one(
-        comodel_name='account.fiscal.position',
-        string="Fiscal Position",
         compute='_compute_fiscal_position_id',
-        store=True, readonly=False, precompute=True, check_company=True,
+        store=True, readonly=False, precompute=True,
         help="Fiscal positions are used to adapt taxes and accounts for particular customers or sales orders/invoices."
             "The default value comes from the customer.",
     )
     payment_term_id = fields.Many2one(
-        comodel_name='account.payment.term',
-        string="Payment Terms",
         compute='_compute_payment_term_id',
-        store=True, readonly=False, precompute=True, check_company=True,  # Unrequired company
-        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+        store=True, readonly=False, precompute=True
+    )
     pricelist_id = fields.Many2one(
         comodel_name='product.pricelist',
         string="Pricelist",
@@ -177,11 +165,9 @@ class SaleOrder(models.Model):
         domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
         help="If you change the pricelist, only newly added lines will be affected.")
     currency_id = fields.Many2one(
-        comodel_name='res.currency',
         compute='_compute_currency_id',
         store=True,
         precompute=True,
-        ondelete='restrict'
     )
     currency_rate = fields.Float(
         string="Currency Rate",
@@ -211,13 +197,11 @@ class SaleOrder(models.Model):
         comodel_name='sale.order.line',
         inverse_name='order_id',
         string="Order Lines",
-        copy=True, auto_join=True)
+        auto_join=True)
 
-    amount_untaxed = fields.Monetary(string="Untaxed Amount", store=True, compute='_compute_amounts', tracking=5)
-    amount_tax = fields.Monetary(string="Taxes", store=True, compute='_compute_amounts')
-    amount_total = fields.Monetary(string="Total", store=True, compute='_compute_amounts', tracking=4)
-    amount_to_invoice = fields.Monetary(string="Amount to invoice", store=True, compute='_compute_amount_to_invoice')
-    amount_invoiced = fields.Monetary(string="Already invoiced", compute='_compute_amount_invoiced')
+    amount_untaxed = fields.Monetary(tracking=5)
+    amount_total = fields.Monetary(tracking=4)
+    amount_to_invoice = fields.Monetary(store=True)
 
     invoice_count = fields.Integer(string="Invoice Count", compute='_get_invoiced')
     invoice_ids = fields.Many2many(
@@ -227,10 +211,9 @@ class SaleOrder(models.Model):
         search='_search_invoice_ids',
         copy=False)
     invoice_status = fields.Selection(
-        selection=INVOICE_STATUS,
-        string="Invoice Status",
-        compute='_compute_invoice_status',
-        store=True)
+        selection_add=INVOICE_STATUS,
+        string="Invoice Status"
+    )
 
     # Payment fields
     transaction_ids = fields.Many2many(
@@ -471,32 +454,7 @@ class SaleOrder(models.Model):
                 )
             order.team_id = cached_teams[key]
 
-    @api.depends('order_line.price_subtotal', 'order_line.price_tax', 'order_line.price_total')
-    def _compute_amounts(self):
-        """Compute the total amounts of the SO."""
-        for order in self:
-            order_lines = order.order_line.filtered(lambda x: not x.display_type)
-
-            if order.company_id.tax_calculation_rounding_method == 'round_globally':
-                tax_results = self.env['account.tax']._compute_taxes(
-                    [
-                        line._convert_to_tax_base_line_dict()
-                        for line in order_lines
-                    ],
-                    order.company_id,
-                )
-                totals = tax_results['totals']
-                amount_untaxed = totals.get(order.currency_id, {}).get('amount_untaxed', 0.0)
-                amount_tax = totals.get(order.currency_id, {}).get('amount_tax', 0.0)
-            else:
-                amount_untaxed = sum(order_lines.mapped('price_subtotal'))
-                amount_tax = sum(order_lines.mapped('price_tax'))
-
-            order.amount_untaxed = amount_untaxed
-            order.amount_tax = amount_tax
-            order.amount_total = order.amount_untaxed + order.amount_tax
-
-    @api.depends('order_line.invoice_lines')
+    @api.depends('order_line.move_line_ids')
     def _get_invoiced(self):
         # The invoice_ids are obtained thanks to the invoice lines of the SO
         # lines, and we also search for possible refunds created directly from
@@ -553,6 +511,7 @@ class SaleOrder(models.Model):
         - invoiced: if all SO lines are invoiced, the SO is invoiced.
         - upselling: if all SO lines are invoiced or upselling, the status is upselling.
         """
+        super()._compute_invoice_status()
         confirmed_orders = self.filtered(lambda so: so.state == 'sale')
         (self - confirmed_orders).invoice_status = 'no'
         if not confirmed_orders:
@@ -650,24 +609,19 @@ class SaleOrder(models.Model):
             else:
                 record.tax_country_id = record.company_id.account_fiscal_country_id
 
-    @api.depends('invoice_ids.state', 'currency_id', 'amount_total')
     def _compute_amount_to_invoice(self):
+        super()._compute_amount_to_invoice()
         for order in self:
             # If the invoice status is 'Fully Invoiced' force the amount to invoice to equal zero and return early.
             if order.invoice_status == 'invoiced':
                 order.amount_to_invoice = 0.0
                 continue
 
-            invoices = order.invoice_ids.filtered(lambda x: x.state == 'posted')
+            invoices = order.account_move_ids.filtered(lambda x: x.state == 'posted')
             # Note: A negative amount can happen, since we can invoice more than the sales order amount.
             # Care has to be taken when summing amount_to_invoice of multiple orders.
             # E.g. consider one invoiced order with -100 and one uninvoiced order of 100: 100 + -100 = 0
             order.amount_to_invoice = order.amount_total - invoices._get_sale_order_invoiced_amount(order)
-
-    @api.depends('amount_total', 'amount_to_invoice')
-    def _compute_amount_invoiced(self):
-        for order in self:
-            order.amount_invoiced = order.amount_total - order.amount_to_invoice
 
     @api.depends('company_id', 'partner_id', 'amount_total')
     def _compute_partner_credit_warning(self):
@@ -825,23 +779,6 @@ class SaleOrder(models.Model):
                     'sale.order', sequence_date=seq_date) or _("New")
 
         return super().create(vals_list)
-
-    def _get_copiable_order_lines(self):
-        """Returns the order lines that can be copied to a new order."""
-        return self.order_line.filtered(lambda l: not l.is_downpayment)
-
-    def copy_data(self, default=None):
-        default = dict(default or {})
-        default_has_no_order_line = 'order_line' not in default
-        default.setdefault('order_line', [])
-        vals_list = super().copy_data(default=default)
-        if default_has_no_order_line:
-            for order, vals in zip(self, vals_list):
-                vals['order_line'] = [
-                    Command.create(line_vals)
-                    for line_vals in order._get_copiable_order_lines().copy_data()
-                ]
-        return vals_list
 
     @api.ondelete(at_uninstall=False)
     def _unlink_except_draft_or_cancel(self):
@@ -1216,7 +1153,7 @@ class SaleOrder(models.Model):
         overridden to implement custom invoice generation (making sure to call super() to establish
         a clean extension chain).
         """
-        self.ensure_one()
+        values = super()._prepare_invoice()
 
         txs_to_be_linked = self.transaction_ids.filtered(
             lambda tx: (
@@ -1225,11 +1162,10 @@ class SaleOrder(models.Model):
             )
         )
 
-        values = {
+        values.update({
             'ref': self.client_order_ref or '',
             'move_type': 'out_invoice',
             'narration': self.note,
-            'currency_id': self.currency_id.id,
             'campaign_id': self.campaign_id.id,
             'medium_id': self.medium_id.id,
             'source_id': self.source_id.id,
@@ -1237,15 +1173,11 @@ class SaleOrder(models.Model):
             'partner_id': self.partner_invoice_id.id,
             'partner_shipping_id': self.partner_shipping_id.id,
             'fiscal_position_id': (self.fiscal_position_id or self.fiscal_position_id._get_fiscal_position(self.partner_invoice_id)).id,
-            'invoice_origin': self.name,
-            'invoice_payment_term_id': self.payment_term_id.id,
             'invoice_user_id': self.user_id.id,
             'payment_reference': self.reference,
             'transaction_ids': [Command.set(txs_to_be_linked.ids)],
-            'company_id': self.company_id.id,
-            'invoice_line_ids': [],
             'user_id': self.user_id.id,
-        }
+        })
         if self.journal_id:
             values['journal_id'] = self.journal_id.id
         return values
@@ -1343,39 +1275,7 @@ class SaleOrder(models.Model):
                 return self.env['account.move']
 
         # 1) Create invoices.
-        invoice_vals_list = []
-        invoice_item_sequence = 0 # Incremental sequencing to keep the lines order on the invoice.
-        for order in self:
-            order = order.with_company(order.company_id).with_context(lang=order.partner_invoice_id.lang)
-
-            invoice_vals = order._prepare_invoice()
-            invoiceable_lines = order._get_invoiceable_lines(final)
-
-            if not any(not line.display_type for line in invoiceable_lines):
-                continue
-
-            invoice_line_vals = []
-            down_payment_section_added = False
-            for line in invoiceable_lines:
-                if not down_payment_section_added and line.is_downpayment:
-                    # Create a dedicated section for the down payments
-                    # (put at the end of the invoiceable_lines)
-                    invoice_line_vals.append(
-                        Command.create(
-                            order._prepare_down_payment_section_line(sequence=invoice_item_sequence)
-                        ),
-                    )
-                    down_payment_section_added = True
-                    invoice_item_sequence += 1
-                invoice_line_vals.append(
-                    Command.create(
-                        line._prepare_invoice_line(sequence=invoice_item_sequence)
-                    ),
-                )
-                invoice_item_sequence += 1
-
-            invoice_vals['invoice_line_ids'] += invoice_line_vals
-            invoice_vals_list.append(invoice_vals)
+        invoice_vals_list = self._generate_invoice_values(final)
 
         if not invoice_vals_list and self._context.get('raise_if_nothing_to_invoice', True):
             raise UserError(self._nothing_to_invoice_error_message())
@@ -1508,6 +1408,15 @@ class SaleOrder(models.Model):
                 subtype_xmlid='mail.mt_note',
             )
         return moves
+
+    def _get_order_direction(self):
+        return -1
+
+    def _create_new_order_line(self, values):
+        return self.env['sale.order.line'].create(values)
+
+    def _is_locked(self):
+        return self.locked
 
     # MAIL #
 
@@ -1661,25 +1570,6 @@ class SaleOrder(models.Model):
     def get_portal_last_transaction(self):
         self.ensure_one()
         return self.transaction_ids.sudo()._get_last()
-
-    def _get_order_lines_to_report(self):
-        down_payment_lines = self.order_line.filtered(lambda line:
-            line.is_downpayment
-            and not line.display_type
-            and not line._get_downpayment_state()
-        )
-
-        def show_line(line):
-            if not line.is_downpayment:
-                return True
-            elif line.display_type and down_payment_lines:
-                return True  # Only show the down payment section if down payments were posted
-            elif line in down_payment_lines:
-                return True  # Only show posted down payments
-            else:
-                return False
-
-        return self.order_line.filtered(show_line)
 
     def _get_default_payment_link_values(self):
         self.ensure_one()
@@ -1842,29 +1732,6 @@ class SaleOrder(models.Model):
             analytic = self.env['account.analytic.account'].create(order._prepare_analytic_account_data(prefix))
             order.analytic_account_id = analytic
 
-    def _prepare_down_payment_section_line(self, **optional_values):
-        """ Prepare the values to create a new down payment section.
-
-        :param dict optional_values: any parameter that should be added to the returned down payment section
-        :return: `account.move.line` creation values
-        :rtype: dict
-        """
-        self.ensure_one()
-        context = {'lang': self.partner_id.lang}
-        down_payments_section_line = {
-            'display_type': 'line_section',
-            'name': _("Down Payments"),
-            'product_id': False,
-            'product_uom_id': False,
-            'quantity': 0,
-            'discount': 0,
-            'price_unit': 0,
-            'account_id': False,
-            **optional_values
-        }
-        del context
-        return down_payments_section_line
-
     def _get_prepayment_required_amount(self):
         """ Return the minimum amount needed to confirm automatically the quotation.
 
@@ -1903,7 +1770,7 @@ class SaleOrder(models.Model):
 
         for order in self:
             downpayment_wizard = order.env['sale.advance.payment.inv'].create({
-                'sale_order_ids': order,
+                'order_ids': order,
                 'advance_payment_method': 'fixed',
                 'fixed_amount': order.amount_paid,
             })
@@ -2011,11 +1878,3 @@ class SaleOrder(models.Model):
         """
         self.ensure_one()
         return self.currency_id.compare_amounts(self.amount_paid, self.amount_total) >= 0
-
-    def _get_lang(self):
-        self.ensure_one()
-
-        if self.partner_id.lang and not self.partner_id.is_public:
-            return self.partner_id.lang
-
-        return self.env.lang

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -202,7 +202,7 @@ class SaleOrderLine(models.Model):
         comodel_name='account.analytic.line', inverse_name='so_line',
         string="Analytic lines")
 
-    invoice_lines = fields.Many2many(
+    account_move_line_ids = fields.Many2many(
         comodel_name='account.move.line',
         relation='sale_order_line_invoice_rel', column1='order_line_id', column2='invoice_line_id',
         string="Invoice Lines",
@@ -710,7 +710,7 @@ class SaleOrderLine(models.Model):
 
         return result
 
-    @api.depends('invoice_lines.move_id.state', 'invoice_lines.quantity')
+    @api.depends('account_move_line_ids.move_id.state', 'account_move_line_ids.quantity')
     def _compute_qty_invoiced(self):
         """
         Compute the quantity invoiced. If case of a refund, the quantity invoiced is decreased. Note
@@ -786,7 +786,8 @@ class SaleOrderLine(models.Model):
         self.ensure_one()
         return self.product_id.id != self.company_id.sale_discount_product_id.id
 
-    @api.depends('invoice_lines', 'invoice_lines.price_total', 'invoice_lines.move_id.state', 'invoice_lines.move_id.move_type')
+    @api.depends('account_move_line_ids', 'account_move_line_ids.price_total', 'account_move_line_ids.move_id.state',
+                 'account_move_line_ids.move_id.move_type')
     def _compute_untaxed_amount_invoiced(self):
         """ Compute the untaxed amount already invoiced from the sale order line, taking the refund attached
             the so line into account. This amount is computed as
@@ -1028,7 +1029,7 @@ class SaleOrderLine(models.Model):
         return self.filtered(
             lambda line:
                 line.state == 'sale'
-                and (line.invoice_lines or not line.is_downpayment)
+                and (line.account_move_line_ids or not line.is_downpayment)
                 and not line.display_type
         )
 
@@ -1096,7 +1097,7 @@ class SaleOrderLine(models.Model):
         })
         self._set_analytic_distribution(res, **optional_values)
         if self.is_downpayment:
-            res['account_id'] = self.invoice_lines.filtered('is_downpayment').account_id[:1].id
+            res['account_id'] = self.account_move_line_ids.filtered('is_downpayment').account_id[:1].id
         if optional_values:
             res.update(optional_values)
         if self.display_type:

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -123,7 +123,7 @@ class SaleOrderLine(models.Model):
     )
 
     # Pricing fields
-    tax_id = fields.Many2many(
+    tax_ids = fields.Many2many(
         compute='_compute_tax_id',
         store=True, readonly=False, precompute=True)
 
@@ -416,7 +416,7 @@ class SaleOrderLine(models.Model):
                     taxes = line.product_id.taxes_id._filter_taxes_by_company(company)
                 if not line.product_id or not taxes:
                     # Nothing to map
-                    line.tax_id = False
+                    line.tax_ids = False
                     continue
                 fiscal_position = line.order_id.fiscal_position_id
                 cache_key = (fiscal_position.id, company.id, tuple(taxes.ids))
@@ -427,7 +427,7 @@ class SaleOrderLine(models.Model):
                     result = fiscal_position.map_tax(taxes)
                     cached_taxes[cache_key] = result
                 # If company_id is set, always filter taxes by the company
-                line.tax_id = result
+                line.tax_ids = result
 
     def _get_custom_compute_tax_cache_key(self):
         """Hook method to be able to set/get cached taxes while computing them"""
@@ -593,7 +593,7 @@ class SaleOrderLine(models.Model):
             partner=self.order_id.partner_id,
             currency=self.order_id.currency_id,
             product=self.product_id,
-            taxes=self.tax_id,
+            taxes=self.tax_ids,
             price_unit=self.price_unit,
             quantity=self.product_uom_qty,
             discount=self.discount,
@@ -827,11 +827,11 @@ class SaleOrderLine(models.Model):
                 uom_qty_to_consider = line.qty_delivered if line.product_id.invoice_policy == 'delivery' else line.product_uom_qty
                 price_reduce = line.price_unit * (1 - (line.discount or 0.0) / 100.0)
                 price_subtotal = price_reduce * uom_qty_to_consider
-                if len(line.tax_id.filtered(lambda tax: tax.price_include)) > 0:
+                if len(line.tax_ids.filtered(lambda tax: tax.price_include)) > 0:
                     # As included taxes are not excluded from the computed subtotal, `compute_all()` method
                     # has to be called to retrieve the subtotal without them.
                     # `price_reduce_taxexcl` cannot be used as it is computed from `price_subtotal` field. (see upper Note)
-                    price_subtotal = line.tax_id.compute_all(
+                    price_subtotal = line.tax_ids.compute_all(
                         price_reduce,
                         currency=line.currency_id,
                         quantity=uom_qty_to_consider,
@@ -991,7 +991,7 @@ class SaleOrderLine(models.Model):
         """
         return [
             'product_id', 'name', 'price_unit', 'product_uom', 'product_uom_qty',
-            'tax_id', 'analytic_distribution'
+            'tax_ids', 'analytic_distribution'
         ]
 
     def _update_line_quantity(self, values):
@@ -1091,7 +1091,7 @@ class SaleOrderLine(models.Model):
             'sequence': self.sequence,
             'name': line_name,
             'price_unit': self.price_unit,
-            'tax_ids': [Command.set(self.tax_id.ids)],
+            'tax_ids': [Command.set(self.tax_ids.ids)],
             'sale_line_ids': [Command.link(self.id)],
         })
         self._set_analytic_distribution(res, **optional_values)

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -7,16 +7,16 @@ from datetime import timedelta
 
 from markupsafe import Markup
 
-from odoo import _, _lt, api, fields, models
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 from odoo.fields import Command
 from odoo.osv import expression
-from odoo.tools import float_compare, float_is_zero, format_date, groupby
+from odoo.tools import float_compare, float_is_zero, groupby
 
 
 class SaleOrderLine(models.Model):
     _name = 'sale.order.line'
-    _inherit = 'analytic.mixin'
+    _inherit = ['analytic.mixin', 'account.order.line.mixin']
     _description = "Sales Order Line"
     _rec_names_search = ['name', 'order_id.name']
     _order = 'order_id, sequence, id'
@@ -46,10 +46,6 @@ class SaleOrderLine(models.Model):
     company_id = fields.Many2one(
         related='order_id.company_id',
         store=True, index=True, precompute=True)
-    currency_id = fields.Many2one(
-        related='order_id.currency_id',
-        depends=['order_id.currency_id'],
-        store=True, precompute=True)
     order_partner_id = fields.Many2one(
         related='order_id.partner_id',
         string="Customer",
@@ -65,29 +61,17 @@ class SaleOrderLine(models.Model):
     tax_country_id = fields.Many2one(related='order_id.tax_country_id')
 
     # Fields specifying custom line logic
-    display_type = fields.Selection(
-        selection=[
-            ('line_section', "Section"),
-            ('line_note', "Note"),
-        ],
-        default=False)
     is_configurable_product = fields.Boolean(
         string="Is the product configurable?",
         related='product_template_id.has_configurable_attributes',
         depends=['product_id'])
-    is_downpayment = fields.Boolean(
-        string="Is a down payment",
-        help="Down payments are made when creating invoices from a sales order."
-            " They are not copied when duplicating a sales order.")
     is_expense = fields.Boolean(
         string="Is expense",
         help="Is true if the sales order line comes from an expense or a vendor bills")
 
     # Generic configuration fields
     product_id = fields.Many2one(
-        comodel_name='product.product',
-        string="Product",
-        change_default=True, ondelete='restrict', index='btree_not_null',
+        ondelete='restrict',
         domain="[('sale_ok', '=', True)]")
     product_template_id = fields.Many2one(
         string="Product Template",
@@ -118,22 +102,14 @@ class SaleOrderLine(models.Model):
         store=True, readonly=False, precompute=True, ondelete='restrict')
     is_product_archived = fields.Boolean(compute="_compute_is_product_archived")
 
-    name = fields.Text(
-        string="Description",
-        compute='_compute_name',
-        store=True, readonly=False, required=True, precompute=True)
-
     product_uom_qty = fields.Float(
         string="Quantity",
         compute='_compute_product_uom_qty',
         digits='Product Unit of Measure', default=1.0,
         store=True, readonly=False, required=True, precompute=True)
     product_uom = fields.Many2one(
-        comodel_name='uom.uom',
-        string="Unit of Measure",
         compute='_compute_product_uom',
-        store=True, readonly=False, precompute=True, ondelete='restrict',
-        domain="[('category_id', '=', product_uom_category_id)]")
+        store=True, readonly=False, precompute=True, ondelete='restrict')
     linked_line_id = fields.Many2one(
         string="Linked Order Line",
         comodel_name='sale.order.line',
@@ -148,40 +124,23 @@ class SaleOrderLine(models.Model):
 
     # Pricing fields
     tax_id = fields.Many2many(
-        comodel_name='account.tax',
-        string="Taxes",
         compute='_compute_tax_id',
-        store=True, readonly=False, precompute=True,
-        context={'active_test': False},
-        check_company=True)
+        store=True, readonly=False, precompute=True)
 
     # Tech field caching pricelist rule used for price & discount computation
     pricelist_item_id = fields.Many2one(
         comodel_name='product.pricelist.item',
         compute='_compute_pricelist_item_id')
 
-    price_unit = fields.Float(
-        string="Unit Price",
-        compute='_compute_price_unit',
-        digits='Product Price',
-        store=True, readonly=False, required=True, precompute=True)
-
-    discount = fields.Float(
-        string="Discount (%)",
-        compute='_compute_discount',
-        digits='Discount',
-        store=True, readonly=False, precompute=True)
+    price_unit = fields.Float(compute='_compute_price_unit', store=True, precompute=True)
 
     price_subtotal = fields.Monetary(
-        string="Subtotal",
-        compute='_compute_amount',
-        store=True, precompute=True)
-    price_tax = fields.Float(
-        string="Total Tax",
         compute='_compute_amount',
         store=True, precompute=True)
     price_total = fields.Monetary(
-        string="Total",
+        compute='_compute_amount',
+        store=True, precompute=True)
+    price_tax = fields.Monetary(
         compute='_compute_amount',
         store=True, precompute=True)
     price_reduce_taxexcl = fields.Monetary(
@@ -238,11 +197,6 @@ class SaleOrderLine(models.Model):
         compute='_compute_qty_invoiced',
         digits='Product Unit of Measure',
         store=True)
-    qty_to_invoice = fields.Float(
-        string="Quantity To Invoice",
-        compute='_compute_qty_to_invoice',
-        digits='Product Unit of Measure',
-        store=True)
 
     analytic_line_ids = fields.One2many(
         comodel_name='account.analytic.line', inverse_name='so_line',
@@ -297,6 +251,17 @@ class SaleOrderLine(models.Model):
                 name = f'{name} {additional_name}'
             so_line.display_name = name
 
+    def _additional_name_per_id(self):
+        return {
+            so_line.id: so_line._get_partner_display()
+            for so_line in self
+        }
+
+    def _get_partner_display(self):
+        self.ensure_one()
+        commercial_partner = self.order_partner_id.commercial_partner_id
+        return f'({commercial_partner.ref or commercial_partner.name})'
+
     @api.depends('product_id')
     def _compute_product_template_id(self):
         for line in self:
@@ -340,20 +305,16 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'linked_line_id', 'linked_line_ids')
     def _compute_name(self):
+        super()._compute_name()
         for line in self:
-            if not line.product_id and not line.is_downpayment:
+            if not line.product_id:
                 continue
 
             lang = line.order_id._get_lang()
             if lang != self.env.lang:
                 line = line.with_context(lang=lang)
 
-            if line.product_id:
-                line.name = line._get_sale_order_line_multiline_description_sale()
-                continue
-
-            if line.is_downpayment:
-                line.name = line._get_downpayment_description()
+            line.name = line._get_sale_order_line_multiline_description_sale()
 
     def _get_sale_order_line_multiline_description_sale(self):
         """ Compute a default multiline description for this sales order line.
@@ -417,33 +378,6 @@ class SaleOrderLine(models.Model):
         for patv in sorted_custom_ptav:
             pacv = self.product_custom_attribute_value_ids.filtered(lambda pcav: pcav.custom_product_template_attribute_value_id == patv)
             name += "\n" + pacv.display_name
-
-        return name
-
-    def _get_downpayment_description(self):
-        self.ensure_one()
-        if self.display_type:
-            return _("Down Payments")
-
-        dp_state = self._get_downpayment_state()
-        name = _lt("Down Payment")
-        if dp_state == 'draft':
-            name = _(
-                "Down Payment: %(date)s (Draft)",
-                date=format_date(self.env, self.create_date.date()),
-            )
-        elif dp_state == 'cancel':
-            name = _("Down Payment (Cancelled)")
-        else:
-            invoice = self._get_invoice_lines().filtered(
-                lambda aml: aml.quantity >= 0
-            ).move_id.filtered(lambda move: move.move_type == 'out_invoice')
-            if len(invoice) == 1 and invoice.payment_reference and invoice.invoice_date:
-                name = _(
-                    "Down Payment (ref: %(reference)s on %(date)s)",
-                    reference=invoice.payment_reference,
-                    date=format_date(self.env, invoice.invoice_date),
-                )
 
         return name
 
@@ -514,6 +448,7 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
     def _compute_price_unit(self):
+        super()._compute_price_unit()
         for line in self:
             # check if there is already invoiced amount. if so, the price shouldn't change as it might have been
             # manually edited
@@ -616,6 +551,7 @@ class SaleOrderLine(models.Model):
 
     @api.depends('product_id', 'product_uom', 'product_uom_qty')
     def _compute_discount(self):
+        super()._compute_discount()
         for line in self:
             if not line.product_id or line.display_type:
                 line.discount = 0.0
@@ -665,25 +601,9 @@ class SaleOrderLine(models.Model):
             **kwargs,
         )
 
-    @api.depends('product_uom_qty', 'discount', 'price_unit', 'tax_id')
+    @api.depends('product_uom_qty')
     def _compute_amount(self):
-        """
-        Compute the amounts of the SO line.
-        """
-        for line in self:
-            tax_results = self.env['account.tax']._compute_taxes(
-                [line._convert_to_tax_base_line_dict()],
-                line.company_id,
-            )
-            totals = list(tax_results['totals'].values())[0]
-            amount_untaxed = totals['amount_untaxed']
-            amount_tax = totals['amount_tax']
-
-            line.update({
-                'price_subtotal': amount_untaxed,
-                'price_tax': amount_tax,
-                'price_total': amount_untaxed + amount_tax,
-            })
+        super()._compute_amount()
 
     @api.depends('price_subtotal', 'product_uom_qty')
     def _compute_price_reduce_taxexcl(self):
@@ -756,20 +676,6 @@ class SaleOrderLine(models.Model):
         for so_line in lines_by_analytic:
             so_line.qty_delivered = mapping.get(so_line.id or so_line._origin.id, 0.0)
 
-    def _get_downpayment_state(self):
-        self.ensure_one()
-
-        if self.display_type:
-            return ''
-
-        invoice_lines = self._get_invoice_lines()
-        if all(line.parent_state == 'draft' for line in invoice_lines):
-            return 'draft'
-        if all(line.parent_state == 'cancel' for line in invoice_lines):
-            return 'cancel'
-
-        return ''
-
     def _get_delivered_quantity_by_analytic(self, additional_domain):
         """ Compute and write the delivered quantity of current SO lines, based on their related
             analytic lines.
@@ -822,15 +728,6 @@ class SaleOrderLine(models.Model):
                         qty_invoiced -= invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_uom)
             line.qty_invoiced = qty_invoiced
 
-    def _get_invoice_lines(self):
-        self.ensure_one()
-        if self._context.get('accrual_entry_date'):
-            return self.invoice_lines.filtered(
-                lambda l: l.move_id.invoice_date and l.move_id.invoice_date <= self._context['accrual_entry_date']
-            )
-        else:
-            return self.invoice_lines
-
     # no trigger product_id.invoice_policy to avoid retroactively changing SO
     @api.depends('qty_invoiced', 'qty_delivered', 'product_uom_qty', 'state')
     def _compute_qty_to_invoice(self):
@@ -838,6 +735,7 @@ class SaleOrderLine(models.Model):
         Compute the quantity to invoice. If the invoice policy is order, the quantity to invoice is
         calculated from the ordered quantity. Otherwise, the quantity delivered is used.
         """
+        super()._compute_qty_to_invoice()
         for line in self:
             if line.state == 'sale' and not line.display_type:
                 if line.product_id.invoice_policy == 'order':
@@ -1038,7 +936,7 @@ class SaleOrderLine(models.Model):
                 vals['product_uom_qty'] = 0.0
 
         lines = super().create(vals_list)
-        if self.env.context.get('sale_no_log_for_new_lines'):
+        if self.env.context.get('no_log_for_new_lines'):
             return lines
 
         for line in lines:
@@ -1159,6 +1057,8 @@ class SaleOrderLine(models.Model):
     def compute_uom_qty(self, new_qty, stock_move, rounding=True):
         return self.product_uom._compute_quantity(new_qty, stock_move.product_uom, rounding)
 
+    # INVOICING #
+
     def _get_invoice_line_sequence(self, new=0, old=0):
         """
         Method intended to be overridden in third-party module if we want to prevent the resequencing
@@ -1177,7 +1077,7 @@ class SaleOrderLine(models.Model):
         :param optional_values: any parameter that should be added to the returned invoice line
         :rtype: dict
         """
-        self.ensure_one()
+        res = super()._prepare_invoice_line(**optional_values)
 
         # Compatibility fix for creating invoices from a SO since the computation of the line name has been changed in the account module.
         # Has to be removed as soon as the new behavior for the line name has been implemented in the sale module.
@@ -1186,19 +1086,14 @@ class SaleOrderLine(models.Model):
             line_name = re.sub(re.escape(self.product_id.display_name), '', line_name)
             line_name = re.sub(r'^\n', '', line_name)
             line_name = re.sub(r'(?<=\n) ', '', line_name)
-        res = {
-            'display_type': self.display_type or 'product',
+
+        res.update({
             'sequence': self.sequence,
             'name': line_name,
-            'product_id': self.product_id.id,
-            'product_uom_id': self.product_uom.id,
-            'quantity': self.qty_to_invoice,
-            'discount': self.discount,
             'price_unit': self.price_unit,
             'tax_ids': [Command.set(self.tax_id.ids)],
             'sale_line_ids': [Command.link(self.id)],
-            'is_downpayment': self.is_downpayment,
-        }
+        })
         self._set_analytic_distribution(res, **optional_values)
         if self.is_downpayment:
             res['account_id'] = self.invoice_lines.filtered('is_downpayment').account_id[:1].id
@@ -1219,33 +1114,21 @@ class SaleOrderLine(models.Model):
             else:
                 inv_line_vals['analytic_distribution'] = {analytic_account_id: 100}
 
-    def _prepare_procurement_values(self, group_id=False):
-        """ Prepare specific key for moves or other components that will be created from a stock rule
-        coming from a sale order line. This method could be override in order to add other custom key that could
-        be used in move/po creation.
-        """
-        return {}
-
     def _validate_analytic_distribution(self):
-        for line in self.filtered(lambda l: not l.display_type and l.state in ['draft', 'sent']):
-            line._validate_distribution(**{
-                'product': line.product_id.id,
-                'business_domain': 'sale_order',
-                'company_id': line.company_id.id,
-            })
+        for line in self.filtered(
+            lambda sol: not sol.display_type and sol.state in ['draft', 'sent']
+        ):
+            line._validate_distribution(
+                product=line.product_id.id,
+                business_domain='sale_order',
+                company_id=line.company_id.id,
+            )
 
-    #=== CORE METHODS OVERRIDES ===#
+    def has_valued_move_ids(self):
+        return self.move_ids
 
-    def _get_partner_display(self):
-        self.ensure_one()
-        commercial_partner = self.order_partner_id.commercial_partner_id
-        return f'({commercial_partner.ref or commercial_partner.name})'
-
-    def _additional_name_per_id(self):
-        return {
-            so_line.id: so_line._get_partner_display()
-            for so_line in self
-        }
+    def _has_valid_qty_to_invoice(self, final=False):
+        return self.qty_to_invoice > 0 or (self.qty_to_invoice < 0 and final)
 
     #=== HOOKS ===#
 
@@ -1322,6 +1205,13 @@ class SaleOrderLine(models.Model):
                 # price will be computed in batch with pricelist utils so not given here
             }
 
+    def _prepare_procurement_values(self, group_id=False):
+        """ Prepare specific key for moves or other components that will be created from a stock rule
+        coming from a sale order line. This method could be override in order to add other custom key that could
+        be used in move/po creation.
+        """
+        return {}
+
     #=== TOOLING ===#
 
     def _convert_to_sol_currency(self, amount, currency):
@@ -1346,6 +1236,3 @@ class SaleOrderLine(models.Model):
                 round=False,
             )
         return amount
-
-    def has_valued_move_ids(self):
-        return self.move_ids

--- a/addons/sale/report/ir_actions_report_templates.xml
+++ b/addons/sale/report/ir_actions_report_templates.xml
@@ -110,7 +110,7 @@
                                 <td t-if="display_discount" class="text-end">
                                     <span t-field="line.discount">-</span>
                                 </td>
-                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_id])"/>
+                                <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.tax_ids])"/>
                                 <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
                                     <span t-out="taxes">Tax 15%</span>
                                 </td>

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -52,7 +52,7 @@ class TestAccruedSaleOrders(AccountTestInvoicingCommon):
                     'product_uom_qty': 10.0,
                     'product_uom': cls.product_a.uom_id.id,
                     'price_unit': cls.product_a.list_price,
-                    'tax_id': False,
+                    'tax_ids': False,
                     'analytic_distribution': {
                         cls.analytic_account_a.id : 80.0,
                         cls.analytic_account_b.id : 20.0,
@@ -64,7 +64,7 @@ class TestAccruedSaleOrders(AccountTestInvoicingCommon):
                     'product_uom_qty': 10.0,
                     'product_uom': cls.product_b.uom_id.id,
                     'price_unit': cls.product_b.list_price,
-                    'tax_id': False,
+                    'tax_ids': False,
                     'analytic_distribution': {
                         cls.analytic_account_b.id : 100.0,
                     },

--- a/addons/sale/tests/test_credit_limit.py
+++ b/addons/sale/tests/test_credit_limit.py
@@ -78,7 +78,7 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
                 'product_uom_qty': 1,
                 'product_uom': self.company_data['product_order_no'].uom_id.id,
                 'price_unit': 1000.0,
-                'tax_id': False,
+                'tax_ids': False,
             })]
         })
 
@@ -153,7 +153,7 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
                     'product_id': self.company_data['product_order_no'].id,
                     'product_uom_qty': 1,
                     'price_unit': 45.0,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })
             ]
         })
@@ -166,7 +166,7 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
                     'product_id': self.company_data['product_order_no'].id,
                     'product_uom_qty': 1,
                     'price_unit': 65.0,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })
             ],
         })

--- a/addons/sale/tests/test_credit_limit.py
+++ b/addons/sale/tests/test_credit_limit.py
@@ -103,7 +103,7 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
             'amount': 50,
         }).create_invoices()
 
-        invoice = sale_order.invoice_ids
+        invoice = sale_order.account_move_ids
 
         # Check that the warning does not appear even though we are creating an invoice
         # that should bring partner_a's credit above its limit.
@@ -131,7 +131,7 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
             'journal_id': invoice.journal_id.id,
         }).reverse_moves()
 
-        credit_note = sale_order.invoice_ids[1]
+        credit_note = sale_order.account_move_ids[1]
         credit_note.action_post()
 
         # Check that the credit note is accounted for correctly for the amount_to_invoice

--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -231,7 +231,7 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
 
         self.assertEqual(self.sale_order.state, 'sale')
         self.assertTrue(tx.invoice_ids)
-        self.assertTrue(self.sale_order.invoice_ids)
+        self.assertTrue(self.sale_order.account_move_ids)
 
     def test_auto_done_and_auto_invoice(self):
         # Set automatic invoice
@@ -248,7 +248,7 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
         self.assertEqual(self.sale_order.state, 'sale')
         self.assertTrue(self.sale_order.locked)
         self.assertTrue(tx.invoice_ids)
-        self.assertTrue(self.sale_order.invoice_ids)
+        self.assertTrue(self.sale_order.account_move_ids)
         self.assertTrue(tx.invoice_ids.is_move_sent)
 
     def test_so_partial_payment_no_invoice(self):
@@ -263,7 +263,7 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
 
         self.assertEqual(self.sale_order.state, 'draft')
         self.assertFalse(tx.invoice_ids)
-        self.assertFalse(self.sale_order.invoice_ids)
+        self.assertFalse(self.sale_order.account_move_ids)
 
     def test_already_confirmed_so_payment(self):
         # Set automatic invoice
@@ -278,7 +278,7 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
         tx._post_process()
 
         self.assertTrue(tx.invoice_ids)
-        self.assertTrue(self.sale_order.invoice_ids)
+        self.assertTrue(self.sale_order.account_move_ids)
 
     def test_invoice_is_final(self):
         """Test that invoice generated from a payment are always final"""
@@ -341,9 +341,9 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
         self.sale_order.action_confirm()
         self.sale_order._create_invoices()
 
-        self.assertEqual(len(self.sale_order.invoice_ids), 1, msg="1 invoice should be created.")
+        self.assertEqual(len(self.sale_order.account_move_ids), 1, msg="1 invoice should be created.")
 
-        first_invoice = self.sale_order.invoice_ids
+        first_invoice = self.sale_order.account_move_ids
         linked_txs = first_invoice.transaction_ids
         msg = "The newly created invoice should be linked to the done and pending transactions."
         self.assertEqual(len(linked_txs), 2, msg=msg)
@@ -360,7 +360,7 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
         self.sale_order.order_line[0].product_uom_qty += 2
         self.sale_order._create_invoices()
 
-        second_invoice = self.sale_order.invoice_ids - first_invoice
+        second_invoice = self.sale_order.account_move_ids - first_invoice
         msg = "The newly created invoice should only be linked to the pending transaction."
         self.assertEqual(len(second_invoice.transaction_ids), 1, msg=msg)
         self.assertEqual(second_invoice.transaction_ids.state, 'pending', msg=msg)
@@ -449,7 +449,7 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
         with mute_logger('odoo.addons.sale.models.payment_transaction'):
             tx._post_process()
 
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         self.assertTrue(len(invoice) == 1)
         self.assertTrue(invoice.line_ids[0].is_downpayment)
 

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -411,14 +411,14 @@ class TestSaleOrder(SaleCommon):
                     'product_uom_qty': 1,
                     'price_unit': 6.7,
                     'discount': 0,
-                    'tax_id': tax_a.ids,
+                    'tax_ids': tax_a.ids,
                 }),
                 Command.create({
                     'product_id': self.product.id,
                     'product_uom_qty': 1,
                     'price_unit': 6.7,
                     'discount': 0,
-                    'tax_id': tax_a.ids,
+                    'tax_ids': tax_a.ids,
                 }),
             ],
         })
@@ -434,14 +434,14 @@ class TestSaleOrder(SaleCommon):
                     'product_uom_qty': 1,
                     'price_unit': 6.7,
                     'discount': 0,
-                    'tax_id': tax_a.ids,
+                    'tax_ids': tax_a.ids,
                 }),
                 Command.create({
                     'product_id': self.product.id,
                     'product_uom_qty': 1,
                     'price_unit': 6.7,
                     'discount': 0,
-                    'tax_id': tax_a.ids,
+                    'tax_ids': tax_a.ids,
                 }),
             ],
         })
@@ -653,10 +653,10 @@ class TestSaleOrder(SaleCommon):
             line.product_id = product_no_tax
         so = so_form.save()
         self.assertRecordValues(so.order_line, [
-            {'product_id': product_all_taxes.id, 'tax_id': tax_xx.ids},
-            {'product_id': product_no_xx_tax.id, 'tax_id': tax_x.ids},
-            {'product_id': product_no_branch_tax.id, 'tax_id': (tax_a + tax_b).ids},
-            {'product_id': product_no_tax.id, 'tax_id': []},
+            {'product_id': product_all_taxes.id, 'tax_ids': tax_xx.ids},
+            {'product_id': product_no_xx_tax.id, 'tax_ids': tax_x.ids},
+            {'product_id': product_no_branch_tax.id, 'tax_ids': (tax_a + tax_b).ids},
+            {'product_id': product_no_tax.id, 'tax_ids': []},
         ])
 
 
@@ -823,11 +823,11 @@ class TestSalesTeam(SaleCommon):
             'name': product.name,
             'product_id': product.id,
             'order_id': sale_order.id,
-            'tax_id': tax_a,
+            'tax_ids': tax_a,
         })
 
         with self.assertRaises(UserError):
-            sol.tax_id = tax_b
+            sol.tax_ids = tax_b
 
     def test_assign_tax_multi_company(self):
         root_company = self.env['res.company'].create({'name': 'B0 company'})
@@ -868,15 +868,15 @@ class TestSalesTeam(SaleCommon):
             'name': product.name,
             'product_id': product.id,
             'order_id': sale_order.id,
-            'tax_id': tax_b1,
+            'tax_ids': tax_b1,
         })
 
         # should not raise anything
-        sol_b1.tax_id = tax_b0
-        sol_b1.tax_id = tax_b1
+        sol_b1.tax_ids = tax_b0
+        sol_b1.tax_ids = tax_b1
         # should raise (b2 is not on the same branch lineage as b1)
         with self.assertRaises(UserError):
-            sol_b1.tax_id = tax_b2
+            sol_b1.tax_ids = tax_b2
 
     def test_downpayment_amount_constraints(self):
         """Down payment amounts should be in the interval ]0, 1]."""

--- a/addons/sale/tests/test_sale_order_discount.py
+++ b/addons/sale/tests/test_sale_order_discount.py
@@ -28,7 +28,7 @@ class TestSaleOrderDiscount(SaleCommon):
         discount_line = self.sale_order.order_line[-1]
         self.assertEqual(discount_line.price_unit, -55)
         self.assertEqual(discount_line.product_uom_qty, 1.0)
-        self.assertFalse(discount_line.tax_id)
+        self.assertFalse(discount_line.tax_ids)
 
     def test_so_discount(self):
         solines = self.sale_order.order_line
@@ -36,7 +36,7 @@ class TestSaleOrderDiscount(SaleCommon):
         self.assertEqual(len(solines), 2)
 
         # No taxes
-        solines.tax_id = [Command.clear()]
+        solines.tax_ids = [Command.clear()]
         self.wizard.write({
             'discount_percentage': 0.5,  # 50%
             'discount_type': 'so_discount',
@@ -45,31 +45,31 @@ class TestSaleOrderDiscount(SaleCommon):
 
         discount_line = self.sale_order.order_line[-1]
         self.assertAlmostEqual(discount_line.price_unit, -amount_before_discount*0.5)
-        self.assertFalse(discount_line.tax_id)
+        self.assertFalse(discount_line.tax_ids)
         self.assertEqual(discount_line.product_uom_qty, 1.0)
 
         # One tax group
         discount_line.unlink()
         dumb_tax = self.env['account.tax'].create({'name': 'test'})
-        solines.tax_id = dumb_tax
+        solines.tax_ids = dumb_tax
         self.wizard.action_apply_discount()
 
         discount_line = self.sale_order.order_line - solines
         discount_line.ensure_one()
         self.assertAlmostEqual(discount_line.price_unit, -amount_before_discount*0.5)
-        self.assertEqual(discount_line.tax_id, dumb_tax)
+        self.assertEqual(discount_line.tax_ids, dumb_tax)
         self.assertEqual(discount_line.product_uom_qty, 1.0)
 
         # Two tax groups
         discount_line.unlink()
-        solines[0].tax_id = [Command.clear()]
+        solines[0].tax_ids = [Command.clear()]
         self.wizard.action_apply_discount()
         discount_lines = self.sale_order.order_line - solines
         self.assertEqual(len(discount_lines), 2)
         self.assertEqual(discount_lines[0].price_unit, -solines[0].price_subtotal * 0.5)
         self.assertEqual(discount_lines[1].price_unit, -solines[1].price_subtotal * 0.5)
-        self.assertEqual(discount_lines[0].tax_id, solines[0].tax_id)
-        self.assertEqual(discount_lines[1].tax_id, solines[1].tax_id)
+        self.assertEqual(discount_lines[0].tax_ids, solines[0].tax_ids)
+        self.assertEqual(discount_lines[1].tax_ids, solines[1].tax_ids)
         self.assertTrue(all(line.product_uom_qty == 1.0 for line in discount_lines))
 
     def test_sol_discount(self):

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -140,7 +140,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
         # Full Invoice
         invoicing_wizard = self.env['sale.advance.payment.inv'].create({
-            'sale_order_ids': [Command.link(self.sale_order.id)],
+            'order_ids': [Command.link(self.sale_order.id)],
             'advance_payment_method': 'delivered',
         })
         action = invoicing_wizard.create_invoices()
@@ -1033,7 +1033,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         invoicing_wizard = self.env['sale.advance.payment.inv'].create({
             'advance_payment_method': 'fixed',
             'fixed_amount': sale_order.amount_total / 2.0,
-            'sale_order_ids': [Command.link(sale_order.id)],
+            'order_ids': [Command.link(sale_order.id)],
         })
 
         # Down payment invoice
@@ -1049,7 +1049,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
         # Full Invoice
         invoicing_wizard = self.env['sale.advance.payment.inv'].create({
-            'sale_order_ids': [Command.link(sale_order.id)],
+            'order_ids': [Command.link(sale_order.id)],
             'advance_payment_method': 'delivered',
         })
         self.assertEqual(sale_order.invoice_status, 'to invoice')

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -114,7 +114,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = self.sale_order.amount_total / 2
         # pylint: disable=C0326
         expected = [
@@ -174,11 +174,11 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[0].tax_ids = self.tax_15
         (self.sale_order.order_line - self.sale_order.order_line[0]).unlink()
         self.make_downpayment(amount=25)
-        first_invoice = self.sale_order.invoice_ids
+        first_invoice = self.sale_order.account_move_ids
         first_invoice.invoice_line_ids.tax_ids = None
         first_invoice.action_post()
         self.make_downpayment(amount=25)
-        invoice = self.sale_order.invoice_ids - first_invoice
+        invoice = self.sale_order.account_move_ids - first_invoice
         down_pay_amt = self.sale_order.amount_total / 4
         # ruff: noqa: E202
         expected = [
@@ -199,7 +199,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = self.sale_order.amount_total / 2
         # pylint: disable=C0326
         expected = [
@@ -222,7 +222,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(advance_payment_method='fixed', fixed_amount=222.5, amount=0)
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = 222.5
         # pylint: disable=C0326
         expected = [
@@ -246,7 +246,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[2].tax_ids = self.tax_10
         self.sale_order.order_line[3].tax_ids = self.tax_10
         self.make_downpayment(advance_payment_method='fixed', fixed_amount=222.5, amount=0)
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = 222.5
         # pylint: disable=C0326
         expected = [
@@ -269,7 +269,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = self.sale_order.amount_total / 2
         # pylint: disable=C0326
         expected = [
@@ -294,7 +294,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = self.sale_order.amount_total / 2
         # pylint: disable=C0326
         expected = [
@@ -318,7 +318,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[1].discount = 25.0
         self.sale_order.order_line[2].tax_ids = self.tax_15
         self.make_downpayment()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = self.sale_order.amount_total / 2
         # pylint: disable=C0326
         expected = [
@@ -344,7 +344,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = self.sale_order.amount_total / 2
         # pylint: disable=C0326
         expected = [
@@ -391,7 +391,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         # Line 4: 200
         # Total: 944
 
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         # pylint: disable=C0326
         expected = [
             # keys
@@ -435,7 +435,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             })
         downpayment.create_invoices()
         sale_order.action_confirm()
-        invoice = sale_order.invoice_ids
+        invoice = sale_order.account_move_ids
 
         self.assertRecordValues(invoice.invoice_line_ids, [{'price_unit': 200.0, 'tax_ids': tax_percentage.ids}])
         self.assertRecordValues(invoice.line_ids, [
@@ -455,7 +455,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[2].tax_ids = self.tax_10
         self.sale_order.order_line[2].analytic_distribution = {an_acc_01: 100}
         self.make_downpayment()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         down_pay_amt = self.sale_order.amount_total / 2
         # pylint: disable=C0326
         expected = [
@@ -508,7 +508,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         # Total: 944
 
         self.make_downpayment()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         # pylint: disable=C0326
         expected = [
             # keys
@@ -558,7 +558,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         downpayment.create_invoices()
-        invoice = self.sale_order.invoice_ids
+        invoice = self.sale_order.account_move_ids
         # pylint: disable=C0326
         expected = [
             # keys

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -34,7 +34,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_uom': cls.company_data['product_order_no'].uom_id.id,
             'price_unit': 100,
             'order_id': cls.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol_serv_deliver = cls.env['sale.order.line'].create({
             'name': cls.company_data['product_service_delivery'].name,
@@ -43,7 +43,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_uom': cls.company_data['product_service_delivery'].uom_id.id,
             'price_unit': 100,
             'order_id': cls.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol_serv_order = cls.env['sale.order.line'].create({
             'name': cls.company_data['product_service_order'].name,
@@ -52,7 +52,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_uom': cls.company_data['product_service_order'].uom_id.id,
             'price_unit': 100,
             'order_id': cls.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol_product_deliver = cls.env['sale.order.line'].create({
             'name': cls.company_data['product_delivery_no'].name,
@@ -61,7 +61,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_uom': cls.company_data['product_delivery_no'].uom_id.id,
             'price_unit': 100,
             'order_id': cls.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         cls.revenue_account = cls.company_data['default_account_revenue']
@@ -110,9 +110,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         income_acc_2 = self.revenue_account.copy()
         self.sale_order.order_line[1].product_id.product_tmpl_id.property_account_income_id = income_acc_2
 
-        self.sale_order.order_line[0].tax_id = self.tax_15 + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -171,7 +171,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
     def test_tax_with_diff_tax_on_invoice_breakdown(self):
         # if a generated invoice has it's taxes changed, this should not affect the next downpayment on an SO
-        self.sale_order.order_line[0].tax_id = self.tax_15
+        self.sale_order.order_line[0].tax_ids = self.tax_15
         (self.sale_order.order_line - self.sale_order.order_line[0]).unlink()
         self.make_downpayment(amount=25)
         first_invoice = self.sale_order.invoice_ids
@@ -195,9 +195,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
     def test_tax_breakdown_other_currency(self):
         self.sale_order.currency_id = self.other_currency  # rate = 2.0
-        self.sale_order.order_line[0].tax_id = self.tax_15 + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -218,9 +218,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_fixed_payment_method(self):
-        self.sale_order.order_line[0].tax_id = self.tax_15 + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment(advance_payment_method='fixed', fixed_amount=222.5, amount=0)
         invoice = self.sale_order.invoice_ids
         down_pay_amt = 222.5
@@ -241,10 +241,10 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_fixed_payment_method_with_taxes_on_all_lines(self):
-        self.sale_order.order_line[0].tax_id = self.tax_15
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
-        self.sale_order.order_line[3].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
+        self.sale_order.order_line[3].tax_ids = self.tax_10
         self.make_downpayment(advance_payment_method='fixed', fixed_amount=222.5, amount=0)
         invoice = self.sale_order.invoice_ids
         down_pay_amt = 222.5
@@ -265,9 +265,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
     def test_tax_price_include_breakdown(self):
         tax_10_incl = self.create_tax(10, {'price_include': True})
-        self.sale_order.order_line[0].tax_id = tax_10_incl + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = tax_10_incl + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -290,9 +290,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
     def test_tax_price_include_include_base_amount_breakdown(self):
         tax_10_pi_ba = self.create_tax(10, {'price_include': True, 'include_base_amount': True})
         self.tax_10.sequence = 2
-        self.sale_order.order_line[0].tax_id = tax_10_pi_ba + self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = tax_10_pi_ba + self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -313,10 +313,10 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self._assert_invoice_lines_values(invoice.line_ids, expected)
 
     def test_tax_breakdown_with_discount(self):
-        self.sale_order.order_line[0].tax_id = self.tax_10
-        self.sale_order.order_line[1].tax_id = self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[1].discount = 25.0
-        self.sale_order.order_line[2].tax_id = self.tax_15
+        self.sale_order.order_line[2].tax_ids = self.tax_15
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -339,10 +339,10 @@ class TestSaleOrderDownPayment(TestSaleCommon):
     def test_tax_price_include_include_base_amount_breakdown_with_discount(self):
         tax_10_pi_ba = self.create_tax(10, {'price_include': True, 'include_base_amount': True})
         self.tax_10.sequence = 2
-        self.sale_order.order_line[0].tax_id = tax_10_pi_ba + self.tax_10
+        self.sale_order.order_line[0].tax_ids = tax_10_pi_ba + self.tax_10
         self.sale_order.order_line[0].discount = 25.0
-        self.sale_order.order_line[1].tax_id = self.tax_10
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
         down_pay_amt = self.sale_order.amount_total / 2
@@ -380,9 +380,9 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'children_tax_ids': [Command.set((tax_10_fix_c + tax_10_a).ids)],
             'type_tax_use': 'sale',
         })
-        self.sale_order.order_line[0].tax_id = tax_group_1
-        self.sale_order.order_line[1].tax_id = tax_group_2
-        self.sale_order.order_line[2].tax_id = tax_10_a
+        self.sale_order.order_line[0].tax_ids = tax_group_1
+        self.sale_order.order_line[1].tax_ids = tax_group_2
+        self.sale_order.order_line[2].tax_ids = tax_10_a
         self.make_downpayment()
 
         # Line 1: 200 + 80 = 284
@@ -422,7 +422,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
                     'product_id': self.company_data['product_order_no'].id,
                     'product_uom_qty': 1,
                     'price_unit': 1210,
-                    'tax_id': [Command.set((tax_fix + tax_percentage).ids)],
+                    'tax_ids': [Command.set((tax_fix + tax_percentage).ids)],
                 }),
             ],
         })
@@ -448,11 +448,11 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         analytic_plan = self.env['account.analytic.plan'].create({'name': 'Plan Test'})
         an_acc_01 = str(self.env['account.analytic.account'].create({'name': 'Account 01', 'plan_id': analytic_plan.id}).id)
         an_acc_02 = str(self.env['account.analytic.account'].create({'name': 'Account 02', 'plan_id': analytic_plan.id}).id)
-        self.sale_order.order_line[0].tax_id = self.tax_15 + self.tax_10
+        self.sale_order.order_line[0].tax_ids = self.tax_15 + self.tax_10
         self.sale_order.order_line[0].analytic_distribution = {an_acc_01: 100}
-        self.sale_order.order_line[1].tax_id = self.tax_10
+        self.sale_order.order_line[1].tax_ids = self.tax_10
         self.sale_order.order_line[1].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
-        self.sale_order.order_line[2].tax_id = self.tax_10
+        self.sale_order.order_line[2].tax_ids = self.tax_10
         self.sale_order.order_line[2].analytic_distribution = {an_acc_01: 100}
         self.make_downpayment()
         invoice = self.sale_order.invoice_ids
@@ -496,10 +496,10 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'children_tax_ids': [Command.set((tax_10_fix_c + tax_10_a).ids)],
             'type_tax_use': 'sale',
         })
-        self.sale_order.order_line[0].tax_id = tax_group_1
+        self.sale_order.order_line[0].tax_ids = tax_group_1
         self.sale_order.order_line[0].analytic_distribution = {an_acc_01: 50, an_acc_02: 50}
-        self.sale_order.order_line[1].tax_id = tax_group_2
-        self.sale_order.order_line[2].tax_id = tax_10_a
+        self.sale_order.order_line[1].tax_ids = tax_group_2
+        self.sale_order.order_line[2].tax_ids = tax_10_a
 
         # Line 1: 200 + 80 = 284
         # Line 2: 200 + 40 = 240
@@ -533,15 +533,15 @@ class TestSaleOrderDownPayment(TestSaleCommon):
 
         self.sale_order.order_line[0].price_unit = 900
         self.sale_order.order_line[0].product_uom_qty = 1
-        self.sale_order.order_line[0].tax_id = tax_21
+        self.sale_order.order_line[0].tax_ids = tax_21
 
         self.sale_order.order_line[1].price_unit = 90
         self.sale_order.order_line[1].product_uom_qty = 2
-        self.sale_order.order_line[1].tax_id = tax_21
+        self.sale_order.order_line[1].tax_ids = tax_21
 
         self.sale_order.order_line[2].price_unit = 49
         self.sale_order.order_line[2].product_uom_qty = 4
-        self.sale_order.order_line[2].tax_id = tax_21
+        self.sale_order.order_line[2].tax_ids = tax_21
 
         self.sale_order.order_line[3].unlink()
         self.sale_order.action_confirm()
@@ -586,13 +586,13 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[0].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[0].product_uom_qty = 1
         self.sale_order.order_line[0].qty_delivered = 0
-        self.sale_order.order_line[0].tax_id = tax_21_a
+        self.sale_order.order_line[0].tax_ids = tax_21_a
         self.sale_order.order_line[0].price_unit = 1000
 
         self.sale_order.order_line[1].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[1].product_uom_qty = 1
         self.sale_order.order_line[1].qty_delivered = 0
-        self.sale_order.order_line[1].tax_id = tax_21_b
+        self.sale_order.order_line[1].tax_ids = tax_21_b
         self.sale_order.order_line[1].price_unit = 1000
 
         self.sale_order.order_line[2:].unlink()
@@ -692,13 +692,13 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[0].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[0].product_uom_qty = 1
         self.sale_order.order_line[0].qty_delivered = 0
-        self.sale_order.order_line[0].tax_id = tax_24_a
+        self.sale_order.order_line[0].tax_ids = tax_24_a
         self.sale_order.order_line[0].price_unit = 1000
 
         self.sale_order.order_line[1].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[1].product_uom_qty = 1
         self.sale_order.order_line[1].qty_delivered = 0
-        self.sale_order.order_line[1].tax_id = tax_24_b
+        self.sale_order.order_line[1].tax_ids = tax_24_b
         self.sale_order.order_line[1].price_unit = 1000
 
         self.sale_order.order_line[2:].unlink()
@@ -801,30 +801,30 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.sale_order.order_line[0].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[0].product_uom_qty = 1
         self.sale_order.order_line[0].qty_delivered = 1
-        self.sale_order.order_line[0].tax_id = tax_21_a
+        self.sale_order.order_line[0].tax_ids = tax_21_a
         self.sale_order.order_line[0].price_unit = 1000
 
         self.sale_order.order_line[1].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[1].product_uom_qty = 1
         self.sale_order.order_line[1].qty_delivered = 1
-        self.sale_order.order_line[1].tax_id = tax_21_b
+        self.sale_order.order_line[1].tax_ids = tax_21_b
         self.sale_order.order_line[1].price_unit = 1000
 
         self.sale_order.order_line[2].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[2].product_uom_qty = 1
         self.sale_order.order_line[2].qty_delivered = 1
-        self.sale_order.order_line[2].tax_id = tax_25_a
+        self.sale_order.order_line[2].tax_ids = tax_25_a
         self.sale_order.order_line[2].price_unit = 968
 
         self.sale_order.order_line[3].product_id = self.company_data['product_delivery_no'].id,
         self.sale_order.order_line[3].product_uom_qty = 1
         self.sale_order.order_line[3].qty_delivered = 1
-        self.sale_order.order_line[3].tax_id = tax_25_b
+        self.sale_order.order_line[3].tax_ids = tax_25_b
         self.sale_order.order_line[3].price_unit = 968
 
         self.sale_order.order_line[3].copy({
             'order_id':self.sale_order.id,
-            'tax_id': tax_25_c,
+            'tax_ids': tax_25_c,
             'qty_delivered': 1,
         })
 
@@ -912,7 +912,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             self.sale_order.order_line[i].product_id = self.company_data['product_delivery_no'].id
             self.sale_order.order_line[i].product_uom_qty = 1
             self.sale_order.order_line[i].qty_delivered = 1
-            self.sale_order.order_line[i].tax_id = tax_20
+            self.sale_order.order_line[i].tax_ids = tax_20
             self.sale_order.order_line[i].price_unit = price_unit
 
         self.sale_order.order_line.qty_delivered_method = 'manual'
@@ -959,7 +959,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 1,
             'price_unit': 100,
-            'tax_id': self.tax_15.ids,
+            'tax_ids': self.tax_15.ids,
             'order_id': sale_order.id,
         })
         sale_order.action_confirm()

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -604,7 +604,7 @@ class TestSalePrices(SaleCommon):
             "Wrong subtotal price computed for specified product & pricelist"
         )
         self.assertEqual(
-            self.empty_order.order_line.tax_id.id, tax_b.id,
+            self.empty_order.order_line.tax_ids.id, tax_b.id,
             "Wrong tax applied for specified product & pricelist"
         )
 
@@ -854,7 +854,7 @@ class TestSalePrices(SaleCommon):
             'product_id': self.product.id,
             'product_uom_qty': 1,
             'price_unit': 0.0,
-            'tax_id': [
+            'tax_ids': [
                 Command.set(taxes.ids),
             ],
         })]
@@ -882,11 +882,11 @@ class TestSalePrices(SaleCommon):
         }])
 
         # Apply taxes on the sale order lines
-        self.sale_order.order_line[0].write({'tax_id': [Command.link(tax_include.id)]})
-        self.sale_order.order_line[1].write({'tax_id': [Command.link(tax_exclude.id)]})
+        self.sale_order.order_line[0].write({'tax_ids': [Command.link(tax_include.id)]})
+        self.sale_order.order_line[1].write({'tax_ids': [Command.link(tax_exclude.id)]})
 
         for line in self.sale_order.order_line:
-            if line.tax_id.price_include:
+            if line.tax_ids.price_include:
                 price = line.price_unit * line.product_uom_qty - line.price_tax
             else:
                 price = line.price_unit * line.product_uom_qty
@@ -922,7 +922,7 @@ class TestSalePrices(SaleCommon):
         # Same with an included-in-price tax
         order = order.copy()
         line = order.order_line
-        line.tax_id = [Command.create({
+        line.tax_ids = [Command.create({
             'name': 'Super Tax',
             'amount_type': 'percent',
             'amount': 15.0,
@@ -972,7 +972,7 @@ class TestSalePrices(SaleCommon):
         # Same with an included-in-price tax
         order = order.copy()
         line = order.order_line
-        line.tax_id = [Command.create({
+        line.tax_ids = [Command.create({
             'name': 'Super Tax',
             'amount_type': 'percent',
             'amount': 10.0,

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -78,7 +78,7 @@ class TestSaleRefund(TestSaleCommon):
                 self.assertEqual(line.qty_invoiced, 0.0, "Invoiced quantity should be zero as no any invoice created for SO")
                 self.assertEqual(line.untaxed_amount_to_invoice, 0.0, "The amount to invoice should be zero, as the line based on delivered quantity")
                 self.assertEqual(line.untaxed_amount_invoiced, 0.0, "The invoiced amount should be zero, as the line based on delivered quantity")
-                self.assertFalse(line.invoice_lines, "The line based on delivered qty are not invoiced, so they should not be linked to invoice line")
+                self.assertFalse(line.account_move_line_ids, "The line based on delivered qty are not invoiced, so they should not be linked to invoice line")
             else:
                 if line == self.sol_prod_order:
                     self.assertEqual(line.qty_to_invoice, 0.0, "The ordered sale line are totally invoiced (qty to invoice is zero)")
@@ -88,7 +88,7 @@ class TestSaleRefund(TestSaleCommon):
                     self.assertEqual(line.qty_invoiced, 3.0, "The ordered (serv) sale line are totally invoiced (qty invoiced = the invoice lines)")
                 self.assertEqual(line.untaxed_amount_to_invoice, line.price_unit * line.qty_to_invoice, "Amount to invoice is now set as qty to invoice * unit price since no price change on invoice, for ordered products")
                 self.assertEqual(line.untaxed_amount_invoiced, line.price_unit * line.qty_invoiced, "Amount invoiced is now set as qty invoiced * unit price since no price change on invoice, for ordered products")
-                self.assertEqual(len(line.invoice_lines), 1, "The lines 'ordered' qty are invoiced, so it should be linked to 1 invoice lines")
+                self.assertEqual(len(line.account_move_line_ids), 1, "The lines 'ordered' qty are invoiced, so it should be linked to 1 invoice lines")
 
         # Make a credit note
         credit_note_wizard = self.env['account.move.reversal'].with_context({'active_ids': [self.invoice.id], 'active_id': self.invoice.id, 'active_model': 'account.move'}).create({
@@ -113,20 +113,20 @@ class TestSaleRefund(TestSaleCommon):
                 self.assertEqual(line.qty_invoiced, 0.0, "Invoiced quantity should be zero as no any invoice created for SO line based on delivered qty")
                 self.assertEqual(line.untaxed_amount_to_invoice, 0.0, "The amount to invoice should be zero, as the line based on delivered quantity")
                 self.assertEqual(line.untaxed_amount_invoiced, 0.0, "The invoiced amount should be zero, as the line based on delivered quantity")
-                self.assertFalse(line.invoice_lines, "The line based on delivered are not invoiced, so they should not be linked to invoice line")
+                self.assertFalse(line.account_move_line_ids, "The line based on delivered are not invoiced, so they should not be linked to invoice line")
             else:
                 if line == self.sol_prod_order:
                     self.assertEqual(line.qty_to_invoice, 5.0, "As the refund is created, the invoiced quantity cancel each other (consu ordered)")
                     self.assertEqual(line.qty_invoiced, 0.0, "The qty to invoice should have decreased as the refund is created for ordered consu SO line")
                     self.assertEqual(line.untaxed_amount_to_invoice, 0.0, "Amount to invoice is zero as the refund is not validated")
                     self.assertEqual(line.untaxed_amount_invoiced, line.price_unit * 5, "Amount invoiced is now set as unit price * ordered qty - refund qty) even if the ")
-                    self.assertEqual(len(line.invoice_lines), 2, "The line 'ordered consumable' is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
+                    self.assertEqual(len(line.account_move_line_ids), 2, "The line 'ordered consumable' is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
                 else:
                     self.assertEqual(line.qty_to_invoice, 3.0, "As the refund is created, the invoiced quantity cancel each other (consu ordered)")
                     self.assertEqual(line.qty_invoiced, 0.0, "The qty to invoice should have decreased as the refund is created for ordered service SO line")
                     self.assertEqual(line.untaxed_amount_to_invoice, 0.0, "Amount to invoice is zero as the refund is not validated")
                     self.assertEqual(line.untaxed_amount_invoiced, line.price_unit * 3, "Amount invoiced is now set as unit price * ordered qty - refund qty) even if the ")
-                    self.assertEqual(len(line.invoice_lines), 2, "The line 'ordered service' is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
+                    self.assertEqual(len(line.account_move_line_ids), 2, "The line 'ordered service' is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
 
         # Validate the refund
         invoice_refund.action_post()
@@ -137,20 +137,20 @@ class TestSaleRefund(TestSaleCommon):
                 self.assertEqual(line.qty_invoiced, 0.0, "Invoiced quantity should be zero as no any invoice created for SO")
                 self.assertEqual(line.untaxed_amount_to_invoice, 0.0, "The amount to invoice should be zero, as the line based on delivered quantity")
                 self.assertEqual(line.untaxed_amount_invoiced, 0.0, "The invoiced amount should be zero, as the line based on delivered quantity")
-                self.assertFalse(line.invoice_lines, "The line based on delivered are not invoiced, so they should not be linked to invoice line")
+                self.assertFalse(line.account_move_line_ids, "The line based on delivered are not invoiced, so they should not be linked to invoice line")
             else:
                 if line == self.sol_prod_order:
                     self.assertEqual(line.qty_to_invoice, 5.0, "As the refund still exists, the quantity to invoice is the ordered quantity")
                     self.assertEqual(line.qty_invoiced, 0.0, "The qty to invoice should be zero as, with the refund, the quantities cancel each other")
                     self.assertEqual(line.untaxed_amount_to_invoice, line.price_unit * 5, "Amount to invoice is now set as qty to invoice * unit price since no price change on invoice, as refund is validated")
                     self.assertEqual(line.untaxed_amount_invoiced, 0.0, "Amount invoiced decreased as the refund is now confirmed")
-                    self.assertEqual(len(line.invoice_lines), 2, "The line 'ordered consumable' is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
+                    self.assertEqual(len(line.account_move_line_ids), 2, "The line 'ordered consumable' is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
                 else:
                     self.assertEqual(line.qty_to_invoice, 3.0, "As the refund still exists, the quantity to invoice is the ordered quantity")
                     self.assertEqual(line.qty_invoiced, 0.0, "The qty to invoice should be zero as, with the refund, the quantities cancel each other")
                     self.assertEqual(line.untaxed_amount_to_invoice, line.price_unit * 3, "Amount to invoice is now set as qty to invoice * unit price since no price change on invoice, as refund is validated")
                     self.assertEqual(line.untaxed_amount_invoiced, 0.0, "Amount invoiced decreased as the refund is now confirmed")
-                    self.assertEqual(len(line.invoice_lines), 2, "The line 'ordered service' is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
+                    self.assertEqual(len(line.account_move_line_ids), 2, "The line 'ordered service' is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
 
     def test_refund_modify(self):
         """ Test invoice with a refund in 'modify' mode, and check customer invoices credit note is created from respective invoice """
@@ -171,7 +171,7 @@ class TestSaleRefund(TestSaleCommon):
                 self.assertEqual(line.qty_invoiced, 0.0, "Invoiced quantity should be zero as no any invoice created for SO")
                 self.assertEqual(line.untaxed_amount_to_invoice, 0.0, "The amount to invoice should be zero, as the line based on delivered quantity")
                 self.assertEqual(line.untaxed_amount_invoiced, 0.0, "The invoiced amount should be zero, as the line based on delivered quantity")
-                self.assertFalse(line.invoice_lines, "The line based on delivered qty are not invoiced, so they should not be linked to invoice line")
+                self.assertFalse(line.account_move_line_ids, "The line based on delivered qty are not invoiced, so they should not be linked to invoice line")
             else:
                 if line == self.sol_prod_order:
                     self.assertEqual(line.qty_to_invoice, 2.0, "The ordered sale line are totally invoiced (qty to invoice is zero)")
@@ -181,7 +181,7 @@ class TestSaleRefund(TestSaleCommon):
                     self.assertEqual(line.qty_invoiced, 2.0, "The ordered (serv) sale line are totally invoiced (qty invoiced = the invoice lines)")
                 self.assertEqual(line.untaxed_amount_to_invoice, line.price_unit * line.qty_to_invoice, "Amount to invoice is now set as qty to invoice * unit price since no price change on invoice, for ordered products")
                 self.assertEqual(line.untaxed_amount_invoiced, line.price_unit * line.qty_invoiced, "Amount invoiced is now set as qty invoiced * unit price since no price change on invoice, for ordered products")
-                self.assertEqual(len(line.invoice_lines), 1, "The lines 'ordered' qty are invoiced, so it should be linked to 1 invoice lines")
+                self.assertEqual(len(line.account_move_line_ids), 1, "The lines 'ordered' qty are invoiced, so it should be linked to 1 invoice lines")
 
         # Make a credit note
         credit_note_wizard = self.env['account.move.reversal'].with_context({'active_ids': [self.invoice.id], 'active_id': self.invoice.id, 'active_model': 'account.move'}).create({
@@ -205,20 +205,20 @@ class TestSaleRefund(TestSaleCommon):
                 self.assertEqual(line.qty_invoiced, 0.0, "Invoiced quantity should be zero as no any invoice created for SO")
                 self.assertEqual(line.untaxed_amount_to_invoice, 0.0, "The amount to invoice should be zero, as the line based on delivered quantity")
                 self.assertEqual(line.untaxed_amount_invoiced, 0.0, "The invoiced amount should be zero, as the line based on delivered quantity")
-                self.assertFalse(line.invoice_lines, "The line based on delivered are not invoiced, so they should not be linked to invoice line")
+                self.assertFalse(line.account_move_line_ids, "The line based on delivered are not invoiced, so they should not be linked to invoice line")
             else:
                 if line == self.sol_prod_order:
                     self.assertEqual(line.qty_to_invoice, 2.0, "The qty to invoice does not change when confirming the new invoice (2)")
                     self.assertEqual(line.qty_invoiced, 3.0, "The ordered (prod) sale line does not change on invoice 2 confirmation")
                     self.assertEqual(line.untaxed_amount_to_invoice, line.price_unit * 5, "Amount to invoice is now set as qty to invoice * unit price since no price change on invoice, for ordered products")
                     self.assertEqual(line.untaxed_amount_invoiced, 0.0, "Amount invoiced is zero as the invoice 1 and its refund are reconcilied")
-                    self.assertEqual(len(line.invoice_lines), 3, "The line 'ordered consumable' is invoiced, so it should be linked to 3 invoice lines (invoice and refund)")
+                    self.assertEqual(len(line.account_move_line_ids), 3, "The line 'ordered consumable' is invoiced, so it should be linked to 3 invoice lines (invoice and refund)")
                 else:
                     self.assertEqual(line.qty_to_invoice, 1.0, "The qty to invoice does not change when confirming the new invoice (2)")
                     self.assertEqual(line.qty_invoiced, 2.0, "The ordered (serv) sale line does not change on invoice 2 confirmation")
                     self.assertEqual(line.untaxed_amount_to_invoice, line.price_unit * 3, "Amount to invoice is now set as unit price * ordered qty - refund qty) even if the ")
                     self.assertEqual(line.untaxed_amount_invoiced, 0.0, "Amount invoiced is zero as the invoice 1 and its refund are reconcilied")
-                    self.assertEqual(len(line.invoice_lines), 3, "The line 'ordered service' is invoiced, so it should be linked to 3 invoice lines (invoice and refund)")
+                    self.assertEqual(len(line.account_move_line_ids), 3, "The line 'ordered service' is invoiced, so it should be linked to 3 invoice lines (invoice and refund)")
 
         # Change unit of ordered product on refund lines
         move_form = Form(invoice_refund)
@@ -237,20 +237,20 @@ class TestSaleRefund(TestSaleCommon):
                 self.assertEqual(line.qty_invoiced, 0.0, "Invoiced quantity should be zero as no any invoice created for SO")
                 self.assertEqual(line.untaxed_amount_to_invoice, 0.0, "The amount to invoice should be zero, as the line based on delivered quantity")
                 self.assertEqual(line.untaxed_amount_invoiced, 0.0, "The invoiced amount should be zero, as the line based on delivered quantity")
-                self.assertFalse(line.invoice_lines, "The line based on delivered are not invoiced, so they should not be linked to invoice line, even after validation")
+                self.assertFalse(line.account_move_line_ids, "The line based on delivered are not invoiced, so they should not be linked to invoice line, even after validation")
             else:
                 if line == self.sol_prod_order:
                     self.assertEqual(line.qty_to_invoice, 2.0, "The qty to invoice does not change when confirming the new invoice (3)")
                     self.assertEqual(line.qty_invoiced, 3.0, "The ordered sale line are totally invoiced (qty invoiced = ordered qty)")
                     self.assertEqual(line.untaxed_amount_to_invoice, 1100.0, "")
                     self.assertEqual(line.untaxed_amount_invoiced, 300.0, "")
-                    self.assertEqual(len(line.invoice_lines), 3, "The line 'ordered consumable' is invoiced, so it should be linked to 2 invoice lines (invoice and refund), even after validation")
+                    self.assertEqual(len(line.account_move_line_ids), 3, "The line 'ordered consumable' is invoiced, so it should be linked to 2 invoice lines (invoice and refund), even after validation")
                 else:
                     self.assertEqual(line.qty_to_invoice, 1.0, "The qty to invoice does not change when confirming the new invoice (3)")
                     self.assertEqual(line.qty_invoiced, 2.0, "The ordered sale line are totally invoiced (qty invoiced = ordered qty)")
                     self.assertEqual(line.untaxed_amount_to_invoice, 170.0, "")
                     self.assertEqual(line.untaxed_amount_invoiced, 100.0, "")
-                    self.assertEqual(len(line.invoice_lines), 3, "The line 'ordered service' is invoiced, so it should be linked to 2 invoice lines (invoice and refund), even after validation")
+                    self.assertEqual(len(line.account_move_line_ids), 3, "The line 'ordered service' is invoiced, so it should be linked to 2 invoice lines (invoice and refund), even after validation")
 
     def test_refund_invoice_with_downpayment(self):
         sale_order_refund = self.env['sale.order'].create({
@@ -329,10 +329,10 @@ class TestSaleRefund(TestSaleCommon):
         self.assertEqual(sol_product.qty_invoiced, 0.0, "The qty invoiced should be zero as, with the refund, the quantities cancel each other")
         self.assertEqual(sol_product.untaxed_amount_to_invoice, sol_product.price_unit * 5, "Amount to invoice is now set as qty to invoice * unit price since no price change on invoice, as refund is validated")
         self.assertEqual(sol_product.untaxed_amount_invoiced, 0.0, "Amount invoiced decreased as the refund is now confirmed")
-        self.assertEqual(len(sol_product.invoice_lines), 2, "The product line is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
+        self.assertEqual(len(sol_product.account_move_line_ids), 2, "The product line is invoiced, so it should be linked to 2 invoice lines (invoice and refund)")
 
         self.assertEqual(sol_downpayment.qty_to_invoice, -1.0, "As the downpayment was invoiced separately, it will still have to be deducted from the total invoice (hence -1.0), after the refund.")
         self.assertEqual(sol_downpayment.qty_invoiced, 1.0, "The qty to invoice should be 1 as, with the refund, the products are not invoiced anymore, but the downpayment still is")
         self.assertEqual(sol_downpayment.untaxed_amount_to_invoice, -(sol_product.price_unit * 5)/2, "Amount to invoice decreased as the refund is now confirmed")
         self.assertEqual(sol_downpayment.untaxed_amount_invoiced, (sol_product.price_unit * 5)/2, "Amount invoiced is now set as half of all products' total amount to invoice, as refund is validated")
-        self.assertEqual(len(sol_downpayment.invoice_lines), 3, "The product line is invoiced, so it should be linked to 3 invoice lines (downpayment invoice, partial invoice and refund)")
+        self.assertEqual(len(sol_downpayment.account_move_line_ids), 3, "The product line is invoiced, so it should be linked to 3 invoice lines (downpayment invoice, partial invoice and refund)")

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -24,22 +24,22 @@ class TestSaleRefund(TestSaleCommon):
                 Command.create({
                     'product_id': cls.company_data['product_order_no'].id,
                     'product_uom_qty': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_service_delivery'].id,
                     'product_uom_qty': 4,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_service_order'].id,
                     'product_uom_qty': 3,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_delivery_no'].id,
                     'product_uom_qty': 2,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -263,7 +263,7 @@ class TestSaleRefund(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 5,
             'order_id': sale_order_refund.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         self.assertRecordValues(sol_product, [{

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -65,7 +65,7 @@ class TestSaleRefund(TestSaleCommon):
         })
         payment.create_invoices()
 
-        cls.invoice = cls.sale_order.invoice_ids[0]
+        cls.invoice = cls.sale_order.account_move_ids[0]
 
     def test_refund_create(self):
         # Validate invoice
@@ -96,14 +96,14 @@ class TestSaleRefund(TestSaleCommon):
             'journal_id': self.invoice.journal_id.id,
         })
         credit_note_wizard.refund_moves()
-        invoice_refund = self.sale_order.invoice_ids.sorted(key=lambda inv: inv.id, reverse=False)[-1]  # the first invoice, its refund, and the new invoice
+        invoice_refund = self.sale_order.account_move_ids.sorted(key=lambda inv: inv.id, reverse=False)[-1]  # the first invoice, its refund, and the new invoice
 
         # Check invoice's type and number
         self.assertEqual(invoice_refund.move_type, 'out_refund', 'The last created invoiced should be a refund')
         self.assertEqual(invoice_refund.state, 'draft', 'Last Customer invoices should be in draft')
         self.assertEqual(self.sale_order.invoice_count, 2, "The SO should have 2 related invoices: the original, the new refund")
-        self.assertEqual(len(self.sale_order.invoice_ids.filtered(lambda inv: inv.move_type == 'out_refund')), 1, "The SO should be linked to only one refund")
-        self.assertEqual(len(self.sale_order.invoice_ids.filtered(lambda inv: inv.move_type == 'out_invoice')), 1, "The SO should be linked to only one customer invoices")
+        self.assertEqual(len(self.sale_order.account_move_ids.filtered(lambda inv: inv.move_type == 'out_refund')), 1, "The SO should be linked to only one refund")
+        self.assertEqual(len(self.sale_order.account_move_ids.filtered(lambda inv: inv.move_type == 'out_invoice')), 1, "The SO should be linked to only one customer invoices")
 
         # At this time, the invoice 1 is opend (validated) and its refund is in draft, so the amounts invoiced are not zero for
         # invoiced sale line. The amounts only take validated invoice/refund into account.
@@ -194,8 +194,8 @@ class TestSaleRefund(TestSaleCommon):
         self.assertEqual(invoice_refund.move_type, 'out_invoice', 'The last created invoiced should be a customer invoice')
         self.assertEqual(invoice_refund.state, 'draft', 'Last Customer invoices should be in draft')
         self.assertEqual(self.sale_order.invoice_count, 3, "The SO should have 3 related invoices: the original, the refund, and the new one")
-        self.assertEqual(len(self.sale_order.invoice_ids.filtered(lambda inv: inv.move_type == 'out_refund')), 1, "The SO should be linked to only one refund")
-        self.assertEqual(len(self.sale_order.invoice_ids.filtered(lambda inv: inv.move_type == 'out_invoice')), 2, "The SO should be linked to two customer invoices")
+        self.assertEqual(len(self.sale_order.account_move_ids.filtered(lambda inv: inv.move_type == 'out_refund')), 1, "The SO should be linked to only one refund")
+        self.assertEqual(len(self.sale_order.account_move_ids.filtered(lambda inv: inv.move_type == 'out_invoice')), 2, "The SO should be linked to two customer invoices")
 
         # At this time, the invoice 1 and its refund are confirmed, so the amounts invoiced are zero. The third invoice
         # (2nd customer inv) is in draft state.
@@ -293,7 +293,7 @@ class TestSaleRefund(TestSaleCommon):
         downpayment.create_invoices()
         # order_line[1] is the down payment section
         sol_downpayment = sale_order_refund.order_line[2]
-        dp_invoice = sale_order_refund.invoice_ids[0]
+        dp_invoice = sale_order_refund.account_move_ids[0]
         dp_invoice.action_post()
 
         self.assertRecordValues(sol_downpayment, [{
@@ -310,7 +310,7 @@ class TestSaleRefund(TestSaleCommon):
         payment = self.env['sale.advance.payment.inv'].with_context(so_context).create({})
         payment.create_invoices()
 
-        so_invoice = max(sale_order_refund.invoice_ids)
+        so_invoice = max(sale_order_refund.account_move_ids)
         self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))),
                          len(sale_order_refund.order_line.filtered(lambda l: not (l.display_type == 'line_section' and l.name == "Down Payments"))), 'All lines should be invoiced')
         self.assertEqual(len(so_invoice.invoice_line_ids.filtered(lambda l: l.display_type == 'line_section' and l.name == "Down Payments")), 1, 'A single section for downpayments should be present')
@@ -322,7 +322,7 @@ class TestSaleRefund(TestSaleCommon):
             'journal_id': so_invoice.journal_id.id,
         })
         credit_note_wizard.refund_moves()
-        invoice_refund = sale_order_refund.invoice_ids.sorted(key=lambda inv: inv.id, reverse=False)[-1]
+        invoice_refund = sale_order_refund.account_move_ids.sorted(key=lambda inv: inv.id, reverse=False)[-1]
         invoice_refund.action_post()
 
         self.assertEqual(sol_product.qty_to_invoice, 5.0, "As the refund still exists, the quantity to invoice is the ordered quantity")

--- a/addons/sale/tests/test_sale_tax_totals.py
+++ b/addons/sale/tests/test_sale_tax_totals.py
@@ -26,7 +26,7 @@ class SaleTestTaxTotals(TestTaxTotals):
                 'product_id': self.so_product.id,
                 'price_unit': amount,
                 'product_uom_qty': 1,
-                'tax_id': [(6, 0, taxes.ids)],
+                'tax_ids': [(6, 0, taxes.ids)],
             })
         for amount, taxes in lines_data]
 

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -214,7 +214,7 @@ class TestSaleToInvoice(TestSaleCommon):
         }
         # Let's do an invoice for a down payment of 50
         self.env['sale.advance.payment.inv'].with_context(context).create({
-            'sale_order_ids': [Command.set(sale_order.ids)],
+            'order_ids': [Command.set(sale_order.ids)],
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
         }).create_invoices()
@@ -1053,7 +1053,7 @@ class TestSaleToInvoice(TestSaleCommon):
 
         self.env['sale.advance.payment.inv'].create({
             'advance_payment_method': 'delivered',
-            'sale_order_ids': [Command.set((sale_order_1 + sale_order_2).ids)],
+            'order_ids': [Command.set((sale_order_1 + sale_order_2).ids)],
         }).create_invoices()
 
         sale_order_1.invoice_ids.action_post()
@@ -1091,7 +1091,7 @@ class TestSaleToInvoice(TestSaleCommon):
 
         self.env['sale.advance.payment.inv'].create({
             'advance_payment_method': 'delivered',
-            'sale_order_ids': [Command.set((sale_order_2).ids)],
+            'order_ids': [Command.set((sale_order_2).ids)],
         }).create_invoices()
 
         sale_order_1.invoice_ids = sale_order_2.invoice_ids

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -27,22 +27,22 @@ class TestSaleToInvoice(TestSaleCommon):
                 Command.create({
                     'product_id': cls.company_data['product_order_no'].id,
                     'product_uom_qty': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_service_delivery'].id,
                     'product_uom_qty': 4,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_service_order'].id,
                     'product_uom_qty': 3,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': cls.company_data['product_delivery_no'].id,
                     'product_uom_qty': 2,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -162,7 +162,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'order_line': [Command.create({
                 'product_id': self.company_data['product_order_no'].id,
                 'product_uom_qty': 5,
-                'tax_id': False,
+                'tax_ids': False,
             }),]
         })
         # Confirm the SO
@@ -202,7 +202,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'order_line': [Command.create({
                 'product_id': self.company_data['product_order_no'].id,
                 'product_uom_qty': 5,
-                'tax_id': False,
+                'tax_ids': False,
             }),]
         })
         # Confirm the SO
@@ -244,7 +244,7 @@ class TestSaleToInvoice(TestSaleCommon):
                 'product_id': self.company_data['product_order_no'].id,
                 'product_uom_qty': 5,
                 'price_unit': 0,
-                'tax_id': False,
+                'tax_ids': False,
             }), ]
         })
         sale_order.action_confirm()
@@ -505,7 +505,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 5,
             'order_id': sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         # Confirm the SO
@@ -545,7 +545,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'product_id': self.company_data['product_order_no'].id,
             'product_uom_qty': 5,
             'order_id': sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         # Confirm the SO
@@ -790,7 +790,7 @@ class TestSaleToInvoice(TestSaleCommon):
             'product_uom': False,
             'price_unit': 0,
             'order_id': self.sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })]
 
         # confirm quotation
@@ -942,7 +942,7 @@ class TestSaleToInvoice(TestSaleCommon):
         })
         self.assertEqual(so_1.order_line.product_uom_qty, 1)
 
-        self.assertEqual(so_1.order_line.tax_id, self.company_data['default_tax_sale'],
+        self.assertEqual(so_1.order_line.tax_ids, self.company_data['default_tax_sale'],
             'Only taxes from the right company are put by default')
         so_1.action_confirm()
         # i'm not interested in groups/acls, but in the multi-company flow only

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -309,7 +309,7 @@ class TestSaleToInvoice(TestSaleCommon):
         self.assertEqual(downpayment_line.price_unit, 100)
 
         # post the downpayment invoice and ensure the downpayment_line amount is still 100
-        downpayment_invoice = downpayment_line.order_id.order_line.invoice_lines.move_id
+        downpayment_invoice = downpayment_line.order_id.order_line.account_move_line_ids.move_id
         downpayment_invoice.action_post()
         self.assertEqual(downpayment_line.price_unit, 100)
 
@@ -469,7 +469,7 @@ class TestSaleToInvoice(TestSaleCommon):
         sale_order_data = self.sale_order.copy_data()[0]
         sale_order_data['order_line'] = [
             (0, 0, line.copy_data({
-                'invoice_lines': [(6, 0, line.invoice_lines.ids)],
+                'account_move_line_ids': [(6, 0, line.account_move_line_ids.ids)],
             })[0])
             for line in self.sale_order.order_line
         ]

--- a/addons/sale/views/account_views.xml
+++ b/addons/sale/views/account_views.xml
@@ -53,12 +53,6 @@
                     <field string="Sale Orders" name="sale_order_count" widget="statinfo"/>
                 </button>
             </xpath>
-            <xpath expr="//field[@name='invoice_line_ids']/tree" position="inside">
-                <field name="is_downpayment" column_invisible="1"/>
-            </xpath>
-            <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='product_id']" position="attributes">
-                <attribute name="readonly">is_downpayment</attribute>
-            </xpath>
         </field>
     </record>
 

--- a/addons/sale/views/sale_order_line_views.xml
+++ b/addons/sale/views/sale_order_line_views.xml
@@ -69,7 +69,7 @@
                             <field name="price_unit"/>
                             <field name="discount" groups="sale.group_discount_per_so_line"/>
                             <field name="price_subtotal" widget="monetary"/>
-                            <field name="tax_id"
+                            <field name="tax_ids"
                                 widget="many2many_tags"
                                 options="{'no_create': True}"
                                 context="{'search_view_ref': 'account.account_tax_view_search'}"

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -477,8 +477,8 @@
                                 <label for="name" string="Note" invisible="display_type != 'line_note'"/>
                                 <field name="name"/>
                                 <div name="invoice_lines" groups="base.group_no_one" invisible="display_type">
-                                    <label for="invoice_lines"/>
-                                    <field name="invoice_lines"/>
+                                    <label for="account_move_line_ids"/>
+                                    <field name="account_move_line_ids"/>
                                 </div>
                                 <field name="state" invisible="1"/>
                                 <field name="company_id" invisible="1"/>

--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -446,8 +446,8 @@
                                         <field name="product_packaging_qty" invisible="not product_id or not product_packaging_id" groups="product.group_stock_packaging"/>
                                         <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" />
                                         <field name="price_unit"/>
-                                        <field name="tax_id" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
-                                            readonly="qty_invoiced &gt; 0"/>
+                                        <field name="tax_ids" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
+                                               readonly="qty_invoiced &gt; 0"/>
                                         <t groups="sale.group_discount_per_so_line">
                                             <label for="discount"/>
                                             <div name="discount">
@@ -605,7 +605,7 @@
                                     name="price_unit"
                                     readonly="qty_invoiced &gt; 0"/>
                                 <field
-                                    name="tax_id"
+                                    name="tax_ids"
                                     widget="many2many_tags"
                                     options="{'no_create': True}"
                                     domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
@@ -639,7 +639,7 @@
                                 <field name="price_total"/>
                                 <field name="price_unit"/>
                                 <field name="display_type"/>
-                                <field name="tax_id"/>
+                                <field name="tax_ids"/>
                                 <field name="company_id"/>
                                 <field name="tax_calculation_rounding_method"/>
                                 <field name="currency_id"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -574,7 +574,7 @@
                                             </strong>
                                         </td>
                                         <td t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}" id="taxes">
-                                            <span t-out="', '.join(map(lambda x: (x.name), line.tax_id))"/>
+                                            <span t-out="', '.join(map(lambda x: (x.name), line.tax_ids))"/>
                                         </td>
                                         <td t-if="not line.is_downpayment" class="text-end" id="subtotal">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -460,7 +460,7 @@
                         <div t-field="sale_order.partner_shipping_id" t-options='{ "widget": "contact", "fields": [ "name", "address"]}'/>
                     </span>
                 </div>
-                <t t-set="invoices" t-value="sale_order.invoice_ids.filtered(lambda i: i.state not in ['draft', 'cancel']).sorted('date', reverse=True)[:3]"/>
+                <t t-set="invoices" t-value="sale_order.account_move_ids.filtered(lambda i: i.state not in ['draft', 'cancel']).sorted('date', reverse=True)[:3]"/>
                 <div id="sale_invoices" t-if="invoices and sale_order.state in ['sale', 'cancel']" class="col-12 col-lg-6 mb-4">
                     <h5 class="mb-1">Last Invoices</h5>
                     <hr class="mt-1 mb-2"/>

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -30,9 +30,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
     def _get_product_account_internal_group(self):
         return 'income'
 
-    def _taxes_field_name(self):
-        return 'tax_id'
-
     def _create_down_payment_invoice(self):
         invoice = super()._create_down_payment_invoice()
         poster = self.env.user._is_internal() and self.env.user.id or SUPERUSER_ID

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -1,342 +1,48 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models, SUPERUSER_ID
-from odoo.exceptions import UserError
-from odoo.fields import Command
-from odoo.tools import format_date, frozendict
+from odoo import _, fields, models, SUPERUSER_ID
 
 
 class SaleAdvancePaymentInv(models.TransientModel):
     _name = 'sale.advance.payment.inv'
     _description = "Sales Advance Payment Invoice"
+    _inherit = ['account.advance.payment.wizard']
 
-    advance_payment_method = fields.Selection(
-        selection=[
-            ('delivered', "Regular invoice"),
-            ('percentage', "Down payment (percentage)"),
-            ('fixed', "Down payment (fixed amount)"),
-        ],
-        string="Create Invoice",
-        default='delivered',
-        required=True,
-        help="A standard invoice is issued with all the order lines ready for invoicing,"
-            "according to their invoicing policy (based on ordered or delivered quantity).")
-    count = fields.Integer(string="Order Count", compute='_compute_count')
-    sale_order_ids = fields.Many2many(
-        'sale.order', default=lambda self: self.env.context.get('active_ids'))
+    amount_to_invoice = fields.Monetary(help="The amount to invoice = Sale Order Total - Amount already invoiced.")
+    order_ids = fields.Many2many('sale.order')
 
-    # Down Payment logic
-    has_down_payments = fields.Boolean(
-        string="Has down payments", compute="_compute_has_down_payments")
-    deduct_down_payments = fields.Boolean(string="Deduct down payments", default=True)
-
-    # New Down Payment
-    amount = fields.Float(
-        string="Down Payment",
-        help="The percentage of amount to be invoiced in advance.")
-    fixed_amount = fields.Monetary(
-        string="Down Payment Amount (Fixed)",
-        help="The fixed amount to be invoiced in advance.")
-    currency_id = fields.Many2one(
-        comodel_name='res.currency',
-        compute='_compute_currency_id',
-        store=True)
-    company_id = fields.Many2one(
-        comodel_name='res.company',
-        compute='_compute_company_id',
-        store=True)
-    amount_invoiced = fields.Monetary(
-        string="Already invoiced",
-        compute="_compute_invoice_amounts",
-        help="Only confirmed down payments are considered.")
-    amount_to_invoice = fields.Monetary(
-        string="Amount to invoice",
-        compute="_compute_invoice_amounts",
-        help="The amount to invoice = Sale Order Total - Confirmed Down Payments.")
-
-    # UI
-    display_draft_invoice_warning = fields.Boolean(compute="_compute_display_draft_invoice_warning")
-    display_invoice_amount_warning = fields.Boolean(compute="_compute_display_invoice_amount_warning")
     consolidated_billing = fields.Boolean(
         string="Consolidated Billing", default=True,
-        help="Create one invoice for all orders related to same customer and same invoicing address"
+        help="Create one invoice for all orders related to same customer and same invoicing address",
     )
 
-    #=== COMPUTE METHODS ===#
-
-    @api.depends('sale_order_ids')
-    def _compute_count(self):
-        for wizard in self:
-            wizard.count = len(wizard.sale_order_ids)
-
-    @api.depends('sale_order_ids')
-    def _compute_has_down_payments(self):
-        for wizard in self:
-            wizard.has_down_payments = bool(
-                wizard.sale_order_ids.order_line.filtered('is_downpayment')
-            )
-
-    # next computed fields are only used for down payments invoices and therefore should only
-    # have a value when 1 unique SO is invoiced through the wizard
-    @api.depends('sale_order_ids')
-    def _compute_currency_id(self):
-        self.currency_id = False
-        for wizard in self:
-            if wizard.count == 1:
-                wizard.currency_id = wizard.sale_order_ids.currency_id
-
-    @api.depends('sale_order_ids')
-    def _compute_company_id(self):
-        self.company_id = False
-        for wizard in self:
-            if wizard.count == 1:
-                wizard.company_id = wizard.sale_order_ids.company_id
-
-    @api.depends('amount', 'fixed_amount', 'advance_payment_method', 'amount_to_invoice')
-    def _compute_display_invoice_amount_warning(self):
-        for wizard in self:
-            invoice_amount = wizard.fixed_amount
-            if wizard.advance_payment_method == 'percentage':
-                invoice_amount = wizard.amount / 100 * sum(wizard.sale_order_ids.mapped('amount_total'))
-            wizard.display_invoice_amount_warning = invoice_amount > wizard.amount_to_invoice
-
-    @api.depends('sale_order_ids')
-    def _compute_display_draft_invoice_warning(self):
-        for wizard in self:
-            wizard.display_draft_invoice_warning = wizard.sale_order_ids.invoice_ids.filtered(lambda invoice: invoice.state == 'draft')
-
-    @api.depends('sale_order_ids')
-    def _compute_invoice_amounts(self):
-        for wizard in self:
-            wizard.amount_invoiced = sum(wizard.sale_order_ids._origin.mapped('amount_invoiced'))
-            wizard.amount_to_invoice = sum(wizard.sale_order_ids._origin.mapped('amount_to_invoice'))
-
-    #=== ONCHANGE METHODS ===#
-
-    @api.onchange('advance_payment_method')
-    def _onchange_advance_payment_method(self):
-        if self.advance_payment_method == 'percentage':
-            amount = self.default_get(['amount']).get('amount')
-            return {'value': {'amount': amount}}
-
-    #=== CONSTRAINT METHODS ===#
-
-    def _check_amount_is_positive(self):
-        for wizard in self:
-            if wizard.advance_payment_method == 'percentage' and wizard.amount <= 0.00:
-                raise UserError(_('The value of the down payment amount must be positive.'))
-            elif wizard.advance_payment_method == 'fixed' and wizard.fixed_amount <= 0.00:
-                raise UserError(_('The value of the down payment amount must be positive.'))
-
-    #=== ACTION METHODS ===#
-
-    def create_invoices(self):
-        self._check_amount_is_positive()
-        invoices = self._create_invoices(self.sale_order_ids)
-        return self.sale_order_ids.action_view_invoice(invoices=invoices)
-
     def view_draft_invoices(self):
-        return {
-            'name': _('Draft Invoices'),
-            'type': 'ir.actions.act_window',
-            'view_mode': 'tree',
-            'views': [(False, 'list'), (False, 'form')],
-            'res_model': 'account.move',
-            'domain': [('line_ids.sale_line_ids.order_id', 'in', self.sale_order_ids.ids), ('state', '=', 'draft')],
-        }
+        res = super().view_draft_invoices()
+        res['domain'].append(('line_ids.sale_line_ids.order_id', 'in', self.order_ids.ids))
+        return res
 
-    #=== BUSINESS METHODS ===#
+    def _needs_to_group_on_invoice(self):
+        return not self.consolidated_billing
 
-    def _create_invoices(self, sale_orders):
-        self.ensure_one()
-        if self.advance_payment_method == 'delivered':
-            return sale_orders._create_invoices(final=self.deduct_down_payments, grouped=not self.consolidated_billing)
-        else:
-            self.sale_order_ids.ensure_one()
-            self = self.with_company(self.company_id)
-            order = self.sale_order_ids
+    def _get_payment_term_account_type(self):
+        return 'asset_receivable'
 
-            # Create down payment section if necessary
-            SaleOrderline = self.env['sale.order.line'].with_context(sale_no_log_for_new_lines=True)
-            if not any(line.display_type and line.is_downpayment for line in order.order_line):
-                SaleOrderline.create(
-                    self._prepare_down_payment_section_values(order)
-                )
+    def _get_product_account_internal_group(self):
+        return 'income'
 
-            values, accounts = self._prepare_down_payment_lines_values(order)
-            down_payment_lines = SaleOrderline.create(values)
+    def _taxes_field_name(self):
+        return 'tax_id'
 
-            invoice = self.env['account.move'].sudo().create(
-                self._prepare_invoice_values(order, down_payment_lines, accounts)
-            )
-
-            # Ensure the invoice total is exactly the expected fixed amount.
-            if self.advance_payment_method == 'fixed':
-                delta_amount = (invoice.amount_total - self.fixed_amount) * (1 if invoice.is_inbound() else -1)
-                if not order.currency_id.is_zero(delta_amount):
-                    receivable_line = invoice.line_ids\
-                        .filtered(lambda aml: aml.account_id.account_type == 'asset_receivable')[:1]
-                    product_lines = invoice.line_ids\
-                        .filtered(lambda aml: aml.display_type == 'product')
-                    tax_lines = invoice.line_ids\
-                        .filtered(lambda aml: aml.tax_line_id.amount_type not in (False, 'fixed'))
-
-                    if product_lines and tax_lines and receivable_line:
-                        line_commands = [Command.update(receivable_line.id, {
-                            'amount_currency': receivable_line.amount_currency + delta_amount,
-                        })]
-                        delta_sign = 1 if delta_amount > 0 else -1
-                        for lines, attr, sign in (
-                            (product_lines, 'price_total', -1),
-                            (tax_lines, 'amount_currency', 1),
-                        ):
-                            remaining = delta_amount
-                            lines_len = len(lines)
-                            for line in lines:
-                                if order.currency_id.compare_amounts(remaining, 0) != delta_sign:
-                                    break
-                                amt = delta_sign * max(
-                                    order.currency_id.rounding,
-                                    abs(order.currency_id.round(remaining / lines_len)),
-                                )
-                                remaining -= amt
-                                line_commands.append(Command.update(line.id, {attr: line[attr] + amt * sign}))
-                        invoice.line_ids = line_commands
-
-            # Unsudo the invoice after creation if not already sudoed
-            invoice = invoice.sudo(self.env.su)
-
-            poster = self.env.user._is_internal() and self.env.user.id or SUPERUSER_ID
-            invoice.with_user(poster).message_post_with_source(
-                'mail.message_origin_link',
-                render_values={'self': invoice, 'origin': order},
-                subtype_xmlid='mail.mt_note',
-            )
-
-            title = _("Down payment invoice")
-            order.with_user(poster).message_post(
-                body=_("%s has been created", invoice._get_html_link(title=title)),
-            )
-
-            return invoice
-
-    def _prepare_down_payment_section_values(self, order):
-        return {
-            'product_uom_qty': 0.0,
-            'order_id': order.id,
-            'display_type': 'line_section',
-            'is_downpayment': True,
-            'sequence': order.order_line and order.order_line[-1].sequence + 1 or 10,
-        }
-
-    def _prepare_down_payment_lines_values(self, order):
-        """ Create one down payment line per tax or unique taxes combination and per account.
-            Apply the tax(es) to their respective lines.
-
-            :param order: Order for which the down payment lines are created.
-            :return:      An array of dicts with the down payment lines values.
-        """
-        self.ensure_one()
-
-        if self.advance_payment_method == 'percentage':
-            ratio = self.amount / 100
-        else:
-            ratio = self.fixed_amount / order.amount_total if order.amount_total else 1
-
-        order_lines = order.order_line.filtered(lambda l: not l.display_type and not l.is_downpayment)
-        base_downpayment_lines_values = self._prepare_base_downpayment_line_values(order)
-
-        tax_base_line_dicts = [
-            line._convert_to_tax_base_line_dict(
-                analytic_distribution=line.analytic_distribution,
-                handle_price_include=False
-            )
-            for line in order_lines
-        ]
-        computed_taxes = self.env['account.tax']._compute_taxes(tax_base_line_dicts, self.company_id)
-        down_payment_values = []
-        for line, tax_repartition in computed_taxes['base_lines_to_update']:
-            account = line['product'].product_tmpl_id.get_product_accounts(
-                fiscal_pos=order.fiscal_position_id
-            ).get('income')
-            taxes = line['taxes'].flatten_taxes_hierarchy()
-            fixed_taxes = taxes.filtered(lambda tax: tax.amount_type == 'fixed')
-            down_payment_values.append([
-                taxes - fixed_taxes,
-                line['analytic_distribution'],
-                tax_repartition['price_subtotal'],
-                account,
-            ])
-            for fixed_tax in fixed_taxes:
-                # Fixed taxes cannot be set as taxes on down payments as they always amounts to 100%
-                # of the tax amount. Therefore fixed taxes are removed and are replace by a new line
-                # with appropriate amount, and non fixed taxes if the fixed tax affected the base of
-                # any other non fixed tax.
-                if fixed_tax.price_include:
-                    continue
-
-                if fixed_tax.include_base_amount:
-                    pct_tax = taxes[list(taxes).index(fixed_tax) + 1:]\
-                        .filtered(lambda t: t.is_base_affected and t.amount_type != 'fixed')
-                else:
-                    pct_tax = self.env['account.tax']
-                down_payment_values.append([
-                    pct_tax,
-                    line['analytic_distribution'],
-                    line['quantity'] * fixed_tax.amount,
-                    account
-                ])
-
-        downpayment_line_map = {}
-        for tax_id, analytic_distribution, price_subtotal, account in down_payment_values:
-            grouping_key = frozendict({
-                'tax_id': tuple(sorted(tax_id.ids)),
-                'analytic_distribution': analytic_distribution,
-                'account_id': account,
-            })
-            downpayment_line_map.setdefault(grouping_key, {
-                **base_downpayment_lines_values,
-                'tax_id': grouping_key['tax_id'],
-                'analytic_distribution': grouping_key['analytic_distribution'],
-                'product_uom_qty': 0.0,
-                'price_unit': 0.0,
-            })
-            downpayment_line_map[grouping_key]['price_unit'] += price_subtotal
-        for key in downpayment_line_map:
-            downpayment_line_map[key]['price_unit'] = \
-                order.currency_id.round(downpayment_line_map[key]['price_unit'] * ratio)
-
-        return list(downpayment_line_map.values()), [key['account_id'] for key in downpayment_line_map]
-
-    def _prepare_base_downpayment_line_values(self, order):
-        self.ensure_one()
-        return {
-            'product_uom_qty': 0.0,
-            'order_id': order.id,
-            'discount': 0.0,
-            'is_downpayment': True,
-            'sequence': order.order_line and order.order_line[-1].sequence + 1 or 10,
-        }
-
-    def _prepare_invoice_values(self, order, so_lines, accounts):
-        self.ensure_one()
-        return {
-            **order._prepare_invoice(),
-            'invoice_line_ids': [Command.create(
-                line._prepare_invoice_line(
-                    name=self._get_down_payment_description(order),
-                    quantity=1.0,
-                    **({'account_id': account.id} if account else {}),
-                )
-            ) for line, account in zip(so_lines, accounts)],
-        }
-
-    def _get_down_payment_description(self, order):
-        self.ensure_one()
-        context = {'lang': order.partner_id.lang}
-        if self.advance_payment_method == 'percentage':
-            name = _("Down payment of %s%%", self.amount)
-        else:
-            name = _('Down Payment')
-        del context
-        return name
+    def _create_down_payment_invoice(self):
+        invoice = super()._create_down_payment_invoice()
+        poster = self.env.user._is_internal() and self.env.user.id or SUPERUSER_ID
+        invoice.with_user(poster).message_post_with_source(
+            'mail.message_origin_link',
+            render_values={'self': invoice, 'origin': self.order_ids},
+            subtype_xmlid='mail.mt_note',
+        )
+        title = _("Down payment invoice")
+        self.order_ids.with_user(poster).message_post(
+            body=_("%s has been created", invoice._get_html_link(title=title)),
+        )
+        return invoice

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -2,62 +2,24 @@
 <odoo>
 
     <record id="view_sale_advance_payment_inv" model="ir.ui.view">
-        <field name="name">Invoice Orders</field>
+        <field name="inherit_id" ref="account.view_account_advance_payment"/>
+        <field name="mode">primary</field>
         <field name="model">sale.advance.payment.inv</field>
+        <field name="name">Invoice Orders</field>
         <field name="arch" type="xml">
-            <form string="Invoice Sales Order">
-                <field name="display_draft_invoice_warning" invisible="1"/>
-                <field name="has_down_payments" invisible="1"/>
-                <div class="alert alert-warning pb-1" role="alert" invisible="not display_draft_invoice_warning">
-                    <p>There are existing <a name="view_draft_invoices" type="object">Draft Invoices</a> for this Sale Order.</p>
-                    <p invisible="advance_payment_method != 'delivered'">
-                        The new invoice will deduct draft invoices linked to this sale order.
-                    </p>
-                </div>
-                <group>
-                    <field name="sale_order_ids" invisible="1"/>
-                    <field name="count" invisible="count == 1"/>
-                    <field name="consolidated_billing" invisible="count == 1"/>
-                    <field name="advance_payment_method" class="oe_inline"
-                        widget="radio"
-                        invisible="count &gt; 1"/>
-                </group>
-                <group name="down_payment_specification"
-                    invisible="advance_payment_method not in ('fixed', 'percentage')">
-                    <field name="company_id" invisible="1"/>
-                    <label for="amount"/>
-                    <div id="payment_method_details">
-                        <field name="currency_id" invisible="1"/>
-                        <field name="display_invoice_amount_warning" invisible="1"/>
-                        <field name="fixed_amount"
-                            invisible="advance_payment_method != 'fixed'"
-                            required="advance_payment_method == 'fixed'"
-                            class="oe_inline"/>
-                        <field name="amount"
-                            invisible="advance_payment_method != 'percentage'"
-                            required="advance_payment_method == 'percentage'"
-                            class="oe_inline"/>
-                        <span invisible="advance_payment_method != 'percentage'"
-                            class="oe_inline">% </span>
-                        <span invisible="not display_invoice_amount_warning"
-                              class="oe_inline text-danger"
-                              title="The Down Payment is greater than the amount remaining to be invoiced.">
-                            <i class="fa fa-warning"/>
-                        </span>
-                    </div>
-                </group>
-                <group invisible="not has_down_payments">
-                    <field name="amount_invoiced"/>
-                    <field name="amount_to_invoice"/>
-                </group>
-                <footer>
-                    <button name="create_invoices" type="object"
-                        id="create_invoice_open"
-                        string="Create Draft"
-                        class="btn-primary" data-hotkey="q"/>
-                    <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
-                </footer>
+            <form position="attributes">
+                <attribute name="string">Invoice Sales Order</attribute>
             </form>
+            <a name="view_draft_invoices" position="inside">There are existing Draft Invoices for this Sale Order.</a>
+            <p name="deduct_draft" position="inside">
+                The new invoice will deduct draft invoices linked to this sale order.
+            </p>
+            <field name="count" position="after">
+                <field name="consolidated_billing" invisible="count == 1"/>
+            </field>
+            <span name="amount_warning" position="attributes">
+                <attribute name="title">The Down Payment is greater than the amount remaining to be invoiced.</attribute>
+            </span>
         </field>
     </record>
 
@@ -65,6 +27,7 @@
         <field name="name">Create invoice(s)</field>
         <field name="res_model">sale.advance.payment.inv</field>
         <field name="view_mode">form</field>
+        <field name="view_id" ref="sale.view_sale_advance_payment_inv"/>
         <field name="target">new</field>
         <field name="binding_model_id" ref="sale.model_sale_order"/>
         <field name="binding_view_types">list</field>

--- a/addons/sale/wizard/sale_order_cancel.py
+++ b/addons/sale/wizard/sale_order_cancel.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo import api, fields, models
 
 
 class SaleOrderCancel(models.TransientModel):
@@ -47,7 +46,7 @@ class SaleOrderCancel(models.TransientModel):
     def _compute_display_invoice_alert(self):
         for wizard in self:
             wizard.display_invoice_alert = bool(
-                wizard.order_id.invoice_ids.filtered(lambda inv: inv.state == 'draft')
+                wizard.order_id.account_move_ids.filtered(lambda inv: inv.state == 'draft')
             )
 
     @api.depends('order_id')

--- a/addons/sale/wizard/sale_order_discount.py
+++ b/addons/sale/wizard/sale_order_discount.py
@@ -55,7 +55,7 @@ class SaleOrderDiscount(models.TransientModel):
             'product_id': product.id,
             'sequence': 999,
             'price_unit': -amount,
-            'tax_id': [Command.set(taxes.ids)],
+            'tax_ids': [Command.set(taxes.ids)],
         }
         if description:
             # If not given, name will fallback on the standard SOL logic (cf. _compute_name)
@@ -93,7 +93,7 @@ class SaleOrderDiscount(models.TransientModel):
                 if not line.product_uom_qty or not line.price_unit:
                     continue
 
-                total_price_per_tax_groups[line.tax_id] += line.price_subtotal
+                total_price_per_tax_groups[line.tax_ids] += line.price_subtotal
 
             if not total_price_per_tax_groups:
                 # No valid lines on which the discount can be applied

--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -37,8 +37,8 @@ class SaleOrderLine(models.Model):
             line = line.with_company(line.company_id)
             fpos = line.order_id.fiscal_position_id or line.order_id.fiscal_position_id._get_fiscal_position(line.order_partner_id)
             # If company_id is set, always filter taxes by the company
-            taxes = line.tax_id.filtered(lambda r: not line.company_id or r.company_id == line.company_id)
-            line.tax_id = fpos.map_tax(taxes)
+            taxes = line.tax_ids.filtered(lambda r: not line.company_id or r.company_id == line.company_id)
+            line.tax_ids = fpos.map_tax(taxes)
 
     def _get_display_price(self):
         # A product created from a promotion does not have a list_price.

--- a/addons/sale_loyalty/tests/test_loyalty.py
+++ b/addons/sale_loyalty/tests/test_loyalty.py
@@ -350,7 +350,7 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -397,7 +397,7 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -438,11 +438,11 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': self.product_B.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -491,11 +491,11 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 Command.create({
                     'product_id': self.product_B.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -522,7 +522,7 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })
@@ -570,7 +570,7 @@ class TestLoyalty(TestSaleCouponCommon):
             'order_line': [
                 Command.create({
                     'product_id': self.product_A.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
             ]
         })

--- a/addons/sale_loyalty/tests/test_pay_with_gift_card.py
+++ b/addons/sale_loyalty/tests/test_pay_with_gift_card.py
@@ -205,8 +205,8 @@ class TestPayWithGiftCard(TestSaleCouponCommon):
         gift_card_line = order.order_line - sol
         self.assertAlmostEqual(gift_card_line.price_total, -100.0)
         self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
-        self.assertTrue(all(line.tax_id for line in order.order_line))
-        self.assertEqual(order.order_line.tax_id, self.tax_15pc_excl)
+        self.assertTrue(all(line.tax_ids for line in order.order_line))
+        self.assertEqual(order.order_line.tax_ids, self.tax_15pc_excl)
 
         # TAX INCL
         gift_card_line.unlink()  # Remove gift card
@@ -217,8 +217,8 @@ class TestPayWithGiftCard(TestSaleCouponCommon):
         gift_card_line = order.order_line - sol
         self.assertAlmostEqual(gift_card_line.price_total, -100.0)
         self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
-        self.assertTrue(all(line.tax_id for line in order.order_line))
-        self.assertEqual(gift_card_line.tax_id, self.tax_10pc_incl)
+        self.assertTrue(all(line.tax_ids for line in order.order_line))
+        self.assertEqual(gift_card_line.tax_ids, self.tax_10pc_incl)
 
         # TAX INCL + TAX EXCL
         gift_card_line.unlink()  # Remove gift card
@@ -229,5 +229,5 @@ class TestPayWithGiftCard(TestSaleCouponCommon):
         gift_card_line = order.order_line - sol
         self.assertAlmostEqual(gift_card_line.price_total, -100.0)
         self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
-        self.assertTrue(all(line.tax_id for line in order.order_line))
-        self.assertEqual(gift_card_line.tax_id, self.tax_10pc_incl + self.tax_15pc_excl)
+        self.assertTrue(all(line.tax_ids for line in order.order_line))
+        self.assertEqual(gift_card_line.tax_ids, self.tax_10pc_incl + self.tax_15pc_excl)

--- a/addons/sale_loyalty/tests/test_program_numbers.py
+++ b/addons/sale_loyalty/tests/test_program_numbers.py
@@ -126,7 +126,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
 
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line.ids), 1, "We should not get the reduction line since we dont have 320$ tax excluded (cabinet is 320$ tax included)")
-        sol1.tax_id.price_include = False
+        sol1.tax_ids.price_include = False
         sol1._compute_tax_id()
         self.env.flush_all()
         self.env['account.tax'].invalidate_model(['price_include'])
@@ -533,7 +533,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'name': 'Drawer Black',
             'product_uom_qty': 1.0,
             'order_id': order.id,
-            'tax_id': [(4, self.tax_0pc_excl.id)]
+            'tax_ids': [(4, self.tax_0pc_excl.id)]
         })
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 0, "Total should be null. The fixed amount discount is higher than the SO total, it should be reduced to the SO total")
@@ -698,7 +698,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, (self.tax_15pc_excl.id,))],
+            'tax_ids': [(6, 0, (self.tax_15pc_excl.id,))],
         },
         {
             'product_id': self.pedalBin.id,
@@ -706,7 +706,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, [])],
+            'tax_ids': [(6, 0, [])],
         },
         {
             'product_id': self.product_A.id,
@@ -714,7 +714,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, [])],
+            'tax_ids': [(6, 0, [])],
         },
         ])
 
@@ -785,7 +785,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, (self.tax_10pc_incl.id,))],
+            'tax_ids': [(6, 0, (self.tax_10pc_incl.id,))],
         },
         {
             'product_id': self.pedalBin.id,
@@ -793,7 +793,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, [])],
+            'tax_ids': [(6, 0, [])],
         },
         {
             'product_id': self.product_A.id,
@@ -801,7 +801,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'price_unit': 100.0,
             'order_id': order.id,
-            'tax_id': [(6, 0, [])],
+            'tax_ids': [(6, 0, [])],
         },
         ])
 
@@ -911,7 +911,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'amount': 30,
             'price_include': True,
         })
-        sol2.tax_id = percent_tax
+        sol2.tax_ids = percent_tax
 
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(len(order.order_line.ids), 4, "Conference Chair + Drawer Black + 20% on no TVA product (Conference Chair) + 20% on 15% tva product (Drawer Black)")
@@ -1066,7 +1066,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 14.0,
             'price_unit': 118.0,
             'order_id': order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         self._auto_rewards(order, self.all_programs)
         self.assertEqual(order.amount_total, 1486.80, "10% discount should be applied")
@@ -1489,26 +1489,26 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertEqual(order.amount_total, 5, 'Price should be 10$ - 5$(discount) = 5$')
         self.assertEqual(order.amount_tax, 0, 'No taxes are applied yet')
 
-        sol.tax_id = self.tax_10pc_base_incl
+        sol.tax_ids = self.tax_10pc_base_incl
         self._auto_rewards(order, program)
 
         self.assertEqual(order.amount_total, 5, 'Price should be 10$ - 5$(discount) = 5$')
         self.assertEqual(float_compare(order.amount_tax, 5 / 11, precision_rounding=3), 0, '10% Tax included in 5$')
 
-        sol.tax_id = self.tax_10pc_excl
+        sol.tax_ids = self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         # Value is 5.99 instead of 6 because you cannot have 6 with 10% tax excluded and a precision rounding of 2
         self.assertAlmostEqual(order.amount_total, 6, 1, msg='Price should be 11$ - 5$(discount) = 6$')
         self.assertEqual(float_compare(order.amount_tax, 6 / 11, precision_rounding=3), 0, '10% Tax included in 6$')
 
-        sol.tax_id = self.tax_20pc_excl
+        sol.tax_ids = self.tax_20pc_excl
         self._auto_rewards(order, program)
 
         self.assertEqual(order.amount_total, 7, 'Price should be 12$ - 5$(discount) = 7$')
         self.assertEqual(float_compare(order.amount_tax, 7 / 12, precision_rounding=3), 0, '20% Tax included on 7$')
 
-        sol.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
+        sol.tax_ids = self.tax_10pc_base_incl + self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 6, 1, msg='Price should be 11$ - 5$(discount) = 6$')
@@ -1551,21 +1551,21 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self.assertAlmostEqual(order.amount_total, 15, 1, msg='Price should be 20$ - 5$(discount) = 15$')
         self.assertEqual(order.amount_tax, 0, 'No taxes are applied yet')
 
-        sol1.tax_id = self.tax_10pc_base_incl
+        sol1.tax_ids = self.tax_10pc_base_incl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 15, 1, msg='Price should be 20$ - 5$(discount) = 15$')
         self.assertEqual(float_compare(order.amount_tax, 5 / 11 + 0, precision_rounding=3), 0,
                          '10% Tax included in 5$ in sol1 (highest cost) and 0 in sol2')
 
-        sol2.tax_id = self.tax_10pc_excl
+        sol2.tax_ids = self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 16, 1, msg='Price should be 21$ - 5$(discount) = 16$')
         # Tax amount = 10% in 10$ + 10% in 11$ - 10% in 5$ (apply on excluded)
         self.assertEqual(float_compare(order.amount_tax, 5 / 11, precision_rounding=3), 0)
 
-        sol2.tax_id = self.tax_10pc_base_incl + self.tax_10pc_excl
+        sol2.tax_ids = self.tax_10pc_base_incl + self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 16, 1, msg='Price should be 21$ - 5$(discount) = 16$')
@@ -1581,7 +1581,7 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
             'product_uom_qty': 1.0,
             'order_id': order.id,
         })
-        sol3.tax_id = self.tax_10pc_excl
+        sol3.tax_ids = self.tax_10pc_excl
         self._auto_rewards(order, program)
 
         self.assertAlmostEqual(order.amount_total, 27, 1, msg='Price should be 32$ - 5$(discount) = 27$')
@@ -1815,6 +1815,6 @@ class TestSaleCouponProgramNumbers(TestSaleCouponNumbersCommon):
         self._auto_rewards(order, loyalty_program)
 
         self.assertEqual(len(order.order_line), 2, 'Promotion should add 1 line')
-        self.assertEqual(order.order_line[0].tax_id, tax_15pc_excl)
-        self.assertEqual(order.order_line[1].tax_id, tax_15pc_excl)
+        self.assertEqual(order.order_line[0].tax_ids, tax_15pc_excl)
+        self.assertEqual(order.order_line[1].tax_ids, tax_15pc_excl)
         self.assertEqual(order.amount_total, 156.0, '140$ + 15% - 5$ = 156$')

--- a/addons/sale_loyalty/views/sale_order_views.xml
+++ b/addons/sale_loyalty/views/sale_order_views.xml
@@ -27,7 +27,7 @@
             <xpath expr="//tree//field[@name='price_unit']" position="attributes">
                 <attribute name="readonly" add="is_reward_line" separator=" or "/>
             </xpath>
-            <xpath expr="//tree//field[@name='tax_id']" position="attributes">
+            <xpath expr="//tree//field[@name='tax_ids']" position="attributes">
                 <attribute name="readonly" add="is_reward_line" separator=" or "/>
             </xpath>
         </field>

--- a/addons/sale_loyalty_delivery/models/sale_order.py
+++ b/addons/sale_loyalty_delivery/models/sale_order.py
@@ -47,7 +47,7 @@ class SaleOrder(models.Model):
             'order_id': self.id,
             'is_reward_line': True,
             'sequence': max(self.order_line.filtered(lambda x: not x.is_reward_line).mapped('sequence'), default=0) + 1,
-            'tax_id': [(Command.CLEAR, 0, 0)] + [(Command.LINK, tax.id, False) for tax in taxes],
+            'tax_ids': [(Command.CLEAR, 0, 0)] + [(Command.LINK, tax.id, False) for tax in taxes],
         }]
 
     def _get_reward_line_values(self, reward, coupon, **kwargs):

--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -19,7 +19,7 @@ class AccountMoveLine(models.Model):
                 bom = boms[0]
                 is_line_reversing = self.move_id.move_type == 'out_refund'
                 qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
-                account_moves = so_line.invoice_lines.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
+                account_moves = so_line.account_move_line_ids.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
                 posted_invoice_lines = account_moves.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
                 qty_invoiced = sum([x.product_uom_id._compute_quantity(x.quantity, x.product_id.uom_id) for x in posted_invoice_lines])
                 reversal_cogs = posted_invoice_lines.move_id.reversal_move_id.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -91,7 +91,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1.0,
                     'product_uom': self.kit_a.uom_id.id,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -254,7 +254,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 3.0,
                     'product_uom': kit.uom_id.id,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -358,7 +358,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 3.0,
                     'product_uom': kit.uom_id.id,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -451,7 +451,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1.0,
                     'product_uom': kit.uom_id.id,
                     'price_unit': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -504,7 +504,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 2.0,
                     'product_uom': kit.uom_id.id,
                     'price_unit': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -192,7 +192,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
             pick.button_validate()
             # Create the invoice
             so._create_invoices()
-            invoice = so.invoice_ids
+            invoice = so.account_move_ids
             invoice.action_post()
             return invoice
 
@@ -404,7 +404,7 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
         create_invoice_wizard = self.env['sale.advance.payment.inv'].with_context(ctx).create(
             {'advance_payment_method': 'delivered'})
         create_invoice_wizard.create_invoices()
-        reverse_invoice = so.invoice_ids[-1]
+        reverse_invoice = so.account_move_ids[-1]
         with Form(reverse_invoice) as reverse_invoice_form:
             with reverse_invoice_form.invoice_line_ids.edit(0) as line:
                 line.quantity = 1

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -5,7 +5,6 @@ from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_c
 from odoo.tests import common, Form
 from odoo.exceptions import UserError
 from odoo.tools import mute_logger, float_compare
-from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 
 
 # these tests create accounting entries, and therefore need a chart of accounts
@@ -667,7 +666,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         pick.button_validate()
         # Create the invoice
         self.so._create_invoices()
-        self.invoice = self.so.invoice_ids
+        self.invoice = self.so.account_move_ids
         # Changed the invoiced quantity of the finished product to 2
         move_form = Form(self.invoice)
         with move_form.invoice_line_ids.edit(0) as line_form:
@@ -1762,7 +1761,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         p2_bom.type = "normal"
 
         so._create_invoices()
-        invoice = so.invoice_ids
+        invoice = so.account_move_ids
         invoice.action_post()
         self.assertEqual(invoice.state, 'posted')
 
@@ -1894,7 +1893,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         # Create the invoice
         so._create_invoices()
         # Validate the invoice
-        invoice = so.invoice_ids
+        invoice = so.account_move_ids
         invoice.action_post()
 
         amls = invoice.line_ids
@@ -2038,7 +2037,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
         # Create the invoice
         so._create_invoices()
         # Validate the invoice
-        invoice = so.invoice_ids
+        invoice = so.account_move_ids
         invoice.action_post()
 
         amls = invoice.line_ids

--- a/addons/sale_mrp/tests/test_sale_mrp_flow.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_flow.py
@@ -2328,7 +2328,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
                     'product_uom_qty': 1.0,
                     'product_uom': kit.uom_id.id,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -2394,7 +2394,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
                     'product_uom_qty': 1.0,
                     'product_uom': kit.uom_id.id,
                     'price_unit': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -2417,7 +2417,7 @@ class TestSaleMrpFlow(TestSaleMrpFlowCommon):
                     'product_uom_qty': 1.0,
                     'product_uom': self.kit_1.uom_id.id,
                     'price_unit': 5,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         self.bom_kit_1.toggle_active()

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -175,7 +175,7 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_uom_qty': 10.0,
                     'product_uom': self.kit.uom_id.id,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -240,7 +240,7 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_uom_qty': 1.0,
                     'product_uom': self.kitA.uom_id.id,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -294,7 +294,7 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_uom_qty': 1.0,
                     'product_uom': kitA.uom_id.id,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })]
         })
         so.action_confirm()
@@ -369,7 +369,7 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_uom_qty': 1.0,
                     'product_uom': kitAB.uom_id.id,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 }),
                 (0, 0, {
                     'name': kitABC.name,
@@ -377,7 +377,7 @@ class TestSaleMrpKitBom(TransactionCase):
                     'product_uom_qty': 1.0,
                     'product_uom': kitABC.uom_id.id,
                     'price_unit': 1,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()

--- a/addons/sale_pdf_quote_builder/data/ir_config_parameters.xml
+++ b/addons/sale_pdf_quote_builder/data/ir_config_parameters.xml
@@ -28,7 +28,7 @@
                 "quantity": "product_uom_qty",
                 "tax_excl_price": "price_subtotal",
                 "tax_incl_price": "price_total",
-                "taxes": "tax_id",
+                "taxes": "tax_ids",
                 "uom": "product_uom.name",
                 "user_id__name": "salesman_id.name",
                 "validity_date": "order_id.validity_date"

--- a/addons/sale_project/controllers/portal.py
+++ b/addons/sale_project/controllers/portal.py
@@ -33,6 +33,6 @@ class SaleProjectCustomerPortal(ProjectCustomerPortal):
         if search_in == 'sale_order':
             return ['|', ('sale_order_id.name', 'ilike', search), ('sale_line_id.name', 'ilike', search)]
         elif search_in == 'invoice':
-            return [('sale_order_id.invoice_ids.name', 'ilike', search)]
+            return [('sale_order_id.account_move_ids.name', 'ilike', search)]
         else:
             return super()._task_get_search_domain(search_in, search, milestones_allowed, project)

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -644,7 +644,7 @@ class ProjectProject(models.Model):
             ['id:recordset'],
         )[0][0]
         revenue_items_from_invoices = self._get_revenues_items_from_invoices(
-            excluded_move_line_ids=sale_lines.invoice_lines.ids,
+            excluded_move_line_ids=sale_lines.account_move_line_ids.ids,
             with_action=with_action
         )
         profitability_items['revenues']['data'] += revenue_items_from_invoices['data']

--- a/addons/sale_project/tests/test_project_profitability.py
+++ b/addons/sale_project/tests/test_project_profitability.py
@@ -599,7 +599,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
         # Therefore, the amount of the dp is higher than the amount of the sol created.
         down_payment_invoiced = 100.00
         downpayment.create_invoices()
-        self.sale_order.invoice_ids[2].action_post()
+        self.sale_order.account_move_ids[2].action_post()
         # Ensures the down payment is correctly computed for the project profitability.
         self._assert_dict_equal(invoice_type, sequence_per_invoice_type, material_order_line, service_sols, manual_service_order_line, down_payment_invoiced)
 
@@ -610,7 +610,7 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
         })
         down_payment_invoiced = 2 * down_payment_invoiced
         downpayment.create_invoices()
-        self.sale_order.invoice_ids[3].action_post()
+        self.sale_order.account_move_ids[3].action_post()
         # Ensures the 2 down payments are correctly computed for the project profitability.
         self._assert_dict_equal(invoice_type, sequence_per_invoice_type, material_order_line, service_sols, manual_service_order_line, down_payment_invoiced)
 

--- a/addons/sale_purchase/models/sale_order_line.py
+++ b/addons/sale_purchase/models/sale_order_line.py
@@ -208,7 +208,7 @@ class SaleOrderLine(models.Model):
             'product_uom': self.product_id.uom_po_id.id,
             'price_unit': price_unit,
             'date_planned': purchase_order.date_order + relativedelta(days=int(supplierinfo.delay)),
-            'taxes_id': [(6, 0, taxes.ids)],
+            'tax_ids': [(6, 0, taxes.ids)],
             'order_id': purchase_order.id,
             'sale_line_id': self.id,
             'discount': supplierinfo.discount,

--- a/addons/sale_purchase/tests/test_access_rights.py
+++ b/addons/sale_purchase/tests/test_access_rights.py
@@ -42,7 +42,7 @@ class TestAccessRights(TestCommonSalePurchaseNoChart):
             'product_id': self.service_purchase_1.id,
             'product_uom_qty': 4,
             'order_id': sale_order.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         # confirming SO will create the PO even if you don't have the rights

--- a/addons/sale_purchase/tests/test_sale_purchase.py
+++ b/addons/sale_purchase/tests/test_sale_purchase.py
@@ -38,19 +38,19 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
             'product_id': cls.company_data['product_service_delivery'].id,
             'product_uom_qty': 1,
             'order_id': cls.sale_order_1.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol1_product_order = cls.env['sale.order.line'].create({
             'product_id': cls.company_data['product_order_no'].id,
             'product_uom_qty': 2,
             'order_id': cls.sale_order_1.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol1_service_purchase_1 = cls.env['sale.order.line'].create({
             'product_id': cls.service_purchase_1.id,
             'product_uom_qty': 4,
             'order_id': cls.sale_order_1.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
         cls.sale_order_2 = SaleOrder.create({
@@ -63,19 +63,19 @@ class TestSalePurchase(TestCommonSalePurchaseNoChart):
             'product_id': cls.company_data['product_delivery_no'].id,
             'product_uom_qty': 5,
             'order_id': cls.sale_order_2.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol2_service_order = cls.env['sale.order.line'].create({
             'product_id': cls.company_data['product_service_order'].id,
             'product_uom_qty': 6,
             'order_id': cls.sale_order_2.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
         cls.sol2_service_purchase_2 = cls.env['sale.order.line'].create({
             'product_id': cls.service_purchase_2.id,
             'product_uom_qty': 7,
             'order_id': cls.sale_order_2.id,
-            'tax_id': False,
+            'tax_ids': False,
         })
 
     def test_sale_create_purchase(self):

--- a/addons/sale_purchase_stock/tests/test_access_rights.py
+++ b/addons/sale_purchase_stock/tests/test_access_rights.py
@@ -55,7 +55,7 @@ class TestAccessRights(TestCommonSalePurchaseNoChart):
             'product_uom_qty': 1,
             'product_uom': product.uom_id.id,
             'price_unit': product.list_price,
-            'tax_id': False,
+            'tax_ids': False,
             'order_id': so.id,
         }, {
             'name': 'Super Section',

--- a/addons/sale_purchase_stock/tests/test_lead_time.py
+++ b/addons/sale_purchase_stock/tests/test_lead_time.py
@@ -54,7 +54,7 @@ class TestLeadTime(TestCommonSalePurchaseNoChart):
             'product_uom_qty': 1,
             'product_uom': product.uom_id.id,
             'price_unit': product.list_price,
-            'tax_id': False,
+            'tax_ids': False,
             'order_id': so.id,
         })
         so.action_confirm()

--- a/addons/sale_stock/models/account_move.py
+++ b/addons/sale_stock/models/account_move.py
@@ -38,7 +38,7 @@ class AccountMove(models.Model):
             return res
 
         current_invoice_amls = self.invoice_line_ids.filtered(lambda aml: aml.display_type == 'product' and aml.product_id and aml.product_id.type == 'consu' and aml.quantity)
-        all_invoices_amls = current_invoice_amls.sale_line_ids.invoice_lines.filtered(lambda aml: aml.move_id.state == 'posted').sorted(lambda aml: (aml.date, aml.move_name, aml.id))
+        all_invoices_amls = current_invoice_amls.sale_line_ids.account_move_line_ids.filtered(lambda aml: aml.move_id.state == 'posted').sorted(lambda aml: (aml.date, aml.move_name, aml.id))
         index = all_invoices_amls.ids.index(current_invoice_amls[:1].id) if current_invoice_amls[:1] in all_invoices_amls else 0
         previous_amls = all_invoices_amls[:index]
         invoiced_qties = current_invoice_amls._get_invoiced_qty_per_product()
@@ -153,7 +153,7 @@ class AccountMoveLine(models.Model):
             qty_to_invoice = self.product_uom_id._compute_quantity(self.quantity, self.product_id.uom_id)
             if self.move_id.move_type == 'out_refund' and down_payment:
                 qty_to_invoice = -qty_to_invoice
-            account_moves = so_line.invoice_lines.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
+            account_moves = so_line.account_move_line_ids.move_id.filtered(lambda m: m.state == 'posted' and bool(m.reversed_entry_id) == is_line_reversing)
 
             posted_cogs = account_moves.line_ids.filtered(lambda l: l.display_type == 'cogs' and l.product_id == self.product_id and l.balance > 0)
             qty_invoiced = 0

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -228,8 +228,8 @@ class SaleOrder(models.Model):
         action['context'] = dict(default_partner_id=self.partner_id.id, default_picking_type_id=picking_id.picking_type_id.id, default_origin=self.name, default_group_id=picking_id.group_id.id)
         return action
 
-    def _prepare_invoice(self):
-        invoice_vals = super(SaleOrder, self)._prepare_invoice()
+    def _prepare_account_move_values(self):
+        invoice_vals = super()._prepare_account_move_values()
         invoice_vals['invoice_incoterm_id'] = self.incoterm.id
         return invoice_vals
 

--- a/addons/sale_stock/models/stock.py
+++ b/addons/sale_stock/models/stock.py
@@ -36,7 +36,7 @@ class StockMove(models.Model):
         related to this stock move.
         """
         rslt = super(StockMove, self)._get_related_invoices()
-        invoices = self.mapped('picking_id.sale_id.invoice_ids').filtered(lambda x: x.state == 'posted')
+        invoices = self.mapped('picking_id.sale_id.account_move_ids').filtered(lambda x: x.state == 'posted')
         rslt += invoices
         #rslt += invoices.mapped('reverse_entry_ids')
         return rslt

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1536,7 +1536,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         ctx = {'active_model': 'sale.order', 'active_ids': so.ids}
         create_invoice_wizard = self.env['sale.advance.payment.inv'].with_context(ctx).create({'advance_payment_method': 'delivered'})
         create_invoice_wizard.create_invoices()
-        reverse_invoice = so.invoice_ids[-1]
+        reverse_invoice = so.account_move_ids[-1]
         with Form(reverse_invoice) as reverse_invoice_form:
             with reverse_invoice_form.invoice_line_ids.edit(0) as line:
                 line.quantity = 1
@@ -1762,7 +1762,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         })
         down_payment.create_invoices()
         # Invoice the delivered part from the down payment
-        down_payment_invoices = so.invoice_ids
+        down_payment_invoices = so.account_move_ids
         down_payment_invoices.action_post()
 
         # Deliver a part of it with a backorder
@@ -1774,7 +1774,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
 
         invoice_wizard = self.env['sale.advance.payment.inv'].with_context(active_ids=so.ids, open_invoices=True).create({})
         invoice_wizard.create_invoices()
-        credit_note = so.invoice_ids.filtered(lambda i: i.state != 'posted')
+        credit_note = so.account_move_ids.filtered(lambda i: i.state != 'posted')
         self.assertEqual(len(credit_note), 1)
         self.assertEqual(len(credit_note.invoice_line_ids.filtered(lambda line: line.display_type == 'product')), 2)
         down_payment_line = credit_note.invoice_line_ids.filtered(lambda line: line.sale_line_ids.is_downpayment)
@@ -1789,7 +1789,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         invoice_wizard = self.env['sale.advance.payment.inv'].with_context(active_ids=so.ids, open_invoices=True).create({})
         invoice_wizard.create_invoices()
 
-        invoice = so.invoice_ids.filtered(lambda i: i.state != 'posted')
+        invoice = so.account_move_ids.filtered(lambda i: i.state != 'posted')
         invoice.action_post()
 
         # Check the resulting accounting entries

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -38,7 +38,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 2.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 12,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         sale_order.flush_recordset()
@@ -941,7 +941,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 10.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 12,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         sale_order.action_confirm()
@@ -1031,7 +1031,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 20,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         sale_order.action_confirm()
@@ -1050,7 +1050,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 6,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 20,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         sale_order.action_confirm()
@@ -1095,7 +1095,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 10.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 12,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         sale_order.action_confirm()
@@ -1175,7 +1175,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 12,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         so_2.action_confirm()
@@ -1271,7 +1271,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1,
                     'product_uom': unit_12.id,
                     'price_unit': 18,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         so_1.action_confirm()
@@ -1331,7 +1331,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1,
                     'product_uom': unit_12.id,
                     'price_unit': 18,
-                    'tax_id': False,  # no love taxes amls
+                    'tax_ids': False,  # no love taxes amls
                 })],
         })
         so_2.action_confirm()
@@ -1398,7 +1398,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 3.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -1491,7 +1491,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 3.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -1578,7 +1578,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 3.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -1668,7 +1668,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 1.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()
@@ -1749,7 +1749,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
                     'product_uom_qty': 10.0,
                     'product_uom': self.product.uom_id.id,
                     'price_unit': 100,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })],
         })
         so.action_confirm()

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation.py
@@ -1758,7 +1758,7 @@ class TestAngloSaxonValuation(ValuationReconciliationTestCommon):
         down_payment = self.env['sale.advance.payment.inv'].create({
             'advance_payment_method': 'percentage',
             'amount': 100,
-            'sale_order_ids': so.ids,
+            'order_ids': so.ids,
         })
         down_payment.create_invoices()
         # Invoice the delivered part from the down payment

--- a/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
+++ b/addons/sale_stock/tests/test_anglo_saxon_valuation_reconciliation.py
@@ -49,7 +49,7 @@ class TestValuationReconciliationCommon(ValuationReconciliationTestCommon):
             })],
         })
 
-        sale_order.invoice_ids += rslt
+        sale_order.account_move_ids += rslt
         return rslt
 
     def _set_initial_stock_for_product(self, product):

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -235,7 +235,7 @@ class TestSaleStock(TestSaleStockCommon, ValuationReconciliationTestCommon):
             'advance_payment_method': 'delivered',
         })
         adv_wiz.with_context(open_invoices=True).create_invoices()
-        self.inv_2 = self.so.invoice_ids.filtered(lambda r: r.state == 'draft')
+        self.inv_2 = self.so.account_move_ids.filtered(lambda r: r.state == 'draft')
         self.assertAlmostEqual(self.inv_2.invoice_line_ids.sorted()[0].quantity, 2.0, msg='Sale Stock: refund quantity on the invoice should be 2.0 instead of "%s".' % self.inv_2.invoice_line_ids.sorted()[0].quantity)
         self.assertEqual(self.so.invoice_status, 'no', 'Sale Stock: so invoice_status should be "no" instead of "%s" after invoicing the return' % self.so.invoice_status)
 

--- a/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
+++ b/addons/sale_stock/tests/test_sale_stock_accrued_entries.py
@@ -29,7 +29,7 @@ class TestAccruedStockSaleOrders(AccountTestInvoicingCommon):
                     'product_uom_qty': 10.0,
                     'product_uom': cls.product_order.uom_id.id,
                     'price_unit': cls.product_order.list_price,
-                    'tax_id': False,
+                    'tax_ids': False,
                 })
             ]
         })

--- a/addons/sale_timesheet/controllers/portal.py
+++ b/addons/sale_timesheet/controllers/portal.py
@@ -39,7 +39,7 @@ class PortalProjectAccount(PortalAccount, ProjectCustomerPortal):
         if not task:
             return NotFound()
 
-        domain = [('id', 'in', task.sale_order_id.invoice_ids.ids)]
+        domain = [('id', 'in', task.sale_order_id.account_move_ids.ids)]
         values = self._prepare_my_invoices_values(page, date_begin, date_end, sortby, filterby, domain=domain)
 
         # pager
@@ -100,7 +100,7 @@ class SaleTimesheetCustomerPortal(TimesheetCustomerPortal):
             pass
 
         moves = request.env['account.move']
-        invoice_ids = task.sale_order_id.invoice_ids
+        invoice_ids = task.sale_order_id.account_move_ids
         if invoice_ids and request.env['account.move'].check_access_rights('read', raise_exception=False):
             moves = request.env['account.move'].search([('id', 'in', invoice_ids.ids)])
             values['invoices_accessible'] = moves.ids

--- a/addons/sale_timesheet/models/sale_order_line.py
+++ b/addons/sale_timesheet/models/sale_order_line.py
@@ -171,7 +171,7 @@ class SaleOrderLine(models.Model):
         """
         lines_by_timesheet = self.filtered(lambda sol: sol.product_id and sol.product_id._is_delivered_timesheet())
         domain = lines_by_timesheet._timesheet_compute_delivered_quantity_domain()
-        refund_account_moves = self.order_id.invoice_ids.filtered(lambda am: am.state == 'posted' and am.move_type == 'out_refund').reversed_entry_id
+        refund_account_moves = self.order_id.account_move_ids.filtered(lambda am: am.state == 'posted' and am.move_type == 'out_refund').reversed_entry_id
         timesheet_domain = [
             '|',
             ('timesheet_invoice_id', '=', False),

--- a/addons/sale_timesheet/tests/test_sale_service.py
+++ b/addons/sale_timesheet/tests/test_sale_service.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheet
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import UserError
 from odoo.tests import tagged
 
 
@@ -629,7 +629,7 @@ class TestSaleService(TestCommonSaleTimesheet):
         self.sale_order._create_invoices()
 
         # Check that the resulting invoice line and the project have the same analytic account
-        invoice_line = self.sale_order.invoice_ids.line_ids.filtered(lambda line: line.product_id == product_add)
+        invoice_line = self.sale_order.account_move_ids.line_ids.filtered(lambda line: line.product_id == product_add)
         self.assertEqual(invoice_line.analytic_distribution, {str(self.project_global.analytic_account_id.id): 100},
              "SOL's analytic distribution should contain the project analytic account")
 

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -125,7 +125,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         # create second invoice
         invoice2 = sale_order._create_invoices()[0]
 
-        self.assertEqual(len(sale_order.invoice_ids), 2, "A second invoice should have been created from the SO")
+        self.assertEqual(len(sale_order.account_move_ids), 2, "A second invoice should have been created from the SO")
         self.assertTrue(float_is_zero(invoice2.amount_total - so_line_ordered_task_in_project.price_unit * 3, precision_digits=2), 'Sale: invoice generation on timesheets product is wrong')
 
         self.assertFalse(timesheet1.timesheet_invoice_id, "The timesheet1 should not be linked to the invoice, since we are in ordered quantity")
@@ -224,7 +224,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
         # create a second invoice
         invoice2 = sale_order._create_invoices()[0]
-        self.assertEqual(len(sale_order.invoice_ids), 2, "A second invoice should have been created from the SO")
+        self.assertEqual(len(sale_order.account_move_ids), 2, "A second invoice should have been created from the SO")
         self.assertEqual(so_line_deliver_global_project.invoice_status, 'invoiced', 'Sale Timesheet: "invoice on delivery" timesheets should set the so line in "to invoice" status when logged')
         self.assertEqual(sale_order.invoice_status, 'no', 'Sale Timesheet: "invoice on delivery" timesheets should be invoiced completely by now')
         self.assertEqual(timesheet2.timesheet_invoice_id, invoice2, "The timesheet2 should not be linked to the invoice 2")
@@ -446,7 +446,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         with self.assertRaises(UserError):
             wizard.create_invoices()
 
-        self.assertFalse(sale_order.invoice_ids, 'Normally, no invoice will be created because the timesheet logged is after the period defined in date_start_invoice_timesheet and date_end_invoice_timesheet field')
+        self.assertFalse(sale_order.account_move_ids, 'Normally, no invoice will be created because the timesheet logged is after the period defined in date_start_invoice_timesheet and date_end_invoice_timesheet field')
 
         wizard.write({
             'date_start_invoice_timesheet': today - timedelta(days=10),
@@ -454,11 +454,11 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         })
         wizard.create_invoices()
 
-        self.assertTrue(sale_order.invoice_ids, 'One invoice should be created because the timesheet logged is between the period defined in wizard')
+        self.assertTrue(sale_order.account_move_ids, 'One invoice should be created because the timesheet logged is between the period defined in wizard')
         self.assertTrue(all(line.invoice_status == "to invoice" for line in sale_order.order_line if line.qty_delivered != line.qty_invoiced),
                         "All lines that still have some quantity to be invoiced should have an invoice status of 'to invoice', regardless if they were considered for previous invoicing, but didn't belong to the timesheet domain")
 
-        invoice = sale_order.invoice_ids[0]
+        invoice = sale_order.account_move_ids[0]
         self.assertEqual(so_line_deliver_global_project.qty_invoiced, timesheet1.unit_amount)
 
         # validate invoice
@@ -470,8 +470,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         })
         wizard.create_invoices()
 
-        self.assertEqual(len(sale_order.invoice_ids), 2)
-        invoice2 = sale_order.invoice_ids[-1]
+        self.assertEqual(len(sale_order.account_move_ids), 2)
 
         self.assertEqual(so_line_deliver_global_project.qty_invoiced, timesheet1.unit_amount + timesheet3.unit_amount, "The last invoice done should have the quantity of the timesheet 3, because the date this timesheet is the only one before the 'date_end_invoice_timesheet' field in the wizard.")
 
@@ -482,8 +481,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
         wizard.create_invoices()
 
-        self.assertEqual(len(sale_order.invoice_ids), 3)
-        invoice3 = sale_order.invoice_ids[-1]
+        self.assertEqual(len(sale_order.account_move_ids), 3)
 
         # Check if all timesheets have been invoiced
         self.assertEqual(so_line_deliver_global_project.qty_invoiced, timesheet1.unit_amount + timesheet2.unit_amount + timesheet3.unit_amount)

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1,12 +1,11 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from datetime import date, timedelta
+from datetime import timedelta
 
 from odoo import Command
 from odoo.fields import Date
 from odoo.tools import float_is_zero
 from odoo.exceptions import UserError
-from odoo.addons.hr_timesheet.tests.test_timesheet import TestCommonTimesheet
 from odoo.addons.sale_timesheet.tests.common import TestCommonSaleTimesheet
 from odoo.tests import Form, tagged
 
@@ -114,7 +113,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         self.assertEqual(len(sale_order.project_ids), 2, "No new project should have been created by the SO, when selling 'new task in new project' product, since it reuse the one from 'project only'.")
 
         # get first invoice line of sale line linked to timesheet1
-        invoice_line_1 = so_line_ordered_global_project.invoice_lines.filtered(lambda line: line.move_id == invoice1)
+        invoice_line_1 = so_line_ordered_global_project.account_move_line_ids.filtered(lambda line: line.move_id == invoice1)
 
         self.assertEqual(so_line_ordered_global_project.product_uom_qty, invoice_line_1.quantity, "The invoice (ordered) quantity should not change when creating timesheet")
 
@@ -488,7 +487,7 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
         # Check if all timesheets have been invoiced
         self.assertEqual(so_line_deliver_global_project.qty_invoiced, timesheet1.unit_amount + timesheet2.unit_amount + timesheet3.unit_amount)
-        self.assertTrue(so_line_deliver_task_project.invoice_lines)
+        self.assertTrue(so_line_deliver_task_project.account_move_line_ids)
         self.assertEqual(so_line_deliver_task_project.qty_invoiced, timesheet4.unit_amount)
 
     def test_transfert_project(self):

--- a/addons/sale_timesheet/tests/test_sale_timesheet_report.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet_report.py
@@ -29,7 +29,7 @@ class TestSaleTimesheetReport(TestCommonSaleTimesheet):
             'product_uom_qty': 3,
             'order_id': sale_order.id,
             'price_unit': 10.0,
-            'tax_id': [Command.set(self.tax_sale_a.ids)],
+            'tax_ids': [Command.set(self.tax_sale_a.ids)],
         })
         sale_order.action_confirm()
         task = self.env['project.task'].search([('sale_line_id', '=', so_line.id)])

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -82,7 +82,7 @@
                     <span t-else="" t-field="task.sale_order_id"></span>
                 </div>
                 <div t-if="invoices_accessible"><strong>Invoices:</strong>
-                    <span t-foreach="task.sale_order_id.invoice_ids" t-as="invoice_line">
+                    <span t-foreach="task.sale_order_id.account_move_ids" t-as="invoice_line">
                         <t t-if="invoice_line.id in invoices_accessible">
                             <a t-attf-href="/my/invoices/{{ invoice_line.id }}">
                                 <i t-if="invoice_line.state == 'draft'">Draft Invoice</i>

--- a/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
+++ b/addons/sale_timesheet/wizard/sale_make_invoice_advance.py
@@ -17,11 +17,11 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
     #=== COMPUTE METHODS ===#
 
-    @api.depends('sale_order_ids')
+    @api.depends('order_ids')
     def _compute_invoicing_timesheet_enabled(self):
         for wizard in self:
             wizard.invoicing_timesheet_enabled = bool(
-                wizard.sale_order_ids.order_line.filtered(
+                wizard.order_ids.order_line.filtered(
                     lambda sol: sol.invoice_status == 'to invoice'
                 ).product_id.filtered(
                     lambda p: p._is_delivered_timesheet()
@@ -46,6 +46,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
             return sale_orders.with_context(
                 timesheet_start_date=self.date_start_invoice_timesheet,
                 timesheet_end_date=self.date_end_invoice_timesheet
-            )._create_invoices(final=self.deduct_down_payments, grouped=not self.consolidated_billing)
+            )._create_invoices(final=True, grouped=not self.consolidated_billing)
 
         return super()._create_invoices(sale_orders)

--- a/addons/stock_delivery/tests/test_delivery_stock_move.py
+++ b/addons/stock_delivery/tests/test_delivery_stock_move.py
@@ -65,11 +65,11 @@ class StockMoveInvoice(AccountTestInvoicingCommon):
         self.sale_prepaid._create_invoices()
 
         # I check that the invoice was created
-        self.assertEqual(len(self.sale_prepaid.invoice_ids), 1, "Invoice not created.")
+        self.assertEqual(len(self.sale_prepaid.account_move_ids), 1, "Invoice not created.")
 
         # I confirm the invoice
 
-        self.invoice = self.sale_prepaid.invoice_ids
+        self.invoice = self.sale_prepaid.account_move_ids
         self.invoice.action_post()
 
         # I pay the invoice.

--- a/addons/stock_dropshipping/tests/test_stockvaluation.py
+++ b/addons/stock_dropshipping/tests/test_stockvaluation.py
@@ -47,7 +47,7 @@ class TestStockValuation(ValuationReconciliationTestCommon):
                 'product_uom_qty': 1,
                 'product_uom': self.product1.uom_id.id,
                 'price_unit': 12,
-                'tax_id': [(6, 0, [])],
+                'tax_ids': [(6, 0, [])],
             })],
             'picking_policy': 'direct',
         })

--- a/addons/stock_landed_costs/models/purchase.py
+++ b/addons/stock_landed_costs/models/purchase.py
@@ -3,7 +3,7 @@ from odoo import api,models
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'
 
-    def _prepare_account_move_line(self, move=False):
-        res = super()._prepare_account_move_line(move)
+    def _prepare_invoice_line(self, move=False, **optional_values):
+        res = super()._prepare_invoice_line(move, **optional_values)
         res.update({'is_landed_costs_line': self.product_id.landed_cost_ok})
         return res

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs.py
@@ -203,7 +203,7 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
             po.order_line[1].qty_received = 1
 
             po.action_create_invoice()
-            bill = po.invoice_ids
+            bill = po.account_move_ids
             bill.invoice_date = fields.Date.today()
 
             self.env['account.move.line'].create({

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs.py
@@ -185,7 +185,7 @@ class TestStockLandedCosts(TestStockLandedCostsCommon):
                         'product_qty': 1.0,
                         'product_uom': self.product_a.uom_po_id.id,
                         'price_unit': 100.0,
-                        'taxes_id': False,
+                        'tax_ids': False,
                     }),
                     (0, 0, {
                         'name': self.landed_cost.name,

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_branches.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_branches.py
@@ -74,7 +74,7 @@ class TestStockLandedCostsBranches(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 1
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
 

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -444,7 +444,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
                     'product_qty': 1.0,
                     'product_uom': self.product_a.uom_po_id.id,
                     'price_unit': 100.0,
-                    'taxes_id': False,
+                    'tax_ids': False,
                 }),
                 (0, 0, {
                     'name': self.landed_cost.name,

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_purchase.py
@@ -3,7 +3,6 @@
 import unittest
 from odoo.addons.stock_landed_costs.tests.common import TestStockLandedCostsCommon
 from odoo.addons.stock_landed_costs.tests.test_stockvaluationlayer import TestStockValuationLCCommon
-from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 
 from odoo.fields import Date
 from odoo.tests import tagged, Form
@@ -462,7 +461,7 @@ class TestLandedCostsWithPurchaseAndInv(TestStockValuationLCCommon):
         po.order_line[1].qty_received = 1
 
         po.action_create_invoice()
-        bill = po.invoice_ids
+        bill = po.account_move_ids
 
         # Create and validate LC
         lc = self.env['stock.landed.cost'].create(dict(

--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -315,7 +315,7 @@ class TestStockValuationLCAVCO(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 1
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
         po = po_form.save()
         po.button_confirm()
 
@@ -371,7 +371,7 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 10
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
 
         rfq = rfq.save()
         rfq.button_confirm()
@@ -459,7 +459,7 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 10
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
 
         rfq = rfq.save()
         rfq.button_confirm()
@@ -512,7 +512,7 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
             po_line.product_id = self.product1
             po_line.product_qty = 10
             po_line.price_unit = 10
-            po_line.taxes_id.clear()
+            po_line.tax_ids.clear()
 
         rfq = rfq.save()
         rfq.button_confirm()

--- a/addons/website_sale/models/sale_order_line.py
+++ b/addons/website_sale/models/sale_order_line.py
@@ -51,7 +51,7 @@ class SaleOrderLine(models.Model):
         show_tax = self.order_id.website_id.show_line_subtotals_tax_selection
         tax_display = 'total_excluded' if show_tax == 'tax_excluded' else 'total_included'
 
-        return self.tax_id.compute_all(
+        return self.tax_ids.compute_all(
             self.price_unit, self.currency_id, 1, self.product_id, self.order_partner_id,
         )[tax_display]
 

--- a/addons/website_sale/tests/test_website_sale_invoice.py
+++ b/addons/website_sale/tests/test_website_sale_invoice.py
@@ -32,4 +32,4 @@ class TestWebsiteSaleInvoice(AccountPaymentCommon, SaleCommon):
             tx._post_process()
 
         self.assertEqual(self.sale_order.website_id.id, self.website.id)
-        self.assertEqual(self.sale_order.invoice_ids.website_id.id, self.website.id)
+        self.assertEqual(self.sale_order.account_move_ids.website_id.id, self.website.id)

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -234,7 +234,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
                 'product_uom_qty': 1,
                 'product_uom': product.uom_id.id,
                 'price_unit': product.list_price,
-                'tax_id': False,
+                'tax_ids': False,
             })],
         })
         sol = so.order_line
@@ -274,7 +274,7 @@ class TestWebsitePriceList(WebsiteSaleCommon):
                 'product_uom_qty': 5,
                 'product_uom': product.uom_id.id,
                 'price_unit': product.list_price,
-                'tax_id': False,
+                'tax_ids': False,
             })]
         })
         sol = so.order_line

--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -125,7 +125,7 @@ class SaleOrder(models.Model):
                     continue
                 new_lines += self.env['sale.order.line'].new({
                     'product_id': lines[0].product_id.id,
-                    'tax_id': False,
+                    'tax_ids': False,
                     'price_unit': sum(lines.mapped('price_unit')),
                     'price_subtotal': sum(lines.mapped('price_subtotal')),
                     'price_total': sum(lines.mapped('price_total')),

--- a/addons/website_sale_loyalty/tests/test_website_sale_auto_invoice.py
+++ b/addons/website_sale_loyalty/tests/test_website_sale_auto_invoice.py
@@ -44,4 +44,4 @@ class TestWebsiteSaleAutoInvoice(WebsiteSaleCommon):
 
         with MockRequest(self.env, sale_order_id=self.cart.id, website=self.website):
             self.Controller.shop_payment_validate()
-        self.assertTrue(self.cart.invoice_ids, "No invoices were created for orders with zero total amount.")
+        self.assertTrue(self.cart.account_move_ids, "No invoices were created for orders with zero total amount.")


### PR DESCRIPTION
A lot of behavior is shared between the sale order (line) and purchase order (line). To avoid having to maintain this code in parallel and allow for sharing of the overlapping code, we introduce two new mixins:
1. account.order.mixin, for sale.order and purchase.order
2. account.order.line.mixin, for sale.order.line and purchase.order.line

We make use of this opportunity to also rename some of the shared fields to conform to the naming standards.

Additionally, this PR adds the option to create down payments for purchase orders by moving the existing functionality from sale orders into the newly created mixins. This new function is disabled by default for purchase, but can be turned on with a new checkbox in the settings.

task-3600910

Enterprise PR: https://github.com/odoo/enterprise/pull/55711
Upgrade PR: https://github.com/odoo/upgrade/pull/5627

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
