### PR TITLE
[FIX] point_of_sale: remove popup declaration

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -91,13 +91,9 @@ export class PosStore extends Reactive {
         this.ready = this.setup(...arguments).then(() => this);
     }
     // use setup instead of constructor because setup can be patched.
-    async setup(
-        env,
-        { popup, orm, number_buffer, hardware_proxy, barcode_reader, ui, dialog, printer }
-    ) {
+    async setup(env, { orm, number_buffer, hardware_proxy, barcode_reader, ui, dialog, printer }) {
         this.env = env;
         this.orm = orm;
-        this.popup = popup;
         this.numberBuffer = number_buffer;
         this.barcodeReader = barcode_reader;
         this.ui = ui;


### PR DESCRIPTION
In the commit 136bb1d we completely removed the `popup` service, but the `PosStore` still contains a reference to the ( what is now undefined ) `popup`.

This has not caused errors, as there is no call to access this `popup` variable, but we still remove it in this commit as it serves no purpose and is misleading.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
