### PR TITLE
[FIX] account: multi language invoice print

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1923,6 +1923,8 @@ class AccountMove(models.Model):
                                                                 }
             }
         """
+        if self._context.get('use_partner_lang'):
+            self = self.with_context(lang=partner.lang)
         account_tax = self.env['account.tax']
 
         grouped_taxes = defaultdict(lambda: defaultdict(lambda: {'base_amount': 0.0, 'tax_amount': 0.0, 'base_line_keys': set()}))

--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -137,7 +137,7 @@ class ReportInvoiceWithoutPayment(models.AbstractModel):
 
     @api.model
     def _get_report_values(self, docids, data=None):
-        docs = self.env['account.move'].browse(docids)
+        docs = self.env['account.move'].with_context(use_partner_lang=True).browse(docids)
 
         qr_code_urls = {}
         for invoice in docs:


### PR DESCRIPTION
The issue:
having 2 invoices with different customer, each customer has a different language, the 'Unaxed amount' string will get translated into the first language of the first invoice partner.

The fix:
set a context key for the invoice reports which indicate to use the partner language instead.

opw-3569173

Exploring solutions for @amay-odoo 's PR https://github.com/odoo/odoo/pull/143321




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
