### PR TITLE
[FIX] PoS: payment date should be order date

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -75,7 +75,7 @@ class PosPayment(models.Model):
             journal = pos_session.config_id.journal_id
             payment_move = self.env['account.move'].with_context(default_journal_id=journal.id).create({
                 'journal_id': journal.id,
-                'date': fields.Date.context_today(payment),
+                'date': fields.Date.context_today(payment, order.date_order),
                 'ref': _('Invoice payment for %s (%s) using %s', order.name, order.account_move.name, payment_method.name),
                 'pos_payment_ids': payment.ids,
             })

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -934,5 +934,10 @@ class TestPoSBasicConfig(TestPoSCommon):
             order_to_invoice.write({'partner_id': test_customer.id})
             order_to_invoice.action_pos_order_invoice()
             # check invoice
-            self.assertTrue(order_to_invoice.account_move, 'Invoice should be created.')
-            self.assertTrue(order_to_invoice.account_move.invoice_date != order_to_invoice.date_order.date(), 'Invoice date should not be the same as order date since the session was closed.')
+            invoice = order_to_invoice.account_move
+            self.assertTrue(invoice, 'Invoice should be created.')
+            self.assertNotEqual(invoice.invoice_date, order_to_invoice.date_order.date(), 'Invoice date should not be the same as order date since the session was closed.')
+
+            # check that the payment date is set to the payment date and not to the invoice_date
+            payment = invoice.line_ids.full_reconcile_id.reconciled_line_ids.move_id - invoice
+            self.assertEqual(payment.date, order_to_invoice.date_order.date())


### PR DESCRIPTION
The aim of this commit is to correct the date of the payment.

Context:
When creating a PoS session and a PoS order on date X The customer gets its invoice on date Y
the payment date is printed on the invoice

Before this commit:
The payment date will always be the date of the invoice

After this commit:
The payment date will always be the date of the order, the date at which is was really paid.

Corner case not taken care of in this commit:
Claiming the invoice after the `fiscalyear_lock_date`. In such a case, the payment date will be set to today (the invoice_date) again.
This should be really rare as setting that lock date in short time frame is quite unusual.

task-id: 3629054





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
