### PR TITLE
[FIX] stock: escape single quote in translation

### DIFF
--- a/addons/stock/i18n/fr.po
+++ b/addons/stock/i18n/fr.po
@@ -179,7 +179,7 @@ msgstr "'Numéro de Lot - %s' % object.name"
 #. module: stock
 #: model:ir.actions.report,print_report_name:stock.action_report_picking_type_label
 msgid "'Operation-type - %s' % object.name"
-msgstr "'Type d'opération - %s' % object.name"
+msgstr "'Type d\'opération - %s' % object.name"
 
 #. module: stock
 #: model:ir.actions.report,print_report_name:stock.action_report_picking


### PR DESCRIPTION
Issue:
When printing type of operation in french we need to escape single quote to prevent syntax error

Steps to reproduce:
1- install inventory app
2- change language to french
3- go to settings
4- click operation types
5- choose one of the operation types
6- click print

Solution:
Addin backslash before the single quote in the translation will escape the single quote and prevent the runtime syntax error

opw-3630792

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
