### PR TITLE
[IMP] web_editor, html_editor: select cells in rectangular manner on shift + arrow

### DIFF
--- a/addons/html_editor/static/src/core/clipboard_plugin.js
+++ b/addons/html_editor/static/src/core/clipboard_plugin.js
@@ -4,6 +4,7 @@ import { closestBlock, isBlock } from "../utils/blocks";
 import { unwrapContents } from "../utils/dom";
 import { ancestors, childNodes, closestElement } from "../utils/dom_traversal";
 import { parseHTML } from "../utils/html";
+import { getTableCells } from "../utils/table";
 
 /**
  * @typedef { import("./selection_plugin").EditorSelection } EditorSelection
@@ -147,9 +148,7 @@ export class ClipboardPlugin extends Plugin {
             const isTableFullySelected =
                 (table.parentElement &&
                     !!closestElement(table.parentElement, "td.o_selected_td")) ||
-                [...table.querySelectorAll("td")]
-                    .filter((td) => closestElement(td, "table") === table)
-                    .every((td) => td.classList.contains("o_selected_td"));
+                getTableCells(table).every((td) => td.classList.contains("o_selected_td"));
             if (!isTableFullySelected) {
                 for (const td of tableClone.querySelectorAll("td:not(.o_selected_td)")) {
                     if (closestElement(td, "table") === tableClone) {

--- a/addons/html_editor/static/src/main/table/table_plugin.js
+++ b/addons/html_editor/static/src/main/table/table_plugin.js
@@ -704,6 +704,25 @@ export class TablePlugin extends Plugin {
                 this.selectTableCells(selection);
             }
         } else if (!traversedNodes.every((node) => closestElement(node.parentElement, "table"))) {
+            const endSelectionTable = closestElement(selection.focusNode, "table");
+            const endSelectionTableTds = endSelectionTable && getTableCells(endSelectionTable);
+            const traversedTds = new Set(traversedNodes.map((node) => closestElement(node, "td")));
+            const isTableFullySelected = endSelectionTableTds?.every((td) => traversedTds.has(td));
+            if (endSelectionTable && !isTableFullySelected) {
+                // Make sure all the cells are traversed in actual selection
+                // when selecting full table. If not, they will be selected
+                // forcefully and updateSelectionTable will be called again.
+                const targetTd =
+                    selection.direction === DIRECTIONS.RIGHT
+                        ? endSelectionTableTds.pop()
+                        : endSelectionTableTds.shift();
+                this.dependencies.selection.setSelection({
+                    anchorNode: selection.anchorNode,
+                    anchorOffset: selection.anchorOffset,
+                    focusNode: targetTd,
+                    focusOffset: selection.direction === DIRECTIONS.RIGHT ? nodeSize(targetTd) : 0,
+                });
+            }
             const traversedTables = new Set(
                 traversedNodes
                     .map((node) => closestElement(node, "table"))

--- a/addons/html_editor/static/src/main/table/table_selection.scss
+++ b/addons/html_editor/static/src/main/table/table_selection.scss
@@ -1,3 +1,8 @@
+.odoo-editor-editable {
+    ::selection {
+        background-color: rgba(117, 167, 249, 0.5) !important; /* #bad3fc equivalent when over white*/
+    }
+}
 .o_selected_table {
     caret-color: transparent;
 

--- a/addons/html_editor/static/src/utils/table.js
+++ b/addons/html_editor/static/src/utils/table.js
@@ -22,3 +22,14 @@ export function getRowIndex(trOrTd) {
 export function getColumnIndex(td) {
     return td.cellIndex;
 }
+
+/**
+ * Get all the cells of given table
+ * (excluding nested table cells).
+ *
+ * @param {HTMLTableElement} table
+ * @returns {Array<HTMLTableCellElement>}
+ */
+export function getTableCells(table) {
+    return [...table.querySelectorAll("td")].filter((td) => closestElement(td, "table") === table);
+}

--- a/addons/html_editor/static/tests/data-oe/protected.test.js
+++ b/addons/html_editor/static/tests/data-oe/protected.test.js
@@ -146,9 +146,9 @@ test("should handle table selection in unprotected elements", async () => {
                     <div data-oe-protected="false" contenteditable="true">
                         <p>a[bc</p>
                         <table class="o_selected_table"><tbody><tr>
-                            <td class="o_selected_td">a]b</td>
+                            <td class="o_selected_td">ab</td>
                             <td class="o_selected_td">cd</td>
-                            <td class="o_selected_td">ef</td>
+                            <td class="o_selected_td">ef]</td>
                         </tr></tbody></table>
                     </div>
                 </div>

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1725,3 +1725,44 @@ describe("single cell selection", () => {
         );
     });
 });
+
+describe("deselecting table", () => {
+    test("deselect table using keyboard if it is fully selected", async () => {
+        const { el } = await setupEditor(
+            unformat(
+                `<p>[abc</p>
+                <table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td>]<br></td></tr>
+                    </tbody>
+                </table>`
+            )
+        );
+
+        expectContentToBe(
+            el,
+            `<p>[abc</p>
+                <table class="table table-bordered o_table o_selected_table">
+                    <tbody>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td></tr>
+                    </tbody>
+                </table>`
+        );
+
+        press(["Shift", "ArrowUp"]);
+        await animationFrame();
+
+        expectContentToBe(
+            el,
+            `<p>[abc]</p>
+            <table class="table table-bordered o_table">
+                <tbody>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+    });
+});

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -1,10 +1,11 @@
 import { describe, expect, test } from "@odoo/hoot";
 import { setupEditor, testEditor } from "../_helpers/editor";
 import { unformat } from "../_helpers/format";
-import { bold, resetSize, setColor } from "../_helpers/user_actions";
-import { getContent } from "../_helpers/selection";
+import { bold, resetSize, setColor, insertText } from "../_helpers/user_actions";
+import { getContent, setSelection } from "../_helpers/selection";
 import { press, queryAll, manuallyDispatchProgrammaticEvent } from "@odoo/hoot-dom";
 import { animationFrame } from "@odoo/hoot-mock";
+import { nodeSize } from "@html_editor/utils/position";
 
 function expectContentToBe(el, html) {
     expect(getContent(el)).toBe(unformat(html));
@@ -1500,6 +1501,136 @@ describe("move cursor with arrow keys", () => {
                 `),
             });
         });
+    });
+});
+
+describe("symmetrical selection", () => {
+    test("select cells symmetrically when pressing shift + arrow key", async () => {
+        const { el } = await setupEditor(
+            unformat(
+                `<table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td>[]<br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>`
+            )
+        );
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+
+        // Select single empty cell
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+
+        // Select two cells consecutively
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+
+        press(["Shift", "ArrowDown"]);
+        await animationFrame();
+
+        // Extend selection from two cells to four cells
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td"><br></td><td class="o_selected_td">]<br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+
+        press(["Shift", "ArrowLeft"]);
+        await animationFrame();
+
+        // Shrink selection from four cells to two cells
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[<br></td><td><br></td><td><br></td></tr>
+                    <tr><td class="o_selected_td">]<br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+
+        press(["Shift", "ArrowUp"]);
+        await animationFrame();
+
+        // Shrink selection from two cells to single cell
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[]<br></td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+    });
+
+    test("select single cell containing text when pressing shift + arrow key", async () => {
+        const { el, editor } = await setupEditor(
+            unformat(
+                `<table class="table table-bordered o_table">
+                    <tbody>
+                        <tr><td>[]<br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody>
+                </table>`
+            )
+        );
+        insertText(editor, "ab");
+        await animationFrame();
+
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table">
+                <tbody>
+                    <tr><td>ab[]<br></td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
+        const firstTd = el.querySelector("td");
+        setSelection({
+            anchorNode: firstTd,
+            anchorOffset: 0,
+            focusNode: firstTd,
+            focusOffset: nodeSize(firstTd),
+        }); // <td>[ab]</td>
+
+        press(["Shift", "ArrowRight"]);
+        await animationFrame();
+
+        expectContentToBe(
+            el,
+            `<table class="table table-bordered o_table o_selected_table">
+                <tbody>
+                    <tr><td class="o_selected_td">[ab<br>]</td><td><br></td><td><br></td></tr>
+                    <tr><td><br></td><td><br></td><td><br></td></tr>
+                </tbody>
+            </table>`
+        );
     });
 });
 

--- a/addons/html_editor/static/tests/table/selection.test.js
+++ b/addons/html_editor/static/tests/table/selection.test.js
@@ -58,9 +58,9 @@ describe("select a full table on cross over", () => {
                 contentAfterEdit:
                     "<p>a[bc</p>" +
                     '<table class="o_selected_table"><tbody><tr>' +
-                    '<td class="o_selected_td">a]b</td>' +
+                    '<td class="o_selected_td">ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
-                    '<td class="o_selected_td">ef</td>' +
+                    '<td class="o_selected_td">ef]</td>' +
                     "</tr></tbody></table>",
             });
         });
@@ -99,9 +99,9 @@ describe("select a full table on cross over", () => {
                     '<td class="o_selected_td">cd</td>' +
                     '<td class="o_selected_td">ef</td></tr></tbody></table>' +
                     '<p>abc</p><table class="o_selected_table"><tbody><tr>' +
-                    '<td class="o_selected_td">a]b</td>' +
+                    '<td class="o_selected_td">ab</td>' +
                     '<td class="o_selected_td">cd</td>' +
-                    '<td class="o_selected_td">ef</td></tr></tbody></table>',
+                    '<td class="o_selected_td">ef]</td></tr></tbody></table>',
             });
         });
 
@@ -273,13 +273,13 @@ describe("select a full table on cross over", () => {
                         <tbody>
                             <tr>
                                 <td class="o_selected_td">
-                                    <font style="color: aquamarine;">a]b</font>
+                                    <font style="color: aquamarine;">ab</font>
                                 </td>
                                 <td class="o_selected_td">
                                     <font style="color: aquamarine;">cd</font>
                                 </td>
                                 <td class="o_selected_td">
-                                    <font style="color: aquamarine;">ef</font>
+                                    <font style="color: aquamarine;">ef]</font>
                                 </td>
                             </tr>
                         </tbody>
@@ -389,13 +389,13 @@ describe("select a full table on cross over", () => {
                     <table class="o_selected_table">
                         <tbody><tr>
                             <td class="o_selected_td">
-                                <font style="color: aquamarine;">a]b</font>
+                                <font style="color: aquamarine;">ab</font>
                             </td>
                             <td class="o_selected_td">
                                 <font style="color: aquamarine;">cd</font>
                             </td>
                             <td class="o_selected_td">
-                                <font style="color: aquamarine;">ef</font>
+                                <font style="color: aquamarine;">ef]</font>
                             </td>
                         </tr></tbody>
                     </table>`),

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1830,6 +1830,18 @@ export function getColumnIndex(td) {
     return tdSiblings.findIndex(child => child === td);
 }
 
+/**
+ * Get all the cells of given table
+ * (excluding nested table cells).
+ *
+ * @param {HTMLTableElement} table
+ * @returns {Array<HTMLTableCellElement>}
+ */
+export function getTableCells(table) {
+    return [...table.querySelectorAll('td')]
+        .filter(td => closestElement(td, 'table') === table);
+}
+
 // This is a list of "paragraph-related elements", defined as elements that
 // behave like paragraphs.
 export const paragraphRelatedElements = [

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -5597,9 +5597,9 @@ X[]
                             contentBefore: '<p>a[bc</p><table><tbody><tr><td>a]b</td><td>cd</td><td>ef</td></tr></tbody></table>',
                             contentAfterEdit: '<p>a[bc</p>' +
                                             '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td">a]b</td>' +
+                                                '<td class="o_selected_td">ab</td>' +
                                                 '<td class="o_selected_td">cd</td>' +
-                                                '<td class="o_selected_td">ef</td>' +
+                                                '<td class="o_selected_td">ef]</td>' +
                                             '</tr></tbody></table>',
                         });
                     });
@@ -5629,9 +5629,9 @@ X[]
                                             '<td class="o_selected_td">cd</td>' +
                                             '<td class="o_selected_td">ef</td></tr></tbody></table>' +
                                             '<p>abc</p><table class="o_selected_table"><tbody><tr>' +
-                                            '<td class="o_selected_td">a]b</td>' +
+                                            '<td class="o_selected_td">ab</td>' +
                                             '<td class="o_selected_td">cd</td>' +
-                                            '<td class="o_selected_td">ef</td></tr></tbody></table>',
+                                            '<td class="o_selected_td">ef]</td></tr></tbody></table>',
                         });
                     });
                     it('should select some characters, a table, some more characters, another table and some more characters', async () => {
@@ -5784,13 +5784,13 @@ X[]
                                     <tbody>
                                         <tr>
                                             <td class="o_selected_td">
-                                                <font style="color: aquamarine;">a]b</font>
+                                                <font style="color: aquamarine;">ab</font>
                                             </td>
                                             <td class="o_selected_td">
                                                 <font style="color: aquamarine;">cd</font>
                                             </td>
                                             <td class="o_selected_td">
-                                                <font style="color: aquamarine;">ef</font>
+                                                <font style="color: aquamarine;">ef]</font>
                                             </td>
                                         </tr>
                                     </tbody>
@@ -5894,13 +5894,13 @@ X[]
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">a]b</font>
+                                            <font style="color: aquamarine;">ab</font>
                                         </td>
                                         <td class="o_selected_td">
                                             <font style="color: aquamarine;">cd</font>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ef</font>
+                                            <font style="color: aquamarine;">ef]</font>
                                         </td>
                                     </tr></tbody>
                                 </table>`),
@@ -7742,9 +7742,9 @@ X[]
                         <div data-oe-protected="false">
                             <p>a[bc</p>
                             <table class="o_selected_table"><tbody><tr>
-                                <td class="o_selected_td">a]b</td>
+                                <td class="o_selected_td">ab</td>
                                 <td class="o_selected_td">cd</td>
-                                <td class="o_selected_td">ef</td>
+                                <td class="o_selected_td">ef]</td>
                             </tr></tbody></table>
                         </div>
                     </div>

--- a/addons/web_editor/static/tests/table_tests.js
+++ b/addons/web_editor/static/tests/table_tests.js
@@ -1,0 +1,161 @@
+import { setSelection, nodeSize } from "@web_editor/js/editor/odoo-editor/src/utils/utils";
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+import { patchWithCleanup, nextTick } from "@web/../tests/helpers/utils";
+import { Wysiwyg } from "@web_editor/js/wysiwyg/wysiwyg";
+import { triggerEvent, unformat, insertText } from "@web_editor/js/editor/odoo-editor/test/utils";
+
+function onMount() {
+    const editor = wysiwyg.odooEditor;
+    const editable = editor.editable;
+    editor.testMode = true;
+    return { editor, editable };
+}
+
+let serverData;
+let wysiwyg;
+
+QUnit.module(
+    "Table",
+    {
+        before: function () {
+            serverData = {
+                models: {
+                    note: {
+                        fields: {
+                            body: {
+                                string: "Editor",
+                                type: "html",
+                            },
+                        },
+                        records: [
+                            {
+                                id: 1,
+                                display_name: "first record",
+                                body: unformat(`
+                                        <table class='table table-bordered o_table'><tbody>
+                                            <tr><td><br></td><td><br></td><td><br></td></tr>
+                                            <tr><td><br></td><td><br></td><td><br></td></tr>
+                                        </tbody></table>`),
+                            },
+                        ],
+                    },
+                },
+            };
+        },
+        beforeEach: async function () {
+            setupViewRegistries();
+            patchWithCleanup(Wysiwyg.prototype, {
+                init() {
+                    super.init(...arguments);
+                    wysiwyg = this;
+                },
+            });
+            await makeView({
+                type: "form",
+                serverData,
+                resModel: "note",
+                arch:
+                    "<form>" +
+                    '<field name="body" widget="html_legacy" style="height: 100px"/>' +
+                    "</form>",
+                resId: 1,
+            });
+        },
+    },
+    function () {
+        QUnit.module("Table selection");
+
+        QUnit.test("Select cells symmetrically using keyboard", async function (assert) {
+            const { editor, editable } = onMount();
+            const firstTd = editable.querySelector("td");
+            setSelection(firstTd, 0);
+            triggerEvent(editor.editable, "keydown", { key: "ArrowRight", shiftKey: true });
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                unformat(`
+                    <table class="table table-bordered o_table o_selected_table"><tbody>
+                        <tr><td class="o_selected_td"><br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody></table>`, "Should select single empty cell"),
+            )
+            triggerEvent(editor.editable, "keydown", { key: "ArrowRight", shiftKey: true });
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                unformat(`
+                    <table class="table table-bordered o_table o_selected_table"><tbody>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody></table>`, "Should select two cells consecutively"),
+            )
+            triggerEvent(editor.editable, "keydown", { key: "ArrowDown", shiftKey: true });
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                unformat(`
+                    <table class="table table-bordered o_table o_selected_table"><tbody>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                    </tbody></table>`, "Should extend selection from two cells to four cells"),
+            )
+            triggerEvent(editor.editable, "keydown", { key: "ArrowRight", shiftKey: true });
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                unformat(`
+                    <table class="table table-bordered o_table o_selected_table"><tbody>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td></tr>
+                    </tbody></table>`, "Should extend selection from four cells to six cells"),
+            )
+            triggerEvent(editor.editable, "keydown", { key: "ArrowLeft", shiftKey: true });
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                unformat(`
+                    <table class="table table-bordered o_table o_selected_table"><tbody>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                    </tbody></table>`, "Should shrink selection from six cells to four cells"),
+            )
+            triggerEvent(editor.editable, "keydown", { key: "ArrowUp", shiftKey: true });
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                unformat(`
+                    <table class="table table-bordered o_table o_selected_table"><tbody>
+                        <tr><td class="o_selected_td"><br></td><td class="o_selected_td"><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody></table>`, "Should shrink selection from four cells to two cells"),
+            )
+            triggerEvent(editor.editable, "keydown", { key: "ArrowLeft", shiftKey: true });
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                unformat(`
+                    <table class="table table-bordered o_table o_selected_table"><tbody>
+                        <tr><td class="o_selected_td"><br></td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody></table>`, "Should shrink selection from two cells to single cell"),
+            )
+        });
+        QUnit.test("Select single cell containing text", async function (assert) {
+            const { editor, editable } = onMount();
+            const firstTd = editable.querySelector("td");
+            setSelection(firstTd, 0);
+            insertText(editor, 'ab');
+            setSelection(firstTd, 0, firstTd, nodeSize(firstTd)); // <td>[ab]</td>
+            triggerEvent(editor.editable, "keydown", { key: "ArrowRight", shiftKey: true });
+            await nextTick();
+            assert.strictEqual(
+                editable.innerHTML,
+                unformat(`
+                    <table class="table table-bordered o_table o_selected_table"><tbody>
+                        <tr><td class="o_selected_td">ab</td><td><br></td><td><br></td></tr>
+                        <tr><td><br></td><td><br></td><td><br></td></tr>
+                    </tbody></table>`, "Should select single cell when selection reaches at the edge of text"),
+            )
+        });
+    }
+);


### PR DESCRIPTION
**Current behaviour before PR:**

- In table, when trying to select cells using shift + any arrow key, cells are
 selected irregularly and not rectangularly.


**Desired behaviour after PR:**

- This PR aims to improve the behaviour of cell selection
 through keyboad in more convenient (symmetrical) way.

- When there is one or more cells are selected, pressing
 shift + any arrow key expends or shrinks cell-selection
 rectangularly  relative to the arrow key directions.

- It also improves the behaviour of selecting and deselecting
  multiple tables.

task-3442805




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
