### PR TITLE
[FIX] website_event_booth: make images of booth categories accessible by public user

### DIFF
--- a/addons/website_event_booth/security/ir.model.access.csv
+++ b/addons/website_event_booth/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_event_booth_public,event.booth.public,event_booth.model_event_booth,base.group_public,1,0,0,0
 access_event_booth_portal,event.booth.public,event_booth.model_event_booth,base.group_portal,1,0,0,0
 access_event_booth_employee,event.booth.public,event_booth.model_event_booth,base.group_user,1,0,0,0
+access_event_booth_category,event.booth.category,event_booth.model_event_booth_category,base.group_public,1,0,0,0


### PR DESCRIPTION
[FIX] website_event_booth: make images of booth categories accessible by public user

Currently, categories' images can only be seen while logged in. This fix will allow public user to have access to images.

Description of the issue/feature this PR addresses: add access rights for booth category for public user
Current behavior before PR: images of booths' are not loading if not logged in
Desired behavior after PR is merged: images of booths' are loading regardless of the user

opw-3625773

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
