### PR TITLE
[FIX] crm : Contact name value changes into email

### DIFF
--- a/addons/mail/static/src/core/thread_service.js
+++ b/addons/mail/static/src/core/thread_service.js
@@ -912,7 +912,7 @@ export class ThreadService {
                 .map((recipient) => recipient.persona.id);
             recipientEmails = thread.suggestedRecipients
                 .filter((recipient) => recipient.checked && !recipient.persona)
-                .map((recipient) => recipient.email);
+                .map((recipient) => `${recipient.name} <${recipient.email}>`);
             partner_ids?.push(...recipientIds);
         }
         const tmpId = this.messageService.getNextTemporaryId();


### PR DESCRIPTION
[FIX] crm : Contact name value changes into email
Steps to reproduce:
	1- Install CRM module
	2- Activate Leads from CRM settings
	3- Create a new lead
	4- Set the Contact name and the Email of the lead but do not set a Customer
	5- Send a message in the chatter

Current behavior before PR:
When creating a lead without addressing a customer but set a contact name and an email if you send mail it will create a partner first but the contact name is not passed when creating the partner so the partner name is set to be the email which make the contact name in the lead change to the email. This is happening because the the contact name is not passed to the API endpoint which is sending mails.

Desired behavior after PR is merged:
This has been fixed now by adding the contact name to the post_data that is been passed with that data been sent to the API endpoint.

opw-3618467