### PR TITLE
[FIX] stock: handle traceback when the lead time value is overflowed

### DIFF
--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -7367,6 +7367,14 @@ msgid "The lot name must contain at least one digit."
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/models/stock_orderpoint.py:0
+#: code:addons/stock/models/stock_rule.py:0
+#: code:addons/stock/models/stock_rule.py:0
+#, python-format
+msgid "The lead time value %s in stock rule is too far into the future"
+msgstr ""
+
+#. module: stock
 #: model:ir.model.constraint,message:stock.constraint_stock_warehouse_warehouse_name_uniq
 msgid "The name of the warehouse must be unique per company!"
 msgstr ""

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -125,7 +125,10 @@ class StockWarehouseOrderpoint(models.Model):
                 continue
             values = orderpoint._get_lead_days_values()
             lead_days, dummy = orderpoint.rule_ids._get_lead_days(orderpoint.product_id, **values)
-            lead_days_date = fields.Date.today() + relativedelta.relativedelta(days=lead_days)
+            try:
+                lead_days_date = fields.Date.today() + relativedelta.relativedelta(days=lead_days)
+            except OverflowError:
+                raise UserError(_("The lead time value %s in stock rule is too far into the future", lead_days))
             orderpoint.lead_days_date = lead_days_date
 
     @api.depends('route_id', 'product_id', 'location_id', 'company_id', 'warehouse_id', 'product_id.route_ids')


### PR DESCRIPTION
This traceback arises when the user gives too large value in delay.

To reproduce sentry traceback:

1) Install `purchase_stock`
2) Activate `multi-step routes` from `Inventory/configuration/settings`
3) Now open `Rules` from `Inventory/configuration` 
4) Open any existing rule, which is having action as `Buy` 
5) Change the action to `Pull from` and lead time to `12000000` 
6) Now open `replenishment` from `Inventory/operations` and remove the filters

Error:- 

```
OverflowError: date value out of range
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/stock/wizard/product_replenish.py", line 91, in launch_replenishment
    notification = orderpoint.action_replenish()
  File "addons/stock/models/stock_orderpoint.py", line 228, in action_replenish
    self._procure_orderpoint_confirm(company_id=self.env.company)
  File "addons/stock/models/stock_orderpoint.py", line 522, in _procure_orderpoint_confirm
    date = orderpoint._get_orderpoint_procurement_date()
  File "addons/stock/models/stock_orderpoint.py", line 583, in _get_orderpoint_procurement_date
    return timezone(self.company_id.partner_id.tz or 'UTC').localize(datetime.combine(self.lead_days_date, time(12))).astimezone(UTC).replace(tzinfo=None)
  File "odoo/fields.py", line 1206, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4858, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/purchase_stock/models/stock.py", line 107, in _compute_lead_days
    return super()._compute_lead_days()
  File "addons/stock/models/stock_orderpoint.py", line 118, in _compute_lead_days
    lead_days_date = fields.Date.today() + relativedelta.relativedelta(days=lead_days['total_delay'])
  File "dateutil/relativedelta.py", line 405, in __radd__
    return self.__add__(other)
  File "dateutil/relativedelta.py", line 387, in __add__
    ret = (other.replace(**repl)
```

The `delay` value is used to calculate the datetime in so many places in inventory. 
When the user gives too large value in `delay` it leads to the above traceback.

https://github.com/odoo/odoo/blob/b2fa69202c6b3ab677973643711ccd561a2edaea/addons/stock/models/stock_orderpoint.py#L128

sentry-4703440373

