### PR TITLE
[TEXT] l10n_cl: fix terms in english that are wrongly defined

### DIFF
--- a/addons/l10n_cl/data/l10n_latam.document.type.csv
+++ b/addons/l10n_cl/data/l10n_latam.document.type.csv
@@ -3,16 +3,16 @@ dc_a_f_dte,1,33,Electronic Invoice,INVOICE,invoice,FAC,base.cl,True,True
 dc_y_f_dte,2,34,Unaffected or Exempt Electronic Invoice,F-EXENTA,invoice,FNA,base.cl,True,True
 dc_nc_f_dte,3,61,Electronic Credit Note,CREDIT NOTE,credit_note,N/C,base.cl,True,True
 dc_nd_f_dte,4,56,Electronic Debit Note,DEBIT NOTE,debit_note,N/D,base.cl,True,True
-dc_b_f_dte,5,39,Electronic Ballot,BEL,invoice,BEL,base.cl,True,True
+dc_b_f_dte,5,39,Electronic Receipt,BEL,invoice,BEL,base.cl,True,True
 dc_m_d_dtn,6,71,Electronic Fee Slips,BHE,invoice,BHE,base.cl,True,True
-dc_b_e_dtn,7,38,Exempt ballot,BEX,invoice,BEX,base.cl,False,False
+dc_b_e_dtn,7,38,Exempt Receipt,BEX,invoice,BEX,base.cl,False,False
 dc_gd_dte,8,52,Electronic Dispatch Guide,GDE,stock_picking,GDE,base.cl,False,True
 dc_I_f_dtn,10,29,Invoice of Initiation,FAI,invoice,FAI,base.cl,False,False
 dc_a_f_dtn,10,30,Invoice,"INVOICE",invoice,FAC,base.cl,False,False
 dc_y_f_dtn,10,32,Invoice of Sales and Services not Affected or Exempt from VAT,F-EXENTA,invoice,FNA,base.cl,False,False
 dc_b_f_dtn,10,35,Bill of Sale,BOL,invoice,BOL,base.cl,False,False
 dc_l_f_dtn,10,40,Invoice Settlement,L-FACTURAM,invoice,FAL,base.cl,False,False
-dc_b_e_dte,10,41,Electronic Tax Receipt,BXE,invoice,BXE,base.cl,True,True
+dc_b_e_dte,10,41,Electronic Exempt Receipt,BXE,invoice,BXE,base.cl,True,True
 dc_l_f_dte,10,43,Electronic Invoice Settlement,L-FACTURAE,invoice,FAL,base.cl,False,False
 dc_fc_f_dtn,10,45,Purchase Invoice,"INVOICE",invoice_in,FAC,base.cl,False,False
 dc_fc_f_dte,10,46,Electronic Purchase Invoice,"INVOICE",invoice_in,FAC,base.cl,False,True

--- a/addons/l10n_cl/i18n/es.po
+++ b/addons/l10n_cl/i18n/es.po
@@ -456,7 +456,7 @@ msgstr ""
 
 #. module: l10n_cl
 #: model:l10n_latam.document.type,name:l10n_cl.dc_b_f_dte
-msgid "Electronic Ballot"
+msgid "Electronic Receipt"
 msgstr "Boleta Electrónica"
 
 #. module: l10n_cl
@@ -511,7 +511,7 @@ msgstr "Factura de Compra Electrónica"
 
 #. module: l10n_cl
 #: model:l10n_latam.document.type,name:l10n_cl.dc_b_e_dte
-msgid "Electronic Tax Receipt"
+msgid "Electronic Exempt Receipt"
 msgstr "Boleta Exenta Electrónica"
 
 #. module: l10n_cl
@@ -544,7 +544,7 @@ msgstr "Ventas Exentas"
 
 #. module: l10n_cl
 #: model:l10n_latam.document.type,name:l10n_cl.dc_b_e_dtn
-msgid "Exempt ballot"
+msgid "Exempt Receipt"
 msgstr "Boleta exenta"
 
 #. module: l10n_cl

--- a/addons/l10n_cl/i18n/l10n_cl.pot
+++ b/addons/l10n_cl/i18n/l10n_cl.pot
@@ -437,7 +437,7 @@ msgstr ""
 
 #. module: l10n_cl
 #: model:l10n_latam.document.type,name:l10n_cl.dc_b_f_dte
-msgid "Electronic Ballot"
+msgid "Electronic Receipt"
 msgstr ""
 
 #. module: l10n_cl
@@ -492,7 +492,7 @@ msgstr ""
 
 #. module: l10n_cl
 #: model:l10n_latam.document.type,name:l10n_cl.dc_b_e_dte
-msgid "Electronic Tax Receipt"
+msgid "Electronic Exempt Receipt"
 msgstr ""
 
 #. module: l10n_cl
@@ -525,7 +525,7 @@ msgstr ""
 
 #. module: l10n_cl
 #: model:l10n_latam.document.type,name:l10n_cl.dc_b_e_dtn
-msgid "Exempt ballot"
+msgid "Exempt Receipt"
 msgstr ""
 
 #. module: l10n_cl


### PR DESCRIPTION
Before this PR:
The term "ballot" has wrongly been used as a receipt (or ticket), when if you translate this term to Spanish it shows that this term is applied to a voting voucher and not to a sales voucher.
Besides, the document type called "Electronic Tax Receipt" does not express its correct name which is an "Electronic Exempt Receipt" (precisely the document is exempt because it does not have taxes involved).
After this PR:
The term "ballot" was replaced by "receipt" which is more accurate. and "Electronic Tax Receipt" is called as it should be, an exempt receipt.
This includes the translation untranslated terms for pot and po




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
