### PR TITLE
[FIX] account: disable onchange_name_predictive when importing

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -763,7 +763,6 @@ class AccountJournal(models.Model):
             all_invoices |= invoice
 
             invoice.with_context(
-                account_predictive_bills_disable_prediction=True,
                 no_new_invoice=True,
             ).message_post(attachment_ids=attachment.ids)
 

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3033,7 +3033,7 @@ class AccountMove(models.Model):
 
             try:
                 if decoder and not success:
-                    with self.env.cr.savepoint(), self._get_edi_creation() as invoice:
+                    with self.env.cr.savepoint(), self.with_context(disable_onchange_name_predictive=True)._get_edi_creation() as invoice:
                         # pylint: disable=not-callable
                         success = decoder(invoice, file_data, new)
                         if success:


### PR DESCRIPTION
When a bill is imported, the predictive computation of accounts and products should be disabled, so that the default account on the journal is used. It is already disabled in other edi modules and used to be disabled in previous versions. `account_predictive_bills_disable_prediction` doesn't seem to be used anymore, so can be deleted.

opw-3628030



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
