### PR TITLE
[FIX] mail: fix non deterministic typing status test

### DIFF
--- a/addons/mail/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/components/thread_textual_typing_status_tests.js
@@ -6,14 +6,13 @@ import {
     start,
     startServer,
 } from "@mail/../tests/helpers/test_utils";
+import { contains } from "@web/../tests/utils";
 
 QUnit.module("mail", {}, function () {
     QUnit.module("components", {}, function () {
         QUnit.module("thread_textual_typing_status_tests.js");
 
         QUnit.test('receive other member typing status "is typing"', async function (assert) {
-            assert.expect(2);
-
             const pyEnv = await startServer();
             const resPartnerId1 = pyEnv["res.partner"].create({ name: "Demo" });
             const mailChannelId1 = pyEnv["mail.channel"].create({
@@ -28,31 +27,18 @@ QUnit.module("mail", {}, function () {
                 },
             });
             await openDiscuss();
-
-            assert.strictEqual(
-                document.querySelector(".o_ThreadTextualTypingStatusView").textContent,
-                "",
-                "Should display no one is currently typing"
-            );
-
-            // simulate receive typing notification from demo
-            await afterNextRender(() =>
-                messaging.rpc({
-                    route: "/mail/channel/notify_typing",
-                    params: {
-                        channel_id: mailChannelId1,
-                        context: {
-                            mockedPartnerId: resPartnerId1,
-                        },
-                        is_typing: true,
+            await contains(".o_ThreadTextualTypingStatusView", { text: "" });
+            messaging.rpc({
+                route: "/mail/channel/notify_typing",
+                params: {
+                    channel_id: mailChannelId1,
+                    context: {
+                        mockedPartnerId: resPartnerId1,
                     },
-                })
-            );
-            assert.strictEqual(
-                document.querySelector(".o_ThreadTextualTypingStatusView").textContent,
-                "Demo is typing...",
-                "Should display that demo user is typing"
-            );
+                    is_typing: true,
+                },
+            });
+            await contains(".o_ThreadTextualTypingStatusView", { text: "Demo is typing..." });
         });
 
         QUnit.test(


### PR DESCRIPTION
Before this PR, the "receive other member typing status 'is typing'"
test was sometimes failing. According to the `afterNextRender` helper,
the render never stops. This helper is known for being unreliable.

This PR adapts this test to use the `contains` helper instead that
relies on a MutationObserver to detect the changes in the DOM. It's
much more reliable: we have no guarantee that a render will be enough
to reach the desired state. This might not fix the issue but it will
provide more information to debug this test.

fixes runbot-54484