### PR TITLE
[IMP] web: give server error time & host on error messages

### DIFF
--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -19,6 +19,8 @@ export const standardErrorDialogProps = {
     subType: { type: [String, { value: null }], optional: true },
     code: { type: [Number, String, { value: null }], optional: true },
     type: { type: [String, { value: null }], optional: true },
+    serverHost: { type: [String, { value: null }], optional: true },
+    date: { type: [Date, { value: null }], optional: true },
     close: Function, // prop added by the Dialog service
 };
 

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -55,6 +55,10 @@
          <div role="alert">
           <p class="text-prewrap">
             <p><b>An error occurred</b></p>
+            <p>
+              <div t-if="props.serverHost">Server URL: <t t-esc="props.serverHost"/></div>
+              <div t-if="props.date and props.date.getTime()">Time: <t t-esc="props.date.toISOString().split('.')[0].replace('T', ' ')"/> UTC</div>
+            </p>
             <p>Please use the copy button to report the error to your support service.</p>
           </p>
 

--- a/addons/web/static/src/core/errors/error_handlers.js
+++ b/addons/web/static/src/core/errors/error_handlers.js
@@ -62,7 +62,6 @@ export function rpcErrorHandler(env, error, originalError) {
                 ErrorComponent = errorDialogRegistry.get(exceptionClass);
             }
         }
-
         env.services.dialog.add(ErrorComponent || RPCErrorDialog, {
             traceback: error.traceback,
             message: originalError.message,
@@ -72,6 +71,8 @@ export function rpcErrorHandler(env, error, originalError) {
             subType: originalError.subType,
             code: originalError.code,
             type: originalError.type,
+            date: originalError.date,
+            serverHost: error.event.target?.location.host,
         });
         return true;
     }

--- a/addons/web/static/tests/core/errors/error_dialogs_tests.js
+++ b/addons/web/static/tests/core/errors/error_dialogs_tests.js
@@ -60,6 +60,8 @@ QUnit.test("ErrorDialog with traceback", async (assert) => {
         [...target.querySelector("main p").childNodes].map((el) => el.textContent),
         [
             "An error occurred",
+            "",
+            "",
             "Please use the copy button to report the error to your support service.",
         ]
     );
@@ -114,6 +116,8 @@ QUnit.test("Client ErrorDialog with traceback", async (assert) => {
         [...target.querySelector("main p").childNodes].map((el) => el.textContent),
         [
             "An error occurred",
+            "",
+            "",
             "Please use the copy button to report the error to your support service.",
         ]
     );

--- a/addons/web/static/tests/core/errors/error_service_tests.js
+++ b/addons/web/static/tests/core/errors/error_service_tests.js
@@ -87,6 +87,7 @@ QUnit.test("handle RPC_ERROR of type='server' and no associated dialog class", a
     error.message = "Some strange error occured";
     error.data = { debug: "somewhere" };
     error.subType = "strange_error";
+    error.date = new Date('Fri, 05 Jan 2024 08:34:56 GMT');
     function addDialog(dialogClass, props) {
         assert.strictEqual(dialogClass, RPCErrorDialog);
         assert.deepEqual(props, {
@@ -100,6 +101,8 @@ QUnit.test("handle RPC_ERROR of type='server' and no associated dialog class", a
             message: "Some strange error occured",
             exceptionName: null,
             traceback: error.stack,
+            date: new Date('Fri, 05 Jan 2024 08:34:56 GMT'),
+            serverHost: undefined,
         });
     }
     serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
@@ -129,6 +132,7 @@ QUnit.test(
             name: "strange_error",
         };
         error.data = errorData;
+        error.date = new Date('Fri, 05 Jan 2024 12:34:56 GMT');
         function addDialog(dialogClass, props) {
             assert.strictEqual(dialogClass, CustomDialog);
             assert.deepEqual(props, {
@@ -140,6 +144,8 @@ QUnit.test(
                 message: "Some strange error occured",
                 exceptionName: null,
                 traceback: error.stack,
+                date: new Date('Fri, 05 Jan 2024 12:34:56 GMT'),
+                serverHost: undefined,
             });
         }
         serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });
@@ -174,6 +180,7 @@ QUnit.test(
         };
         error.exceptionName = "normal_error";
         error.data = errorData;
+        error.date = new Date('Fri, 05 Jan 2024 15:34:56 GMT');
         function addDialog(dialogClass, props) {
             assert.strictEqual(dialogClass, NormalDialog);
             assert.deepEqual(props, {
@@ -185,6 +192,8 @@ QUnit.test(
                 message: "A normal error occured",
                 exceptionName: "normal_error",
                 traceback: error.stack,
+                date: new Date('Fri, 05 Jan 2024 15:34:56 GMT'),
+                serverHost: undefined,
             });
         }
         serviceRegistry.add("dialog", makeFakeDialogService(addDialog), { force: true });


### PR DESCRIPTION
Some Odoo users take screenshots of the error message that they send to the support. This is generally a waste of time as we can not infer any information from it.
By showing the time, we can then search in the logs at that time to have more details.

Before:
![image](https://github.com/odoo/odoo/assets/60775325/40464a2c-3c72-4eec-9881-d75d0fdc31b7)

After:
![image](https://github.com/odoo/odoo/assets/60775325/63409084-23f1-4464-96d7-d1d0a145e13d)

Notes:
 - The time may differ from the time in the logs as it is calculated on a different time.

task-3672805

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
