### PR TITLE
[FIX] web_editor: address zero-width-space bug in link inner content

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -87,7 +87,7 @@ const Link = Widget.extend({
                 $node = $node.parent();
             }
             const linkNode = this.$link[0] || this.data.range.cloneContents();
-            const linkText = linkNode.textContent;
+            const linkText = linkNode.innerText.replaceAll("\u200B", "");
             this.data.content = linkText.replace(/[ \t\r\n]+/g, ' ');
             this.data.originalText = this.data.content;
             if (linkNode instanceof DocumentFragment) {


### PR DESCRIPTION
This commit resolves a bug related to zero-width spaces within the inner content of a link. The bug led to a test failure in 17.0 link_tools when comparing the input value with the expected value. The bug originated from [another commit] that manipulates zero-width spaces to allow users to select the edges of the link. To reproduce the error:
- Create a link containing "odoo.com"
- Compare the value of the input element `#o_link_dialog_label_input` and the string "odoo.com"
- The test fails due to the trailing zero-width-space around the string It's maybe just a complement to this [fix commit]

[fix commit]: https://github.com/odoo/odoo/commit/7f90af627f54821237d1caf25b346c6e2a8e795e
[another commit]: https://github.com/odoo/odoo/commit/ab40f484d55e151e175ccf9d6b3ea3bf34c56b35

runbot-44779
