### PR TITLE
[FIX] web: add 'Remove Cover' button

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanCoverImageDialog">
-        <Dialog title="'Set a Cover Image'" size="'lg'">
+        <Dialog title="'Set Cover Image'" size="'lg'">
             <div t-if="attachments.length" class="o_kanban_cover_container bg-100">
                 <t t-foreach="attachments" t-as="attachment" t-key="attachment.id">
                     <div class="o_kanban_cover_image position-relative d-inline-block m-2 border bg-white o_cursor_pointer" t-att-class="{
@@ -33,8 +33,8 @@
                 <button class="btn btn-primary" t-on-click="uploadImage">
                     Upload and Set
                 </button>
-                <button t-if="coverId" class="btn btn-secondary" t-on-click="removeCover">
-                    Remove Cover Image
+                <button t-if="state.selectedAttachmentId" class="btn btn-secondary" t-on-click="removeCover">
+                    Remove Cover
                 </button>
                 <button class="btn btn-secondary" t-on-click="dialog.close">
                     Discard


### PR DESCRIPTION
- This commit introduces the 'Remove Cover' button feature by updating the visibility condition
- The button will now be visible only when the image cover is set otherwise, it remains hidden.

task - 3624059

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
