### PR TITLE
[FIX] website_sale: remove warning select a pick-up point

### DIFF
--- a/addons/website_sale/static/src/js/website_sale_delivery.js
+++ b/addons/website_sale/static/src/js/website_sale_delivery.js
@@ -201,7 +201,7 @@ publicWidget.registry.websiteSaleDelivery = publicWidget.Widget.extend({
     _disablePayButtonNoPickupPoint : function (ev){
         const selectedCarrierEl = ev.currentTarget.closest('.o_delivery_carrier_select');
         const address = selectedCarrierEl.querySelector('.o_order_location_address').innerText
-        const isPickUp = selectedCarrierEl.lastChild.previousSibling.children;
+        const isPickUp = selectedCarrierEl.querySelector('.o_order_location').parentNode.parentNode.children;
 
         document.querySelectorAll('.error_no_pick_up_point').forEach(el => el.remove());
 


### PR DESCRIPTION
Currently, if you select a delivery method that has a multi-line text (> 2 lines) description, a warning message *Select a pick-up point" will be shown, even when there is no pick-up to select.

Steps to reproduce:
-------------------
* Go to ´Sales´ -> ´Configuration´ -> ´Shipping methods´
* Make sure at least two of the methods are published
* Select one of the published methods
* Write a multi-line description (> 2 lines) -> Save
* Go to ´Website´ -> ´Shop´
* Add a product to your cart and proceed to checkout
* In payment tab, select the delivery method that has the multi-line description
* If the delivery method was selected by default, choose another one and chose it back
* You should see "Select a pick-up point" warning appear.

Why the fix:
------------
A multiline description of the delivery method induces `<br>` HTML tags, thus `isPickUp.length` is equal to the number of `<br>` tags.

Two possible solutions:
* Ensure that `isPickUp` is not related to the description element. (website_sale_delivery.js)
* Put `<div t-field="delivery.website_description" class="text-muted mt8"/>` into a \<div> tag. It will make it so that the length of the description element is always 1. (website_sale_delivery_templates.xml)

opw-3654012