### PR TITLE
[IMP] stock: package location now editable

### DIFF
--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -257,6 +257,7 @@
                 <field name="name" string="Package Name"/>
                 <field name="location_id"/>
                 <field name="package_type_id"/>
+                <filter string="In internal locations" name="internal" domain="['|', ('location_id.usage', '=', 'internal'), ('location_id', '=', False)]"/>
                 <group  expand='0' string='Group by...'>
                    <filter string='Location' name="location" domain="[]" context="{'group_by' : 'location_id'}"/>
                    <filter string='Package Type' name="package_type" domain="[]" context="{'group_by' : 'package_type_id'}"/>
@@ -303,6 +304,32 @@
                             <field name="quantity"/>
                             <field name="product_uom_id" groups="uom.group_uom"/>
                         </tree>
+                        <kanban class="o_kanban_mobile">
+                            <templates>
+                                <t t-name="kanban-box">
+                                    <div class="oe_kanban_global_click">
+                                        <div class="o_kanban_card_content">
+                                            <div class="row">
+                                                <div class="col-12">
+                                                    <strong><field name="product_id"/></strong>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-12">
+                                                    <field name="lot_id"/>
+                                                </div>
+                                            </div>
+                                            <div class="row">
+                                                <div class="col-12">
+                                                    <field name="quantity"/>
+                                                    <field class="mx-2" name="product_uom_id" groups="uom.group_uom"/>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </t>
+                            </templates>
+                        </kanban>
                     </field>
                 </sheet>
             </form>
@@ -348,10 +375,14 @@
     </record>
 
     <record model="ir.actions.act_window" id="action_package_view">
-        <field name="context">{}</field>
         <field name="name">Packages</field>
         <field name="res_model">stock.quant.package</field>
         <field name="view_mode">kanban,tree,form</field>
+        <field name="context">{
+            'search_default_location': True,
+            'search_default_internal': True,
+            }
+        </field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 Create a new package


### PR DESCRIPTION
This commit adds the ability to edit the location_id of a package by either changing the field in the form or by dragging the package to another location.
The packages are now grouped by location by default and filtered by internal locations or empty locations.
When a package is moved, a move is created for each of it quants to reflect in Moves History.
Also, a kanban view is added to reflect package contents when on mobile as its better on the smaller screen.

TaskId:3479578


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
