### PR TITLE
[FIX] delivery: fix discount on SOL with pricelists

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -119,6 +119,7 @@ class SaleOrder(models.Model):
             'product_id': carrier.product_id.id,
             'tax_id': [(6, 0, taxes_ids)],
             'is_delivery': True,
+            'discount': 0.,
         }
         if carrier.invoice_policy == 'real':
             values['price_unit'] = 0


### PR DESCRIPTION
- Install sale,delivery and loyalty
- Set up a delivery method with a delivery product
- Set up a pricelist with a reduced price for the delivery product and change discount policy to "showing public price and discount to the customer"
- Create a new quotation with the new pricelist and add a storable product
- Click on "Add shipping" and select the delivery method defined above

Current behaviour:
The unit price on the delivery line is the final price, but there is a discount computed on it since the price is reduced from the list_price

Expected behaviour:
The line price should be the one as provided from the shipping wizard

In order to obtaint the expected behaviour in stable, the only way is to force the discount to be 0 on the SOL.

opw-3517879
