### PR TITLE
[FIX] web: fix `archParseBoolean` for str ending w/ 0

### DIFF
--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -67,7 +67,7 @@ export function addFieldDependencies(activeFields, fields, dependencies = {}) {
  * @returns {boolean}
  */
 export function archParseBoolean(str, trueIfEmpty = false) {
-    return str ? !/^false|0$/i.test(str) : trueIfEmpty;
+    return str ? !/^(false|0)$/i.test(str) : trueIfEmpty;
 }
 
 /**

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser_tests.js
@@ -92,7 +92,14 @@ QUnit.test("hasQuickCreate", (assert) => {
     check(assert, "quick_add", "true", "hasQuickCreate", true);
     check(assert, "quick_add", "True", "hasQuickCreate", true);
     check(assert, "quick_add", "1", "hasQuickCreate", true);
+    check(assert, "quick_add", "10", "hasQuickCreate", true);
+    check(assert, "quick_add", "00", "hasQuickCreate", true);
+    check(assert, "quick_add", "7923640", "hasQuickCreate", true);
+    check(assert, "quick_add", "7923641", "hasQuickCreate", true);
+    check(assert, "quick_add", "fals0", "hasQuickCreate", true);
+    check(assert, "quick_add", "falseButTrue", "hasQuickCreate", true);
     check(assert, "quick_add", "false", "hasQuickCreate", false);
+    check(assert, "quick_add", "fALse", "hasQuickCreate", false);
     check(assert, "quick_add", "False", "hasQuickCreate", false);
     check(assert, "quick_add", "0", "hasQuickCreate", false);
 });


### PR DESCRIPTION
__Expected behavior:__
The `archParseBoolean` function is meant to return `true` for any value
of `str` except `"false"` (case insensitive) and `"0"`. 

__Current behavior:__
The current regex is equivalent to `/(^false)|(0$)/i`. Therefore the 
function returns `false` for any string that ends with `"0"`.

Since `quick_add` represents a view id, the calendar quick create view
doesn't show up if its id ends with `"0"`.

opw-3632007