### PR TITLE
[FIX] purchase_stock: replenish default route causing onchange recursion

### DIFF
--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -28,6 +28,13 @@ class ProductReplenish(models.TransientModel):
                 res['supplier_id'] = orderpoint.supplier_id.id
             elif product_tmpl_id.seller_ids:
                 res['supplier_id'] = product_tmpl_id.seller_ids[0].id
+
+            buy_route_ref = self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False)
+            if buy_route_ref and res.get("route_id") == buy_route_ref.id and not product_id.product_tmpl_id.seller_ids:
+                # Do not set the buy route as default when the vendors are not configured.
+                # Otherwise, a warning is shown as soon as the wizard is displayed, which is not supported by the frontend.
+                res["route_id"] = False
+
         return res
 
     @api.depends('route_id', 'supplier_id')


### PR DESCRIPTION
## Steps to reproduce:
1. Install `purchase_stock`
2. Create a new product
3. Click on Replenish
4. `onchange` is called *ad vitam aeternam*

## Before this commit:
When the wizard is rendered, a first `onchange` is triggered. However, the `onchange` returns a warning, triggering a re-render of the wizard, but the latter has not yet finished rendering, causing an infinite `onchange` loop.
Note that it's a current limitation:
> We don't support a dialog warning being returned on the first
> onChange. So in the case of wizards, we can't do it.

## After this commit:
Do not set the default `route_id` to the buy route when there are no vendors on the product. This way, the warning is not displayed during the wizard's rendering.

opw-3641315