### PR TITLE
[draft][fix] project: prevent the compute of the company of tasks

### DIFF
--- a/addons/project/tests/test_multicompany.py
+++ b/addons/project/tests/test_multicompany.py
@@ -478,3 +478,17 @@ class TestMultiCompanyProject(TestMultiCompanyCommon):
             with self.assertRaises(AccessError):
                 with Form(task) as task_form:
                     task_form.name = "Testing changing name in a company I can not read/write"
+
+    def test_company_not_reset_on_task(self):
+        """ This test ensure that when a task has a company set but not its project, setting the company of the project to False does not trigger the compute of the task.
+            This behavior is needed because when a user changes the value of a field in the project view form, that field will be present in the 'vals' of the write,
+            even if the value was set back to its original value. In such a case with the company of a project, it is not expected for the task to have their companies be reset.
+        """
+        project = self.Project.create({'name': 'Project'})
+        task = self.env['project.task'].create({
+            'name': 'task no company',
+            'project_id': project.id,
+            'company_id': self.company_a.id,
+        })
+        project.write({'company_id': False})
+        self.assertEqual(task.company_id, self.company_a, "The company of the task should not have been updated")


### PR DESCRIPTION
This commit's purpose is to prevent the recompute of the company_id of task when no changes is done on their project.

Step to reproduce:
- install the project app in any saas-16.4+ db
- click on the 'office design' project
- enter the debugg mode to have access to the field 'company_id' of tasks
- click on any task
- change the company of the task to any available company
- go back to the projects view
- open the setting of the 'office desin' project
- change its company to any company, then change it back to false
- press save to save the changes

The task that was modified no longer has its custom company set. It was reset to False

Source of the issue:
When a field is modified in a form view, this field is added to the vals of the write, even if the final value when the save is triggered is the same as the current value of the record. In this case, it is a problem, since adding the 'company_id': False to vals trigger the compute of the tasks of the project, and thus all the tasks have their companies reset.

Solution:
In order to prevent that, the record set is split in two. The first record contains the project for which the value of company_id is indeed a change, and thus need to trigger the compute. The super.write is called as before. The second part of the recordset contains the project with the same company_id. The key'company_id' is removed from the vals, then the super.write is call on this recordset too

affected version: saas-16.4 -> master

task - 3628331
https://www.odoo.com/web#id=3628331&menu_id=4720&cids=1&action=333&active_id=4105&model=project.task&view_type=form

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
