### PR TITLE
[FIX] web_editor: create p on enter at the end of table

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -308,7 +308,9 @@ function addRow(editor, beforeOrAfter) {
     const cells = row.querySelectorAll('td');
     newRow.append(...Array.from(Array(cells.length)).map(() => {
         const td = document.createElement('td');
-        td.append(document.createElement('br'));
+        const p = document.createElement('p');
+        p.appendChild(document.createElement('br'));
+        td.append(p);
         return td;
     }));
     row[beforeOrAfter](newRow);
@@ -659,7 +661,7 @@ export const editorCommands = {
     },
     // Table
     insertTable: (editor, { rowNumber = 2, colNumber = 2 } = {}) => {
-        const tdsHtml = new Array(colNumber).fill('<td><br></td>').join('');
+        const tdsHtml = new Array(colNumber).fill('<td><p><br></p></td>').join('');
         const trsHtml = new Array(rowNumber).fill(`<tr>${tdsHtml}</tr>`).join('');
         const tableHtml = `<table class="table table-bordered"><tbody>${trsHtml}</tbody></table>`;
         const sel = editor.document.getSelection();
@@ -676,7 +678,7 @@ export const editorCommands = {
             setSelection(...newPosition, ...newPosition, false);
         }
         const [table] = editorCommands.insertHTML(editor, tableHtml);
-        setCursorStart(table.querySelector('td'));
+        setCursorStart(table.querySelector('td > p'));
     },
     addColumnLeft: editor => {
         addColumn(editor, 'before');

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/enter.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/enter.js
@@ -115,6 +115,19 @@ HTMLLIElement.prototype.oEnter = function () {
     this.oShiftTab();
 };
 /**
+ * Specifc behaviour for Table: When cursor at end of table and then enter
+ */
+HTMLTableElement.prototype.oEnter = function () {
+    const newEl = HTMLElement.prototype.oEnter.call(this, ...arguments);
+    ['table', 'table-bordered'].forEach((className) => {
+        if (newEl.classList.contains(className)) {
+            newEl.classList.remove(className);
+        }
+    });
+    const node = setTagName(newEl, 'P');
+    setCursorStart(node);
+};
+/**
  * Specific behavior for pre: insert newline (\n) in text or insert p at end.
  */
 HTMLPreElement.prototype.oEnter = function (offset) {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -3781,7 +3781,7 @@ X[]
                 await testEditor(BasicEditor, {
                     contentBefore: '<table><tbody><tr><td>ab</td><td>cd</td><td>ef[]</td></tr></tbody></table>',
                     stepFunction: async editor => triggerEvent(editor.editable, 'keydown', { key: 'Tab'}),
-                    contentAfter: '<table><tbody><tr><td>ab</td><td>cd</td><td>ef</td></tr><tr><td>[]<br></td><td><br></td><td><br></td></tr></tbody></table>',
+                    contentAfter: '<table><tbody><tr><td>ab</td><td>cd</td><td>ef</td></tr><tr><td>[<p><br></p>]</td><td><p><br></p></td><td><p><br></p></td></tr></tbody></table>',
                 });
             });
         });


### PR DESCRIPTION
**Current behavior before PR:**

pressing the Enter key at the end of a table would result in the creation of a new
table below the existing one.

**Desired behavior after PR is merged:**

Now, pressing the Enter key at the end of the table will no longer create a new
table. Instead, a paragraph tag will be generated.

task-3618833

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
