### PR TITLE
[FIX] hr_holidays: fix layout of the form view

### DIFF
--- a/addons/hr_holidays/static/src/scss/time_off.scss
+++ b/addons/hr_holidays/static/src/scss/time_off.scss
@@ -46,5 +46,11 @@
         .o_leave_stats {
             margin-bottom: 16px;
         }
+        .o_time_off_attachments {
+            .o_attachment {
+                width: 350px;
+                padding-left: 0;
+            }
+        }
     }
 }

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -335,7 +335,7 @@
                             <field name="user_id" invisible="1" />
                             <field name="leave_type_support_document" invisible="1" />
                             <label for="supported_attachment_ids" string="Supporting Document" attrs="{'invisible': ['|', ('leave_type_support_document', '=', False), ('state', 'not in', ('draft', 'confirm', 'validate1'))]}" />
-                            <field name="supported_attachment_ids" widget="many2many_binary" nolabel="1" attrs="{'invisible': ['|', ('leave_type_support_document', '=', False), ('state', 'not in', ('draft', 'confirm', 'validate1'))]}" />
+                            <field name="supported_attachment_ids" widget="many2many_binary" class="o_time_off_attachments" nolabel="1" attrs="{'invisible': ['|', ('leave_type_support_document', '=', False), ('state', 'not in', ('draft', 'confirm', 'validate1'))]}" />
                         </group>
                     </div>
                 </div>


### PR DESCRIPTION
Before this commit, the form view got messed up while attaching the file with the long name.

In this commit, the width of the attached file has been adjusted to a fixed-size

**NOTE**-We get references from social media apps.

task-3613301