### PR TITLE
[FIX] stock_account: Wrong aml on valuation change

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -588,8 +588,14 @@ class ProductProduct(models.Model):
             if not product_accounts[product.id].get('stock_valuation'):
                 raise UserError(_('You don\'t have any stock valuation account defined on your product category. You must define one before processing this operation.'))
 
-            debit_account_id = expense_account.id
-            credit_account_id = product_accounts[product.id]['stock_valuation'].id
+            value = out_stock_valuation_layer.value
+            if out_stock_valuation_layer.currency_id.compare_amounts(value, 0) < 0:
+                debit_account_id = expense_account.id
+                credit_account_id = product_accounts[product.id]['stock_valuation'].id
+            else:
+                debit_account_id = product_accounts[product.id]['stock_valuation'].id
+                credit_account_id = expense_account.id
+
             value = out_stock_valuation_layer.value
             move_vals = {
                 'journal_id': product_accounts[product.id]['stock_journal'].id,
@@ -624,11 +630,11 @@ class ProductProduct(models.Model):
             if not product_accounts[product.id].get('stock_valuation'):
                 raise UserError(_('You don\'t have any stock valuation account defined on your product category. You must define one before processing this operation.'))
 
-            debit_account_id = product_accounts[product.id]['stock_valuation'].id
-            credit_account_id = product_accounts[product.id]['stock_input'].id
             value = out_stock_valuation_layer.value
-            if out_stock_valuation_layer.currency_id.compare_amounts(value, 0) < 0:
-                # Swap accounts makes a negative value in accounting
+            if out_stock_valuation_layer.currency_id.compare_amounts(value, 0) > 0:
+                debit_account_id = product_accounts[product.id]['stock_valuation'].id
+                credit_account_id = product_accounts[product.id]['stock_input'].id
+            else:
                 debit_account_id = product_accounts[product.id]['stock_output'].id
                 credit_account_id = product_accounts[product.id]['stock_valuation'].id
 


### PR DESCRIPTION
Following #130674

Steps to reproduce:
-Create a new product category, using Average Costing, Automated Valuation, and the new account for Valuation -Create 2 storable products in that category.
	3a. Product1 with a cost of $100.
	3b. Product2 with a cost of $10.
-Adjust stock.
	4a. Create and process a receipt for 10 x Product1.
	4b. Create and process a delivery for 10 x Product2.

-Check GL. New account has correct balance ($900, being $1000 for +ve Product1, and -100 for -ve Product2). -Change product category from "average" to "FIFO" costing

Current behavior:
The GL now shifts from "stock value" $900, to $700

Expected behavior:
Value in GL should still be $900

It seems that any valuation modification will always impact stock input and expense. However for move with a negative quantity. We should rather target the stock output account.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
