### PR TITLE
[FIX] website_slides: remove traceback error on DateTime object

### DIFF
--- a/addons/website_slides/static/src/js/slides.js
+++ b/addons/website_slides/static/src/js/slides.js
@@ -2,7 +2,6 @@
 
 import publicWidget from '@web/legacy/js/public/public_widget';
 import { deserializeDateTime } from "@web/core/l10n/dates";
-const { DateTime } = luxon;
 
 publicWidget.registry.websiteSlides = publicWidget.Widget.extend({
     selector: '#wrapwrap',
@@ -20,10 +19,10 @@ publicWidget.registry.websiteSlides = publicWidget.Widget.extend({
             // if presentation 7 days, 24 hours, 60 min, 60 second, 1000 millis old(one week)
             // then return fix formate string else timeago
             var displayStr = '';
-            if (datetimeObj && new Date().getTime() - datetimeObj.getTime() > 7 * 24 * 60 * 60 * 1000) {
-                displayStr = DateTime.fromJSDate(datetimeObj).toFormat('DD');
+            if (datetimeObj && new Date().getTime() - new Date(datetimeObj).getTime() > 7 * 24 * 60 * 60 * 1000) {
+                displayStr = datetimeObj.toFormat('DD');
             } else {
-                displayStr = DateTime.fromJSDate(datetimeObj).toRelative();
+                displayStr = datetimeObj.toRelative();
             }
             $(el).text(displayStr);
         });

--- a/addons/website_slides/static/tests/tours/slides_article.js
+++ b/addons/website_slides/static/tests/tours/slides_article.js
@@ -1,0 +1,21 @@
+/** @odoo-module **/
+
+import wTourUtils from '@website/js/tours/tour_utils';
+
+/**
+ * Global use case:
+ * - a user lands on the article of a course;
+ *
+ * This tour tests a fix because a traceback error would appear when
+ * selecting an article of a course.
+ *
+ */
+ wTourUtils.registerWebsitePreviewTour('course_article', {
+    url: '/slides/all',
+    test: true,
+}, () => [{
+    trigger: 'iframe a:contains("Furniture Technical Specifications")'
+}, {
+    trigger: 'iframe a:contains("Foreword")',
+    run: function () {} // check we land on the articleand no traceback appears
+}]);

--- a/addons/website_slides/tests/test_ui_wslides.py
+++ b/addons/website_slides/tests/test_ui_wslides.py
@@ -172,6 +172,13 @@ class TestUi(TestUICommon):
 
         self.start_tour('/slides', 'course_reviews', login=user_demo.login)
 
+    def test_course_article(self):
+        user_demo = self.env.ref('base.user_demo')
+        user_demo.write({
+            'groups_id': [(5, 0), (4, self.env.ref('base.group_user').id), (4, self.env.ref('website.group_website_restricted_editor').id)]
+        })
+        self.start_tour(self.env['website'].get_client_action_url('/slides/all'), 'course_article', login=user_demo.login)
+
 
 @tests.common.tagged('post_install', '-at_install')
 class TestUiPublisher(HttpCaseGamification):


### PR DESCRIPTION
Currently, there is a traceback error when opening an article of a course.

Steps to reproduce:
-------------------
* Install ´eLearning´ with demo data
* Skip website building
* Go to ´Website´
* Select page ´Courses´
* Select a course that has articles (ex: Furniture Technical Specifications)
* Select an article (ex: Foreword)

Why this fix:
-------------
datetimeObj.getTime() is not a function.
new Date(datetimeObj).getTime() and datetimeObj.ts are equivalent fixes.

Note:
-----
After changing `DateTime.fromJSDate(datetimeObj)` to `datetimeObj`, `const { DateTime } = luxon;` had to be removed as it was now assigned but never used.

opw-3622688