### PR TITLE
[FIX] point_of_sale: discount not applied to group taxes

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -3479,13 +3479,14 @@ exports.Order = Backbone.Model.extend({
     calculate_base_amount(tax_ids_array, lines) {
         // Consider price_include taxes use case
         let has_taxes_included_in_price = tax_ids_array.filter(tax_id =>
-            this.pos.taxes_by_id[tax_id].price_include
+            this.pos.taxes_by_id[tax_id].price_include ||
+            this.pos.taxes_by_id[tax_id].children_tax_ids.length > 0 &&
+            this.pos.taxes_by_id[tax_id].children_tax_ids.every(child_tax => child_tax.price_include)
         ).length;
 
         let base_amount = lines.reduce((sum, line) =>
                 sum +
-                line.get_price_without_tax() +
-                (has_taxes_included_in_price ? line.get_total_taxes_included_in_price() : 0),
+                (has_taxes_included_in_price ? line.get_price_with_tax() : line.get_price_without_tax()),
             0
         );
         return base_amount;


### PR DESCRIPTION
In Point of Sale > Configuration > Settings enable 'Global Discounts' 
Create a tax [TAX A] included in price
Create a tax [TAX G] as group of taxes, including only [TAX A] 
Configure a product [PROD] with [TAX G]
Open POS session
Add [PROD], hit 'Discount' button, add 50% discount

Issue: Tax will not be included in the discount
This occurs because the system does not take into account the tax group

opw-3576452
