### PR TITLE
[FIX] tests: avoid error in cascade.

### DIFF
--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -790,23 +790,6 @@ class SingleTransactionCase(BaseCase):
 class ChromeBrowserException(Exception):
     pass
 
-def fmap(future, map_fun):
-    """Maps a future's result through a callback.
-
-    Resolves to the application of ``map_fun`` to the result of ``future``.
-
-    .. warning:: this does *not* recursively resolve futures, if that's what
-                 you need see :func:`fchain`
-    """
-    fmap_future = Future()
-    @future.add_done_callback
-    def _(f):
-        try:
-            fmap_future.set_result(map_fun(f.result()))
-        except Exception as e:
-            fmap_future.set_exception(e)
-    return fmap_future
-
 def fchain(future, next_callback):
     """Chains a future's result to a new future through a callback.
 
@@ -1184,11 +1167,17 @@ class ChromeBrowser:
 
         log_type = type
         _logger = self._logger.getChild('browser')
+        level = self._TO_LEVEL.get(log_type, logging.INFO)
+        if self._result.done() and self.had_failure and level > logging.RUNBOT:
+            message = f'{log_type} message received while result already set:\n {message}'
+            log_type = 'runbot'
+            level = logging.RUNBOT
+
         _logger.log(
-            self._TO_LEVEL.get(log_type, logging.INFO),
+            level,
             "%s%s",
             "Error received after termination: " if self._result.done() else "",
-            message # might still have %<x> characters
+            message, # might still have %<x> characters
         )
 
         if log_type == 'error':
@@ -1196,8 +1185,6 @@ class ChromeBrowser:
             if self._result.done():
                 return
             if not self.error_checker or self.error_checker(message):
-                self.take_screenshot()
-                self._save_screencast()
                 try:
                     self._result.set_exception(ChromeBrowserException(message))
                 except CancelledError:
@@ -1207,6 +1194,8 @@ class ChromeBrowser:
                         "Trying to set result to failed (%s) but found the future settled (%s)",
                         message, self._result
                     )
+                self.take_screenshot()
+                self._save_screencast()
         elif 'test successful' in message:
             if self.test_class.allow_end_on_form:
                 self._result.set_result(True)
@@ -1257,12 +1246,12 @@ which leads to stray network requests and inconsistencies."""
             message += '\n' + stack
 
         if self._result.done():
-            self._logger.getChild('browser').error(
-                "Exception received after termination: %s", message)
+            log = self._logger.getChild('browser').error
+            if self._result._exception or self._result._result:
+                log = self._logger.getChild('browser').runbot
+            log("Exception received after termination: %s", message)
             return
 
-        self.take_screenshot()
-        self._save_screencast()
         try:
             self._result.set_exception(ChromeBrowserException(message))
         except CancelledError:
@@ -1272,6 +1261,9 @@ which leads to stray network requests and inconsistencies."""
                 "Trying to set result to failed (%s) but found the future settled (%s)",
                 message, self._result
             )
+
+        self.take_screenshot()
+        self._save_screencast()
 
     def _handle_frame_stopped_loading(self, frameId):
         wait = self._frames.pop(frameId, None)
@@ -1292,6 +1284,7 @@ which leads to stray network requests and inconsistencies."""
         'debug': logging.DEBUG,
         'log': logging.INFO,
         'info': logging.INFO,
+        'runbot': logging.RUNBOT,
         'warning': logging.WARNING,
         'error': logging.ERROR,
         # TODO: what do with
@@ -1416,11 +1409,14 @@ which leads to stray network requests and inconsistencies."""
             # if the runcode was a promise which took some time to execute,
             # discount that from the timeout
             if self._result.result(time.time() - start + timeout) and not self.had_failure:
-                return
+                return  # successful
         except CancelledError:
             # regular-ish shutdown
             return
         except Exception as e:
+            if not self._result.done():
+                self._result.set_exception(e)
+            self.had_failure = True
             err = e
 
         self.take_screenshot()


### PR DESCRIPTION
In some case a test can fail and create many error log that can generate noise, after the real cause of the error.

As an exemple, if a test timeouts from the python wait_code_ok
- a first log notifies the timeout error. (only interresting info)
- the browser is killed
- the javascript can generate fetch error (logged as error and setting the future)
- a second error following the fetch can be logged
- a warning is logged because of the second log tries to set the future but the future was set by the previous log.
All of that is kind of random because the take screenshot takes time.

A first fix takes the screenshot after the result is set so that the check is `self._result.done()` will avoid to log reach the warning

Another fix modifies the catch of an exception during the wait_code_ok to set the result and set had_failure in case of timeout error.

A last one lowers the level to runbot if an console.error occurs after another error, to avoid being cached by runbot as a build.error Since the main cause is most likedly in the previous logs.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
