### PR TITLE
[FIX] web_editor: run updateCurrentRevision promises concurrently

### DIFF
--- a/addons/web_editor/static/src/components/history_dialog/history_dialog.js
+++ b/addons/web_editor/static/src/components/history_dialog/history_dialog.js
@@ -48,11 +48,14 @@ class HistoryDialog extends Component {
         }
         this.env.services.ui.block();
         this.state.revisionId = revisionId;
-        this.state.revisionContent = await this.getRevisionContent(revisionId);
-        this.state.revisionComparison = await this.getRevisionComparison(
-            revisionId
-        );
-        this.env.services.ui.unblock();
+        try {
+            [this.state.revisionContent, this.state.revisionComparison] = await Promise.all([
+                this.getRevisionContent(revisionId),
+                this.getRevisionComparison(revisionId),
+            ]);
+        } finally {
+            this.env.services.ui.unblock();
+        }
     }
 
     getRevisionComparison = memoize(


### PR DESCRIPTION
Purpose:
--------
Instead of getting the revision content and the revision comparison sequentially, get them concurrently to reduce the loading time.

It also moves the unblocking of the ui inside a "finally" close so that if getting the revision content or comparison somehow fails, the user is not stuck on the history dialog.

Task-3560666