### PR TITLE
[FIX] hr_expense: handle traceback when attachment is not selected

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -481,7 +481,7 @@ class HrExpense(models.Model):
 
     def attach_document(self, **kwargs):
         """When an attachment is uploaded as a receipt, set it as the main attachment."""
-        self.message_main_attachment_id = kwargs['attachment_ids'][-1]
+        self.message_main_attachment_id = kwargs['attachment_ids'] and kwargs['attachment_ids'][-1]
 
     def create_expense_from_attachments(self, attachment_ids=None, view_type='list'):
         """


### PR DESCRIPTION
This traceback arises when the user tries to attach a receipt in the expense

To reproduce this issue:

1) Install `hr_expense`
2) Open any existing `my expense` record
3) Click on the `Attach Receipt` button and attach a file 
4) Now again attach a file through the `Attach Receipt` button 
5) Now this time click on `cancel` while attaching a file through `Attach Receipt`

Error:- 
```
IndexError: list index out of range
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/hr_expense/models/hr_expense.py", line 484, in attach_document
    self.message_main_attachment_id = kwargs['attachment_ids'][-1]
```

When the user clicks on the `cancel` button when trying to attach a file, 
the `kwargs` returns an empty `attchemnt_ids` record.

This leads to the above traceback from here

https://github.com/odoo/odoo/blob/5d00b4146aa5cc1942d66e60dc92d321f79bf891/addons/hr_expense/models/hr_expense.py#L482-L484

sentry-4705156379

