### PR TITLE
[IMP] account, purchase_requisition: product catalog

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -73,6 +73,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'views/bill_preview_template.xml',
         'data/account_reports_data.xml',
         'views/uom_uom_views.xml',
+        'views/product_views.xml',
     ],
     'demo': [
         'demo/account_demo.xml',

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -3232,6 +3232,52 @@ class AccountMoveLine(models.Model):
         action['context'] = ctx
         return action
 
+    def action_add_from_catalog(self):
+        """ Will open the catalog view """
+        move = self.env['account.move'].browse(self.env.context.get('order_id'))
+        return move.action_add_from_catalog()
+
+    # -------------------------------------------------------------------------
+    # Catalog
+    # -------------------------------------------------------------------------
+    def _get_product_catalog_lines_data(self, **kwargs):
+        """
+        Return information about account_move_line in `self`.
+        If `self` is empty, this method returns only the default value(s) needed for the product
+        catalog. In this case, the quantity that equals 0.
+        Otherwise, it returns a quantity and a price based on the product of the move line(s) and whether
+        the product is read-only or not.
+        A product is considered read-only if the order is considered read-only or if `self` contains multiple records.
+        Note: This method cannot be called with multiple records that have different products linked.
+
+        :param products: Recordset of `product.product`.
+        :param dict kwargs: additional values given for inherited models.
+        :rtype: dict
+        :return: A dict with the following structure:
+            {
+                'quantity': float,
+                'price': float,
+                'readOnly': bool,
+                'min_qty': int, (optional)
+            }
+        """
+        if self:
+            self.product_id.ensure_one()
+            return {
+                **self[0].move_id._get_product_price_and_data(self[0].product_id),
+                'quantity': sum(
+                    self.mapped(
+                        lambda line: line.product_uom_id._compute_quantity(
+                            qty=line.quantity,
+                            to_unit=line.product_id.uom_id,
+                        )
+                    )
+                ),
+                'readOnly': self.move_id._is_readonly(),
+            }
+        return {
+            'quantity': 0,
+        }
     # -------------------------------------------------------------------------
     # TOOLING
     # -------------------------------------------------------------------------

--- a/addons/account/static/src/components/product_catalog/account_move_line.js
+++ b/addons/account/static/src/components/product_catalog/account_move_line.js
@@ -1,0 +1,9 @@
+/** @odoo-module */
+import { ProductCatalogOrderLine } from "@product/product_catalog/order_line/order_line";
+
+export class ProductCatalogAccountMoveLine extends ProductCatalogOrderLine {
+    static props = {
+        ...ProductCatalogOrderLine.props,
+        min_qty: { type: Number, optional: true },
+    };
+}

--- a/addons/account/static/src/components/product_catalog/kanban_controller.js
+++ b/addons/account/static/src/components/product_catalog/kanban_controller.js
@@ -1,0 +1,22 @@
+/** @odoo-module */
+import { ProductCatalogKanbanController } from "@product/product_catalog/kanban_controller";
+import { patch } from "@web/core/utils/patch";
+import { _t } from "@web/core/l10n/translation";
+
+patch(ProductCatalogKanbanController.prototype, {
+    async _defineButtonContent() {
+        const fields = this.orderResModel === "account.move" ? ["state", "move_type"] : ["state"];
+        const orderStateInfo = await this.orm.searchRead(
+            this.orderResModel,
+            [["id", "=", this.orderId]],
+            fields,
+        );
+        if (orderStateInfo[0]?.move_type === "out_invoice") {
+            this.buttonString = _t("Back to Invoice");
+        } else if (orderStateInfo[0]?.move_type === "in_invoice") {
+            this.buttonString = _t("Back to Bill");
+        } else {
+            this.buttonString = super._defineButtonContent();
+        }
+    },
+});

--- a/addons/account/static/src/components/product_catalog/kanban_record.js
+++ b/addons/account/static/src/components/product_catalog/kanban_record.js
@@ -1,0 +1,21 @@
+/** @odoo-module */
+import { ProductCatalogKanbanRecord } from "@product/product_catalog/kanban_record";
+import { ProductCatalogAccountMoveLine } from "./account_move_line";
+import { patch } from "@web/core/utils/patch";
+
+patch(ProductCatalogKanbanRecord.prototype, {
+    get orderLineComponent() {
+        if (this.env.orderResModel === "account.move") {
+            return ProductCatalogAccountMoveLine;
+        }
+        return super.orderLineComponent;
+    },
+
+    addProduct() {
+        if (this.productCatalogData.quantity === 0 && this.productCatalogData.min_qty) {
+            super.addProduct(this.productCatalogData.min_qty);
+        } else {
+            super.addProduct(...arguments);
+        }
+    },
+})

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -1014,6 +1014,7 @@
                                             <create name="add_line_control" string="Add a line"/>
                                             <create name="add_section_control" string="Add a section" context="{'default_display_type': 'line_section'}"/>
                                             <create name="add_note_control" string="Add a note" context="{'default_display_type': 'line_note'}"/>
+                                            <button name="action_add_from_catalog" string="Catalog" type="object" class="btn-link" context="{'order_id': parent.id}"/>
                                         </control>
 
                                         <!-- Displayed fields -->

--- a/addons/account/views/product_views.xml
+++ b/addons/account/views/product_views.xml
@@ -1,0 +1,13 @@
+<odoo>
+     <record id="product_view_search_catalog" model="ir.ui.view">
+         <field name="name">product.view.search.catalog.inherit.account</field>
+         <field name="model">product.product</field>
+         <field name="mode">primary</field>
+         <field name="inherit_id" ref="product.product_view_search_catalog"/>
+         <field name="arch" type="xml">
+             <xpath expr="//field[@name='product_tmpl_id']" position="after">
+                 <field name="seller_ids" string="Vendor"/>
+             </xpath>
+         </field>
+     </record>
+</odoo>

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -830,6 +830,12 @@ class PurchaseOrder(models.Model):
         new_default_data = self.env['purchase.order.line']._get_product_catalog_lines_data()
         return {**default_data, **new_default_data}
 
+    def action_add_from_catalog(self):
+        res = super().action_add_from_catalog()
+        if res['context'].get('product_catalog_order_model') == 'purchase.order':
+            res['search_view_id'] = [self.env.ref('purchase.product_view_search_catalog').id, 'search']
+        return res
+
     def _get_action_add_from_catalog_extra_context(self):
         return {
             **super()._get_action_add_from_catalog_extra_context(),

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -166,6 +166,7 @@
         <record id="product_view_search_catalog" model="ir.ui.view">
             <field name="name">product.view.search.catalog.inherit.purchase</field>
             <field name="model">product.product</field>
+            <field name="mode">primary</field>
             <field name="inherit_id" ref="product.product_view_search_catalog"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='product_tmpl_id']" position="after">

--- a/addons/purchase_requisition/models/product.py
+++ b/addons/purchase_requisition/models/product.py
@@ -16,7 +16,7 @@ class ProductProduct(models.Model):
 
     def _prepare_sellers(self, params=False):
         sellers = super(ProductProduct, self)._prepare_sellers(params=params)
-        if params and params.get('order_id'):
+        if params and params.get('order_id') and params['order_id']._fields.get("requisition_id"):
             return sellers.filtered(lambda s: not s.purchase_requisition_id or s.purchase_requisition_id == params['order_id'].requisition_id)
         else:
             return sellers


### PR DESCRIPTION
A new catalog feature was added on Sales, Purchase and Field services. To be compliant with the other modules, it needed to be imported to account.

In product a mixins was created to be able to extend the code to other modules. This commit will override the mixins method to add the catalog feature to account move.

When being on a bill (with a partner set), a filter is put by default.

task: 3635565

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
