### PR TITLE
[FIX] mrp: assign serial numbers using list

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -3900,6 +3900,12 @@ msgid "Plastic Laminate"
 msgstr ""
 
 #. module: mrp
+#: code:addons/mrp/wizard/stock_assign_serial_numbers.py:0
+#, python-format
+msgid "Please provide The first Serial Number or a list of serial numbers"
+msgstr ""
+
+#. module: mrp
 #. odoo-python
 #: code:addons/mrp/models/mrp_production.py:0
 msgid "Please set the first Serial Number or a default sequence"

--- a/addons/mrp/wizard/stock_assign_serial_numbers.py
+++ b/addons/mrp/wizard/stock_assign_serial_numbers.py
@@ -4,7 +4,7 @@
 from collections import Counter
 
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 class StockAssignSerialNumbers(models.TransientModel):
@@ -18,6 +18,11 @@ class StockAssignSerialNumbers(models.TransientModel):
     show_backorders = fields.Boolean() # Technical field to show the Create Backorder and No Backorder buttons
     multiple_lot_components_names = fields.Text() # Names of components with multiple lots, used to show warning
     mark_as_done = fields.Boolean("Valide all the productions after the split")
+
+    def _check_first_sn(self):
+        for wizard in self:
+            if not (wizard.next_serial_number or wizard.serial_numbers):
+                raise ValidationError(_("Please provide The first Serial Number or a list of serial numbers"))
 
     def generate_serial_numbers_production(self):
         if self.next_serial_number and self.next_serial_count:

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -5787,6 +5787,12 @@ msgid "There is nothing eligible to put in a pack. Either there are no quantitie
 msgstr ""
 
 #. module: stock
+#: code:addons/stock/wizard/stock_assign_serial_numbers.py:0
+#, python-format
+msgid "Please provide The first Serial Number"
+msgstr ""
+
+#. module: stock
 #: model_terms:ir.ui.view,arch_db:stock.report_return_slip
 msgid ""
 "Please put this document inside your return parcel.<br/>\n"

--- a/addons/stock/wizard/stock_assign_serial_numbers.py
+++ b/addons/stock/wizard/stock_assign_serial_numbers.py
@@ -18,9 +18,15 @@ class StockAssignSerialNumbers(models.TransientModel):
     product_id = fields.Many2one('product.product', 'Product',
         related='move_id.product_id')
     move_id = fields.Many2one('stock.move')
-    next_serial_number = fields.Char('First SN', required=True)
+    next_serial_number = fields.Char('First SN')
     next_serial_count = fields.Integer('Number of SN',
         default=_default_next_serial_count, required=True)
+
+    @api.constrains('next_serial_count')
+    def _check_first_sn(self):
+        for wizard in self:
+            if not wizard.next_serial_number:
+                raise ValidationError(_("Please provide The first Serial Number"))
 
     @api.constrains('next_serial_count')
     def _check_next_serial_count(self):


### PR DESCRIPTION
Steps to reproduce:
- Create an MO for a product that requires a SN for example 2 units
- Click on massproduce
- paste your SNs in "Produced serial numbers"

Bug:
"First SN" field is required

Fix:
use python constraint to check that either field is filled

opw-3634341