### PR TITLE
[FIX] web: display datetime_picker correctly in mobile view

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -153,3 +153,18 @@
         direction: ltr;
     }
 }
+
+.popover:has(.o_datetime_picker){
+    @include media-breakpoint-down(sm) {
+        position: fixed;
+        top: auto !important;
+        left: 0 !important;
+        bottom: 0;
+        right: 0 !important;
+        width: auto;
+        max-height: 90vh;
+        overflow-y: auto;
+        @include border-top-radius(1rem);
+        box-shadow: $box-shadow-lg;
+    }
+}


### PR DESCRIPTION
Issue:
======
In mobile view, the overflow part of datetime_picker doesn't show.

Steps to reproduce the issue:
=============================
- Install attendance
- Switch to mobile view
- Go to attendance/attendances
- Go to any attendance and click on it
- Change the check out

(The error can be reproduce in any view using datetime_picker , planning for example)

Solution:
=========
Applied the same css styles used in daterangepicker to display in mobile view
https://github.com/odoo/odoo/blob/9b130347f3594b10019b495fbf35c6794281b915/addons/web/static/src/legacy/scss/daterangepicker.scss#L153-L177

Before:
======
![before](https://github.com/odoo/odoo/assets/61123610/fe08bfdf-c9be-4617-9e58-5f4b494942b7)

After:
====
![after](https://github.com/odoo/odoo/assets/61123610/b2f2ac4a-a8bc-449e-a691-bd46155d479c)

opw-3624881