### PR TITLE
[FIX] web_editor: setTag to convert inline nodes

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -45,6 +45,7 @@ import {
     getCursorDirection,
     firstLeaf,
     lastLeaf,
+    getAdjacents,
 } from '../utils/utils.js';
 
 const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/;
@@ -352,30 +353,45 @@ export const editorCommands = {
     // Change tags
     setTag(editor, tagName) {
         const range = getDeepRange(editor.editable, { correctTripleClick: true });
-        const selectedBlocks = [...new Set(getTraversedNodes(editor.editable, range).map(closestBlock))];
-        const deepestSelectedBlocks = selectedBlocks.filter(block => (
-            !descendants(block).some(descendant => selectedBlocks.includes(descendant))
+        // Get unique nodes in a specified range,
+        // includes inline nodes when the parent is a 'DIV' or 'TD'
+        // otherwise, consider the closest block node.
+        const selectedNodes = [...new Set(getTraversedNodes(editor.editable, range).map((node) => {
+            const block = closestBlock(node);
+            const ancestor = ancestors(node, block);
+            const closestEl = ancestor[ancestor.length - 2] || node;
+            return (block.nodeName === 'DIV' || block.nodeName === 'TD') ? closestEl : block;
+        }))];
+        const deepestSelectedNodes = selectedNodes.filter(node => (
+            !descendants(node).some(descendant => selectedNodes.includes(descendant))
         ));
         const [startContainer, startOffset, endContainer, endOffset] = [firstLeaf(range.startContainer), range.startOffset, lastLeaf(range.endContainer), range.endOffset];
-        for (const block of deepestSelectedBlocks) {
+        for (const node of deepestSelectedNodes) {
             if (
                 ['P', 'PRE', 'H1', 'H2', 'H3', 'H4', 'H5', 'H6', 'LI', 'BLOCKQUOTE'].includes(
-                    block.nodeName,
+                    node.nodeName
                 )
             ) {
-                const inLI = block.closest('li');
+                const inLI = node.closest('li');
                 if (inLI && tagName === "P") {
                     inLI.oToggleList(0);
                 } else {
-                    setTagName(block, tagName);
+                    setTagName(node, tagName);
                 }
-            } else {
-                // eg do not change a <div> into a h1: insert the h1
+            } else if (node.parentNode.nodeName !== tagName.toUpperCase()) {
+                // for multiple inline nodes into h1: insert all the adjacents
+                // inline nodes into h1 or if the node is block: insert the h1
                 // into it instead.
+                const inlineNodes = getAdjacents(node, n => !isBlock(n));
                 const newBlock = editor.document.createElement(tagName);
-                const children = [...block.childNodes];
-                block.insertBefore(newBlock, block.firstChild);
-                children.forEach(child => newBlock.appendChild(child));
+                node.parentNode.insertBefore(newBlock, node);
+                if (inlineNodes.length) {
+                    inlineNodes.forEach(n => newBlock.appendChild(n));
+                } else {
+                    const children = [...node.childNodes];
+                    node.insertBefore(newBlock, node.firstChild);
+                    children.forEach(child => newBlock.appendChild(child));
+                }
             }
         }
         const newRange = new Range();

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/format.test.js
@@ -940,6 +940,13 @@ describe('setTagName', () => {
                 contentAfter: '<table><tbody><tr><td><h1>[a</h1></td><td><h1>b</h1></td><td><h1>c]</h1></td></tr></tbody></table>',
             });
         });
+        it('should wrap inline elements within a div in a heading 1', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div><font style="color: red;">a[b</font><span style="font-size: 12px;">c]d</span><font style="color: red;">ef</font><p>gh</p><font style="color: red;">ij</font><span style="font-size: 12px;">kl</span></div>',
+                stepFunction: editor => editor.execCommand('setTag', 'h1'),
+                contentAfter: '<div><h1><font style="color: red;">a[b</font><span style="font-size: 12px;">c]d</span><font style="color: red;">ef</font></h1><p>gh</p><font style="color: red;">ij</font><span style="font-size: 12px;">kl</span></div>',
+            });
+        });
     });
     describe('to heading 2', () => {
         it('should turn a heading 1 into a heading 2', async () => {
@@ -982,6 +989,13 @@ describe('setTagName', () => {
                 contentBefore: '<table><tbody><tr><td><p>[a</p></td><td><p>b</p></td><td><p>c]</p></td></tr></tbody></table>',
                 stepFunction: editor => editor.execCommand('setTag', 'h2'),
                 contentAfter: '<table><tbody><tr><td><h2>[a</h2></td><td><h2>b</h2></td><td><h2>c]</h2></td></tr></tbody></table>',
+            });
+        });
+        it('should turn a inline elements within a div into a heading 2', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<div><font style="color: red;">ab</font><span style="font-size: 12px;">cd</span><font style="color: red;">ef</font><p>gh</p><font style="color: red;">[ij</font><span style="font-size: 12px;">k]l</span></div>',
+                stepFunction: editor => editor.execCommand('setTag', 'h2'),
+                contentAfter: '<div><font style="color: red;">ab</font><span style="font-size: 12px;">cd</span><font style="color: red;">ef</font><p>gh</p><h2><font style="color: red;">[ij</font><span style="font-size: 12px;">k]l</span></h2></div>',
             });
         });
     });


### PR DESCRIPTION
Current behavior before PR:

- When a block node, such as `DIV` or `TD`, had inline `childNodes` it failed to correctly change the tag of those inline nodes.

Desired behavior after PR is merged:

- Fix `setTag` such that now it wraps all the `inlineNodes` correctly into `newBlock`.

task-3245819