### PR TITLE
[IMP] sale_project: remove description for appointment tasks

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -233,13 +233,11 @@ class SaleOrderLine(models.Model):
             allocated_hours = self._convert_qty_company_hours(self.company_id)
         sale_line_name_parts = self.name.split('\n')
         title = sale_line_name_parts[0] or self.product_id.name
-        description = '<br/>'.join(sale_line_name_parts[1:])
         return {
             'name': title if project.sale_line_id else '%s - %s' % (self.order_id.name or '', title),
             'analytic_account_id': project.analytic_account_id.id,
             'allocated_hours': allocated_hours,
             'partner_id': self.order_id.partner_id.id,
-            'description': description,
             'project_id': project.id,
             'sale_line_id': self.id,
             'sale_order_id': self.order_id.id,


### PR DESCRIPTION
When a task is created from an SO itself generated by an appointment,
the task description contains the planned dates of the appointment.
This commit removes this feature as we directly set the planned_date_begin
and date_dealine fields instead.

Task-3619453

Enterprise: https://github.com/odoo/enterprise/pull/64981
