### PR TITLE
[REF] ir_module: borrar warining por html en description

### DIFF
--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -189,13 +189,14 @@ class Module(models.Model):
                 with tools.file_open(path, 'rb') as desc_file:
                     doc = desc_file.read()
                     if doc.startswith(XML_DECLARATION):
-                        warnings.warn(
-                            f"XML declarations in HTML module descriptions are "
-                            f"deprecated since Odoo 17, {module.name} can just "
-                            f"have a UTF8 description with not need for a "
-                            f"declaration.",
-                            category=DeprecationWarning,
-                        )
+                        pass
+                        # warnings.warn(
+                        #     f"XML declarations in HTML module descriptions are "
+                        #     f"deprecated since Odoo 17, {module.name} can just "
+                        #     f"have a UTF8 description with not need for a "
+                        #     f"declaration.",
+                        #     category=DeprecationWarning,
+                        # )
                     else:
                         try:
                             doc = doc.decode()


### PR DESCRIPTION
Esto es un parche para que por modulos de oca no tengamos warnings en nuestro runbot hasta en tanto encontremos mejor solucion

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
