### PR TITLE
[fix] iOS CORS issue still appears sometimes

### DIFF
--- a/addons/web/static/src/core/browser/feature_detection.js
+++ b/addons/web/static/src/core/browser/feature_detection.js
@@ -15,6 +15,15 @@ export function isBrowserChrome() {
     return browser.navigator.userAgent.includes("Chrome");
 }
 
+/**
+ * true if the browser is based on Safari (Safari, Epiphany)
+ *
+ * @returns {boolean}
+ */
+export function isBrowserSafari() {
+    return !isBrowserChrome() && browser.navigator.userAgent.includes("Safari");
+}
+
 export function isAndroid() {
     return /Android/i.test(browser.navigator.userAgent);
 }

--- a/addons/web/static/src/core/errors/error_service.js
+++ b/addons/web/static/src/core/errors/error_service.js
@@ -4,8 +4,7 @@ import { browser } from "../browser/browser";
 import { _lt } from "../l10n/translation";
 import { registry } from "../registry";
 import { completeUncaughtError, getErrorTechnicalName } from "./error_utils";
-import { isIOS } from "@web/core/browser/feature_detection";
-import { session } from "@web/session";
+import { isIOS, isBrowserSafari } from "@web/core/browser/feature_detection";
 
 /**
  * Uncaught Errors have 4 properties:
@@ -86,7 +85,7 @@ export const errorService = {
             }
             let uncaughtError;
             if (!filename && !lineno && !colno) {
-                if (isIOS() && session.is_frontend && odoo.debug !== "assets") {
+                if ((isIOS() || isBrowserSafari()) && odoo.debug !== "assets") {
                     // In Safari 16.4+ (as of Jun 14th 2023), an error occurs
                     // when going back and forward through the browser when the
                     // cache is enabled. A feedback has been reported but in the

--- a/doc/cla/individual/euvm-odoo.md
+++ b/doc/cla/individual/euvm-odoo.md
@@ -1,0 +1,11 @@
+Mexico, 2024-01-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Eduardo euvm@odoo.com https://github.com/euvm-odoo


### PR DESCRIPTION
Fixes an issue that causes the CORS error to still show up in iOS devices. 
This PR is identical to #124286 looking to target 16.0

## Description of the issue/feature this PR addresses:
As described in the source code:
> In Safari 16.4+ (as of Jun 14th 2023), an error occurs
> when going back and forward through the browser when the
> cache is enabled. A feedback has been reported but in the
> meantime, hide any script error in these versions.

This is checked with the following condition: 
`if (isIOS() && session.is_frontend && odoo.debug !== "assets") return;`
However there are cases in which `session` is an empty object which causes the condition to be false and the error to be shown. 

`session.is_frontend` is redundant as it appears on the website frontend

## Current behavior before PR:
On ocassions the error still shows up.
![simulator_screenshot_EC7B9D81-A563-4A29-843F-CF48742C8617](https://github.com/odoo/odoo/assets/141070241/d3db2589-997f-4821-a1ac-3a81f4128d90)

Desired behavior after PR is merged:
The error should never show up.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
