### PR TITLE
[FIX] sale_stock,account: invoice report bootstrap

### DIFF
--- a/addons/account/views/report_invoice.xml
+++ b/addons/account/views/report_invoice.xml
@@ -60,29 +60,29 @@
                             <span t-if="o.name != '/'" t-field="o.name"/>
                         </h2>
 
-                        <div id="informations" class="row mt-4 mb-4">
-                            <div class="col-auto col-3 mw-100 mb-2" t-if="o.invoice_date" name="invoice_date">
+                        <div id="informations" class="row mt-3 mb-1">
+                            <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" t-if="o.invoice_date" name="invoice_date">
                                 <t t-if="o.move_type == 'out_invoice'"><strong>Invoice Date:</strong></t>
                                 <t t-elif="o.move_type == 'out_refund'"><strong>Credit Note Date:</strong></t>
                                 <t t-elif="o.move_type == 'out_receipt'"><strong>Receipt Date:</strong></t>
-                                <t t-else=""><strong>Date:</strong></t>
-                                <p class="m-0" t-field="o.invoice_date"/>
+                                <t t-else=""><strong>Date:</strong></t><br/>
+                                <span t-field="o.invoice_date"/>
                             </div>
-                            <div class="col-auto col-3 mw-100 mb-2" t-if="o.invoice_date_due and o.move_type == 'out_invoice' and o.state == 'posted'" name="due_date">
-                                <strong>Due Date:</strong>
-                                <p class="m-0" t-field="o.invoice_date_due"/>
+                            <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" t-if="o.invoice_date_due and o.move_type == 'out_invoice' and o.state == 'posted'" name="due_date">
+                                <strong>Due Date:</strong><br/>
+                                <span t-field="o.invoice_date_due"/>
                             </div>
-                            <div class="col-auto col-3 mw-100 mb-2" t-if="o.invoice_origin" name="origin">
-                                <strong>Source:</strong>
-                                <p class="m-0" t-field="o.invoice_origin"/>
+                            <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" t-if="o.invoice_origin" name="origin">
+                                <strong>Source:</strong><br/>
+                                <span t-field="o.invoice_origin"/>
                             </div>
-                            <div class="col-auto col-3 mw-100 mb-2" t-if="o.partner_id.ref" name="customer_code">
-                                <strong>Customer Code:</strong>
-                                <p class="m-0" t-field="o.partner_id.ref"/>
+                            <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" t-if="o.partner_id.ref" name="customer_code">
+                                <strong>Customer Code:</strong><br/>
+                                <span t-field="o.partner_id.ref"/>
                             </div>
-                            <div class="col-auto col-3 mw-100 mb-2" t-if="o.ref" name="reference">
-                                <strong>Reference:</strong>
-                                <p class="m-0" t-field="o.ref"/>
+                            <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" t-if="o.ref" name="reference">
+                                <strong>Reference:</strong><br/>
+                                <span t-field="o.ref"/>
                             </div>
                         </div>
 
@@ -283,7 +283,7 @@
                     <span t-esc="tax_totals['formatted_rounding_amount']"/>
                 </td>
             </t>
-            
+
             <!--Total amount with all taxes-->
             <tr class="border-black o_total">
                 <td><strong>Total</strong></td>

--- a/addons/sale_stock/report/sale_order_report_templates.xml
+++ b/addons/sale_stock/report/sale_order_report_templates.xml
@@ -2,19 +2,19 @@
 <odoo>
     <template id="report_saleorder_document_inherit_sale_stock" inherit_id="sale.report_saleorder_document">
         <xpath expr="//div[@name='expiration_date']" position="after">
-            <div class="col-auto col-3 mw-100 mb-2" t-if="doc.incoterm" groups="sale_stock.group_display_incoterm">
-                <strong>Incoterm:</strong>
-                <p t-if="doc.incoterm_location" t-out="'%s %s' % (doc.incoterm.code, doc.incoterm_location)" class="m-0"/>
-                <p t-else="" t-field="doc.incoterm.code" class="m-0"/>
+            <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" t-if="doc.incoterm" groups="sale_stock.group_display_incoterm">
+                <strong>Incoterm:</strong><br/>
+                <p t-if="doc.incoterm_location" t-out="'%s %s' % (doc.incoterm.code, doc.incoterm_location)"/>
+                <span t-else="" t-field="doc.incoterm.code" class="m-0"/>
             </div>
         </xpath>
     </template>
 
     <template id="report_invoice_document_inherit_sale_stock" inherit_id="account.report_invoice_document">
         <xpath expr="//div[@name='reference']" position="after">
-            <div class="col-auto col-3 mw-100 mb-2" t-if="o.invoice_incoterm_id" groups="sale_stock.group_display_incoterm" name="invoice_incoterm_id">
-                <strong>Incoterm:</strong>
-                <p class="m-0" t-field="o.invoice_incoterm_id.code"/>
+            <div t-attf-class="#{'col-auto col-3 mw-100' if report_type != 'html' else 'col'} mb-2" t-if="o.invoice_incoterm_id" groups="sale_stock.group_display_incoterm" name="invoice_incoterm_id">
+                <strong>Incoterm:</strong><br/>
+                <span t-field="o.invoice_incoterm_id.code" class="m-0"/>
             </div>
         </xpath>
     </template>


### PR DESCRIPTION
[FIX] sale_stock,account: invoice report bootstrap

Issue:
When trying to print an invoice with invoice date, due date, customer code, reference and incoterm, the css gets broken

Steps to reproduce:
1- Install invoicing App
2- Allow incoterms in settings
3- Create an invoice
4- Create and edit customer
5- In sales and purchase tab in misc group assign a reference 6- Go back to invoice creation
7- Assign date
8- In other info tab in invoice group assign relatively long customer reference 9- In other info tab in accounting group assign EX-Works as incoterm 10- Confirm and print the invoice

Solution:
Change the div classes to be dynamic based on whether we want pdf or html like in v17.0

opw-3626532

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
