### PR TITLE
[IMP] hr_recruitment(_skills): created the matching and missing skills fields

### DIFF
--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -1,14 +1,14 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import re
+
 from markupsafe import Markup
+from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, tools, SUPERUSER_ID
 from odoo.exceptions import AccessError, UserError
 from odoo.osv import expression
 from odoo.tools.translate import _
-
-from dateutil.relativedelta import relativedelta
 
 AVAILABLE_PRIORITIES = [
     ('0', 'Normal'),
@@ -462,10 +462,21 @@ class Applicant(models.Model):
 
         nocontent_body = Markup("""
 <p class="o_view_nocontent_smiling_face">%(help_title)s</p>
-<p>%(para_1)s<br/>%(para_2)s</p>""") % {
+<p class="mb-0">%(para_1)s<br/>%(para_2)s</p>""") % {
             'help_title': _("No application found. Let's create one !"),
             'para_1': _('People can also apply by email to save time.'),
             'para_2': _("You can search into attachment's content, like resumes, with the searchbar."),
+        }
+
+        if hr_job:
+            pattern = r'(.*)<a>(.*?)<\/a>(.*)'
+            match = re.fullmatch(pattern, _('Have you tried to <a>add skills to your job position</a> and search into the Reserve ?'))
+            nocontent_body += Markup("""
+<p>%(para_1)s<a href="%(link)s">%(para_2)s</a>%(para_3)s</p>""") % {
+            'para_1': match[1],
+            'para_2': match[2],
+            'para_3': match[3],
+            'link': f'/odoo/recruitement/{hr_job.id}',
         }
 
         if hr_job.alias_email:
@@ -570,7 +581,10 @@ class Applicant(models.Model):
         applicant = self[0]
         # When applcant is unarchived, they are put back to the default stage automatically. In this case,
         # don't post automated message related to the stage change.
-        if 'stage_id' in changes and applicant.exists() and applicant.stage_id.template_id and not applicant._context.get('just_unarchived'):
+        if 'stage_id' in changes and applicant.exists()\
+            and applicant.stage_id.template_id\
+            and not applicant._context.get('just_moved')\
+            and not applicant._context.get('just_unarchived'):
             res['stage_id'] = (applicant.stage_id.template_id, {
                 'auto_delete_keep_log': False,
                 'subtype_id': self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note'),

--- a/addons/hr_recruitment/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment/views/hr_applicant_views.xml
@@ -5,7 +5,7 @@
         <field name="name">Applicants</field>
         <field name="model">hr.applicant</field>
         <field name="arch" type="xml">
-            <tree string="Applicants" multi_edit="1" sample="1" decoration-danger="application_status == 'refused'">
+            <tree string="Applicants" class="o_search_matching_applicant" multi_edit="1" sample="1" decoration-danger="application_status == 'refused'">
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="last_stage_id" column_invisible="True"/>
                 <field name="date_last_stage_update" column_invisible="True"/>
@@ -13,8 +13,8 @@
                 <field name="create_date" readonly="1" optional="show"/>
                 <field name="type_id" column_invisible="True"/>
                 <field name="job_id" optional="show"/>
-                <field name="name" readonly="1" optional="show"/>
                 <field name="stage_id" optional="show"/>
+                <field name="name" readonly="1" optional="show"/>
                 <field name="application_status" optional="show" invisible="application_status == 'ongoing'"/>
                 <field name="refuse_reason_id" optional='hide'/>
                 <field name="priority" widget="priority" optional="show"/>
@@ -313,7 +313,7 @@
         <field name="name">Hr Applicants kanban</field>
         <field name="model">hr.applicant</field>
         <field name="arch" type="xml">
-            <kanban default_group_by="stage_id" class="o_kanban_applicant" quick_create_view="hr_recruitment.quick_create_applicant_form" sample="1">
+            <kanban default_group_by="stage_id" class="o_kanban_applicant o_search_matching_applicant" quick_create_view="hr_recruitment.quick_create_applicant_form" sample="1">
                 <field name="stage_id" options='{"group_by_tooltip": {"requirements": "Requirements"}}'/>
                 <field name="date_closed"/>
                 <field name="color"/>
@@ -426,7 +426,7 @@
         <field name="res_model">hr.applicant</field>
         <field name="view_mode">kanban,tree,form,graph,calendar,pivot,activity</field>
         <field name="search_view_id" ref="hr_applicant_view_search_bis"/>
-        <field name="context">{'search_default_job_id': [active_id], 'default_job_id': active_id, 'search_default_stage':1,'dialog_size':'medium'}</field>
+        <field name="context">{'search_default_job_id': [active_id], 'default_job_id': active_id, 'search_default_stage':1, 'dialog_size':'medium', 'allow_search_matching_applicants': 1}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_empty_folder">
                 No applications yet

--- a/addons/hr_recruitment_skills/__manifest__.py
+++ b/addons/hr_recruitment_skills/__manifest__.py
@@ -12,8 +12,14 @@
         'security/hr_recruitment_skills_security.xml',
         'views/hr_applicant_views.xml',
         'views/hr_applicant_skill_views.xml',
+        'views/hr_job_views.xml',
         'security/ir.model.access.csv',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'hr_recruitment_skills/static/src/**/*',
+        ],
+    },
     'installable': True,
     'auto_install': True,
     'license': 'LGPL-3',

--- a/addons/hr_recruitment_skills/models/__init__.py
+++ b/addons/hr_recruitment_skills/models/__init__.py
@@ -3,3 +3,4 @@
 
 from . import hr_applicant
 from . import hr_applicant_skill
+from . import hr_job

--- a/addons/hr_recruitment_skills/models/hr_applicant.py
+++ b/addons/hr_recruitment_skills/models/hr_applicant.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from ast import literal_eval
 
 from odoo import fields, models, api
 
@@ -10,6 +11,9 @@ class HrApplicant(models.Model):
     applicant_skill_ids = fields.One2many('hr.applicant.skill', 'applicant_id', string="Skills")
     skill_ids = fields.Many2many('hr.skill', compute='_compute_skill_ids', store=True)
     is_interviewer = fields.Boolean(compute='_compute_is_interviewer')
+    matching_skill_ids = fields.Many2many(comodel_name='hr.skill', string="Matching Skills", compute="_compute_matching_skill_ids")
+    missing_skill_ids = fields.Many2many(comodel_name='hr.skill', string="Missing Skills", compute="_compute_matching_skill_ids")
+    matching_score = fields.Float(string="Matching Score(%)", compute="_compute_matching_skill_ids")
 
     @api.depends_context('uid')
     @api.depends('interviewer_ids', 'job_id.interviewer_ids')
@@ -22,6 +26,20 @@ class HrApplicant(models.Model):
     def _compute_skill_ids(self):
         for applicant in self:
             applicant.skill_ids = applicant.applicant_skill_ids.skill_id
+
+    @api.depends_context('active_id')
+    @api.depends('skill_ids')
+    def _compute_matching_skill_ids(self):
+        job_id = self.env.context.get('active_id')
+        if not job_id:
+            self.matching_skill_ids = False
+            self.matching_score = 0
+        else:
+            for applicant in self:
+                job_skills = self.env['hr.job'].browse(job_id).skill_ids
+                applicant.matching_skill_ids = job_skills & applicant.skill_ids
+                applicant.missing_skill_ids = job_skills - applicant.skill_ids
+                applicant.matching_score = (len(applicant.matching_skill_ids) / len(job_skills)) * 100 if job_skills else 0
 
     def _get_employee_create_vals(self):
         vals = super()._get_employee_create_vals()
@@ -45,3 +63,12 @@ class HrApplicant(models.Model):
             } for skill in skills_to_create])
         self.env['hr.employee.skill'].create(vals_list)
         return super()._update_employee_from_applicant()
+
+    def action_add_to_job(self):
+        self.with_context(just_moved=True).write({
+            'job_id': self.env['hr.job'].browse(self.env.context.get('active_id')).id,
+            'stage_id': self.env.ref('hr_recruitment.stage_job0'),
+        })
+        action = self.env['ir.actions.actions']._for_xml_id('hr_recruitment.action_hr_job_applications')
+        action['context'] = literal_eval(action['context'].replace('active_id', str(self.job_id.id)))
+        return action

--- a/addons/hr_recruitment_skills/models/hr_job.py
+++ b/addons/hr_recruitment_skills/models/hr_job.py
@@ -1,0 +1,31 @@
+from markupsafe import Markup
+from ast import literal_eval
+
+from odoo import fields, models, _
+
+
+class HrJob(models.Model):
+    _inherit = "hr.job"
+
+    skill_ids = fields.Many2many(comodel_name='hr.skill', string="Expected Skills")
+
+    def action_search_matching_applicant(self):
+        help_message_1 = _("No Matching Applicants")
+        help_message_2 = _("We do not have any applicants who meet the skill requirements for this job position in the database at the moment.")
+        action = self.env['ir.actions.actions']._for_xml_id('hr_recruitment.crm_case_categ0_act_job')
+        context = literal_eval(action['context'])
+        context['active_id'] = self.id
+        action.update({
+            'name': _("Matching Applicants"),
+            'views': [
+                (self.env.ref('hr_recruitment_skills.crm_case_tree_view_inherit_hr_recruitment_skills').id, 'tree'),
+                (False, 'form'),
+            ],
+            'context': context,
+            'domain': [
+                ('job_id', '!=', self.id),
+                ('skill_ids', 'in', self.skill_ids.ids),
+            ],
+            'help': Markup("<p class='o_view_nocontent_empty_folder'>%s</p><p>%s</p>") % (help_message_1, help_message_2),
+        })
+        return action

--- a/addons/hr_recruitment_skills/static/src/components/search_job_applicant_menu/search_job_applicant_menu.js
+++ b/addons/hr_recruitment_skills/static/src/components/search_job_applicant_menu/search_job_applicant_menu.js
@@ -1,0 +1,53 @@
+import { Component, markup } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { useService } from "@web/core/utils/hooks";
+import { DropdownItem } from "@web/core/dropdown/dropdown_item";
+import { STATIC_ACTIONS_GROUP_NUMBER } from "@web/search/action_menus/action_menus";
+
+const cogMenuRegistry = registry.category("cogMenu");
+
+/**
+ * 'Search Matching Applicants' menu
+ *
+ * This component is used to search matching skills among the all applicants
+ * It's only available in the kanban and list view of the applicants.
+ * @extends Component
+ */
+export class SearchJobApplicant extends Component {
+    static template = "hr_recruitment_skills.SearchJobApplicant";
+    static components = { DropdownItem };
+    static props = {};
+
+    setup() {
+        this.action = useService("action");
+    }
+
+    //---------------------------------------------------------------------
+    // Protected
+    //---------------------------------------------------------------------
+
+    async openMatchingJobApplicants() {
+        const { globalContext } = this.env.searchModel;
+        const action = await this.env.services.orm.call(
+            "hr.job",
+            "action_search_matching_applicant",
+            [globalContext.active_id],
+        );
+        action.help = markup(action.help);
+        return this.action.doAction(action);
+    }
+}
+
+export const searchJobApplicant = {
+    Component: SearchJobApplicant,
+    groupNumber: STATIC_ACTIONS_GROUP_NUMBER,
+    isDisplayed: ({ config, searchModel }) => {
+        return (
+            searchModel.resModel === "hr.applicant" &&
+            searchModel.globalContext.allow_search_matching_applicants &&
+            config.viewArch.classList.contains('o_search_matching_applicant')
+        );
+    },
+};
+
+cogMenuRegistry.add("search-job-applicants-menu", searchJobApplicant, { sequence: 11 });

--- a/addons/hr_recruitment_skills/static/src/components/search_job_applicant_menu/search_job_applicant_menu.xml
+++ b/addons/hr_recruitment_skills/static/src/components/search_job_applicant_menu/search_job_applicant_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<templates id="template" xml:space="preserve">
+    <t t-name="hr_recruitment_skills.SearchJobApplicant">
+        <DropdownItem onSelected.bind="openMatchingJobApplicants">
+            <i class="fa fa-fw fa-search me-1" aria-hidden="true"></i>Search Matching Applicants
+        </DropdownItem>
+    </t>
+</templates>

--- a/addons/hr_recruitment_skills/views/hr_applicant_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_applicant_views.xml
@@ -51,4 +51,48 @@
             </filter>
         </field>
     </record>
+
+    <record id="crm_case_tree_view_inherit_hr_recruitment_skills" model="ir.ui.view">
+        <field name="name">hr.applicant.view.tree.inherit.skills</field>
+        <field name="model">hr.applicant</field>
+        <field name="inherit_id" ref="hr_recruitment.crm_case_tree_view_job"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//tree" position="attributes">
+                <attribute name="class" add="o_search_matching_applicant" separator=" "/>
+            </xpath>
+            <xpath expr="//tree" position="inside">
+                <header>
+                    <button name="action_add_to_job" string="Move to this Job Position" type="object" class="btn-secondary"/>
+                </header>
+            </xpath>
+            <field name="application_status" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="priority" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="partner_mobile" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="categ_ids" position="attributes">
+                <attribute name="optional">hide</attribute>
+            </field>
+            <field name="name" position="after">
+                <field name="matching_score"/>
+                <field name="matching_skill_ids" widget="many2many_tags"/>
+                <field name="missing_skill_ids" widget="many2many_tags"/>
+            </field>
+        </field>
+    </record>
+
+    <record id="action_applicant_search_applicant" model="ir.actions.server">
+        <field name="name">Search Matching Applicants</field>
+        <field name="model_id" ref="hr_recruitment.model_hr_job"/>
+        <field name="binding_model_id" ref="hr_recruitment.model_hr_job"/>
+        <field name="binding_view_types">form</field>
+        <field name="state">code</field>
+        <field name="code">action = records.action_search_matching_applicant()</field>
+    </record>
+
 </odoo>

--- a/addons/hr_recruitment_skills/views/hr_job_views.xml
+++ b/addons/hr_recruitment_skills/views/hr_job_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="hr_job_form_inherit_hr_recruitment_skills" model="ir.ui.view">
+        <field name="name">hr.job.view.form.inherit</field>
+        <field name="model">hr.job</field>
+        <field name="inherit_id" ref="hr.view_hr_job_form"/>
+        <field name="arch" type="xml">
+            <field name="contract_type_id" position="after">
+                <field name="skill_ids" widget="many2many_tags"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
In this PR
- Now, the form-view of the job position has the Expected Skills field in which we can define the skills for the job position
- Missing Skills, Matching Score, and Matching Skills are added to the list view of the applicant
- Add to Job button is added to the list view of the Search Matching Applicants while clicking upon the add to job will change the job position of the applicant to the current
- Search Matching Applicants button will search across all the applicants and give the matched applicant based on the expected skills
- Applicants in the pipeline do not receive an acknowledgment email anymore

Task-3636002
