### PR TITLE
FIX] base: Improving Performance of 'discard_records' Method in 'ir.default' Model by fixing the suboptimal query

### DIFF
--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -164,9 +164,11 @@ class IrDefault(models.Model):
             records.
         """
         json_vals = [json.dumps(id) for id in records.ids]
-        domain = [('field_id.ttype', '=', 'many2one'),
-                  ('field_id.relation', '=', records._name),
-                  ('json_value', 'in', json_vals)]
+        subquery_fields_ids = self.env['ir.model.fields']._search([
+            ('ttype', '=', 'many2one'),
+            ('relation', '=', records._name),
+        ])
+        domain = [('field_id', 'in', subquery_fields_ids), ('json_value', 'in', json_vals)]
         return self.search(domain).unlink()
 
     @api.model


### PR DESCRIPTION
This pull request addresses a performance issue in the 'discard_records' method of the 'ir.default' model within the Odoo framework. Currently, the logic involves retrieving a large number of ids from the 'ir_model_fields' table based on the 'ttype' field, which are then used to query the 'ir_default' table. This approach can be resource-intensive and lead to performance issues, especially with large datasets.

To address this, I have implemented an optimization that pre-fetches the required 'field_ids' values, eliminating the need for multiple queries. This optimization significantly improves the execution speed of the 'discard_records' method, enhancing the overall efficiency of the 'ir.default' model.

This change is backward-compatible and does not introduce any breaking changes. It is recommended to merge this pull request to enhance the efficiency of Odoo's 'ir.default' model and improve user experience.


before:

```SQL
SELECT "ir_model_fields".id FROM "ir_model_fields" WHERE ("ir_model_fields"."ttype" = 'many2one') ORDER BY "ir_model_fields"."id";
SELECT "ir_model_fields".id FROM "ir_model_fields" WHERE ("ir_model_fields"."relation" = 'dtdream.content.event.affairs') ORDER BY "ir_model_fields"."id";
SELECT "ir_default".id FROM "ir_default" WHERE ((("ir_default"."field_id" in (___A_TUPLE_CONTAINING_MORE_THAN_12,000_IDS___))  AND  FALSE)  AND  ("ir_default"."json_value" in ('1504599'))) ORDER BY "ir_default"."id";
```

after:
```SQL
SELECT "ir_model_fields".id FROM "ir_model_fields" WHERE (("ir_model_fields"."ttype" = 'many2one')  AND  ("ir_model_fields"."relation" = 'dtdream.content.event.affairs')) ORDER BY "ir_model_fields"."name";
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
