### PR TITLE
[FIX] purchase_stock: accurate valuation with credit note

### DIFF
--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -308,7 +308,13 @@ class AccountMoveLine(models.Model):
             aml_price_unit = aml.currency_id._convert(aml_gross_price_unit, aml.company_id.currency_id, aml.company_id, aml.move_id.invoice_date, round=False)
             aml_price_unit = aml.product_uom_id._compute_price(aml_price_unit, product_uom)
 
-            unit_valuation_difference = aml_price_unit - layer_price_unit
+            if self.is_refund:
+                refund_gross_price_unit = self._get_gross_unit_price()
+                refund_price_unit = self.currency_id._convert(sign * refund_gross_price_unit, self.company_id.currency_id, self.company_id, self.move_id.invoice_date, round=False)
+                refund_price_unit = self.product_uom_id._compute_price(refund_price_unit, product_uom)
+                unit_valuation_difference = min(refund_price_unit, aml_price_unit - layer_price_unit)
+            else:
+                unit_valuation_difference = aml_price_unit - layer_price_unit
 
             # Generate the AML values for the already out quantities
             unit_valuation_difference_curr = self.company_id.currency_id._convert(unit_valuation_difference, self.currency_id, self.company_id, self.move_id.invoice_date, round=False)
@@ -319,7 +325,10 @@ class AccountMoveLine(models.Model):
 
             # Generate the SVL values for the on hand quantities (and impact the parent layer)
             po_pu_curr = po_line.currency_id._convert(po_line.price_unit, self.currency_id, self.company_id, self.move_id.invoice_date, round=False)
-            price_difference_curr = po_pu_curr - aml_gross_price_unit
+            if self.is_refund:
+                price_difference_curr = max(refund_gross_price_unit, po_pu_curr - aml_gross_price_unit)
+            else:
+                price_difference_curr = po_pu_curr - aml_gross_price_unit
             if not float_is_zero(unit_valuation_difference * qty_to_correct, precision_rounding=self.company_id.currency_id.rounding):
                 svl_vals = self._prepare_pdiff_svl_vals(layer, sign * qty_to_correct, unit_valuation_difference, price_difference_curr)
                 layer.remaining_value += svl_vals['value']


### PR DESCRIPTION
Case:
- PO for 1 unit at price 100
- receive product (layer for 100 created)
- bill for 1 unit at price 110 (layer for 10 created)
- credit note for 1 unit at price 5 (layer for -10 created)

Issue: the third layer should logically be at -5 instead of -10.

Fix: for in_refund account move, use refund_price_unit as unit_valuation_difference if it is smaller than the difference between aml_price_unit and layer_price_unit. Do the reverse for price_difference_curr since the values are normally in the negative.

No change of behavior if the bill is lower than the PO price.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
