### PR TITLE
[IMP] l10n_in: add default to gst_treatment

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -34,7 +34,7 @@ class AccountMove(models.Model):
     @api.depends('partner_id')
     def _compute_l10n_in_gst_treatment(self):
         for record in self:
-            record.l10n_in_gst_treatment = record.partner_id.l10n_in_gst_treatment
+            record.l10n_in_gst_treatment = gst if (gst := record.partner_id.l10n_in_gst_treatment) else 'unregistered'
 
     @api.model
     def _l10n_in_get_indian_state(self, partner):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add a default value for gst_treatment in l10n_in

Current behavior before PR:
OCR digitization fails in India due to a required field not being set

Desired behavior after PR is merged:
Add default to gst_treatment necessary to allow for OCR digitization

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
