### PR TITLE
[FIX] stock: prevent tuple index out of range error

### DIFF
--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -85,7 +85,8 @@ class ProductReplenish(models.TransientModel):
         if 'route_id' in fields and 'route_id' not in res and product_tmpl_id:
             res['route_id'] = self.env['stock.route'].search(self._get_route_domain(product_tmpl_id), limit=1).id
             if not res['route_id']:
-                res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
+                route_ids = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)
+                res['route_id'] = route_ids[0].id if route_ids else False
         return res
 
     def _get_date_planned(self, route_id, **kwargs):


### PR DESCRIPTION
Currently, an error occurs when the user clicks the "Replenish" button of the product.

Steps to produce:
- Install Inventory (stock)
- Go to Inventory > Products > Products
- Open any product > click on  "Replenish" >>> Error occur

Stack Trace:
```
IndexError: tuple index out of range
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 934, in onchange
    defaults = self.default_get(missing_names)
  File "addons/stock/wizard/product_replenish.py", line 88, in default_get
    res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
  File "odoo/models.py", line 6588, in __getitem__
    return self.browse((self._ids[key],))
```

This is because [1] was added via recently refactored changes with https://github.com/odoo/odoo/commit/b93e1d8345cc6be634fe9ed18ab17e047c6fbda8#diff-5989bbc9547ba2ec48c2aa67fba29ce9ce8b0b1b7efbfd44b8bda4fd33612e8dR69-R72  (PR-https://github.com/odoo/odoo/pull/139182), it tries to access first rout ids via index `[0]` but there are no rout ids.

This commit fixes the above issue by accessing the first route, if it exists.

[1]-https://github.com/odoo/odoo/blob/5284cb3b7661f575262d358dce884cef61a34902/addons/stock/wizard/product_replenish.py#L88

sentry-4715905728


