### PR TITLE
[FIX] hr_fleet : Driver employee auto fill

### DIFF
--- a/addons/hr_fleet/models/fleet_vehicle.py
+++ b/addons/hr_fleet/models/fleet_vehicle.py
@@ -27,7 +27,7 @@ class FleetVehicle(models.Model):
         for vehicle in self:
             if vehicle.driver_id:
                 vehicle.driver_employee_id = self.env['hr.employee'].search([
-                    ('address_home_id', '=', vehicle.driver_id.id),
+                    ('name', '=', vehicle.driver_id.name),
                 ], limit=1)
             else:
                 vehicle.driver_employee_id = False


### PR DESCRIPTION
[FIX] hr_fleet : Driver employee auto fill

Steps to reproduce:
	1- Install Fleet module
	2- New Vehicle
	3- Add Employee name field from studio
	4- Assign a driver to the vehicle
	5- Check the 'Employee' smart button will not appear and Employee name field will not auto fill

Current behavior before PR:
When you add a driver to a vehicle sometimes the fields that depends on this driver field is not filled. This happens because it search in hr.employee module using the address which is not always has value.

Desired behavior after PR is merged:
The auto filling is working now as we are getting the employee by his name.

opw-3610053