### PR TITLE
[IMP] hr: open the merge wizard while connecting user and employee

### DIFF
--- a/addons/hr/static/src/components/merge_partner/user_many2one_field.js
+++ b/addons/hr/static/src/components/merge_partner/user_many2one_field.js
@@ -1,0 +1,32 @@
+/* @odoo-module */
+
+import { useService } from "@web/core/utils/hooks";
+import { Many2OneField } from '@web/views/fields/many2one/many2one_field';
+
+export class UserMany2OneField extends Many2OneField {
+
+    setup() {
+        super.setup();
+        this.orm = useService("orm")
+        this.actionService = useService("action")
+    }
+
+    async updateRecord(values) {
+        if (!values[0]) return super.updateRecord(values);
+        const data = this.props.record.data;
+        const workContactId = data.work_contact_id[0];
+        const userData = await this.orm.read("res.users", [values[0]], ["partner_id"]);
+        const partnerId = userData?.[0].partner_id?.[0];
+        if (workContactId && partnerId != workContactId) {
+            this.env.services.action.doAction("base.action_partner_merge", {
+                additionalContext: {
+                    default_dst_partner_id: partnerId,
+                    default_state: 'selection',
+                    default_partner_ids: [workContactId, partnerId],
+
+                },
+            });
+        }
+        return super.updateRecord(values);
+    }
+}

--- a/addons/hr/static/src/components/merge_partner/user_many2one_field_avatar.js
+++ b/addons/hr/static/src/components/merge_partner/user_many2one_field_avatar.js
@@ -1,0 +1,16 @@
+// /* @odoo-module */
+
+import { registry } from "@web/core/registry";
+import { UserMany2OneField } from "./user_many2one_field";
+import { Many2OneAvatarUserField } from "@mail/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field";
+
+export class UserMany2OneAvatarField extends Many2OneAvatarUserField {
+    static components = {
+        ...Many2OneAvatarUserField.component,
+        Many2OneField: UserMany2OneField
+    }
+}
+
+registry.category("fields").add("merge_partner", {
+    component: UserMany2OneAvatarField,
+});

--- a/addons/hr/views/hr_employee_views.xml
+++ b/addons/hr/views/hr_employee_views.xml
@@ -189,7 +189,7 @@
                                 <group>
                                     <group string='Status' name="active_group">
                                         <field name="employee_type"/>
-                                        <field name="user_id" string="Related User" domain="[('company_ids', 'in', company_id), ('share', '=', False)]" context="{'default_create_employee_id': id}" widget="many2one_avatar_user"/>
+                                        <field name="user_id" string="Related User" domain="[('company_ids', 'in', company_id), ('share', '=', False)]" context="{'default_create_employee_id': id}" widget="merge_partner"/>
                                     </group>
                                     <group string="Attendance/Point of Sale" name="identification_group">
                                         <field name="pin" string="PIN Code"/>


### PR DESCRIPTION
There are different partners for the employee and the user and if we connect those still we have multiple partners which leads to unnecessary data

This commit opens the Merge Partner wizard while connecting those two using Related User field in the form view of the employee. In the wizard, the employee's partner is the one who is going to merge with the user's partner.

task-3609634

