### PR TITLE
[FIX] web: fixes the overlapping issue when groupby

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -36,7 +36,7 @@
                     <span class="d-none d-xl-block me-auto"/> <!-- Spacer -->
                 </div>
 
-                <div class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-start justify-content-lg-around order-2 order-lg-1 w-100 w-lg-auto">
+                <div class="o_control_panel_actions d-empty-none d-flex align-items-center justify-content-start justify-content-lg-around order-2 order-lg-1 w-100 w-lg-25">
                     <t t-if="display.layoutActions" t-slot="layout-actions"/>
                     <t t-slot="control-panel-selection-actions"/>
                 </div>


### PR DESCRIPTION
Steps to Reproduce:
- install planning module
- click on groupby
- click on add custom group
- grouby many fields

Issue:
- the search bar is overlapping when groupby multiple fields.

Cause:
- this is because the width is given as auto , so it will increase till end.

Solution:
- if we fixes the width issue, then the issue will be solved.

task-3653034

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
