### PR TITLE
[FIX] purchase, sale: allow sending PO/SO to any specified partner

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -422,6 +422,23 @@ class PurchaseOrder(models.Model):
             self.filtered(lambda o: o.state == 'draft').write({'state': 'sent'})
         return super(PurchaseOrder, self.with_context(mail_post_autofollow=self.env.context.get('mail_post_autofollow', True))).message_post(**kwargs)
 
+    def _notify_get_groups(self, msg_vals=None):
+        groups = super()._notify_get_groups(msg_vals=msg_vals)
+        self.ensure_one()
+
+        if self.state not in ('draft', 'cancel'):
+            recipient_group = (
+                'additional_intended_recipient',
+                lambda pdata: pdata['id'] in msg_vals.get('partner_ids', []) and pdata['id'] != self.partner_id.id,
+                {
+                    'has_button_access': True,
+                    'notification_is_customer': True,
+                }
+            )
+
+            groups.insert(0, recipient_group)
+        return groups
+
     def print_quotation(self):
         self.write({'state': "sent"})
         return self.env.ref('purchase.report_purchase_quotation').report_action(self)

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -367,3 +367,44 @@ class TestPurchase(AccountTestInvoicingCommon):
         po.button_confirm()
 
         self.assertEqual(po.order_line.product_id.seller_ids.mapped('name'), delivery_address)
+
+
+    def test_purchase_order_sent_to_additional_partner(self):
+        """
+        Make sure that when a PO is deliberately sent to a partner who is not
+        the invoiced customer, they receive a link containing an access token,
+        allowing them to view the PO without needing to log in.
+        """
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+        })
+
+        self.partner_b.email = "partner_b@example.com"
+        purchase_order.message_subscribe(self.partner_b.ids)
+
+        additional_partner = self.env['res.partner'].create({
+            'name': "Additional Partner",
+            'email': "additional@example.com",
+        })
+
+        email_ctx = purchase_order.action_rfq_send().get('context', {})
+        composer = self.env['mail.compose.message'].with_context(email_ctx).create({})
+        composer.partner_ids |= additional_partner
+        composer.template_id.auto_delete = False
+
+        composer.action_send_mail()
+
+        additional_partner_mail = self.env['mail.mail'].search([
+            ('res_id', '=', purchase_order.id),
+            ('recipient_ids', '=', additional_partner.id)
+        ])
+
+        self.assertIn('access_token=', additional_partner_mail.body_html,
+                        "The additional partner should be sent the link including the token")
+
+        follower_mail = self.env['mail.mail'].search([
+            ('res_id', '=', purchase_order.id),
+            ('recipient_ids', '=', self.partner_b.id)
+        ])
+        self.assertNotIn('access_token=', follower_mail.body_html,
+                        "The followers should not bet sent the access token by default")

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1050,6 +1050,16 @@ class SaleOrder(models.Model):
                 if group_name not in ('customer', 'portal'):
                     group_data['has_button_access'] = True
 
+            recipient_group = (
+                'additional_intended_recipient',
+                lambda pdata: pdata['id'] in msg_vals.get('partner_ids', []) and pdata['id'] != self.partner_id.id,
+                {
+                    'has_button_access': True,
+                    'notification_is_customer': True,
+                }
+            )
+            groups.insert(0, recipient_group)
+
         return groups
 
     def preview_sale_order(self):

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -936,3 +936,39 @@ class TestSaleOrder(TestSaleCommon):
 
         with self.assertRaises(UserError):
             sol.tax_id = tax_b
+
+    def test_sale_order_sent_to_additional_partner(self):
+        """
+        Make sure that when a SO is deliberately sent to a partner who is not
+        the invoiced customer, they receive a link containing an access token,
+        allowing them to view the SO without needing to log in.
+        """
+        self.partner_b.email = "partner_b@example.com"
+        self.sale_order.message_subscribe(self.partner_b.ids)
+
+        additional_partner = self.env['res.partner'].create({
+            'name': "Additional Partner",
+            'email': "additional@example.com",
+        })
+
+        email_ctx = self.sale_order.action_quotation_send().get('context', {})
+        composer = self.env['mail.compose.message'].with_context(email_ctx).create({})
+        composer.partner_ids |= additional_partner
+        composer.template_id.auto_delete = False
+
+        composer.action_send_mail()
+
+        additional_partner_mail = self.env['mail.mail'].search([
+            ('res_id', '=', self.sale_order.id),
+            ('recipient_ids', '=', additional_partner.id)
+        ])
+
+        self.assertIn('access_token=', additional_partner_mail.body_html,
+                        "The additional partner should be sent the link including the token")
+
+        follower_mail = self.env['mail.mail'].search([
+            ('res_id', '=', self.sale_order.id),
+            ('recipient_ids', '=', self.partner_b.id)
+        ])
+        self.assertNotIn('access_token=', follower_mail.body_html,
+                        "The followers should not bet sent the access token by default")


### PR DESCRIPTION
Currently, when you send an invoice, the invoice's customer and any recipient added manually on the mail composed receives the link including the access token (allowing them to view the invoice without needing an account). However, for Sale/Purchase orders, only the document's partner receives the access token.

This commit allows any partners manually added as recipients in the email for a Sale/Purchase order to also receive an access token.

### Steps to reproduce

* Create and validate a SO/PO
* Click on the Send By Email button, then add a recipient R who is not the customer associated with the invoice
* Proceed to send the SO/PO.
* Access the email that was sent to the added recipient
* Using an incognito or private browsing window, open the link on the email

=> you should see that you are asked to log in, instead of being directed to the customer portal.

opw-3385302
opw-3114579