### PR TITLE
[FIX] bus: fix non-deterministic channel managment test

### DIFF
--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -8,6 +8,7 @@ const { multiTabService } = require('@bus/multi_tab_service');
 const { WEBSOCKET_CLOSE_CODES } = require("@bus/workers/websocket_worker");
 const { startServer } = require('@bus/../tests/helpers/mock_python_environment');
 const { patchWebsocketWorkerWithCleanup } = require("@bus/../tests/helpers/mock_websocket");
+const { waitForChannels } = require('@bus/../tests/helpers/websocket_event_deferred');
 
 const { browser } = require("@web/core/browser/browser");
 const { registry } = require("@web/core/registry");
@@ -261,32 +262,29 @@ QUnit.module('Bus', {
         ]);
     });
 
-    QUnit.test('channel management from multiple tabs', async function (assert) {
-        assert.expect(3);
-
+    QUnit.only('channel management from multiple tabs', async function (assert) {
         patchWebsocketWorkerWithCleanup({
             _sendToServer({ event_name, data }) {
                 assert.step(`${event_name} - [${data.channels.toString()}]`);
             },
         });
-
         const firstTabEnv = await makeTestEnv();
         const secTabEnv = await makeTestEnv();
         firstTabEnv.services['bus_service'].addChannel('channel1');
-        await nextTick();
+        await waitForChannels(["channel1"]);
         // this should not trigger a subscription since the channel1 was
         // aleady known.
         secTabEnv.services['bus_service'].addChannel('channel1');
-        await nextTick();
+        await waitForChannels(["channel1"]);
         // removing channel1 from first tab should not trigger
         // re-subscription since the second tab still listens to this
         // channel.
         firstTabEnv.services['bus_service'].deleteChannel('channel1');
-        await nextTick();
+        await waitForChannels(["channel1"], { operation: "delete" });
         // this should trigger a subscription since the channel2 was not
         // known.
         secTabEnv.services['bus_service'].addChannel('channel2');
-        await nextTick();
+        await waitForChannels(["channel2"]);
 
         assert.verifySteps([
             'subscribe - [channel1]',

--- a/addons/bus/static/tests/helpers/websocket_event_deferred.js
+++ b/addons/bus/static/tests/helpers/websocket_event_deferred.js
@@ -1,0 +1,52 @@
+/* @odoo-module */
+
+import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
+
+import { makeDeferred } from "@web/../tests/helpers/utils";
+
+// Should be enough to decide whether or not notifications/channel
+// subscriptions... are received.
+const TIMEOUT = 500;
+
+/**
+ * Returns a deferred that resolves when the given channel(s) addition/deletion
+ * is notified to the websocket worker.
+ *
+ * @param {string[]} channels
+ * @param {object} [options={}]
+ * @param {"add"|"delete"} [options.operation="add"]
+ *
+ * @returns {import("@web/core/utils/concurrency").Deferred} */
+export function waitForChannels(channels, { operation = "add" } = {}) {
+    const channelsSeen = new Set();
+    const successDeferred = makeDeferred();
+    function check({ crashOnFail = false } = {}) {
+        const success = channelsSeen.size === channels.length;
+        if (!success && !crashOnFail) {
+            return;
+        }
+        clearTimeout(failTimeout);
+        const msg = success
+            ? `Channel(s) [${channels.join(", ")}] ${operation === "add" ? "added" : "deleted"}.`
+            : `Waited ${TIMEOUT}ms for ${channels.join(", ")} to be ${
+                  operation === "add" ? "added" : "deleted"
+              }`;
+        QUnit.assert.ok(success, msg);
+        if (success) {
+            successDeferred.resolve();
+        } else {
+            successDeferred.reject(new Error(msg));
+        }
+    }
+    const failTimeout = setTimeout(() => check({ crashOnFail: true }), TIMEOUT);
+    patchWebsocketWorkerWithCleanup({
+        async [operation === "add" ? "_addChannel" : "_deleteChannel"](client, channel) {
+            await this._super(client, channel);
+            if (channels.includes(channel)) {
+                channelsSeen.add(channel);
+            }
+            check();
+        },
+    });
+    return successDeferred;
+}


### PR DESCRIPTION
This commit fixes a non-deterministic error in the bus module. Testing
the bus service is difficult because it relies heavily on async code.
Until now, `nextTick` was used but there is no guarantee that this is
enough. This commit introduces the `waitForChannels` method that
awaits the channel subscriptions to be done before resolving.

fixes runbot-54467
backport of https://github.com/odoo/odoo/pull/138383