### PR TITLE
[FIX] web, project: add option to force date range for datepicker

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -380,9 +380,7 @@ class Project(models.Model):
 
     @api.onchange('date_start', 'date')
     def _onchange_planned_date(self):
-        if not self.date and self.date_start:
-            self.date_start = False
-        elif not self.date_start and self.date:
+        if not self.date_start and self.date:
             self.date = False
 
     @api.model

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -87,7 +87,7 @@
                         <group>
                             <field name="active" invisible="1"/>
                             <field name="user_id" string="Project Manager" widget="many2one_avatar_user" readonly="not active" domain="[('share', '=', False)]" options="{'no_quick_create': True}"/>
-                            <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date"}' required="date_start or date" />
+                            <field name="date_start" string="Planned Date" widget="daterange" options='{"end_date_field": "date", "force_range": True}' required="date_start or date" />
                             <field name="date" invisible="1" />
                         </group>
                     </group>

--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -3181,6 +3181,13 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
+#: code:addons/web/static/src/views/fields/datetime/datetime_field.js:0
+#, python-format
+msgid "Force range"
+msgstr ""
+
+#. module: web
+#. odoo-javascript
 #: code:addons/web/static/src/views/fields/float/float_field.js:0
 #: code:addons/web/static/src/views/fields/integer/integer_field.js:0
 #, python-format

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -28,6 +28,7 @@ import { standardFieldProps } from "../standard_field_props";
  *  rounding?: number;
  *  startDateField?: string;
  *  warnFuture?: boolean;
+ *  forceRange?: boolean;
  * }} DateTimeFieldProps
  *
  * @typedef {import("@web/core/datetime/datetime_picker").DateTimePickerProps} DateTimePickerProps
@@ -45,6 +46,7 @@ export class DateTimeField extends Component {
         rounding: { type: Number, optional: true },
         startDateField: { type: String, optional: true },
         warnFuture: { type: Boolean, optional: true },
+        forceRange: { type: Boolean, optional: true },
     };
 
     static template = "web.DateTimeField";
@@ -198,7 +200,7 @@ export class DateTimeField extends Component {
         if (!this.relatedField) {
             return false;
         }
-        return this.props.required || ensureArray(value).filter(Boolean).length === 2;
+        return this.props.forceRange || ensureArray(value).filter(Boolean).length === 2;
     }
 
     /**
@@ -217,7 +219,7 @@ export class DateTimeField extends Component {
     shouldShowSeparator() {
         return (
             this.state.range &&
-            (this.props.required ||
+            (this.props.forceRange ||
                 (!this.isEmpty(this.startDateField) && !this.isEmpty(this.endDateField)))
         );
     }
@@ -280,6 +282,7 @@ export const dateField = {
         rounding: options.rounding && parseInt(options.rounding, 10),
         startDateField: options[START_DATE_FIELD_OPTION],
         warnFuture: archParseBoolean(options.warn_future),
+        forceRange: options.force_range || dynamicInfo.required,
     }),
     fieldDependencies: ({ type, attrs, options }) => {
         const deps = [];
@@ -341,6 +344,11 @@ export const dateRangeField = {
             name: END_DATE_FIELD_OPTION,
             type: "field",
             availableTypes: ["date", "datetime"],
+        },
+        {
+            label: _t("Force range"),
+            name: "force_range",
+            type: "boolean",
         },
     ],
     supportedTypes: ["date", "datetime"],


### PR DESCRIPTION
Versions:
---------
- 17.0+

Steps to reproduce:
-------------------
1. Go to Project / Configuration / Projects;
2. create a new project;
3. set a Planned Date.

Issue:
------
Date picker closes after selecting a date while leaving the field empty.

Cause:
------
The `daterange` widget checks on changes whether the dates are a range using a `isRange` method. Before https://github.com/odoo/odoo/pull/125039, this was true for any array, after it is only true if the date field has a related field to form the range, and if the field is required or neither field is empty.

For project, this still worked because it had *a* `required` attribute for the date field, but https://github.com/odoo/odoo/pull/143509 changed this so that it only counts as required if the given expression evaluates to a non-falsy value.

For project, the date fields are only required if one of two dates has been given, but an `onChange` method clears both fields if only one is given, which makes it impossible to select any date, as the date picker doesn't allow you to pick a range, and the `onChange` method clears any selected date because it's not a range.

Solution:
---------
Add a `force_range` option to the `daterange` widget to force range selection. This would make sense in models like `project.project` that take either 0 or 2 dates, but cannot force the 2 date requirement based on another field.

Also modify `project.project`'s `onChange` method to not clear the `start_date` if no end `date` is given. This change alone allows the user to enter dates again without updating the `project` module's XML files, but with the minor annoyance of having to open the date picker twice to select a range.

opw-3644238