### PR TITLE
[IMP] ir_cron: add job_id con context to be used on _trigger

### DIFF
--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -100,7 +100,7 @@ class ir_cron(models.Model):
         for cron in self:
             cron._try_lock()
             _logger.info('Manually starting job `%s`.', cron.name)
-            cron.with_user(cron.user_id).with_context({'lastcall': cron.lastcall}).ir_actions_server_id.run()
+            cron.with_user(cron.user_id).with_context({'lastcall': cron.lastcall, 'job_id': cron.id}).ir_actions_server_id.run()
             self.env.flush_all()
             _logger.info('Job `%s` done.', cron.name)
             cron.lastcall = fields.Datetime.now()
@@ -317,7 +317,7 @@ class ir_cron(models.Model):
         with cls.pool.cursor() as job_cr:
             lastcall = fields.Datetime.to_datetime(job['lastcall'])
             interval = _intervalTypes[job['interval_type']](job['interval_number'])
-            env = api.Environment(job_cr, job['user_id'], {'lastcall': lastcall})
+            env = api.Environment(job_cr, job['user_id'], {'lastcall': lastcall, 'job_id': job['id']})
             ir_cron = env[cls._name]
 
             # Use the user's timezone to compare and compute datetimes,

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -100,7 +100,11 @@ class ir_cron(models.Model):
         for cron in self:
             cron._try_lock()
             _logger.info('Manually starting job `%s`.', cron.name)
-            cron.with_user(cron.user_id).with_context({'lastcall': cron.lastcall, 'job_id': cron.id}).ir_actions_server_id.run()
+            context = {
+                'lastcall': cron.lastcall,
+                'cron_id': cron.id,
+            }
+            cron.with_user(cron.user_id).with_context(**context).ir_actions_server_id.run()
             self.env.flush_all()
             _logger.info('Job `%s` done.', cron.name)
             cron.lastcall = fields.Datetime.now()
@@ -317,7 +321,7 @@ class ir_cron(models.Model):
         with cls.pool.cursor() as job_cr:
             lastcall = fields.Datetime.to_datetime(job['lastcall'])
             interval = _intervalTypes[job['interval_type']](job['interval_number'])
-            env = api.Environment(job_cr, job['user_id'], {'lastcall': lastcall, 'job_id': job['id']})
+            env = api.Environment(job_cr, job['user_id'], {'lastcall': lastcall, 'cron_id': job['id']})
             ir_cron = env[cls._name]
 
             # Use the user's timezone to compare and compute datetimes,


### PR DESCRIPTION
By adding the job_id on the context we allow the user to use the ._trigger functionality to batch crons without reliying on the external Id that is not so secure.

For eg. the user creates a new ir.cron record for subscription invoices with some changes but keeps calling the method `_cron_recurring_create_invoice`. This method is today making the trigger by external Id, so the next batch will be run on the wrong ir.cron. Of course this PR is not enought, it gives more possibilties that should be implemented on cron methods but can already be used for custom crons being created from UI.

Usage example on custom module [here](https://github.com/ingadhoc/product/pull/551/files#diff-108da9fcdcfe1298509954faf21c56ffe3a739aab43ea3717e51b21013504ad2R98)
