### PR TITLE
[FIX] account: allow access information on company parent

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -386,7 +386,7 @@ class AccountTax(models.Model):
                 name += ' (%s)' % type_tax_use.get(record.type_tax_use)
             if record.tax_scope:
                 name += ' (%s)' % tax_scope.get(record.tax_scope)
-            if record.country_id != record.company_id.account_fiscal_country_id:
+            if record.country_id != record.sudo().company_id.account_fiscal_country_id:
                 name += ' (%s)' % record.country_code
             record.display_name = name
 


### PR DESCRIPTION
Steps to reproduce:
[purchase, account]
- Create a branch br1
- create a user with acces only to br1
- connect with new user
- create a quotation
- add a product with a basic tax

Issue:
Access Error

Cause:
Even if taxes (and more generally Accounting) is shared across children companies (branches), information on Parent company is not shared. An ugly sudo is needed to access this basic information

opw-3637310

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
