### PR TITLE
[IMP] spreadsheet_account: account_codes helper message

### DIFF
--- a/addons/spreadsheet_account/static/src/accounting_functions.js
+++ b/addons/spreadsheet_account/static/src/accounting_functions.js
@@ -129,7 +129,12 @@ export function parseAccountingDate(dateRange, locale) {
 }
 
 const ODOO_FIN_ARGS = () => [
-    arg("account_codes (string)", _t("The prefix of the accounts.")),
+    arg(
+        "account_codes (string)",
+        _t(
+            "The prefix of the accounts. Multiple accounts can be specified by separating them with a comma. For example: 1, 201, 961000"
+        )
+    ),
     arg(
         "date_range (string, date)",
         _t(`The date range. Supported formats are "21/12/2022", "Q1/2022", "12/2022", and "2022".`)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Updated the `account_codes` helper message in the `ODOO.BALANCE` function to explicitly mention users can add multiple account codes separated by commas.

TaskID: 3620651

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
