### PR TITLE
[FIX] base_import_module: update module dependencies after data modul…

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -97,7 +97,7 @@ class IrModule(models.Model):
             mode = 'update' if not force else 'init'
         else:
             assert terp.get('installable', True), "Module not installable"
-            self.create(dict(name=module, state='installed', imported=True, **values))
+            mod = self.create(dict(name=module, state='installed', imported=True, **values))
             mode = 'init'
 
         kind_of_files = ['data', 'init_xml', 'update_xml']
@@ -193,6 +193,8 @@ class IrModule(models.Model):
             'res_id': asset.id,
         } for asset in created_assets])
 
+        mod._update_dependencies(terp.get('depends', []), terp.get('auto_install'))
+        mod._update_exclusions(terp.get('excludes', []))
         return True
 
     @api.model

--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -179,6 +179,7 @@ class TestImportModule(odoo.tests.TransactionCase):
                 ]
             },
             'license': 'LGPL-3',
+            'depends': ['base'],
         })
 
         stream = BytesIO()
@@ -203,6 +204,9 @@ class TestImportModule(odoo.tests.TransactionCase):
         asset_data = self.env['ir.model.data'].search([('model', '=', 'ir.asset'), ('res_id', '=', asset.id)])
         self.assertEqual(asset_data.module, 'test_module')
         self.assertEqual(asset_data.name, f'{bundle}_{path}'.replace(".", "_"))
+
+        module = self.env['ir.module.module'].search([('name', '=', 'test_module')])
+        self.assertEqual(module.dependencies_id.mapped('name'), ['base'])
 
         # Uninstall test module
         self.env['ir.module.module'].search([('name', '=', 'test_module')]).module_uninstall()


### PR DESCRIPTION
…e install

**steps to reproduce:**
- install an industry (ex: bar_and_lounge)
- uninstall a dependency of that module (ex: mrp)

**before this commit:**
- bar_and_lounge is not uninstalled if you uninstall mrp

**after this commit:**
- data model dependencies are handled the same way as 'regular' modules

opw-3660052

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
