### PR TITLE
[FIX] models: return a query in _search with False domain

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -4724,7 +4724,7 @@ Fields:
 
         if expression.is_false(self, args):
             # optimization: no need to query, as no record satisfies the domain
-            return 0 if count else []
+            return 0 if count else expression.expression(expression.FALSE_DOMAIN, self).query
 
         # the flush must be done before the _where_calc(), as the latter can do some selects
         self._flush_search(args, order=order)


### PR DESCRIPTION
When the domain does not match any records, _search should return a Query object instead of an empty list in case it is used by the caller, e.g. using query.order

```
    query.order = None
 AttributeError: 'list' object has no attribute 'order'
```





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
