### PR TITLE
[FIX] web,spreadsheet:tests: make test current-date agnostic

### DIFF
--- a/addons/spreadsheet/static/tests/public_spreadsheet/freeze_test.js
+++ b/addons/spreadsheet/static/tests/public_spreadsheet/freeze_test.js
@@ -8,6 +8,7 @@ import { createSpreadsheetWithPivot } from "../utils/pivot";
 import { createModelWithDataSource } from "@spreadsheet/../tests/utils/model";
 import { THIS_YEAR_GLOBAL_FILTER } from "@spreadsheet/../tests/utils/global_filter";
 import { addGlobalFilter } from "@spreadsheet/../tests/utils/commands";
+import { patchDate } from "@web/../tests/helpers/utils";
 
 QUnit.module("freezing spreadsheet", {}, function () {
     QUnit.test("odoo pivot functions are replaced with their value", async function (assert) {
@@ -99,6 +100,7 @@ QUnit.module("freezing spreadsheet", {}, function () {
     });
 
     QUnit.test("global filters and their display value are exported", async function (assert) {
+        patchDate(2023, 2, 22, 1, 0, 0);
         const model = await createModelWithDataSource();
         await addGlobalFilter(model, THIS_YEAR_GLOBAL_FILTER);
         const data = await freezeOdooData(model);

--- a/addons/web/static/tests/views/pivot_view_tests.js
+++ b/addons/web/static/tests/views/pivot_view_tests.js
@@ -5274,6 +5274,7 @@ QUnit.module("Views", (hooks) => {
         "comparison with two groupbys: rows from reference period should be displayed",
         async function (assert) {
             assert.expect(3);
+            patchDate(2023, 2, 22, 1, 0, 0);
 
             serverData.models.partner.records = [
                 { id: 1, date: "2021-10-10", product_id: 1, customer: 1 },


### PR DESCRIPTION
Tests relied on current year being 2023.
Date was not patched, so tests were only passing during 2023.