### PR TITLE
[IMP] {google_,microsoft_}calendar: utilize description method

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -24,7 +24,7 @@ from odoo.addons.calendar.models.calendar_recurrence import (
 )
 from odoo.tools.translate import _
 from odoo.tools.misc import get_lang
-from odoo.tools import html2plaintext, is_html_empty, single_email_re
+from odoo.tools import html2plaintext, html_sanitize, is_html_empty, single_email_re
 from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
@@ -1390,7 +1390,7 @@ class Meeting(models.Model):
             event.add('dtstart').value = ics_datetime(meeting.start, meeting.allday)
             event.add('dtend').value = ics_datetime(meeting.stop, meeting.allday)
             event.add('summary').value = meeting._get_customer_summary()
-            description = meeting._get_customer_description()
+            description = html2plaintext(meeting._get_customer_description())
             if description:
                 event.add('description').value = description
             if meeting.location:
@@ -1429,8 +1429,8 @@ class Meeting(models.Model):
         return result
 
     def _get_customer_description(self):
-        """:return (str): The description to include in calendar exports"""
-        return html2plaintext(self.description) if self.description else ''
+        """:return (html): Sanitized HTML description for customer to include in calendar exports"""
+        return html_sanitize(self.description) if not is_html_empty(self.description) else ''
 
     def _get_customer_summary(self):
         """:return (str): The summary to include in calendar exports"""

--- a/addons/google_calendar/models/calendar.py
+++ b/addons/google_calendar/models/calendar.py
@@ -312,7 +312,7 @@ class Meeting(models.Model):
             'start': start,
             'end': end,
             'summary': self.name,
-            'description': tools.html_sanitize(self.description) if not tools.is_html_empty(self.description) else '',
+            'description': self._get_customer_description(),
             'location': self.location or '',
             'guestsCanModify': not self.guests_readonly,
             'organizer': {'email': self.user_id.email, 'self': self.user_id == self.env.user},

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -10,7 +10,7 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import is_html_empty, email_normalize
+from odoo.tools import email_normalize
 from odoo.osv import expression
 
 ATTENDEE_CONVERTER_O2M = {
@@ -502,7 +502,7 @@ class Meeting(models.Model):
 
         if 'description' in fields_to_sync:
             values['body'] = {
-                'content': self.description if not is_html_empty(self.description) else '',
+                'content': self._get_customer_description(),
                 'contentType': "html",
             }
 


### PR DESCRIPTION
This commit does the following-
-Makes `_get_customer_description` to return HTML data.
-Replace the description field with `_get_customer_description` for google_calendar and
microsoft_calendar syncs.

Task-3458669
