### PR TITLE
[FIX] website_sale: not reset access point on payment method change

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale/static/src/js/website_sale_delivery.js
@@ -257,6 +257,7 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
             route: '/shop/update_carrier',
             params: {
                 'carrier_id': carrier_id,
+                'no_reset_access_point_address': true,
             },
         })
         this._enableButton(result.status);


### PR DESCRIPTION
Similar to this: https://github.com/odoo/odoo/commit/677bff31d3acdd05fff6567b693de78cff256ea2

Issue:
======
The shiping and billing address are the same when choosing pick up locations which is not true.

Steps to reproduce the error:
=============================
- install website_sale and delivery_sendcloud module;
- create a shipping method (use Sendcloud provider);
- configure the integration with "Mondial Relay Point Relais International 1-2kg";
- configure option with shipping rule and use location;
- on website create a new quotation with the pubic user;
- process the checkout;

(Check in backend the shipping weight)

- fill City and Zip Code fields with correct value (example: Paris | 75011)

(- configure the company's country)

Origin of the issue:
====================
Updating the payment method will trigger a cart update which will reset the access_point_address.

Solution:
=========
Using the context variable `no_reset_access_point_address` introduced in the commit mentioned above.

opw-3615829
opw-3596705
