### PR TITLE
[FIX] mail: placement of the attachment action button distorted

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -282,6 +282,11 @@ class DiscussController(http.Controller):
             attachment = channel_member.env['ir.attachment'].create(vals)
             attachment._post_add_create()
             attachmentData = {
+                'author': {
+                    'id': attachment.create_uid.id,
+                    'name': attachment.create_uid.name,
+                    'partnerId': attachment.create_uid.partner_id.id,
+                },
                 'filename': ufile.filename,
                 'id': attachment.id,
                 'mimetype': attachment.mimetype,

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -75,6 +75,11 @@ class IrAttachment(models.Model):
         res_list = []
         for attachment in self:
             res = {
+                'author': {
+                    'id': attachment.create_uid.id,
+                    'name': attachment.create_uid.name,
+                    'partnerId': attachment.create_uid.partner_id.id,
+                },
                 'checksum': attachment.checksum,
                 'id': attachment.id,
                 'filename': attachment.name,

--- a/addons/mail/static/src/components/attachment_image/attachment_image.js
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.js
@@ -13,6 +13,12 @@ export class AttachmentImage extends Component {
         return this.props.record;
     }
 
+    onImageLoad(ev) {
+        const image = ev.target;
+        if (image && image.height <= 30) {
+            this.attachmentImage.update({ isSmallImg: true });
+        }
+    }
 }
 
 Object.assign(AttachmentImage, {

--- a/addons/mail/static/src/components/attachment_image/attachment_image.scss
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.scss
@@ -17,3 +17,7 @@
 .o_AttachmentImage {
     cursor: zoom-in;
 }
+
+.o_AttachmentImage_action{
+    z-index: 1;
+}

--- a/addons/mail/static/src/components/attachment_image/attachment_image.xml
+++ b/addons/mail/static/src/components/attachment_image/attachment_image.xml
@@ -16,19 +16,24 @@
                     t-att-data-mimetype="attachmentImage.attachment.mimetype"
                 >
                     <t t-if="!attachmentImage.attachment.isUploading">
-                        <img class="img img-fluid my-0 mx-auto" t-att-src="attachmentImage.imageUrl" t-att-alt="attachmentImage.attachment.name" t-attf-style="max-width: min(100%, {{ attachmentImage.width }}px); max-height: {{ attachmentImage.height }}px;"/>
+                        <img class="img img-fluid my-0 mx-auto"
+                            t-att-src="attachmentImage.imageUrl"
+                            t-att-alt="attachmentImage.attachment.name"
+                            t-attf-style="max-width: min(100%, {{ attachmentImage.width }}px); max-height: {{ attachmentImage.height }}px;"
+                            t-on-load="(ev) => this.onImageLoad(ev)"
+                        />
                     </t>
                     <t t-if="attachmentImage.attachment.isUploading">
                         <div class="o_AttachmentImageUploading position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
                             <i class="fa fa-spin fa-spinner"/>
                         </div>
                     </t>
-                    <div class="o_AttachmentImage_imageOverlay position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
-                        <div t-if="attachmentImage.attachment.isDeletable" class="o_AttachmentImage_action o_AttachmentImage_actionUnlink btn btn-sm btn-dark rounded opacity-75 opacity-100-hover" t-att-class="{'o-pretty': attachmentImage.attachmentList.composerViewOwner}" tabindex="0" aria-label="Remove" role="menuitem" t-on-click="attachmentImage.onClickUnlink" title="Remove">
-                            <i class="fa fa-trash"/>
-                        </div>
-                        <div t-if="attachmentImage.hasDownloadButton" class="o_AttachmentImage_action o_AttachmentImage_actionDownload btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click="attachmentImage.onClickDownload" title="Download">
+                    <div t-if="!attachmentImage.isSmallImg" class="o_AttachmentImage_imageOverlay position-absolute top-0 bottom-0 start-0 end-0 p-2 ms-3 text-white opacity-0 opacity-100-hover d-flex align-items-end flex-wrap flex-column justify-content-end">
+                        <div t-if="attachmentImage.hasDownloadButton" class="o_AttachmentImage_action o_AttachmentImage_actionDownload btn btn-sm btn-dark rounded opacity-75 opacity-100-hover " t-on-click="attachmentImage.onClickDownload" title="Download">
                             <i class="fa fa-download"/>
+                        </div>
+                        <div t-if="attachmentImage.attachment.isDeletable" class="o_AttachmentImage_action o_AttachmentImage_actionUnlink ms-1 btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-att-class="{'o-pretty': attachmentImage.attachmentList.composerViewOwner}" tabindex="0" aria-label="Remove" role="menuitem" t-on-click="attachmentImage.onClickUnlink" title="Remove">
+                            <i class="fa fa-trash"/>
                         </div>
                     </div>
                 </div>

--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.js
@@ -82,6 +82,16 @@ export class AttachmentViewer extends Component {
         return this.props.record;
     }
 
+    /**
+     * @returns {Boolean}
+     */
+    get isDeletable() {
+        const attachmentList = this.attachmentViewer.attachmentList;
+        if (attachmentList) {
+            return attachmentList.selectedAttachment.isDeletable;
+        }
+    }
+
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------

--- a/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
+++ b/addons/mail/static/src/components/attachment_viewer/attachment_viewer.xml
@@ -31,6 +31,12 @@
                             <span>Download</span>
                         </t>
                     </div>
+                    <div t-if="isDeletable" class="o_AttachmentViewer_buttonDelete o_AttachmentViewer_headerItem o_AttachmentViewer_headerItemButton d-flex align-items-center px-3 cursor-pointer" t-on-click="attachmentViewer.onClickDelete" role="button" title="Delete">
+                        <i class="o_AttachmentViewer_headerItemButtonIcon fa fa-trash fa-fw" t-att-class="{ 'o-hasLabel me-2': messaging.device.sizeClass > messaging.device.sizeClasses.MD }" role="img"/>
+                        <t t-if="messaging.device.sizeClass > messaging.device.sizeClasses.MD">
+                            <span>Delete</span>
+                        </t>
+                    </div>
                     <div class="o_AttachmentViewer_headerItem o_AttachmentViewer_headerItemButton o_AttachmentViewer_headerItemButtonClose d-flex align-items-center mb-0 px-3 h4 text-reset cursor-pointer" t-on-click="attachmentViewer.onClickClose" role="button" title="Close (Esc)" aria-label="Close">
                         <i class="fa fa-fw fa-times" role="img"/>
                     </div>

--- a/addons/mail/static/src/models/attachment_image.js
+++ b/addons/mail/static/src/models/attachment_image.js
@@ -131,5 +131,11 @@ registerModel({
             },
             required: true,
         }),
+        /**
+         * Determine if the image is a small-sized image.
+         */
+        isSmallImg: attr({
+            default: false,
+        })
     },
 });

--- a/addons/mail/static/src/models/attachment_viewer.js
+++ b/addons/mail/static/src/models/attachment_viewer.js
@@ -63,6 +63,16 @@ registerModel({
             this.attachmentViewerViewable.download();
         },
         /**
+         * Called when clicking on delete icon.
+         *
+         * @param {MouseEvent} ev
+         */
+        onClickDelete(ev) {
+            ev.stopPropagation();
+            this.attachmentViewerViewable.remove();
+            this.close();
+        },
+        /**
          * Called when clicking on the header. Stop propagation of event to prevent
          * closing the dialog.
          *

--- a/addons/mail/static/src/models/attachment_viewer_viewable.js
+++ b/addons/mail/static/src/models/attachment_viewer_viewable.js
@@ -15,6 +15,9 @@ registerModel({
         download() {
             return this.attachmentOwner.download();
         },
+        remove() {
+            return this.attachmentOwner.remove();
+        },
     },
     fields: {
         attachmentOwner: one("Attachment", {

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1202,7 +1202,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
             ]
         }])
 
-        with self.assertQueryCount(employee=6):
+        with self.assertQueryCount(employee=7):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:
@@ -1211,7 +1211,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         self.env.flush_all()
         self.env.invalidate_all()
 
-        with self.assertQueryCount(employee=19):
+        with self.assertQueryCount(employee=20):
             res = messages.message_format()
             self.assertEqual(len(res), 2)
             for message in res:


### PR DESCRIPTION
**Before this PR:**
When the attachment size was too small, the download and delete buttons on the 
image overlay were incorrectly positioned, leading to a less user-friendly experience.

**Aftert this PR:**
The delete and download button is available only when the image is zommed in.

task-3563828
