### PR TITLE
[FIX] website_sale: include "Sort By" in the form

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -543,71 +543,72 @@
                         </div>
                     </div>
                 </div>
-                <div t-if="is_view_active('website_sale.sort')" class="accordion-item">
-                    <t t-if="isSortingBy" t-set="isSortingBy" t-value="isSortingBy[0][1]"/>
-                    <t t-else="" t-set="isSortingBy" t-value="website.shop_default_sort"/>
-                    <h2 id="o_wsale_offcanvas_orderby_header" class="accordion-header mb-0">
-                        <button class="o_wsale_offcanvas_title accordion-button border-top rounded-0 collapsed"
-                                type="button"
-                                data-bs-toggle="collapse"
-                                data-bs-target="#o_wsale_offcanvas_orderby"
-                                aria-expanded="false"
-                                aria-controls="o_wsale_offcanvas_orderby">
-                                <b>Sort By</b>
-                        </button>
-                    </h2>
-                    <div id="o_wsale_offcanvas_orderby"
-                         class="accordion-collapse collapse"
-                         aria-labelledby="o_wsale_offcanvas_orderby_header">
-                        <div class="accordion-body pt-0">
-                            <div class="list-group list-group-flush">
-                                <a t-foreach="website_sale_sortable" t-as="sortby"
-                                   role="menuitem"
-                                   rel="noindex,nofollow"
-                                   t-att-href="keep('/shop', order=sortby[0])"
-                                   class="list-group-item border-0 ps-0 pb-0">
-                                    <div class="form-check d-inline-block">
-                                        <input type="radio"
-                                               t-attf-onclick="location.href='#{keep('/shop', order=sortby[0])}';"
-                                               class="form-check-input o_not_editable"
-                                               name="wsale_sortby_radios_offcanvas"
-                                               t-att-checked="isSortingBy and isSortingBy == sortby[1]">
-                                            <label class="form-check-label fw-normal" t-out="sortby[1]"/>
-                                        </input>
-                                    </div>
-                                </a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-                <div t-if="opt_wsale_categories"
-                     class="accordion-item">
-                    <h2 id="o_wsale_offcanvas_categories_header" class="accordion-header mb-0">
-                        <button class="o_wsale_offcanvas_title accordion-button border-top rounded-0 collapsed"
-                                type="button"
-                                data-bs-toggle="collapse"
-                                data-bs-target="#o_wsale_offcanvas_categories"
-                                aria-expanded="false"
-                                aria-controls="o_wsale_offcanvas_categories">
-                                <b>Categories</b>
-                        </button>
-                    </h2>
-                    <div id="o_wsale_offcanvas_categories"
-                         class="accordion-collapse collapse"
-                         aria-labelledby="o_wsale_offcanvas_categories_header">
-                        <div class="accordion-body pt-0">
-                            <t t-call="website_sale.products_categories_list">
-                                <t t-set="isOffcanvas" t-value="true"/>
-                                <t t-set="_titleClasses" t-valuef="d-none"/>
-                                <t t-set="_radioGroup" t-valuef="_offcanvas"/>
-                            </t>
-                        </div>
-                    </div>
-                </div>
 
                 <form t-if="opt_wsale_attributes or opt_wsale_attributes_top"
                       t-attf-class="js_attributes d-flex flex-column"
                       method="get">
+                    <div t-if="is_view_active('website_sale.sort')" class="accordion-item">
+                        <t t-if="isSortingBy" t-set="isSortingBy" t-value="isSortingBy[0][1]"/>
+                        <t t-else="" t-set="isSortingBy" t-value="website.shop_default_sort"/>
+                        <h2 id="o_wsale_offcanvas_orderby_header" class="accordion-header mb-0">
+                            <button class="o_wsale_offcanvas_title accordion-button border-top rounded-0 collapsed"
+                                    type="button"
+                                    data-bs-toggle="collapse"
+                                    data-bs-target="#o_wsale_offcanvas_orderby"
+                                    aria-expanded="false"
+                                    aria-controls="o_wsale_offcanvas_orderby">
+                                    <b>Sort By</b>
+                            </button>
+                        </h2>
+                        <div id="o_wsale_offcanvas_orderby"
+                            class="accordion-collapse collapse"
+                            aria-labelledby="o_wsale_offcanvas_orderby_header">
+                            <div class="accordion-body pt-0">
+                                <div class="list-group list-group-flush">
+                                    <a t-foreach="website_sale_sortable" t-as="sortby"
+                                    role="menuitem"
+                                    rel="noindex,nofollow"
+                                    t-att-href="keep('/shop', order=sortby[0])"
+                                    class="list-group-item border-0 ps-0 pb-0">
+                                        <div class="form-check d-inline-block">
+                                            <input type="radio"
+                                                class="form-check-input o_not_editable"
+                                                name="order"
+                                                t-att-value="sortby[0]"
+                                                t-att-checked="isSortingBy and isSortingBy == sortby[1]">
+                                                <label class="form-check-label fw-normal" t-out="sortby[1]"/>
+                                            </input>
+                                        </div>
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div t-if="opt_wsale_categories"
+                        class="accordion-item">
+                        <h2 id="o_wsale_offcanvas_categories_header" class="accordion-header mb-0">
+                            <button class="o_wsale_offcanvas_title accordion-button border-top rounded-0 collapsed"
+                                    type="button"
+                                    data-bs-toggle="collapse"
+                                    data-bs-target="#o_wsale_offcanvas_categories"
+                                    aria-expanded="false"
+                                    aria-controls="o_wsale_offcanvas_categories">
+                                    <b>Categories</b>
+                            </button>
+                        </h2>
+                        <div id="o_wsale_offcanvas_categories"
+                            class="accordion-collapse collapse"
+                            aria-labelledby="o_wsale_offcanvas_categories_header">
+                            <div class="accordion-body pt-0">
+                                <t t-call="website_sale.products_categories_list">
+                                    <t t-set="isOffcanvas" t-value="true"/>
+                                    <t t-set="_titleClasses" t-valuef="d-none"/>
+                                    <t t-set="_radioGroup" t-valuef="_offcanvas"/>
+                                </t>
+                            </div>
+                        </div>
+                    </div>
+
                     <input t-if="category" type="hidden" name="category" t-att-value="category.id"/>
                     <input type="hidden" name="search" t-att-value="search"/>
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
- go to the shop page;
- with website editor add attribute on "top";
- click on "sort by" and select "Price low to high";
- click on the filter attribute option on top of the shop page;
- select an attribute;

Issue:
------
The system will not display the correct low to high prices when we filter the products from the top.

Cause:
------
The url is composed:
`http://domain/shop?order=ORDER_NAME&search=&attrib=ATTRIB_1&attrib=ATTRIB_2&...`

The filter consists of two parts (to simplify the problem):
- Sort By: When we click on an input, we trigger an `onclick` which redirects the page with a url that retains the existing attributes and adds the "sortby", i.e. the "order" in the query string. So we will send: `http://domain/shop?order=ORDER_SELECTED&search=&attrib=SELECTED_ATTRIB_1&attrib=SELECTED_ATTRIB_2&...`.

- Attributes: When we click on an input, we trigger a GET method for the form which includes these attributes. We would therefore send: `http://domain/shop?search=&attrib=SELECTED_ATTRIB_1&attrib=SELECTED_ATTRIB_2&...`. We therefore lose the "sort by" information.

Solution:
---------
Include the "Sort By" in the form in order to keep its value in the query string generated when an attribute is selected.

opw-3554592