### PR TITLE
[FIX] pos_self_order: allow opening mobile menu when country was not set

### DIFF
--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -332,7 +332,7 @@ class PosConfig(models.Model):
             "company": {
                 **self.company_id.read(["name", "color", "email", "website", "vat", "name", "phone", "point_of_sale_use_ticket_qr_code", "point_of_sale_ticket_unique_code"])[0],
                 "partner_id": [None, self.company_id.partner_id.contact_address],
-                "country": self.company_id.country_id.read(["vat_label"])[0],
+                "country": self.company_id.country_id.read(["vat_label"])[0] if self.company_id.country_id else False,
             },
             "base_url": self.get_base_url(),
             "custom_links": self._get_self_order_custom_links(),


### PR DESCRIPTION
This issue arises when a user removes the `country` from their company and then attempts to open the `mobile menu` for the restaurant using the POS module.

Steps to produce :
- Install `pos_self_order` module.
- Navigate to Settings > User & Companies > Companies
- Open your company > Remove the country of your company.
- Now go to POS module open the `mobile menu` for the restaurant.
- Error will be generated.

See traceback :
```
IndexError: list index out of range
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1873, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/pos_self_order/controllers/self_entry.py", line 58, in start_self_ordering
    **pos_config._get_self_ordering_data(),
  File "addons/pos_self_order_epson_printer/models/pos_config.py", line 11, in _get_self_ordering_data
    data = super()._get_self_ordering_data()
  File "addons/pos_online_payment_self_order/models/pos_config.py", line 20, in _get_self_ordering_data
    res = super()._get_self_ordering_data()
  File "addons/pos_self_order/models/pos_config.py", line 335, in _get_self_ordering_data
    "country": self.company_id.country_id.read(["vat_label"])[0],
```

This issue occurs because here
https://github.com/odoo/odoo/blob/78cbdc604ec6ef48ef291d354126d7b171eaec64/addons/pos_self_order/models/pos_config.py#L335 when try to access the `country_id` it will not get that because country was not selected in the company and also the country was not a required field.

sentry-4769344261

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
