### PR TITLE
[IMP] sale:remove down payment product setting

### DIFF
--- a/addons/sale/models/res_company.py
+++ b/addons/sale/models/res_company.py
@@ -37,16 +37,6 @@ class ResCompany(models.Model):
         help="Default product used for discounts",
         check_company=True,
     )
-    sale_down_payment_product_id = fields.Many2one(
-        comodel_name='product.product',
-        string="Deposit Product",
-        domain=[
-            ('type', '=', 'service'),
-            ('invoice_policy', '=', 'order'),
-        ],
-        help="Default product used for down payments",
-        check_company=True,
-    )
 
     # sale onboarding
     sale_onboarding_payment_method = fields.Selection(

--- a/addons/sale/tests/test_credit_limit.py
+++ b/addons/sale/tests/test_credit_limit.py
@@ -69,7 +69,6 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
         }).create({
             'advance_payment_method': 'percentage',
             'amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id,
         }).create_invoices()
 
         invoice = sale_order.invoice_ids

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -94,7 +94,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'percentage',
             'amount': 50,
-            'deposit_account_id': cls.revenue_account.id,
             **kwargs,
         }
         downpayment = cls.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
@@ -442,7 +441,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'fixed',
             'fixed_amount': 550.0,
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         downpayment.create_invoices()
@@ -496,7 +494,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'fixed',
             'fixed_amount': 200.0,
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         action = downpayment.create_invoices()
@@ -519,10 +516,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.assertEqual(downpayment.amount_invoiced, 200.0, "Amount invoiced is not equal to downpayment amount")
 
         # final invoice which is a credit note as there ar no deliveries to invoice and there already is 200 paid
-        payment_params = {
-            'advance_payment_method': 'delivered',
-            'deposit_account_id': self.revenue_account.id,
-        }
+        payment_params = {'advance_payment_method': 'delivered'}
         downpayment = self.env['sale.advance.payment.inv'].with_context({**so_context, 'raise_if_nothing_to_invoice': False}).create(payment_params)
         action = downpayment.create_invoices()
         invoice = self.env['account.move'].browse(action['res_id'])
@@ -604,7 +598,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'fixed',
             'fixed_amount': 200.0,
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         action = downpayment.create_invoices()
@@ -627,10 +620,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.assertEqual(downpayment.amount_invoiced, 200.0, "Amount invoiced is not equal to downpayment amount")
 
         # final invoice which is a credit note as there ar no deliveries to invoice and there already is 200 paid
-        payment_params = {
-            'advance_payment_method': 'delivered',
-            'deposit_account_id': self.revenue_account.id,
-        }
+        payment_params = {'advance_payment_method': 'delivered'}
         downpayment = self.env['sale.advance.payment.inv'].with_context({**so_context, 'raise_if_nothing_to_invoice': False}).create(payment_params)
         action = downpayment.create_invoices()
         invoice = self.env['account.move'].browse(action['res_id'])
@@ -735,7 +725,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'fixed',
             'fixed_amount': 500.0,
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         action = downpayment.create_invoices()
@@ -764,10 +753,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         self.assertEqual(downpayment.amount_invoiced, 500.0, "Amount invoiced is not equal to downpayment amount")
         # final invoice
-        payment_params = {
-            'advance_payment_method': 'delivered',
-            'deposit_account_id': self.revenue_account.id,
-        }
+        payment_params = {'advance_payment_method': 'delivered'}
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         action = downpayment.create_invoices()
         invoice = self.env['account.move'].browse(action['res_id'])

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -289,7 +289,6 @@ class TestSaleRefund(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create({
             'advance_payment_method': 'percentage',
             'amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         # order_line[1] is the down payment section
@@ -308,9 +307,7 @@ class TestSaleRefund(TestSaleCommon):
             'qty_to_invoice': -1.0,
         }])
 
-        payment = self.env['sale.advance.payment.inv'].with_context(so_context).create({
-            'deposit_account_id': self.company_data['default_account_revenue'].id
-        })
+        payment = self.env['sale.advance.payment.inv'].with_context(so_context).create({})
         payment.create_invoices()
 
         so_invoice = max(sale_order_refund.invoice_ids)

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -96,13 +96,11 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         downpayment2 = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment2.create_invoices()
         self._check_order_search(self.sale_order, [('invoice_ids', '=', False)], self.env['sale.order'])
@@ -116,9 +114,7 @@ class TestSaleToInvoice(TestSaleCommon):
         self.sol_prod_deliver.write({'qty_delivered': 2.0})
 
         # Let's do an invoice with refunds
-        payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
-            'deposit_account_id': self.company_data['default_account_revenue'].id
-        })
+        payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({})
         payment.create_invoices()
 
         self.assertEqual(len(self.sale_order.invoice_ids), 3, 'Invoice should be created for the SO')
@@ -142,7 +138,6 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'percentage',
             'amount': 10,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         self._check_order_search(self.sale_order, [('invoice_ids', '=', False)], self.env['sale.order'])
@@ -183,13 +178,10 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(context).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         # Let's do the invoice
-        payment = self.env['sale.advance.payment.inv'].with_context(context).create({
-            'deposit_account_id': self.company_data['default_account_revenue'].id
-        })
+        payment = self.env['sale.advance.payment.inv'].with_context(context).create({})
         payment.create_invoices()
         # Confirm all invoices
         for invoice in sale_order.invoice_ids:
@@ -223,7 +215,6 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(context).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         # Create invoice
         downpayment.create_invoices()
@@ -235,17 +226,10 @@ class TestSaleToInvoice(TestSaleCommon):
         """
         # Confirm the SO
         self.sale_order.action_confirm()
-        tax_downpayment = self.company_data['default_tax_sale'].copy({
-            'name': 'default price included',
-            'price_include': True,
-        })
         # Let's do an invoice for a deposit of 100
-        product_id = self.env.company.sale_down_payment_product_id
-        product_id.taxes_id = tax_downpayment.ids
         payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'percentage',
             'amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id,
         })
         payment.create_invoices()
 
@@ -548,7 +532,6 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(context_for_downpayment).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         self.assertEqual(so_for_downpayment.invoice_ids[0].company_id.id, so_company_id, "The company of the downpayment invoice should be the same as the one from the SO")

--- a/addons/sale/views/account_views.xml
+++ b/addons/sale/views/account_views.xml
@@ -53,6 +53,12 @@
                     <field string="Sale Orders" name="sale_order_count" widget="statinfo"/>
                 </button>
             </xpath>
+            <xpath expr="//field[@name='invoice_line_ids']/tree" position="inside">
+                <field name="is_downpayment" column_invisible="1"/>
+            </xpath>
+            <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='product_id']" position="attributes">
+                <attribute name="readonly">is_downpayment</attribute>
+            </xpath>
         </field>
     </record>
 

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -35,11 +35,6 @@ class ResConfigSettings(models.TransientModel):
              "and not after the delivery.",
         config_parameter='sale.automatic_invoice',
     )
-    deposit_default_product_id = fields.Many2one(
-        related='company_id.sale_down_payment_product_id',
-        readonly=False,
-        # previously config_parameter='sale.default_deposit_product_id',
-    )
 
     invoice_mail_template_id = fields.Many2one(
         comodel_name='mail.template',

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -165,13 +165,6 @@
                                 <field name="invoice_mail_template_id" class="oe_inline" options="{'no_create': True}"/>
                             </div>
                         </setting>
-                        <setting id="down_payments"
-                            string="Down Payments"
-                            help="Product used for down payments"
-                            documentation="/applications/sales/sales/invoicing/down_payment.html"
-                            company_dependent="1">
-                            <field name="deposit_default_product_id" context="{'default_detailed_type': 'service'}"/>
-                        </setting>
                     </block>
                     <block title="Connectors" id="connectors_setting_container">
                         <setting id="amazon_connector" documentation="/applications/sales/sales/amazon_connector/setup.html" help="Import Amazon orders and sync deliveries">

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -32,15 +32,8 @@ class SaleAdvancePaymentInv(models.TransientModel):
     deduct_down_payments = fields.Boolean(string="Deduct down payments", default=True)
 
     # New Down Payment
-    product_id = fields.Many2one(
-        comodel_name='product.product',
-        string="Down Payment Product",
-        domain=[('type', '=', 'service')],
-        compute='_compute_product_id',
-        readonly=False,
-        store=True)
     amount = fields.Float(
-        string="Down Payment Amount",
+        string="Down Payment",
         help="The percentage of amount to be invoiced in advance.")
     fixed_amount = fields.Monetary(
         string="Down Payment Amount (Fixed)",
@@ -61,21 +54,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
         string="Amount to invoice",
         compute="_compute_invoice_amounts",
         help="The amount to invoice = Sale Order Total - Confirmed Down Payments.")
-
-    # Only used when there is no down payment product available
-    #  to setup the down payment product
-    deposit_account_id = fields.Many2one(
-        comodel_name='account.account',
-        string="Income Account",
-        domain=[('deprecated', '=', False)],
-        check_company=True,
-        help="Account used for deposits")
-    deposit_taxes_id = fields.Many2many(
-        comodel_name='account.tax',
-        string="Customer Taxes",
-        domain=[('type_tax_use', '=', 'sale')],
-        check_company=True,
-        help="Taxes used for deposits")
 
     # UI
     display_draft_invoice_warning = fields.Boolean(compute="_compute_display_draft_invoice_warning")
@@ -115,13 +93,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
             if wizard.count == 1:
                 wizard.company_id = wizard.sale_order_ids.company_id
 
-    @api.depends('company_id')
-    def _compute_product_id(self):
-        self.product_id = False
-        for wizard in self:
-            if wizard.count == 1:
-                wizard.product_id = wizard.company_id.sale_down_payment_product_id
-
     @api.depends('amount', 'fixed_amount', 'advance_payment_method', 'amount_to_invoice')
     def _compute_display_invoice_amount_warning(self):
         for wizard in self:
@@ -158,20 +129,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
             elif wizard.advance_payment_method == 'fixed' and wizard.fixed_amount <= 0.00:
                 raise UserError(_('The value of the down payment amount must be positive.'))
 
-    @api.constrains('product_id')
-    def _check_down_payment_product_is_valid(self):
-        for wizard in self:
-            if wizard.count > 1 or not wizard.product_id:
-                continue
-            if wizard.product_id.invoice_policy != 'order':
-                raise UserError(_(
-                    "The product used to invoice a down payment should have an invoice policy"
-                    "set to \"Ordered quantities\"."
-                    " Please update your deposit product to be able to create a deposit invoice."))
-            if wizard.product_id.type != 'service':
-                raise UserError(_(
-                    "The product used to invoice a down payment should be of type 'Service'."
-                    " Please use another product or update this product."))
 
     #=== ACTION METHODS ===#
 
@@ -201,12 +158,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
             self = self.with_company(self.company_id)
             order = self.sale_order_ids
 
-            # Create deposit product if necessary
-            if not self.product_id:
-                self.company_id.sale_down_payment_product_id = self.env['product.product'].create(
-                    self._prepare_down_payment_product_values()
-                )
-                self._compute_product_id()
 
             # Create down payment section if necessary
             SaleOrderline = self.env['sale.order.line'].with_context(sale_no_log_for_new_lines=True)
@@ -215,12 +166,11 @@ class SaleAdvancePaymentInv(models.TransientModel):
                     self._prepare_down_payment_section_values(order)
                 )
 
-            down_payment_lines = SaleOrderline.create(
-                self._prepare_down_payment_lines_values(order)
-            )
+            values, accounts = self._prepare_down_payment_lines_values(order)
+            down_payment_lines = SaleOrderline.create(values)
 
             invoice = self.env['account.move'].sudo().create(
-                self._prepare_invoice_values(order, down_payment_lines)
+                self._prepare_invoice_values(order, down_payment_lines, accounts)
             ).with_user(self.env.uid)  # Unsudo the invoice after creation
 
             # Ensure the invoice total is exactly the expected fixed amount.
@@ -270,17 +220,6 @@ class SaleAdvancePaymentInv(models.TransientModel):
 
             return invoice
 
-    def _prepare_down_payment_product_values(self):
-        self.ensure_one()
-        return {
-            'name': _('Down payment'),
-            'type': 'service',
-            'invoice_policy': 'order',
-            'company_id': self.company_id.id,
-            'property_account_income_id': self.deposit_account_id.id,
-            'taxes_id': [Command.set(self.deposit_taxes_id.ids)],
-        }
-
     def _prepare_down_payment_section_values(self, order):
         context = {'lang': order.partner_id.lang}
 
@@ -297,7 +236,7 @@ class SaleAdvancePaymentInv(models.TransientModel):
         return so_values
 
     def _prepare_down_payment_lines_values(self, order):
-        """ Create one down payment line per tax or unique taxes combination.
+        """ Create one down payment line per tax or unique taxes combination and per account.
             Apply the tax(es) to their respective lines.
 
             :param order: Order for which the down payment lines are created.
@@ -306,11 +245,11 @@ class SaleAdvancePaymentInv(models.TransientModel):
         self.ensure_one()
 
         if self.advance_payment_method == 'percentage':
-            percentage = self.amount / 100
+            ratio = self.amount / 100
         else:
-            percentage = self.fixed_amount / order.amount_total if order.amount_total else 1
+            ratio = self.fixed_amount / order.amount_total if order.amount_total else 1
 
-        order_lines = order.order_line.filtered(lambda l: not l.display_type)
+        order_lines = order.order_line.filtered(lambda l: not l.display_type and not l.is_downpayment)
         base_downpayment_lines_values = self._prepare_base_downpayment_line_values(order)
 
         tax_base_line_dicts = [
@@ -324,12 +263,16 @@ class SaleAdvancePaymentInv(models.TransientModel):
             tax_base_line_dicts)
         down_payment_values = []
         for line, tax_repartition in computed_taxes['base_lines_to_update']:
+            account = line['product'].product_tmpl_id.get_product_accounts(
+                fiscal_pos=order.fiscal_position_id
+            ).get('income')
             taxes = line['taxes'].flatten_taxes_hierarchy()
             fixed_taxes = taxes.filtered(lambda tax: tax.amount_type == 'fixed')
             down_payment_values.append([
                 taxes - fixed_taxes,
                 line['analytic_distribution'],
-                tax_repartition['price_subtotal']
+                tax_repartition['price_subtotal'],
+                account,
             ])
             for fixed_tax in fixed_taxes:
                 # Fixed taxes cannot be set as taxes on down payments as they always amounts to 100%
@@ -344,25 +287,28 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 down_payment_values.append([
                     pct_tax,
                     line['analytic_distribution'],
-                    line['quantity'] * fixed_tax.amount
+                    line['quantity'] * fixed_tax.amount,
+                    account
                 ])
 
         downpayment_line_map = {}
-        for tax_id, analytic_distribution, price_subtotal in down_payment_values:
+        for tax_id, analytic_distribution, price_subtotal, account in down_payment_values:
             grouping_key = frozendict({
                 'tax_id': tuple(sorted(tax_id.ids)),
                 'analytic_distribution': analytic_distribution,
+                'account_id': account,
             })
             downpayment_line_map.setdefault(grouping_key, {
                 **base_downpayment_lines_values,
-                **grouping_key,
+                'tax_id': grouping_key['tax_id'],
+                'analytic_distribution': grouping_key['analytic_distribution'],
                 'product_uom_qty': 0.0,
                 'price_unit': 0.0,
             })
             downpayment_line_map[grouping_key]['price_unit'] += \
-                order.currency_id.round(price_subtotal * percentage)
+                order.currency_id.round(price_subtotal * ratio)
 
-        return list(downpayment_line_map.values())
+        return list(downpayment_line_map.values()), [key['account_id'] for key in downpayment_line_map]
 
     def _prepare_base_downpayment_line_values(self, order):
         self.ensure_one()
@@ -374,14 +320,13 @@ class SaleAdvancePaymentInv(models.TransientModel):
             'product_uom_qty': 0.0,
             'order_id': order.id,
             'discount': 0.0,
-            'product_id': self.product_id.id,
             'is_downpayment': True,
             'sequence': order.order_line and order.order_line[-1].sequence + 1 or 10,
         }
         del context
         return so_values
 
-    def _prepare_invoice_values(self, order, so_lines):
+    def _prepare_invoice_values(self, order, so_lines, accounts):
         self.ensure_one()
         return {
             **order._prepare_invoice(),
@@ -389,8 +334,9 @@ class SaleAdvancePaymentInv(models.TransientModel):
                 line._prepare_invoice_line(
                     name=self._get_down_payment_description(order),
                     quantity=1.0,
+                    **({'account_id': account.id} if account else {}),
                 )
-            ) for line in so_lines],
+            ) for line, account in zip(so_lines, accounts)],
         }
 
     def _get_down_payment_description(self, order):

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -25,7 +25,6 @@
                 <group name="down_payment_specification"
                     invisible="advance_payment_method not in ('fixed', 'percentage')">
                     <field name="company_id" invisible="1"/>
-                    <field name="product_id" invisible="1"/>
                     <label for="amount"/>
                     <div id="payment_method_details">
                         <field name="currency_id" invisible="1"/>
@@ -46,13 +45,6 @@
                             <i class="fa fa-warning"/>
                         </span>
                     </div>
-                    <field name="deposit_account_id"
-                        options="{'no_create': True}"
-                        invisible="product_id"
-                        groups="account.group_account_manager"/>
-                    <field name="deposit_taxes_id"
-                        widget="many2many_tags"
-                        invisible="product_id"/>
                 </group>
                 <group invisible="not has_down_payments">
                     <field name="amount_invoiced"/>
@@ -61,7 +53,7 @@
                 <footer>
                     <button name="create_invoices" type="object"
                         id="create_invoice_open"
-                        string="Create Draft Invoice"
+                        string="Create Draft"
                         class="btn-primary" data-hotkey="q"/>
                     <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
@@ -70,7 +62,7 @@
     </record>
 
     <record id="action_view_sale_advance_payment_inv" model="ir.actions.act_window">
-        <field name="name">Create invoices</field>
+        <field name="name">Create invoice</field>
         <field name="res_model">sale.advance.payment.inv</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -425,7 +425,7 @@ class Project(models.Model):
             domain = []
         return expression.AND([
             [
-                ('product_id', '!=', False),
+                '|', ('product_id', '!=', False), ('is_downpayment', '=', True),
                 ('is_expense', '=', False),
                 ('state', '=', 'sale'),
                 '|', ('qty_to_invoice', '>', 0), ('qty_invoiced', '>', 0),

--- a/addons/sale_project/tests/test_project_profitability.py
+++ b/addons/sale_project/tests/test_project_profitability.py
@@ -589,7 +589,6 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
         downpayment = self.env['sale.advance.payment.inv'].with_context(Downpayment).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 115,
-            'deposit_account_id': self.company_data['default_account_revenue'].id,
         })
         # When a down payment is created, the default 15% tax is included. The SOL associated it then created by removing the taxed amount.
         # Therefore, the amount of the dp is higher than the amount of the sol created.
@@ -603,7 +602,6 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
         downpayment = self.env['sale.advance.payment.inv'].with_context(Downpayment).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 115,
-            'deposit_account_id': self.company_data['default_account_revenue'].id,
         })
         down_payment_invoiced = 2 * down_payment_invoiced
         downpayment.create_invoices()

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -144,15 +144,9 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         self.assertTrue(self.so.picking_ids, 'Sale Stock: no picking created for "invoice on order" storable products')
         # let's do an invoice for a deposit of 5%
 
-        advance_product = self.env['product.product'].create({
-            'name': 'Deposit',
-            'type': 'service',
-            'invoice_policy': 'order',
-        })
         adv_wiz = self.env['sale.advance.payment.inv'].with_context(active_ids=[self.so.id]).create({
             'advance_payment_method': 'percentage',
             'amount': 5.0,
-            'product_id': advance_product.id,
         })
         act = adv_wiz.with_context(open_invoices=True).create_invoices()
         inv = self.env['account.move'].browse(act['res_id'])
@@ -1412,16 +1406,9 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         })
         so.action_confirm()
 
-        advance_product = self.env['product.product'].create({
-            'name': 'Deposit',
-            'type': 'service',
-            'invoice_policy': 'order',
-        })
-
         adv_wiz = self.env['sale.advance.payment.inv'].with_context(active_ids=[so.id]).create({
             'advance_payment_method': 'percentage',
             'amount': 5.0,
-            'product_id': advance_product.id,
         })
 
         act = adv_wiz.with_context(open_invoices=True).create_invoices()


### PR DESCRIPTION
Since version 16.2, the Down Payments setting became obsolete. Dead field, never used.

Enterprise: https://github.com/odoo/enterprise/pull/52574
Upgrade: https://github.com/odoo/upgrade/pull/5430

Task: 3618096
