### PR TITLE
[FIX] mail: Incorrect tracking values

### DIFF
--- a/addons/mail/models/mail_tracking_duration_mixin.py
+++ b/addons/mail/models/mail_tracking_duration_mixin.py
@@ -56,6 +56,7 @@ class MailTrackingDurationMixin(models.AbstractModel):
                   AND m.res_id IN %(record_ids)s
              ORDER BY v.id
         """
+        self.env.cr.flush()
         self.env.cr.execute(query, {"field_id": field.id, "model_name": self._name, "record_ids": tuple(self.ids)})
         trackings = self.env.cr.dictfetchall()
 

--- a/addons/mail/static/src/views/fields/statusbar_duration/statusbar_duration_field.js
+++ b/addons/mail/static/src/views/fields/statusbar_duration/statusbar_duration_field.js
@@ -14,7 +14,7 @@ export class StatusBarDurationField extends StatusBarField {
         if (Object.keys(durationTracking).length) {
             for (const item of items) {
                 const duration = durationTracking[item.value];
-                if (duration > 0) {
+                if (duration >= 0) {
                     item.shortTimeInStage = formatDuration(duration, false);
                     item.fullTimeInStage = formatDuration(duration, true);
                 } else {

--- a/addons/mail/tests/mail_tracking_duration_mixin_case.py
+++ b/addons/mail/tests/mail_tracking_duration_mixin_case.py
@@ -195,5 +195,5 @@ class MailTrackingDurationMixinCase(MailCommon):
         self.flush_tracking()
         batch[self.track_duration_field] = self.stage_2.id
 
-        with self.assertQueryCount(2):
+        with self.assertQueryCount(4):
             batch._compute_duration_tracking()


### PR DESCRIPTION
Before this commit user was getting incorrect values in the statusbar when user is changing stage 
from one stage to another. The duration of previous stage is carried forward to the next stage.

Steps to reproduce:
-  ​Open a demo data lead or task and move it to another stage from statusbar in form view.

Observed behavior:
​The tracking values in the statusbar are incorrect.

Expected behavior:
​When moving to a new stage for example, it should not keep the old value.

After this commit user will be able to get correct values in the statusbar when user will change stage 
from one stage to another.

Task-3584456

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
