### PR TITLE
[FIX] hr_timesheet: Take into account non-billable hours in remaining_hours

### DIFF
--- a/addons/hr_timesheet/models/project.py
+++ b/addons/hr_timesheet/models/project.py
@@ -97,14 +97,8 @@ class Project(models.Model):
 
     @api.depends('allow_timesheets', 'timesheet_ids')
     def _compute_remaining_hours(self):
-        timesheets_read_group = self.env['account.analytic.line']._read_group(
-            [('project_id', 'in', self.ids)],
-            ['project_id', 'unit_amount'],
-            ['project_id'],
-            lazy=False)
-        timesheet_time_dict = {res['project_id'][0]: res['unit_amount'] for res in timesheets_read_group}
         for project in self:
-            project.remaining_hours = project.allocated_hours - timesheet_time_dict.get(project.id, 0)
+            project.remaining_hours = project.allocated_hours - sum(project.tasks.mapped('effective_hours'))
             project.is_project_overtime = project.remaining_hours < 0
 
     @api.model


### PR DESCRIPTION
Steps:
	- Install `hr_timesheet`
	- Open project -> kanban view

Remaining hours field with `timesheet_uom` widget is the difference between allocated_hours and billable hours, but this should also take into account non-billable hours.