### PR TITLE
[FIX] config.py Traceback when saving new added section

### DIFF
--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -664,7 +664,8 @@ class configmanager(object):
                 p.set('options', opt, self.options[opt])
 
         for sec in sorted(self.misc):
-            p.add_section(sec)
+            if not p.has_section(sec):
+                p.add_section(sec)
             for opt in sorted(self.misc[sec]):
                 p.set(sec,opt,self.misc[sec][opt])
 


### PR DESCRIPTION
[FIX] config.py Traceback when saving new added section
    
    Before: When creating new section in odoo.conf (eg: [IOT]), first
    save is ok since it doesn't exists. But subsequent save fails ->
    configparser.DuplicateSectionError: Section 'IOT' already exists
    
    Now: Subsequent saves work

mool


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
