### PR TITLE
[FIX] web: refine touch drag bounce animation

### DIFF
--- a/addons/web/static/src/core/utils/draggable_hook_builder.js
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.js
@@ -690,7 +690,9 @@ export function makeDraggableHook(hookParams) {
                 if (initiationDelay) {
                     if (hasTouch()) {
                         if (ev.pointerType === "touch") {
-                            dom.addClass(target.closest(ctx.elementSelector), "o_touch_bounce");
+                            const el = target.closest(ctx.elementSelector);
+                            el.style.setProperty("animation-delay",  initiationDelay + "ms");
+                            dom.addClass(el, "o_touch_drag_initiated");
                         }
                         if (isBrowserFirefox()) {
                             // On Firefox mobile, long-touch events trigger an unpreventable

--- a/addons/web/static/src/core/utils/draggable_hook_builder.scss
+++ b/addons/web/static/src/core/utils/draggable_hook_builder.scss
@@ -1,12 +1,12 @@
-@keyframes bounce {
+@keyframes drag_initiated {
     0% {
-        transform: scale(1);
+        filter: none;
     }
     60% {
-        transform: scale(.95);
+        filter: brightness(0.5) opacity(0.5);
     }
     100% {
-        transform: scale(1);
+        filter: none;
     }
 }
 
@@ -19,7 +19,8 @@
     pointer-events: none;
 }
 
-.o_touch_bounce {
-    animation: bounce .4s forwards;
+.o_touch_drag_initiated {
+    // animation to indicate the touch can start dragging the element
+    animation: drag_initiated .5s forwards;
     user-select: none;
 }

--- a/addons/web/static/tests/core/utils/draggable_tests.js
+++ b/addons/web/static/tests/core/utils/draggable_tests.js
@@ -304,7 +304,7 @@ QUnit.module("Draggable", ({ beforeEach }) => {
                     elements: ".item",
                     onDragStart({ element }) {
                         assert.step("start");
-                        assert.hasClass(element, "o_touch_bounce", "element has the animation class applied");
+                        assert.hasClass(element, "o_touch_drag_initiated", "element has the animation class applied");
                     },
                     onDrag() {
                         assert.step("drag");
@@ -315,7 +315,7 @@ QUnit.module("Draggable", ({ beforeEach }) => {
                     async onDrop({ element }) {
                         assert.step("drop");
                         await nextTick();
-                        assert.doesNotHaveClass(element, "o_touch_bounce", "element no longer has the animation class applied");
+                        assert.doesNotHaveClass(element, "o_touch_drag_initiated", "element no longer has the animation class applied");
                     },
                 });
             }


### PR DESCRIPTION
This commit changes the bouncing animation when initiating a drag and drop using a touch input.

This animation has been added by commit (1), to indicate that the user must maintain the finger on the screen up until the delay has been met. But is happens too much when scrolling a list of draggable elements.

In some scenarios, the animation makes too much noise on large draggable elements (kanban columns or cards).

This refinements make the animation less annoying, by adding another effect instead of changing the size of the element.