### PR TITLE
[FIX] web: form_view > beforeLeave

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -181,10 +181,11 @@ export class Record extends DataPoint {
         });
     }
 
-    discard() {
+    async discard() {
         if (this.model._closeUrgentSaveNotification) {
             this.model._closeUrgentSaveNotification();
         }
+        await this.model._askChanges();
         return this.model.mutex.exec(() => this._discard());
     }
 

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -114,6 +114,39 @@ export async function loadSubViews(
 // -----------------------------------------------------------------------------
 
 export class FormController extends Component {
+    static template = `web.FormView`;
+    static components = {
+        FormStatusIndicator,
+        Layout,
+        ButtonBox,
+        ViewButton,
+        Field,
+        CogMenu,
+    };
+    static props = {
+        ...standardViewProps,
+        discardRecord: { type: Function, optional: true },
+        mode: {
+            optional: true,
+            validate: (m) => ["edit", "readonly"].includes(m),
+        },
+        saveRecord: { type: Function, optional: true },
+        removeRecord: { type: Function, optional: true },
+        Model: Function,
+        Renderer: Function,
+        Compiler: Function,
+        archInfo: Object,
+        buttonTemplate: String,
+        preventCreate: { type: Boolean, optional: true },
+        preventEdit: { type: Boolean, optional: true },
+        onDiscard: { type: Function, optional: true },
+        onSave: { type: Function, optional: true },
+    };
+    static defaultProps = {
+        preventCreate: false,
+        preventEdit: false,
+    };
+
     setup() {
         this.evaluateBooleanExpr = evaluateBooleanExpr;
         this.dialogService = useService("dialog");
@@ -355,7 +388,8 @@ export class FormController extends Component {
     }
 
     async beforeLeave() {
-        if (this.model.root.dirty) {
+        const dirty = await this.model.root.isDirty();
+        if (dirty) {
             return this.model.root.save({
                 reload: false,
                 onError: this.onSaveError.bind(this),
@@ -574,36 +608,3 @@ export class FormController extends Component {
         return result;
     }
 }
-
-FormController.template = `web.FormView`;
-FormController.components = {
-    FormStatusIndicator,
-    Layout,
-    ButtonBox,
-    ViewButton,
-    Field,
-    CogMenu,
-};
-FormController.props = {
-    ...standardViewProps,
-    discardRecord: { type: Function, optional: true },
-    mode: {
-        optional: true,
-        validate: (m) => ["edit", "readonly"].includes(m),
-    },
-    saveRecord: { type: Function, optional: true },
-    removeRecord: { type: Function, optional: true },
-    Model: Function,
-    Renderer: Function,
-    Compiler: Function,
-    archInfo: Object,
-    buttonTemplate: String,
-    preventCreate: { type: Boolean, optional: true },
-    preventEdit: { type: Boolean, optional: true },
-    onDiscard: { type: Function, optional: true },
-    onSave: { type: Function, optional: true },
-};
-FormController.defaultProps = {
-    preventCreate: false,
-    preventEdit: false,
-};

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -14644,6 +14644,40 @@ QUnit.module("Views", (hooks) => {
         }
     );
 
+    QUnit.test("edit char field and save without bluring", async function (assert) {
+        serverData.actions[2] = {
+            id: 2,
+            name: "Partners Action 2",
+            res_model: "partner",
+            type: "ir.actions.act_window",
+            views: [
+                [false, "list"],
+                [false, "form"],
+            ],
+            view_mode: "list",
+        };
+        serverData.views = {
+            "partner,false,list": `<tree><field name="foo"/></tree>`,
+            "partner,false,form": `<form><field name="foo"/></form>`,
+            "partner,false,search": "<search></search>",
+        };
+        const webClient = await createWebClient({ serverData });
+        await doAction(webClient, 2);
+        assert.containsOnce(target, ".o_list_view");
+
+        await click(target.querySelector(".o_data_cell"));
+        assert.containsOnce(target, ".o_form_view");
+
+        // update the value but do not blur the input
+        const input = target.querySelector(".o_field_widget[name=foo] input");
+        input.value = "What a Goal !!! JD11";
+
+        // leave the view without clicking out s.t. the input isn't blured (use keynav instead)
+        await triggerHotkey("alt+b"); // alt+b is the hotkey for breadcrumb back
+        assert.containsOnce(target, ".o_list_view");
+        assert.strictEqual(target.querySelector(".o_data_cell").innerText, "What a Goal !!! JD11");
+    });
+
     QUnit.test("nested form view doesn't parasite the main one", async (assert) => {
         await makeView({
             type: "form",


### PR DESCRIPTION
Before this commit:

Let's modify the value of a field in a form view and do not trigger a blur event on it. Then exit the view (alt+b). The value was not saved.

After this commit:

The value is now saved because we check if the value has not been modified using the isDirty() function which checks that there is no pending promise.

task-3586303
