### PR TITLE
[FIX] mail: placement of the attachment action button distorted on small size

### DIFF
--- a/addons/mail/controllers/attachment.py
+++ b/addons/mail/controllers/attachment.py
@@ -34,6 +34,11 @@ class AttachmentController(http.Controller):
             attachment = env["ir.attachment"].create(vals)
             attachment._post_add_create()
             attachmentData = {
+                "author": {
+                    "id": attachment.create_uid.id,
+                    "name": attachment.create_uid.name,
+                    "partnerId": attachment.create_uid.partner_id.id,
+                },
                 "filename": ufile.filename,
                 "id": attachment.id,
                 "mimetype": attachment.mimetype,

--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -76,6 +76,11 @@ class IrAttachment(models.Model):
         safari = request and request.httprequest.user_agent and request.httprequest.user_agent.browser == 'safari'
         return [
             {
+                'author': {
+                    'id': attachment.create_uid.id,
+                    'name': attachment.create_uid.name,
+                    'partnerId': attachment.create_uid.partner_id.id,
+                },
                 'checksum': attachment.checksum,
                 'id': attachment.id,
                 'filename': attachment.name,

--- a/addons/mail/static/src/attachments/attachment_list.js
+++ b/addons/mail/static/src/attachments/attachment_list.js
@@ -28,6 +28,13 @@ export class AttachmentList extends Component {
         this.attachmentViewer = useAttachmentViewer();
     }
 
+    onImageLoaded({ ev, attachment }) {
+        const image = ev.target;
+        if (image) {
+            attachment.isSmallImg = image.height <= 30;
+        }
+    }
+
     /**
      * @return {import("@mail/attachments/attachment_model").Attachment[]}
      */

--- a/addons/mail/static/src/attachments/attachment_list.scss
+++ b/addons/mail/static/src/attachments/attachment_list.scss
@@ -33,6 +33,10 @@
     }
 }
 
+.o-mail-AttachmentImage-actions{
+    z-index: 1;
+}
+
 .o-viewable {
     cursor: zoom-in;
 }

--- a/addons/mail/static/src/attachments/attachment_list.xml
+++ b/addons/mail/static/src/attachments/attachment_list.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="mail.AttachmentList" owl="1">
-        <div class="o-mail-AttachmentList overflow-y-auto d-flex flex-column mt-1"
+        <div class="o-mail-AttachmentList d-flex flex-column mt-1"
             t-att-class="{
                 'o-inComposer': env.inComposer,
                 'o-inChatWindow': env.inChatWindow,
@@ -12,7 +12,7 @@
         >
             <div class="d-flex flex-grow-1 flex-wrap mx-1" role="menu">
                 <div t-foreach="imagesAttachments" t-as="attachment" t-key="attachment.id" t-att-aria-label="attachment.filename"
-                    class="o-mail-AttachmentImage d-flex position-relative flex-shrink-0 mw-100 mb-1 me-1"
+                    class="o-mail-AttachmentImage mw-100 mb-1 me-1"
                     t-att-title="attachment.name"
                     t-att-class="{ 'o-isUploading': attachment.uploading }"
                     tabindex="0"
@@ -21,24 +21,33 @@
                     t-att-data-mimetype="attachment.mimetype"
                     t-on-click="() => this.attachmentViewer.open(attachment, props.attachments)"
                 >
-                    <img
-                        class="img img-fluid my-0 mx-auto o-viewable"
-                        t-att-class="{ 'opacity-25': attachment.uploading }"
-                        t-att-src="getImageUrl(attachment)"
-                        t-att-alt="attachment.name"
-                        t-attf-style="max-width: min(100%, {{ imagesWidth }}px); max-height: {{ props.imagesHeight }}px;"
-                    />
-                    <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
-                        <i class="fa fa-spin fa-spinner"/>
-                    </div>
-                    <div class="position-absolute top-0 bottom-0 start-0 end-0 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flax-wrap flex-column">
-                        <div t-if="attachment.isDeletable"
-                            class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
-                            tabindex="0" aria-label="Remove" role="menuitem" t-on-click.stop="() => this.onClickUnlink(attachment)" title="Remove">
-                            <i class="fa fa-trash"/>
+                    <div class="d-flex position-relative flex-shrink-0">
+                        <img
+                            class="img img-fluid my-0 mx-auto o-viewable"
+                            t-att-class="{ 'opacity-25': attachment.uploading }"
+                            t-att-src="getImageUrl(attachment)"
+                            t-att-alt="attachment.name"
+                            t-attf-style="max-width: min(100%, {{ imagesWidth }}px); max-height: {{ props.imagesHeight }}px;"
+                            t-on-load="(ev) => this.onImageLoaded({ ev, attachment })"
+                        />
+                        <div t-if="attachment.uploading" class="position-absolute top-0 bottom-0 start-0 end-0 d-flex align-items-center justify-content-center" title="Uploading">
+                            <i class="fa fa-spin fa-spinner"/>
                         </div>
-                        <div t-if="canDownload(attachment)" class="btn btn-sm btn-dark rounded opacity-75 opacity-100-hover mt-auto" t-on-click.stop="() => this.onClickDownload(attachment)" title="Download">
-                            <i class="fa fa-download"/>
+                        <div t-if="!attachment.isSmallImg" class="position-absolute top-0 bottom-0 start-0 end-0 ms-3 p-2 text-white opacity-0 opacity-100-hover d-flex align-items-end flex-wrap flex-column justify-content-end">
+                            <div t-if="canDownload(attachment)"
+                                class="o-mail-AttachmentImage-actions btn btn-sm btn-dark rounded opacity-75 opacity-100-hover"
+                                t-on-click.stop="() => this.onClickDownload(attachment)"
+                                title="Download"
+                            >
+                                <i class="fa fa-download"/>
+                            </div>
+                            <div t-if="attachment.isDeletable"
+                                class="o-mail-AttachmentImage-actions btn btn-sm btn-dark rounded opacity-75 ms-1 opacity-100-hover mt-auto"
+                                t-on-click.stop="() => this.onClickUnlink(attachment)"
+                                title="Remove"
+                            >
+                                <i class="fa fa-trash"/>
+                            </div>
                         </div>
                     </div>
                 </div>

--- a/addons/mail/static/src/attachments/attachment_model.js
+++ b/addons/mail/static/src/attachments/attachment_model.js
@@ -8,6 +8,7 @@ export class Attachment extends Record {
     /** @type {import("@mail/core/store_service").Store} */
     _store;
     accessToken;
+    author;
     checksum;
     extension;
     filename;
@@ -24,13 +25,26 @@ export class Attachment extends Record {
     uploading;
     /** @type {import("@mail/core/message_model").Message} */
     message;
+    /** @type {string} */
+    isSmallImg;
 
     /** @type {import("@mail/core/thread_model").Thread} */
     get originThread() {
         return this._store.threads[this.originThreadLocalId];
     }
 
+    get inChatter() {
+        return this.originThread?.type === "chatter";
+    }
+
     get isDeletable() {
+        if (this.inChatter) {
+            if (this._store.user?.isAdmin) {
+                return true;
+            } else if (this.author?.partnerId !== this._store.user.id) {
+                return false;
+            }
+        }
         if (this.message && this.originThread?.model === "discuss.channel") {
             return this.message.editable;
         }

--- a/addons/mail/static/src/attachments/attachment_service.js
+++ b/addons/mail/static/src/attachments/attachment_service.js
@@ -29,6 +29,7 @@ export class AttachmentService {
 
     update(attachment, data) {
         assignDefined(attachment, data, [
+            "author",
             "checksum",
             "filename",
             "mimetype",

--- a/addons/mail/static/src/attachments/attachment_viewer.js
+++ b/addons/mail/static/src/attachments/attachment_viewer.js
@@ -1,7 +1,7 @@
 /* @odoo-module */
 
 import { Component, useRef, useState } from "@odoo/owl";
-import { useAutofocus } from "@web/core/utils/hooks";
+import { useAutofocus, useService } from "@web/core/utils/hooks";
 
 /**
  * @typedef {Object} Props
@@ -20,6 +20,7 @@ export class AttachmentViewer extends Component {
         useAutofocus();
         this.imageRef = useRef("image");
         this.zoomerRef = useRef("zoomer");
+        this.attachmentService = useService("mail.attachment");
 
         this.isDragging = false;
         this.dragStartX = 0;
@@ -233,5 +234,10 @@ export class AttachmentViewer extends Component {
                     </body>
                 </html>`);
         printWindow.document.close();
+    }
+
+    onDeleteAttachement() {
+        this.attachmentService.delete(this.state.attachment);
+        this.props.close();
     }
 }

--- a/addons/mail/static/src/attachments/attachment_viewer.xml
+++ b/addons/mail/static/src/attachments/attachment_viewer.xml
@@ -21,6 +21,12 @@
                             <span>Download</span>
                         </a>
                     </div>
+                    <div t-if="this.state.attachment.isDeletable" class="o-mail-AttachmentViewer-delete o-mail-AttachmentViewer-headerButton d-flex align-items-center px-3 cursor-pointer" role="button" title="Delete">
+                        <a class="text-reset" t-on-click="() => this.onDeleteAttachement()">
+                            <i class="fa fa-trash fa-fw" role="img"/>
+                            <span>Delete</span>
+                        </a>
+                    </div>
 
                     <div t-on-click.stop="close" class="o-mail-AttachmentViewer-headerButton d-flex align-items-center mb-0 px-3 h4 text-reset cursor-pointer" role="button" title="Close (Esc)" aria-label="Close">
                         <i class="fa fa-fw fa-times" role="img"/>

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -1247,7 +1247,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
         """
         messages_all = self.messages_all.with_env(self.env)
 
-        with self.assertQueryCount(employee=24):  # test_mail: 24
+        with self.assertQueryCount(employee=26):  # test_mail: 26
             res = messages_all.message_format()
 
         self.assertEqual(len(res), 2*2)
@@ -1260,7 +1260,7 @@ class TestMailComplexPerformance(BaseMailPerformance):
     def test_message_format_single(self):
         message = self.messages_all[0].with_env(self.env)
 
-        with self.assertQueryCount(employee=21):  # test_mail: 21
+        with self.assertQueryCount(employee=23):  # test_mail: 23
             res = message.message_format()
 
         self.assertEqual(len(res), 1)


### PR DESCRIPTION
**Before this PR:**
When the attachment size was too small, the download and delete buttons on the
image overlay were incorrectly positioned, leading to a less user-friendly experience.

**Aftert this PR:**
The delete and download button is available only when the image is zommed in.

task-3563828