### PR TITLE
[FIX] event: don't delete message (only mail) on event registration

### DIFF
--- a/addons/event/models/event_mail.py
+++ b/addons/event/models/event_mail.py
@@ -299,6 +299,7 @@ class EventMailRegistration(models.Model):
 
             email_values = {
                 'author_id': author.id,
+                'is_notification': True,
             }
             if not reg_mail.scheduler_id.template_ref.email_from:
                 email_values['email_from'] = author.email_formatted


### PR DESCRIPTION
Steps to reproduce:

  - Install `Events` module
  - Create an event
  - In communication tab, create a new email template that will be sent a mail immediately after registration
  - Publish the event
  - Create attendee and confirm
  - Go to Settings > Technical > Email > Messages: you should see the message by the registration
  - Go to Settings > Technical > Scheduled Actions: run the action `Mail: Email Queue Manager`
  - Go to Settings > Technical > Email > Messages

Issue:

  The message is deleted.

Cause:

  Sending mail from a template will delete the related message if not
  set as notification.

Solution:

  Set `is_notification` to True on the mail.

opw-3614444