### PR TITLE
[FIX] web: display last day of allday event in day view calendar

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -138,7 +138,7 @@ export class CalendarCommonRenderer extends Component {
             title: record.title,
             start: record.start.toISO(),
             end:
-                ["week", "month"].includes(this.props.model.scale) && record.isAllDay
+                ["week", "month", "day"].includes(this.props.model.scale) && record.isAllDay
                     ? record.end.plus({ days: 1 }).toISO()
                     : record.end.toISO(),
             allDay: record.isAllDay,

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -5003,4 +5003,44 @@ QUnit.module("Views", ({ beforeEach }) => {
             assert.containsOnce(target, ".o_view_sample_data", "should have sample data");
         }
     );
+
+    QUnit.test("Display last day of allday event in day mode", async (assert) => {
+        serverData.models.event.records = [
+            {
+                id: 1,
+                user_id: uid,
+                partner_id: 1,
+                name: "allday",
+                start: "2016-12-12 15:55:05",
+                stop: "2016-12-13 18:55:05",
+                allday: true,
+                partner_ids: [1],
+                type: 2,
+                is_hatched: false,
+                is_striked: false,
+            },
+        ];
+        await makeView({
+            type: "calendar",
+            resModel: "event",
+            serverData,
+            arch: `
+                <calendar date_start="start" date_stop="stop" all_day="allday" mode="day" color="partner_id"/>
+            `,
+        });
+
+        await click(target, ".scale_button_selection");
+        await click(target, ".o_calendar_button_day");
+        assert.strictEqual(
+            target.querySelector(".fc-day-grid .o_event_title").textContent,
+            "allday",
+            "We should have an all day event in the first day."
+        );
+        await click(target, ".o_calendar_button_next");
+        assert.strictEqual(
+            target.querySelector(".fc-day-grid .o_event_title").textContent,
+            "allday",
+            "We should have an all day event in the second day."
+        );
+    });
 });


### PR DESCRIPTION
Issue:
======
Last day of an allday event doesn't appear in day view in calendar.

Steps to reproduce the issue:
=============================
- Create and allday event for 2 days in calendar
- Switch the view to day view and go the second day of the event
- The event will not appear

Origin of the issue:
====================
The error happens in calculating the intersection of the allday event and the last day in
https://github.com/odoo/odoo/blob/ab049b9a8e433c41028d3b6da94e4eca6fe2ea19/addons/web/static/lib/fullcalendar/core/main.js#L1471, in the last day we have our range is (2023/12/18 00:00:00, 2023/12/18 00:00:00) so the intersection will give us a range with start=end which will return null.

Note: Even fixing this with <= isn't enough since calculating the lastIndex in `DaySeries.prototype.sliceRange` will give -1 for the last day so it will need more changes.

opw-3624463