### PR TITLE
[FIX] im_livechat: allowed user to close chat when user deleted channel

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -283,5 +283,6 @@ class LivechatController(http.Controller):
         domain = [("channel_id", "=", channel_sudo.id), ("is_self", "=", True)]
         member = request.env["discuss.channel.member"].search(domain)
         # sudo: discuss.channel.rtc.session - member of current user can leave call
-        member.sudo()._rtc_leave_call()
+        if member:
+            member.sudo()._rtc_leave_call()
         channel_sudo._close_livechat_session()


### PR DESCRIPTION
When user tries to close chat window  when current channels/members
 are deleted.

Steps to reproduce error:
- Activate 'im_livechat' and 'website' module
- Open the 'website' module and clicked Contact us menu
- Open chat-bot and start conversation
- Duplicate the tab and Go to the Settings>Technical>Channels/Members in second tab
- Delete the current channels/members from second tab
- Go to the first tab and close chat window
- Error will be generated

sentry traceback-

```ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5830, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: discuss.channel.member()
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/mail/models/discuss/mail_guest.py", line 40, in wrapper
    return func(self, *args, **kwargs)
  File "addons/im_livechat/controllers/main.py", line 286, in visitor_leave_session
    member.sudo()._rtc_leave_call()
  File "addons/mail/models/discuss/discuss_channel_member.py", line 297, in _rtc_leave_call
    self.ensure_one()
  File "odoo/models.py", line 5833, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```

Here at [1] member got empty value when current channels/members  are deleted from  'discuss.channel.member' model by user.

This commit resolved the above issue by calling  '_rtc_leave_call()' method when a member is available.

[1]-https://github.com/odoo/odoo/blob/952ebac37dc65b3fd62ae211cee1fd45fa63cd47/addons/im_livechat/controllers/main.py#L284-L286

sentry-4719812967






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
