### PR TITLE
[FIX] base: q keyboard shortcut overlaps with the x button to remove a filter

### DIFF
--- a/addons/web/static/lib/bootstrap/scss/forms/_input-group.scss
+++ b/addons/web/static/lib/bootstrap/scss/forms/_input-group.scss
@@ -28,7 +28,7 @@
   // as our inputs.
   .btn {
     position: relative;
-    z-index: 2;
+    z-index: 0;
 
     &:focus {
       z-index: 3;


### PR DESCRIPTION
Steps to reproduce:
- go to field service > my tasks
- press Alt to display keyboard shortcuts

Observed behavior:
the Q shortcut and the x button overlap

Expected behavior:
the x button should be hidden by the Q shortcut

Task-3635644