### PR TITLE
[IMP] l10n_*: change all many2one ir.attachment to Binary

### DIFF
--- a/addons/l10n_eg_edi_eta/models/account_move.py
+++ b/addons/l10n_eg_edi_eta/models/account_move.py
@@ -19,7 +19,12 @@ class AccountMove(models.Model):
     l10n_eg_qr_code = fields.Char(string='ETA QR Code', compute='_compute_eta_qr_code_str')
     l10n_eg_submission_number = fields.Char(string='Submission ID', compute='_compute_eta_response_data', store=True, copy=False)
     l10n_eg_uuid = fields.Char(string='Document UUID', compute='_compute_eta_response_data', store=True, copy=False)
-    l10n_eg_eta_json_doc_id = fields.Many2one('ir.attachment', copy=False)
+    l10n_eg_eta_json_doc_id = fields.Many2one(
+        'ir.attachment',
+        compute=lambda self: self._compute_linked_attachment_id('l10n_eg_eta_json_doc_id', 'l10n_eg_eta_json_doc_bin'),
+        depends=['l10n_eg_eta_json_doc_bin'],
+    )
+    l10n_eg_eta_json_doc_bin = fields.Binary(copy=False)
     l10n_eg_signing_time = fields.Datetime('Signing Time', copy=False)
     l10n_eg_is_signed = fields.Boolean(copy=False)
 
@@ -30,7 +35,7 @@ class AccountMove(models.Model):
             create_column(self.env.cr, "account_move", "l10n_eg_submission_number", "VARCHAR")
         return super()._auto_init()
 
-    @api.depends('l10n_eg_eta_json_doc_id.raw')
+    @api.depends('l10n_eg_eta_json_doc_bin')
     def _compute_eta_long_id(self):
         for rec in self:
             response_data = rec.l10n_eg_eta_json_doc_id and json.loads(rec.l10n_eg_eta_json_doc_id.raw).get('response')
@@ -50,7 +55,7 @@ class AccountMove(models.Model):
             else:
                 move.l10n_eg_qr_code = ''
 
-    @api.depends('l10n_eg_eta_json_doc_id.raw')
+    @api.depends('l10n_eg_eta_json_doc_bin')
     def _compute_eta_response_data(self):
         for rec in self:
             response_data = rec.l10n_eg_eta_json_doc_id and json.loads(rec.l10n_eg_eta_json_doc_id.raw).get('response')
@@ -64,7 +69,7 @@ class AccountMove(models.Model):
                 rec.l10n_eg_long_id = False
 
     def button_draft(self):
-        self.l10n_eg_eta_json_doc_id = False
+        self.l10n_eg_eta_json_doc_bin = False
         self.l10n_eg_is_signed = False
         return super().button_draft()
 
@@ -93,16 +98,16 @@ class AccountMove(models.Model):
 
         for invoice in invoices:
             eta_invoice = self.env['account.edi.format']._l10n_eg_eta_prepare_eta_invoice(invoice)
-            attachment = self.env['ir.attachment'].create({
+            self.env['ir.attachment'].create({
                     'name': _('ETA_INVOICE_DOC_%s', invoice.name),
                     'res_id': invoice.id,
                     'res_model': invoice._name,
                     'type': 'binary',
+                    'res_field': 'l10n_eg_eta_json_doc_bin',
                     'raw': json.dumps(dict(request=eta_invoice)),
                     'mimetype': 'application/json',
                     'description': _('Egyptian Tax authority JSON invoice generated for %s.', invoice.name),
                 })
-            invoice.l10n_eg_eta_json_doc_id = attachment.id
         return drive_id.action_sign_invoices(self)
 
     def action_get_eta_invoice_pdf(self):

--- a/addons/l10n_eg_edi_eta/tests/test_edi_json.py
+++ b/addons/l10n_eg_edi_eta/tests/test_edi_json.py
@@ -45,18 +45,18 @@ def mocked_action_post_sign_invoices(self):
     for invoice in self:
         eta_invoice = self.env['account.edi.format']._l10n_eg_eta_prepare_eta_invoice(self)
         eta_invoice['signatures'] = ETA_TEST_SIGNATURES
-        attachment = self.env['ir.attachment'].create(
+        self.env['ir.attachment'].create(
             {
                 'name': ('ETA_INVOICE_DOC_%s', invoice.name),
                 'res_id': invoice.id,
                 'res_model': invoice._name,
                 'type': 'binary',
+                'res_field': 'l10n_eg_eta_json_doc_bin',
                 'raw': json.dumps(dict(request=eta_invoice)),
                 'mimetype': 'application/json',
                 'description': ('Egyptian Tax authority JSON invoice generated for %s.', invoice.name),
             }
         )
-        invoice.l10n_eg_eta_json_doc_id = attachment.id
     return True
 
 

--- a/addons/l10n_id_efaktur/views/account_move_views.xml
+++ b/addons/l10n_id_efaktur/views/account_move_views.xml
@@ -8,12 +8,12 @@
             <field name="arch" type="xml">
                 <field name="partner_id" position="after">
                     <field name="l10n_id_need_kode_transaksi" invisible="1"/>
-                    <field name="l10n_id_attachment_id" invisible="1"/>
+                    <field name="l10n_id_attachment_bin" invisible="1"/>
                     <field name="l10n_id_kode_transaksi" invisible="country_code != 'ID' or not l10n_id_need_kode_transaksi" readonly="state in ['cancel', 'posted']" required="l10n_id_need_kode_transaksi"/>
                     <field name="l10n_id_replace_invoice_id" invisible="country_code != 'ID'" readonly="state != 'draft'" options="{'m2o_dialog': False, 'no_create': True}"/>
                 </field>
                 <button name="button_draft" position="after">
-                    <button name="reset_efaktur" string="Reset E-Faktur" type="object" invisible="country_code != 'ID' or not l10n_id_tax_number or state != 'cancel' or l10n_id_attachment_id"/>
+                    <button name="reset_efaktur" string="Reset E-Faktur" type="object" invisible="country_code != 'ID' or not l10n_id_tax_number or state != 'cancel' or l10n_id_attachment_bin"/>
                 </button>
                 <xpath expr=".//group[@id='other_tab_group']" position="inside">
                     <group string="Electronic Tax" invisible="country_code != 'ID'">
@@ -53,7 +53,7 @@
                     <field name="l10n_id_tax_number"/>
                     <field name="l10n_id_attachment_id"/>
                     <group>
-                        <filter string="To Generate e-Faktur" name="tax_csv_upload" domain="[('l10n_id_tax_number', '!=', False), ('l10n_id_attachment_id', '=', False), ('state', '=', 'posted')]" />
+                        <filter string="To Generate e-Faktur" name="tax_csv_upload" domain="[('l10n_id_tax_number', '!=', False), ('l10n_id_attachment_bin', '=', False), ('state', '=', 'posted')]" />
                     </group>
                 </field>
             </field>


### PR DESCRIPTION
Switching from Many2one('ir.attachment') to Binary for enhanced security.
Although Binary and Many2one('ir.attachment') function similarly in default settings, Binary provides additional security checks that are not present in Many2one('ir.attachment').
This change ensures a higher level of data protection and integrity across the l10n modules.

task-3177630




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
