### PR TITLE
[FIX] base: Fix discrepancy on how sequence take date

### DIFF
--- a/doc/cla/individual/rockavoldy.md
+++ b/doc/cla/individual/rockavoldy.md
@@ -1,0 +1,11 @@
+Indonesia, 2023-12-27
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Akhmad Maulana Akbar akhmad0598@gmail.com https://github.com/rockavoldy

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -259,7 +259,8 @@ class IrSequence(models.Model):
         if not self.use_date_range:
             return self._next_do()
         # date mode
-        dt = sequence_date or self._context.get('ir_sequence_date', fields.Date.today())
+        default_today = fields.Date.context_today(self.with_context(tz=self._context.get('tz', 'UTC')))
+        dt = sequence_date or self._context.get('ir_sequence_date', default_today)
         seq_date = self.env['ir.sequence.date_range'].search([('sequence_id', '=', self.id), ('date_from', '<=', dt), ('date_to', '>=', dt)], limit=1)
         if not seq_date:
             seq_date = self._create_date_range_seq(dt)


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

There is discrepancy on how sequence take date for Prefix/Suffix, and date to determine Next Number. This issue have already been reported in #65312 , but it still persist in 14.0, 15.0, 16.0, and 17.0.

I only check `pos.session` that are affected by this discrepancy, but there is a chance another apps that are using sequence will be affected too by this bug.

#### Step to reproduce:
1. Current local user timezone is UTC+7, server timezone is UTC. And says current user datetime is 2023-12-28 03:00 UTC+7, and server datetime is 2023-12-27 21:00 UTC.
2. Go to `Settings / Technical / Sequences & Identifiers / Sequences`.
3. Select sequence with Sequence Code `pos.session`.
4. Add Prefix by adding date, e.g. `POS/%(year)s/%(month)s/%(day)s/`, and check `Use subsequences per date_range`.
5. Add new `date range` and put yesterday's date in `From` and `To` (in this case, would be `2023-12-27`), and `Next Number` with random number (e.g. `400`).
7. Open new POS Session.
8. `Session ID` will be created as `POS/2023/12/28/00400` and it's wrong. It should be starting from 1 again since there is no date range for 2023-12-28. While the prefix generated is correct by taking user timezone, the sequence number is not correct since it take the next number from `2023-12-27` date range. 

By default, Odoo will create new date range when looking for the next number and no match found. But, since it is using UTC timezone, it will use yesterday's date, and take the next number from that date range. While it should be taken from the same timezone as how prefix/suffix generated.

### Current behavior before PR:
Sequence using different timezone to generate prefix/suffix and next number
See screen record:
https://github.com/odoo/odoo/assets/48157179/9f50317f-691c-42d7-9cba-265f7e4444ef


### Desired behavior after PR is merged:
Sequence prefix/suffix and next number should use the same timezone



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
