### PR TITLE
[FIX] portal_rating: remove label for ratings

### DIFF
--- a/addons/portal_rating/i18n/portal_rating.pot
+++ b/addons/portal_rating/i18n/portal_rating.pot
@@ -103,44 +103,9 @@ msgid "Half a star"
 msgstr ""
 
 #. module: portal_rating
-#. openerp-web
-#: code:addons/portal_rating/static/src/js/portal_composer.js:0
-#, python-format
-msgid "I don't like it"
-msgstr ""
-
-#. module: portal_rating
-#. openerp-web
-#: code:addons/portal_rating/static/src/js/portal_composer.js:0
-#, python-format
-msgid "I hate it"
-msgstr ""
-
-#. module: portal_rating
-#. openerp-web
-#: code:addons/portal_rating/static/src/js/portal_composer.js:0
-#, python-format
-msgid "I like it"
-msgstr ""
-
-#. module: portal_rating
-#. openerp-web
-#: code:addons/portal_rating/static/src/js/portal_composer.js:0
-#, python-format
-msgid "I love it"
-msgstr ""
-
-#. module: portal_rating
 #: code:addons/portal_rating/controllers/portal_rating.py:0
 #, python-format
 msgid "Invalid rating"
-msgstr ""
-
-#. module: portal_rating
-#. openerp-web
-#: code:addons/portal_rating/static/src/js/portal_composer.js:0
-#, python-format
-msgid "It's okay"
 msgstr ""
 
 #. module: portal_rating

--- a/addons/portal_rating/static/src/js/portal_composer.js
+++ b/addons/portal_rating/static/src/js/portal_composer.js
@@ -16,7 +16,6 @@ var PortalComposer = portalComposer.PortalComposer;
 PortalComposer.include({
     events: _.extend({}, PortalComposer.prototype.events, {
         'click .stars i': '_onClickStar',
-        'mouseleave .stars': '_onMouseleaveStarBlock',
         'mousemove .stars i': '_onMoveStar',
         'mouseleave .stars i': '_onMoveLeaveStar',
     }),
@@ -39,15 +38,6 @@ PortalComposer.include({
             'default_rating_value': 0.0,
             'force_submit_url': false,
         });
-        // star input widget
-        this.labels = {
-            '0': "",
-            '1': _t("I hate it"),
-            '2': _t("I don't like it"),
-            '3': _t("It's okay"),
-            '4': _t("I like it"),
-            '5': _t("I love it"),
-        };
         this.user_click = false; // user has click or not
         this.set("star_value", this.options.default_rating_value);
         this.on("change:star_value", this, this._onChangeStarValue);
@@ -96,7 +86,6 @@ PortalComposer.include({
         if (decimal) {
             this.$('.stars').find("i:eq(" + index + ")").removeClass('fa-star-o fa-star fa-star-half-o').addClass('fa-star-half-o');
         }
-        this.$('.rate_text .badge').text(this.labels[index]);
     },
     /**
      * @private
@@ -109,17 +98,10 @@ PortalComposer.include({
     },
     /**
      * @private
-     */
-    _onMouseleaveStarBlock: function () {
-        this.$('.rate_text').hide();
-    },
-    /**
-     * @private
      * @param {MouseEvent} ev
      */
     _onMoveStar: function (ev) {
         var index = this.$('.stars i').index(ev.currentTarget);
-        this.$('.rate_text').show();
         this.set("star_value", index + 1);
     },
     /**

--- a/addons/portal_rating/static/src/scss/portal_rating.scss
+++ b/addons/portal_rating/static/src/scss/portal_rating.scss
@@ -64,10 +64,6 @@ $o-w-rating-star-color: #FACC2E;
     .stars.enabled{
         cursor: pointer;
     }
-
-    .rate_text{
-        display: inline-block;
-    }
 }
 
 /* Rating Popup Composer */

--- a/addons/portal_rating/static/src/xml/portal_tools.xml
+++ b/addons/portal_rating/static/src/xml/portal_tools.xml
@@ -80,9 +80,6 @@
                     <i class="fa fa-star-o text-black-25"></i>
                 </t>
             </div>
-            <div class="rate_text">
-                <span class="badge badge-info"></span>
-            </div>
             <input type="hidden" readonly="readonly" name="rating_value" t-att-value="default_rating || ''"/>
         </div>
     </t>


### PR DESCRIPTION
**Before the PR:**
The rating stars were associated with the rating label, but they 
seemed to be unnecessary.

**After this PR:**
Rating labels are removed since the stars are pretty much 
self-explanatory.

task-3617971
