### PR TITLE
[FIX] auth_totp_mail_enforce: friendlier error message

### DIFF
--- a/addons/auth_totp_mail_enforce/controllers/home.py
+++ b/addons/auth_totp_mail_enforce/controllers/home.py
@@ -1,9 +1,12 @@
 # -*- coding: utf-8 -*-
+import logging
 import odoo.addons.auth_totp.controllers.home
 
 from odoo import http
 from odoo.exceptions import AccessDenied, UserError
 from odoo.http import request
+
+_logger = logging.getLogger(__name__)
 
 
 class Home(odoo.addons.auth_totp.controllers.home.Home):
@@ -22,5 +25,7 @@ class Home(odoo.addons.auth_totp.controllers.home.Home):
             response.qcontext['user']._send_totp_mail_code()
         except (AccessDenied, UserError) as e:
             response.qcontext['error'] = str(e)
-
+        except Exception as e:
+            _logger.exception('Unable to send TOTP email')
+            response.qcontext['error'] = str(e)
         return response


### PR DESCRIPTION
**steps to reproduce:**
- install the module auth_totp_mail_enforce
- open settings
- activate "Two-factor authentification enforcing policy" to "Employees only" (or "All users") and save
- try to (re)connect with a user (demo/demo or admin/admin) 

**before this commit:**
- internal server error

**after this commit:**
- error is passed to the user, allowing him (or the admin) to debug without contacting odoo support

opw-3624816


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
