### PR TITLE
[FIX] point_of_sale: display manually change price on orderline

### DIFF
--- a/addons/point_of_sale/static/tests/tours/BarcodeScanning.tour.js
+++ b/addons/point_of_sale/static/tests/tours/BarcodeScanning.tour.js
@@ -26,7 +26,7 @@ registry.category("web_tour.tours").add("BarcodeScanningTour", {
             ProductScreen.scan_ean13_barcode("2305000000004"),
             ProductScreen.selectedOrderlineHas("Magnetic Board", 1, "0.00"),
             ProductScreen.scan_ean13_barcode("2305000123451"),
-            ProductScreen.selectedOrderlineHas("Magnetic Board", 1, "123.45"),
+            ProductScreen.selectedOrderlineHas("Magnetic Board", 2),
 
             // Test "Weighted product" EAN-13 `21.....{NNDDD}` barcode pattern
             ProductScreen.scan_ean13_barcode("2100005000000"),


### PR DESCRIPTION
In this commit:
==================
- If the cashier manually enters the price from the numpad on the order line,
  then the displayed price will be Tax Excluded (maintaining the same behaviour
  as the POS price configuration set to Tax Excluded), regardless of the POS
  price the configuration being in Tax Included.

- If an orderline already has the same product with a manually changed price,
  then quantity of the orderline will increase without creating duplicate
  entries for the same product with different price.

Task - 3599027