### PR TITLE
[FIX] website: HTML-escape submitted form fields

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -9,7 +9,7 @@ from werkzeug.exceptions import BadRequest
 
 from odoo import http, SUPERUSER_ID, _, _lt
 from odoo.http import request
-from odoo.tools import plaintext2html
+from odoo.tools import html_escape, plaintext2html
 from odoo.addons.base.models.ir_qweb_fields import nl2br
 from odoo.exceptions import AccessDenied, ValidationError, UserError
 from odoo.tools.misc import hmac, consteq
@@ -175,7 +175,10 @@ class WebsiteForm(http.Controller):
             # If it's a known field
             elif field_name in authorized_fields:
                 try:
-                    input_filter = self._input_filters[authorized_fields[field_name]['type']]
+                    field_type = authorized_fields[field_name]['type']
+                    if field_type == 'html':
+                        field_value = html_escape(field_value)
+                    input_filter = self._input_filters[field_type]
                     data['record'][field_name] = input_filter(self, field_name, field_value)
                 except ValueError:
                     error_fields.append(field_name)
@@ -191,6 +194,7 @@ class WebsiteForm(http.Controller):
 
             # If it's a custom field
             elif field_name not in ('context', 'website_form_signature'):
+                field_value = html_escape(field_value)
                 custom_fields.append((field_name, field_value))
 
         data['custom'] = "\n".join([u"%s : %s" % v for v in custom_fields])


### PR DESCRIPTION
When fields are submitted through the website form, their values are
used as they are. Because of this it is possible to include HTML in the
sent email while this is not desired.

To avoid this, this commit HTML-encodes the values received for custom
fields and html fields.

Steps to reproduce:
- Go to the "Contact us" page.
- Fill in the form.
- In the name put `John <b>Smith</b>`.
- In the description put:
`<a style="color:red" href="[https://odoo.com">Click](https://odoo.com"%3Eclick/) me</a>`.
- Submit the form.

=> The HTML was displayed as HTML inside the received mail.

task-3650953