### PR TITLE
[FIX] l10n_sa_edi: QR for non-edi invoices

### DIFF
--- a/addons/l10n_sa_edi/models/account_move.py
+++ b/addons/l10n_sa_edi/models/account_move.py
@@ -36,21 +36,22 @@ class AccountMove(models.Model):
                  'l10n_sa_invoice_signature', 'l10n_sa_chain_index')
     def _compute_qr_code_str(self):
         """ Override to update QR code generation in accordance with ZATCA Phase 2"""
-        for move in self:
+        sa_edi_moves = self.filtered(lambda m: m.country_code == 'SA' and m.move_type in ('out_invoice', 'out_refund') and m.l10n_sa_chain_index)
+        for move in sa_edi_moves:
             move.l10n_sa_qr_code_str = ''
-            if move.country_code == 'SA' and move.move_type in ('out_invoice', 'out_refund') and move.l10n_sa_chain_index:
-                edi_format = self.env.ref('l10n_sa_edi.edi_sa_zatca')
-                zatca_document = move.edi_document_ids.filtered(lambda d: d.edi_format_id == edi_format)
-                if move._l10n_sa_is_simplified():
-                    x509_cert = json.loads(move.journal_id.l10n_sa_production_csid_json)['binarySecurityToken']
-                    xml_content = self.env.ref('l10n_sa_edi.edi_sa_zatca')._l10n_sa_generate_zatca_template(move)
-                    qr_code_str = move._l10n_sa_get_qr_code(move.journal_id, xml_content, b64decode(x509_cert), move.l10n_sa_invoice_signature, move._l10n_sa_is_simplified())
-                    move.l10n_sa_qr_code_str = b64encode(qr_code_str).decode()
-                elif zatca_document.state == 'sent' and zatca_document.attachment_id.datas:
-                    document_xml = zatca_document.attachment_id.with_context(bin_size=False).datas.decode()
-                    root = etree.fromstring(b64decode(document_xml))
-                    qr_node = root.xpath('//*[local-name()="ID"][text()="QR"]/following-sibling::*/*')[0]
-                    move.l10n_sa_qr_code_str = qr_node.text
+            edi_format = self.env.ref('l10n_sa_edi.edi_sa_zatca')
+            zatca_document = move.edi_document_ids.filtered(lambda d: d.edi_format_id == edi_format)
+            if move._l10n_sa_is_simplified():
+                x509_cert = json.loads(move.journal_id.l10n_sa_production_csid_json)['binarySecurityToken']
+                xml_content = self.env.ref('l10n_sa_edi.edi_sa_zatca')._l10n_sa_generate_zatca_template(move)
+                qr_code_str = move._l10n_sa_get_qr_code(move.journal_id, xml_content, b64decode(x509_cert), move.l10n_sa_invoice_signature, move._l10n_sa_is_simplified())
+                move.l10n_sa_qr_code_str = b64encode(qr_code_str).decode()
+            elif zatca_document.state == 'sent' and zatca_document.attachment_id.datas:
+                document_xml = zatca_document.attachment_id.with_context(bin_size=False).datas.decode()
+                root = etree.fromstring(b64decode(document_xml))
+                qr_node = root.xpath('//*[local-name()="ID"][text()="QR"]/following-sibling::*/*')[0]
+                move.l10n_sa_qr_code_str = qr_node.text
+        super(AccountMove, self - sa_edi_moves)._compute_qr_code_str()
 
 
     def _l10n_sa_get_qr_code_encoding(self, tag, field, int_length=1):


### PR DESCRIPTION
- Install l10n_sa (only) and switch to company SA company
- Create and confirm an invoice for a customer having the country 'Saudi Arabia'
- Print Report, QR-code prints correctly
- Install 10n_sa_edi
- Re-print the same invoice

Issue: the QR code is no longer available on the report. This occurs because in `l10n_sa_edi` we override the qr compute method and the system do not generate qr for non-edi invoices

opw-3648937

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
