### PR TITLE
[FIX] point_of_sale: leftpane overflow on small devices

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -3,7 +3,7 @@
     <t t-name="point_of_sale.ProductScreen">
         <div class="product-screen d-flex h-100 bg-100" t-att-class="{ 'd-none': !props.isShown }">
             <div t-if="!ui.isSmall || pos.mobile_pane === 'left'"
-                t-att-class="{'flex-grow-1': ui.isSmall}"
+                t-att-class="{'flex-grow-1 mw-100': ui.isSmall}"
                 class="leftpane d-flex flex-column border-end bg-200" >
                 <OrderWidget lines="currentOrder.orderlines" t-slot-scope="scope"
                     total="env.utils.formatCurrency(currentOrder.get_total_with_tax())"


### PR DESCRIPTION
This commit fixes an issue introduced by commit[1]. Commit[1] aimed to fix an overflow issue related to long customer name, but while fixing an issue, it introduced a new one, on small devices.

To fix the downside of this commit, we add a `mw-100` on the left panel only when the UI is small, ensuring we have no overflow issue.

Commit[1]: 9f5609fd705f335926a73526aee4cbb880edad55
