### PR TITLE
[IMP] base: introduce _search_display_name

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -640,11 +640,13 @@ class AccountAccount(models.Model):
         return self._get_most_frequent_accounts_for_partner(company_id, partner_id, move_type)
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def name_search(self, name, args=None, operator='ilike', limit=None):
         if not name and self._context.get('partner_id') and self._context.get('move_type'):
-            return self._order_accounts_by_frequency_for_partner(
-                            self.env.company.id, self._context.get('partner_id'), self._context.get('move_type'))
-        return super()._name_search(name, domain, operator, limit, order)
+            records = self.browse(self._order_accounts_by_frequency_for_partner(
+                            self.env.company.id, self._context.get('partner_id'), self._context.get('move_type')))
+            records.fetch(['display_name'])
+            return [(record.id, record.display_name) for record in records.sudo()]
+        return super().name_search(name, args, operator, limit)
 
     @api.model
     def _search_display_name(self, name, operator="ilike"):

--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -91,10 +91,6 @@ class AccountTax(models.Model):
     _check_company_domain = models.check_company_domain_parent_of
 
     name = fields.Char(string='Tax Name', required=True, translate=True, tracking=True)
-    name_searchable = fields.Char(store=False, search='_search_name',
-          help="This dummy field lets us use another search method on the field 'name'."
-               "This allows more freedom on how to search the 'name' compared to 'filter_domain'."
-               "See '_search_name' and '_parse_name_search' for why this is not possible with 'filter_domain'.")
     type_tax_use = fields.Selection(TYPE_TAX_USE, string='Tax Type', required=True, default="sale", tracking=True,
         help="Determines where the tax is selectable. Note: 'None' means a tax can't be used by itself, however it can still be used in a group. 'adjustment' is used to perform tax adjustment.")
     tax_scope = fields.Selection([('service', 'Services'), ('consu', 'Goods')], string="Tax Scope", help="Restrict the use of taxes to a type of product.")
@@ -429,16 +425,10 @@ class AccountTax(models.Model):
                 list_name[i] = '%'.join(re.sub(r"\W+", "", name))
         return ''.join(list_name)
 
-    @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, name, operator='ilike'):
         if operator in ("ilike", "like"):
             name = AccountTax._parse_name_search(name)
-        return super()._name_search(name, domain, operator, limit, order)
-
-    def _search_name(self, operator, value):
-        if operator not in ("ilike", "like") or not isinstance(value, str):
-            return [('name', operator, value)]
-        return [('name', operator, AccountTax._parse_name_search(value))]
+        return super()._search_display_name(name, operator)
 
     def _check_repartition_lines(self, lines):
         self.ensure_one()

--- a/addons/account/views/account_tax_views.xml
+++ b/addons/account/views/account_tax_views.xml
@@ -98,7 +98,7 @@
             <field name="model">account.tax</field>
             <field name="arch" type="xml">
                 <search string="Search Taxes">
-                    <field name="name_searchable" string="Name"/>
+                    <field name="name"/>
                     <field name="description"/>
                     <field name="company_id" groups="base.group_multi_company"/>
                     <filter string="Sale" name="sale" domain="[('type_tax_use','=','sale')]" />

--- a/addons/event/models/mail_template.py
+++ b/addons/event/models/mail_template.py
@@ -9,14 +9,14 @@ class MailTemplate(models.Model):
     _inherit = 'mail.template'
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, name, operator='ilike'):
         """Context-based hack to filter reference field in a m2o search box to emulate a domain the ORM currently does not support.
 
         As we can not specify a domain on a reference field, we added a context
         key `filter_template_on_event` on the template reference field. If this
-        key is set, we add our domain in the `domain` in the `_name_search`
+        key is set, we add our domain in the `domain` in the `_search_display_name`
         method to filtrate the mail templates.
         """
         if self.env.context.get('filter_template_on_event'):
-            domain = expression.AND([[('model', '=', 'event.registration')], domain])
-        return super()._name_search(name, domain, operator, limit, order)
+            return [('model', '=', 'event.registration')]
+        return super()._search_display_name(name, operator=operator)

--- a/addons/event_sms/models/sms_template.py
+++ b/addons/event_sms/models/sms_template.py
@@ -9,14 +9,14 @@ class SmsTemplate(models.Model):
     _inherit = 'sms.template'
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, name,operator='ilike'):
         """Context-based hack to filter reference field in a m2o search box to emulate a domain the ORM currently does not support.
 
         As we can not specify a domain on a reference field, we added a context
         key `filter_template_on_event` on the template reference field. If this
-        key is set, we add our domain in the `domain` in the `_name_search`
+        key is set, we add our domain in the `domain` in the `_search_display_name`
         method to filtrate the SMS templates.
         """
         if self.env.context.get('filter_template_on_event'):
-            domain = expression.AND([[('model', '=', 'event.registration')], domain])
-        return super()._name_search(name, domain, operator, limit, order)
+            return [('model', '=', 'event.registration')]
+        return super()._search_display_name(name, operator=operator)

--- a/addons/fleet/models/fleet_vehicle_model.py
+++ b/addons/fleet/models/fleet_vehicle_model.py
@@ -47,12 +47,10 @@ class FleetVehicleModel(models.Model):
     vehicle_properties_definition = fields.PropertiesDefinition('Vehicle Properties')
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
+    def _search_display_name(self, name, operator='ilike'):
         if operator != 'ilike' or (name or '').strip():
-            name_domain = ['|', ('name', 'ilike', name), ('brand_id.name', 'ilike', name)]
-            domain = expression.AND([name_domain, domain])
-        return self._search(domain, limit=limit, order=order)
+            return ['|', ('name', 'ilike', name), ('brand_id.name', 'ilike', name)]
+        return super()._search_display_name(name, operator)
 
     @api.depends('brand_id')
     def _compute_display_name(self):

--- a/addons/l10n_eg_edi_eta/models/eta_activity_type.py
+++ b/addons/l10n_eg_edi_eta/models/eta_activity_type.py
@@ -9,14 +9,7 @@ from odoo.osv import expression
 class EtaActivityType(models.Model):
     _name = 'l10n_eg_edi.activity.type'
     _description = 'ETA code for activity type'
+    _rec_names_search = ['name', 'code']
 
     name = fields.Char(required=True, translate=True)
     code = fields.Char(required=True)
-
-    @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
-        if operator != 'ilike' or not (name or '').strip():
-            # ignore 'ilike' with name containing only spaces
-            domain = expression.AND([['|', ('name', operator, name), ('code', operator, name)], domain])
-        return self._search(domain, limit=limit, order=order)

--- a/addons/maintenance/models/maintenance.py
+++ b/addons/maintenance/models/maintenance.py
@@ -138,14 +138,6 @@ class MaintenanceEquipment(models.Model):
             else:
                 record.display_name = record.name
 
-    @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
-        query = None
-        if name and operator not in expression.NEGATIVE_TERM_OPERATORS and operator != '=':
-            query = self._search([('name', '=', name)] + domain, limit=limit, order=order)
-        return query or super()._name_search(name, domain, operator, limit, order)
-
     name = fields.Char('Equipment Name', required=True, translate=True)
     active = fields.Boolean(default=True)
     owner_user_id = fields.Many2one('res.users', string='Owner', tracking=True)

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -534,9 +534,8 @@ class ProductProduct(models.Model):
     def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
         domain = domain or []
         if name:
-            positive_operators = ['=', 'ilike', '=ilike', 'like', '=like']
             product_ids = []
-            if operator in positive_operators:
+            if operator not in expression.NEGATIVE_TERM_OPERATORS:
                 product_ids = list(self._search([('default_code', '=', name)] + domain, limit=limit, order=order))
                 if not product_ids:
                     product_ids = list(self._search([('barcode', '=', name)] + domain, limit=limit, order=order))
@@ -558,7 +557,7 @@ class ProductProduct(models.Model):
                 ])
                 domain2 = expression.AND([domain, domain2])
                 product_ids = list(self._search(domain2, limit=limit, order=order))
-            if not product_ids and operator in positive_operators:
+            if not product_ids and operator not in expression.NEGATIVE_TERM_OPERATORS:
                 ptrn = re.compile('(\[(.*?)\])')
                 res = ptrn.search(name)
                 if res:

--- a/addons/sale_expense/models/sale_order.py
+++ b/addons/sale_expense/models/sale_order.py
@@ -12,16 +12,16 @@ class SaleOrder(models.Model):
     expense_count = fields.Integer("# of Expenses", compute='_compute_expense_count', compute_sudo=True)
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, name, operator='ilike'):
         """ For expense, we want to show all sales order but only their display_name (no ir.rule applied), this is the only way to do it. """
+        domain = super()._search_display_name(name, operator)
         if (
             self._context.get('sale_expense_all_order')
             and self.user_has_groups('sales_team.group_sale_salesman')
             and not self.user_has_groups('sales_team.group_sale_salesman_all_leads')
         ):
-            domain = expression.AND([domain or [], ['&', ('state', '=', 'sale'), ('company_id', 'in', self.env.companies.ids)]])
-            return super(SaleOrder, self.sudo())._name_search(name, domain, operator, limit, order)
-        return super()._name_search(name, domain, operator, limit, order)
+            domain = expression.AND([domain ['&', ('state', '=', 'sale'), ('company_id', 'in', self.env.companies.ids)]])
+        return domain
 
     @api.depends('expense_ids')
     def _compute_expense_count(self):

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -235,13 +235,12 @@ class PickingType(models.Model):
                 picking_type.use_existing_lots = True
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, name, operator='ilike'):
         # Try to reverse the `display_name` structure
         parts = name.split(': ')
         if len(parts) == 2:
-            name_domain = [('warehouse_id.name', operator, parts[0]), ('name', operator, parts[1])]
-            return self._search(expression.AND([name_domain, domain]), limit=limit, order=order)
-        return super()._name_search(name, domain, operator, limit, order)
+            return [('warehouse_id.name', operator, parts[0]), ('name', operator, parts[1])]
+        return super()._search_display_name(name, operator)
 
     @api.depends('code')
     def _compute_default_location_src_id(self):

--- a/addons/web/models/res_users.py
+++ b/addons/web/models/res_users.py
@@ -1,30 +1,16 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
-from odoo.osv import expression
-
+from odoo.tools.sql import SQL
 
 class ResUsers(models.Model):
     _inherit = "res.users"
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        user_query = super()._name_search(name, domain, operator, limit, order)
-        if limit is None:
-            return user_query
-        user_ids = list(user_query)
-        if self._uid in user_ids:
-            if user_ids.index(self._uid) != 0:
-                user_ids.remove(self._uid)
-                user_ids.insert(0, self._uid)
-        elif limit and len(user_ids) == limit:
-            new_user_ids = super()._name_search(
-                name,
-                expression.AND([domain or [], [('id', '=', self._uid)]]),
-                operator,
-                limit=1,
-            )
-            if new_user_ids:
-                user_ids.pop()
-                user_ids.insert(0, self._uid)
-        return user_ids
+    def name_search(self, name, args=None, operator='ilike', limit=None):
+        args = args or [] + self._search_display_name(name, operator)
+        query = self._search(args, limit=limit, order=self._order)
+        query.order = SQL(",").join(
+            SQL("%s = %s",self._field_to_sql(self.table, fname="id"), self._uid),
+            query.order)
+        return [(record.id, record.display_name) for record in query.sudo()]

--- a/addons/website/models/website_rewrite.py
+++ b/addons/website/models/website_rewrite.py
@@ -20,11 +20,11 @@ class WebsiteRoute(models.Model):
     path = fields.Char('Route')
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        query = super()._name_search(name, domain, operator, limit, order)
+    def name_search(self, name, args=None, operator='ilike', limit=None):
+        query = super().name_search(name, args, operator, limit)
         if not query:
             self._refresh()
-            return super()._name_search(name, domain, operator, limit, order)
+            return super().name_search(name, args, operator, limit)
         return query
 
     def _refresh(self):

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -37,14 +37,13 @@ class Bank(models.Model):
             bank.display_name = name
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
+    def _search_display_name(self, name, operator='ilike'):
         if name:
-            name_domain = ['|', ('bic', '=ilike', name + '%'), ('name', operator, name)]
+            domain = ['|', ('bic', '=ilike', name + '%'), ('name', operator, name)]
             if operator in expression.NEGATIVE_TERM_OPERATORS:
-                name_domain = ['&', '!'] + name_domain[1:]
-            domain = domain + name_domain
-        return self._search(domain, limit=limit, order=order)
+                domain = ['&', '!'] + domain[1:]
+            return domain
+        return super()._search_display_name(name, operator)
 
     @api.onchange('country')
     def _onchange_country_id(self):

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -235,7 +235,7 @@ class Company(models.Model):
         return arch, view
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def name_search(self, name, args=None, operator='ilike', limit=None):
         context = dict(self.env.context)
         newself = self
         if context.pop('user_preference', None):
@@ -244,10 +244,10 @@ class Company(models.Model):
             # which are probably to allow to see the child companies) even if
             # she belongs to some other companies.
             companies = self.env.user.company_ids
-            domain = (domain or []) + [('id', 'in', companies.ids)]
+            args = (args or []) + [('id', 'in', companies.ids)]
             newself = newself.sudo()
         self = newself.with_context(context)
-        return super()._name_search(name, domain, operator, limit, order)
+        return super().name_search(name, args, operator, limit)
 
     @api.model
     @api.returns('self', lambda value: value.id)

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -449,8 +449,8 @@ class CurrencyRate(models.Model):
                 raise ValidationError("Currency rates should only be created for main companies")
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        return super()._name_search(parse_date(self.env, name), domain, operator, limit, order)
+    def _search_display_name(self, name, operator='ilike'):
+        return super()._search_display_name(parse_date(self.env, name), operator)
 
     @api.model
     def _get_view_cache_key(self, view_id=None, view_type='form', **options):

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -139,14 +139,10 @@ class PartnerCategory(models.Model):
             category.display_name = ' / '.join(reversed(names))
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
-        domain = domain or []
-        if name:
-            # Be sure name_search is symetric to display_name
-            name = name.split(' / ')[-1]
-            domain = [('name', operator, name)] + domain
-        return self._search(domain, limit=limit, order=order)
-
+    def _search_display_name(self, name, operator='ilike'):
+        # Be sure name_search is symetric to display_name
+        name = (name or '').split('/')[-1]
+        return super()._search_display_name(name, operator)
 
 class PartnerTitle(models.Model):
     _name = 'res.partner.title'

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -155,7 +155,7 @@
                             </h2>
                         </div>
                         <group name="phone_numbers">
-                            <field name="company_id" context="{'user_preference': 0}" groups="base.group_multi_company"/>
+                            <field name="company_id" groups="base.group_multi_company"/>
                             <label for="groups_id" string="Access Rights"
                                     invisible="id &gt; 0" groups="base.group_no_one"/>
                             <div invisible="id &gt; 0" groups="base.group_no_one">
@@ -221,7 +221,7 @@
                             <page name="access_rights" string="Access Rights">
                                 <group string="Multi Companies" invisible="companies_count &lt;= 1">
                                     <field string="Allowed Companies" name="company_ids" widget="many2many_tags" options="{'no_create': True, 'color_field': 'color'}"/>
-                                    <field string="Default Company" name="company_id" context="{'user_preference': 0}"/>
+                                    <field string="Default Company" name="company_id"/>
                                     <field string="Companies count" name="companies_count" invisible="1"/>
                                 </group>
                                 <field name="groups_id"/>

--- a/odoo/addons/test_impex/models.py
+++ b/odoo/addons/test_impex/models.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models, _
+from odoo.osv import expression
 
 def selection_fn(self):
     return [
@@ -51,11 +52,11 @@ for name, field in MODELS:
                 record.display_name = f"{self._name}:{record.value}"
 
         @api.model
-        def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+        def _search_display_name(self, name, operator='ilike'):
             if isinstance(name, str) and name.split(':')[0] == self._name:
-                return self._search([('value', operator, int(name.split(':')[1]))], limit=limit, order=order)
+                return [('value', operator, int(name.split(':')[1]))]
             else:
-                return []
+                return expression.FALSE_DOMAIN
 
 class One2ManyChild(models.Model):
     _name = 'export.one2many.child'
@@ -73,11 +74,11 @@ class One2ManyChild(models.Model):
             record.display_name = f"{self._name}:{record.value}"
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, name, domain=None, operator='ilike', limit=None, order=None):
         if isinstance(name, str) and name.split(':')[0] == self._name:
-            return self._search([('value', operator, int(name.split(':')[1]))], limit=limit, order=order)
+            return [('value', operator, int(name.split(':')[1]))]
         else:
-            return []
+            return expression.FALSE_DOMAIN
 
 
 class One2ManyMultiple(models.Model):
@@ -132,11 +133,11 @@ class Many2ManyChild(models.Model):
             record.display_name = f"{self._name}:{record.value}"
 
     @api.model
-    def _name_search(self, name, domain=None, operator='ilike', limit=None, order=None):
+    def _search_display_name(self, name, operator='ilike'):
         if isinstance(name, str) and name.split(':')[0] == self._name:
-            return self._search([('value', operator, int(name.split(':')[1]))], limit=limit, order=order)
+            return [('value', operator, int(name.split(':')[1]))]
         else:
-            return []
+            return expression.FALSE_DOMAIN
 
 
 class SelectionWithDefault(models.Model):

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -244,7 +244,7 @@ class MetaModel(api.Meta):
 
             add('id', fields.Id(automatic=True))
             add_default('display_name', fields.Char(
-                string='Display Name', automatic=True, compute='_compute_display_name'))
+                string='Display Name', automatic=True, compute='_compute_display_name', search='_search_display_name'))
 
             if attrs.get('_log_access', self._auto):
                 add_default('create_uid', fields.Many2one(
@@ -1697,8 +1697,11 @@ class BaseModel(metaclass=MetaModel):
         This method is used to implement the search on the ``display_name``
         field, and can be overridden to change the search criteria.
         """
+        if name == '' and operator in ('like', 'ilike'):
+            return []
+
         if not self._rec_name and not self._rec_names_search:
-            _logger.error("Cannot execute name_search, no _rec_name or _rec_names_search defined on %s", self._name)
+            _logger.error("Cannot execute _search_display_name, no _rec_name or _rec_names_search defined on %s", self._name)
 
         aggregator = expression.OR
         if operator in expression.NEGATIVE_TERM_OPERATORS:
@@ -7053,7 +7056,6 @@ class BaseModel(metaclass=MetaModel):
         if create_values:
             records_batches.append(self.create(create_values))
         return self.concat(*records_batches)
-
 
 collections.abc.Set.register(BaseModel)
 # not exactly true as BaseModel doesn't have index or count


### PR DESCRIPTION
This new function returns a domain instead of ids which enables us new optimisation when applying an ilike on one2many's.

For example given the following domain [('age', '>', '16'), ('bar', 'ilike', "cool%")] given that bar is an one2many before  this search had to be done in two queries a first one doing a name_search on the one2many and a second one checking if there is any match for bar and if age is over 16

This PR requires https://github.com/odoo/odoo/pull/144807 to be merged before

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
