### PR TITLE
[FIX] mail: deleted message notification issues

### DIFF
--- a/addons/mail/static/src/components/discuss/tests/discuss_tests.js
+++ b/addons/mail/static/src/components/discuss/tests/discuss_tests.js
@@ -3688,6 +3688,7 @@ QUnit.test('receive new chat message: out of odoo focus (notification, channel)'
                 id: 20,
                 message: {
                     id: 126,
+                    body: "Test",
                     model: 'mail.channel',
                     res_id: 20,
                 },
@@ -3730,6 +3731,7 @@ QUnit.test('receive new chat message: out of odoo focus (notification, chat)', a
                 id: 10,
                 message: {
                     id: 126,
+                    body: "Test",
                     model: 'mail.channel',
                     res_id: 10,
                 },
@@ -3785,6 +3787,7 @@ QUnit.test('receive new chat messages: out of odoo focus (tab title)', async fun
                 id: 20,
                 message: {
                     id: 126,
+                    body: "Test",
                     model: 'mail.channel',
                     res_id: 20,
                 },
@@ -3801,6 +3804,7 @@ QUnit.test('receive new chat messages: out of odoo focus (tab title)', async fun
                 id: 10,
                 message: {
                     id: 127,
+                    body: "Test",
                     model: 'mail.channel',
                     res_id: 10,
                 },
@@ -3817,6 +3821,7 @@ QUnit.test('receive new chat messages: out of odoo focus (tab title)', async fun
                 id: 10,
                 message: {
                     id: 128,
+                    body: "Test",
                     model: 'mail.channel',
                     res_id: 10,
                 },

--- a/addons/mail/static/src/components/notification_list/tests/notification_list_tests.js
+++ b/addons/mail/static/src/components/notification_list/tests/notification_list_tests.js
@@ -50,12 +50,14 @@ QUnit.test('marked as read thread notifications are ordered by last message date
         {
             date: "2019-01-01 00:00:00",
             id: 42,
+            body: "<p>Message 2019</p>",
             model: 'mail.channel',
             res_id: 100,
         },
         {
             date: "2020-01-01 00:00:00",
             id: 43,
+            body: "<p>Message 2020</p>",
             model: 'mail.channel',
             res_id: 200,
         }

--- a/addons/mail/static/src/components/thread_needaction_preview/tests/thread_needaction_preview_tests.js
+++ b/addons/mail/static/src/components/thread_needaction_preview/tests/thread_needaction_preview_tests.js
@@ -45,6 +45,7 @@ QUnit.test('mark as read', async function (assert) {
 
     this.data['mail.message'].records.push({
         id: 21,
+        body: "Test",
         model: 'res.partner',
         needaction: true,
         needaction_partner_ids: [this.data.currentPartnerId],
@@ -107,6 +108,7 @@ QUnit.test('click on preview should mark as read and open the thread', async fun
 
     this.data['mail.message'].records.push({
         id: 21,
+        body: "Test",
         model: 'res.partner',
         needaction: true,
         needaction_partner_ids: [this.data.currentPartnerId],
@@ -188,6 +190,7 @@ QUnit.test('click on expand from chat window should close the chat window and op
     });
     this.data['mail.message'].records.push({
         id: 21,
+        body: "Test",
         model: 'res.partner',
         needaction: true,
         needaction_partner_ids: [this.data.currentPartnerId],
@@ -252,6 +255,7 @@ QUnit.test('[technical] opening a non-channel chat window should not call channe
 
     this.data['mail.message'].records.push({
         id: 21,
+        body: "Test",
         model: 'res.partner',
         needaction: true,
         needaction_partner_ids: [this.data.currentPartnerId],

--- a/addons/mail/static/src/models/thread/thread.js
+++ b/addons/mail/static/src/models/thread/thread.js
@@ -1608,7 +1608,7 @@ function factory(dependencies) {
             const {
                 length: l,
                 [l - 1]: lastMessage,
-            } = this.orderedMessages;
+            } = this.orderedNonEmptyMessages;
             if (lastMessage) {
                 return link(lastMessage);
             }
@@ -1710,9 +1710,9 @@ function factory(dependencies) {
                 baseCounter = 0;
                 countFromId = this.lastSeenByCurrentPartnerMessageId;
             }
-            // Include all the messages that are known locally but the server
+            // Include all the non-empty messages that are known locally but the server
             // didn't take into account.
-            return this.orderedMessages.reduce((total, message) => {
+            return this.orderedNonEmptyMessages.reduce((total, message) => {
                 if (message.id <= countFromId) {
                     return total;
                 }
@@ -1749,7 +1749,7 @@ function factory(dependencies) {
          * @returns {mail.message[]}
          */
         _computeNeedactionMessagesAsOriginThread() {
-            return replace(this.messagesAsOriginThread.filter(message => message.isNeedaction));
+            return replace(this.messagesAsOriginThread.filter(message => message.isNeedaction && !message.isEmpty));
         }
 
         /**
@@ -1798,6 +1798,14 @@ function factory(dependencies) {
          */
         _computeOrderedMessages() {
             return replace(this.messages.sort((m1, m2) => m1.id < m2.id ? -1 : 1));
+        }
+
+        /**
+         * @private
+         * @returns {mail.message[]}
+         */
+        _computeOrderedNonEmptyMessages() {
+            return replace(this.orderedMessages.filter(message => !message.isEmpty));
         }
 
         /**
@@ -2500,6 +2508,12 @@ function factory(dependencies) {
          */
         orderedMessages: many2many('mail.message', {
             compute: '_computeOrderedMessages',
+        }),
+        /**
+         * All non empty messages ordered like they are displayed.
+         */
+        orderedNonEmptyMessages: many2many('mail.message', {
+            compute: '_computeOrderedNonEmptyMessages'
         }),
         /**
          * All messages ordered like they are displayed. This field does not


### PR DESCRIPTION
**Current behaviour before PR:**

- Unread messages counter does not adapt after message is deleted
- If the last unread message is deleted then even after reading unread messages counter does not disappear

**Desired behaviour after PR is merged:**

Unread messages counter adapts properly after messages get deleted.

task-[2746505](https://www.odoo.com/web#id=2746505&cids=2&menu_id=4720&action=4043&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
