### PR TITLE
[FIX] stock: prevent the traceback if value is zero

### DIFF
--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -36,7 +36,7 @@
                                 <field name="date" readonly="state == 'done'"/>
                                 <field name="target_model" widget="radio" invisible="1" readonly="state == 'done'"/>
                                 <field name="picking_ids" widget="many2many_tags" 
-                                    options="{'no_create_edit': True}" invisible="target_model != 'picking'" readonly="state == 'done'"
+                                    options="{'no_create': True}" invisible="target_model != 'picking'" readonly="state == 'done'"
                                     domain="[('company_id', '=', company_id), ('move_ids.stock_valuation_layer_ids', '!=', False)]"/>
                             </group>
                             <group>


### PR DESCRIPTION
This traceback arises when the user clicks on the validate button.

To reproduce this issue:
1. Install ``stock`` and ``sales_management``
2. Enable ``Inventory->setting->valuation->landed cost``
3. Create a new ``Landed Cost`` record from ``Inventory->Operation->Landed Cost``
4. Create a new transfer in it and make sure that when you add a line in Product the costing method should be "fifo" or "avco" and demand should not be "zero".
5. Add a line in ``Additional Costs`` and click on ``Validate`` button

Error:- 

```
ZeroDivisionError: float division by zero
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/stock_landed_costs/models/stock_landed_cost.py", line 134, in button_validate
    cost_to_add = (remaining_qty / line.move_id.quantity) * line.additional_landed_cost
```

This commit will fix the above error by not letting the user create the transfer
in landed cost because it's not a correct way to a create a transfer.
Transfer should be created from receipts and should be validated.

https://github.com/odoo/odoo/blob/ad35458e8bfc30602f927944031a0bf87a92f82d/addons/stock_landed_costs/views/stock_landed_cost_views.xml#L39

sentry-4747089941

