### PR TITLE
[IMP] l10n_in_edi_ewaybill: minor improvement in error message

### DIFF
--- a/addons/l10n_in_edi_ewaybill/__manifest__.py
+++ b/addons/l10n_in_edi_ewaybill/__manifest__.py
@@ -24,6 +24,7 @@ Step 4: Repeat steps 1,2,3 for all GSTIN you have in odoo. If you have a multi-c
         "data/account_edi_data.xml",
         "data/ewaybill_type_data.xml",
         "views/account_move_views.xml",
+        "views/account_move_line_views.xml",
         "views/edi_pdf_report.xml",
         "views/res_config_settings_views.xml",
     ],

--- a/addons/l10n_in_edi_ewaybill/i18n/l10n_in_edi_ewaybill.pot
+++ b/addons/l10n_in_edi_ewaybill/i18n/l10n_in_edi_ewaybill.pot
@@ -30,7 +30,7 @@ msgstr ""
 #. module: l10n_in_edi_ewaybill
 #. odoo-python
 #: code:addons/l10n_in_edi_ewaybill/models/account_edi_format.py:0
-msgid "%s number should be set and not more than 16 characters"
+msgid "%s number cannot be more than 16 characters"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -847,15 +847,15 @@ msgstr ""
 
 #. module: l10n_in_edi_ewaybill
 #. odoo-python
-#: code:addons/l10n_in_edi_ewaybill/models/account_edi_format.py:0
-msgid "HSN code is not set in product %s"
+#: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
+msgid ""
+"HSN code of at least one item should be of goods to generate e-Way Bill"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
 #. odoo-python
-#: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
-msgid ""
-"HSN code of at least one item should be of goods to generate e-Way Bill"
+#: code:addons/l10n_in_edi_ewaybill/models/account_edi_format.py:0
+msgid "HSN/SAC code is missing on Invoice Line"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -879,12 +879,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
 msgid "IMEI does not belong to the user"
-msgstr ""
-
-#. module: l10n_in_edi_ewaybill
-#. odoo-python
-#: code:addons/l10n_in_edi_ewaybill/models/account_edi_format.py:0
-msgid "Impossible to send the Ewaybill."
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -1027,12 +1021,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
 msgid "Invalid HSN Code"
-msgstr ""
-
-#. module: l10n_in_edi_ewaybill
-#. odoo-python
-#: code:addons/l10n_in_edi_ewaybill/models/account_edi_format.py:0
-msgid "Invalid HSN Code (%s) in product %s"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -1263,15 +1251,6 @@ msgstr ""
 
 #. module: l10n_in_edi_ewaybill
 #. odoo-python
-#: code:addons/l10n_in_edi_ewaybill/models/account_move.py:0
-msgid ""
-"Invalid invoice configuration:\n"
-"\n"
-"%s"
-msgstr ""
-
-#. module: l10n_in_edi_ewaybill
-#. odoo-python
 #: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
 msgid "Invalid json"
 msgstr ""
@@ -1462,6 +1441,17 @@ msgid "Journal Entry"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
+#: model:ir.model,name:l10n_in_edi_ewaybill.model_account_move_line
+msgid "Journal Item"
+msgstr ""
+
+#. module: l10n_in_edi_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_edi_ewaybill/models/account_move.py:0
+msgid "Journal Items(s)"
+msgstr ""
+
+#. module: l10n_in_edi_ewaybill
 #: model:ir.model.fields,field_description:l10n_in_edi_ewaybill.field_l10n_in_ewaybill_type__write_uid
 msgid "Last Updated by"
 msgstr ""
@@ -1624,6 +1614,11 @@ msgstr ""
 #. module: l10n_in_edi_ewaybill
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi_ewaybill.res_config_settings_view_form_inherit_l10n_in_edi_ewaybill
 msgid "Production Environment"
+msgstr ""
+
+#. module: l10n_in_edi_ewaybill
+#: model_terms:ir.ui.view,arch_db:l10n_in_edi_ewaybill.view_move_line_tree_l10n_in
+msgid "Products"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -2131,6 +2126,15 @@ msgstr ""
 
 #. module: l10n_in_edi_ewaybill
 #. odoo-python
+#: code:addons/l10n_in_edi_ewaybill/models/account_move.py:0
+msgid ""
+"Unable to send Ewaybill:\n"
+"\n"
+"%s"
+msgstr ""
+
+#. module: l10n_in_edi_ewaybill
+#. odoo-python
 #: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
 msgid ""
 "Unit Code is not matching with any of the Unit Code from eway bill ItemList"
@@ -2271,6 +2275,12 @@ msgstr ""
 #. module: l10n_in_edi_ewaybill
 #: model_terms:ir.ui.view,arch_db:l10n_in_edi_ewaybill.res_config_settings_view_form_inherit_l10n_in_edi_ewaybill
 msgid "Verify Username and Password"
+msgstr ""
+
+#. module: l10n_in_edi_ewaybill
+#. odoo-python
+#: code:addons/l10n_in_edi_ewaybill/models/account_move.py:0
+msgid "View lines without HSN/SAC"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill
@@ -2467,12 +2477,6 @@ msgstr ""
 #. odoo-python
 #: code:addons/l10n_in_edi_ewaybill/models/error_codes.py:0
 msgid "operating-system-type is mandatory in header"
-msgstr ""
-
-#. module: l10n_in_edi_ewaybill
-#. odoo-python
-#: code:addons/l10n_in_edi_ewaybill/models/account_edi_format.py:0
-msgid "product is required to get HSN code"
 msgstr ""
 
 #. module: l10n_in_edi_ewaybill

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -1,10 +1,25 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.addons.l10n_in_edi.tests.test_edi_json import TestEdiJson
+from odoo.exceptions import RedirectWarning
 from odoo.tests import tagged
 
 
 @tagged("post_install_l10n", "post_install", "-at_install")
 class TestEdiEwaybillJson(TestEdiJson):
+
+    def test_edi_empty_hsn(self):
+        invoice = self.init_invoice("out_invoice", products=self.product_a)
+        invoice.write({
+            "l10n_in_type_id": self.env.ref("l10n_in_edi_ewaybill.type_tax_invoice_sub_type_supply"),
+            "l10n_in_distance": 20,
+            "l10n_in_mode": "1",
+            "l10n_in_vehicle_no": "GJ11AA1234",
+            "l10n_in_vehicle_type": "R",
+        })
+        invoice.invoice_line_ids.l10n_in_hsn_code = False
+        invoice.action_post()
+        with self.assertRaises(RedirectWarning):
+            invoice.l10n_in_edi_ewaybill_send()
 
     def test_edi_json(self):
         (self.invoice + self.invoice_full_discount + self.invoice_zero_qty).write({

--- a/addons/l10n_in_edi_ewaybill/views/account_move_line_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_line_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_move_line_tree_l10n_in" model="ir.ui.view">
+        <field name="name">account.move.line.tree.l10n_in</field>
+        <field name="model">account.move.line</field>
+        <field name="arch" type="xml">
+            <tree string="Products" editable="top" create="0">
+                <field name="product_id"/>
+                <field name="name" widget="section_and_note_text"/>
+                <field name="l10n_in_hsn_code"/>
+            </tree>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This PR enhances the error message for E-WayBill errors, providing a line view for empty HSN codes. This improvement quickly redirects to the invoice line view with an empty HSN code. Additionally,  minor enhancements have been implemented for a smoother user experience.

**Task**-3660731

