### PR TITLE
[FIX] account: COALESCE is_rounding_line in tax details query to false

### DIFF
--- a/addons/account/models/account_move_line_tax_details.py
+++ b/addons/account/models/account_move_line_tax_details.py
@@ -391,7 +391,7 @@ class AccountMoveLine(models.Model):
                     tax_line.tax_repartition_line_id,
 
                     tax_line.company_id,
-                    tax_line.is_rounding_line,
+                    COALESCE(tax_line.is_rounding_line, FALSE) AS is_rounding_line,
                     comp_curr.id AS company_currency_id,
                     comp_curr.decimal_places AS comp_curr_prec,
                     curr.id AS currency_id,


### PR DESCRIPTION
Postgres and other SQL systems have 3 values for boolean: 'true', 'false', and 'null'. Because is_rounding_line is used in the groupby in the tax reports, the tax detail query portion was not being properly consolidated into one line.

Now a null is_rounding_line will be considered false just like the ORM interprets it.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
