### PR TITLE
[FIX] web_editor: toolbar styles missing

### DIFF
--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -26,22 +26,22 @@
                         <a class="dropdown-item" href="#" id="display-4" data-call="setTag" data-arg1="h1,display-4" data-extended-text-style="">Header 1 Display 4</a>
                     </li>
                     <li t-if="props.showHeading1" id="heading1-dropdown-item">
-                        <a class="dropdown-item" href="#" id="heading1" data-call="setTag" data-arg1="h1">Header 1</a>
+                        <a class="dropdown-item" href="#" id="heading1" data-call="setTag" data-arg1="h1"><h1>Header 1</h1></a>
                     </li>
                     <li t-if="props.showHeading2" id="heading2-dropdown-item">
-                        <a class="dropdown-item" href="#" id="heading2" data-call="setTag" data-arg1="h2">Header 2</a>
+                        <a class="dropdown-item" href="#" id="heading2" data-call="setTag" data-arg1="h2"><h2>Header 2</h2></a>
                     </li>
                     <li t-if="props.showHeading3" id="heading3-dropdown-item">
-                        <a class="dropdown-item" href="#" id="heading3" data-call="setTag" data-arg1="h3">Header 3</a>
+                        <a class="dropdown-item" href="#" id="heading3" data-call="setTag" data-arg1="h3"><h3>Header 3</h3></a>
                     </li>
                     <li t-if="props.showHeading4" id="heading4-dropdown-item">
-                        <a class="dropdown-item" href="#" id="heading4" data-call="setTag" data-arg1="h4">Header 4</a>
+                        <a class="dropdown-item" href="#" id="heading4" data-call="setTag" data-arg1="h4"><h4>Header 4</h4></a>
                     </li>
                     <li t-if="props.showHeading5" id="heading5-dropdown-item">
-                        <a class="dropdown-item" href="#" id="heading5" data-call="setTag" data-arg1="h5">Header 5</a>
+                        <a class="dropdown-item" href="#" id="heading5" data-call="setTag" data-arg1="h5"><h5>Header 5</h5></a>
                     </li>
                     <li t-if="props.showHeading6" id="heading6-dropdown-item">
-                        <a class="dropdown-item" href="#" id="heading6" data-call="setTag" data-arg1="h6">Header 6</a>
+                        <a class="dropdown-item" href="#" id="heading6" data-call="setTag" data-arg1="h6"><h6>Header 6</h6></a>
                     </li>
                     <li id="paragraph-dropdown-item">
                         <a class="dropdown-item" href="#" id="paragraph" data-call="setTag" data-arg1="p">Normal</a>
@@ -53,10 +53,12 @@
                         <a class="dropdown-item" href="#" id="small" data-call="setTag" data-arg1="p,small" data-extended-text-style="">Small</a>
                     </li>
                     <li id="pre-dropdown-item">
-                        <a class="dropdown-item" href="#" id="pre" data-call="setTag" data-arg1="pre">Code</a>
+                        <a class="dropdown-item" href="#" id="pre" data-call="setTag" data-arg1="pre"><pre>Code</pre></a>
                     </li>
                     <li id="blockquote-dropdown-item">
-                        <a class="dropdown-item" href="#" id="blockquote" data-call="setTag" data-arg1="blockquote">Quote</a>
+                        <a class="dropdown-item" href="#" id="blockquote" data-call="setTag" data-arg1="blockquote">
+                            <blockquote>Quote</blockquote>
+                        </a>
                     </li>
                 </ul>
             </div>


### PR DESCRIPTION
**Current behavior before PR:**

selection text and opening toolbar and try to apply header 1 you can see that there is no styles in toolbar.
[1] in this pr they remove h1,h2,h3.. tags from the `editor.xml`.

**Desired behavior after PR is merged:**

Now in floating toolbar dropdown styles are loaded as we have added h1,h2,h3...tags back in `editor.xml`.

[1]: https://github.com/odoo-dev/odoo/commit/0a9324b2991b19e1cbc971fb550ea1fd27ec3ff9#diff-d7f83de40358090d3f78ba330ef758e40096ac405d77fea5811cf7064dc5a0ea

task-3624505

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
