### PR TITLE
[IMP] point_of_sale, pos_restaurant: concurrential update of orders

### DIFF
--- a/addons/point_of_sale/static/src/app/navbar/navbar.js
+++ b/addons/point_of_sale/static/src/app/navbar/navbar.js
@@ -76,7 +76,7 @@ export class Navbar extends Component {
     }
 
     _shouldLoadOrders() {
-        return this.pos.config.trusted_config_ids.length > 0;
+        return this.pos.config.raw.trusted_config_ids.length > 0;
     }
 
     get isTicketScreenShown() {

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.js
@@ -25,7 +25,6 @@ export class PartnerEditor extends Component {
 
     setup() {
         this.pos = usePos();
-        this.orm = useService("orm");
         this.dialog = useService("dialog");
         this.intFields = ["country_id", "state_id", "property_product_pricelist"];
         const partner = this.props.partner;
@@ -108,7 +107,7 @@ export class PartnerEditor extends Component {
             });
         }
         processedChanges.id = this.props.partner.id || false;
-        await this.orm.call("res.partner", "create_from_ui", [processedChanges]);
+        await this.pos.data.call("res.partner", "create_from_ui", [processedChanges]);
         await this.pos.load_new_partners();
         this.props.close();
     }

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt_screen.js
@@ -33,7 +33,7 @@ export class ReceiptScreen extends Component {
             // to send in preparation it is automatically sent
             if (this.pos.orderPreparationCategories.size) {
                 try {
-                    await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
+                    await this.pos.sendOrderInPreparation(this.currentOrder, false, true);
                 } catch (error) {
                     Promise.reject(error);
                 }

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -152,7 +152,7 @@ export class TicketScreen extends Component {
         }
         if (order && (await this._onBeforeDeleteOrder(order))) {
             if (Object.keys(order.lastOrderPrepaChange).length > 0) {
-                await this.pos.sendOrderInPreparationUpdateLastChange(order, true);
+                await this.pos.sendOrderInPreparation(order, true, false);
             }
             if (order === this.pos.get_order()) {
                 this._selectNextOrder(order);

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1113,6 +1113,9 @@ export class Order extends PosModel {
             (this.pos_session_id % 10) * 100 +
             (this.sequence_number % 100)
         ).toString();
+        this.lastOpenedOrderTime = null;
+        this.startingOrderlinesUUID = [];
+        this.startingLastOrderPreparationChanges = {};
     }
 
     getEmailItems() {
@@ -1272,6 +1275,11 @@ export class Order extends PosModel {
             access_token: this.access_token || "",
             last_order_preparation_change: JSON.stringify(this.lastOrderPrepaChange),
             ticket_code: this.ticketCode || "",
+            last_opened_order_time: this.lastOpenedOrderTime
+                ? serializeDateTime(this.lastOpenedOrderTime)
+                : false,
+            starting_orderlines_uuid: this.startingOrderlinesUUID,
+            starting_last_order_preparation_changes: this.startingLastOrderPreparationChanges,
         };
         if (!this.is_paid && this.user_id) {
             json.user_id = this.user_id;
@@ -1415,6 +1423,12 @@ export class Order extends PosModel {
                 delete this.lastOrderPrepaChange[lineKey];
             }
         }
+
+        // sync preparation changes with server
+        this.pos.data.call("pos.order", "update_last_order_changes", [
+            this.server_id,
+            JSON.stringify(this.lastOrderPrepaChange),
+        ]);
     }
 
     /**

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -10,6 +10,9 @@ class PosOrderLine(models.Model):
 
     note = fields.Char('Internal Note added by the waiter.')
 
+    def _get_note(self):
+        return self.note or ''
+
 
 class PosOrder(models.Model):
     _inherit = 'pos.order'
@@ -93,3 +96,11 @@ class PosOrder(models.Model):
     def export_for_ui_table_draft(self, table_ids):
         orders = self.env['pos.order'].search([('state', '=', 'draft'), ('table_id', 'in', table_ids)])
         return orders.export_for_ui()
+
+    def _update_order(self, order):
+        result = super(PosOrder, self)._update_order(order)
+        if order.get('customer_count'):
+            self.customer_count = order['customer_count']
+        if order.get('table_id'):
+            self.table_id = self.env['restaurant.table'].browse(order['table_id'])
+        return result

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/actionpad_widget/actionpad_widget.js
@@ -23,7 +23,7 @@ patch(ActionpadWidget.prototype, {
         if (!this.clicked) {
             this.clicked = true;
             try {
-                await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
+                await this.pos.sendOrderInPreparation(this.currentOrder);
             } finally {
                 this.clicked = false;
             }

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/product_screen.js
@@ -34,7 +34,7 @@ patch(ProductScreen.prototype, {
         return this.pos.config.module_pos_restaurant && this.pos.orderPreparationCategories.size;
     },
     submitOrder() {
-        this.pos.sendOrderInPreparationUpdateLastChange(this.pos.get_order());
+        this.pos.sendOrderInPreparation(this.pos.get_order());
     },
     get primaryReviewButton() {
         return (


### PR DESCRIPTION
Prior to this commit, when two waiters were updating the same order
at the same time, the last one to save was overwriting the changes.
This commit introduces the merge of the changes coming from concurrential
updates.

The principle is that, if an order is already saved on the server
and two waiter are updating it simultaneously, both changes are merged.
However, if two waiters open a table at the same moment that does not
have any order on it beforehand, two orders will be created.

This also works for retail point of sale. If two cashiers are updating
the same order at the same time, the changes are merged.

Enterprise PR: odoo/enterprise#52781

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
