### PR TITLE
[FIX] stock: respect reservation method on push rules

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1751,7 +1751,7 @@ class StockMove(models.Model):
         for move_dest in moves_todo.move_dest_ids:
             move_dests_per_company[move_dest.company_id.id] |= move_dest
         for company_id, move_dests in move_dests_per_company.items():
-            move_dests.sudo().with_company(company_id)._action_assign()
+            move_dests.sudo().with_company(company_id).filtered(lambda m: m.picking_type_id.reservation_method == 'at_confirm')._action_assign()
 
         # We don't want to create back order for scrap moves
         # Replace by a kwarg in master


### PR DESCRIPTION
Steps to reproduce:
- Create a second warehouse and a new Push To route
- Create a new location for the Rule
- The Delivery Orders Operation type should have the Reservation Method set Manually
- In the inventory app -> create a new Receipt.
- this automatically generate a new delivery order.

Bug:
While the operation type has the manual reservation method selected, it is not reflected on the delivery order,
and the product is reserved automatically.

Fix:
when creating the move only reserve products if the picking type is set to do so

opw-3601445
