### PR TITLE
[FIX] base: allow duplicate IDs to be printed in a single report

### DIFF
--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from collections import OrderedDict
 from zlib import error as zlib_error
 try:
     from PyPDF2.errors import PdfStreamError, PdfReadError
@@ -24,7 +23,7 @@ class IrActionsReport(models.Model):
         if not original_attachments:
             raise UserError(_("No original purchase document could be found for any of the selected purchase documents."))
 
-        collected_streams = OrderedDict()
+        collected_streams = []
         for invoice in invoices:
             attachment = invoice.message_main_attachment_id
             if attachment:
@@ -38,10 +37,10 @@ class IrActionsReport(models.Model):
                             "There was an error when trying to add the banner to the original PDF.\n"
                             "Please make sure the source file is valid."
                         ))
-                collected_streams[invoice.id] = {
+                collected_streams.append(self.StreamInfo(invoice.id, {
                     'stream': stream,
                     'attachment': attachment,
-                }
+                }))
         return collected_streams
 
     def _is_invoice_report(self, report_ref):

--- a/addons/account_edi/models/ir_actions_report.py
+++ b/addons/account_edi/models/ir_actions_report.py
@@ -22,7 +22,8 @@ class IrActionsReport(models.Model):
                 to_embed = invoice.edi_document_ids
                 # Add the attachments to the pdf file
                 if to_embed:
-                    pdf_stream = collected_streams[invoice.id]['stream']
+                    stream_idx = next(i for i, stream_info in enumerate(collected_streams) if stream_info.id == invoice.id)
+                    pdf_stream = collected_streams[stream_idx].data['stream']
 
                     # Read pdf content.
                     pdf_content = pdf_stream.getvalue()
@@ -42,6 +43,6 @@ class IrActionsReport(models.Model):
                     pdf_stream.close()
                     new_pdf_stream = io.BytesIO()
                     writer.write(new_pdf_stream)
-                    collected_streams[invoice.id]['stream'] = new_pdf_stream
+                    collected_streams[stream_idx].data['stream'] = new_pdf_stream
 
         return collected_streams

--- a/addons/product/static/src/scss/report_label_sheet.scss
+++ b/addons/product/static/src/scss/report_label_sheet.scss
@@ -68,12 +68,17 @@
     }
 
     // generic 4x12 label w/ all same size font
-    div.o_label_4x12 {
+    .o_label_4x12 {
         padding:0;
         line-height:1;
         font-size:55%;
         overflow:visible;
         white-space:normal;
         word-wrap: break-word;
+    }
+
+    .lot-table {
+        border-collapse: separate;
+        border-spacing: 2.5mm 0;
     }
 }

--- a/addons/stock/report/report_lot_barcode.xml
+++ b/addons/stock/report/report_lot_barcode.xml
@@ -6,8 +6,8 @@
         <t t-set='nRows' t-value='12'/>
         <t t-set='nCols' t-value='4'/>
         <div class="oe_structure"></div>
-        <div t-foreach="[docs[x:x + nRows * nCols] for x in range(0, len(docs), nRows * nCols)]" t-as="page_docs" class="o_label_sheet" t-att-style="'padding: 20mm 8mm'">
-            <table class="my-0 table table-sm table-borderless">
+        <div t-foreach="[docs[x:x + nRows * nCols] for x in range(0, len(docs), nRows * nCols)]" t-as="page_docs" class="o_label_sheet" t-att-style="'padding: 20mm 8mm;'">
+            <table class="my-0 lot-table table-borderless">
                 <t t-foreach="range(nRows)" t-as="row">
                     <tr>
                         <t t-foreach="range(nCols)" t-as="col">
@@ -19,7 +19,8 @@
                                 <t t-set="o" t-value="page_docs[0]"/>
                             </t>
                             <td t-att-style="barcode_index &gt;= len(page_docs) and 'visibility:hidden'">
-                                <div t-att-style="'position:relative; width:43mm; height:34mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black')">
+                                <t t-set="no_border_top" t-value="'border-top: 0;' if barcode_index &gt;= nCols else ''"/>
+                                <div t-att-style="'position:relative; width:45.7mm; height:21.2mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black') + no_border_top">
                                     <t t-set="final_barcode" t-value="''"/>
                                     <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
                                         <t t-if="o.product_id.valid_ean" t-set="final_barcode" t-value="'01' + '0' * (14 - len(o.product_id.barcode)) + o.product_id.barcode"/>

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -23,7 +23,7 @@ from lxml import etree
 from contextlib import closing
 from reportlab.graphics.barcode import createBarcodeDrawing
 from PyPDF2 import PdfFileWriter, PdfFileReader
-from collections import OrderedDict
+from collections import namedtuple
 from collections.abc import Iterable
 from PIL import Image, ImageFile
 from itertools import islice
@@ -110,6 +110,7 @@ class IrActionsReport(models.Model):
     _table = 'ir_act_report_xml'
     _order = 'name'
     _allow_sudo_commands = False
+    StreamInfo = namedtuple('StreamInfo', ['id', 'data'])
 
     type = fields.Char(default='ir.actions.report')
     binding_type = fields.Selection(default='report')
@@ -675,7 +676,7 @@ class IrActionsReport(models.Model):
         # access the report details with sudo() but evaluation context as current user
         report_sudo = self._get_report(report_ref)
 
-        collected_streams = OrderedDict()
+        collected_streams = []
 
         # Fetch the existing attachments from the database for later use.
         # Reload the stream from the attachment in case of 'attachment_use'.
@@ -699,13 +700,13 @@ class IrActionsReport(models.Model):
                             stream.close()
                             stream = new_stream
 
-                collected_streams[record.id] = {
+                collected_streams.append(self.StreamInfo(record.id, {
                     'stream': stream,
                     'attachment': attachment,
-                }
+                }))
 
         # Call 'wkhtmltopdf' to generate the missing streams.
-        res_ids_wo_stream = [res_id for res_id, stream_data in collected_streams.items() if not stream_data['stream']]
+        res_ids_wo_stream = [res_id for res_id, stream_data in collected_streams if not stream_data['stream']]
         is_whtmltopdf_needed = not res_ids or res_ids_wo_stream
 
         if is_whtmltopdf_needed:
@@ -729,7 +730,7 @@ class IrActionsReport(models.Model):
 
             bodies, html_ids, header, footer, specific_paperformat_args = self.with_context(**additional_context)._prepare_html(html, report_model=report_sudo.model)
 
-            if report_sudo.attachment and set(res_ids_wo_stream) != set(html_ids):
+            if report_sudo.attachment and sorted(res_ids_wo_stream) != sorted(html_ids):
                 raise UserError(_(
                     "The report's template %r is wrong, please contact your administrator. \n\n"
                     "Can not separate file to save as attachment because the report's template does not contains the"
@@ -750,18 +751,19 @@ class IrActionsReport(models.Model):
 
             # Printing a PDF report without any records. The content could be returned directly.
             if not res_ids:
-                return {
-                    False: {
+                return [self.StreamInfo(
+                    False, {
                         'stream': pdf_content_stream,
                         'attachment': None,
                     }
-                }
+                )]
 
             # Split the pdf for each record using the PDF outlines.
 
             # Only one record: append the whole PDF.
             if len(res_ids_wo_stream) == 1:
-                collected_streams[res_ids_wo_stream[0]]['stream'] = pdf_content_stream
+                assert collected_streams[0].id == res_ids_wo_stream[0]
+                collected_streams[0].data['stream'] = pdf_content_stream
                 return collected_streams
 
             # In case of multiple docs, we need to split the pdf according the records.
@@ -775,7 +777,8 @@ class IrActionsReport(models.Model):
                     attachment_writer.addPage(reader.getPage(i))
                     stream = io.BytesIO()
                     attachment_writer.write(stream)
-                    collected_streams[res_ids[i]]['stream'] = stream
+                    assert collected_streams[i].id == res_ids[i]
+                    collected_streams[i].data['stream'] = stream
                 return collected_streams
 
             # In cases where the number of res_ids != the number of pages,
@@ -783,15 +786,15 @@ class IrActionsReport(models.Model):
             # An outline is a <h?> html tag found on the document. To retrieve this table,
             # we look on the pdf structure using pypdf to compute the outlines_pages from
             # the top level heading in /Outlines.
-            if len(res_ids_wo_stream) > 1 and set(res_ids_wo_stream) == set(html_ids_wo_none):
+            if len(res_ids_wo_stream) > 1 and sorted(res_ids_wo_stream) == sorted(html_ids_wo_none):
                 root = reader.trailer['/Root']
                 has_valid_outlines = '/Outlines' in root and '/First' in root['/Outlines']
                 if not has_valid_outlines:
-                    return {False: {
+                    return [self.StreamInfo(False, {
                         'report_action': self,
                         'stream': pdf_content_stream,
                         'attachment': None,
-                    }}
+                    })]
 
                 outlines_pages = []
                 node = root['/Outlines']['/First']
@@ -817,11 +820,12 @@ class IrActionsReport(models.Model):
                             attachment_writer.addPage(reader.getPage(j))
                         stream = io.BytesIO()
                         attachment_writer.write(stream)
-                        collected_streams[res_ids[i]]['stream'] = stream
+                        assert collected_streams[i].id == res_ids[i]
+                        collected_streams[i].data['stream'] = stream #
 
                     return collected_streams
 
-            collected_streams[False] = {'stream': pdf_content_stream, 'attachment': None}
+            collected_streams.append(self.StreamInfo(False, {'stream': pdf_content_stream, 'attachment': None}))
 
         return collected_streams
 
@@ -845,7 +849,7 @@ class IrActionsReport(models.Model):
         # Generate the ir.attachment if needed.
         if report_sudo.attachment and not self._context.get("report_pdf_no_attachment"):
             attachment_vals_list = []
-            for res_id, stream_data in collected_streams.items():
+            for res_id, stream_data in collected_streams:
                 # An attachment already exists.
                 if stream_data['attachment']:
                     continue
@@ -883,7 +887,7 @@ class IrActionsReport(models.Model):
                     _logger.info("The PDF documents %r are now saved in the database", attachment_names)
 
         # Merge all streams together for a single record.
-        streams_to_merge = [x['stream'] for x in collected_streams.values() if x['stream']]
+        streams_to_merge = [stream['stream'] for (_, stream) in collected_streams if stream['stream']]
         if len(streams_to_merge) == 1:
             pdf_content = streams_to_merge[0].getvalue()
         else:

--- a/odoo/addons/base/tests/test_reports.py
+++ b/odoo/addons/base/tests/test_reports.py
@@ -4,6 +4,7 @@ import io
 import logging
 from base64 import b64decode
 from unittest import skipIf
+from collections import namedtuple
 
 import odoo
 import odoo.tests
@@ -440,6 +441,46 @@ class TestReportsRendering(TestReportsRenderingCommon):
             ])
         pages_contents = [[elem[1] for elem in page] for page in pages]
         self.assertEqual(pages_contents, expected_pages_contents)
+
+    def test_report_pdf_duplicate_ids(self):
+        PartnerType = namedtuple('PartnerType', ['ids', 'names'])
+        partner_id = self.partners[0].id
+        partner_name = self.partners[0].name
+        partners = PartnerType([partner_id, partner_id], [partner_name, partner_name])
+        page_content = '''
+                <div class="page">
+                    <div style="background-color:red">
+                        Name: <t t-esc="o.name"/>
+                    </div>
+                    <div style="page-break-before:always;background-color:blue">
+                        Last page for <t t-esc="o.name"/>
+                    </div>
+                </div>
+            '''
+
+        pdf_content = self.create_pdf(partners=partners, page_content=page_content)
+
+        pages = self._parse_pdf(pdf_content)
+
+        self.assertEqual(len(pages), 4, "Expecting 2 pages * 2 partners")
+
+        expected_pages_contents = []
+        for partner_name in partners.names:
+            expected_pages_contents.append([
+                'LTFigure', #logo
+                'Some header Text',
+                f'Name: {partner_name}',
+                f'Footer for {partner_name} Page: 1 / 2',
+            ])
+            expected_pages_contents.append([
+                'LTFigure', #logo
+                'Some header Text',
+                f'Last page for {partner_name}',
+                f'Footer for {partner_name} Page: 2 / 2',
+            ])
+        pages_contents = [[elem[1] for elem in page] for page in pages]
+        self.assertEqual(pages_contents, expected_pages_contents)
+
 
     def test_pdf_render_page_overflow(self):
         nb_lines = 80


### PR DESCRIPTION
### Current behavior before PR
The same item cannot be printed multiple times in a single report (as with the case with lot printing).

### Desired behavior after PR is merged
The same item can now be printed multiple times in a single report because resources IDs are now pushed into a `list` and not a `dict` with `ID` as the key.

task-3629043

![image](https://github.com/odoo/odoo/assets/56171892/e860986a-473c-4440-8355-a2e6710b305b)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
