### PR TITLE
[FIX] website_sale_stock: get the right warehouse for product

### DIFF
--- a/addons/website_sale_stock/models/product_product.py
+++ b/addons/website_sale_stock/models/product_product.py
@@ -27,8 +27,8 @@ class ProductProduct(models.Model):
         return 0
 
     def _is_sold_out(self):
-        combination_info = self.with_context(website_sale_stock_get_quantity=True).product_tmpl_id._get_combination_info(product_id=self.id)
-        return combination_info['product_type'] == 'product' and combination_info['free_qty'] <= 0
+        free_qty = self.with_context(warehouse=self.website_id._get_warehouse_available()).free_qty
+        return self.type == 'product' and free_qty <= 0
 
     def _website_show_quick_add(self):
         return (self.allow_out_of_stock_order or not self._is_sold_out()) and super()._website_show_quick_add()


### PR DESCRIPTION
### Steps to reproduce:
- Install **Inventory** app, **Ecommerce** app and **l10n_mx** module.
- In **Inventory** settings > **Warehouse**, turn on **Storage Locations**
- In **Website** settings > **Website Info**, assign **My Website** to **ZAPATERIA URTADO ÑERI** and **My Website 2** to **My Company (San Francisco)**
- Go to **Inventory** > **Products** > **Products** and create a new product
- For the newly created product, Under **Sales** tab, un-check the **Continue Selling** of **Out-of-Stock** property
- Click on **Go To Website** button, U should that both websites are showing Out of Stock message.
- Subscribe an email to be notified when the product is back in stock.
- Go back to the product, and update its quantity as follows:
	- keep **WH/Stock** quantity as **_zero_**
	- Set **ZAPAT/Stock** quantity to **_greater than zero_** (ex. 10)
- Now the product should be out of stock on website 1 but in stock on website 2
- Go to **Settings** > **Technical** > **Scheduled Actions** > **Product: send email regarding products availability**
- Set the **Next Execution Date** to be a minute later or so.
- Wait till the cron executes.
- No email is Sent! although the product at ZAPAT/Stock is back at stock!

### Investigation:
- The `_send_availability_email` method uses `_is_sold_out` method https://github.com/odoo/odoo/blob/7e48111a9678c5acf8188796824f2cb9b4f1af9d/addons/website_sale_stock/models/product_product.py#L38
- which uses `_get_combination_info` method https://github.com/odoo/odoo/blob/7e48111a9678c5acf8188796824f2cb9b4f1af9d/addons/website_sale_stock/models/product_product.py#L30
- that uses `get_current_website` method https://github.com/odoo/odoo/blob/7e48111a9678c5acf8188796824f2cb9b4f1af9d/addons/website_sale_stock/models/product_template.py#L27
- In case of automatic triggering of cron, there's no request and hence we try to interfere the website using `_get_current_website_id` https://github.com/odoo/odoo/blob/7e48111a9678c5acf8188796824f2cb9b4f1af9d/addons/website/models/website.py#L981
- As there's no domain, the method ends up returning the first website at https://github.com/odoo/odoo/blob/7e48111a9678c5acf8188796824f2cb9b4f1af9d/addons/website/models/website.py#L1038
- In our case, this is **My Website 1**, the one having the zero quantity of our product. and so the product is considered as **sold out** although it's not at **My Website 2**!

opw-3578276