### PR TITLE
[FIX] hr_holidays_attendance: Public leave in _get_overtime_leave_domain

### DIFF
--- a/addons/hr_holidays_attendance/models/hr_attendance.py
+++ b/addons/hr_holidays_attendance/models/hr_attendance.py
@@ -9,4 +9,5 @@ class HrAttendance(models.Model):
 
     def _get_overtime_leave_domain(self):
         domain = super()._get_overtime_leave_domain()
-        return AND([domain, [('holiday_id.holiday_status_id.time_type', '=', 'leave')]])
+        # resource_id = False => Public holidays
+        return AND([domain, ['|', ('holiday_id.holiday_status_id.time_type', '=', 'leave'), ('resource_id', '=', False)]])

--- a/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
+++ b/addons/hr_holidays_attendance/tests/test_holidays_overtime.py
@@ -232,3 +232,14 @@ class TestHolidaysOvertime(TransactionCase):
 
         alloc.number_of_days = 2
         self.assertEqual(self.employee.total_overtime, 0)
+
+    def test_public_leave_overtime(self):
+        self.env['resource.calendar.leaves'].create([{
+            'name': 'Public Holiday',
+            'date_from': datetime(2022, 5, 5, 6),
+            'date_to': datetime(2022, 5, 5, 18),
+            'time_type': 'leave',
+        }])
+
+        self.new_attendance(check_in=datetime(2022, 5, 5, 8), check_out=datetime(2022, 5, 5, 16))
+        self.assertEqual(self.employee.total_overtime, 8, 'Should have 8 hours of overtime')

--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -382,14 +382,16 @@ class ResourceCalendar(models.Model):
         """ Return the attendance intervals in the given datetime range.
             The returned intervals are expressed in specified tz or in the resource's timezone.
         """
-        self.ensure_one()
-        resources = self.env['resource.resource'] if not resources else resources
         assert start_dt.tzinfo and end_dt.tzinfo
         self.ensure_one()
         combine = datetime.combine
         required_tz = tz
 
-        resources_list = list(resources) + [self.env['resource.resource']]
+        if not resources:
+            resources = self.env['resource.resource']
+            resources_list = [resources]
+        else:
+            resources_list = list(resources) + [self.env['resource.resource']]
         resource_ids = [r.id for r in resources_list]
         domain = domain if domain is not None else []
         domain = expression.AND([domain, [
@@ -469,15 +471,18 @@ class ResourceCalendar(models.Model):
         """ Return the leave intervals in the given datetime range.
             The returned intervals are expressed in specified tz or in the calendar's timezone.
         """
-        resources = self.env['resource.resource'] if not resources else resources
         assert start_dt.tzinfo and end_dt.tzinfo
         self.ensure_one()
 
-        # for the computation, express all datetimes in UTC
-        resources_list = list(resources) + [self.env['resource.resource']]
+        if not resources:
+            resources = self.env['resource.resource']
+            resources_list = [resources]
+        else:
+            resources_list = list(resources) + [self.env['resource.resource']]
         resource_ids = [r.id for r in resources_list]
         if domain is None:
             domain = [('time_type', '=', 'leave')]
+        # for the computation, express all datetimes in UTC
         domain = domain + [
             ('calendar_id', 'in', [False, self.id]),
             ('resource_id', 'in', resource_ids),
@@ -515,7 +520,7 @@ class ResourceCalendar(models.Model):
             resources = self.env['resource.resource']
             resources_list = [resources]
         else:
-            resources_list = list(resources)
+            resources_list = list(resources) + [self.env['resource.resource']]
 
         attendance_intervals = self._attendance_intervals_batch(start_dt, end_dt, resources, tz=tz)
         leave_intervals = self._leave_intervals_batch(start_dt, end_dt, resources, domain, tz=tz)
@@ -580,8 +585,11 @@ class ResourceCalendar(models.Model):
         @return dict with hours of attendance in each day between `from_datetime` and `to_datetime`
         """
         self.ensure_one()
-        resources = self.env['resource.resource'] if not resources else resources
-        resources_list = list(resources) + [self.env['resource.resource']]
+        if not resources:
+            resources = self.env['resource.resource']
+            resources_list = [resources]
+        else:
+            resources_list = list(resources) + [self.env['resource.resource']]
         # total hours per day:  retrieve attendances with one extra day margin,
         # in order to compute the total hours on the first and last days
         from_full = from_datetime - timedelta(days=1)


### PR DESCRIPTION
The _get_overtime_leave_domain was added to help check for overtime on
employee leaves, but failed to account for public leaves

Note:
Backport of commit 1407052d3ff0663180ea11342569ace643c0cd00 from
odoo/odoo#141235

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
