### PR TITLE
[FIX] crm: merging opportunities with same followers but one following

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -1533,6 +1533,7 @@ class Lead(models.Model):
         followers_to_update = self.env['mail.followers'].browse(followers_to_update).sudo()
         followers_by_old_lead = dict(groupby(followers_to_update, lambda f: f.res_id))
         followers_to_update.write({'res_id': self.id})
+        followers_to_update.flush_recordset()
         return followers_by_old_lead
 
     def _merge_log_summary(self, merged_followers, opportunities_tail):


### PR DESCRIPTION
Issue: Under some circumstances when trying to merge leads we will get
an SQL constraint error regarding the followers of the leads.

Steps to reproduce:

Install CRM
Create at least 2 opportunities with the same salesperson and customer.
Now make sure that we don't follow the destination opportunity.
Try to merge the 2 opportunities using the same user as salesperson.
Solution:

After merging the follower of the leads to merge, we will need to
flush our model in order to really take into account the changes on the
DB for the new followers added, this way we won't be trying to write the
same follower twice.

fw-bot up to master

opw-3634410