### PR TITLE
[FIX] account: fix fiscalyear computation

### DIFF
--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -55,7 +55,7 @@ def get_fiscal_year(date, day=31, month=12):
 
     def fix_day(year, month, day):
         max_day = calendar.monthrange(year, month)[1]
-        if (month == 2 and day in (28, max_day)) or (month != 2 and day in (30, max_day)):
+        if (month == 2 and day in (28, max_day)):
             return max_day
         return min(day, max_day)
 


### PR DESCRIPTION
The aim of this commit is to fix the computation for the unlikely edge case in which a company would have its fiscal year end date on the previous day before the end of the month.
Example: 2021-12-30 or 2021-03-30
Even if it is unlikely, Odoo should be able to handle it in order to avoid unexpected bug.

Context:
PR for India supporting the 2 years sequence.
There is a failing testcase in community which is setting its date this exact way.

Before the commit:
The fiscal year end dates are computed as this:
2021-12-30->2021-12-30
2021-03-30->2021-03-30
completly ignoring the real end date

After the commit:
The fiscal year end date stays as computed except for the special case of the 28 of February which could becomes 29 of February.

task-id: None

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
