### PR TITLE
[FIX] website_event: editor options breaking design

### DIFF
--- a/addons/website_event/static/src/scss/event_templates_page.scss
+++ b/addons/website_event/static/src/scss/event_templates_page.scss
@@ -71,51 +71,6 @@
 }
 
 /*
- * EVENT PAGE VIEW
- */
-
-.o_wevent_event .event_color_0 {
-    background-color: $o-wevent-bg-color-base;
-    color: $o-wevent-color;
-}
-.o_wevent_event .event_color_1 {
-    background-color: #cccccc;
-    color: #424242;
-}
-.o_wevent_event .event_color_2 {
-    background-color: #ffc7c7;
-    color: #7a3737;
-}
-.o_wevent_event .event_color_3 {
-    background-color: #fff1c7;
-    color: #756832;
-}
-.o_wevent_event .event_color_4 {
-    background-color: #e3ffc7;
-    color: #5d6937;
-}
-.o_wevent_event .event_color_5 {
-    background-color: #c7ffd5;
-    color: #1a7759;
-}
-.o_wevent_event .event_color_6 {
-    background-color: #c7ffff;
-    color: #1a5d83;
-}
-.o_wevent_event .event_color_7 {
-    background-color: #c7d5ff;
-    color: #3b3e75;
-}
-.o_wevent_event .event_color_8 {
-    background-color: #e3c7ff;
-    color: #4c3668;
-}
-.o_wevent_event .event_color_9 {
-    background-color: #ffc7f1;
-    color: #6d2c70;
-}
-
-/*
  * SPONSORS
  */
 

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -78,10 +78,10 @@
                 </div>
             </div>
             <!-- Off canvas filters on mobile-->
-            <div id="o_wevent_index_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none p-0 overflow-visible">
+            <div id="o_wevent_index_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none p-0 overflow-visible bg-body">
                 <div class="offcanvas-header">
                     <h5 class="offcanvas-title">Filters</h5>
-                    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
+                    <button type="button" class="btn-close bg-white" data-bs-dismiss="offcanvas" aria-label="Close"/>
                 </div>
                 <div class="offcanvas-body p-0">
                     <div class="accordion accordion-flush">
@@ -97,13 +97,11 @@
                                     </button>
                                 </h2>
                                 <div t-attf-class="o_wevent_offcanvas_cat_#{category.name} accordion-collapse collapse">
-                                    <div class="accordion-body pt-0">
+                                    <div class="accordion-body bg-white pt-0">
                                         <ul class="list-group list-group-flush">
                                             <li t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" class="list-group-item">
                                                 <t t-foreach="category.tag_ids" t-as="tag">
-                                                    <a t-if="tag.color"
-                                                        t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))"
-                                                        t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
+                                                    <a t-if="tag.color" t-att-href="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids))" t-attf-class="d-flex align-items-center justify-content-between #{'active' if tag in search_tags else ''}">
                                                         <t t-out="tag.name"/>
                                                     </a>
                                                 </t>
@@ -124,12 +122,12 @@
                                 </button>
                             </h2>
                             <div class="o_wevent_offcanvas_date accordion-collapse collapse">
-                                <div class="accordion-body pt-0">
+                                <div class="accordion-body bg-white pt-0">
                                     <ul class="list-group list-group-flush">
                                         <li class="list-group-item">
                                             <t t-foreach="dates" t-as="date">
                                                 <t t-if="date[3] or (date[0] in ('old','upcoming','all'))">
-                                                    <a t-att-href="keep('/event', date=date[0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{searches.get('date') == date[0] and 'active'}">
+                                                    <a t-att-href="keep('/event', date=date[0])" t-attf-class="d-flex align-items-center justify-content-between #{searches.get('date') == date[0] and 'active'}">
                                                         <t t-out="date[1]"/>
                                                         <span t-if="date[3]" t-out="date[3]" t-attf-class="badge rounded-pill #{searches.get('date') == date[0] and 'bg-light text-primary' or 'bg-primary'} ms-3"/>
                                                     </a>
@@ -233,7 +231,7 @@
     </div>
     <!-- List -->
     <div t-foreach="event_ids" t-as="event" t-attf-class=" #{opt_event_size}">
-        <a t-cache="event if not editable and event.website_published else None" t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-dark " t-att-data-publish="event.website_published and 'on' or 'off'">
+        <a t-cache="event if not editable and event.website_published else None" t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset " t-att-data-publish="event.website_published and 'on' or 'off'">
             <article t-attf-class="h-100 #{opt_events_list_cards and 'card'}" itemscope="itemscope" itemtype="http://schema.org/Event">
                 <div t-attf-class="h-100 #{opt_events_list_columns and 'd-flex flex-wrap flex-column' or 'row mx-0'}">
                     <!-- Header -->
@@ -286,8 +284,8 @@
                             <h5 t-attf-class="card-title mt-2 mb-0 text-truncate #{(not event.website_published) and 'text-danger'}">
                                 <span t-field="event.name" itemprop="name"/>
                             </h5>
-                            <!-- Start Date & Time -->
-                            <small class="o_not_editable text-muted" itemprop="description" t-out="event.subtitle">
+                            <!-- Description -->
+                            <small class="o_not_editable" itemprop="description" t-out="event.subtitle">
                             </small>
                         </div>
                         <!-- Location -->
@@ -297,7 +295,7 @@
                     <!-- Footer -->
                     <footer t-if="not event.event_registrations_open and opt_events_list_columns and opt_events_list_cards"
                         t-att-class="'small align-self-end w-100 %s %s' % (
-                            opt_events_list_cards and 'card-footer' or (not opt_events_list_columns and 'py-2 mt-2') or 'py-2',
+                            opt_events_list_cards and 'card-footer bg-body' or (not opt_events_list_columns and 'py-2 mt-2') or 'py-2',
                             opt_events_list_cards and 'border-top' or 'px-2',
                         )">
                         <span t-if="not event.event_registrations_open">

--- a/addons/website_event/views/event_templates_page.xml
+++ b/addons/website_event/views/event_templates_page.xml
@@ -25,7 +25,7 @@
     <div class="mb-3">
         <div class="container d-flex flex-wrap flex-lg-nowrap justify-content-between align-items-center">
             <t t-set="active_submenu" t-value="event.menu_id.child_id.filtered(lambda sm: sm._is_active())"></t>
-            <h6 t-field="event.name" t-attf-class="flex-grow-1 #{'my-3' if active_submenu else 'mb-0'}"/>
+            <h6 t-field="event.name" t-attf-class="flex-grow-1 #{'my-3' if active_submenu else 'my-0'}"/>
             <div class="d-flex flex-grow-1 align-items-center justify-content-end gap-2">
                 <nav t-if="active_submenu" class="navbar navbar-light navbar-expand-md p-0 d-md-none">
                     <div class="container align-items-baseline">

--- a/addons/website_event/views/event_templates_page_misc.xml
+++ b/addons/website_event/views/event_templates_page_misc.xml
@@ -29,7 +29,7 @@
             <div class="container">
                 <div class="row">
                     <div class="col-12">
-                        <h3>Event Location</h3>
+                        <h3 class="mt-0">Event Location</h3>
                         <h4 class="mb-3" t-field="event.address_id" t-options='{
                             "widget": "contact",
                             "fields": ["name"],

--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -103,7 +103,7 @@
                             <!-- Organizer -->
                             <div t-if="event.organizer_id" class="o_wevent_sidebar_block border-bottom pb-3 mb-3">
                                 <h6 class="o_wevent_sidebar_title text-muted text-uppercase">Organizer</h6>
-                                <h4 t-field="event.organizer_id"/>
+                                <h4 class="mt-0" t-field="event.organizer_id"/>
                                 <div itemprop="location" t-field="event.organizer_id" t-options="{'widget': 'contact', 'fields': ['phone', 'mobile', 'email']}"/>
                             </div>
                             <!-- Social -->
@@ -173,9 +173,9 @@
         <div class="modal-dialog modal-lg" role="document">
             <form id="attendee_registration" t-attf-action="/event/#{slug(event)}/registration/confirm" method="post" class="js_website_submit_form">
                 <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-                <div class="modal-content">
+                <div class="modal-content bg-body">
                     <div class="modal-header align-items-center">
-                        <h4 class="modal-title">Attendees</h4>
+                        <h4 class="modal-title my-0">Attendees</h4>
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"/>
                     </div>
                     <t t-set="counter" t-value="0"/>
@@ -348,7 +348,7 @@
     <!-- Modal -->
     <div class="modal fade" id="modal_ticket_registration" data-bs-backdrop="static" data-bs-keyboard="false" tabindex="-1" aria-labelledby="staticBackdropLabel" aria-hidden="true">
         <div class="modal-dialog">
-            <div class="modal-content">
+            <div class="modal-content bg-body">
             <div class="modal-header">
                 <div class="o_wevent_registration_title modal-title fs-5" id="staticBackdropLabel">Tickets</div>
                 <div t-if="len(event.event_ticket_ids) &gt; 1" class="o_wevent_price_range ms-2"/>

--- a/addons/website_event_booth/views/event_booth_templates.xml
+++ b/addons/website_event_booth/views/event_booth_templates.xml
@@ -7,7 +7,7 @@
                  itemscope="itemscope" itemtype="http://schema.org/Event">
                 <section>
                     <div class="container overflow-hidden">
-                        <h3>Get A Booth</h3>
+                        <h3 class="mt-0">Get A Booth</h3>
                         <div class="row g-0">
                             <t t-out="0"/>
                         </div>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -52,10 +52,10 @@
         </div>
     </div>
     <!-- Off canvas filters on mobile-->
-    <div id="o_wevent_exhibitors_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none p-0 overflow-visible">
+    <div id="o_wevent_exhibitors_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none p-0 overflow-visible bg-body">
         <div class="offcanvas-header">
             <h5 class="offcanvas-title">Filters</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
+            <button type="button" class="btn-close bg-white" data-bs-dismiss="offcanvas" aria-label="Close"/>
         </div>
         <div class="offcanvas-body p-0">
             <form class="o_wevent_event_tags_mobile_form" action="#" method="POST">
@@ -103,7 +103,7 @@
                 </button>
             </h2>
             <div class="o_wevent_offcanvas_country accordion-collapse collapse">
-                <div class="accordion-body pt-0">
+                <div class="accordion-body bg-white pt-0">
                     <ul class="list-group list-group-flush">
                         <li class="list-group-item">
                             <a t-att-href="'/event/%s/exhibitors?%s' % (
@@ -160,17 +160,17 @@
                 <button class="accordion-button collapsed"
                     type="button"
                     data-bs-toggle="collapse"
-                    data-bs-target=".o_wevent_offcanvas_country"
+                    data-bs-target=".o_wevent_offcanvas_level"
                     aria-expanded="false"
-                    aria-controls="o_wevent_offcanvas_country">
+                    aria-controls="o_wevent_offcanvas_level">
                     By Level
                 </button>
             </h2>
-            <div class="o_wevent_offcanvas_country accordion-collapse collapse">
-                <div class="accordion-body pt-0">
+            <div class="o_wevent_offcanvas_level accordion-collapse collapse">
+                <div class="accordion-body bg-white pt-0">
                     <ul class="list-group list-group-flush">
                         <li class="list-group-item">
-                            <a >
+                            <a class="o_dropdown_reset_tags cursor-pointer">
                                 All Levels
                             </a>
                         </li>
@@ -262,7 +262,7 @@
                 </div>
             </header>
             <div class="col-12 h-100 border-top">
-                <main class="card-body">
+                <main class="card-body h-100">
                     <!-- Title -->
                     <h5 class="card-title d-flex align-items-start justify-content-between mt-0 mb-0">
                         <span t-field="sponsor.name" itemprop="name" class="text-break"/>

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -176,7 +176,7 @@
                 </a>
             </div>
             <ul id="collapse_exhibitor_aside" class="list-group list-group-flush collapse d-lg-block">
-                <li class="list-group-item list-group-item-action" t-foreach="sponsors_other" t-as="sponsor_other">
+                <li class="list-group-item list-group-item-action bg-body text-reset" t-foreach="sponsors_other" t-as="sponsor_other">
                     <a class="d-flex flex-wrap flex-md-nowrap text-decoration-none text-dark"
                         t-att-href="sponsor_other.website_url"
                         t-att-data-publish="sponsor_other.website_published and 'on' or 'off'">

--- a/addons/website_event_meet/views/event_meet_templates_list.xml
+++ b/addons/website_event_meet/views/event_meet_templates_list.xml
@@ -29,7 +29,7 @@
     <div class="col-12 col-lg-8 col-xl-9 ps-0">
         <t t-call="website_event.navbar"/>
         <div class="d-flex flex-row align-items-center justify-content-between mb-2">
-            <h3 class="mb-0">Join a room</h3>
+            <h3 class="my-0">Join a room</h3>
             <div class="dropdown">
                 <a class="dropdown-toggle btn btn-light" title="Languages Menu"
                     aria-label="Dropdown menu" data-bs-display="static" data-bs-toggle="dropdown" href="#" role="button">
@@ -118,7 +118,7 @@
     </t>
 
     <a t-if="is_event_user or not meeting_room.room_is_full"
-        class="card o_wevent_meeting_room_card w-100 my-2 d-block text-decoration-none rounded-0 text-dark"
+        class="card o_wevent_meeting_room_card w-100 my-2 d-block text-decoration-none rounded-0 bg-body text-dark"
         t-att-data-meeting-room-id="meeting_room.id"
         t-att-data-open-room="opened"
         t-att-data-is-event-manager="int(is_event_user)"
@@ -129,7 +129,7 @@
             <div class="o_wevent_meeting_room_corner_ribbon" t-if="meeting_room.room_is_full">Full</div>
             <div class="d-flex flex-column">
                 <div class="d-flex flex-row">
-                    <h4 t-att-class="'text-break %s' % ('w-75' if meeting_room.website_published else 'w-50')" t-out="meeting_room.name"/>
+                    <h4 t-att-class="'my-0 text-break %s' % ('w-75' if meeting_room.website_published else 'w-50')" t-out="meeting_room.name"/>
                     <div t-if="not meeting_room.is_published" class="w-25">
                         <span class="badge text-bg-danger">Unpublished</span>
                     </div>

--- a/addons/website_event_meet/views/event_meet_templates_page.xml
+++ b/addons/website_event_meet/views/event_meet_templates_page.xml
@@ -110,7 +110,7 @@
                 </a>
             </div>
             <ul id="collapse_meet_room_aside" class="list-group list-group-flush collapse d-lg-block border-top">
-                <li class="list-group-item list-group-item-action" t-foreach="meeting_rooms_other" t-as="meeting_room_other">
+                <li class="list-group-item list-group-item-action bg-body text-reset" t-foreach="meeting_rooms_other" t-as="meeting_room_other">
                     <a class="text-decoration-none text-dark"
                         t-att-href="'/event/%s/meeting_room/%s' % (slug(event), slug(meeting_room_other))">
                         <div class="flex-grow-1 mw-100">

--- a/addons/website_event_track/static/src/scss/event_track_templates_online.scss
+++ b/addons/website_event_track/static/src/scss/event_track_templates_online.scss
@@ -87,20 +87,6 @@
             @media screen and (min-width: 1900px) {
                 min-width: auto;
             }
-
-            // Navigation: keel layout simple
-            .o_wesession_track_aside_nav {
-                .nav-link {
-                    background-color: transparent;
-                    border: 0;
-                    color: $gray-600;
-
-                    &.active {
-                        color: $gray-800;
-                        font-weight: 500;
-                    }
-                }
-            }
         }
     }
 }

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -79,7 +79,7 @@
             <div class="d-flex flex-column flex-grow-1">
                 <span class="m-0 fw-bold" t-out="day" t-options="{'widget': 'date', 'format': 'EEEE '}"/>
                 <div class="d-flex align-items-center justify-content-start">
-                    <span class="h3 mb-0 fw-bold" t-out="day" t-options="{'widget': 'date', 'format': 'dd MMMM YYYY'}"/>
+                    <span class="h3 my-0 fw-bold" t-out="day" t-options="{'widget': 'date', 'format': 'dd MMMM YYYY'}"/>
                     <span class="small ms-2 fw-light">(<t t-out="event.date_tz"/>)</span>
                 </div>
             </div>
@@ -117,8 +117,9 @@
                         <t t-if="tracks">
                             <t t-foreach="tracks" t-as="track">
                                 <t t-set="_classes"
-                                    t-value="'text-center %s %s %s' % (
+                                    t-value="'text-center %s %s %s %s' % (
                                         'event_color_%s' % (track.color or 0),
+                                        'text-bg-light bg-opacity-75' if not track.color else 'text-black',
                                         'event_track h-100' if track else '',
                                         'o_location_size_%d' % len(locations),
                                     )"/>
@@ -175,17 +176,17 @@
         <div class="o_we_agenda_card_content d-flex flex-column justify-content-center my-1">
             <div class="o_we_agenda_card_title">
                 <t t-if="track.website_published or is_event_user">
-                    <a t-att-href="'/event/%s/track/%s' % (slug(event), slug(track))" class="text-black text-bold">
+                    <a t-att-href="'/event/%s/track/%s' % (slug(event), slug(track))" class="text-reset text-bold">
                         <t t-out="track.name"/>
                     </a>
                 </t>
                 <t t-else="">
-                    <span class="text-muted text-bold">
+                    <span class="text-reset text-bold">
                         <t t-out="track.name"/>
                     </span>
                 </t>
             </div>
-            <div class="text-muted text-center" t-if="track.partner_tag_line">
+            <div class="text-reset text-center" t-if="track.partner_tag_line">
                 <small t-out="track.partner_tag_line"/>
             </div>
             <div class="d-flex justify-content-center flex-wrap">

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -66,10 +66,10 @@
             </div>
         </div>
         <!-- Off canvas filters on mobile-->
-        <div id="o_wevent_talk_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none p-0 overflow-visible">
+        <div id="o_wevent_talk_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none p-0 overflow-visible bg-body">
             <div class="offcanvas-header">
                 <h5 class="offcanvas-title">Filters</h5>
-                <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="Close"/>
+                <button type="button" class="btn-close bg-white" data-bs-dismiss="offcanvas" aria-label="Close"/>
             </div>
             <div class="offcanvas-body p-0">
                 <div class="accordion accordion-flush">
@@ -85,7 +85,7 @@
                             </button>
                         </h2>
                         <div class="o_wevent_offcanvas_fav accordion-collapse collapse">
-                            <div class="accordion-body pt-0">
+                            <div class="accordion-body bg-white pt-0">
                                 <ul class="list-group list-group-flush">
                                     <!-- Optional wishlist filter -->
                                     <li t-if="option_track_wishlist" class="list-group-item">                         
@@ -120,7 +120,7 @@
                             </button>
                         </h2>
                         <div t-attf-class="o_wevent_offcanvas_tag_#{tag_category.name} accordion-collapse collapse">
-                            <div class="accordion-body pt-0">
+                            <div class="accordion-body bg-white pt-0">
                                 <ul class="list-group list-group-flush">
                                         <li t-if="tag_category.tag_ids and any(tag.color for tag in tag_category.tag_ids)" class="list-group-item">
                                             <t t-foreach="tag_category.tag_ids" t-as="tag">
@@ -244,7 +244,7 @@
                         <span class="m-0 fw-bold" t-out="tracks_date"
                             t-options="{'widget': 'date', 'format': 'EEEE '}"/>
                         <div class="d-flex align-items-center justify-content-start">
-                            <span class="h3 mb-0 fw-bold" t-out="tracks_date"
+                            <span class="h3 my-0 fw-bold" t-out="tracks_date"
                                 t-options="{'widget': 'date', 'format': 'dd MMMM YYYY'}"/>
                                 <span class="small ms-2 fw-light">(<t t-out="event.date_tz"/>)</span>
                         </div>
@@ -253,7 +253,7 @@
                         <span class="h1 m-0 fw-bold"
                             t-out="tracks_header_name"/>
                     </div>
-                    <a t-attf-class="my-auto align-self-start text-black {{ 'collapsed' if tracks_info['default_collapsed'] else '' }}"
+                    <a t-attf-class="my-auto align-self-start text-reset {{ 'collapsed' if tracks_info['default_collapsed'] else '' }}"
                         t-attf-href="#collapse_session_list_{{ tracks_info_index }}"
                         t-attf-aria-controls="collapse_session_list_{{ tracks_info_index }}"
                         t-att-aria-expanded="'false' if tracks_info['default_collapsed'] else 'true'"
@@ -384,7 +384,7 @@
                 </div>
             </header>
             <div class="col-12">
-                <main class="card-body">
+                <main class="card-body text-reset">
                     <!-- Tags> -->
                     <div class="mb-2">
                         <t t-foreach="track.tag_ids" t-as="tag">
@@ -392,7 +392,7 @@
                         </t>
                     </div>
                     <!-- Title -->
-                    <h5 class="card-title mb-0 text-truncate">
+                    <h5 class="card-title my-0 text-truncate">
                         <span t-field="track.name" itemprop="name"/>
                     </h5>
                 </main>

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -77,7 +77,7 @@
         <div class="o_wesession_track_main_description overflow-auto">
             <div class="p-3 border-bottom">
                 <div class="d-flex flex-wrap justify-content-between align-items-center">
-                    <span class="h4 mb-0" t-out="track.name"/>
+                    <span class="h4 my-0" t-out="track.name"/>
                     <div>
                         <t t-foreach="track.tag_ids" t-as="tag">
                             <span t-if="tag.color"
@@ -190,7 +190,7 @@
             <div class="d-flex align-items-center justify-content-between py-2 border-bottom">
                 <ul class="nav nav-tabs o_wesession_track_aside_nav d-flex border-0" role="tablist">
                     <li class="nav-item flex-grow-1">
-                        <a href="#track_list" aria-controls="track_list" class="nav-link active" role="tab" data-bs-toggle="tab">
+                        <a href="#track_list" aria-controls="track_list" class="nav-link active border-0 bg-body text-reset" role="tab" data-bs-toggle="tab">
                             Talks
                         </a>
                     </li>
@@ -203,10 +203,10 @@
                 class="tab-content collapse d-md-block o_wesession_track_aside_tabs">
                 <div class="tab-pane fade show active" id="track_list" role="tabpanel">
                     <ul class="list-group list-group-flush">
-                        <li t-foreach="tracks_other" t-as="track_other" class="list-group-item list-group-item-action">
+                        <li t-foreach="tracks_other" t-as="track_other" class="list-group-item list-group-item-action bg-body text-reset">
                             <a t-if="is_event_user or track_other.is_published"
                                 t-att-data-publish="track_other.website_published and 'on' or 'off'"
-                                class="d-flex flex-column flex-wrap flex-md-nowrap text-decoration-none text-dark"
+                                class="d-flex flex-column flex-wrap flex-md-nowrap text-decoration-none text-reset"
                                 t-att-href="track_other.website_url">
                                 <t t-call="website_event_track.event_track_aside_other_track"/>
                             </a>

--- a/addons/website_event_track/views/event_track_templates_proposal.xml
+++ b/addons/website_event_track/views/event_track_templates_proposal.xml
@@ -10,7 +10,7 @@
                 <div class="col-lg-8 col-xl-9">
                     <t t-call="website_event.navbar"/>
                     <section>
-                        <h3>Call for Proposals</h3>
+                        <h3 class="mt-0">Call for Proposals</h3>
                     </section>
                     <section id="forms" t-if="not event.website_track_proposal">
                         <h2>Proposals are closed!</h2>

--- a/addons/website_event_track_live/views/event_track_templates_page.xml
+++ b/addons/website_event_track_live/views/event_track_templates_page.xml
@@ -42,13 +42,13 @@
     </xpath>
     <xpath expr="//ul[hasclass('o_wesession_track_aside_nav')]/li" position="before">
         <li t-if="track.is_youtube_chat_available and not is_mobile_chat_disabled" class="nav-item flex-grow-1">
-            <a href="#track_chat" aria-controls="track_chat" class="nav-link active" role="tab" data-bs-toggle="tab">
+            <a href="#track_chat" aria-controls="track_chat" class="nav-link active border-0 bg-body text-reset" role="tab" data-bs-toggle="tab">
                 Chat
             </a>
         </li>
     </xpath>
     <xpath expr="//a[@href='#track_list']" position="attributes">
-        <attribute name="t-attf-class">#{'nav-link' if track.is_youtube_chat_available and not is_mobile_chat_disabled else 'nav-link active'}</attribute>
+        <attribute name="t-attf-class">#{'nav-link border-0 bg-body text-reset' if track.is_youtube_chat_available and not is_mobile_chat_disabled else 'nav-link active border-0 bg-body text-reset'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('o_wesession_track_aside_tabs')]" position="inside">
         <div t-if="track.is_youtube_chat_available and not is_mobile_chat_disabled" id="track_chat"


### PR DESCRIPTION
Prior to this PR, the colors and margin options in the `web editor` were breaking the design, like weird spacing on elements that are not editable by the user, or white background with white text on dark body.

task-3616044

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
