### PR TITLE
[FIX] mail: allow markup for the email body

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2268,7 +2268,10 @@ class MailThread(models.AbstractModel):
                         node.set('src', f'/web/image/{att_id}?access_token={token}')
                         postprocessed = True
                 if postprocessed:
+                    body_is_markup = isinstance(body, Markup)
                     return_values['body'] = lxml.html.tostring(root, pretty_print=False, encoding='unicode')
+                    if body_is_markup:
+                        return_values['body'] = Markup(return_values['body'])
         return_values['attachment_ids'] = m2m_attachment_ids
         return return_values
 

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -199,6 +199,23 @@ class TestChatterTweaks(MailCommon, TestRecipients):
         self.env['res.partner'].create({'name': 'Actual Partner'})
         self.assertTrue(record.name)
 
+    def test_chatter_message_as_marked_up_value(self):
+        attachments = [self.env['mail.thread']._Attachment('test_image.jpeg', 'test', {'encoding': None, 'cid': 'ii_lps7a8sm0'})]
+        attachment_ids = []
+        test_record = self.env['mail.test.nothread'].create({
+            'customer_id': self.partner_1.id,
+            'name': 'Not A Thread',
+        })
+        message_values = {
+            'model': test_record._name,
+            'res_id': test_record.id,
+            'body': Markup('<div dir="ltr"><div><img src="cid:ii_lps7a8sm0" alt="test_image.jpeg" width="542" height="253" data-filename="test_image.jpeg"/><br/></div></div>&#13;\n')
+        }
+        test = self.env['mail.thread']._process_attachments_for_post(attachments, attachment_ids, message_values)
+        self.assertTrue(isinstance(test['body'], Markup))
+        message_values['body'] = '<div dir="ltr"><div><img src="cid:ii_lps7a8sm0" alt="test_image.jpeg" width="542" height="253" data-filename="test_image.jpeg"/><br/></div></div>&#13;\n'
+        test_1 = self.env['mail.thread']._process_attachments_for_post(attachments, attachment_ids, message_values)
+        self.assertFalse(isinstance(test_1['body'], Markup))
 
 @tagged('mail_thread')
 class TestDiscuss(MailCommon, TestRecipients):


### PR DESCRIPTION
In some cases the markup body value passed to lxml.html.tostring is converted to a string and the correct markup is not found.
So, in this commit the value of return_values['body'] is marked up again

**Task**-3619348