### PR TITLE
[FIX] base: set parent company only once

### DIFF
--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -294,7 +294,7 @@ class Company(models.Model):
             # and thus needs to invalidate the assets cache when this is changed
             self.env.registry.clear_cache('assets')  # not 100% it is useful a test is missing if it is the case
 
-        if 'parent_id' in values:
+        if 'parent_id' in values and any(company.parent_id for company in self):
             raise UserError(_("The company hierarchy cannot be changed."))
 
         if values.get('currency_id'):


### PR DESCRIPTION
### Steps to reproduce:
- Go to **Settings** > **Users & Companies** > **Companies**
- Create a new company called **Child Company**
- Create a new company called **Parent Company**
- Go to the **Child Company**
- In **General Information** tab, set the **Parent Company** property to **Parent Company**
- An Error is raised stating that "The company hierarchy cannot be changed."

### Investigation:
The following commit https://github.com/odoo/odoo/pull/125642/commits/b5d000141a58e6ab4b59c76f127f68ff22cb984c changed the behavior to prevent changing/updating the company hierarchy -Parent > Child- with https://github.com/odoo/odoo/blob/a0741f6427514be5246a5476b5c2f1ca1c23e6e5/odoo/addons/base/models/res_company.py#L297-L298

opw-3660943