### PR TITLE
[FIX] account: clarify terminology (draft instead of unposted)

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12258,6 +12258,13 @@ msgid "Show unposted entries"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/company.py:0
+#, python-format
+msgid "Show draft entries"
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,field_description:account.field_res_config_settings__module_snailmail_account
 msgid "Snailmail"
 msgstr ""
@@ -14043,6 +14050,15 @@ msgstr ""
 #, python-format
 msgid ""
 "There are still unposted entries in the period you want to lock. You should "
+"either post or delete them."
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/company.py:0
+#, python-format
+msgid ""
+"There are still draft entries in the period you want to lock. You should "
 "either post or delete them."
 msgstr ""
 

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -338,17 +338,17 @@ class ResCompany(models.Model):
                 ('state', '=', 'draft'),
                 ('date', '<=', values['fiscalyear_lock_date'])])
             if draft_entries:
-                error_msg = _('There are still unposted entries in the period you want to lock. You should either post or delete them.')
+                error_msg = _('There are still draft entries in the period you want to lock. You should either post or delete them.')
                 action_error = {
                     'view_mode': 'tree',
-                    'name': _('Unposted Entries'),
+                    'name': _('Draft Entries'),
                     'res_model': 'account.move',
                     'type': 'ir.actions.act_window',
                     'domain': [('id', 'in', draft_entries.ids)],
                     'search_view_id': [self.env.ref('account.view_account_move_filter').id, 'search'],
                     'views': [[self.env.ref('account.view_move_tree').id, 'list'], [self.env.ref('account.view_move_form').id, 'form']],
                 }
-                raise RedirectWarning(error_msg, action_error, _('Show unposted entries'))
+                raise RedirectWarning(error_msg, action_error, _('Show draft entries'))
 
             unreconciled_statement_lines = self.env['account.bank.statement.line'].search([
                 ('company_id', 'in', self.ids),


### PR DESCRIPTION
When applying the all users lock dates, a check is made to verify that there are no existing draft entries. Users must either post them, cancel them, or delete them. Currently, the terminology isn't quite correct. Unposted entries could include canceled. Let's call things by their name and replace "unposted" with "draft". 

task-3619987




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
