### PR TITLE
[FIX] hr_holidays: Fix multi_employee _check_holidays singleton error

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -706,8 +706,8 @@ class HolidaysRequest(models.Model):
                 unallocated_employees = []
                 for employee in holiday.employee_ids:
                     leave_days = mapped_days[employee.id][holiday.holiday_status_id.id]
-                    if float_compare(leave_days['remaining_leaves'], self.number_of_days, precision_digits=2) == -1\
-                            or float_compare(leave_days['virtual_remaining_leaves'], self.number_of_days, precision_digits=2) == -1:
+                    if float_compare(leave_days['remaining_leaves'], holiday.number_of_days, precision_digits=2) == -1\
+                            or float_compare(leave_days['virtual_remaining_leaves'], holiday.number_of_days, precision_digits=2) == -1:
                         unallocated_employees.append(employee.name)
                 if unallocated_employees:
                     raise ValidationError(_('The number of remaining time off is not sufficient for this time off type.\n'


### PR DESCRIPTION
The _check_holidays constraint uses self.number_of_days when checking the allocations for multiple employees. However the check is within a recordset loop and should be called with holiday.number_of_days

If there are two or more time offs with multi_employee set to True, and a server action is used to approve or refuse in tree view, there will be a singleton error

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
