### PR TITLE
[FIX] account: wrong company after demo data loading

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -93,6 +93,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/js/tours/account.js',
             'account/static/src/views/**/*.js',
             'account/static/src/js/search/search_bar/search_bar.js',
+            'account/static/src/webclient/**/*',
         ],
         'web.assets_frontend': [
             'account/static/src/js/account_portal_sidebar.js',

--- a/addons/account/models/__init__.py
+++ b/addons/account/models/__init__.py
@@ -34,6 +34,7 @@ from . import digest
 from . import res_users
 from . import ir_attachment
 from . import ir_actions_report
+from . import ir_demo
 from . import ir_module
 from . import res_currency
 from . import account_report

--- a/addons/account/models/ir_demo.py
+++ b/addons/account/models/ir_demo.py
@@ -1,0 +1,32 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+from odoo.modules.loading import force_demo
+from odoo.addons.base.models.ir_module import assert_log_admin_access
+
+
+class IrDemo(models.TransientModel):
+
+    _inherit = 'ir.demo'
+    _description = 'Demo override for demo data'
+
+    @assert_log_admin_access
+    def install_demo(self):
+        original_company_country_code = self.env.company.country_code
+
+        force_demo(self.env)
+
+        if target_company := self.env['res.company'].search([('country_code', '=', original_company_country_code)], limit=1):
+            return {
+                'type': 'ir.actions.client',
+                'tag': 'switch_company',
+                'params': {
+                    'company': target_company.id,
+                },
+            }
+        return {
+            'type': 'ir.actions.act_url',
+            'target': 'self',
+            'url': '/web',
+        }

--- a/addons/account/static/src/webclient/actions/client_actions.js
+++ b/addons/account/static/src/webclient/actions/client_actions.js
@@ -1,0 +1,13 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+/**
+ * Client action to switch the selected company
+ * Serves as a way to change the company from a backend call
+ */
+async function switchCompany(env, action) {
+    env.services.company.setCompanies([action.params.company], false);
+}
+
+registry.category("actions").add("switch_company", switchCompany);


### PR DESCRIPTION
Description of the issue/feature this commit addresses:

When initializing a database without demo data then setting a country on the company that is being used. If demo data are loaded, a new company is created with the demo data of the country that was set on the initial company. The issue lies in the fact that once that demo data is done loading, the used company is still the initial one while we would want to use the new one.

---

Desired behavior after the commit is merged:

Adding this commit, a new operation is done after the demo data is loaded. When demo data are done loading, we switch to the company that uses the country which was set on the initial company before loading the demo data.

---

task-3600521



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
