### PR TITLE
[FIX] account: missing loca on account import

### DIFF
--- a/addons/account/demo/account_demo.xml
+++ b/addons/account/demo/account_demo.xml
@@ -2,12 +2,6 @@
 <odoo>
     <data>
 
-        <function model="account.chart.template" name="try_loading">
-            <value eval="[]"/>
-            <value>generic_coa</value>
-            <value model="res.company" search="[('partner_id.country_id.code', 'in', ['US', False])]"/>
-        </function>
-
         <!-- TAGS FOR RETRIEVING THE DEMO ACCOUNTS -->
         <record id="demo_capital_account" model="account.account.tag">
             <field name="name">Demo Capital Account</field>


### PR DESCRIPTION
Description of the feature/issue this commit fixes:

When initializing a database with demo data, if a country is set on the main company, when installing the account module, the localization linked to the country set on the company should be installed which is not the case.

It was done in prior versions but in 16.2 and later versions it is not the case anymore. This fixes makes sure the loca is imported too.

---

Desired behavior after the commit is merged:

This commits makes it so that when a country is set on a the main company, installing the accounting module (account) also installs the localization module linked to the said country.

---

task-3603079



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
