### PR TITLE
[FIX] base: prevent TypeError when adding submenu without saving parent

### DIFF
--- a/odoo/addons/base/models/ir_ui_menu.py
+++ b/odoo/addons/base/models/ir_ui_menu.py
@@ -55,7 +55,7 @@ class IrUiMenu(models.Model):
         if level <= 0:
             return '...'
         if self.parent_id:
-            return self.parent_id._get_full_name(level - 1) + MENU_ITEM_SEPARATOR + (self.name or "")
+            return (self.parent_id._get_full_name(level - 1) or '') + MENU_ITEM_SEPARATOR + (self.name or "")
         else:
             return self.name
 


### PR DESCRIPTION
Currently, a traceback occurs when the user tries to add a submenu by following the following steps:
- Open menu items (ir.ui.menu) list view
- Click the Create button > Open Submenus tab
- Click on Add a line >>> traceback will appear.

Stack Trace:
```
TypeError: unsupported operand type(s) for +: 'bool' and 'str'
  File "odoo/http.py", line 2157, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1732, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1759, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1960, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 207, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 1076, in onchange
    snapshot1 = RecordSnapshot(record, fields_spec)
  File "addons/web/models/models.py", line 1163, in __init__
    self.fetch(name)
  File "addons/web/models/models.py", line 1178, in fetch
    self[field_name] = self.record[field_name]
  File "odoo/models.py", line 6584, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1206, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4858, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "odoo/addons/base/models/ir_ui_menu.py", line 48, in _compute_complete_name
    menu.complete_name = menu._get_full_name()
  File "odoo/addons/base/models/ir_ui_menu.py", line 55, in _get_full_name
    return self.parent_id._get_full_name(level - 1) + MENU_ITEM_SEPARATOR + (self.name or "")
```

This is because at [1] in the code 'self.parent_id._get_full_name(level - 1)' we got False because currently parent is not saved.

This commit solves the above issue by adding a blank string instead of the parent menu's full name if it is False.

[1]-https://github.com/odoo/odoo/blob/472ea5f6c0c33bb24d453432c4169f077c376581/odoo/addons/base/models/ir_ui_menu.py#L58

sentry-4769838838

