### PR TITLE
[IMP] web: Switch company menu ux improvements (search, controls, navigation)

### DIFF
--- a/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
+++ b/addons/mail/static/tests/legacy/web/fields/m2x_avatar_user_tests.js
@@ -205,7 +205,7 @@ test('many2one_avatar_user widget edited by the smart action "Assign to me" in f
 
         // Unassign me
         await triggerHotkey("control+k");
-        await click("#o_command_2");
+        await click(".o_command", { text: "Unassign from meALT + SHIFT + I" });
         await contains(".o_field_many2one_avatar_user input", { value: "" });
     });
 });

--- a/addons/web/static/src/core/navigation/navigation.js
+++ b/addons/web/static/src/core/navigation/navigation.js
@@ -118,9 +118,6 @@ class Navigator {
         this.hotkeyService = hotkeyService;
 
         this.allowedInEditableHotkeys = ["arrowup", "arrowdown", "enter", "tab", "shift+tab"];
-        if (this.options.hotkeys.space) {
-            this.allowedInEditableHotkeys.push("space");
-        }
     }
 
     enable() {
@@ -191,6 +188,7 @@ class Navigator {
         if (!this.containerRef.el) {
             return;
         }
+        const oldItemsLength = this.items.length;
         this.clearItems();
 
         const elements = [...this.containerRef.el.querySelectorAll(this.options.itemsSelector)];
@@ -202,6 +200,10 @@ class Navigator {
                 setActiveItem: (index, el) => this.setActiveItem(index, el),
             });
         });
+
+        if (oldItemsLength != this.items.length && this.currentActiveIndex >= this.items.length) {
+            this.items.at(-1)?.focus();
+        }
     }
 
     setActiveItem(index, item) {

--- a/addons/web/static/src/core/utils/objects.js
+++ b/addons/web/static/src/core/utils/objects.js
@@ -104,7 +104,12 @@ export function deepMerge(target, extension) {
     const output = Object.assign({}, target);
     if (isObject(extension)) {
         for (const key of Reflect.ownKeys(extension)) {
-            if (key in target && isObject(extension[key]) && !Array.isArray(extension[key])) {
+            if (
+                key in target &&
+                isObject(extension[key]) &&
+                !Array.isArray(extension[key]) &&
+                typeof extension[key] !== "function"
+            ) {
                 output[key] = deepMerge(target[key], extension[key]);
             } else {
                 Object.assign(output, { [key]: extension[key] });

--- a/addons/web/static/src/webclient/burger_menu/mobile_switch_company_menu/mobile_switch_company_menu.js
+++ b/addons/web/static/src/webclient/burger_menu/mobile_switch_company_menu/mobile_switch_company_menu.js
@@ -1,13 +1,20 @@
-import {
-    SwitchCompanyMenu,
-    SwitchCompanyItem,
-} from "@web/webclient/switch_company_menu/switch_company_menu";
+import { SwitchCompanyMenu } from "@web/webclient/switch_company_menu/switch_company_menu";
 
-export class MobileSwitchCompanyItem extends SwitchCompanyItem {
-    static template = "web.MobileSwitchCompanyItem";
-    static components = { ...SwitchCompanyItem, MobileSwitchCompanyItem };
-}
 export class MobileSwitchCompanyMenu extends SwitchCompanyMenu {
     static template = "web.MobileSwitchCompanyMenu";
-    static components = { ...SwitchCompanyMenu, MobileSwitchCompanyItem };
+
+    setup() {
+        super.setup();
+        this.state.isOpen = false;
+    }
+
+    get show() {
+        return !this.hasLotsOfCompanies || this.state.isOpen === true;
+    }
+
+    toggleCollapsible() {
+        if (this.hasLotsOfCompanies) {
+            this.state.isOpen = !this.state.isOpen;
+        }
+    }
 }

--- a/addons/web/static/src/webclient/burger_menu/mobile_switch_company_menu/mobile_switch_company_menu.xml
+++ b/addons/web/static/src/webclient/burger_menu/mobile_switch_company_menu/mobile_switch_company_menu.xml
@@ -2,40 +2,15 @@
 <templates id="template" xml:space="preserve">
 
 <t t-name="web.MobileSwitchCompanyMenu">
-    <div class="o_burger_menu_companies p-3">
-        <div class="o_burger_menu_user_title h6 mb-3">Companies</div>
-        <t t-foreach="Object.values(companyService.allowedCompaniesWithAncestors)
-                      .filter((c) => !c.parent_id)
-                      .sort((c1, c2) => c1.sequence - c2.sequence)
-                     " t-as="company" t-key="company.id">
-            <MobileSwitchCompanyItem company="company" level="0"/>
-        </t>
-    </div>
-</t>
-
-<t t-name="web.MobileSwitchCompanyItem">
-    <t t-set="checkIcon" t-value="isCompanySelected ? 'fa-check-square text-primary' : 'fa-square-o'"/>
-    <div class="d-flex menu_companies_item" t-att-class="{'disabled': !isCompanyAllowed }" t-att-data-company-id="props.company.id">
-        <div class="border-end toggle_company" t-att-class="{'border-primary' : isCurrent}" t-on-click="() => this.toggleCompany()">
-            <span class="btn border-0 p-2" t-att-class="{'disabled': !isCompanyAllowed }">
-                <i t-attf-class="fa fa-fw fs-2 m-0 {{checkIcon}}"/>
-            </span>
+    <div class="o_burger_menu_companies p-3 pb-0">
+        <div class="w-100" t-on-click="() => this.toggleCollapsible()">
+            <i t-if="hasLotsOfCompanies" class="fa me-2" style="width: 10px" t-att-class="{ 'fa-caret-right': !state.isOpen, 'fa-caret-down': state.isOpen }"/>
+            <span class="mb-3 fs-4">Companies</span>
         </div>
-        <div
-            class="flex-grow-1 p-2 log_into"
-            t-att-class="{'bg-primary-subtle': isCurrent, 'text-muted': !isCompanyAllowed}" t-on-click="() => this.logIntoCompany()"
-        >
-            <span
-                t-esc="props.company.name" class="company_label"
-                t-att-class="isCurrent ? 'text-900 fw-bold' : ''"
-                t-att-style="'padding-left:' + (props.level * 10) + 'px';"
-            />
-            <small t-if="isCurrent" class="ms-1">(current)</small>
+        <div t-if="show" class="mt-2">
+            <t t-call="web.SwitchCompanyMenu.Items"/>
         </div>
     </div>
-    <t t-foreach="props.company.child_ids" t-as="child" t-key="child">
-        <MobileSwitchCompanyItem company="companyService.getCompany(child)" level="props.level + 1"/>
-    </t>
 </t>
 
 </templates>

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_item.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_item.js
@@ -1,0 +1,41 @@
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { Component, useState } from "@odoo/owl";
+import { useService } from "@web/core/utils/hooks";
+
+export class SwitchCompanyItem extends Component {
+    static template = "web.SwitchCompanyItem";
+    static components = { DropdownItem, SwitchCompanyItem };
+    static props = {
+        company: {},
+        level: { type: Number },
+    };
+
+    setup() {
+        this.companyService = useService("company");
+        this.companySelector = useState(this.env.companySelector);
+    }
+
+    get isCompanySelected() {
+        return this.companySelector.isCompanySelected(this.props.company.id);
+    }
+
+    get isCompanyAllowed() {
+        return this.props.company.id in this.companyService.allowedCompanies;
+    }
+
+    get isCurrent() {
+        return this.props.company.id === this.companyService.currentCompany.id;
+    }
+
+    logIntoCompany() {
+        if (this.isCompanyAllowed) {
+            this.companySelector.switchCompany("loginto", this.props.company.id);
+        }
+    }
+
+    toggleCompany() {
+        if (this.isCompanyAllowed) {
+            this.companySelector.switchCompany("toggle", this.props.company.id);
+        }
+    }
+}

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_item.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_item.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+<t t-name="web.SwitchCompanyItem">
+    <span
+        class="d-flex o_switch_company_item dropdown-item p-0 w-100"
+        t-att-class="{
+            'disabled': !isCompanyAllowed,
+            'o-navigable': isCompanyAllowed,
+            'alert-secondary': isCompanySelected,
+        }"
+        tabindex="0"
+        data-menu="company"
+        t-att-data-company-id="props.company.id"
+    >
+        <div
+            role="menuitemcheckbox"
+            t-att-aria-checked="isCompanySelected ? 'true' : 'false'"
+            t-att-aria-label="props.company.name"
+            t-att-title="(isCompanySelected ? 'Hide ' : 'Show ') + props.company.name + ' content.'"
+            class="border-end"
+            t-att-class="{ 'border-primary': isCompanySelected, 'disabled': !isCompanyAllowed }"
+            t-on-click.stop="() => this.toggleCompany()"
+        >
+            <span class="btn border-0 px-2" t-att-class="isCompanyAllowed ? 'btn-link text-primary' : 'disabled'">
+                <i class="fa fa-fw py-1" t-att-class="isCompanySelected ? 'fa-check-square text-primary' : 'fa-square-o'"/>
+            </span>
+        </div>
+
+        <div
+            role="button"
+            t-att-aria-pressed="isCurrent ? 'true' : 'false'"
+            t-att-aria-label="'Switch to ' + props.company.name"
+            t-att-title="'Switch to ' + props.company.name"
+            class="d-flex flex-grow-1 align-items-center py-0 log_into ps-2"
+            t-att-class="isCurrent ? 'bg-primary-subtle' : 'btn fw-normal border-0 ' + (isCompanyAllowed ? 'btn-link text-primary' : 'disabled')"
+            t-on-click="() => this.logIntoCompany()"
+        >
+            <span
+                class="company_label text-700 text-truncate"
+                t-attf-style="padding-left:{{props.level * 20}}px;">
+                <t t-out="props.company.name"/>
+            </span>
+        </div>
+    </span>
+</t>
+
+</templates>

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -3,16 +3,27 @@ import { DropdownGroup } from "@web/core/dropdown/dropdown_group";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { registry } from "@web/core/registry";
 
-import { Component, useChildSubEnv, useState } from "@odoo/owl";
-import { debounce } from "@web/core/utils/timing";
-import { useService } from "@web/core/utils/hooks";
+import { Component, useChildSubEnv, useRef, useState } from "@odoo/owl";
+import { useCommand } from "@web/core/commands/command_hook";
+import { _t } from "@web/core/l10n/translation";
+import { symmetricalDifference } from "@web/core/utils/arrays";
+import { useChildRef, useService } from "@web/core/utils/hooks";
+import { SwitchCompanyItem } from "@web/webclient/switch_company_menu/switch_company_item";
+import { useHotkey } from "@web/core/hotkeys/hotkey_hook";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
 
 class CompanySelector {
-    constructor(companyService, toggleDelay) {
+    constructor(companyService, dropdownState) {
         this.companyService = companyService;
+        this.dropdownState = dropdownState;
         this.selectedCompaniesIds = companyService.activeCompanyIds.slice();
+    }
 
-        this._debouncedApply = debounce(() => this._apply(), toggleDelay);
+    get hasSelectionChanged() {
+        return (
+            symmetricalDifference(this.selectedCompaniesIds, this.companyService.activeCompanyIds)
+                .length > 0
+        );
     }
 
     isCompanySelected(companyId) {
@@ -26,13 +37,31 @@ class CompanySelector {
             } else {
                 this._selectCompany(companyId);
             }
-            this._debouncedApply();
         } else if (mode === "loginto") {
             if (this._isSingleCompanyMode()) {
                 this.selectedCompaniesIds.splice(0, this.selectedCompaniesIds.length);
             }
             this._selectCompany(companyId, true);
-            this._apply();
+            this.apply();
+
+            this.dropdownState.close?.();
+        }
+    }
+
+    apply() {
+        this.companyService.setCompanies(this.selectedCompaniesIds, false);
+    }
+
+    reset() {
+        this.selectedCompaniesIds = this.companyService.activeCompanyIds.slice();
+    }
+
+    selectAll() {
+        if (this.selectedCompaniesIds.length > 0) {
+            this.selectedCompaniesIds.splice(0, this.selectedCompaniesIds.length);
+        } else {
+            const newIds = Object.values(this.companyService.allowedCompanies).map((c) => c.id);
+            this.selectedCompaniesIds.splice(0, this.selectedCompaniesIds.length, ...newIds);
         }
     }
 
@@ -59,11 +88,7 @@ class CompanySelector {
     }
 
     _getBranches(companyId) {
-        return this.companyService.getCompany(companyId).child_ids;
-    }
-
-    _apply() {
-        this.companyService.setCompanies(this.selectedCompaniesIds, false);
+        return this.companyService.getCompany(companyId).child_ids || [];
     }
 
     _isSingleCompanyMode() {
@@ -94,7 +119,7 @@ class CompanySelector {
 
         // If some children or sub-children of the root company
         // are not active, we are in multi-company mode.
-        if (rootCompany) {
+        if (rootCompany && rootCompany.child_ids) {
             const queue = [...rootCompany.child_ids];
             while (queue.length > 0) {
                 const company = getActiveCompany(queue.pop());
@@ -110,57 +135,146 @@ class CompanySelector {
     }
 }
 
-export class SwitchCompanyItem extends Component {
-    static template = "web.SwitchCompanyItem";
-    static components = { DropdownItem, SwitchCompanyItem };
-    static props = {
-        company: {},
-        level: { type: Number },
-    };
-
-    setup() {
-        this.companyService = useService("company");
-        this.companySelector = useState(this.env.companySelector);
-    }
-
-    get isCompanySelected() {
-        return this.companySelector.isCompanySelected(this.props.company.id);
-    }
-
-    get isCompanyAllowed() {
-        return this.props.company.id in this.companyService.allowedCompanies;
-    }
-
-    get isCurrent() {
-        return this.props.company.id === this.companyService.currentCompany.id;
-    }
-
-    logIntoCompany() {
-        if (this.isCompanyAllowed) {
-            this.companySelector.switchCompany("loginto", this.props.company.id);
-        }
-    }
-
-    toggleCompany() {
-        if (this.isCompanyAllowed) {
-            this.companySelector.switchCompany("toggle", this.props.company.id);
-        }
-    }
-}
-
 export class SwitchCompanyMenu extends Component {
     static template = "web.SwitchCompanyMenu";
-    static components = { Dropdown, DropdownItem, SwitchCompanyItem, DropdownGroup };
+    static components = { Dropdown, DropdownItem, DropdownGroup, SwitchCompanyItem };
     static props = {};
-    static toggleDelay = 1000;
 
     setup() {
+        this.dropdown = useDropdownState();
         this.companyService = useService("company");
-
-        this.companySelector = useState(
-            new CompanySelector(this.companyService, this.constructor.toggleDelay)
-        );
+        this.companySelector = useState(new CompanySelector(this.companyService, this.dropdown));
         useChildSubEnv({ companySelector: this.companySelector });
+
+        this.searchInputRef = useRef("inputRef");
+        this.state = useState({});
+        this.resetState();
+
+        useHotkey("control+enter", () => this.confirm(), {
+            bypassEditableProtection: true,
+            isAvailable: () => this.companySelector.hasSelectionChanged,
+        });
+
+        useCommand(_t("Switch Company"), () => this.dropdown.open(), { hotkey: "alt+shift+u" });
+
+        this.containerRef = useChildRef();
+        this.navigationOptions = {
+            hotkeys: {
+                space: (index, items) => {
+                    if (!items[index]) {
+                        return;
+                    }
+                    if (items[index].el.classList.contains("o_switch_company_item")) {
+                        const companyId = parseInt(items[index].el.dataset.companyId);
+                        this.companySelector.switchCompany("toggle", companyId);
+                    }
+                },
+                enter: (index, items) => {
+                    if (!items[index]) {
+                        return;
+                    }
+                    if (items[index].el.classList.contains("o_switch_company_item")) {
+                        const companyId = parseInt(items[index].el.dataset.companyId);
+                        this.companySelector.switchCompany("loginto", companyId);
+                        this.dropdown.close();
+                    } else {
+                        items[index].select();
+                    }
+                },
+            },
+        };
+    }
+
+    get hasLotsOfCompanies() {
+        return Object.values(this.companyService.allowedCompaniesWithAncestors).length > 9;
+    }
+
+    get companiesEntries() {
+        const companies = [];
+
+        const addCompany = (company, level = 0) => {
+            if (this.matchSearch(company.name)) {
+                companies.push({ company, level });
+            }
+
+            if (company.child_ids) {
+                for (const companyId of company.child_ids) {
+                    addCompany(this.companyService.getCompany(companyId), level + 1);
+                }
+            }
+        };
+
+        Object.values(this.companyService.allowedCompaniesWithAncestors)
+            .filter((c) => !c.parent_id)
+            .sort((c1, c2) => c1.sequence - c2.sequence)
+            .forEach((c) => addCompany(c));
+
+        return companies;
+    }
+
+    get selectAllClass() {
+        if (
+            this.companySelector.selectedCompaniesIds.length >=
+            Object.values(this.companyService.allowedCompanies).length
+        ) {
+            return "btn-link text-primary";
+        } else {
+            return "btn-link text-secondary";
+        }
+    }
+
+    get selectAllIcon() {
+        if (
+            this.companySelector.selectedCompaniesIds.length >=
+            Object.values(this.companyService.allowedCompanies).length
+        ) {
+            return "fa-check-square text-primary";
+        } else if (this.companySelector.selectedCompaniesIds.length > 0) {
+            return "fa-minus-square-o";
+        } else {
+            return "fa-square-o";
+        }
+    }
+
+    resetState() {
+        this.state.searchFilter = "";
+        this.state.showFilter = this.hasLotsOfCompanies;
+    }
+
+    onSearch(ev) {
+        this.state.searchFilter = ev.target.value;
+        this.state.showFilter = true;
+    }
+
+    matchSearch(companyName) {
+        if (!this.state.searchFilter) {
+            return true;
+        }
+
+        const name = companyName.toLocaleLowerCase().replace(/\s/g, "");
+        const filter = this.state.searchFilter.toLocaleLowerCase().replace(/\s/g, "");
+        return name.includes(filter);
+    }
+
+    handleDropdownChange(isOpen) {
+        if (isOpen) {
+            if (this.searchInputRef.el) {
+                this.searchInputRef.el.focus();
+            }
+
+            if (this.containerRef.el) {
+                // Fixes the container width so it doesn't change when searching.
+                const currentWidth = this.containerRef.el.getBoundingClientRect().width;
+                this.containerRef.el.style.width = currentWidth + "px";
+            }
+        } else {
+            this.resetState();
+        }
+    }
+
+    confirm() {
+        this.dropdown.close();
+        this.companySelector.apply();
     }
 
     get isSingleCompany() {

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.scss
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.scss
@@ -1,5 +1,48 @@
-.dropdown-item {
-  [data-menu="company"].disabled {
-      cursor: default;
-  }
+
+.o_switch_company_menu_dropdown {
+    min-width: 20rem;
+}
+
+.o_switch_company_menu_items {
+    max-height: 20rem;
+    overflow-x: auto;
+
+    .o_switch_company_item {
+        height: 33px;
+
+        [role=button] {
+            min-width: 0;
+        }
+
+        &.focus,
+        &.focus > * {
+            background-color: var(--gray-200);
+        }
+
+        .disabled {
+            cursor: default;
+        }
+    }
+}
+
+.o_switch_company_menu_buttons {
+    .btn-primary {
+        $color-theme: map-get($o-btns-bs-override, "primary");
+        $background: map-get($color-theme, "background");
+        color: color-contrast($background);
+    }
+
+    .focus {
+        &.btn-primary {
+            outline: 2px solid var(--o-cc1-text);
+        }
+
+        &.btn-secondary {
+            outline: 2px solid var(--o-cc1-text);
+        }
+    }
+}
+
+.o_switch_company_menu .oe_topbar_name {
+    max-width: 15rem;
 }

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -4,69 +4,80 @@
 <t t-name="web.SwitchCompanyMenu">
     <div class="o_switch_company_menu d-none d-md-block">
         <DropdownGroup group="'web-navbar-group'">
-            <Dropdown disabled="isSingleCompany" position="'bottom-end'">
-                <button t-att-disabled="isSingleCompany">
+            <Dropdown
+                position="'bottom-end'"
+                menuRef="containerRef"
+                state="this.dropdown"
+                onStateChanged.bind="handleDropdownChange"
+                navigationOptions="navigationOptions"
+                menuClass="'o_switch_company_menu_dropdown'"
+                disabled="isSingleCompany"
+            >
+                <button data-hotkey="shift+u" t-att-disabled="isSingleCompany" t-att-title="companyService.currentCompany.name">
                     <i class="fa fa-building d-lg-none"/>
-                    <span class="oe_topbar_name d-none d-lg-block" t-esc="companyService.currentCompany.name"/>
+                    <span class="oe_topbar_name d-none d-lg-block text-truncate" t-esc="companyService.currentCompany.name"/>
                 </button>
+
                 <t t-set-slot="content">
-                    <t t-foreach="Object.values(companyService.allowedCompaniesWithAncestors)
-                        .filter((c) => !c.parent_id)
-                        .sort((c1, c2) => c1.sequence - c2.sequence)
-                        " t-as="company" t-key="company.id">
-                        <SwitchCompanyItem company="company" level="0"/>
-                    </t>
+                    <t t-call="web.SwitchCompanyMenu.Items"/>
                 </t>
             </Dropdown>
         </DropdownGroup>
     </div>
 </t>
 
-
-<t t-name="web.SwitchCompanyItem">
-    <DropdownItem class="'p-0'" closingMode="!isCompanyAllowed ? 'none' : 'all'">
+<t t-name="web.SwitchCompanyMenu.Items">
+    <div class="d-flex flex-row pe-2 mb-2" t-att-class="{ 'visually-hidden': !state.showFilter }">
         <div
-            class="d-flex"
-            t-att-class="{ 'disabled': !isCompanyAllowed }"
-            data-menu="company"
-            t-att-data-company-id="props.company.id">
-            <div
-                role="menuitemcheckbox"
-                t-att-aria-checked="isCompanySelected ? 'true' : 'false'"
-                t-att-aria-label="props.company.name"
-                t-att-title="(isCompanySelected ? 'Hide ' : 'Show ') + props.company.name + ' content.'"
-                tabindex="0"
-                class="border-end toggle_company"
-                t-att-class="{ 'border-primary': isCurrent, 'disabled': !isCompanyAllowed }"
-                t-on-click.stop="() => this.toggleCompany()">
-
-                <span class="btn border-0 p-2" t-att-class="isCompanyAllowed ? 'btn-link text-primary' : 'disabled'">
-                    <i class="fa fa-fw py-2" t-att-class="isCompanySelected ? 'fa-check-square text-primary' : 'fa-square-o'"/>
-                </span>
-            </div>
-
-            <div
-                role="button"
-                t-att-aria-pressed="isCurrent ? 'true' : 'false'"
-                t-att-aria-label="'Switch to ' + props.company.name "
-                t-att-title="'Switch to ' + props.company.name "
-                tabindex="0"
-                class="d-flex flex-grow-1 align-items-center py-0 log_into ps-2"
-                t-att-class="isCurrent ? 'bg-primary-subtle' : 'btn fw-normal border-0 ' + (isCompanyAllowed ? 'btn-link text-primary' : 'disabled')"
-                t-on-click="() => this.logIntoCompany()">
-
-                <span
-                    class='company_label pe-3'
-                    t-att-class="isCurrent ? 'text-900 fw-bold' : ''"
-                    t-attf-style="padding-left:{{props.level * 20}}px;">
-                    <t t-out="props.company.name"/>
-                </span>
+            role="menuitemcheckbox"
+            t-att-aria-checked="companySelector.selectedCompaniesIds.length > 0 ? 'true' : 'false'"
+            t-att-aria-label="companySelector.selectedCompaniesIds.length > 0 ? 'Deselect all' : 'Select all'"
+            t-att-title="companySelector.selectedCompaniesIds.length > 0 ? 'Deselect all' : 'Select all'"
+            t-on-click="() => companySelector.selectAll()"
+        >
+            <span class="btn border-0 pt-2 px-2" t-att-class="selectAllClass">
+                <i class="fa fa-fw" t-att-class="selectAllIcon"/>
+            </span>
+        </div>
+        <div
+            class="form-control d-flex align-items-center py-1"
+            role="search"
+        >
+            <i class="oi oi-search me-2" role="img" aria-label="Search..." title="Search..."/>
+            <div class="d-flex flex-grow-1 flex-wrap gap-1">
+                <input
+                    t-on-input="this.onSearch"
+                    t-att-value="this.state.searchFilter"
+                    t-ref="inputRef"
+                    type="text"
+                    class="o_input flex-grow-1 border-0 o-navigable"
+                    placeholder="Search..."
+                    role="searchbox"
+                />
             </div>
         </div>
-    </DropdownItem>
-    <t t-foreach="props.company.child_ids" t-as="child" t-key="child">
-        <SwitchCompanyItem company="companyService.getCompany(child)" level="props.level + 1"/>
-    </t>
+    </div>
+
+    <div class="o_switch_company_menu_items">
+        <t t-foreach="companiesEntries" t-as="entry" t-key="entry.company.id">
+            <SwitchCompanyItem company="entry.company" level="entry.level"/>
+        </t>
+    </div>
+
+    <div t-if="companySelector.hasSelectionChanged" class="o_switch_company_menu_buttons d-flex justify-content-end gap-2 px-2 pt-2">
+        <button
+            class="btn btn-primary o-navigable flex-grow-1 text-center"
+            t-on-click="() => this.confirm()"
+        >
+            Confirm
+        </button>
+        <button
+            class="btn btn-secondary o-navigable flex-grow-1 text-center"
+            t-on-click="() => companySelector.reset()"
+        >
+            Reset
+        </button>
+    </div>
 </t>
 
 </templates>

--- a/addons/web/static/tests/core/utils/objects.test.js
+++ b/addons/web/static/tests/core/utils/objects.test.js
@@ -182,6 +182,9 @@ test("deepMerge", () => {
     expect(deepMerge("foo", 1)).toBe(undefined);
     expect(deepMerge(null, null)).toBe(undefined);
 
+    const f = () => {};
+    expect(deepMerge({ a: undefined }, { a: f })).toEqual({ a: f });
+
     // There's no current use for arrays, support can be added if needed
     expect(deepMerge({ a: [1, 2, 3] }, { a: [4] })).toEqual({ a: [4] });
 

--- a/addons/web/static/tests/legacy/helpers/mock_services.js
+++ b/addons/web/static/tests/legacy/helpers/mock_services.js
@@ -245,9 +245,11 @@ export const fakeCompanyService = {
     start() {
         return {
             allowedCompanies: {},
+            allowedCompaniesWithAncestors: {},
             activeCompanyIds: [],
             currentCompany: {},
             setCompanies: () => {},
+            getCompany: () => {},
         };
     },
 };

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -5861,18 +5861,16 @@ test(`Navigate between the list and kanban view using the command palette`, asyn
 
     press("control+k");
     await animationFrame();
-    expect(`.o_command_category:eq(1) .o_command`).toHaveCount(1);
-    expect(`.o_command_category:eq(1) .o_command`).toHaveText("Show Kanban view");
+    expect(`.o_command_category .o_command:contains(Show Kanban view)`).toHaveCount(1);
 
-    await contains(`.o_command_category:eq(1) .o_command`).click();
+    await contains(`.o_command:contains(Show Kanban view)`).click();
     expect(`.o_kanban_view`).toHaveCount(1);
 
     press("control+k");
     await animationFrame();
-    expect(`.o_command_category:eq(1) .o_command`).toHaveCount(1);
-    expect(`.o_command_category:eq(1) .o_command`).toHaveText("Show List view");
+    expect(`.o_command_category .o_command:contains(Show List view)`).toHaveCount(1);
 
-    await contains(`.o_command_category:eq(1) .o_command`).click();
+    await contains(`.o_command:contains(Show List view)`).click();
     expect(`.o_list_view`).toHaveCount(1);
 });
 

--- a/addons/web/static/tests/webclient/mobile/mobile_switch_company.test.js
+++ b/addons/web/static/tests/webclient/mobile/mobile_switch_company.test.js
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { Deferred, runAllTimers } from "@odoo/hoot-mock";
+import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
+import { queryAllTexts } from "@odoo/hoot-dom";
 import {
     contains,
     getService,
@@ -31,6 +32,14 @@ async function createSwitchCompanyMenu(options = { toggleDelay: 0 }) {
 
 describe.current.tags("mobile");
 
+async function toggle(index) {
+    await contains(`[data-company-id] [role=menuitemcheckbox]:eq(${index})`).click();
+}
+
+async function confirm() {
+    await contains(".o_switch_company_menu_buttons button:first").click();
+}
+
 beforeEach(() => {
     patchWithCleanup(session.user_companies, {
         allowed_companies: {
@@ -47,22 +56,21 @@ test("basic rendering", async () => {
 
     expect(".o_burger_menu_companies").toHaveProperty("tagName", "DIV");
     expect(".o_burger_menu_companies").toHaveClass("o_burger_menu_companies");
-    expect(".toggle_company").toHaveCount(3);
+    expect("[data-company-id]").toHaveCount(3);
     expect(".log_into").toHaveCount(3);
     expect(".fa-check-square").toHaveCount(1);
     expect(".fa-square-o").toHaveCount(2);
 
-    expect(".menu_companies_item:eq(0)").toHaveText("Hermit(current)");
-    expect(".menu_companies_item:eq(1)").toHaveText("Herman's");
-    expect(".menu_companies_item:eq(2)").toHaveText("Heroes TM");
+    expect(".o_switch_company_item:eq(0)").toHaveText("Hermit");
+    expect(".o_switch_company_item:eq(0)").toHaveClass("alert-secondary");
+    expect(".o_switch_company_item:eq(1)").toHaveText("Herman's");
+    expect(".o_switch_company_item:eq(2)").toHaveText("Heroes TM");
 
-    expect(".menu_companies_item i:eq(0)").toHaveClass("fa-check-square");
-    expect(".menu_companies_item i:eq(1)").toHaveClass("fa-square-o");
-    expect(".menu_companies_item i:eq(2)").toHaveClass("fa-square-o");
+    expect(".o_switch_company_item i:eq(0)").toHaveClass("fa-check-square");
+    expect(".o_switch_company_item i:eq(1)").toHaveClass("fa-square-o");
+    expect(".o_switch_company_item i:eq(2)").toHaveClass("fa-square-o");
 
-    expect(".o_burger_menu_companies").toHaveText(
-        "Companies\nHermit(current)\nHerman's\nHeroes TM"
-    );
+    expect(".o_burger_menu_companies").toHaveText("Companies\nHermit\nHerman's\nHeroes TM");
 });
 
 test("companies can be toggled: toggle a second company", async () => {
@@ -90,22 +98,17 @@ test("companies can be toggled: toggle a second company", async () => {
      *   [x] Company 2      -> toggle
      *   [ ] Company 3
      */
-    await contains(".toggle_company:eq(1)").click();
+    await toggle(1);
     expect("[data-company-id] .fa-check-square").toHaveCount(2);
     expect("[data-company-id] .fa-square-o").toHaveCount(1);
+    await confirm();
     expect.verifySteps(["1-2"]);
 });
 
 test("can toggle multiple companies at once", async () => {
-    const prom = new Deferred();
-    let step = 0;
     function onSetCookie(key, values) {
         if (key === "cids") {
             expect.step(values);
-            if (step === 1) {
-                prom.resolve();
-            }
-            step++;
         }
     }
     await createSwitchCompanyMenu({ onSetCookie, toggleDelay: ORIGINAL_TOGGLE_DELAY });
@@ -126,14 +129,14 @@ test("can toggle multiple companies at once", async () => {
      *   [x] Company 2      -> toggle all
      *   [x] Company 3      -> toggle all
      */
-    await contains(".toggle_company:eq(0)").click();
-    await contains(".toggle_company:eq(1)").click();
-    await contains(".toggle_company:eq(2)").click();
+    await toggle(0);
+    await toggle(1);
+    await toggle(2);
     expect("[data-company-id] .fa-check-square").toHaveCount(2);
     expect("[data-company-id] .fa-square-o").toHaveCount(1);
 
     expect.verifySteps([]);
-    await prom; // await toggle promise
+    await confirm();
     expect.verifySteps(["2-3"]);
 });
 
@@ -164,9 +167,8 @@ test("single company selected: toggling it off will keep it", async () => {
      *   [ ] Company 2
      *   [ ] Company 3
      */
-    await contains(".toggle_company:eq(0)").click();
-    await runAllTimers();
-
+    await toggle(0);
+    await confirm();
     expect.verifySteps(["1"]);
     expect(getService("company").activeCompanyIds).toEqual([1]);
     expect(getService("company").currentCompany.id).toBe(1);
@@ -288,8 +290,81 @@ test("companies can be logged in even if some toggled within delay", async () =>
      *   [ ] Company 2      -> logged in
      *   [ ] Company 3      -> toggled
      */
-    await contains(".toggle_company:eq(2)").click();
-    await contains(".toggle_company:eq(0)").click();
+    await contains("[data-company-id] [role=menuitemcheckbox]:eq(2)").click();
+    await contains("[data-company-id] [role=menuitemcheckbox]:eq(0)").click();
     await contains(".log_into:eq(1)").click();
     expect.verifySteps(["2"]);
+});
+
+test("show confirm and reset buttons only when selection has changed", async () => {
+    await createSwitchCompanyMenu();
+    expect(".o_switch_company_menu_buttons").toHaveCount(0);
+    await toggle(1);
+    expect(".o_switch_company_menu_buttons button").toHaveCount(2);
+    await toggle(1);
+    expect(".o_switch_company_menu_buttons").toHaveCount(0);
+});
+
+test("No collapse and no search input when less that 10 companies", async () => {
+    await createSwitchCompanyMenu();
+    expect(".o_burger_menu_companies .fa-caret-right").toHaveCount(0);
+    expect(".o_burger_menu_companies .visually-hidden input").toHaveCount(1);
+});
+
+test("Show search input when more that 10 companies & search filters items but ignore case and spaces", async () => {
+    patchWithCleanup(session.user_companies, {
+        allowed_companies: {
+            3: { id: 3, name: "Hermit", sequence: 1, parent_id: false, child_ids: [] },
+            2: { id: 2, name: "Herman's", sequence: 2, parent_id: false, child_ids: [] },
+            1: {
+                id: 1,
+                name: "Heroes TM",
+                sequence: 3,
+                parent_id: false,
+                child_ids: [4, 5],
+            },
+            4: { id: 4, name: "Hercules", sequence: 4, parent_id: 1, child_ids: [] },
+            5: { id: 5, name: "Hulk", sequence: 5, parent_id: 1, child_ids: [] },
+            6: {
+                id: 6,
+                name: "Random Company a",
+                sequence: 6,
+                parent_id: false,
+                child_ids: [7, 8],
+            },
+            7: {
+                id: 7,
+                name: "Random Company aa",
+                sequence: 7,
+                parent_id: 6,
+                child_ids: [],
+            },
+            8: {
+                id: 8,
+                name: "Random Company ab",
+                sequence: 8,
+                parent_id: 6,
+                child_ids: [],
+            },
+            9: { id: 9, name: "Random d", sequence: 9, parent_id: false, child_ids: [] },
+            10: { id: 10, name: "Random e", sequence: 10, parent_id: false, child_ids: [] },
+        },
+        disallowed_ancestor_companies: {},
+        current_company: 3,
+    });
+    await createSwitchCompanyMenu();
+    await contains(".o_burger_menu_companies > div").click();
+    expect(".o_burger_menu_companies input").toHaveCount(1);
+    expect(".o_burger_menu_companies input").not.toBeFocused();
+
+    expect(".o_switch_company_item").toHaveCount(10);
+    contains(".o_burger_menu_companies input").edit("omcom");
+    await animationFrame();
+
+    expect(".o_switch_company_item").toHaveCount(3);
+    expect(queryAllTexts(".o_switch_company_item.o-navigable")).toEqual([
+        "Random Company a",
+        "Random Company aa",
+        "Random Company ab",
+    ]);
 });

--- a/addons/web/static/tests/webclient/switch_company_menu.test.js
+++ b/addons/web/static/tests/webclient/switch_company_menu.test.js
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { queryAllAttributes } from "@odoo/hoot-dom";
-import { Deferred, runAllTimers } from "@odoo/hoot-mock";
+import { edit, keyDown, press, queryAll, queryAllAttributes, queryAllTexts } from "@odoo/hoot-dom";
+import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import {
     contains,
     getService,
@@ -32,6 +32,18 @@ async function createSwitchCompanyMenu(options = { toggleDelay: 0 }) {
 
 describe.current.tags("desktop");
 
+async function open() {
+    await contains(".dropdown-toggle").click();
+}
+
+async function toggle(index) {
+    await contains(queryAll("[data-company-id] [role=menuitemcheckbox]")[index]).click();
+}
+
+async function confirm() {
+    await contains(queryAll(".o_switch_company_menu_buttons button")[0]).click();
+}
+
 beforeEach(() => {
     patchWithCleanup(session.user_companies, {
         allowed_companies: {
@@ -52,8 +64,8 @@ test("basic rendering", async () => {
     expect("div.o_switch_company_menu").toHaveCount(1);
     expect("div.o_switch_company_menu").toHaveText("Hermit");
 
-    await contains(".dropdown-toggle").click();
-    expect(".toggle_company").toHaveCount(5);
+    await open();
+    expect("[data-company-id] [role=menuitemcheckbox]").toHaveCount(5);
     expect(".log_into").toHaveCount(5);
     expect(".fa-check-square").toHaveCount(1);
     expect(".fa-square-o").toHaveCount(4);
@@ -80,17 +92,13 @@ test("companies can be toggled: toggle a second company", async () => {
      */
     expect(getService("company").activeCompanyIds).toEqual([3]);
     expect(getService("company").currentCompany.id).toBe(3);
-    await contains(".dropdown-toggle").click();
+    await open();
     expect("[data-company-id]").toHaveCount(5);
     expect("[data-company-id] .fa-check-square").toHaveCount(1);
     expect("[data-company-id] .fa-square-o").toHaveCount(4);
-    expect(queryAllAttributes("[data-company-id] .toggle_company", "aria-checked")).toEqual([
-        "true",
-        "false",
-        "false",
-        "false",
-        "false",
-    ]);
+    expect(queryAllAttributes("[data-company-id] [role=menuitemcheckbox]", "aria-checked")).toEqual(
+        ["true", "false", "false", "false", "false"]
+    );
     expect(queryAllAttributes("[data-company-id] .log_into", "aria-pressed")).toEqual([
         "true",
         "false",
@@ -106,17 +114,13 @@ test("companies can be toggled: toggle a second company", async () => {
      *   [ ]    Hercules
      *   [ ]    Hulk
      */
-    await contains(".toggle_company:eq(1)").click();
+    await toggle(1);
     expect(".dropdown-menu").toHaveCount(1, { message: "dropdown is still opened" });
     expect("[data-company-id] .fa-check-square").toHaveCount(2);
     expect("[data-company-id] .fa-square-o").toHaveCount(3);
-    expect(queryAllAttributes("[data-company-id] .toggle_company", "aria-checked")).toEqual([
-        "true",
-        "true",
-        "false",
-        "false",
-        "false",
-    ]);
+    expect(queryAllAttributes("[data-company-id] [role=menuitemcheckbox]", "aria-checked")).toEqual(
+        ["true", "true", "false", "false", "false"]
+    );
     expect(queryAllAttributes("[data-company-id] .log_into", "aria-pressed")).toEqual([
         "true",
         "false",
@@ -124,19 +128,14 @@ test("companies can be toggled: toggle a second company", async () => {
         "false",
         "false",
     ]);
+    await confirm();
     expect.verifySteps(["3-2"]);
 });
 
 test("can toggle multiple companies at once", async () => {
-    const prom = new Deferred();
-    let step = 0;
     function onSetCookie(key, values) {
         if (key === "cids") {
             expect.step(values);
-            if (step === 1) {
-                prom.resolve();
-            }
-            step++;
         }
     }
     await createSwitchCompanyMenu({ onSetCookie, toggleDelay: ORIGINAL_TOGGLE_DELAY });
@@ -151,7 +150,7 @@ test("can toggle multiple companies at once", async () => {
      */
     expect(getService("company").activeCompanyIds).toEqual([3]);
     expect(getService("company").currentCompany.id).toBe(3);
-    await contains(".dropdown-toggle").click();
+    await open();
     expect("[data-company-id]").toHaveCount(5);
     expect("[data-company-id] .fa-check-square").toHaveCount(1);
     expect("[data-company-id] .fa-square-o").toHaveCount(4);
@@ -163,15 +162,15 @@ test("can toggle multiple companies at once", async () => {
      *   [ ]    Hercules
      *   [ ]    Hulk
      */
-    await contains(".toggle_company:eq(0)").click();
-    await contains(".toggle_company:eq(1)").click();
-    await contains(".toggle_company:eq(2)").click();
+    await toggle(0);
+    await toggle(1);
+    await toggle(2);
     expect(".dropdown-menu").toHaveCount(1, { message: "dropdown is still opened" });
     expect("[data-company-id] .fa-check-square").toHaveCount(4);
     expect("[data-company-id] .fa-square-o").toHaveCount(1);
 
     expect.verifySteps([]);
-    await prom;
+    await confirm();
     expect.verifySteps(["2-1-4-5"]);
 });
 
@@ -195,7 +194,7 @@ test("single company selected: toggling it off will keep it", async () => {
     expect(cookie.get("cids")).toBe("3");
     expect(getService("company").activeCompanyIds).toEqual([3]);
     expect(getService("company").currentCompany.id).toBe(3);
-    await contains(".dropdown-toggle").click();
+    await open();
     expect("[data-company-id]").toHaveCount(5);
     expect("[data-company-id] .fa-check-square").toHaveCount(1);
     expect("[data-company-id] .fa-square-o").toHaveCount(4);
@@ -207,13 +206,14 @@ test("single company selected: toggling it off will keep it", async () => {
      *   [ ]    Hercules
      *   [ ]    Hulk
      */
-    await contains(".toggle_company:eq(0)").click();
-    await runAllTimers();
-
+    await toggle(0);
+    await confirm();
+    await animationFrame();
     expect.verifySteps(["3"]);
     expect(getService("company").activeCompanyIds).toEqual([3]);
     expect(getService("company").currentCompany.id).toBe(3);
-    expect(".dropdown-menu").toHaveCount(1, { message: "dropdown is still opened" });
+
+    await open();
     expect("[data-company-id] .fa-check-square").toHaveCount(0);
     expect("[data-company-id] .fa-square-o").toHaveCount(5);
 });
@@ -236,7 +236,7 @@ test("single company mode: companies can be logged in", async () => {
      */
     expect(getService("company").activeCompanyIds).toEqual([3]);
     expect(getService("company").currentCompany.id).toBe(3);
-    await contains(".dropdown-toggle").click();
+    await open();
     expect("[data-company-id]").toHaveCount(5);
     expect("[data-company-id] .fa-check-square").toHaveCount(1);
     expect("[data-company-id] .fa-square-o").toHaveCount(4);
@@ -272,7 +272,7 @@ test("multi company mode: log into a non selected company", async () => {
      */
     expect(getService("company").activeCompanyIds).toEqual([3, 1]);
     expect(getService("company").currentCompany.id).toBe(3);
-    await contains(".dropdown-toggle").click();
+    await open();
     expect("[data-company-id]").toHaveCount(5);
     expect("[data-company-id] .fa-check-square").toHaveCount(2);
     expect("[data-company-id] .fa-square-o").toHaveCount(3);
@@ -308,7 +308,7 @@ test("multi company mode: log into an already selected company", async () => {
      */
     expect(getService("company").activeCompanyIds).toEqual([2, 1]);
     expect(getService("company").currentCompany.id).toBe(2);
-    await contains(".dropdown-toggle").click();
+    await open();
     expect("[data-company-id]").toHaveCount(5);
     expect("[data-company-id] .fa-check-square").toHaveCount(2);
     expect("[data-company-id] .fa-square-o").toHaveCount(3);
@@ -343,7 +343,7 @@ test("companies can be logged in even if some toggled within delay", async () =>
      */
     expect(getService("company").activeCompanyIds).toEqual([3]);
     expect(getService("company").currentCompany.id).toBe(3);
-    await contains(".dropdown-toggle").click();
+    await open();
     expect("[data-company-id]").toHaveCount(5);
     expect("[data-company-id] .fa-check-square").toHaveCount(1);
     expect("[data-company-id] .fa-square-o").toHaveCount(4);
@@ -355,8 +355,8 @@ test("companies can be logged in even if some toggled within delay", async () =>
      *   [ ]    Hercules
      *   [ ]    Hulk
      */
-    await contains(".toggle_company:eq(2)").click();
-    await contains(".toggle_company:eq(0)").click();
+    await contains("[data-company-id] [role=menuitemcheckbox]:eq(2)").click();
+    await contains("[data-company-id] [role=menuitemcheckbox]:eq(0)").click();
     await contains(".log_into:eq(1)").click();
     expect(".dropdown-menu").toHaveCount(0, { message: "dropdown is directly closed" });
     expect.verifySteps(["2"]);
@@ -425,6 +425,7 @@ test("single company mode: from company loginto branch", async () => {
 
 test("single company mode: from branch loginto company", async () => {
     expect.assertions(7);
+
     function onSetCookie(key, values) {
         if (key === "cids") {
             expect.step(values);
@@ -529,4 +530,219 @@ test("multi company mode: switching company doesn't deselect already selected on
      */
     await contains(".log_into:eq(1)").click();
     expect.verifySteps(["2-1-4-5"]);
+});
+
+test("show confirm and reset buttons only when selection has changed", async () => {
+    await createSwitchCompanyMenu();
+    await open();
+
+    expect(".o_switch_company_menu_buttons").toHaveCount(0);
+
+    await toggle(1);
+    expect(".o_switch_company_menu_buttons button").toHaveCount(2);
+
+    await toggle(1);
+    expect(".o_switch_company_menu_buttons").toHaveCount(0);
+});
+
+test("no search input when less that 10 companies", async () => {
+    await createSwitchCompanyMenu();
+
+    await open();
+    expect(".o-dropdown--menu .visually-hidden input").toHaveCount(1);
+});
+
+test("show search input when more that 10 companies & search filters items but ignore case and spaces", async () => {
+    patchWithCleanup(session.user_companies, {
+        allowed_companies: {
+            3: { id: 3, name: "Hermit", sequence: 1, parent_id: false, child_ids: [] },
+            2: { id: 2, name: "Herman's", sequence: 2, parent_id: false, child_ids: [] },
+            1: {
+                id: 1,
+                name: "Heroes TM",
+                sequence: 3,
+                parent_id: false,
+                child_ids: [4, 5],
+            },
+            4: { id: 4, name: "Hercules", sequence: 4, parent_id: 1, child_ids: [] },
+            5: { id: 5, name: "Hulk", sequence: 5, parent_id: 1, child_ids: [] },
+            6: {
+                id: 6,
+                name: "Random Company a",
+                sequence: 6,
+                parent_id: false,
+                child_ids: [7, 8],
+            },
+            7: {
+                id: 7,
+                name: "Random Company aa",
+                sequence: 7,
+                parent_id: 6,
+                child_ids: [],
+            },
+            8: {
+                id: 8,
+                name: "Random Company ab",
+                sequence: 8,
+                parent_id: 6,
+                child_ids: [],
+            },
+            9: { id: 9, name: "Random d", sequence: 9, parent_id: false, child_ids: [] },
+            10: { id: 10, name: "Random e", sequence: 10, parent_id: false, child_ids: [] },
+        },
+        disallowed_ancestor_companies: {},
+        current_company: 3,
+    });
+
+    await createSwitchCompanyMenu();
+
+    await open();
+    expect(".o-dropdown--menu input").toHaveCount(1);
+    expect(".o-dropdown--menu input").toBeFocused();
+    expect(".o-dropdown--menu .o_switch_company_item").toHaveCount(10);
+
+    edit("omcom");
+    await animationFrame();
+    expect(".o-dropdown--menu .o_switch_company_item").toHaveCount(3);
+
+    expect(queryAllTexts(".o-dropdown--menu .o_switch_company_item")).toEqual([
+        "Random Company a",
+        "Random Company aa",
+        "Random Company ab",
+    ]);
+});
+
+test("when less than 10 companies, typing key makes the search input visible", async () => {
+    await createSwitchCompanyMenu();
+    await open();
+
+    expect(".o-dropdown--menu input").toHaveCount(1);
+    expect(".o-dropdown--menu input").toBeFocused();
+    expect(".o-dropdown--menu .visually-hidden input").toHaveCount(1);
+
+    edit("a");
+    await animationFrame();
+
+    expect(".o-dropdown--menu input").toHaveValue("a");
+    expect(".o-dropdown--menu :not(.visually-hidden) input").toHaveCount(1);
+});
+
+test("navigation with search input", async () => {
+    patchWithCleanup(session.user_companies, {
+        allowed_companies: {
+            3: { id: 3, name: "Hermit", sequence: 1, parent_id: false, child_ids: [] },
+            2: { id: 2, name: "Herman's", sequence: 2, parent_id: false, child_ids: [] },
+            1: { id: 1, name: "Heroes TM", sequence: 3, parent_id: false, child_ids: [4, 5] },
+            4: { id: 4, name: "Hercules", sequence: 4, parent_id: 1, child_ids: [] },
+            5: { id: 5, name: "Hulk", sequence: 5, parent_id: 1, child_ids: [] },
+            6: {
+                id: 6,
+                name: "Random Company a",
+                sequence: 6,
+                parent_id: false,
+                child_ids: [7, 8],
+            },
+            7: { id: 7, name: "Random Company aa", sequence: 7, parent_id: 6, child_ids: [] },
+            8: { id: 8, name: "Random Company ab", sequence: 8, parent_id: 6, child_ids: [] },
+            9: { id: 9, name: "Random d", sequence: 9, parent_id: false, child_ids: [] },
+            10: { id: 10, name: "Random e", sequence: 10, parent_id: false, child_ids: [] },
+        },
+        disallowed_ancestor_companies: {},
+        current_company: 3,
+    });
+
+    function onSetCookie(key, values) {
+        if (key === "cids") {
+            expect.step(values);
+        }
+    }
+    await createSwitchCompanyMenu({ onSetCookie });
+    expect.verifySteps(["3"]);
+    await open();
+
+    expect(".o-dropdown--menu input").toBeFocused();
+    expect(".o_switch_company_item.focus").toHaveCount(0);
+
+    const navigationEvents = [
+        { hotkey: "arrowdown", focused: 1, selectedCompanies: [3] }, // Go to first item
+        { hotkey: "arrowup", focused: 0 }, // Go to search input
+        { hotkey: "arrowup", focused: 10 }, // Go to last item
+        { hotkey: "Space", focused: 10, selectedCompanies: [3, 10] }, // Select last item
+        { hotkey: "shift+tab", focused: 9, selectedCompanies: [3, 10] }, // Go to previous item
+        { hotkey: "tab", focused: 10, selectedCompanies: [3, 10] }, // Go to next item
+        { hotkey: "arrowdown", focused: 11 }, // Go to Confirm
+        { hotkey: "arrowdown", focused: 12 }, // Go to Reset
+        { hotkey: "enter", focused: 10, selectedCompanies: [3] }, // Reset, focus is on last item
+        { hotkey: "arrowdown", focused: 0 }, // Go to seach input
+        { input: "a", focused: 0 }, // Type "a"
+        { hotkey: "arrowdown", focused: 1 }, // Go to first item
+        { hotkey: "Space", focused: 1, selectedCompanies: [2] }, // Select first item
+    ];
+
+    for (let i = 0; i < navigationEvents.length; i++) {
+        const { hotkey, focused, selectedCompanies, input } = navigationEvents[i];
+        if (hotkey) {
+            press(hotkey);
+        }
+
+        if (input) {
+            edit(input);
+        }
+
+        // Ensure debounced mutation listener update and owl re-render
+        await animationFrame();
+        await runAllTimers();
+
+        const item = queryAll(".o_popover .o-navigable")[focused];
+        expect(item).toHaveClass("focus", {
+            message: `step ${i}: item has focus class (${JSON.stringify(navigationEvents[i])})`,
+        });
+        expect(item).toBeFocused({
+            message: `step ${i}: item is focused (${JSON.stringify(navigationEvents[i])})`,
+        });
+
+        if (selectedCompanies) {
+            const companies = queryAllAttributes(
+                ".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])",
+                "data-company-id"
+            ).map((i) => parseInt(i));
+
+            expect(companies).toEqual(selectedCompanies, {
+                message: `step ${i}: selected companies match`,
+            });
+        }
+    }
+
+    keyDown("control+enter");
+    await animationFrame();
+
+    expect.verifySteps(["3-2"]);
+    expect(".o_switch_company_item").toHaveCount(0);
+});
+
+test("select and de-select all", async () => {
+    await createSwitchCompanyMenu();
+    await open();
+
+    // Show search
+    edit(" ");
+    await animationFrame();
+
+    // One company is selected, there should be a check box with minus inside
+    expect("[role=menuitemcheckbox][title='Deselect all'] i").toHaveClass("fa-minus-square-o");
+
+    await contains("[role=menuitemcheckbox][title='Deselect all']").click();
+    // No company is selected, there should be a empty check box
+    expect("[role=menuitemcheckbox][title='Select all'] i").toHaveClass("fa-square-o");
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(0);
+
+    await contains("[role=menuitemcheckbox][title='Select all']").click();
+    // All companies are selected, there should be a checked check box
+    expect("[role=menuitemcheckbox][title='Deselect all'] i").toHaveClass("fa-check-square");
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(5);
+
+    await contains("[role=menuitemcheckbox][title='Deselect all']").click();
+    // No company is selected, there should be a empty check box
+    expect("[role=menuitemcheckbox][title='Select all'] i").toHaveClass("fa-square-o");
+    expect(".o_switch_company_item:has([role=menuitemcheckbox][aria-checked=true])").toHaveCount(0);
 });

--- a/odoo/addons/test_main_flows/static/tests/tours/switch_company_access_error_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/switch_company_access_error_tour.js
@@ -38,7 +38,11 @@ registry.category("web_tour.tours").add("test_company_switch_access_error", {
             run: "click",
         },
         {
-            trigger: ".o-dropdown--menu .dropdown-item:contains(second company) .toggle_company",
+            trigger: ".o_switch_company_item:contains(second company) [role=menuitemcheckbox]",
+            run: "click",
+        },
+        {
+            trigger: ".o_switch_company_menu_buttons button:contains(Confirm)",
             run: "click",
         },
         {

--- a/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
@@ -22,13 +22,13 @@ registry.category("web_tour.tours").add("test_company_access_error_redirect", {
             trigger: ".o-dropdown--menu",
             run() {
                 assertEqual(
-                    document.querySelectorAll(".o-dropdown-item .toggle_company[aria-checked=true]")
+                    document.querySelectorAll(".o_switch_company_item [role=menuitemcheckbox][aria-checked=true]")
                         .length,
                     2
                 );
                 assertEqual(
                     cookie.get("cids"),
-                    [...document.querySelectorAll(".o-dropdown-item [data-company-id]")]
+                    [...document.querySelectorAll(".o_switch_company_item[data-company-id]")]
                         .flatMap((x) => x.getAttribute("data-company-id"))
                         .join("-")
                 );


### PR DESCRIPTION
The goal of the PR is to improve the usability of the company switcher.
Task: [3601063](https://www.odoo.com/web#id=3601063&cids=1&menu_id=4720&action=333&active_id=133&model=project.task&view_type=form)

#### Before this commit:
The user can only either click on a company to log into this one (triggering a reload) or select companies one by one but after 1 second of inactivity it reloads the page automatically to apply the changes. This felt unpractical to use, even more with large amount of companies.


#### After this commit:
- Toggling different companies now makes a "Confirm" and "Reset" buttons appear to apply or revert the selection.
- Added keyboard navigation and shortcuts:
  - Navigation between companies using tab and arrows
  - Enter logs into a company (reload page)
  - Spacebar toggles a company
  - Shift+Enter apply changes
- Added searching and scrolling when there is more than 10 companies
- The search also appears if the user starts typing
- Added button to select-all or deselect-all 

On mobile
  - When there is more than 10 companies, companies are collapsible and a search input is added.
  - Added "Confirm" and "Reset" buttons as well.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
