### PR TITLE
[FIX] stock: support no rules for the product

### DIFF
--- a/addons/stock/tests/test_replenish.py
+++ b/addons/stock/tests/test_replenish.py
@@ -66,3 +66,12 @@ class TestStockReplenish(TestStockCommon):
             self.assertEqual(fields.Datetime.from_string('2023-01-01 00:00:00'), wizard._values['date_planned'])
             wizard.route_id = route_delay
             self.assertEqual(fields.Datetime.from_string('2023-01-07 00:00:00'), wizard._values['date_planned'])
+
+    def test_replenish_no_routes(self):
+        product = self.env['product.template'].create({
+            'name': 'Brand new product',
+            'type': 'product',
+        })
+        self.assertEqual(len(product.route_ids), 0)
+        wizard = Form(self.env['product.replenish'].with_context(default_product_tmpl_id=product.id))
+        self.assertEqual(wizard._values['quantity'], 1)

--- a/addons/stock/wizard/product_replenish.py
+++ b/addons/stock/wizard/product_replenish.py
@@ -85,7 +85,8 @@ class ProductReplenish(models.TransientModel):
         if 'route_id' in fields and 'route_id' not in res and product_tmpl_id:
             res['route_id'] = self.env['stock.route'].search(self._get_route_domain(product_tmpl_id), limit=1).id
             if not res['route_id']:
-                res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
+                if product_tmpl_id.route_ids:
+                    res['route_id'] = product_tmpl_id.route_ids.filtered(lambda r: r.company_id == self.env.company or not r.company_id)[0].id
         return res
 
     def _get_date_planned(self, route_id, **kwargs):


### PR DESCRIPTION
Currently traceback appears if no rules are available on the product.
(Steps to reproduce: install sale and stock, but not purchase, go to the product and click "Replenish")
Index is out of range because route_ids is an empty list.
This fix will allow route_ids to be empty.

Description of the issue/feature this PR addresses:
Empty list of rules creates a situation where index becomes out of range in a wizard

Current behavior before PR:
Traceback appears when no rules are available

Desired behavior after PR is merged:
No traceback appears

opw-3637054



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
