### PR TITLE
[FIX] account: fix traceback when from or to value is false

### DIFF
--- a/addons/account/models/account_account.py
+++ b/addons/account/models/account_account.py
@@ -832,13 +832,13 @@ class AccountGroup(models.Model):
     @api.depends('code_prefix_start')
     def _compute_code_prefix_end(self):
         for group in self:
-            if not group.code_prefix_end or group.code_prefix_end < group.code_prefix_start:
+            if not group.code_prefix_end or (group.code_prefix_start and group.code_prefix_end < group.code_prefix_start):
                 group.code_prefix_end = group.code_prefix_start
 
     @api.depends('code_prefix_end')
     def _compute_code_prefix_start(self):
         for group in self:
-            if not group.code_prefix_start or group.code_prefix_start > group.code_prefix_end:
+            if not group.code_prefix_start or (group.code_prefix_end and group.code_prefix_start > group.code_prefix_end):
                 group.code_prefix_start = group.code_prefix_end
 
     @api.depends('code_prefix_start', 'code_prefix_end')


### PR DESCRIPTION
This traceback arises when the user removes the `from` or `to` values.

To reproduce this traceback:

1) Install `account_accountant` and make sure the debugger mode is on 
2) Open `Accounting/Configuration/Account Groups`
3) Create a new record
4) Give the `from` value  and then remove the `to` value

Error:- 

```
TypeError: '>' not supported between instances of 'str' and 'bool'
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 1069, in onchange
    todo = [
  File "addons/web/models/models.py", line 1072, in <listcomp>
    if field_name not in done and snapshot0.has_changed(field_name)
  File "addons/web/models/models.py", line 1185, in has_changed
    return self[field_name] != self.record[field_name]
  File "odoo/models.py", line 6584, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1151, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1366, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1339, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4858, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/account/models/account_account.py", line 841, in _compute_code_prefix_start
    if not group.code_prefix_start or group.code_prefix_start > group.code_prefix_end:
```

When removing the `to` value `code_prefix_end` will be False. 
It leads to the above traceback from here.

https://github.com/odoo/odoo/blob/230b680bf92583c9f5e4a3739be1d8602df44331/addons/account/models/account_account.py#L838-L842

sentry-4715927815
