### PR TITLE
[FIX] mass_mailing: display the unsubscribe page in user language

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -36,6 +36,9 @@ class MassMailController(http.Controller):
             if not self._valid_unsubscribe_token(mailing_id, res_id, email, str(token)):
                 raise exceptions.AccessDenied()
 
+            logged_in = not request.env.user._is_public()
+            lang = request.env.user.lang if logged_in else request.env.context.get('lang', 'en_US')
+            request.context = dict(request.context, lang=lang)
             if mailing.mailing_model_real == 'mailing.contact':
                 # Unsubscribe directly + Let the user choose his subscriptions
                 mailing.update_opt_out(email, mailing.contact_list_ids.ids, True)

--- a/addons/mass_mailing/models/__init__.py
+++ b/addons/mass_mailing/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import ir_http
 from . import ir_model
 from . import link_tracker
 from . import mailing_contact

--- a/addons/mass_mailing/models/ir_http.py
+++ b/addons/mass_mailing/models/ir_http.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = "ir.http"
+
+    @classmethod
+    def _get_translation_frontend_modules_name(cls):
+        mods = super()._get_translation_frontend_modules_name()
+        return mods + ["mass_mailing"]


### PR DESCRIPTION
Steps to reproduce:

  - Install `mass_mailing` module
  - Change current user language to French (for test purpose)
  - Create a mailing list with a current user
  - Create a mailing with above mailing list
  - Select `Plain Text` as mail body (should be an unsubscribe link in the body)
  - Send mailing
  - Open the unsubscribe link in the email received in the same browser where current is connected

Issue:

  The unsubscribe page is not translated in the user language

Cause:

  - Not rendering the page in the user language
  - Missing `mass_mailing` in frontend modules to translate text rendered in JS

opw-3554271