### PR TITLE
[FIX] base: prevent traceback while set value less than zero

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -25760,6 +25760,17 @@ msgid ""
 msgstr ""
 
 #. module: base
+#: model:ir.model.constraint,message:base.constraint_ir_sequence_date_range_number_next_not_negative
+#: model:ir.model.constraint,message:base.constraint_ir_sequence_number_next_actual_not_negative
+msgid "The value of Next Number should not be less than zero."
+msgstr ""
+
+#. module: base
+#: model:ir.model.constraint,message:base.constraint_ir_sequence_number_increment_not_negative
+msgid "The value of Step should not be less than zero."
+msgstr ""
+
+#. module: base
 #: code:addons/base/models/ir_qweb_fields.py:0
 #, python-format
 msgid "The value send to monetary field is not a number."

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -150,6 +150,11 @@ class IrSequence(models.Model):
     use_date_range = fields.Boolean(string='Use subsequences per date_range')
     date_range_ids = fields.One2many('ir.sequence.date_range', 'sequence_id', string='Subsequences')
 
+    _sql_constraints = [
+    ('number_next_actual_not_negative', 'CHECK (number_next >= 0) ', 'The value of Next Number should not be less than zero.'),
+    ('number_increment_not_negative', 'CHECK (number_increment >= 0) ', 'The value of Step should not be less than zero.')
+    ]
+
     @api.model
     def create(self, values):
         """ Create a sequence, in implementation == standard a fast gaps-allowed PostgreSQL sequence is used.
@@ -344,6 +349,10 @@ class IrSequenceDateRange(models.Model):
                                         string='Actual Next Number',
                                         help="Next number that will be used. This number can be incremented "
                                              "frequently so the displayed value might already be obsolete")
+
+    _sql_constraints = [
+    ('number_next_not_negative', 'CHECK (number_next >= 0) ', 'The value of Next Number should not be less than zero.')
+    ]
 
     def _next(self):
         if self.sequence_id.implementation == 'standard':


### PR DESCRIPTION
This issue occurs when the customer enters a value in the `Next Number` and `Step` fields that is less than zero; an error will be generated.

step to reproduce:
-  Go to `Settings / Technical / Sequences & Identifiers / Sequences`
- Create the new sequence
- Enter the -1 in Next Number fields.
- Or select the `Use subsequences per date_range`
- Add a line > Enter the -1 in Next Number fields.
- Error will be generated.

sentry traceback-
```
InvalidParameterValue: RESTART value (-1) cannot be less than MINVALUE (1)

  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 71, in web_save
    self.write(vals)
  File "odoo/addons/base/models/ir_sequence.py", line 196, in write
    res = super(IrSequence, self).write(values)
  File "odoo/models.py", line 4422, in write
    fields[0].determine_inverse(real_recs)
  File "odoo/fields.py", line 1397, in determine_inverse
    determine(self.inverse, records)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_sequence.py", line 113, in _set_number_next_actual
    seq.write({'number_next': seq.number_next_actual or 1})
  File "odoo/addons/base/models/ir_sequence.py", line 181, in write
    _alter_sequence(self._cr, "ir_sequence_%03d" % seq.id, number_next=n)
  File "odoo/addons/base/models/ir_sequence.py", line 48, in _alter_sequence
    cr.execute(statement.join(' '), params)
  File "odoo/sql_db.py", line 332, in execute
    res = self._obj.execute(query, params)

```

After this commit , When a customer enters a value that is less than zero, a validation error is showed.

sentry- 4713364442