### PR TITLE
[FIX] project_timesheet_holidays: restore public holiday timesheets a…

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -106,10 +106,27 @@ class Holidays(models.Model):
             'company_id': self.holiday_status_id.timesheet_task_id.company_id.id or self.holiday_status_id.timesheet_project_id.company_id.id,
         }
 
+    def _check_missing_global_leave_timesheets(self):
+        if not self:
+            return
+        min_date = min([leave.date_from for leave in self])
+        max_date = max([leave.date_to for leave in self])
+
+        global_leaves = self.env['resource.calendar.leaves'].search([
+            ("resource_id", "=", False),
+            ("date_to", ">=", min_date),
+            ("date_from", "<=", max_date),
+            ("company_id.internal_project_id", "!=", False),
+            ("company_id.leave_timesheet_task_id", "!=", False),
+        ])
+        if global_leaves:
+            global_leaves._generate_public_time_off_timesheets(self.employee_ids)
+
     def action_refuse(self):
         """ Remove the timesheets linked to the refused holidays """
         result = super(Holidays, self).action_refuse()
         timesheets = self.sudo().mapped('timesheet_ids')
         timesheets.write({'holiday_id': False})
         timesheets.unlink()
+        self._check_missing_global_leave_timesheets()
         return result

--- a/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
+++ b/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
@@ -143,6 +143,38 @@ class ResourceCalendarLeaves(models.Model):
             'company_id': employee_id.company_id.id,
         }
 
+    def _generate_public_time_off_timesheets(self, employees):
+        timesheet_vals_list = []
+        work_hours_data = self._work_time_per_day()
+        timesheet_read_group = self.env['account.analytic.line'].read_group(
+            [('global_leave_id', 'in', self.ids), ('employee_id', 'in', employees.ids)],
+            ['date:array_agg'],
+            ['employee_id']
+        )
+        timesheet_dates_per_employee_id = {
+            res['employee_id'][0]: res['date']
+            for res in timesheet_read_group
+        }
+        for leave in self:
+            for employee in employees:
+                if employee.resource_calendar_id != leave.calendar_id:
+                    continue
+                work_hours_list = work_hours_data[leave.id]
+                timesheet_dates = timesheet_dates_per_employee_id.get(employee.id, [])
+                for index, (day_date, work_hours_count) in enumerate(work_hours_list):
+                    generate_timesheet = day_date not in timesheet_dates
+                    if not generate_timesheet:
+                        continue
+                    timesheet_vals = leave._timesheet_prepare_line_values(
+                        index,
+                        employee,
+                        work_hours_list,
+                        day_date,
+                        work_hours_count
+                    )
+                    timesheet_vals_list.append(timesheet_vals)
+        return self.env['account.analytic.line'].sudo().create(timesheet_vals_list)
+
     @api.model_create_multi
     def create(self, vals_list):
         results = super(ResourceCalendarLeaves, self).create(vals_list)


### PR DESCRIPTION
…fter refusal

Before this commit, if a public holiday was created on dates overlapping an existing validated leave, the timesheet entries for the public holiday would not be created as they already existed for the leave. If the leave was then refused, the timesheet records linked to it would be removed and the employee would have missing timesheet entries for the public holiday.

This commit fixes this behavior by recreating the public holiday timesheet records for the affected employees when refusing their leave.

opw-3550523
