### PR TITLE
[FIX] spreadsheet_account: fix spreadsheet account method

### DIFF
--- a/addons/spreadsheet_account/models/account.py
+++ b/addons/spreadsheet_account/models/account.py
@@ -118,6 +118,9 @@ class AccountMove(models.Model):
                 continue
             MoveLines = self.env["account.move.line"].with_company(company_id)
             query = MoveLines._search(domain)
+            if query == []:
+                results.append({"credit": 0, "debit": 0})
+                continue
             query.order = None
             query_str, params = query.select(
                 "SUM(debit) AS debit", "SUM(credit) AS credit"

--- a/addons/spreadsheet_account/static/src/accounting_functions.js
+++ b/addons/spreadsheet_account/static/src/accounting_functions.js
@@ -129,7 +129,7 @@ export function parseAccountingDate(dateRange) {
 }
 
 const ODOO_FIN_ARGS = `
-    account_codes (string) ${_t("The prefix of the accounts.")}
+    account_codes (string) ${_t("The prefix of the accounts splitted by comma.")}
     date_range (string, date) ${_t(
         `The date range. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".`
     )}

--- a/addons/spreadsheet_account/tests/test_debit_credit.py
+++ b/addons/spreadsheet_account/tests/test_debit_credit.py
@@ -253,6 +253,26 @@ class SpreadsheetAccountingFunctionsTest(AccountTestInvoicingCommon):
             ],
         )
 
+    def test_invalid_prefix_code(self):
+        self.assertEqual(
+            self.env["account.account"].spreadsheet_fetch_debit_credit(
+                [
+                    {
+                        "date_range": {
+                            "range_type": "year",
+                            "year": 2022,
+                        },
+                        "codes": ["gr8name"],
+                        "company_id": None,
+                        "include_unposted": True,
+                    }
+                ]
+            ),
+            [
+                {"credit": 0.0, "debit": 0.0},
+            ],
+        )
+
     def test_do_not_count_future_years(self):
         self.env["account.move"].create(
             {


### PR DESCRIPTION
The method `spreadsheet_fetch_debit_credit` would crash when the internal query would not find any result and return an empty array.

Task: 3621113

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
