### PR TITLE
[FIX] payment: enable payment button when only one payment method

### DIFF
--- a/addons/payment/static/src/js/payment_button.js
+++ b/addons/payment/static/src/js/payment_button.js
@@ -44,12 +44,12 @@ publicWidget.registry.PaymentButton = publicWidget.Widget.extend({
      * @return {boolean} Whether the payment button can be enabled.
      */
     _isReady() {
-        const paymentForm = document.querySelector('.o_payment_form');
+        const paymentForm = this.paymentButton.closest('.o_payment_form');
         if (!paymentForm) {  // Neither the checkout form nor the manage form are present.
             return true; // Ignore the check.
         }
 
-        const checkedRadios = document.querySelectorAll('input[name="o_payment_radio"]:checked');
+        const checkedRadios = paymentForm.querySelectorAll('input[name="o_payment_radio"]:checked');
         return checkedRadios.length === 1;
     },
 


### PR DESCRIPTION
Issue:
======
When you want to pay a subscription and we have only 1 payment method available, the Pay Button stays disabled.

Steps to reproduce the issue:
=============================
- Activate a single payment method
- Create a subscription and confirm it.
- Go to preview and you will find the pay button is disabled and canno't be enabled.

Origin of the issue:
====================
There is another payment option in the preview of subscription which has a d-none class so it's not visible that's why it's considered as having multiple payment methods and we need to select one of them.

Solution:
=========
Filter out the d-none options.

opw-3626037
