### PR TITLE
[FIX] base: q keyboard shortcut overlaps with the x button to remove a filter

### DIFF
--- a/addons/web/static/src/search/search_bar/search_bar.scss
+++ b/addons/web/static/src/search/search_bar/search_bar.scss
@@ -13,4 +13,8 @@
     &.o_facet_with_domain:hover .o_searchview_facet_label {
         cursor: pointer;
     }
+    .btn {
+        position: relative;
+        z-index: 0;
+    }
 }


### PR DESCRIPTION
Steps to reproduce:
go to field service > my tasks
press Alt to display keyboard shortcuts

Observed behavior:
the Q shortcut and the x button overlap

Expected behavior:
the x button should be hidden by the Q shortcut

Task-3635644