### PR TITLE
[FIX] account: credit note created in parent company

### DIFF
--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -72,7 +72,9 @@ class AccountMoveReversal(models.TransientModel):
         if any(move.state != "posted" for move in move_ids):
             raise UserError(_('You can only reverse posted moves.'))
         if 'company_id' in fields:
-            res['company_id'] = move_ids.company_id.root_id.id or self.env.company.id
+            if len(move_ids.company_id) > 1:
+                raise UserError(_("You can't create a credit note for entries belonging to different companies."))
+            res['company_id'] = move_ids.company_id.id or self.env.company.id
         if 'move_ids' in fields:
             res['move_ids'] = [(6, 0, move_ids.ids)]
         return res


### PR DESCRIPTION
The issue:
having 2 companies, PARENT and CHILD company
activate the CHILD company, create an invoice on a journal related to the CHILD company, confirm it, then create a credit note from that invoice it will throw an access error saying that you are trying to access record of another company and that causes an issue because the journal is linked to the CHILD but the reversal move is linked to the PARENT company

The fix:
assigning the current company id

opw-3631935
opw-3717643
