### PR TITLE
[FIX] web_editor: line breaks at edges of block anchor nested within li

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2639,10 +2639,15 @@ export class OdooEditor extends EventTarget {
                     if (anchor.nodeName === 'A') {
                         if (brs.includes(anchor.firstChild)) {
                             brs.forEach(br => anchor.before(br));
-                            setSelection(...rightPos(brs[brs.length - 1]));
                         } else if (brs.includes(anchor.lastChild)) {
+                            const brToRemove = isBlock(anchor) ? brs.shift() : null;
                             brs.forEach(br => anchor.after(br));
-                            setSelection(...rightPos(brs[0]));
+                            if (brToRemove) {
+                                brToRemove.remove();
+                                setSelection(...leftPos(brs[0]));
+                            } else {
+                                setSelection(...rightPos(brs[0]));
+                            }
                         }
                     }
                     this.historyStep();

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2968,6 +2968,11 @@ X[]
                         stepFunction: pressEnter,
                         contentAfter: '<div><a>ab</a><br>[]cd</div>',
                     });
+                    await testEditor(BasicEditor, {
+                        contentBefore: '<ul><li><div><a style="display: block;">ab[]</a></div></li></ul>',
+                        stepFunction: pressEnter,
+                        contentAfter: '<ul><li><div><a style="display: block;">ab</a>[]<br></div></li></ul>',
+                    });
                 });
             });
             describe('With attributes', () => {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2174,9 +2174,10 @@ const Wysiwyg = Widget.extend({
         return new Promise(function () {});
     },
     _onSelectionChange() {
-        if (this.options.autohideToolbar) {
-            const isVisible = this.linkPopover && this.linkPopover.el.offsetParent;
-            if (isVisible && !this.odooEditor.document.getSelection().isCollapsed) {
+        if (this.linkPopover) {
+            const selectionInLink = getInSelection(this.odooEditor.document, 'a') === this.linkPopover.target;
+            const isVisible = this.linkPopover.el.offsetParent;
+            if (isVisible && !selectionInLink) {
                 this.linkPopover.hide();
             }
         }


### PR DESCRIPTION
Current behavior before PR:

Commit [[1]](https://github.com/odoo/odoo/commit/df6f8dd0c54c40ea7edbd3821ae068d79b1b7af7) handled cases of pressing enter at the edge of an anchor, which is a child of an unbreakable element. The commit inserted the `br`'s after anchors; however, it missed the situation where the anchor tags are block elements nested inside an unbreakable element inside a `li`. In this specific case, inserting two `br` tags after a anchor block resulted in the creation of two new lines.

Desired behavior after PR is merged:

Line-break on anchor tags that are block elements nested inside an unbreakable element inside a `li` should only insert one `br` tag after the anchor.

task-3631910