### PR TITLE
17.0 fix rendering unit reports aels

### DIFF
--- a/addons/product/static/src/scss/report_label_sheet.scss
+++ b/addons/product/static/src/scss/report_label_sheet.scss
@@ -68,7 +68,7 @@
     }
 
     // generic 4x12 label w/ all same size font
-    div.o_label_4x12 {
+    div.o_label_4x12, div.o_label_4x7 {
         padding:0;
         line-height:1;
         font-size:55%;

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-10-26 21:54+0000\n"
-"PO-Revision-Date: 2023-10-26 21:54+0000\n"
+"POT-Creation-Date: 2023-12-08 09:28+0000\n"
+"PO-Revision-Date: 2023-12-08 09:28+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -77,6 +77,13 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__return_count
 msgid "# Returns"
+msgstr ""
+
+#. module: stock
+#. odoo-python
+#: code:addons/stock/models/stock_warehouse.py:0
+#, python-format
+msgid "%(name)s (copy)(%(id)s)"
 msgstr ""
 
 #. module: stock
@@ -302,7 +309,6 @@ msgid "3.00"
 msgstr ""
 
 #. module: stock
-#: model:ir.model.fields.selection,name:stock.selection__lot_label_layout__print_format__4x12
 #: model:ir.model.fields.selection,name:stock.selection__stock_picking_type__product_label_format__4x12
 msgid "4 x 12"
 msgstr ""
@@ -320,6 +326,11 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields.selection,name:stock.selection__stock_picking_type__product_label_format__4x12xprice
 msgid "4 x 12 with price"
+msgstr ""
+
+#. module: stock
+#: model:ir.model.fields.selection,name:stock.selection__lot_label_layout__print_format__4x7
+msgid "4 x 7"
 msgstr ""
 
 #. module: stock
@@ -422,6 +433,11 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 msgid "<span class=\"o_stat_text\">Allocation</span>"
+msgstr ""
+
+#. module: stock
+#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+msgid "<span class=\"o_stat_text\">Detailed Operations</span>"
 msgstr ""
 
 #. module: stock
@@ -932,13 +948,6 @@ msgid "All at once"
 msgstr ""
 
 #. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid ""
-"All our contractual relations will be governed exclusively by United States "
-"law."
-msgstr ""
-
-#. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__returned_move_ids
 msgid "All returned moves"
 msgstr ""
@@ -1127,6 +1136,11 @@ msgid "At Confirmation"
 msgstr ""
 
 #. module: stock
+#: model_terms:ir.ui.view,arch_db:stock.search_product_lot_filter
+msgid "At Customer"
+msgstr ""
+
+#. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_lot__message_attachment_count
 #: model:ir.model.fields,field_description:stock.field_stock_picking__message_attachment_count
 #: model:ir.model.fields,field_description:stock.field_stock_scrap__message_attachment_count
@@ -1205,8 +1219,8 @@ msgid "Automatic No Step Added"
 msgstr ""
 
 #. module: stock
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/stock/models/stock_picking.py:0
 #: code:addons/stock/static/src/widgets/forecast_widget.xml:0
 #: model:ir.model.fields.selection,name:stock.selection__stock_move__state__assigned
@@ -1315,13 +1329,6 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields.selection,name:stock.selection__stock_picking_type__reservation_method__by_date
 msgid "Before scheduled date"
-msgstr ""
-
-#. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid ""
-"Below text serves as a suggestion and doesn’t engage Odoo S.A. "
-"responsibility."
 msgstr ""
 
 #. module: stock
@@ -1458,18 +1465,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock.field_product_product__route_from_categ_ids
 #: model:ir.model.fields,field_description:stock.field_product_template__route_from_categ_ids
 msgid "Category Routes"
-msgstr ""
-
-#. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid ""
-"Certain countries apply withholding at source on the amount of invoices, in "
-"accordance with their internal legislation. Any withholding at source will "
-"be paid by the client to the tax authorities. Under no circumstances can My "
-"Company (Chicago) become involved in costs related to a country's "
-"legislation. The amount of the invoice will therefore be due to My Company "
-"(Chicago) in its entirety and does not include any costs relating to the "
-"legislation of the country in which the client is located."
 msgstr ""
 
 #. module: stock
@@ -1637,6 +1632,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse__company_id
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse_orderpoint__company_id
 #: model_terms:ir.ui.view,arch_db:stock.quant_search_view
+#: model_terms:ir.ui.view,arch_db:stock.search_product_lot_filter
 msgid "Company"
 msgstr ""
 
@@ -2029,6 +2025,7 @@ msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_picking__date
+#: model_terms:ir.ui.view,arch_db:stock.search_product_lot_filter
 #: model_terms:ir.ui.view,arch_db:stock.view_move_search
 msgid "Creation Date"
 msgstr ""
@@ -2036,6 +2033,11 @@ msgstr ""
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_picking__date
 msgid "Creation Date, usually the time of the order"
+msgstr ""
+
+#. module: stock
+#: model_terms:ir.ui.view,arch_db:stock.search_product_lot_filter
+msgid "Creation date"
 msgstr ""
 
 #. module: stock
@@ -2612,6 +2614,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/stock/models/stock_rule.py:0
 #: model:ir.model.fields,field_description:stock.field_stock_move__location_dest_id
+#: model:ir.model.fields,field_description:stock.field_stock_move_line__picking_location_dest_id
 #: model:ir.model.fields,field_description:stock.field_stock_picking__location_dest_id
 #: model:ir.model.fields,field_description:stock.field_stock_rule__location_dest_id
 #: model_terms:ir.ui.view,arch_db:stock.view_move_search
@@ -2661,7 +2664,7 @@ msgstr ""
 #. module: stock
 #. odoo-python
 #: code:addons/stock/models/stock_move.py:0
-#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+#: code:addons/stock/models/stock_picking.py:0
 #, python-format
 msgid "Detailed Operations"
 msgstr ""
@@ -3519,15 +3522,6 @@ msgid "Icon to indicate an exception activity."
 msgstr ""
 
 #. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid ""
-"If a payment is still outstanding more than sixty (60) days after the due "
-"payment date, My Company (Chicago) reserves the right to call on the "
-"services of a debt recovery company. All legal expenses will be payable by "
-"the client."
-msgstr ""
-
-#. module: stock
 #: model:ir.model.fields.selection,name:stock.selection__stock_storage_category__allow_new_product__same
 msgid "If all products are same"
 msgstr ""
@@ -3670,6 +3664,7 @@ msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,help:stock.field_stock_move__show_operations
+#: model:ir.model.fields,help:stock.field_stock_picking__show_operations
 #: model:ir.model.fields,help:stock.field_stock_picking_type__show_operations
 msgid ""
 "If this checkbox is ticked, the pickings lines will represent detailed stock"
@@ -3750,17 +3745,13 @@ msgid "Import Template for Inventory Adjustments"
 msgstr ""
 
 #. module: stock
-#: model:ir.model.fields,field_description:stock.field_stock_warehouse__in_type_id
-msgid "In Type"
+#: model_terms:ir.ui.view,arch_db:stock.quant_search_view
+msgid "In Stock"
 msgstr ""
 
 #. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid ""
-"In order for it to be admissible, My Company (Chicago) must be notified of "
-"any claim by means of a letter sent by recorded delivery to its registered "
-"office within 8 days of the delivery of the goods or the provision of the "
-"services."
+#: model:ir.model.fields,field_description:stock.field_stock_warehouse__in_type_id
+msgid "In Type"
 msgstr ""
 
 #. module: stock
@@ -3910,6 +3901,7 @@ msgstr ""
 #. module: stock
 #. odoo-python
 #: code:addons/stock/models/product.py:0 code:addons/stock/models/product.py:0
+#: code:addons/stock/models/stock_lot.py:0
 #, python-format
 msgid "Invalid domain operator %s"
 msgstr ""
@@ -3917,6 +3909,7 @@ msgstr ""
 #. module: stock
 #. odoo-python
 #: code:addons/stock/models/product.py:0 code:addons/stock/models/product.py:0
+#: code:addons/stock/models/stock_lot.py:0
 #, python-format
 msgid "Invalid domain right operand '%s'. It must be of type Integer/Float"
 msgstr ""
@@ -4175,6 +4168,14 @@ msgid "Keep Difference"
 msgstr ""
 
 #. module: stock
+#. odoo-javascript
+#: code:addons/stock/static/src/widgets/lots_dialog.xml:0
+#: code:addons/stock/static/src/widgets/lots_dialog.xml:0
+#, python-format
+msgid "Keep current lines"
+msgstr ""
+
+#. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_inventory_conflict_form_view
 msgid ""
 "Keep the <strong>Counted Quantity</strong> (the Difference will be updated)"
@@ -4430,6 +4431,11 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_move_form
 msgid "Linked Moves"
+msgstr ""
+
+#. module: stock
+#: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+msgid "List view of detailed operations"
 msgstr ""
 
 #. module: stock
@@ -4922,17 +4928,6 @@ msgid "My Activity Deadline"
 msgstr ""
 
 #. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid ""
-"My Company (Chicago) undertakes to do its best to supply performant services"
-" in due time in accordance with the agreed timeframes. However, none of its "
-"obligations can be considered as being an obligation to achieve results. My "
-"Company (Chicago) cannot under any circumstances, be required by the client "
-"to appear as a third party in the context of any claim for damages filed "
-"against the client by an end consumer."
-msgstr ""
-
-#. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.quant_search_view
 msgid "My Counts"
 msgstr ""
@@ -5014,12 +5009,6 @@ msgstr ""
 #. module: stock
 #: model:ir.actions.act_window,name:stock.action_picking_form
 msgid "New Transfer"
-msgstr ""
-
-#. module: stock
-#: model:ir.model.fields,field_description:stock.field_stock_lot__activity_calendar_event_id
-#: model:ir.model.fields,field_description:stock.field_stock_picking__activity_calendar_event_id
-msgid "Next Activity Calendar Event"
 msgstr ""
 
 #. module: stock
@@ -5195,8 +5184,8 @@ msgid "Normal"
 msgstr ""
 
 #. module: stock
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/stock/models/stock_picking.py:0
 #: code:addons/stock/static/src/stock_forecasted/forecasted_details.xml:0
 #: code:addons/stock/static/src/widgets/forecast_widget.xml:0
@@ -5310,6 +5299,7 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock.field_stock_warehouse_orderpoint__qty_on_hand
 #: model_terms:ir.ui.view,arch_db:stock.product_product_stock_tree
 #: model_terms:ir.ui.view,arch_db:stock.quant_search_view
+#: model_terms:ir.ui.view,arch_db:stock.search_product_lot_filter
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_product_template_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_product_tree
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_quant_tree_simple
@@ -5318,6 +5308,7 @@ msgid "On Hand"
 msgstr ""
 
 #. module: stock
+#: model:ir.model.fields,field_description:stock.field_stock_lot__product_qty
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_quant_tree_editable
 #: model_terms:ir.ui.view,arch_db:stock.view_stock_quant_tree_inventory_editable
 msgid "On Hand Quantity"
@@ -5535,17 +5526,6 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
 msgid "Other Information"
-msgstr ""
-
-#. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid ""
-"Our invoices are payable within 21 working days, unless another payment "
-"timeframe is indicated on either the invoice or the order. In the event of "
-"non-payment by the due date, My Company (Chicago) reserves the right to "
-"request a fixed interest payment amounting to 10% of the sum remaining due. "
-"My Company (Chicago) will be authorized to suspend any provision of services"
-" without prior warning in the event of late payment."
 msgstr ""
 
 #. module: stock
@@ -6477,6 +6457,7 @@ msgstr ""
 
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_form
+#: model_terms:ir.ui.view,arch_db:stock.view_stock_move_line_detailed_operation_tree
 msgid "Put in Pack"
 msgstr ""
 
@@ -6597,7 +6578,6 @@ msgstr ""
 #: code:addons/stock/static/src/client_actions/stock_traceability_report_backend.xml:0
 #: model:ir.model.fields,field_description:stock.field_product_replenish__quantity
 #: model:ir.model.fields,field_description:stock.field_report_stock_quantity__product_qty
-#: model:ir.model.fields,field_description:stock.field_stock_lot__product_qty
 #: model:ir.model.fields,field_description:stock.field_stock_move__quantity
 #: model:ir.model.fields,field_description:stock.field_stock_move_line__quantity
 #: model:ir.model.fields,field_description:stock.field_stock_quant__quantity
@@ -6763,13 +6743,6 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_return_slip
 msgid "RETURN OF"
-msgstr ""
-
-#. module: stock
-#: model:ir.model.fields,field_description:stock.field_stock_lot__rating_ids
-#: model:ir.model.fields,field_description:stock.field_stock_picking__rating_ids
-#: model:ir.model.fields,field_description:stock.field_stock_scrap__rating_ids
-msgid "Ratings"
 msgstr ""
 
 #. module: stock
@@ -7428,11 +7401,6 @@ msgid "SSCC:"
 msgstr ""
 
 #. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid "STANDARD TERMS AND CONDITIONS OF SALE"
-msgstr ""
-
-#. module: stock
 #. odoo-javascript
 #: code:addons/stock/static/src/widgets/json_widget.xml:0
 #, python-format
@@ -7839,6 +7807,7 @@ msgstr ""
 
 #. module: stock
 #: model:ir.model.fields,field_description:stock.field_stock_move__show_operations
+#: model:ir.model.fields,field_description:stock.field_stock_picking__show_operations
 #: model:ir.model.fields,field_description:stock.field_stock_picking_type__show_operations
 msgid "Show Detailed Operations"
 msgstr ""
@@ -7864,11 +7833,6 @@ msgstr ""
 #: model:ir.model.fields,field_description:stock.field_product_product__show_on_hand_qty_status_button
 #: model:ir.model.fields,field_description:stock.field_product_template__show_on_hand_qty_status_button
 msgid "Show On Hand Qty Status Button"
-msgstr ""
-
-#. module: stock
-#: model:ir.model.fields,field_description:stock.field_stock_picking__show_operations
-msgid "Show Operations"
 msgstr ""
 
 #. module: stock
@@ -8000,6 +7964,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/stock/models/stock_rule.py:0
 #: model:ir.model.fields,field_description:stock.field_stock_move__location_id
+#: model:ir.model.fields,field_description:stock.field_stock_move_line__picking_location_id
 #: model:ir.model.fields,field_description:stock.field_stock_picking__location_id
 #: model:ir.model.fields,field_description:stock.field_stock_rule__location_src_id
 #: model:ir.model.fields,field_description:stock.field_stock_scrap__location_id
@@ -8408,15 +8373,6 @@ msgstr ""
 #. module: stock
 #: model:ir.model.constraint,message:stock.constraint_stock_location_barcode_company_uniq
 msgid "The barcode for a location must be unique per company!"
-msgstr ""
-
-#. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid ""
-"The client explicitly waives its own standard terms and conditions, even if "
-"these were drawn up after these standard terms and conditions of sale. In "
-"order to be valid, any derogation must be expressly agreed to in advance in "
-"writing."
 msgstr ""
 
 #. module: stock
@@ -9344,8 +9300,8 @@ msgid "Update Quantities"
 msgstr ""
 
 #. module: stock
-#. odoo-python
 #. odoo-javascript
+#. odoo-python
 #: code:addons/stock/models/product.py:0
 #: code:addons/stock/static/src/stock_forecasted/forecasted_buttons.xml:0
 #: code:addons/stock/static/src/stock_forecasted/forecasted_buttons.xml:0
@@ -9874,11 +9830,6 @@ msgid "Write one lot/serial name per line, followed by the quantity."
 msgstr ""
 
 #. module: stock
-#: model_terms:ir.ui.view,arch_db:stock.view_stock_move_line_operation_tree
-msgid "Write your SN/LN one by one or copy paste a list."
-msgstr ""
-
-#. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.stock_quant_relocate_view_form
 msgid ""
 "You are about to move quantities in a package without moving the full package.\n"
@@ -10306,11 +10257,6 @@ msgid "You need to supply a Lot/Serial number for products %s."
 msgstr ""
 
 #. module: stock
-#: model_terms:res.company,invoice_terms_html:stock.res_company_1
-msgid "You should update this document to reflect your T&amp;C."
-msgstr ""
-
-#. module: stock
 #. odoo-python
 #: code:addons/stock/models/stock_warehouse.py:0
 #, python-format
@@ -10341,13 +10287,6 @@ msgid ""
 "You'll find here smart replenishment propositions based on inventory forecasts.\n"
 "            Choose the quantity to buy or manufacture and launch orders in a click.\n"
 "            To save time in the future, set the rules as \"automated\"."
-msgstr ""
-
-#. module: stock
-#: model_terms:res.company,lunch_notify_message:stock.res_company_1
-msgid ""
-"Your lunch has been delivered.\n"
-"Enjoy your meal!"
 msgstr ""
 
 #. module: stock
@@ -10457,6 +10396,11 @@ msgstr ""
 #. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.view_picking_type_form
 msgid "e.g. Receptions"
+msgstr ""
+
+#. module: stock
+#: model_terms:ir.ui.view,arch_db:stock.view_stock_move_line_operation_tree
+msgid "e.g. SN000001"
 msgstr ""
 
 #. module: stock

--- a/addons/stock/models/ir_actions_report.py
+++ b/addons/stock/models/ir_actions_report.py
@@ -1,4 +1,45 @@
-from odoo import models
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models, _
+from odoo.exceptions import UserError
+
+import io
+from PyPDF2 import PdfFileWriter, PdfFileReader
+from PIL import Image, ImageFile
+from collections import OrderedDict
+
+# Allow truncated images
+ImageFile.LOAD_TRUNCATED_IMAGES = True
+
+
+class DuplicateKeyDict:
+    def __init__(self) -> None:
+        self._key_count = 0
+        self._items = OrderedDict()
+
+    def insert(self, key, value):
+        cur_key_id = self._key_count
+        self._items[f'{key}|{cur_key_id}'] = (key, value)
+        self._key_count += 1
+        return cur_key_id
+
+    def items(self, include_key_id=False):
+        for internal_key, (key, val) in self._items.items():
+            _, key_id = internal_key.split('|')
+            key_id = int(key_id)
+            if include_key_id:
+                yield (key, key_id, val)
+            else:
+                yield (key, val)
+
+    def values(self):
+        for (_, val) in self._items.values():
+            yield val
+
+    def __getitem__(self, key_tuple):
+        key, key_id = key_tuple
+        internal_key = f'{key}|{key_id}'
+        return self._items[internal_key][1]
 
 
 class IrActionsReport(models.Model):
@@ -14,3 +55,175 @@ class IrActionsReport(models.Model):
                 'docs': docs,
             })
         return data
+
+    def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):
+        if self._get_report(report_ref).report_name != 'stock.report_lot_label':
+            return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
+        
+        if not data:
+            data = {}
+        data.setdefault('report_type', 'pdf')
+
+        # access the report details with sudo() but evaluation context as current user
+        report_sudo = self._get_report(report_ref)
+
+        collected_streams = DuplicateKeyDict()
+
+        # Fetch the existing attachments from the database for later use.
+        # Reload the stream from the attachment in case of 'attachment_use'.
+        if res_ids:
+            records = self.env[report_sudo.model].browse(res_ids)
+            for record in records:
+                stream = None
+                attachment = None
+                if report_sudo.attachment and not self._context.get("report_pdf_no_attachment"):
+                    attachment = report_sudo.retrieve_attachment(record)
+
+                    # Extract the stream from the attachment.
+                    if attachment and report_sudo.attachment_use:
+                        stream = io.BytesIO(attachment.raw)
+
+                        # Ensure the stream can be saved in Image.
+                        if attachment.mimetype.startswith('image'):
+                            img = Image.open(stream)
+                            new_stream = io.BytesIO()
+                            img.convert("RGB").save(new_stream, format="pdf")
+                            stream.close()
+                            stream = new_stream
+
+                collected_streams.insert(record.id, {
+                    'stream': stream,
+                    'attachment': attachment,
+                })
+
+        # Call 'wkhtmltopdf' to generate the missing streams.
+        res_ids_wo_stream = [res_id for res_id, stream_data in collected_streams.items(
+        ) if not stream_data['stream']]
+        key_ids_wo_stream = [key_id for _, key_id, stream_data in collected_streams.items(
+            include_key_id=True) if not stream_data['stream']]
+        is_whtmltopdf_needed = not res_ids or res_ids_wo_stream
+
+        if is_whtmltopdf_needed:
+
+            if self.get_wkhtmltopdf_state() == 'install':
+                # wkhtmltopdf is not installed
+                # the call should be catched before (cf /report/check_wkhtmltopdf) but
+                # if get_pdf is called manually (email template), the check could be
+                # bypassed
+                raise UserError(
+                    _("Unable to find Wkhtmltopdf on this system. The PDF can not be created."))
+
+            # Disable the debug mode in the PDF rendering in order to not split the assets bundle
+            # into separated files to load. This is done because of an issue in wkhtmltopdf
+            # failing to load the CSS/Javascript resources in time.
+            # Without this, the header/footer of the reports randomly disappear
+            # because the resources files are not loaded in time.
+            # https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2083
+            additional_context = {'debug': False}
+
+            html = self.with_context(
+                **additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
+
+            bodies, html_ids, header, footer, specific_paperformat_args = self.with_context(
+                **additional_context)._prepare_html(html, report_model=report_sudo.model)
+
+            if report_sudo.attachment and sorted(res_ids_wo_stream) != sorted(html_ids):
+                raise UserError(_(
+                    "The report's template %r is wrong, please contact your administrator. \n\n"
+                    "Can not separate file to save as attachment because the report's template does not contains the"
+                    " attributes 'data-oe-model' and 'data-oe-id' on the div with 'article' classname.",
+                    self.name,
+                ))
+
+            pdf_content = self._run_wkhtmltopdf(
+                bodies,
+                report_ref=report_ref,
+                header=header,
+                footer=footer,
+                landscape=self._context.get('landscape'),
+                specific_paperformat_args=specific_paperformat_args,
+                set_viewport_size=self._context.get('set_viewport_size'),
+            )
+            pdf_content_stream = io.BytesIO(pdf_content)
+
+            # Printing a PDF report without any records. The content could be returned directly.
+            if not res_ids:
+                collected_streams = DuplicateKeyDict()
+                collected_streams.insert(False, {
+                    'stream': pdf_content_stream,
+                    'attachment': None
+                })
+                return collected_streams
+
+            # Split the pdf for each record using the PDF outlines.
+
+            # Only one record: append the whole PDF.
+            if len(res_ids_wo_stream) == 1:
+                collected_streams[(res_ids_wo_stream[0], 0)]['stream'] = pdf_content_stream
+                return collected_streams
+
+            # In case of multiple docs, we need to split the pdf according the records.
+            # In the simplest case of 1 res_id == 1 page, we use the PDFReader to print the
+            # pages one by one.
+            html_ids_wo_none = [x for x in html_ids if x]
+            reader = PdfFileReader(pdf_content_stream)
+            if reader.numPages == len(res_ids_wo_stream):
+                for i in range(reader.numPages):
+                    attachment_writer = PdfFileWriter()
+                    attachment_writer.addPage(reader.getPage(i))
+                    stream = io.BytesIO()
+                    attachment_writer.write(stream)
+                    collected_streams[(res_ids[i], i)]['stream'] = stream
+                return collected_streams
+
+            # In cases where the number of res_ids != the number of pages,
+            # we split the pdf based on top outlines computed by wkhtmltopdf.
+            # An outline is a <h?> html tag found on the document. To retrieve this table,
+            # we look on the pdf structure using pypdf to compute the outlines_pages from
+            # the top level heading in /Outlines.
+            if len(res_ids_wo_stream) > 1 and set(res_ids_wo_stream) == set(html_ids_wo_none):
+                root = reader.trailer['/Root']
+                has_valid_outlines = '/Outlines' in root and '/First' in root['/Outlines']
+                if not has_valid_outlines:
+                    collected_streams = DuplicateKeyDict()
+                    collected_streams.insert(False, {
+                        'report_action': self,
+                        'stream': pdf_content_stream,
+                        'attachment': None,
+                    })
+                    return collected_streams
+
+                outlines_pages = []
+                node = root['/Outlines']['/First']
+                while True:
+                    outlines_pages.append(root['/Dests'][node['/Dest']][0])
+                    if '/Next' not in node:
+                        break
+                    node = node['/Next']
+                outlines_pages = sorted(set(outlines_pages))
+
+                # The number of outlines must be equal to the number of records to be able to split the document.
+                has_same_number_of_outlines = len(
+                    outlines_pages) == len(res_ids)
+
+                # There should be a top-level heading on first page
+                has_top_level_heading = outlines_pages[0] == 0
+
+                if has_same_number_of_outlines and has_top_level_heading:
+                    # Split the PDF according to outlines.
+                    for i, num in enumerate(outlines_pages):
+                        to = outlines_pages[i + 1] if i + \
+                            1 < len(outlines_pages) else reader.numPages
+                        attachment_writer = PdfFileWriter()
+                        for j in range(num, to):
+                            attachment_writer.addPage(reader.getPage(j))
+                        stream = io.BytesIO()
+                        attachment_writer.write(stream)
+                        collected_streams[(res_ids[i], i)]['stream'] = stream
+
+                    return collected_streams
+
+            collected_streams.insert(False, {
+                'stream': pdf_content_stream, 'attachment': None})
+
+        return collected_streams

--- a/addons/stock/models/ir_actions_report.py
+++ b/addons/stock/models/ir_actions_report.py
@@ -4,42 +4,6 @@ from odoo import models, _
 from odoo.exceptions import UserError
 
 import io
-from PyPDF2 import PdfFileWriter, PdfFileReader
-from PIL import Image, ImageFile
-from collections import OrderedDict
-
-# Allow truncated images
-ImageFile.LOAD_TRUNCATED_IMAGES = True
-
-
-class DuplicateKeyDict:
-    def __init__(self) -> None:
-        self._key_count = 0
-        self._items = OrderedDict()
-
-    def insert(self, key, value):
-        cur_key_id = self._key_count
-        self._items[f'{key}|{cur_key_id}'] = (key, value)
-        self._key_count += 1
-        return cur_key_id
-
-    def items(self, include_key_id=False):
-        for internal_key, (key, val) in self._items.items():
-            _, key_id = internal_key.split('|')
-            key_id = int(key_id)
-            if include_key_id:
-                yield (key, key_id, val)
-            else:
-                yield (key, val)
-
-    def values(self):
-        for (_, val) in self._items.values():
-            yield val
-
-    def __getitem__(self, key_tuple):
-        key, key_id = key_tuple
-        internal_key = f'{key}|{key_id}'
-        return self._items[internal_key][1]
 
 
 class IrActionsReport(models.Model):
@@ -59,7 +23,7 @@ class IrActionsReport(models.Model):
     def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):
         if self._get_report(report_ref).report_name != 'stock.report_lot_label':
             return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
-        
+
         if not data:
             data = {}
         data.setdefault('report_type', 'pdf')
@@ -67,163 +31,50 @@ class IrActionsReport(models.Model):
         # access the report details with sudo() but evaluation context as current user
         report_sudo = self._get_report(report_ref)
 
-        collected_streams = DuplicateKeyDict()
+        if self.get_wkhtmltopdf_state() == 'install':
+            # wkhtmltopdf is not installed
+            # the call should be catched before (cf /report/check_wkhtmltopdf) but
+            # if get_pdf is called manually (email template), the check could be
+            # bypassed
+            raise UserError(
+                _("Unable to find Wkhtmltopdf on this system. The PDF can not be created."))
 
-        # Fetch the existing attachments from the database for later use.
-        # Reload the stream from the attachment in case of 'attachment_use'.
-        if res_ids:
-            records = self.env[report_sudo.model].browse(res_ids)
-            for record in records:
-                stream = None
-                attachment = None
-                if report_sudo.attachment and not self._context.get("report_pdf_no_attachment"):
-                    attachment = report_sudo.retrieve_attachment(record)
+        # Disable the debug mode in the PDF rendering in order to not split the assets bundle
+        # into separated files to load. This is done because of an issue in wkhtmltopdf
+        # failing to load the CSS/Javascript resources in time.
+        # Without this, the header/footer of the reports randomly disappear
+        # because the resources files are not loaded in time.
+        # https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2083
+        additional_context = {'debug': False}
 
-                    # Extract the stream from the attachment.
-                    if attachment and report_sudo.attachment_use:
-                        stream = io.BytesIO(attachment.raw)
+        html = self.with_context(
+            **additional_context)._render_qweb_html(report_ref, res_ids, data=data)[0]
 
-                        # Ensure the stream can be saved in Image.
-                        if attachment.mimetype.startswith('image'):
-                            img = Image.open(stream)
-                            new_stream = io.BytesIO()
-                            img.convert("RGB").save(new_stream, format="pdf")
-                            stream.close()
-                            stream = new_stream
+        bodies, html_ids, header, footer, specific_paperformat_args = self.with_context(
+            **additional_context)._prepare_html(html, report_model=report_sudo.model)
 
-                collected_streams.insert(record.id, {
-                    'stream': stream,
-                    'attachment': attachment,
-                })
+        if report_sudo.attachment and sorted(res_ids) != sorted(html_ids):
+            raise UserError(_(
+                "The report's template %r is wrong, please contact your administrator. \n\n"
+                "Can not separate file to save as attachment because the report's template does not contains the"
+                " attributes 'data-oe-model' and 'data-oe-id' on the div with 'article' classname.",
+                self.name,
+            ))
 
-        # Call 'wkhtmltopdf' to generate the missing streams.
-        res_ids_wo_stream = [res_id for res_id, stream_data in collected_streams.items(
-        ) if not stream_data['stream']]
-        key_ids_wo_stream = [key_id for _, key_id, stream_data in collected_streams.items(
-            include_key_id=True) if not stream_data['stream']]
-        is_whtmltopdf_needed = not res_ids or res_ids_wo_stream
+        pdf_content = self._run_wkhtmltopdf(
+            bodies,
+            report_ref=report_ref,
+            header=header,
+            footer=footer,
+            landscape=self._context.get('landscape'),
+            specific_paperformat_args=specific_paperformat_args,
+            set_viewport_size=self._context.get('set_viewport_size'),
+        )
+        pdf_content_stream = io.BytesIO(pdf_content)
 
-        if is_whtmltopdf_needed:
-
-            if self.get_wkhtmltopdf_state() == 'install':
-                # wkhtmltopdf is not installed
-                # the call should be catched before (cf /report/check_wkhtmltopdf) but
-                # if get_pdf is called manually (email template), the check could be
-                # bypassed
-                raise UserError(
-                    _("Unable to find Wkhtmltopdf on this system. The PDF can not be created."))
-
-            # Disable the debug mode in the PDF rendering in order to not split the assets bundle
-            # into separated files to load. This is done because of an issue in wkhtmltopdf
-            # failing to load the CSS/Javascript resources in time.
-            # Without this, the header/footer of the reports randomly disappear
-            # because the resources files are not loaded in time.
-            # https://github.com/wkhtmltopdf/wkhtmltopdf/issues/2083
-            additional_context = {'debug': False}
-
-            html = self.with_context(
-                **additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
-
-            bodies, html_ids, header, footer, specific_paperformat_args = self.with_context(
-                **additional_context)._prepare_html(html, report_model=report_sudo.model)
-
-            if report_sudo.attachment and sorted(res_ids_wo_stream) != sorted(html_ids):
-                raise UserError(_(
-                    "The report's template %r is wrong, please contact your administrator. \n\n"
-                    "Can not separate file to save as attachment because the report's template does not contains the"
-                    " attributes 'data-oe-model' and 'data-oe-id' on the div with 'article' classname.",
-                    self.name,
-                ))
-
-            pdf_content = self._run_wkhtmltopdf(
-                bodies,
-                report_ref=report_ref,
-                header=header,
-                footer=footer,
-                landscape=self._context.get('landscape'),
-                specific_paperformat_args=specific_paperformat_args,
-                set_viewport_size=self._context.get('set_viewport_size'),
-            )
-            pdf_content_stream = io.BytesIO(pdf_content)
-
-            # Printing a PDF report without any records. The content could be returned directly.
-            if not res_ids:
-                collected_streams = DuplicateKeyDict()
-                collected_streams.insert(False, {
-                    'stream': pdf_content_stream,
-                    'attachment': None
-                })
-                return collected_streams
-
-            # Split the pdf for each record using the PDF outlines.
-
-            # Only one record: append the whole PDF.
-            if len(res_ids_wo_stream) == 1:
-                collected_streams[(res_ids_wo_stream[0], 0)]['stream'] = pdf_content_stream
-                return collected_streams
-
-            # In case of multiple docs, we need to split the pdf according the records.
-            # In the simplest case of 1 res_id == 1 page, we use the PDFReader to print the
-            # pages one by one.
-            html_ids_wo_none = [x for x in html_ids if x]
-            reader = PdfFileReader(pdf_content_stream)
-            if reader.numPages == len(res_ids_wo_stream):
-                for i in range(reader.numPages):
-                    attachment_writer = PdfFileWriter()
-                    attachment_writer.addPage(reader.getPage(i))
-                    stream = io.BytesIO()
-                    attachment_writer.write(stream)
-                    collected_streams[(res_ids[i], i)]['stream'] = stream
-                return collected_streams
-
-            # In cases where the number of res_ids != the number of pages,
-            # we split the pdf based on top outlines computed by wkhtmltopdf.
-            # An outline is a <h?> html tag found on the document. To retrieve this table,
-            # we look on the pdf structure using pypdf to compute the outlines_pages from
-            # the top level heading in /Outlines.
-            if len(res_ids_wo_stream) > 1 and set(res_ids_wo_stream) == set(html_ids_wo_none):
-                root = reader.trailer['/Root']
-                has_valid_outlines = '/Outlines' in root and '/First' in root['/Outlines']
-                if not has_valid_outlines:
-                    collected_streams = DuplicateKeyDict()
-                    collected_streams.insert(False, {
-                        'report_action': self,
-                        'stream': pdf_content_stream,
-                        'attachment': None,
-                    })
-                    return collected_streams
-
-                outlines_pages = []
-                node = root['/Outlines']['/First']
-                while True:
-                    outlines_pages.append(root['/Dests'][node['/Dest']][0])
-                    if '/Next' not in node:
-                        break
-                    node = node['/Next']
-                outlines_pages = sorted(set(outlines_pages))
-
-                # The number of outlines must be equal to the number of records to be able to split the document.
-                has_same_number_of_outlines = len(
-                    outlines_pages) == len(res_ids)
-
-                # There should be a top-level heading on first page
-                has_top_level_heading = outlines_pages[0] == 0
-
-                if has_same_number_of_outlines and has_top_level_heading:
-                    # Split the PDF according to outlines.
-                    for i, num in enumerate(outlines_pages):
-                        to = outlines_pages[i + 1] if i + \
-                            1 < len(outlines_pages) else reader.numPages
-                        attachment_writer = PdfFileWriter()
-                        for j in range(num, to):
-                            attachment_writer.addPage(reader.getPage(j))
-                        stream = io.BytesIO()
-                        attachment_writer.write(stream)
-                        collected_streams[(res_ids[i], i)]['stream'] = stream
-
-                    return collected_streams
-
-            collected_streams.insert(False, {
-                'stream': pdf_content_stream, 'attachment': None})
-
-        return collected_streams
+        return {
+            False: {
+                'stream': pdf_content_stream,
+                'attachment': None
+            }
+        }

--- a/addons/stock/report/report_lot_barcode.xml
+++ b/addons/stock/report/report_lot_barcode.xml
@@ -3,7 +3,7 @@
 <data>
 <template id="report_lot_label">
     <t t-call="web.basic_layout">
-        <t t-set='nRows' t-value='12'/>
+        <t t-set='nRows' t-value='7'/>
         <t t-set='nCols' t-value='4'/>
         <div class="oe_structure"></div>
         <div t-foreach="[docs[x:x + nRows * nCols] for x in range(0, len(docs), nRows * nCols)]" t-as="page_docs" class="o_label_sheet" t-att-style="'padding: 20mm 8mm'">
@@ -26,8 +26,8 @@
                                         <t name="gs1_datamatrix_lot" t-if="o.product_id.tracking == 'lot'" t-set="final_barcode" t-value="(final_barcode or '') + '10' + o.name"/>
                                         <t t-elif="o.product_id.tracking == 'serial'" t-set="final_barcode" t-value="(final_barcode or '') + '21' + o.name"/>
                                     </t>
-                                    <span class="o_label_4x12" t-field="o.product_id.display_name" t-att-style="'width:22mm' if final_barcode else ''">Demo Product</span>
-                                    <span class="o_label_4x12" name="lot_name" t-field="o.name" t-att-style="'width:22mm' if final_barcode else ''">Demo Name</span>
+                                    <span class="o_label_4x7" t-field="o.product_id.display_name" t-att-style="'width:22mm' if final_barcode else ''">Demo Product</span>
+                                    <span class="o_label_4x7" name="lot_name" t-field="o.name" t-att-style="'width:22mm' if final_barcode else ''">Demo Name</span>
                                     <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
                                         <div t-if="final_barcode" t-att-style="'position:absolute; right:.5px; bottom:.5px'">
                                             <span t-out="final_barcode" t-options="{'widget': 'barcode', 'symbology': 'ECC200DataMatrix', 'img_style': 'width:17mm; height:17mm'}">12345678901</span>

--- a/addons/stock/wizard/stock_lot_label_layout.py
+++ b/addons/stock/wizard/stock_lot_label_layout.py
@@ -14,8 +14,8 @@ class ProductLabelLayout(models.TransientModel):
         ('lots', 'One per lot/SN'),
         ('units', 'One per unit')], string="Quantity to print", required=True, default='lots', help="If the UoM of a lot is not 'units', the lot will be considered as a unit and only one label will be printed for this lot.")
     print_format = fields.Selection([
-        ('4x12', '4 x 12'),
-        ('zpl', 'ZPL Labels')], string="Format", default='4x12', required=True)
+        ('4x7', '4 x 7'),
+        ('zpl', 'ZPL Labels')], string="Format", default='4x7', required=True)
 
     def process(self):
         self.ensure_one()

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -674,7 +674,7 @@ class IrActionsReport(models.Model):
         # access the report details with sudo() but evaluation context as current user
         report_sudo = self._get_report(report_ref)
 
-        collected_streams = OrderedDict()
+        collected_streams = []
 
         # Fetch the existing attachments from the database for later use.
         # Reload the stream from the attachment in case of 'attachment_use'.
@@ -698,13 +698,13 @@ class IrActionsReport(models.Model):
                             stream.close()
                             stream = new_stream
 
-                collected_streams[record.id] = {
+                collected_streams.append((record.id, {
                     'stream': stream,
                     'attachment': attachment,
-                }
+                }))
 
         # Call 'wkhtmltopdf' to generate the missing streams.
-        res_ids_wo_stream = [res_id for res_id, stream_data in collected_streams.items() if not stream_data['stream']]
+        res_ids_wo_stream = [res_id for res_id, stream_data in collected_streams if not stream_data['stream']]
         is_whtmltopdf_needed = not res_ids or res_ids_wo_stream
 
         if is_whtmltopdf_needed:
@@ -728,7 +728,7 @@ class IrActionsReport(models.Model):
 
             bodies, html_ids, header, footer, specific_paperformat_args = self.with_context(**additional_context)._prepare_html(html, report_model=report_sudo.model)
 
-            if report_sudo.attachment and set(res_ids_wo_stream) != set(html_ids):
+            if report_sudo.attachment and sorted(res_ids_wo_stream) != sorted(html_ids):
                 raise UserError(_(
                     "The report's template %r is wrong, please contact your administrator. \n\n"
                     "Can not separate file to save as attachment because the report's template does not contains the"
@@ -749,18 +749,18 @@ class IrActionsReport(models.Model):
 
             # Printing a PDF report without any records. The content could be returned directly.
             if not res_ids:
-                return {
-                    False: {
+                return [(
+                    False, {
                         'stream': pdf_content_stream,
                         'attachment': None,
                     }
-                }
+                )]
 
             # Split the pdf for each record using the PDF outlines.
 
             # Only one record: append the whole PDF.
             if len(res_ids_wo_stream) == 1:
-                collected_streams[res_ids_wo_stream[0]]['stream'] = pdf_content_stream
+                collected_streams[0]['stream'] = pdf_content_stream
                 return collected_streams
 
             # In case of multiple docs, we need to split the pdf according the records.
@@ -774,7 +774,7 @@ class IrActionsReport(models.Model):
                     attachment_writer.addPage(reader.getPage(i))
                     stream = io.BytesIO()
                     attachment_writer.write(stream)
-                    collected_streams[res_ids[i]]['stream'] = stream
+                    collected_streams[i]['stream'] = stream
                 return collected_streams
 
             # In cases where the number of res_ids != the number of pages,
@@ -782,15 +782,15 @@ class IrActionsReport(models.Model):
             # An outline is a <h?> html tag found on the document. To retrieve this table,
             # we look on the pdf structure using pypdf to compute the outlines_pages from
             # the top level heading in /Outlines.
-            if len(res_ids_wo_stream) > 1 and set(res_ids_wo_stream) == set(html_ids_wo_none):
+            if len(res_ids_wo_stream) > 1 and sorted(res_ids_wo_stream) == sorted(html_ids_wo_none):
                 root = reader.trailer['/Root']
                 has_valid_outlines = '/Outlines' in root and '/First' in root['/Outlines']
                 if not has_valid_outlines:
-                    return {False: {
+                    return [(False, {
                         'report_action': self,
                         'stream': pdf_content_stream,
                         'attachment': None,
-                    }}
+                    })]
 
                 outlines_pages = []
                 node = root['/Outlines']['/First']
@@ -816,11 +816,11 @@ class IrActionsReport(models.Model):
                             attachment_writer.addPage(reader.getPage(j))
                         stream = io.BytesIO()
                         attachment_writer.write(stream)
-                        collected_streams[res_ids[i]]['stream'] = stream
+                        collected_streams[i]['stream'] = stream #
 
                     return collected_streams
 
-            collected_streams[False] = {'stream': pdf_content_stream, 'attachment': None}
+            collected_streams.append((False, {'stream': pdf_content_stream, 'attachment': None}))
 
         return collected_streams
 
@@ -844,7 +844,7 @@ class IrActionsReport(models.Model):
         # Generate the ir.attachment if needed.
         if report_sudo.attachment and not self._context.get("report_pdf_no_attachment"):
             attachment_vals_list = []
-            for res_id, stream_data in collected_streams.items():
+            for res_id, stream_data in collected_streams:
                 # An attachment already exists.
                 if stream_data['attachment']:
                     continue
@@ -882,7 +882,7 @@ class IrActionsReport(models.Model):
                     _logger.info("The PDF documents %r are now saved in the database", attachment_names)
 
         # Merge all streams together for a single record.
-        streams_to_merge = [x['stream'] for x in collected_streams.values() if x['stream']]
+        streams_to_merge = [stream['stream'] for (_, stream) in collected_streams if stream['stream']]
         if len(streams_to_merge) == 1:
             pdf_content = streams_to_merge[0].getvalue()
         else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The feature allows printing multiple labels corresponding to the quantities of inventory moves, even if they are from the same lot. This issue was that printed items were stored in an `OrderedDict` by the record ID. A quantity of the same item from the same lot will always have the same ID, therefore this item will only be counted once. This was solved by replacing the `OrderedDict` with a normal `list`.

![image](https://github.com/odoo/odoo/assets/56171892/9f9ec69a-0109-4577-9c7d-d2f06158bcb2)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
