### PR TITLE
[FIX] stock: din A/B paper format

### DIFF
--- a/addons/stock/report/report_location_barcode.xml
+++ b/addons/stock/report/report_location_barcode.xml
@@ -35,6 +35,7 @@
 
 <template id="report_location_barcode">
     <t t-set="title">Locations</t>
+    <t t-set="data_report_dpi">96</t>
     <t t-call="stock.report_generic_barcode"/>
 </template>
 </data>

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -164,6 +164,7 @@
         </template>
         <template id="report_picking_type_label">
             <t t-set="title">Operation Types</t>
+            <t t-set="data_report_dpi">96</t>
             <t t-call="stock.report_generic_barcode"/>
         </template>
     </data>


### PR DESCRIPTION
Steps to reproduce:
- Install l10n_de and Barcode
- Go to default company (San Francisco)
- Change default paper format to External Layout Din 5008 Type A or B
- Print Barcode commands

Bug:
Inventory Commands prints off the screen

Fix:
hardcode DPI value similar to other paperformats on that report

opw-3452344
