### PR TITLE
[IMP] sale_project: add customer preview stat button in project form

### DIFF
--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -110,6 +110,14 @@ class ProjectProject(models.Model):
         for project in self:
             project.display_sales_stat_buttons = project.allow_billable and project.partner_id
 
+    def action_customer_preview(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_url',
+            'target': 'self',
+            'url': self.get_portal_url(),
+        }
+
     def action_view_sols(self):
         self.ensure_one()
         all_sale_order_lines = self._fetch_sale_order_items({'project.task': [('is_closed', '=', False)]})

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -51,6 +51,14 @@
         <field name="arch" type="xml">
             <div name="button_box" position="inside">
                 <field name="display_sales_stat_buttons" invisible="1"/>
+                <field name="allow_billable" invisible="1" />
+                <field name="privacy_visibility" invisible="1" />
+                <button class="oe_stat_button" type="object" name="action_customer_preview" icon="fa-globe icon" invisible="not partner_id or not allow_billable or privacy_visibility != 'portal'">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Customer</span>
+                        <span class="o_stat_text">Preview</span>
+                    </div>
+                </button>
                 <button
                     class="oe_stat_button"
                     type="object"


### PR DESCRIPTION
Activate the project & sale_project module
The purpose of this commit to add customer preview stat button in project form which Give users an idea of what the interface will look like to customers when they share their project

task-3630449