### PR TITLE
[FIX] point_of_sale: dummy button on pos order

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -483,6 +483,9 @@ class PosOrder(models.Model):
             'domain': [('id', 'in', self.refunded_order_ids.ids)],
         }
 
+    def button_dummy(self):
+        return True
+
     def _is_pos_order_paid(self):
         return float_is_zero(self._get_rounded_amount(self.amount_total) - self.amount_paid, precision_rounding=self.currency_id.rounding)
 

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -102,7 +102,7 @@
                             <div class="oe_subtotal_footer_separator oe_inline o_td_label">
                                 <label for="amount_total" />
                                 <button name="button_dummy"
-                                    states="draft" string="(update)" class="oe_edit_only oe_link"/>
+                                    states="draft" string="(update)" type="object" class="oe_edit_only oe_link"/>
                             </div>
                             <field name="amount_total"
                                    force_save="1"


### PR DESCRIPTION
Steps to produce:

- open session on point of sale
- add some of products and validate it
- go to the backend and return product
- click on update button

Issue:
- Trackback on update button click.

Cause:
- There is no action bind on that button, it's just a dummy button.

Solution:
- add action that will return true for dummy button.

task-3653090

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
