### PR TITLE
[FIX] website_form: fix form for default email

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -216,7 +216,7 @@ def add_form_signature(html_fragment, env_sudo):
         # the value of email_to can still be None in case of default value
         if 'email_to' not in form_values:
             continue
-        elif not form_values['email_to'].attrib.get('value'):
+        elif form_values['email_to'].attrib.get('value', '') in ('', 'info@yourcompany.example.com'):
             form_values['email_to'].attrib['value'] = env_sudo.company.email or ''
         has_cc = {'email_cc', 'email_bcc'} & form_values.keys()
         value = form_values['email_to'].attrib['value'] + (':email_cc' if has_cc else '')


### PR DESCRIPTION
Steps to reproduce:
- Make a new 15.0 instance with website installed
- change the email_to of the contact form to "info@yourcompany.example.com"
- reload and fill in the form
- invalide signature error

Why?:

There is this line in the js side :
https://github.com/odoo/odoo/blob/67d975b94b8080cd895c90d86005bac0d75f2a95/addons/website/static/src/snippets/s_website_form/000.js#L170 It will replace the email_to if empty or exactly equal to "info@yourcompany.example.com" The python side of the signature computation did not take into account the possibility of having directy "info@yourcompany.example.com" replaced from the js side.

This commit replicate the js behaviour in the python side.
