### PR TITLE
[FIX] website_event_track: prevent an error if track duration is too long

### DIFF
--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -60,7 +60,7 @@
 <!-- Agenda Main Display -->
 <template id="agenda_main" name="Tracks: Main Display">
     <!-- No tracks -->
-    <div class="col-12" t-if="not tracks_by_days">
+    <div class="col-12" t-if="not track_count_by_days">
         <div class="h2 mb-3">No track found.</div>
         <div t-if="search_key" class="alert alert-info text-center">
             <p class="m-0">We did not find any track matching your <strong t-esc="search_key"/> search.</p>
@@ -85,21 +85,22 @@
                         t-options="{'widget': 'date', 'format': 'YYYY'}"/>
                 </div>
             </div>
-            <small class="float-right text-muted align-self-end"><t t-esc="tracks_by_days[day]"/> tracks</small>
+            <small class="float-right text-muted align-self-end"><t t-esc="track_count_by_days[day]"/> tracks</small>
         </div>
         <hr class="mt-2 pb-1 mb-1"/>
 
-        <t t-set="locations" t-value="locations_by_days[day]"/>
+        <t t-set="event_tracks" t-value="tracks_by_days[day]"/>
         <!-- Day Agenda -->
         <div class="o_we_online_agenda">
         <table id="table_search" class="table table-sm border-0 h-100">
             <!--Header-->
             <tr>
                 <th class="border-0 bg-white position-sticky"/>
-                <t t-foreach="locations" t-as="location">
-                    <th t-if="location" class="active text-center">
-                        <span t-esc="location and location.name or 'Unknown'"/>
+                <t t-foreach="event_tracks" t-as="event_track">
+                    <th t-if="event_track.location_id" class="active text-center">
+                        <span t-esc="event_track.location_id.name or 'Unknown'"/>
                     </th>
+                    <th t-else="" class="active"/>
                 </t>
             </tr>
 
@@ -114,24 +115,24 @@
                         <b t-if="is_round_hour" t-esc="time_slots[day][time_slot]['formatted_time']"/>
                     </td>
 
-                    <t t-foreach="locations" t-as="location">
-                        <t t-set="tracks" t-value="time_slots[day][time_slot].get(location, {})"/>
+                    <t t-foreach="event_tracks" t-as="event_track">
+                        <t t-set="tracks" t-value="time_slots[day][time_slot].get(event_track, {})"/>
                         <t t-if="tracks">
                             <t t-foreach="tracks" t-as="track">
                                 <t t-set="_classes"
                                     t-value="'text-center %s %s %s' % (
                                         'event_color_%s' % (track.color) if track.color else 'bg-100',
                                         'event_track h-100' if track else '',
-                                        'o_location_size_%d' % len(locations),
+                                        'o_location_size_%d' % len(event_tracks),
                                     )"/>
-                                <t t-if="track.location_id and track.location_id == location">
+                                <t t-if="track == event_track">
                                     <td t-att-rowspan="tracks[track]['rowspan']"
                                         t-att-class="_classes">
                                         <t t-call="website_event_track.agenda_main_track"/>
                                     </td>
                                 </t>
                                 <t t-else="">
-                                    <td t-att-colspan="len(locations)-1"
+                                    <td t-att-colspan="len(event_tracks)-1"
                                         t-att-rowspan="tracks[track]['rowspan']"
                                         t-att-class="_classes">
                                         <t t-call="website_event_track.agenda_main_track"/>
@@ -140,9 +141,9 @@
                                 <t t-set="used_cells" t-value="used_cells + tracks[track]['occupied_cells']"/>
                             </t>
                         </t>
-                        <t t-elif="location and (time_slot, location) not in used_cells">
+                        <t t-elif="event_track and (time_slot, event_track) not in used_cells">
                             <td t-att-rowspan="1"
-                                t-att-class="'o_location_size_%s %s' % (len(locations),
+                                t-att-class="'o_location_size_%s %s' % (len(event_tracks),
                                     'o_we_agenda_time_slot_half' if is_half_hour else
                                     'o_we_agenda_time_slot_main' if is_round_hour else
                                     ''


### PR DESCRIPTION
Before this commit:

- If the track duration is 25-30 hours long then track timeline goes beyond 24 hours which seems absurd. This also leads to duplicate view.

- The event agenda calendar may display inaccurate results if one track has no location while other tracks have specified locations, In such cases, the track without a location tends to reserve all available locations and tracks that have locations that seem without locations, which leads to inaccurate outcomes. Additionally, inaccuracies can arise when multiple tracks share the same locations. 

- And if the track duration is too long like 50-100 hours, it leads to a DateTime error at [1].

link [1]: https://github.com/odoo/odoo/blob/9835632d8c193218d6705c630aa5c6e8db705312/addons/website_event_track/controllers/event_track.py#L314

Steps to reproduce

- Install a 'website_event_track' module.
- Go to Events > Configuration > Event Templates.
- Create a new event template and make a boolean true of Website Submenu', 'Tracks menu Item', 'Track Proposals Menu Item', and 'Register Button'.
- Open 'Events' and create new events.
- Add an event name, 'Date', and also add an event template that we made.
- Click on the 'Tracks' button, Create an Event Tracks, Add a Title, Track Date,  and Give a value to a duration field more than 48:00.
- Make this Event Tracks state to 'Published'.
- Click on the 'Go to Website' Button, go into 'Agenda', Error is generated.

After this commit:

- In a '_split_track_by_days'  allocate a time slots for next days if track timeline goes more than 24 hours [2].
Link 2: https://github.com/odoo/odoo/blob/b2fa69202c6b3ab677973643711ccd561a2edaea/addons/website_event_track/controllers/event_track.py#L307-L315

- The event agenda calendar shows inaccurate results due to some tracks having no location and some tracks share the same locations. To handle this behavior, Differentiate the tracks occupied timeline by track_id instead of tracks location_id because the location may be the same, But tracks are always unique, Which shows the normal behavior of the event calendar.
Link : https://github.com/odoo/odoo/blob/078903948f32812eca55e20803c9e05e9e44ae1d/addons/website_event_track/controllers/event_track.py#L228-L232

- In '_prepare_calendar_values' return a 'location_id' by all timeline days instead of only for track start date [3].
Link 3: https://github.com/odoo/odoo/blob/b2fa69202c6b3ab677973643711ccd561a2edaea/addons/website_event_track/controllers/event_track.py#L257-L260

Task-3586488

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
