### PR TITLE
[IMP] web_editor: permit to translate media

### DIFF
--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -462,6 +462,13 @@ function _shouldEditableMediaBeEditable(mediaEl) {
     // first non editable ancestor is in fact in an editable parent.
     const parentEl = mediaEl.parentElement;
     const nonEditableAncestorRootEl = parentEl && parentEl.closest('[contenteditable="false"]');
+    if (
+        nonEditableAncestorRootEl
+        && nonEditableAncestorRootEl.id === "wrapwrap"
+        && nonEditableAncestorRootEl.closest("[data-edit_translations]")
+    ) {
+        return true;
+    }
     return nonEditableAncestorRootEl
         && nonEditableAncestorRootEl.parentElement
         && nonEditableAncestorRootEl.parentElement.isContentEditable;

--- a/addons/web_editor/static/src/js/common/utils.js
+++ b/addons/web_editor/static/src/js/common/utils.js
@@ -498,9 +498,9 @@ function _forwardToThumbnail(imgEl) {
         const carouselItemEl = imgEl.closest(".carousel-item");
         if (carouselInnerEl && carouselItemEl) {
             const imageIndex = [...carouselInnerEl.children].indexOf(carouselItemEl);
-            const miniatureEl = carouselEl.querySelector(`.carousel-indicators [data-bs-slide-to="${imageIndex}"]`);
-            if (miniatureEl && miniatureEl.style.backgroundImage) {
-                miniatureEl.style.backgroundImage = `url(${imgEl.getAttribute("src")})`;
+            const miniatureEl = carouselEl.querySelector(`.carousel-indicators [data-bs-slide-to="${imageIndex}"] img`);
+            if (miniatureEl) {
+                miniatureEl.setAttribute("src", imgEl.getAttribute("src"));
             }
         }
     }

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -117,7 +117,7 @@ var SnippetEditor = publicWidget.Widget.extend({
         this.isTargetParentEditable = this.$target.parent().is(':o_editable');
         this.isTargetMovable = this.isTargetParentEditable && this.isTargetMovable && !this.$target.hasClass('oe_unmovable');
         this.isTargetRemovable = this.isTargetParentEditable && !this.$target.parent().is('[data-oe-type="image"]') && !isUnremovable(this.$target[0]);
-        this.displayOverlayOptions = this.displayOverlayOptions || this.isTargetMovable || !this.isTargetParentEditable;
+        this.displayOverlayOptions = !this.options.enableTranslation && (this.displayOverlayOptions || this.isTargetMovable || !this.isTargetParentEditable);
 
         // Initialize move/clone/remove buttons
         if (this.isTargetMovable) {
@@ -3372,8 +3372,9 @@ class SnippetsMenu extends Component {
             return snippetEditor.__isStarted;
         }
 
-        // In translate mode, only allow creating the editor if the target is a
-        // text option snippet.
+        // In translate mode, only allow creating the editor if the target is
+        // among some specific snippets (text option snippet, has a translatable
+        // attribute...).
         if (!forceCreate && this.options.enableTranslation && !this._allowInTranslationMode($snippet)) {
             return Promise.resolve(null);
         }
@@ -4098,7 +4099,9 @@ class SnippetsMenu extends Component {
      * @private
      */
     _allowInTranslationMode($snippet) {
-        return globalSelector.is($snippet, { onlyTextOptions: true });
+        return $snippet[0]?.matches(".o_translatable_attribute")
+            || $snippet[0]?.querySelector(".o_translatable_attribute")
+            || globalSelector.is($snippet, { onlyTextOptions: true });
     }
     /**
      * Allows to update the snippets to build & adapt dynamic content right

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1785,6 +1785,17 @@ export class Wysiwyg extends Component {
                     if (params.node.dataset.oeTranslatableLink) {
                         params.node.dataset.oeTranslatableLink = element.getAttribute("src");
                     }
+                    if (params.node.classList.contains("media_iframe_video")) {
+                        const newSrc = element.querySelector("iframe").getAttribute("src");
+                        params.node.setAttribute("data-oe-expression", newSrc);
+                        const iframeEl = params.node.querySelector("iframe");
+                        iframeEl.setAttribute("src", newSrc);
+                        // We force the replacement of the iframe because of a
+                        // content caching problem with Chrome: after save, the
+                        // src is correct, but the iframe's document still shows
+                        // the previous src.
+                        iframeEl.replaceWith(iframeEl.cloneNode());
+                    }
                     const attributesToKeep = ["data-resize-width", "title", "alt", "data-oe-translation-state", "data-oe-translatable-link"];
                     // We don't replace the node with the element because there
                     // are mutation observers needed for the translation system.
@@ -1807,7 +1818,7 @@ export class Wysiwyg extends Component {
                 }
             }
             this.odooEditor.unbreakableStepUnactive();
-            this.odooEditor.historyStep();
+            this.odooEditor.historyStep(true);
             // Refocus again to save updates when calling `_onWysiwygBlur`
             this.odooEditor.editable.focus();
         } else {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1706,6 +1706,7 @@ export class Wysiwyg extends Component {
             }),
             onAttachmentChange: this._onAttachmentChange.bind(this),
             close: () => restoreSelection(),
+            noIcons: this.options.enableTranslation,
             ...this.options.mediaModalParams,
             ...params,
         });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1796,6 +1796,13 @@ export class Wysiwyg extends Component {
                         // the previous src.
                         iframeEl.replaceWith(iframeEl.cloneNode());
                     }
+                    // Case of a document uploaded through the media dialog
+                    // instead of the link tools: the title must be updated.
+                    // Note that this title is set to the document's name by
+                    // default and cannot be modified in the source language.
+                    if (params.node.tagName === "A" && params.node.classList.contains("o_image")) {
+                        params.node.title = element.getAttribute("title");
+                    }
                     const attributesToKeep = ["data-resize-width", "title", "alt", "data-oe-translation-state", "data-oe-translatable-link"];
                     // We don't replace the node with the element because there
                     // are mutation observers needed for the translation system.

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -415,7 +415,7 @@
          data-selector="img, .media_iframe_video, span.fa, i.fa"
          data-exclude="[data-oe-xpath], a[href^='/website/social/'] > i.fa, a[class*='s_share_'] > i.fa">
         <we-row string="Media">
-            <we-button class="o_we_bg_success" data-replace-media="true" data-no-preview="true">Replace</we-button>
+            <we-button class="o_we_bg_success" data-replace-media="true" data-no-preview="true" data-name="replace_media_opt">Replace</we-button>
             <div>
                 <we-button class="fa fa-link"
                     data-name="media_link_opt"
@@ -721,11 +721,11 @@
         </div>
         <we-input string="Description" class="o_we_large"
             data-select-attribute="" data-attribute-name="alt"
-            placeholder="Alt tag"
+            placeholder="Alt tag" data-name="image_alt_opt"
             title="'Alt tag' specifies an alternate text for an image, if the image cannot be displayed (slow connection, missing image, screen reader ...)."/>
         <we-input string="Tooltip" class="o_we_large"
             data-select-attribute="" data-attribute-name="title"
-            placeholder="Title tag"
+            placeholder="Title tag" data-name="image_title_opt"
             title="'Title tag' is shown as a tooltip when you hover the picture."/>
         <we-row string="Transform">
             <we-button class="fa fa-fw fa-crop" data-crop="true" data-no-preview="true" title="Crop Image"/>

--- a/addons/website/models/ir_qweb.py
+++ b/addons/website/models/ir_qweb.py
@@ -117,18 +117,19 @@ class IrQWeb(models.AbstractModel):
         if website and tagName == 'img' and 'loading' not in atts:
             atts['loading'] = 'lazy'  # default is auto
 
-        # `src` attributes are translatable, but translatable strings
+        # `src` and `href` attributes are translatable, but translatable strings
         # are marked by wrapping them in a span. This can't work for links that
         # are called once the DOM is loaded, as they will create wrong requests
         # that will stall the server. In that case, we make a temporary
         # `data-oe-translatable-link` to safely translate links.
-        # Note that a <script>'s `src` should of course
+        # Note that a <link> tag's `href` or a <script>'s `src` should of course
         # not be translated, but they are marked as such anyway as we don't
         # differentiate the attributes depending on their tag, so we give them
         # the same treatment.
         if website and self.env.context.get('edit_translations'):
             links = {
                 'img': 'src',
+                'link': 'href',
                 'iframe': 'src',
                 'script': 'src',
             }

--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -237,9 +237,9 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         const toTranslateColor = window.getComputedStyle(document.documentElement).getPropertyValue('--o-we-content-to-translate-color');
         const translatedColor = window.getComputedStyle(document.documentElement).getPropertyValue('--o-we-translated-content-color');
 
-        styleEl.sheet.insertRule(`[data-oe-translation-state].o_dirty:not(img) {background: ${translatedColor} !important;}`);
-        styleEl.sheet.insertRule(`[data-oe-translation-state="translated"]:not(img) {background: ${translatedColor} !important;}`);
-        styleEl.sheet.insertRule(`[data-oe-translation-state]:not(img) {background: ${toTranslateColor} !important;}`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state].o_dirty:not(img) {background-color: ${translatedColor} !important;}`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state="translated"]:not(img) {background-color: ${translatedColor} !important;}`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state]:not(img) {background-color: ${toTranslateColor} !important;}`);
 
         styleEl.sheet.insertRule(`[data-oe-translation-state].o_dirty:where(img, .media_iframe_video) {border: 5px solid ${translatedColor} !important;}`);
         styleEl.sheet.insertRule(`[data-oe-translation-state="translated"]:where(img, .media_iframe_video) {border: 5px solid ${translatedColor} !important;}`);

--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -68,6 +68,7 @@ const savableSelector = '[data-oe-translation-source-sha], ' +
     '[value*="data-oe-translation-source-sha="], ' +
     'textarea:contains(data-oe-translation-source-sha), ' +
     '[data-oe-translatable-link*="data-oe-translation-source-sha="], ' +
+    '[data-oe-expression*="data-oe-translation-source-sha="], ' +
     '[alt*="data-oe-translation-source-sha="]';
 
 export class WebsiteTranslator extends WebsiteEditorComponent {
@@ -132,8 +133,8 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         const self = this;
         const $editable = this.getEditableArea();
         const translationRegex = /<span [^>]*data-oe-translation-source-sha="([^"]+)"[^>]*>(.*)<\/span>/;
-        for (const attr of ["placeholder", "title", "alt", "value", "data-oe-translatable-link"]) {
-            const attrEdit = $editable.filter('[' + attr + '*="data-oe-translation-source-sha="]').filter(':empty, input, select, textarea, img');
+        for (const attr of ["placeholder", "title", "alt", "value", "data-oe-translatable-link", "data-oe-expression"]) {
+            const attrEdit = $editable.filter('[' + attr + '*="data-oe-translation-source-sha="]').filter(':empty, input, select, textarea, img, div');
             attrEdit.each(function () {
                 var $node = $(this);
                 var translation = $node.data('translation') || {};
@@ -240,9 +241,9 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         styleEl.sheet.insertRule(`[data-oe-translation-state="translated"]:not(img) {background: ${translatedColor} !important;}`);
         styleEl.sheet.insertRule(`[data-oe-translation-state]:not(img) {background: ${toTranslateColor} !important;}`);
 
-        styleEl.sheet.insertRule(`img[data-oe-translation-state].o_dirty {border: 5px solid ${translatedColor} !important;}`);
-        styleEl.sheet.insertRule(`img[data-oe-translation-state="translated"] {border: 5px solid ${translatedColor} !important;}`);
-        styleEl.sheet.insertRule(`img[data-oe-translation-state] {border: 5px solid ${toTranslateColor} !important;}`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state].o_dirty:where(img, .media_iframe_video) {border: 5px solid ${translatedColor} !important;}`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state="translated"]:where(img, .media_iframe_video) {border: 5px solid ${translatedColor} !important;}`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state]:where(img, .media_iframe_video) {border: 5px solid ${toTranslateColor} !important;}`);
 
         const showNotification = ev => {
             let message = _t('This translation is not editable.');

--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -69,6 +69,7 @@ const savableSelector = '[data-oe-translation-source-sha], ' +
     'textarea:contains(data-oe-translation-source-sha), ' +
     '[data-oe-translatable-link*="data-oe-translation-source-sha="], ' +
     '[data-oe-expression*="data-oe-translation-source-sha="], ' +
+    '[href*="data-oe-translation-source-sha="],' +
     '[alt*="data-oe-translation-source-sha="]';
 
 export class WebsiteTranslator extends WebsiteEditorComponent {
@@ -133,8 +134,8 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         const self = this;
         const $editable = this.getEditableArea();
         const translationRegex = /<span [^>]*data-oe-translation-source-sha="([^"]+)"[^>]*>(.*)<\/span>/;
-        for (const attr of ["placeholder", "title", "alt", "value", "data-oe-translatable-link", "data-oe-expression"]) {
-            const attrEdit = $editable.filter('[' + attr + '*="data-oe-translation-source-sha="]').filter(':empty, input, select, textarea, img, div');
+        for (const attr of ["placeholder", "title", "alt", "value", "data-oe-translatable-link", "data-oe-expression", "href"]) {
+            const attrEdit = $editable.filter('[' + attr + '*="data-oe-translation-source-sha="]').filter(':empty, input, select, textarea, img, div, a');
             attrEdit.each(function () {
                 var $node = $(this);
                 var translation = $node.data('translation') || {};

--- a/addons/website/static/src/components/translator/translator.xml
+++ b/addons/website/static/src/components/translator/translator.xml
@@ -13,7 +13,7 @@
             <li data-oe-translation-state="translated">Translated content</li>
         </ul>
         <p>
-            In this mode, you can only translate texts or replace images with a translated counterpart. To change the structure of the page, you must edit the master page.
+            In this mode, you can only translate texts or replace some elements (images, videos) with a translated counterpart. To change the structure of the page, you must edit the master page.
             Each modification on the master page is automatically applied to all translated versions.
         </p>
     </WebsiteDialog>

--- a/addons/website/static/src/components/translator/translator.xml
+++ b/addons/website/static/src/components/translator/translator.xml
@@ -13,7 +13,7 @@
             <li data-oe-translation-state="translated">Translated content</li>
         </ul>
         <p>
-            In this mode, you can only translate texts or replace some elements (images, videos) with a translated counterpart. To change the structure of the page, you must edit the master page.
+            In this mode, you can only translate texts or replace some elements (images, videos, documents) with a translated counterpart. To change the structure of the page, you must edit the master page.
             Each modification on the master page is automatically applied to all translated versions.
         </p>
     </WebsiteDialog>

--- a/addons/website/static/src/components/translator/translator.xml
+++ b/addons/website/static/src/components/translator/translator.xml
@@ -13,17 +13,9 @@
             <li data-oe-translation-state="translated">Translated content</li>
         </ul>
         <p>
-            In this mode, you can only translate texts. To change the structure of the page, you must edit the master page.
+            In this mode, you can only translate texts or replace images with a translated counterpart. To change the structure of the page, you must edit the master page.
             Each modification on the master page is automatically applied to all translated versions.
         </p>
     </WebsiteDialog>
 </div>
-
-<t t-name="website.AttributeTranslateDialog">
-    <WebsiteDialog close="props.close"
-        title="title"
-        showSecondaryButton="false">
-        <div t-ref="form-container"/>
-    </WebsiteDialog>
-</t>
 </templates>

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1372,6 +1372,17 @@ options.registry.ReplaceMedia.include({
         return this._super(...arguments);
     },
     /**
+     * @override
+     */
+    _computeWidgetTranslateVisibility(widgetName, params) {
+        if (widgetName === "replace_media_opt"
+            && this.$target[0].classList.contains("o_translatable_attribute")
+        ) {
+            return !!this.$target[0].getAttribute("src");
+        }
+        return this._super(...arguments);
+    },
+    /**
      * Fills the dropdown with the available anchors for the page referenced in
      * the href.
      *
@@ -3908,6 +3919,15 @@ options.registry.WebsiteAnimate = options.Class.extend({
     /**
      * @override
      */
+    _computeWidgetTranslateVisibility(widgetName, params) {
+        if (this.$target[0].matches(".o_animated_text")) {
+            return true;
+        }
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
     _computeVisibility(methodName, params) {
         if (this.$target[0].matches('img')) {
             return isImageSupportedForStyle(this.$target[0]);
@@ -4056,6 +4076,15 @@ options.registry.TextHighlight = options.Class.extend({
             await this._refreshPublicWidgets($(this.options.wysiwyg.odooEditor.editable))
         });
     },
+    /**
+     * @override
+     */
+    _computeWidgetTranslateVisibility(widgetName, params) {
+        if (this.$target[0].matches(".o_text_highlight")) {
+            return true;
+        }
+        return this._super(...arguments);
+    },
 
     //--------------------------------------------------------------------------
     // Handlers
@@ -4169,6 +4198,9 @@ options.registry.sizing.include({
     start() {
         const defs = this._super(...arguments);
         const self = this;
+        if (!this.canUseHandle) {
+            return defs;
+        }
         this.$handles.on('mousedown', function (ev) {
             // Since website is edited in an iframe, a div that goes over the
             // iframe is necessary to catch mousemove and mouseup events,

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -1375,10 +1375,10 @@ options.registry.ReplaceMedia.include({
      * @override
      */
     _computeWidgetTranslateVisibility(widgetName, params) {
-        if (widgetName === "replace_media_opt"
-            && this.$target[0].classList.contains("o_translatable_attribute")
-        ) {
-            return !!this.$target[0].getAttribute("src");
+        if (widgetName === "replace_media_opt") {
+            if (this.$target[0].classList.contains("o_translatable_attribute")) {
+                return !!this.$target[0].getAttribute("src") || !!this.$target[0].dataset.oeExpression;
+            }
         }
         return this._super(...arguments);
     },

--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -260,12 +260,12 @@ body.editor_enable {
 // target all inputs and/or target specific snippets in their own app.
 .editor_enable {
     .s_website_form, .s_searchbar_input, .js_subscribe, .s_group, .s_donation_form {
-        input:not(.o_translatable_attribute) {
+        input {
             pointer-events: none;
         }
     }
     .s_website_form {
-        textarea:not(.o_translatable_attribute):not(.o_translatable_text) {
+        textarea {
             pointer-events: none;
         }
     }

--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -154,7 +154,8 @@ $-editor-messages-margin-x: 2%;
 }
 
 .editor_enable .css_non_editable_mode_hidden,
-.o_editable .media_iframe_video .css_editable_mode_display {
+.o_editable .media_iframe_video .css_editable_mode_display,
+[data-translatable] .editor_enable .media_iframe_video .css_editable_mode_display {
     display: block!important;
 }
 

--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -44,7 +44,7 @@
 html[lang] > body.editor_enable {
     [data-oe-translation-state]:not(img) {
         @include translationStateStyles(
-            background,
+            background-color,
             rgba($o-we-content-to-translate-color, 0.5),
             rgba($o-we-translated-content-color, 0.25),
             rgba($o-we-translated-content-color, 0.5)

--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -21,23 +21,42 @@
     }
 }
 
-html[lang] > body.editor_enable [data-oe-translation-state] {
+@mixin translationStateStyles($property, $valueToTranslate, $valueJustTranslated, $valueTranslated) {
     &, .o_translation_select_option, &[data-oe-field="mega_menu_content"] * {
-        background: rgba($o-we-content-to-translate-color, 0.5) !important;
+        #{$property}: $valueToTranslate !important;
     }
 
     &[data-oe-translation-state="translated"] {
         &, .o_translation_select_option, &[data-oe-field="mega_menu_content"] * {
-            background: rgba($o-we-translated-content-color, 0.5) !important;
+            #{$property}: $valueTranslated !important;
         }
     }
 
     &.o_dirty, &.oe_translated, .oe_translated {
-        background: rgba($o-we-translated-content-color, 0.25) !important;
+        #{$property}: $valueJustTranslated !important;
 
         &[data-oe-field="mega_menu_content"] * {
-            background: rgba($o-we-translated-content-color, 0.25) !important;
+            #{$property}: $valueJustTranslated !important;
         }
+    }
+}
+
+html[lang] > body.editor_enable {
+    [data-oe-translation-state]:not(img) {
+        @include translationStateStyles(
+            background,
+            rgba($o-we-content-to-translate-color, 0.5),
+            rgba($o-we-translated-content-color, 0.25),
+            rgba($o-we-translated-content-color, 0.5)
+        );
+    }
+    img[data-oe-translation-state] {
+        @include translationStateStyles(
+            border,
+            5px solid rgba($o-we-content-to-translate-color, 0.5),
+            5px solid rgba($o-we-translated-content-color, 0.25),
+            5px solid rgba($o-we-translated-content-color, 0.5)
+        );
     }
 }
 

--- a/addons/website/static/src/snippets/s_image_gallery/000.js
+++ b/addons/website/static/src/snippets/s_image_gallery/000.js
@@ -104,7 +104,7 @@ const GalleryWidget = publicWidget.Widget.extend({
 });
 
 const GallerySliderWidget = publicWidget.Widget.extend({
-    selector: '.o_slideshow',
+    selector: '.o_slideshow:not([data-vcss="002"])',
     disabledInEditableMode: false,
 
     /**
@@ -114,9 +114,9 @@ const GallerySliderWidget = publicWidget.Widget.extend({
         var self = this;
         this.$carousel = this.$el.is('.carousel') ? this.$el : this.$('.carousel');
         this.$indicator = this.$carousel.find('.carousel-indicators');
-        this.$prev = this.$indicator.find('li.o_indicators_left').css('visibility', ''); // force visibility as some databases have it hidden
-        this.$next = this.$indicator.find('li.o_indicators_right').css('visibility', '');
-        var $lis = this.$indicator.find('li[data-bs-slide-to]');
+        this.$prev = this.$indicator.find('.o_indicators_left').css('visibility', ''); // force visibility as some databases have it hidden
+        this.$next = this.$indicator.find('.o_indicators_right').css('visibility', '');
+        const $btns = this.$indicator.find('[data-bs-slide-to]');
         let indicatorWidth = this.$indicator.width();
         if (indicatorWidth === 0) {
             // An ancestor may be hidden so we try to find it and make it
@@ -128,16 +128,16 @@ const GallerySliderWidget = publicWidget.Widget.extend({
                 $indicatorParent[0].style.display = '';
             }
         }
-        let nbPerPage = Math.floor(indicatorWidth / $lis.first().outerWidth(true)) - 3; // - navigator - 1 to leave some space
+        let nbPerPage = Math.floor(indicatorWidth / $btns.first().outerWidth(true)) - 3; // - navigator - 1 to leave some space
         var realNbPerPage = nbPerPage || 1;
-        var nbPages = Math.ceil($lis.length / realNbPerPage);
+        var nbPages = Math.ceil($btns.length / realNbPerPage);
 
         var index;
         var page;
         update();
 
         function hide() {
-            $lis.each(function (i) {
+            $btns.each(function (i) {
                 $(this).toggleClass('d-none', i < page * nbPerPage || i >= (page + 1) * nbPerPage);
             });
             if (page <= 0) {
@@ -155,8 +155,8 @@ const GallerySliderWidget = publicWidget.Widget.extend({
         }
 
         function update() {
-            const active = $lis.filter('.active');
-            index = active.length ? $lis.index(active) : 0;
+            const active = $btns.filter('.active');
+            index = active.length ? $btns.index(active) : 0;
             page = Math.floor(index / realNbPerPage);
             hide();
         }
@@ -165,12 +165,12 @@ const GallerySliderWidget = publicWidget.Widget.extend({
             setTimeout(function () {
                 var $item = self.$carousel.find('.carousel-inner .carousel-item-prev, .carousel-inner .carousel-item-next');
                 var index = $item.index();
-                $lis.removeClass('active')
+                $btns.removeClass('active')
                     .filter('[data-bs-slide-to="' + index + '"]')
                     .addClass('active');
             }, 0);
         });
-        this.$indicator.on('click.gallery_slider', '> li:not([data-bs-slide-to])', function () {
+        this.$indicator.on('click.gallery_slider', '> span:not([data-bs-slide-to])', function () {
             page += ($(this).hasClass('o_indicators_left') ? -1 : 1);
             page = Math.max(0, Math.min(nbPages - 1, page)); // should not be necessary
             self.$carousel.carousel(page * realNbPerPage);

--- a/addons/website/static/src/snippets/s_image_gallery/000.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/000.xml
@@ -19,17 +19,21 @@
                  </t>
             </div>
 
-            <ul class="carousel-indicators">
-                <li class="o_indicators_left text-center d-none" aria-label="Previous" title="Previous">
-                    <i class="oi oi-chevron-left"/>
-                </li>
+            <div class="carousel-indicators o_not_editable" contenteditable="false">
+                <button type="button" class="o_indicators_left text-center d-none" title="Previous">
+                    <span class="oi oi-chevron-left" aria-hidden="true"/>
+                    <span class="visually-hidden">Previous</span>
+                </button>
                 <t t-foreach="images" t-as="image" t-key="image_index">
-                    <li t-attf-data-bs-target="##{id}" t-att-data-bs-slide-to="image_index" t-att-class="image_index == index and 'active' or None" t-attf-style="background-image: url(#{image.getAttribute('src')})"></li>
+                    <button type="button" class="d-flex overflow-hidden" t-attf-data-bs-target="##{id}" t-att-data-bs-slide-to="image_index" t-att-class="image_index == index and 'active' or None" t-attf-aria-label="Slide to image #{image_index + 1}">
+                        <img class="object-fit-cover h-100 w-100" t-att-src="image.getAttribute('src')" aria-hidden="true"/>
+                    </button>
                 </t>
-                <li class="o_indicators_right text-center d-none" aria-label="Next" title="Next">
-                    <i class="oi oi-chevron-right"/>
-                </li>
-            </ul>
+                <button type="button" class="o_indicators_right text-center d-none" title="Next">
+                    <span class="oi oi-chevron-right" aria-hidden="true"/>
+                    <span class="visually-hidden">Next</span>
+                </button>
+            </div>
 
             <a class="carousel-control-prev o_we_no_overlay o_not_editable" t-attf-href="##{id}" data-bs-slide="prev" aria-label="Previous" title="Previous">
                 <span class="oi oi-chevron-left fa-2x text-white"></span>

--- a/addons/website/static/src/snippets/s_image_gallery/001.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/001.scss
@@ -93,7 +93,7 @@
             .carousel-control-prev {
                 padding-bottom: 64px;
             }
-            ul.carousel-indicators li {
+            .carousel-indicators button {
                 border: 1px solid #aaa;
             }
             .media_iframe_video {
@@ -103,7 +103,7 @@
                 height: 100%;
             }
         }
-        ul.carousel-indicators {
+        .carousel-indicators {
             position: absolute;
             left: 0%;
             bottom: 0;
@@ -112,9 +112,7 @@
             margin-left: 0;
             padding: 0;
             border-width: 0;
-            > * {
-                list-style-image: none;
-                display: inline-block;
+            > button {
                 width: 40px;
                 height: 40px;
                 line-height: 40px;
@@ -150,7 +148,7 @@
             }
         }
         &:not(.s_image_gallery_show_indicators) .carousel {
-            ul.carousel-indicators {
+            .carousel-indicators {
                 display: none;
             }
             .carousel-item.active,
@@ -236,24 +234,27 @@
         }
         &.s_image_gallery_indicators_rounded {
             .carousel {
-                ul.carousel-indicators li {
+                .carousel-indicators button {
                     border-radius: 50%;
                 }
             }
         }
         &.s_image_gallery_indicators_dots {
             .carousel {
-                ul.carousel-indicators {
+                .carousel-indicators {
                     height: 40px;
                     margin: auto;
 
-                    li {
+                    button {
                         max-width: 8px;
                         max-height: 8px;
                         margin: 0 6px;
                         border-radius: 10px;
                         background-color: $black;
-                        background-image: none !important;
+
+                        img {
+                            display: none;
+                        }
 
                         &:not(.active) {
                             opacity: .4;
@@ -281,7 +282,7 @@
             padding: 0;
         }
     }
-    ul.carousel-indicators {
+    .carousel-indicators {
         display: none;
     }
 

--- a/addons/website/static/src/snippets/s_image_gallery/001.xml
+++ b/addons/website/static/src/snippets/s_image_gallery/001.xml
@@ -16,7 +16,15 @@
                 </button>
                 <div class="carousel-indicators s_image_gallery_indicators_bars">
                     <t t-foreach="images" t-as="image" t-key="image_index">
-                        <button type="button" aria-label="Carousel indicator" t-attf-data-bs-target="##{id}" t-att-data-bs-slide-to="image_index" t-att-class="image_index == index and 'active' or None" t-attf-style="background-image: url(#{image.getAttribute('src')})"/>
+                        <button type="button"
+                                t-attf-aria-label="Carousel indicator for image #{image_index + 1}"
+                                class="o_not_editable d-flex overflow-hidden"
+                                contenteditable="false"
+                                t-attf-data-bs-target="##{id}"
+                                t-att-data-bs-slide-to="image_index"
+                                t-att-class="image_index == index and 'active' or None">
+                            <img class="object-fit-cover w-100 h-100" t-att-src="image.getAttribute('src')" aria-hidden="true"/>
+                        </button>
                     </t>
                 </div>
                 <button class="carousel-control-next o_we_no_overlay o_not_editable" contenteditable="false" t-attf-data-bs-target="##{id}" data-bs-slide="next" aria-label="Next" title="Next">

--- a/addons/website/static/src/snippets/s_image_gallery/002.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/002.scss
@@ -184,8 +184,8 @@
         }
 
         // Indicators - Bars
-        &.s_image_gallery_indicators_bars .carousel-indicators > button {
-            background-image: none !important;
+        &.s_image_gallery_indicators_bars .carousel-indicators > button img {
+            display: none;
         }
 
         // Indicators - Squared Miniatures / Rounded Miniatures
@@ -219,9 +219,12 @@
                 height: $-o-carousel-indicators-dots-size;
                 border: 0;
                 border-radius: $border-radius-pill;
-                background-image: none !important;
                 transform: scale(.5);
                 transition: opacity .6s ease, transform .6s ease; // $carousel-indicator-transition values
+
+                img {
+                    display: none;
+                }
 
                 // Increases the click area for easier navigation.
                 &:before {

--- a/addons/website/static/src/snippets/s_image_gallery/options.js
+++ b/addons/website/static/src/snippets/s_image_gallery/options.js
@@ -185,7 +185,7 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
             carouselItemEl.appendChild(imgHolderEls[index]);
         });
         this._replaceContent($slideshow);
-        this.$("img").toArray().forEach((img, index) => {
+        this.$("img:not([aria-hidden])").toArray().forEach((img, index) => {
             $(img).attr({contenteditable: true, 'data-index': index});
         });
         this.$target.css('height', Math.round(window.innerHeight * 0.7));
@@ -199,7 +199,7 @@ options.registry.GalleryLayout = options.registry.CarouselHandler.extend({
      * @override
      */
     _getItemsGallery() {
-        const imgs = this.$('img').get();
+        const imgs = this.$('img:not([aria-hidden])').get();
         imgs.sort((a, b) => this._getIndex(a) - this._getIndex(b));
         return imgs;
     },
@@ -418,11 +418,11 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
      */
     start() {
         // Make sure image previews are updated if images are changed
-        this.$target.on('image_changed.gallery', 'img', ev => {
-            const $img = $(ev.currentTarget);
+        this.$target.on('image_changed.gallery', 'img:not([aria-hidden])', (ev) => {
             const index = this.$target.find('.carousel-item.active').index();
-            this.$('.carousel:first li[data-bs-target]:eq(' + index + ')')
-                .css('background-image', 'url(' + $img.attr('src') + ')');
+            ev.currentTarget.closest("section")
+                .querySelectorAll(".carousel-indicators img[aria-hidden]")[index]
+                ?.setAttribute("src", ev.currentTarget.getAttribute("src"));
         });
 
         // When the snippet is empty, an edition button is the default content
@@ -432,7 +432,7 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
             this.addImages(false);
         });
 
-        this.$target.on('dropped.gallery', 'img', ev => {
+        this.$target.on('dropped.gallery', 'img:not([aria-hidden])', ev => {
             this._relayout();
             if (!ev.target.height) {
                 $(ev.target).one('load', () => {
@@ -480,7 +480,7 @@ options.registry.GalleryImageList = options.registry.GalleryLayout.extend({
      * @see this.selectClass for parameters
      */
     addImages(previewMode) {
-        const $images = this.$('img');
+        const $images = this.$('img:not([aria-hidden])');
         const $container = this.$('> .container, > .container-fluid, > .o_container_small');
         const lastImage = this._getItemsGallery().at(-1);
         let index = lastImage ? this._getIndex(lastImage) : -1;

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -981,7 +981,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         const _super = this._super.bind(this);
         // Build the custom select
         const select = this._getSelect();
-        if (select) {
+        if (select && !this.options.enableTranslation) {
             const field = this._getActiveField();
             await this._replaceField(field);
         }
@@ -1142,6 +1142,9 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
     selectTextareaValue: function (previewMode, value, params) {
         this.$target[0].textContent = value;
         this.$target[0].value = value;
+        // Trigger the change event to be able to detect the change for the
+        // translation system.
+        this.$target[0].dispatchEvent(new Event("change"));
     },
     /**
      * Select the date as value property and convert it to the right format
@@ -1356,6 +1359,20 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 return fieldEl.classList.contains("s_website_form_custom") ||
                     ["one2many", "many2many"].includes(fieldEl.dataset.type);
             }
+        }
+        return this._super(...arguments);
+    },
+    /**
+     * @override
+     */
+    _computeWidgetTranslateVisibility(widgetName, params) {
+        switch (widgetName) {
+            case "placeholder_opt":
+                return !!this.$target[0].getAttribute("placeholder");
+            case "textarea_value_opt":
+                return !!this.$target[0].value;
+            case "value_opt":
+                return !!this.$target[0].getAttribute("value");
         }
         return this._super(...arguments);
     },

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -184,9 +184,7 @@ registerWebsitePreviewTour('rte_translator', {
 }, {
     content: "check if translation is activate",
     trigger: ':iframe [data-oe-translation-source-sha]',
-    run: "click",
-},
-{
+}, {
     trigger: "#oe_snippets.o_loaded",
 },
 {

--- a/addons/website/static/tests/tours/rte.js
+++ b/addons/website/static/tests/tours/rte.js
@@ -128,13 +128,29 @@ registerWebsitePreviewTour('rte_translator', {
     run() {
         $('iframe:not(.o_ignore_in_tour)').contents().find("#wrap p:first").replaceWith('<p>Write one or <font style="background-color: yellow;">two paragraphs <b>describing</b></font> your product or\
             <font style="color: rgb(255, 0, 0);">services</font>. To be successful your content needs to be\
-            useful to your <a href="/999">readers</a>.</p> <input value="test translate default value" placeholder="test translate placeholder"/>\
-            <p>&lt;b&gt;&lt;/b&gt; is an HTML&nbsp;tag &amp; is empty</p>');
+            useful to your <a href="/999">readers</a>.</p>\
+            <p class="test_translate">&lt;b&gt;&lt;/b&gt; is an HTML&nbsp;tag &amp; is empty</p>');
         $('iframe:not(.o_ignore_in_tour)').contents().find("#wrap img").attr("title", "test translate image title");
     }
-    }, {
+}, {
     content: "ensure change was applied",
     trigger: ':iframe #wrap p:first b',
+},
+...insertSnippet({
+    id: "s_website_form",
+    name: "Form",
+}), {
+    content: "Click on form text input",
+    trigger: ':iframe .s_website_form input[type="text"]',
+    run: "click",
+}, {
+    content: "Set a placeholder",
+    trigger: '[data-attribute-name="placeholder"] input',
+    run: 'edit test translate placeholder',
+}, {
+    content: "Set a default value",
+    trigger: '[data-attribute-name="value"] input',
+    run: 'edit test translate default value',
 },
 ...clickOnSave(),
 {
@@ -185,7 +201,7 @@ registerWebsitePreviewTour('rte_translator', {
     },
 }, {
     content: "translate text with special char",
-    trigger: ':iframe #wrap input + p span:first',
+    trigger: ':iframe #wrap p.test_translate span:first',
     async run(actionHelper) {
         await actionHelper.click();
         this.anchor.textContent = '<{translated}>' + this.anchor.textContent;
@@ -200,24 +216,16 @@ registerWebsitePreviewTour('rte_translator', {
 },
 {
     content: "click on input",
-    trigger: ':iframe #wrap input:first',
+    trigger: ':iframe .s_website_form input[type="text"]',
     run: 'click',
 }, {
     content: "translate placeholder",
-    trigger: '.modal-dialog input:first',
+    trigger: '[data-attribute-name="placeholder"] input',
     run: "edit test Parseltongue placeholder",
 }, {
     content: "translate default value",
-    trigger: '.modal-dialog input:last',
+    trigger: '[data-attribute-name="value"] input',
     run: "edit test Parseltongue default value",
-},
-{
-    trigger: '.modal input:value("test Parseltongue placeholder")',
-},
-{
-    content: "close modal",
-    trigger: '.modal-footer .btn-primary',
-    run: "click",
 }, {
     content: "check: input marked as translated",
     trigger: ':iframe input[placeholder="test Parseltongue placeholder"].oe_translated',
@@ -228,7 +236,7 @@ registerWebsitePreviewTour('rte_translator', {
     trigger: ':iframe #wrap p font:first:contains(translated Parseltongue text)',
 }, {
     content: "check: content with special char is translated",
-    trigger: ":iframe #wrap input + p:contains(<{translated}><b></b> is an HTML tag & )",
+    trigger: ":iframe #wrap p.test_translate:contains(<{translated}><b></b> is an HTML tag & )",
 }, {
     content: "check: placeholder translation",
     trigger: ':iframe input[placeholder="test Parseltongue placeholder"]',

--- a/addons/website/static/tests/tours/snippet_image_gallery.js
+++ b/addons/website/static/tests/tours/snippet_image_gallery.js
@@ -36,7 +36,7 @@ registerWebsitePreviewTour("snippet_image_gallery_remove", {
         id: "s_image_gallery",
         name: "Image Gallery",
         groupName: "Images",
-}), 
+}),
 ...clickOnSnippet({
     id: 's_image_gallery',
     name: 'Image Gallery',
@@ -157,5 +157,5 @@ registerWebsitePreviewTour("snippet_image_gallery_thumbnail_update", {
     trigger: ":iframe .s_image_gallery:has(img[data-index='3'])",
 }, {
     content: "Check that the thumbnail of the first image has not been changed",
-    trigger: ":iframe .s_image_gallery div.carousel-indicators button:first-child[style='background-image: url(/web/image/website.library_image_08)']",
+    trigger: ":iframe .s_image_gallery div.carousel-indicators button:first-child img[src='/web/image/website.library_image_08']:not(:visible)",
 }]);

--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -995,9 +995,15 @@ overridden by modules), because:
     </xpath>
     <xpath expr="//div[hasclass('carousel-indicators')]" position="replace">
         <div class="carousel-indicators">
-            <button data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.s_company_team_image_1)" class="active" aria-label="Carousel indicator"/>
-            <button data-bs-target="#slideshow_sample" data-bs-slide-to="1" style="background-image: url(/web/image/website.s_company_team_image_2)" aria-label="Carousel indicator"/>
-            <button data-bs-target="#slideshow_sample" data-bs-slide-to="2" style="background-image: url(/web/image/website.s_company_team_image_3)" aria-label="Carousel indicator"/>
+            <button class="d-flex overflow-hidden active" data-bs-target="#slideshow_sample" data-bs-slide-to="0" aria-label="Carousel indicator for image 1">
+                <img class="object-fit-cover w-100 h-100" src="/web/image/website.s_company_team_image_1"/>
+            </button>
+            <button class="d-flex overflow-hidden" data-bs-target="#slideshow_sample" data-bs-slide-to="1" aria-label="Carousel indicator for image 2">
+                <img class="object-fit-cover w-100 h-100" src="/web/image/website.s_company_team_image_2"/>
+            </button>
+            <button class="d-flex overflow-hidden" data-bs-target="#slideshow_sample" data-bs-slide-to="2" aria-label="Carousel indicator for image 3">
+                <img class="object-fit-cover w-100 h-100" src="/web/image/website.s_company_team_image_3"/>
+            </button>
         </div>
     </xpath>
 </template>

--- a/addons/website/views/snippets/s_image_gallery.xml
+++ b/addons/website/views/snippets/s_image_gallery.xml
@@ -22,9 +22,30 @@
                         <span class="visually-hidden">Previous</span>
                     </button>
                     <div class="carousel-indicators">
-                        <button type="button" data-bs-target="#slideshow_sample" data-bs-slide-to="0" style="background-image: url(/web/image/website.library_image_08)" class="active" aria-label="Carousel indicator"/>
-                        <button type="button" style="background-image: url(/web/image/website.library_image_03)" data-bs-target="#slideshow_sample" data-bs-slide-to="1" aria-label="Carousel indicator"/>
-                        <button type="button" style="background-image: url(/web/image/website.library_image_02)" data-bs-target="#slideshow_sample" data-bs-slide-to="2" aria-label="Carousel indicator"/>
+                        <button class="o_not_editable d-flex overflow-hidden active"
+                                contenteditable="false"
+                                type="button"
+                                data-bs-target="#slideshow_sample"
+                                data-bs-slide-to="0"
+                                aria-label="Carousel indicator for image 1">
+                            <img class="object-fit-cover w-100 h-100" src="/web/image/website.library_image_08" aria-hidden="true"/>
+                        </button>
+                        <button class="o_not_editable d-flex overflow-hidden"
+                                contenteditable="false"
+                                type="button"
+                                data-bs-target="#slideshow_sample"
+                                data-bs-slide-to="1"
+                                aria-label="Carousel indicator for image 2">
+                            <img class="object-fit-cover w-100 h-100" src="/web/image/website.library_image_03" aria-hidden="true"/>
+                        </button>
+                        <button class="o_not_editable d-flex overflow-hidden"
+                                contenteditable="false"
+                                type="button"
+                                data-bs-target="#slideshow_sample"
+                                data-bs-slide-to="2"
+                                aria-label="Carousel indicator for image 3">
+                            <img class="object-fit-cover w-100 h-100" src="/web/image/website.library_image_02" aria-hidden="true"/>
+                        </button>
                     </div>
                     <button class="carousel-control-next o_not_editable" contenteditable="false" t-attf-data-bs-target="#slideshow_sample" data-bs-slide="next" aria-label="Next" title="Next">
                         <span class="carousel-control-next-icon" aria-hidden="true"/>
@@ -119,7 +140,7 @@
                 <t t-set="so_rounded_no_dependencies" t-value="true"/>
             </t>
         </div>
-        <div data-js="gallery_img" data-selector=".s_image_gallery img"></div>
+        <div data-js="gallery_img" data-selector=".s_image_gallery img:not([aria-hidden])"></div>
     </xpath>
 </template>
 

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -205,14 +205,14 @@
                            data-img="/website/static/src/img/snippets_options/pos_right.svg"/>
             </we-button-group>
             <we-checkbox string="Description" data-toggle-description="true" data-no-preview="true"/>
-            <we-input string="Placeholder" class="o_we_large"
+            <we-input string="Placeholder" class="o_we_large" data-name="placeholder_opt"
                 data-select-attribute="" data-attribute-name="placeholder"
                 data-apply-to="input[type='text'], input[type='email'], input[type='number'], input[type='tel'], input[type='url'], textarea"/>
             <t t-set="default_value_label">Default Value</t>
-            <we-input t-att-string="default_value_label" class="o_we_large" data-select-textarea-value="" data-apply-to="textarea"/>
+            <we-input t-att-string="default_value_label" class="o_we_large" data-select-textarea-value="" data-apply-to="textarea" data-name="textarea_value_opt"/>
             <we-checkbox t-att-string="default_value_label" data-select-attribute="checked" data-attribute-name="checked"
                       data-apply-to=".col-sm > * > input[type='checkbox']" data-no-preview="true"/>
-            <we-input t-att-string="default_value_label" class="o_we_large" data-select-attribute="" data-attribute-name="value" data-select-property=""
+            <we-input t-att-string="default_value_label" class="o_we_large" data-select-attribute="" data-attribute-name="value" data-select-property="" data-name="value_opt"
                       data-property-name="value" data-apply-to="input[type='text']:not(.datetimepicker-input), input[type='email'], input[type='tel'], input[type='url']"/>
             <we-input t-att-string="default_value_label" class="o_we_large" data-select-attribute="" data-attribute-name="value" data-select-property=""
                       data-step="1" data-property-name="value" data-apply-to="input[type='number']"/>

--- a/addons/website_event_track_live/views/event_track_templates_page.xml
+++ b/addons/website_event_track_live/views/event_track_templates_page.xml
@@ -47,7 +47,7 @@
             </a>
         </li>
     </xpath>
-    <xpath expr="//a[@href='#track_list']" position="attributes">
+    <xpath expr="//a[@aria-controls='track_list']" position="attributes">
         <attribute name="t-attf-class">#{'nav-link' if track.is_youtube_chat_available and not is_mobile_chat_disabled else 'nav-link active'}</attribute>
     </xpath>
     <xpath expr="//div[hasclass('o_wesession_track_aside_tabs')]" position="inside">

--- a/odoo/addons/base/tests/test_translate.py
+++ b/odoo/addons/base/tests/test_translate.py
@@ -206,7 +206,7 @@ class TranslationToolsTestCase(BaseCase):
         result = xml_translate(terms.append, source)
         self.assertEqual(result, source)
         self.assertItemsEqual(terms,
-            ['<span class="oe_menu_text">Blah</span>'])
+            ['<span class="oe_menu_text">Blah</span>', '/odoo/action-54?menu_id=42'])
 
     def test_translate_xml_with_namespace(self):
         """ Test xml_translate() on elements with namespaces. """

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -169,7 +169,7 @@ TRANSLATED_ATTRS = dict.fromkeys({
 # These attributes must not be exported to .po(t) files and `t-attf-` attributes
 # should not be translated.
 NO_EXPORT_TRANSLATED_ATTRS = dict.fromkeys({
-    'src',
+    'src', 'data-oe-expression',
 }, lambda e: True)
 
 def translate_attrib_value(node):

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import codecs
 import fnmatch
 import functools
+import html as html_stdlib
 import inspect
 import io
 import itertools
@@ -165,6 +166,12 @@ TRANSLATED_ATTRS = dict.fromkeys({
     'value_label', 'data-tooltip', 'label',
 }, lambda e: True)
 
+# These attributes must not be exported to .po(t) files and `t-attf-` attributes
+# should not be translated.
+NO_EXPORT_TRANSLATED_ATTRS = dict.fromkeys({
+    'src',
+}, lambda e: True)
+
 def translate_attrib_value(node):
     # check if the value attribute of a node must be translated
     classes = node.attrib.get('class', '').split(' ')
@@ -179,6 +186,7 @@ TRANSLATED_ATTRS.update(
     value=translate_attrib_value,
     text=lambda e: (e.tag == 'field' and e.attrib.get('widget', '') == 'url'),
     **{f't-attf-{attr}': cond for attr, cond in TRANSLATED_ATTRS.items()},
+    **NO_EXPORT_TRANSLATED_ATTRS,
 )
 
 avoid_pattern = re.compile(r"\s*<!DOCTYPE", re.IGNORECASE | re.MULTILINE | re.UNICODE)
@@ -1025,7 +1033,7 @@ def _extract_translatable_qweb_terms(element, callback):
         if isinstance(el, SKIPPED_ELEMENT_TYPES): continue
         if (el.tag.lower() not in SKIPPED_ELEMENTS
                 and "t-js" not in el.attrib
-                and not (el.tag == 'attribute' and el.get('name') not in TRANSLATED_ATTRS)
+                and not (el.tag == 'attribute' and el.get('name') not in TRANSLATED_ATTRS or el.get('name') in NO_EXPORT_TRANSLATED_ATTRS)
                 and el.get("t-translation", '').strip() != "off"):
 
             _push(callback, el.text, el.sourceline)
@@ -1033,7 +1041,10 @@ def _extract_translatable_qweb_terms(element, callback):
             # component nodes
             is_component = el.tag[0].isupper() or "t-component" in el.attrib or "t-set-slot" in el.attrib
             for attr in el.attrib:
-                if (not is_component and attr in TRANSLATED_ATTRS) or (is_component and attr.endswith(".translate")):
+                if (
+                    (not is_component and attr in TRANSLATED_ATTRS and attr not in NO_EXPORT_TRANSLATED_ATTRS)
+                    or (is_component and attr.endswith(".translate"))
+                ):
                     _push(callback, el.attrib[attr], el.sourceline)
             _extract_translatable_qweb_terms(el, callback)
         _push(callback, el.tail, el.sourceline)
@@ -1193,6 +1204,15 @@ class TranslationReader:
                     _logger.exception("Failed to extract terms from %s %s", xml_name, name)
                     continue
                 for term_en, term_langs in translation_dictionary.items():
+                    term_en_unescaped = html_stdlib.unescape(term_en)
+                    value_en_unescaped = html_stdlib.unescape(value_en)
+                    re_attr_no_export = r'(%s)=[\'"]' % '|'.join(NO_EXPORT_TRANSLATED_ATTRS) + re.escape(term_en_unescaped) + r'[\'"]'
+                    if re.search(re_attr_no_export, value_en_unescaped):
+                        # That's not perfect, we could check that the term
+                        # is ONLY in src attributes, but that's not perfect
+                        # either, because we could have this HTML:
+                        # <img src="X"/> <div style="background-image: url(X)"/>
+                        continue
                     term_lang = term_langs.get(self._lang)
                     self._push_translation(module, trans_type, name, xml_name, term_en, record_id=record.id, value=term_lang if term_lang != term_en else '')
 

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -169,7 +169,7 @@ TRANSLATED_ATTRS = dict.fromkeys({
 # These attributes must not be exported to .po(t) files and `t-attf-` attributes
 # should not be translated.
 NO_EXPORT_TRANSLATED_ATTRS = dict.fromkeys({
-    'src', 'data-oe-expression',
+    'src', 'data-oe-expression', 'href',
 }, lambda e: True)
 
 def translate_attrib_value(node):
@@ -1209,7 +1209,7 @@ class TranslationReader:
                     re_attr_no_export = r'(%s)=[\'"]' % '|'.join(NO_EXPORT_TRANSLATED_ATTRS) + re.escape(term_en_unescaped) + r'[\'"]'
                     if re.search(re_attr_no_export, value_en_unescaped):
                         # That's not perfect, we could check that the term
-                        # is ONLY in src attributes, but that's not perfect
+                        # is ONLY in src/href attributes, but that's not perfect
                         # either, because we could have this HTML:
                         # <img src="X"/> <div style="background-image: url(X)"/>
                         continue


### PR DESCRIPTION
_Note that we will do a migration script to support old carousel. I will do it after the first review of Guru :+1:_ 

Design Theme PR: https://github.com/odoo/design-themes/pull/759
Enterprise PR: https://github.com/odoo/enterprise/pull/70253

### Use img for carousel preview indicators
Before this commit, the carousel preview indicators were using
background images. In a future commit, we will make the img src
attribute translatable. It's better to use img tags for the carousel
preview so that the img is the same as the translated one.
This way we avoid to have to translate the style attribute.

### Allow to translate image src
This commit allows to translate image src. To do so, we changed the way
the translator system works. Now, the translator system is able to start
the options as in edit mode. There is a new function in the option class
to compute the visibility in translation mode
(`_computeWidgetTranslateVisibility`).

In order to avoid having src URLs wrapped inside a translating <span>
(see `translate_func()`), which sends wrong requests when the DOM is
loaded, we watch the actual translatable URL string on a
`data-translatable-link` attribute.

We also prevent src attributes from being exported in .pot files.

As the commit removes `AttributeTranslateDialog` (no need for it now
that we create editors and show the options directly), it also adapts
existing uses, mainly for `s_website_form` inputs and textareas.

### Allow to translate website documents

### Allow to translate website videos
Make sure videos have a proper way to be translated (i.e.
replaced with another video linked to the one of the source language).

We also translate the `data-oe-expression` attribute as we will rely on
this attribute to load website video iframes.
See task 3757205 / [PR 175717].

---

[PR 175717]: https://github.com/odoo/odoo/pull/175717

task-3626918