### PR TITLE
[IMP] mail: open message reaction list from reaction popover hover

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -513,9 +513,13 @@ export class Message extends Component {
         });
     }
 
-    openReactionMenu() {
+    openReactionMenu(reaction) {
         const message = toRaw(this.props.message);
-        this.dialog.add(MessageReactionMenu, { message }, { context: this });
+        this.dialog.add(
+            MessageReactionMenu,
+            { message, initialReaction: reaction },
+            { context: this }
+        );
     }
 
     async onClickToggleTranslation() {

--- a/addons/mail/static/src/core/common/message_reaction_list.js
+++ b/addons/mail/static/src/core/common/message_reaction_list.js
@@ -1,0 +1,94 @@
+import { useHover } from "@mail/utils/common/hooks";
+import { Component, useState } from "@odoo/owl";
+import { Dropdown } from "@web/core/dropdown/dropdown";
+import { useDropdownState } from "@web/core/dropdown/dropdown_hooks";
+
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+
+export class MessageReactionList extends Component {
+    static template = "mail.MessageReactionList";
+    static components = { Dropdown };
+    static props = ["message", "openReactionMenu", "reaction"];
+
+    setup() {
+        super.setup();
+        this.store = useState(useService("mail.store"));
+        this.ui = useService("ui");
+        this.hover = useHover(["reactionButton", "reactionList*"], () => {
+            if (!this.hover.isHover) {
+                clearTimeout(this.showReactionListTimeout);
+                this.showReactionListTimeout = setTimeout(() => (this.preview.isOpen = false), 50);
+            } else {
+                clearTimeout(this.showReactionListTimeout);
+                this.preview.isOpen = true;
+            }
+        });
+        this.preview = useDropdownState();
+    }
+
+    /** @param {import("models").MessageReactions} reaction */
+    previewText(reaction) {
+        const { count, content: emoji } = reaction;
+        const personNames = reaction.personas
+            .map(({ name, displayName }) => name || displayName)
+            .slice(0, 3);
+        switch (count) {
+            case 1:
+                return _t("%(emoji)s reacted by %(person)s", { emoji, person: personNames[0] });
+            case 2:
+                return _t("%(emoji)s reacted by %(person1)s and %(person2)s", {
+                    emoji,
+                    person1: personNames[0],
+                    person2: personNames[1],
+                });
+            case 3:
+                return _t("%(emoji)s reacted by %(person1)s, %(person2)s, and %(person3)s", {
+                    emoji,
+                    person1: personNames[0],
+                    person2: personNames[1],
+                    person3: personNames[2],
+                });
+            case 4:
+                return _t(
+                    "%(emoji)s reacted by %(person1)s, %(person2)s, %(person3)s, and 1 other",
+                    {
+                        emoji,
+                        person1: personNames[0],
+                        person2: personNames[1],
+                        person3: personNames[2],
+                    }
+                );
+            default:
+                return _t(
+                    "%(emoji)s reacted by%(person1)s, %(person2)s, %(person3)s, and %(count)s others",
+                    {
+                        count: count - 3,
+                        emoji,
+                        person1: personNames[0],
+                        person2: personNames[1],
+                        person3: personNames[2],
+                    }
+                );
+        }
+    }
+
+    hasSelfReacted(reaction) {
+        return this.store.self.in(reaction.personas);
+    }
+
+    onClickReaction(reaction) {
+        if (this.hasSelfReacted(reaction)) {
+            reaction.remove();
+        } else {
+            this.props.message.react(reaction.content);
+        }
+    }
+
+    onContextMenu(ev) {
+        if (this.ui.isSmall) {
+            ev.preventDefault();
+            this.props.openReactionMenu();
+        }
+    }
+}

--- a/addons/mail/static/src/core/common/message_reaction_list.scss
+++ b/addons/mail/static/src/core/common/message_reaction_list.scss
@@ -1,0 +1,7 @@
+.o-mail-MessageReactionList-preview {
+    font-family: "text-emoji", $font-family-base;
+
+    &:hover {
+        background-color: $o-gray-100 !important;
+    }
+}

--- a/addons/mail/static/src/core/common/message_reaction_list.xml
+++ b/addons/mail/static/src/core/common/message_reaction_list.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<template xml:space="preserve">
+    <t t-name="mail.MessageReactionList">
+        <Dropdown state="preview" position="'bottom-start'" menuClass="'bg-view border-0 p-0 mt-1 overflow-visible shadow-sm'" manual="true">
+            <t t-call="mail.MessageReactionList.button" />
+            <t t-set-slot="content">
+                <t t-call="mail.MessageReactionList.preview"/>
+            </t>
+        </Dropdown>
+    </t>
+    
+    <t t-name="mail.MessageReactionList.button">
+        <button class="position-relative o-mail-MessageReaction btn d-flex p-0 border rounded-2 mb-1" t-on-click="() => this.onClickReaction(props.reaction)" t-on-contextmenu="onContextMenu" t-ref="reactionButton" t-att-class="{
+            'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(props.reaction),
+            'bg-view': !hasSelfReacted(props.reaction),
+            'ms-1': env.inChatWindow and env.alignedRight,
+            'me-1': !(env.inChatWindow and env.alignedRight),
+        }">
+            <span class="mx-1" t-esc="props.reaction.content" />
+            <span class="mx-1" t-esc="props.reaction.count" />
+        </button>
+    </t>
+    
+    <t t-name="mail.MessageReactionList.preview">
+        <div class="o-mail-MessageReactionList-preview px-0 py-1 border cursor-pointer" t-on-click="(ev) => this.props.openReactionMenu(props.reaction)" t-ref="reactionList">
+            <div class="text-truncate mx-2">
+                <span t-esc="previewText(props.reaction)"/>
+            </div>
+        </div>
+    </t>
+    
+</template>

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -14,7 +14,7 @@ import { Dialog } from "@web/core/dialog/dialog";
 import { useService } from "@web/core/utils/hooks";
 
 export class MessageReactionMenu extends Component {
-    static props = ["close", "message"];
+    static props = ["close", "message", "initialReaction?"];
     static components = { Dialog };
     static template = "mail.MessageReactionMenu";
 
@@ -24,7 +24,9 @@ export class MessageReactionMenu extends Component {
         this.store = useState(useService("mail.store"));
         this.ui = useState(useService("ui"));
         this.state = useState({
-            reaction: this.props.message.reactions[0],
+            reaction: this.props.initialReaction
+                ? this.props.initialReaction
+                : this.props.message.reactions[0],
         });
         useExternalListener(document, "keydown", this.onKeydown);
         onExternalClick("root", () => this.props.close());

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -1,82 +1,16 @@
 import { Component, useState } from "@odoo/owl";
 
-import { _t } from "@web/core/l10n/translation";
+import { MessageReactionList } from "@mail/core/common/message_reaction_list";
 import { useService } from "@web/core/utils/hooks";
 
 export class MessageReactions extends Component {
     static props = ["message", "openReactionMenu"];
     static template = "mail.MessageReactions";
+    static components = { MessageReactionList };
 
     setup() {
         super.setup();
         this.store = useState(useService("mail.store"));
         this.ui = useService("ui");
-    }
-
-    /** @param {import("models").MessageReactions} reaction */
-    getReactionSummary(reaction) {
-        const [firstUserName, secondUserName, thirdUserName] = reaction.personas.map(
-            ({ name, displayName }) => name || displayName
-        );
-        switch (reaction.count) {
-            case 1:
-                return _t("%(user)s has reacted with %(reaction)s", {
-                    user: firstUserName,
-                    reaction: reaction.content,
-                });
-            case 2:
-                return _t("%(user1)s and %(user2)s have reacted with %(reaction)s", {
-                    user1: firstUserName,
-                    user2: secondUserName,
-                    reaction: reaction.content,
-                });
-            case 3:
-                return _t("%(user1)s, %(user2)s, %(user3)s have reacted with %(reaction)s", {
-                    user1: firstUserName,
-                    user2: secondUserName,
-                    user3: thirdUserName,
-                    reaction: reaction.content,
-                });
-            case 4:
-                return _t(
-                    "%(user1)s, %(user2)s, %(user3)s and 1 other person have reacted with %(reaction)s",
-                    {
-                        user1: firstUserName,
-                        user2: secondUserName,
-                        user3: thirdUserName,
-                        reaction: reaction.content,
-                    }
-                );
-            default:
-                return _t(
-                    "%(user1)s, %(user2)s, %(user3)s and %(count)s other persons have reacted with %(reaction)s",
-                    {
-                        user1: firstUserName,
-                        user2: secondUserName,
-                        user3: thirdUserName,
-                        count: reaction.personas.length - 3,
-                        reaction: reaction.content,
-                    }
-                );
-        }
-    }
-
-    hasSelfReacted(reaction) {
-        return this.store.self.in(reaction.personas);
-    }
-
-    onClickReaction(reaction) {
-        if (this.hasSelfReacted(reaction)) {
-            reaction.remove();
-        } else {
-            this.props.message.react(reaction.content);
-        }
-    }
-
-    onContextMenu(ev) {
-        if (this.ui.isSmall) {
-            ev.preventDefault();
-            this.props.openReactionMenu();
-        }
     }
 }

--- a/addons/mail/static/src/core/common/message_reactions.xml
+++ b/addons/mail/static/src/core/common/message_reactions.xml
@@ -7,18 +7,9 @@
             'ms-3': !(env.inChatWindow and env.alignedRight) and (props.message.is_discussion),
         }"
         t-attf-class="{{ props.message.is_discussion ? 'mt-n1' : 'mt-1' }}">
-        <button t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content" class="o-mail-MessageReaction btn d-flex p-0 border rounded-1 mb-1"
-            t-on-click="() => this.onClickReaction(reaction)"
-            t-on-contextmenu="onContextMenu"
-            t-att-class="{
-                'o-selfReacted border-primary text-primary fw-bolder': hasSelfReacted(reaction),
-                'bg-view': !hasSelfReacted(reaction),
-                'ms-1': env.inChatWindow and env.alignedRight,
-                'me-1': !(env.inChatWindow and env.alignedRight),
-         }" t-att-title="getReactionSummary(reaction)">
-            <span class="mx-1" t-esc="reaction.content"/>
-            <span class="mx-1" t-esc="reaction.count"/>
-        </button>
+        <t t-foreach="props.message.reactions" t-as="reaction" t-key="reaction.content">
+            <MessageReactionList message="this.props.message" openReactionMenu="this.props.openReactionMenu" reaction="reaction"/>
+        </t>
     </div>
 </t>
 </templates>

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -13,9 +13,11 @@ import {
     startServer,
     step,
     triggerHotkey,
+    hover,
 } from "@mail/../tests/mail_test_helpers";
 import { describe, expect, test } from "@odoo/hoot";
 import { Deferred, mockDate, mockTimeZone, tick } from "@odoo/hoot-mock";
+import { leave } from "@odoo/hoot-dom";
 import { Command, mockService, onRpc, serverState, withUser } from "@web/../tests/web_test_helpers";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { getOrigin } from "@web/core/utils/urls";
@@ -604,10 +606,10 @@ test("Reaction summary", async () => {
     await contains(".o-mail-Message", { text: "Hello world" });
     const partnerNames = ["Foo", "Bar", "FooBar", "Bob"];
     const expectedSummaries = [
-        "Foo has reacted with 😅",
-        "Foo and Bar have reacted with 😅",
-        "Foo, Bar, FooBar have reacted with 😅",
-        "Foo, Bar, FooBar and 1 other person have reacted with 😅",
+        "😅 reacted by Foo",
+        "😅 reacted by Foo and Bar",
+        "😅 reacted by Foo, Bar, and FooBar",
+        "😅 reacted by Foo, Bar, FooBar, and 1 other",
     ];
     for (const [idx, name] of partnerNames.entries()) {
         const partner_id = pyEnv["res.partner"].create({ name });
@@ -619,7 +621,11 @@ test("Reaction summary", async () => {
                 after: ["span", { textContent: "Smileys & Emotion" }],
                 text: "😅",
             });
-            await contains(`.o-mail-MessageReaction[title="${expectedSummaries[idx]}"]`);
+            await hover(".o-mail-MessageReaction");
+            await contains(".o-mail-MessageReactionList-preview", {
+                text: `${expectedSummaries[idx]}`,
+            });
+            await leave(".o-mail-MessageReaction");
         });
     }
 });


### PR DESCRIPTION
With this commit, list of message reaction can be accessed through
the hover popover of a message reaction.

Before this commit, the message reaction summary was simple a
`title`. This commit turns it into a hoverable dropdown, which when
clicking opens the reaction list in a dialog.

Also this commit rearranges reaction text summary to show emoji
before people that have reacted. This keeps order of showing
emoji and then people that have reacted consistent with message
reaction list.

task-3390326