### PR TITLE
[FIX] point_of_sale: fix firefox customer display

### DIFF
--- a/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
+++ b/addons/point_of_sale/static/src/xml/CustomerFacingDisplay/CustomerFacingDisplayOrder.xml
@@ -6,9 +6,8 @@
             <base t-att-href="origin"/>
             <meta http-equiv="cache-control" content="no-cache" />
             <meta http-equiv="pragma" content="no-cache" />
-            <link rel="stylesheet" type="text/css" href="/web/static/lib/bootstrap/css/bootstrap.css"/>
-            <link rel="stylesheet" type="text/css" href="/web/static/src/libs/fontawesome/css/font-awesome.css"/>
-            <link rel="stylesheet" type="text/css" href="/point_of_sale/static/src/css/customer_facing_display.css"/>
+            <link rel="stylesheet" type="text/css" t-att-href="origin + '/web/static/lib/fontawesome/css/font-awesome.css'"/>
+            <link rel="stylesheet" type="text/css" t-att-href="origin + '/point_of_sale/static/src/css/customer_facing_display.css'"/>
         </div>
     </t>
 


### PR DESCRIPTION
Current behavior:
Firefox customer display was not correctly loading the CSS and the display was not correct.

Steps to reproduce:
- Setup an IoT box with a customer display
- Open the IoT box customer display in Firefox
- Link the customer display to a POS
- Open the POS and add some products to the order
- The customer display is not correctly displayed

opw-3509606
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
