### PR TITLE
[FIX] tools: raise validation error while invalid expression

### DIFF
--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -58,9 +58,9 @@ def locate_node(arch, spec):
         expr = spec.get('expr')
         try:
             xPath = etree.ETXPath(expr)
-        except etree.XPathSyntaxError as e:
+            nodes = xPath(arch)
+        except (etree.XPathEvalError, etree.XPathSyntaxError) as e:
             raise ValidationError(_("Invalid Expression while parsing xpath %r", expr)) from e
-        nodes = xPath(arch)
         return nodes[0] if nodes else None
     elif spec.tag == 'field':
         # Only compare the field name: a field can be only once in a given view


### PR DESCRIPTION
Currently the error occurs when  user tries to modify the view with an invalid xpath expression, an XPathEvalError traceback will appear.

Steps to reproduce:
- Go to Views> New. -Then add View Name.
- View Type> Qweb.
- Inherited View> external_layout_bold.
- View inheritance mode> Extension View.
- Now in Architecture add ` <xpath expr="//div[contains('footer')]" position="replace"></xpath> `
- Then save it.
- The error is generated.

Traceback on sentry-

``` XPathEvalError: Invalid number of arguments
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 71, in web_save
    self.write(vals)
  File "home/odoo/src/enterprise/17.0/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 524, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4390, in write
    field.write(self, value)
  File "odoo/fields.py", line 4312, in write
    self.write_batch([(records, value)])
  File "odoo/fields.py", line 4333, in write_batch
    self.write_real(records_commands_list, create)
  File "odoo/fields.py", line 4487, in write_real
    comodel.browse(command[1]).write(command[2])
  File "home/odoo/src/enterprise/17.0/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 524, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4422, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1397, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_ui_view.py", line 286, in _inverse_arch_base
    view_wo_lang.arch = view.arch_base
  File "odoo/fields.py", line 1321, in __set__
    records.write({self.name: write_value})
  File "home/odoo/src/enterprise/17.0/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 524, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4422, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1397, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_ui_view.py", line 268, in _inverse_arch
    view.write(data)
  File "home/odoo/src/enterprise/17.0/web_studio/models/studio_mixin.py", line 33, in write
    res = super(StudioMixin, self).write(vals)
  File "odoo/addons/base/models/ir_ui_view.py", line 524, in write
    res = super(View, self).write(self._compute_defaults(vals))
  File "odoo/models.py", line 4412, in write
    real_recs._validate_fields(vals, inverse_fields)
  File "odoo/models.py", line 1449, in _validate_fields
    check(self)
  File "odoo/addons/base/models/ir_ui_view.py", line 370, in _check_xml
    combined_arch = view._get_combined_arch()
  File "odoo/addons/base/models/ir_ui_view.py", line 947, in _get_combined_arch
    arch = root.with_prefetch(tree_views._prefetch_ids)._combine(hierarchy)
  File "odoo/addons/base/models/ir_ui_view.py", line 888, in _combine
    combined_arch = view.apply_inheritance_specs(combined_arch, arch)
  File "home/odoo/src/enterprise/17.0/web_studio/models/ir_ui_view.py", line 607, in apply_inheritance_specs
    return super(View, self).apply_inheritance_specs(source, specs_tree,
  File "odoo/addons/base/models/ir_ui_view.py", line 819, in apply_inheritance_specs
    source = apply_inheritance_specs(
  File "odoo/tools/template_inheritance.py", line 144, in apply_inheritance_specs
    node = locate_node(source, spec)
  File "odoo/tools/template_inheritance.py", line 80, in locate_node
    nodes = xPath(arch)
  File "src/lxml/xpath.pxi", line 443, in lxml.etree.XPath.__call__
  File "src/lxml/xpath.pxi", line 225, in lxml.etree._XPathEvaluatorBase._handle_result 
```

This commit handles XPathEvalError by raising ValidationError instead of a traceback.

sentry - 4677618991

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
