### PR TITLE
feat: update domain search to avoid sn on on_hand

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -322,7 +322,7 @@
                                         optional="hide"
                                         options="{'create': [('parent.use_create_lots', '=', True)]}"
                                         context="{'default_company_id': company_id, 'default_product_id': product_id, 'active_picking_id': parent.id}"
-                                        domain="[('product_id','=',product_id)]"
+                                        domain="[('product_id','=',product_id), ('product_qty', '=', 0)]"
                                     />
                                     <button name="action_assign_serial" type="object"
                                             icon="fa-plus-square"


### PR DESCRIPTION
Description of the issue/feature this PR addresses: https://www.odoo.com/web#id=3525776&cids=1&menu_id=4720&action=333&active_id=966&model=project.task&view_type=form

Current behavior before PR: Serial Numbers are listed on drop-down when create a new move line for a product on `inventory/receipts`. When an user select an existing serial number, an error was displayed.

Desired behavior after PR is merged: When create a new move line for a product with requires a serial number, just show only serial numbers who aren't on hand.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
