### PR TITLE
[FIX] calendar : action done access unlinked record

### DIFF
--- a/addons/calendar/models/mail_activity.py
+++ b/addons/calendar/models/mail_activity.py
@@ -29,17 +29,15 @@ class MailActivity(models.Model):
         return action
 
     def _action_done(self, feedback=False, attachment_ids=False):
-        events = self.mapped('calendar_event_id')
-        messages, activities = super(MailActivity, self)._action_done(feedback=feedback, attachment_ids=attachment_ids)
         if feedback:
-            for event in events:
+            for event in self.calendar_event_id:
                 description = event.description
                 description = '%s<br />%s' % (
                     description if not tools.is_html_empty(description) else '',
                     _('Feedback: %(feedback)s', feedback=tools.plaintext2html(feedback)) if feedback else '',
                 )
                 event.write({'description': description})
-        return messages, activities
+        return super(MailActivity, self)._action_done(feedback=feedback, attachment_ids=attachment_ids)
 
     def unlink_w_meeting(self):
         return self.unlink()


### PR DESCRIPTION
Before PR:
The action_done method for activities scheduled on the calendar (call or meeting) causes access errors when a feedback is given as it tries editing the description of the record after calling its super() method, which unlinks the record

After PR:
The behaviour was fixed in commit 33d7ea6fb8198f741cc13765b2f60c820f54ae66 for versions 16.0+, backporting the changes on action_done for 15.0 to 16.0

opw-3626632

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
