### PR TITLE
[FIX] web_editor: insert should paste empty nodes

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -198,6 +198,10 @@ export const editorCommands = {
             }
             // Grab the content of the last child block and isolate it.
             if (isBlock(container.lastChild) && !['TABLE', 'UL', 'OL'].includes(container.lastChild.nodeName)) {
+                // Empty block must contain a br element.
+                if (!container.lastElementChild.hasChildNodes()) {
+                    container.lastElementChild.appendChild(document.createElement('br'));
+                }
                 containerLastChild.replaceChildren(...container.lastElementChild.childNodes);
                 container.lastElementChild.remove();
             }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
@@ -106,6 +106,15 @@ describe('insert HTML', () => {
                 contentAfter: '<p>abefgh</p><p>[]cd</p>',
             });
         });
+        it('should paste an "empty" block', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>abcd[]</p>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<p>efgh</p><p></p>'));
+                },
+                contentAfter: '<p>abcdefgh</p><p>[]<br></p>',
+            });
+        });
     });
     describe('not collapsed selection', () => {
         it('should delete selection and insert html in its place', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
@@ -79,6 +79,33 @@ describe('insert HTML', () => {
                 contentAfter: '<p>contentunwrapped</p><div><i class="fa fa-circle-o-notch"></i></div><p>culprit</p><p>after[]</p>',
             });
         });
+        it('should paste empty last line when pasting at end of a text', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>abcd[]</p>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<p>efgh</p><p><br></p>'));
+                },
+                contentAfter: '<p>abcdefgh</p><p>[]<br></p>',
+            });
+        });
+        it('should not paste br of empty last line when pasting at start of a text', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>[]abcd</p>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<p>efgh</p><p><br></p>'));
+                },
+                contentAfter: '<p>efgh</p><p>[]abcd</p>',
+            });
+        });
+        it('should not paste br of empty last line when pasting in between a text', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab[]cd</p>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<p>efgh</p><p><br></p>'));
+                },
+                contentAfter: '<p>abefgh</p><p>[]cd</p>',
+            });
+        });
     });
     describe('not collapsed selection', () => {
         it('should delete selection and insert html in its place', async () => {


### PR DESCRIPTION
Current behavior before PR:

When the container to paste's last element is an empty element the insert command fails to implement oEnter and causes a traceback.

Desired behavior after PR is merged:

Make sure the if the last element is an empty element it must have at least an empty text node.

task-3624809