### PR TITLE
[FIX] website, web_editor: remove deleted images from website

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -236,6 +236,8 @@ class Web_Editor(http.Controller):
 
             if views:
                 removal_blocked_by[attachment.id] = views.read(['name'])
+            elif kwargs['keep_on_website']:
+                attachment.res_id = -1
             else:
                 attachments_to_remove += attachment
         if attachments_to_remove:

--- a/addons/website/static/src/js/widgets/media.js
+++ b/addons/website/static/src/js/widgets/media.js
@@ -1,14 +1,90 @@
 odoo.define('website.widgets.media', function (require) {
 'use strict';
 
+const { _t } = require('web.core');
+const { removeOnImageChangeAttrs } = require('web_editor.image_processing');
 const {ImageWidget} = require('wysiwyg.widgets.media');
 
 ImageWidget.include({
     _getAttachmentsDomain() {
         const domain = this._super(...arguments);
-        domain.push('|', ['url', '=', false], '!', ['url', '=like', '/web/image/website.%']);
+        domain.push(
+            '|', ['url', '=', false],
+            '!', ['url', '=like', '/web/image/website.%'],
+            "!", ["res_id", "=", -1]
+        );
         domain.push(['key', '=', false]);
         return domain;
-    }
+    },
+    /**
+     * @override
+     */
+    _getRemoveDialogOptions(ev) {
+        const self = this;
+        return {
+            buttons: [
+                {
+                    text: _t("Ok"),
+                    classes: "btn-primary",
+                    click: () => {
+                        self._removeAttachment(ev, { remove_optimized: true, keep_on_website: true });
+                    },
+                    close: true,
+                }, {
+                    text: _t("Delete from all website pages"),
+                    click: () => {
+                        self._removeAttachment(ev, { remove_optimized: true, keep_on_website: false }, self._removeFromCurrentPage);
+                    },
+                    close: true,
+                }, {
+                    text: _t("Cancel"),
+                    close: true,
+                },
+            ],
+        };
+    },
+    _removeFromCurrentPage(attachments) {
+        // Looking for saved attachments, or for attachments that have not yet
+        // been saved, are therefore temporarily stored in base64, and have not
+        // been optimized yet.
+        attachments.forEach(attachment => {
+            const onCurrentPageImgEls = document.querySelector("#wrapwrap")
+                .querySelectorAll(
+                    `[style*='${attachment.image_src}'],
+                    [src*='${attachment.image_src}'],
+                    [data-original-id='${attachment.id}']:is([src*='base64'], [style*='base64'])`
+                );
+            if (!onCurrentPageImgEls) {
+                return;
+            }
+            for (const onCurrentPageImgEl of onCurrentPageImgEls) {
+                const attrsToRemove =  [
+                    ...removeOnImageChangeAttrs,
+                    "bgSrc", "fileName", "originalMimetype", "shape", "shapeColors",
+                ];
+                if (onCurrentPageImgEl.nodeName === "IMG") {
+                    const newImgEl = onCurrentPageImgEl.cloneNode(true);
+                    attrsToRemove.forEach(attr => delete newImgEl.dataset[attr]);
+                    delete newImgEl.alt;
+                    newImgEl.src = "/web/image/website.s_image_text_default_image";
+                    onCurrentPageImgEl.insertAdjacentElement("afterend", newImgEl);
+                    onCurrentPageImgEl.remove();
+                } else if (onCurrentPageImgEl.classList.contains("s_parallax_bg")) {
+                    onCurrentPageImgEl.parentElement.classList
+                        .remove("parallax", "s_parallax_is_fixed");
+                    onCurrentPageImgEl.parentElement.dataset.scrollBackgroundRatio = "0";
+                    onCurrentPageImgEl.remove();
+                } else {
+                    // Not an img nor a parallax: a regular background-image.
+                    onCurrentPageImgEl.style.backgroundImage = "";
+                    onCurrentPageImgEl.classList.remove(
+                        "o_modified_image_to_save", "oe_img_bg", "o_bg_img_center"
+                    );
+                    attrsToRemove.forEach(attr => delete onCurrentPageImgEl.dataset[attr]);
+                    $(onCurrentPageImgEl).trigger("background_changed", false);
+                }
+            }
+        });
+    },
 });
 });


### PR DESCRIPTION
When removing an image through the media dialog, the attachment is deleted. But if this image is used on the website, it is not removed from all the places where it is used. This leads to errors and unexpected behaviors if the user tries to apply an effect (filter / shape) on it and save.

This commit changes the behavior with a 3rd button on the remove dialog: "Delete from all website pages".
If the user chooses "Ok": the image is not deleted from the website, and is therefore not deleted from the DB. It is only hidden from the media dialog.
If the user chooses "Delete from all website pages": the image is removed from the DB and from all the places where it is being used on the website pages, including the current page being edited. Images are replaced by a default image, while background images are simply removed.

Steps to reproduce:
- Drop Text - Image
- Replace Image with uploaded image
- Save
- Edit
- Open media dialog
- Delete image
- Close media dialog
- Apply filter or shape on image
- Save => Silently fails (popup in 15)
- Save again => Image is in base64 inside the page

task-3452267