### PR TITLE
[FIX] web_editor: crop buttons out of the screen

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2803,7 +2803,7 @@ export class Wysiwyg extends Component {
         const closestDialog = e.target.closest('.o_dialog, .o_web_editor_dialog');
         if (
             e.target.closest("#oe_snippets") ||
-            e.target.closest('.oe-toolbar,.oe-powerbox-wrapper,.o_we_crop_widget') ||
+            e.target.closest('.oe-toolbar,.oe-powerbox-wrapper,.o_we_crop_widget,.o_we_crop_buttons') ||
             (closestDialog && closestDialog.querySelector('.o_select_media_dialog, .o_link_dialog'))
         ) {
             this._shouldDelayBlur = true;

--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -609,6 +609,8 @@ img.o_we_selected_image {
     @include o-position-absolute(0, 0, 0, 0);
     /* This value must be higher than dialog z-index in bootstrap */
     z-index: 1056;
+    height: 100%;
+    overflow: auto;
 
     .o_we_cropper_wrapper {
         position: absolute;
@@ -618,7 +620,6 @@ img.o_we_selected_image {
         margin-top: 0.5rem;
         display: flex;
         flex-wrap: wrap;
-        bottom: 1rem;
 
         input[type=radio] {
             display: none;

--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -207,7 +207,7 @@
     @include o-input-number-no-arrows();
     @include o-position-absolute(var(--o-we-toolbar-height), 0, 0, auto);
     position: fixed;
-    z-index: $o-we-zindex;
+    z-index: $o-we-zindex + 16;
     display: flex;
     flex-flow: column nowrap;
     width: $o-we-sidebar-width;

--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -306,7 +306,7 @@
        >
         <div class="o_we_cropper_wrapper">
             <img class="o_we_cropper_img"/>
-            <div class="o_we_crop_buttons text-center mt16 position-fixed o_we_no_overlay" contenteditable="false">
+            <div t-if="this.state.showBtns" class="o_we_crop_buttons text-center mt16 o_we_no_overlay" contenteditable="false">
                 <div class="btn-group btn-group-toggle" title="Aspect Ratio" data-bs-toggle="buttons">
                     <t t-foreach="this.aspectRatios" t-as="ratio" t-key="ratio">
                         <t t-set="is_active" t-value="ratio === this.aspectRatio"/>

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -776,6 +776,49 @@
             <we-colorpicker data-color="true" data-color-name="c5"/>
         </we-row>
     </div>
+
+    <div class="o_snippet_crop" data-js="CropTools" data-selector="img">
+        <div class="o_crop_aspect_ratio">
+            <we-row string="Aspect Ratio">
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="0/0">Flexible</we-button>
+            </we-row>
+            <we-row string=" ">
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="16/9">16:9</we-button>
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="4/3">4:3</we-button>
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="1/1">1:1</we-button>
+                    <we-button class="cropBtn" data-action="ratio" data-no-preview="true" data-value="2/3">2:3</we-button>
+            </we-row>
+        </div>
+        <div class="o_crop_zoom">
+            <we-row string="Zoom">
+                <we-button class="fa fa-fw fa-search-plus cropBtn" data-action="zoom" data-no-preview="true" data-value="0.1" title="Zoom In"/>
+                <we-button class="fa fa-fw fa-search-minus cropBtn" data-action="zoom" data-no-preview="true" data-value="-0.1" title="Zoom Out"/>
+            </we-row>
+        </div>
+        <div class="o_crop_rotate">
+            <we-row string="Rotate">
+                <we-button class="fa fa-fw fa-rotate-left cropBtn" data-action="rotate" data-no-preview="true" data-value="-90" title="Rotate Left"/>
+                <we-button class="fa fa-fw fa-rotate-right cropBtn" data-action="rotate" data-no-preview="true" data-value="90" title="Rotate Right"/>
+            </we-row>
+        </div>
+        <div class="o_crop_flip">
+            <we-row string="Flip">
+                <we-button class="fa fa-fw fa-arrows-h cropBtn" data-action="flip" data-no-preview="true" data-scale-direction="scaleX" title="Flip-Horizontal"/>
+                <we-button class="fa fa-fw fa-arrows-v cropBtn" data-action="flip" data-no-preview="true" data-scale-direction="scaleY" title="Flip-Vertical"/>
+            </we-row>
+        </div>
+        <div class="o_crop_reset">
+            <we-row string="Reset">
+                <we-button class="cropBtn" data-action="reset" data-no-preview="true" title="Reset Image">Reset Image</we-button>
+            </we-row>
+        </div>
+        <div class="o_crop_actions">
+            <we-row string=" ">
+                <we-button class="btn o_we_bg_brand_primary cropBtn" data-action="apply" data-no-preview="true">Apply</we-button>
+                <we-button class="btn o_we_bg_danger cropBtn" data-action="discard" data-no-preview="true">Discard</we-button>
+            </we-row>
+        </div>
+    </div>
 </template>
 
 <!-- default block -->


### PR DESCRIPTION
**Before this PR:**
The crop buttons were attached to the bottom of the screen.

**After this PR:**
The crop buttons will be added to the sidebar in mass-mailing, 
website making the buttons more accessible.

task-3258587