### PR TITLE
[IMP] mail: no preview if already being deleted

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -912,7 +912,7 @@ class Message(models.Model):
                 'notifications': message_sudo.notification_ids._filtered_for_web_client()._notification_format(),
                 'attachment_ids': sorted(message_sudo.attachment_ids._attachment_format(), key=lambda a: a["id"]),
                 'trackingValues': allowed_tracking_ids._tracking_value_format(),
-                'linkPreviews': message_sudo.link_preview_ids._link_preview_format(),
+                'linkPreviews': message_sudo.link_preview_ids.filtered(lambda preview: preview.active)._link_preview_format(),
                 'messageReactionGroups': reaction_groups,
                 'pinned_at': message_sudo.pinned_at,
                 'record_name': record_name,

--- a/addons/mail/tests/test_link_preview.py
+++ b/addons/mail/tests/test_link_preview.py
@@ -74,6 +74,7 @@ class TestLinkPreview(MailCommon):
                     'payload': {
                         'LinkPreview': [{
                             'id': link_preview.id,
+                            'active': True,
                             'message': {'id': message.id},
                             'image_mimetype': False,
                             'og_description': 'Test description',


### PR DESCRIPTION
When deleting the preview and then editing the log note once again, the preview should not shown again.

This commit is adding an extra field `active` in the `mail.link.preview` and when deleting the record, the record will be deactivated rather than being deleted the URL will be hashed and all the other information will be set to null.
When creating the 'mail.link.preview', the URL will be checked to see if it matches one of the deleted records, if it is, it will be ignored to be created.

task-3629586

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
