### PR TITLE
[FIX] web_editor: fix grid columns empty options section

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -642,7 +642,7 @@ var SnippetEditor = Widget.extend({
         // Hide the snippetEditor if none of its options are visible
         // This cannot be done using the visibility of the options' UI
         // because some options can be located in the overlay.
-        const $visibleOptions = this.$optionsSection.find('we-top-button-group, we-customizeblock-option')
+        const $visibleOptions = this.$optionsSection.find('we-customizeblock-option')
                 .children(':not(.d-none)');
         this.$optionsSection.toggleClass('d-none', !$visibleOptions.length);
     },
@@ -2702,7 +2702,9 @@ var SnippetsMenu = Widget.extend({
                     // that the overlay is activated even though there are no
                     // options. That's why we disable the overlay if there are
                     // no options to enable.
-                    if (editorToEnable && !customize$Elements) {
+                    const {isTargetMovable, isTargetRemovable, displayOverlayOptions} = editorToEnable || {};
+                    const overlayHasNoVisibleOption = (!isTargetRemovable && !isTargetMovable) || !displayOverlayOptions;
+                    if (editorToEnable?.$optionsSection[0].classList.contains("d-none") && overlayHasNoVisibleOption) {
                         editorToEnable.toggleOverlay(false);
                     }
                     this._updateRightPanelContent({


### PR DESCRIPTION
Steps to reproduce [A]:

- Go to website ("edit" mode) > Add a new "Media List" snippet.
- Select one of the snippet items > An empty "Column" options section
will appear on the sidebar and an overlay will be covering the item.

After [1], grid layout options were updated to be able to set grid items
padding individually, the new snippet option used for that
(see: `GridColumns`) is targeting every `.row > div` and uses the widget
visibility code to be sure that the option is available only in "Grid"
mode, which leads to the behaviour described above.

There is already an implementation to prevent sections with hidden
widgets from being visible (see: `updateOptionsUIVisibility()`) and
adapt the overlay accordingly, but it only handles specific situations:

[B]- The implementation on [2] (used to move the switchable views to a
`SnippetOption`) led to a situation where an empty "Page Options" editor
was visible on every page.

[C]- This visible section issue from [B] was fixed (see [3]) by hiding
the `snippetEditor` if none of its options are visible (including the
`we-top-button-group` options).

[D]- Even with a hidden "Page Options" `SnippetEditor`, its overlay will
always be visible (with an empty options tab) when the `<main/>` element
is clicked. The code from [4] fixed a specific situation of the issue:
The code will hide the overlay only if there are no options at all
(`customize$Elements === null`), which is the case for `SwitchableViews`
(e.g. for a `SnippetEditor` with parent editors, we only need to hide
the overlay if its `$optionsSection` is empty).

The goal of this commit is to fix the behaviour described in [A] in two
simple steps:

- Allow hiding the `snippetEditor` even if it contains visible
`we-top-button-group` options, since an editor with no
`we-customizeblock-option` is enough to prevent its visibility (also,
the fix in [3] was specifically introduced to hide the "Page Options"
editors).

- Generalize the check from [4] to hide the overlay of every editor with
an empty options section.

[1]: https://github.com/odoo/odoo/commit/11418cc6f0afcc8e14869f4f38ae0d6d462ac712
[2]: https://github.com/odoo/odoo/commit/69af7dcfeb3ff95c40b00ef0cc7c5c0e4021f9d2
[3]: https://github.com/odoo/odoo/commit/39d073ccafddf4b3fbe9ec9f5f11849d77c9bdaa
[4]: https://github.com/odoo/odoo/commit/fccac358dae7092c8c7cd90ba1ee89c712bc86e9

task-3658153