### PR TITLE
[FIX] account: prevent moves from stealing lines

### DIFF
--- a/addons/account/tests/test_account_move_entry.py
+++ b/addons/account/tests/test_account_move_entry.py
@@ -1132,3 +1132,33 @@ class TestAccountMove(AccountTestInvoicingCommon):
             [("account_id", "=", account.id)], ["balance:sum"], ["account_root_id"]
         )[0]["balance"]
         self.assertEqual(balance, 500)
+
+    def test_line_steal(self):
+        honest_move = self.env['account.move'].create({
+            'line_ids': [
+                Command.create({
+                    'name': 'receivable',
+                    'account_id': self.company_data['default_account_receivable'].id,
+                    'balance': 500.0,
+                }),
+                Command.create({
+                    'name': 'tax',
+                    'account_id': self.company_data['default_account_tax_sale'].id,
+                    'balance': -500.0,
+                }),
+            ]
+        })
+        honest_move.action_post()
+
+        with self.assertRaisesRegex(UserError, 'not balanced'), self.env.cr.savepoint():
+            self.env['account.move'].create({'line_ids': [Command.set(honest_move.line_ids[0].ids)]})
+
+        with self.assertRaisesRegex(UserError, 'not balanced'), self.env.cr.savepoint():
+            self.env['account.move'].create({'line_ids': [Command.link(honest_move.line_ids[0].id)]})
+
+        stealer_move = self.env['account.move'].create({})
+        with self.assertRaisesRegex(UserError, 'not balanced'), self.env.cr.savepoint():
+            stealer_move.write({'line_ids': [Command.set(honest_move.line_ids[0].ids)]})
+
+        with self.assertRaisesRegex(UserError, 'not balanced'), self.env.cr.savepoint():
+            stealer_move.write({'line_ids': [Command.link(honest_move.line_ids[0].id)]})


### PR DESCRIPTION
The balance check doesn't work when a line is being moved from one move to another because we never notified the move owning the lines at the start that the lines are being modified.

To reproduce using a simple CSV to import:
```csv
"line_ids/id","line_ids/product_id"
"__export__.account_move_line_9_25fb2fbf","[FURN_7777] Office Chair"
```

To reproduce using a simple server action:
```python
self.env['account.move'].create({'line_ids': [(4, 9)]})
```

We now notify the original move also, triggering everything that needs to be triggered: sync of dynamic lines and the check for the balance.

