### PR TITLE
[FIX] mrp: don’t copy the link to child MO when duplicating a MO

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -105,7 +105,7 @@ class StockMoveLine(models.Model):
 class StockMove(models.Model):
     _inherit = 'stock.move'
 
-    created_production_id = fields.Many2one('mrp.production', 'Created Production Order', check_company=True, index=True)
+    created_production_id = fields.Many2one('mrp.production', 'Created Production Order', check_company=True, index=True, copy=False)
     production_id = fields.Many2one(
         'mrp.production', 'Production Order for finished products', check_company=True, index=True)
     raw_material_production_id = fields.Many2one(

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2702,6 +2702,9 @@ class TestMrpOrder(TestMrpCommon):
                 child_action = mo.action_view_mrp_production_childs()
                 self.assertEqual(source_action.get('res_id', False), source_mo.id, '[%s] Incorrect value for product %s' % (case_description, product.display_name))
                 self.assertEqual(child_action.get('res_id', False), child_mo.id, '[%s] Incorrect value for product %s' % (case_description, product.display_name))
+            duplicate = grandparent_production.copy()
+            self.assertEqual(duplicate.mrp_production_child_count, 0, 'the duplicate MO should not have any child MO')
+            self.assertEqual(duplicate.mrp_production_source_count, 0, 'the duplicate MO should not have any source MO')
 
     @freeze_time('2022-06-28 08:00')
     def test_replan_workorders01(self):


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product called "Semi-Finished Product"
    - Route: MTO
    - BoM:
        - Component: C1

- Create a storable product called "Finished Product":
    - BoM:
        - Component: "Semi-Finished Product"

- Create a MO to produce one unit of "Finished Product"
- Confirm the MO
Result → Child MO for Semi-Finished Good is created

- Duplicate the MO for Finished Product
- Keep the new MO in Draft Stage

**Problem:**
A link to child MO exists because when duplicating an MO, the "created_production_id" field for moves is also copied. Consequently, when the "_get_children" function is called, we find the "created_production_id" set, and thus, the link is established, mistakenly indicating that it is the child MO."

opw-3641684
