### PR TITLE
[FIX] website_sale: disable pay button no pick up point

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale/static/src/js/website_sale_delivery.js
@@ -250,6 +250,7 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
             },
         })
         this._enableButton(result.status);
+        this._disablePayButtonNoPickupPoint(new $.Event("", {currentTarget:carrierChecked}))
     },
     /**
      * Check if the submit button can be enabled.


### PR DESCRIPTION
Issue:
======
The pay button is enabled when no pick up point is selected.

Steps to reproduce the error:
=============================
- Activate a shipping method that has pick up points
- Activae more than one payment method
- Go to cart add any product which is compatible with the shipping method
- Go to checkout and select the shipping method with pick up points without selecting any pick up point
- Select a payment method
- The pay button is enabled but we don't have a selected pick up point which is wrong.

Origin of the issue:
====================
Selecting the payment method didn't check for the pick up points.

Solution:
=========
We need to check for pick up points on selecting payment methods.

opw-3596705