### PR TITLE
[FIX] mrp: have a coherent flow for replenishing after scrap

### DIFF
--- a/addons/mrp/tests/test_replenish.py
+++ b/addons/mrp/tests/test_replenish.py
@@ -3,6 +3,7 @@
 
 from freezegun import freeze_time
 
+from odoo.tests import Form
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo import fields
 
@@ -55,3 +56,34 @@ class TestMrpReplenish(TestMrpCommon):
             bom.days_to_prepare_mo = 4
             wizard3 = self._create_wizard(product, wh)
             self.assertEqual(fields.Datetime.from_string('2023-01-07 00:00:00'), wizard3.date_planned)
+
+    def test_replenish_from_scrap(self):
+        """ Test that when ticking replenish on the scrap wizard of a MO, the new move
+        is linked to the MO and validating it will automatically reserve the quantity
+        on the MO. """
+        warehouse = self.env.ref('stock.warehouse0')
+        warehouse.manufacture_steps = 'pbm'
+        basic_mo, dummy1, dummy2, product_to_scrap, other_product = self.generate_mo(qty_final=1, qty_base_1=1, qty_base_2=1)
+        for product in (product_to_scrap, other_product):
+            self.env['stock.quant'].create({
+                'product_id': product.id,
+                'location_id': warehouse.lot_stock_id.id,
+                'quantity': 2
+            })
+        self.assertEqual(basic_mo.move_raw_ids.location_id, warehouse.pbm_loc_id)
+        basic_mo.action_confirm()
+        self.assertEqual(len(basic_mo.picking_ids), 1)
+        basic_mo.picking_ids.action_assign()
+        basic_mo.picking_ids.button_validate()
+        self.assertEqual(basic_mo.move_raw_ids.mapped('quantity'), [1, 1])
+
+        scrap_wizard_dict = basic_mo.button_scrap()
+        scrap_form = Form(self.env[scrap_wizard_dict['res_model']].with_context(scrap_wizard_dict['context']))
+        scrap_form.product_id = product_to_scrap
+        scrap_form.should_replenish = True
+        self.assertEqual(scrap_form.location_id, warehouse.pbm_loc_id)
+        scrap_form.save().action_validate()
+        self.assertEqual(len(basic_mo.picking_ids), 2)
+        replenish_picking = basic_mo.picking_ids.filtered(lambda x: x.state == 'assigned')
+        replenish_picking.button_validate()
+        self.assertEqual(basic_mo.move_raw_ids.mapped('quantity'), [1, 1])

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -151,8 +151,9 @@ class StockScrap(models.Model):
                 scrap.do_replenish()
         return True
 
-    def do_replenish(self):
+    def do_replenish(self, values=False):
         self.ensure_one()
+        values = values or {}
         self.with_context(clean_context(self.env.context)).env['procurement.group'].run([self.env['procurement.group'].Procurement(
             self.product_id,
             self.scrap_qty,
@@ -161,7 +162,7 @@ class StockScrap(models.Model):
             self.name,
             self.name,
             self.company_id,
-            {}
+            values
         )])
 
     def action_get_stock_picking(self):


### PR DESCRIPTION
When ticking 'Replenish' on a scrapping, the created move is unrelated to the production order. This means that in a 2-steps manufacturing flow, validating the move will not automatically reserve the product(s) on the production order as is done when validating the moves created by the MO confirmation. This is because the new move has no move_dest_ids.

This fix has 2 parts:
- first, add the new move to the already existing procurement group of the MO so that it is easier to find.
- second, assign a move_dest_ids to that move so that when it is validated, the quantity is automatically reserved on the MO.

opw-3560182

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
