### PR TITLE
[FIX] base_import: convert  limit value in integer when it is in string format

### DIFF
--- a/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.js
+++ b/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.js
@@ -32,6 +32,10 @@ export class ImportDataSidepanel extends Component {
     }
 
     setOptionValue(name, value) {
+        if(name === "limit"){
+            this.props.onOptionChanged("limit", !isNaN(parseFloat(value)) ? Number(value) : 1);
+            return
+        }
         this.props.onOptionChanged(name, isNaN(parseFloat(value)) ? value : Number(value));
     }
 


### PR DESCRIPTION

This traceback arises when the user tries to remove the `Batch Limit` value and test the import file

To reproduce this issue:

1. Install `account_base_import`
2. Open `Accounting/ Configuration /accounting/Chart of Accounts`
3. Click on `import` then click on `import Coa`
4. upload file(data must be above 300 or more)
5. Remove the `Batch Limit value 2000`
6. Test the file

Error:

 ```
TypeError: '<' not supported between instances of 'int' and 'str'
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "home/odoo/src/enterprise/17.0/account_bank_statement_import_csv/wizard/account_bank_statement_import_csv.py", line 141, in execute_import
    return super(AccountBankStmtImportCSV, self).execute_import(fields, columns, options, dryrun=dryrun)
  File "addons/base_import/models/base_import.py", line 1332, in execute_import
    import_result = model.load(import_fields, merged_data)
  File "home/odoo/src/enterprise/17.0/account_base_import/models/account_account.py", line 32, in load
    return super().load(fields, data)
  File "addons/account/models/account_account.py", line 659, in load
    rslt = super(AccountAccount, self).load(fields, data)
  File "odoo/models.py", line 1274, in load
    for id, xid, record, info in converted:
  File "odoo/models.py", line 1417, in _convert_records
    for record, extras in stream:
  File "odoo/tools/misc.py", line 889, in next
    val = next(self.stream, _ph)
  File "odoo/models.py", line 1346, in _extract_records
    while index < len(data) and index < limit:
```


when the user tries to remove the Batch Limit value and test the import file
The type error will occur because getting a string value instead of an integer

Which leads to the traceback from here
https://github.com/odoo/odoo/blob/2c40a55232fb501dd70b64f7ddbdc4244f365139/addons/base_import/static/src/import_data_sidepanel/import_data_sidepanel.js#L34-L36

After applying this commit will resolve the issue of getting an int value instead of a string

sentry-4708871473




