### PR TITLE
[FIX] website: properly filter website.page records on list view

### DIFF
--- a/addons/website/static/src/components/views/page_kanban.js
+++ b/addons/website/static/src/components/views/page_kanban.js
@@ -19,6 +19,7 @@ export class PageKanbanRenderer extends PageRendererMixin(kanbanView.Renderer) {
 PageKanbanRenderer.props = [
     ...kanbanView.Renderer.props,
     "activeWebsite",
+    "firstLoad",
 ];
 PageKanbanRenderer.template = 'website.PageKanbanRenderer';
 

--- a/addons/website/static/src/components/views/page_kanban.xml
+++ b/addons/website/static/src/components/views/page_kanban.xml
@@ -13,6 +13,7 @@
 <t t-name="website.PageKanbanView" t-inherit="web.KanbanView" owl="1">
     <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
         <attribute name="activeWebsite">state.activeWebsite</attribute>
+        <attribute name="firstLoad">state.firstLoad</attribute>
     </xpath>
     <xpath expr="//Layout" position="inside">
         <t t-set-slot="control-panel-website-extra-actions">

--- a/addons/website/static/src/components/views/page_list.js
+++ b/addons/website/static/src/components/views/page_list.js
@@ -4,20 +4,11 @@ import {PageControllerMixin, PageRendererMixin} from "./page_views_mixin";
 import {registry} from '@web/core/registry';
 import {listView} from '@web/views/list/list_view';
 import {ConfirmationDialog} from "@web/core/confirmation_dialog/confirmation_dialog";
-import {useService} from "@web/core/utils/hooks";
 import {sprintf} from "@web/core/utils/strings";
 import {DeletePageDialog} from '@website/components/dialog/page_properties';
 
 
 export class PageListController extends PageControllerMixin(listView.Controller) {
-    /**
-     * @override
-     */
-    setup() {
-        super.setup();
-        this.orm = useService('orm');
-    }
-
     /**
      * @override
      */
@@ -78,6 +69,7 @@ export class PageListRenderer extends PageRendererMixin(listView.Renderer) {}
 PageListRenderer.props = [
     ...listView.Renderer.props,
     "activeWebsite",
+    "firstLoad",
 ];
 PageListRenderer.recordRowTemplate = "website.PageListRenderer.RecordRow";
 

--- a/addons/website/static/src/components/views/page_list.xml
+++ b/addons/website/static/src/components/views/page_list.xml
@@ -15,6 +15,7 @@
 <t t-name="website.PageListView" t-inherit="web.ListView" owl="1">
     <xpath expr="//t[@t-component='props.Renderer']" position="attributes">
         <attribute name="activeWebsite">state.activeWebsite</attribute>
+        <attribute name="firstLoad">state.firstLoad</attribute>
     </xpath>
     <xpath expr="//Layout" position="inside">
         <t t-set-slot="control-panel-website-extra-actions">


### PR DESCRIPTION
Since [commit 1], which adapted the website pages list view to OWL, the
records listed on screen are filtered according to the active website
filter. However, the full list of records is still used behind the
scenes for all potential actions.

Steps to reproduce:
1. Go to the pages list view.
2. Select a specific website (if it's not already the case).
=> The total of records in the upper right corner does not match the
number of pages on that specific website.
3. Click on the "Select all" checkbox.
=> All the pages are selected, including those that do not appear on
screen.

This commit updates the records list and kaban when the activeWebsite
changes. Most of the code related to the pages filtering could be
removed after this, but we decided to keep it on the first loading of
the page to avoid a flickering effect (the model is initialized without
the context of existing websites, so it is updated afterwards).
The total of records in the upper right corner is still updated after
the initial load, but is less visible than the whole table being
rerendered.

[commit 1]: https://github.com/odoo/odoo/commit/940f4ee875332dafa1f379970a7683be6b3ee606

opw-3554064
opw-3658648