### PR TITLE
[FIX] stock_account: add access to account tag for stock users

### DIFF
--- a/addons/stock_account/security/ir.model.access.csv
+++ b/addons/stock_account/security/ir.model.access.csv
@@ -7,3 +7,4 @@ access_stock_move_invoicing_payments_readonly,stock.move,model_stock_move,accoun
 access_stock_move_invoicing_payments,stock.move,model_stock_move,account.group_account_invoice,1,1,1,0
 access_stock_valuation_layer,access_stock_valuation_layer,model_stock_valuation_layer,stock.group_stock_manager,1,1,1,0
 access_stock_valuation_layer_revaluation,access_stock_valuation_layer_revaluation,model_stock_valuation_layer_revaluation,stock.group_stock_manager,1,1,1,0
+access_account_account_tag,account.account.tag.stock.user,account.model_account_account_tag,stock.group_stock_user,1,0,0,0


### PR DESCRIPTION
### Steps to reproduce issue:

1. Create or select user account X and remove all access except inventory user
2. Create a tax grid and apply it to a tax
3. Switch to user account X
4. Access inventory products and click on a product on which tax has been added
5. An error will pop telling you you don't have a sufficient role to access Account Tag

### Explanation:

When opening a product page, the method `compute_all` will be called and access multiple properties. If tax grids have been added, the method tries to access `account.account.tag` models.
- [blocking code section](https://github.com/odoo/odoo/blob/15.0/addons/account/models/account_tax.py#L623-L653)

### Suggested fix:

Specific readonly access fixes the issue without adding a risk of data being transformed.  
Already discussed with PO and approved under condition:

> users should not be able to click on the grid

- Accessing account.account.tag views through specific URLs is blocked.
- User only has access to inventory.
- Tax field in product form is not clickable.

opw-3636032