### PR TITLE
[FIX] base: display company name field in partner quick creation wizard

### DIFF
--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -105,11 +105,17 @@
                             <field id="company" name="name" default_focus="1" placeholder="e.g. Lumber Inc" attrs="{'required' : [('type', '=', 'contact'),('is_company','=', True)], 'invisible': [('is_company','=', False)]}"/>
                             <field id="individual" name="name" default_focus="1" placeholder="e.g. Brandom Freeman" attrs="{'required' : [('type', '=', 'contact'),('is_company','=', False)], 'invisible': [('is_company','=', True)]}"/>
                         </h1>
-                        <field name="parent_id"
-                            widget="res_partner_many2one"
-                            placeholder="Company Name..."
-                            domain="[('is_company', '=', True)]" context="{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id}"
-                            attrs="{'invisible': [('is_company','=', True)]}"/>
+                        <div class="o_row">
+                            <field name="parent_id"
+                                widget="res_partner_many2one"
+                                placeholder="Company Name..."
+                                domain="[('is_company', '=', True)]" context="{'default_is_company': True, 'show_vat': True, 'default_user_id': user_id}"
+                                attrs="{'invisible': ['|', '&amp;', ('is_company','=', True),('parent_id', '=', False),('company_name', '!=', False),('company_name', '!=', '')]}"/>
+                            <field name="company_name" attrs="{'invisible': ['|', '|', ('company_name', '=', False), ('company_name', '=', ''), ('is_company', '=', True)]}"/>
+                            <button name="create_company" icon="fa-plus-square" string="Create company"
+                                type="object" class="oe_edit_only btn-link"
+                                attrs="{'invisible': ['|', '|', ('is_company','=', True), ('company_name', '=', ''), ('company_name', '=', False)]}"/>
+                        </div>
                     </div>
                     <group>
                         <field name="function" placeholder="e.g. Sales Director" attrs="{'invisible': [('is_company','=', True)]}"/>


### PR DESCRIPTION
Steps to reproduce:

  - Install `CRM` module (for test purposes)
  - Create a lead and set the name, email, phone, company name and contact name
  - Save the lead
  - Click on `Send message` button in the chatter
  - Uncheck/Check the recipient checkbox

Issue:

  In the wizard, the company name field is not displayed.

Solution:

  Add the field `company_name` to the view so that it will be displayed
  if the partner is of type `individual`.

opw-3512045