### PR TITLE
[FIX] documents: allow uploading file on activity type with folder_id

### DIFF
--- a/addons/mail/controllers/discuss.py
+++ b/addons/mail/controllers/discuss.py
@@ -257,6 +257,8 @@ class DiscussController(http.Controller):
             # Only generate the access token if absolutely necessary (= not for internal user).
             vals['access_token'] = channel_partner.env['ir.attachment']._generate_access_token()
         try:
+            if 'activity_id' in kwargs:
+                channel_partner = channel_partner.with_context(activity_id=int(kwargs['activity_id']))
             attachment = channel_partner.env['ir.attachment'].create(vals)
             attachment._post_add_create()
             attachmentData = {

--- a/addons/mail/static/src/models/file_uploader/file_uploader.js
+++ b/addons/mail/static/src/models/file_uploader/file_uploader.js
@@ -148,9 +148,13 @@ registerModel({
                     return;
                 }
                 try {
+                    const body = this._createFormData({ composer, file, thread });
+                    if (activity && activity.exists()) {
+                        body.append('activity_id', activity.id);
+                    }
                     const response = await (composer || thread).messaging.browser.fetch('/mail/attachment/upload', {
                         method: 'POST',
-                        body: this._createFormData({ composer, file, thread }),
+                        body,
                         signal: uploadingAttachment.uploadingAbortController.signal,
                     });
                     const attachmentData = await response.json();


### PR DESCRIPTION
Steps to reproduce:

  - Install documents_project module (for test purposes)
  - Create a new activity type with:
    - action: Upload Document
    - folder_id: Internal
    - model_id: Task
  - Go to settings and enable `Centralize files attached to projects and
    tasks` (from 16.0, set a default folder on the project)
  - Go to any task and add a new activity with the new activity type
  - Click on Upload Document and select a file

Issue:

  Access right error message.

Solution:

  Add the 'activity_id' as param when uploading attachment and set it in
  the context when creating attachment so it can be used in other
  flows, like when creating a document (ref. ENT PR).

ENT PR: https://github.com/odoo/enterprise/pull/47411

opw-3452859