### PR TITLE
[FIX] industry_fsm: correct default project

### DIFF
--- a/addons/project/views/project_views.xml
+++ b/addons/project/views/project_views.xml
@@ -1167,7 +1167,7 @@
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks" attrs="{'invisible': [('is_private', '=', True)]}">
                             <field name="child_ids"
-                                   context="{'default_user_ids': user_ids, 'default_parent_id': id,
+                                   context="{'default_user_ids': user_ids, 'default_parent_id': id, 'default_project_id': project_id,
                                     'default_partner_id': partner_id, 'default_milestone_id': allow_milestones and milestone_id}"
                                    widget="subtasks_one2many">
                                 <tree editable="bottom" decoration-muted="is_closed == True">


### PR DESCRIPTION
Versions:
---------
- saas-16.2
- saas-16.3

Steps to reproduce:
-------------------
- create a new FSM project;
- create a task in this project;
- create a subtask for this task in the "Sub-tasks" tab.

Issue:
------
The project of the subtask is the "Field Service" project.

Cause:
------
If no project is found in the context, the first project found in the default database is used by default.

Solution:
---------
Add the project of the parent task (current record) to the context in order to use it.

Note:
From version saas-16.4, no project is added.

opw-3602334