### PR TITLE
[FIX] mail: remove unused fields from message formatting

### DIFF
--- a/addons/im_livechat/models/mail_message.py
+++ b/addons/im_livechat/models/mail_message.py
@@ -15,7 +15,7 @@ class MailMessage(models.Model):
         for vals in vals_list:
             message_sudo = self.browse(vals['id']).sudo().with_prefetch(self.ids)
             if message_sudo.model == 'mail.channel' and self.env['mail.channel'].browse(message_sudo.res_id).channel_type == 'livechat':
-                vals.pop('email_from')
+                vals.pop('email_from', None)
                 if message_sudo.author_id.user_livechat_username:
                     vals['author_id'] = (message_sudo.author_id.id, message_sudo.author_id.user_livechat_username, message_sudo.author_id.user_livechat_username)
         return vals_list

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -119,7 +119,7 @@ class Message(models.Model):
         index=True, ondelete='set null')
     is_internal = fields.Boolean('Employee Only', help='Hide to public / portal users, independently from subtype configuration.')
     # origin
-    email_from = fields.Char('From', help="Email address of the sender. This field is set when no matching partner is found and replaces the author_id field in the chatter.")
+    email_from = fields.Char('From', help="Email address of the sender. This field is set when no matching partner is found and replaces the author_id field in the chatter.", groups="base.group_user")
     author_id = fields.Many2one(
         'res.partner', 'Author', index=True, ondelete='set null',
         help="Author of the message. If not set, email_from may hold an email address that did not match any partner.")
@@ -826,6 +826,9 @@ class Message(models.Model):
     def _message_format(self, fnames, format_reply=True):
         """Reads values from messages and formats them for the web client."""
         self.check_access_rule('read')
+
+        if 'email_from' in fnames and not self.env.user.has_group('base.group_user'):
+            fnames.remove('email_from')
         vals_list = self._read_format(fnames)
 
         thread_ids_by_model_name = defaultdict(set)


### PR DESCRIPTION
Purpose
=======
Some fields are never used in the portal views, and so are useless to return in format methods for the portal users.

Task-3586524