### PR TITLE
[IMP] l10n_ec: Portal contact information

### DIFF
--- a/addons/l10n_ec/__manifest__.py
+++ b/addons/l10n_ec/__manifest__.py
@@ -60,6 +60,7 @@ Master Data:
         'views/l10n_ec_sri_payment.xml',
         'views/account_journal_view.xml',
         "views/res_partner_view.xml",
+        'views/templates.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_ec/controllers/__init__.py
+++ b/addons/l10n_ec/controllers/__init__.py
@@ -1,5 +1,3 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from . import controllers
-from . import models
-from . import demo
+from . import portal

--- a/addons/l10n_ec/controllers/portal.py
+++ b/addons/l10n_ec/controllers/portal.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.portal.controllers.portal import CustomerPortal
+from odoo.http import request, route
+
+
+class CustomerPortalEcuador(CustomerPortal):
+
+    OPTIONAL_BILLING_FIELDS = [*CustomerPortal.OPTIONAL_BILLING_FIELDS, "l10n_latam_identification_type_id"]
+
+    def _is_ecuador_company(self):
+        return request.env.company.country_code == 'EC'
+
+    @route()
+    def account(self, redirect=None, **post):
+        # EXTEND 'portal'
+        response = super().account(redirect=redirect, **post)
+
+        if self._is_ecuador_company():
+            if post and request.httprequest.method == 'POST':
+                l10n_latam_identification_type_id = int(post.pop('l10n_latam_identification_type_id') or False) or False
+                partner = request.env.user.partner_id
+                post.update({'l10n_latam_identification_type_id': l10n_latam_identification_type_id})
+                partner.sudo().write({'l10n_latam_identification_type_id': l10n_latam_identification_type_id})
+
+            response.qcontext.update({
+                'identification': post.get('l10n_latam_identification_type_id'),
+                'identification_types': request.env['l10n_latam.identification.type'].search(
+                    ['|', ('country_id', '=', False), ('country_id.code', '=', 'EC')]),
+            })
+
+        return response
+
+    def details_form_validate(self, data, partner_creation=False):
+        # EXTEND 'portal'
+        error, error_message = super(CustomerPortalEcuador, self).details_form_validate(data)
+
+        if self._is_ecuador_company():
+            required_ecuador_fields = ("l10n_latam_identification_type_id", "vat")
+            for field_name in required_ecuador_fields:
+                if not data.get(field_name):
+                    error[field_name] = 'missing'
+
+        return error, error_message

--- a/addons/l10n_ec/views/templates.xml
+++ b/addons/l10n_ec/views/templates.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <template id="partner_info" name="Ecuadorian partner">
+
+        <!-- show identification type -->
+        <div class="clearfix"/>
+        <div t-attf-class="mb-3 #{error.get('l10n_latam_identification_type_id') and 'o_has_error' or ''} col-xl-6">
+            <label class="col-form-label" for="l10n_latam_identification_type_id">Identification Type</label>
+            <t t-if="partner.can_edit_vat()">
+                <select name="l10n_latam_identification_type_id" t-attf-class="form-select #{error.get('l10n_latam_identification_type_id') and 'is-invalid' or ''}">
+                    <option value="">Identification Type...</option>
+                    <t t-foreach="identification_types or []" t-as="id_type">
+                        <option t-att-value="id_type.id" t-att-selected="id_type.id == int(identification) if identification else id_type.id == partner.l10n_latam_identification_type_id.id">
+                            <t t-esc="id_type.name"/>
+                        </option>
+                    </t>
+                </select>
+            </t>
+            <t t-else="">
+                <p class="form-control" t-esc="partner.l10n_latam_identification_type_id.name" readonly="1" title="Changing Identification type is not allowed once document(s) have been issued for your account. Please contact us directly for this operation."/>
+                <input name="l10n_latam_identification_type_id" class="form-control" t-att-value="partner.l10n_latam_identification_type_id.id" type='hidden'/>
+            </t>
+        </div>
+
+    </template>
+
+    <template id="portal_my_details_fields" name="portal_my_details_fields" inherit_id="portal.portal_my_details_fields">
+        <xpath expr="//input[@name='vat']/.." position="before">
+            <t t-if="res_company.country_code == 'EC'">
+                <t t-call="l10n_ec.partner_info"/>
+            </t>
+        </xpath>
+        <label for="vat" position="replace">
+            <t t-if="res_company.country_id.code != 'EC'">$0</t>
+            <t t-else="">
+                <label class="col-form-label label-optional" for="vat">Identification Number</label>
+            </t>
+        </label>
+    </template>
+
+</odoo>


### PR DESCRIPTION
Currently, if a customer wants to edit his/her information from the
Portal access, they cannot modify the information linked to EC.

This commit aims to support Ecuadorian companies needed information when
editing the portal contact information:

- added "Identification Type" field
- renamed "VAT" to "Identification Number"
- make those 2 fields required

task-id: 3620196
