### PR TITLE
[REF] stock_account, purchase_stock: new stock valuation layer

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -3,7 +3,7 @@
 from collections import deque
 
 from odoo import api, Command, fields, models, _
-from odoo.tools.float_utils import float_round, float_is_zero, float_compare
+from odoo.tools.float_utils import float_is_zero
 from odoo.exceptions import UserError
 
 
@@ -41,41 +41,9 @@ class StockMove(models.Model):
         self.ensure_one()
         if self._should_ignore_pol_price():
             return super(StockMove, self)._get_price_unit()
-        price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
         line = self.purchase_line_id
         order = line.order_id
-        received_qty = line.qty_received
-        if self.state == 'done':
-            received_qty -= self.product_uom._compute_quantity(self.quantity, line.product_uom, rounding_method='HALF-UP')
-        if float_compare(line.qty_invoiced, received_qty, precision_rounding=line.product_uom.rounding) > 0:
-            move_layer = line.move_ids.sudo().stock_valuation_layer_ids
-            invoiced_layer = line.sudo().invoice_lines.stock_valuation_layer_ids
-            # value on valuation layer is in company's currency, while value on invoice line is in order's currency
-            receipt_value = 0
-            if move_layer:
-                receipt_value += sum(move_layer.mapped(lambda l: l.currency_id._convert(
-                    l.value, order.currency_id, order.company_id, l.create_date, round=False)))
-            if invoiced_layer:
-                receipt_value += sum(invoiced_layer.mapped(lambda l: l.currency_id._convert(
-                    l.value, order.currency_id, order.company_id, l.create_date, round=False)))
-            invoiced_value = 0
-            invoiced_qty = 0
-            for invoice_line in line.sudo().invoice_lines:
-                if invoice_line.move_id.state != 'posted':
-                    continue
-                if invoice_line.tax_ids:
-                    invoiced_value += invoice_line.tax_ids.with_context(round=False).compute_all(
-                        invoice_line.price_unit, currency=invoice_line.currency_id, quantity=invoice_line.quantity)['total_void']
-                else:
-                    invoiced_value += invoice_line.price_unit * invoice_line.quantity
-                invoiced_qty += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_id.uom_id)
-            # TODO currency check
-            remaining_value = invoiced_value - receipt_value
-            # TODO qty_received in product uom
-            remaining_qty = invoiced_qty - line.product_uom._compute_quantity(received_qty, line.product_id.uom_id)
-            price_unit = float_round(remaining_value / remaining_qty, precision_digits=price_unit_prec)
-        else:
-            price_unit = line._get_gross_price_unit()
+        price_unit = line._get_gross_price_unit()
         if order.currency_id != order.company_id.currency_id:
             # The date must be today, and not the date of the move since the move move is still
             # in assigned state. However, the move date is the scheduled date until move is
@@ -229,3 +197,9 @@ class StockMove(models.Model):
                 [move for move in current_move.move_orig_ids if move not in moves_to_check and move not in seen_moves]
             )
         return None, None
+
+    def _create_in_svl(self, forced_quantity=None):
+        res = super(StockMove, self)._create_in_svl(forced_quantity)
+        if self.purchase_line_id:
+            self.purchase_line_id.sudo().invoice_lines.filtered(lambda aml: aml.move_id.state == 'posted')._apply_price_difference()
+        return res


### PR DESCRIPTION
# The problem
An excellent description of what is currently missing in the stock valuation is outlined clearly in this bugfix PR: 
<todo link adrien PR>

To summarize:
As there is no quantity link between stock moves and the vendor bills used to value them, issues occur when we have vendor refunds and returns in the flow.
As we have no information on the context in which a definitive valuation on a move was done, we don't have enough information to correctly (partially) reverse it in a refund.
This problem was solved in the above patch by using the posting time of the bills to impose an order, then replaying the entire valuation history to infer the context at the time the bill to refund was posted. This was the only way to fix this problem within the limits of the stable policy.
This PR attempts to provide a more fundamental solution to this problem.

# The solution
To mitigate this, the valuation needs to happen more consistently. So we made the following changes:

## Provisional vs definitive valuation (aka root vs correction SVL)
We introduce the (terminology) distinction between a provisional and a definitive stock valuation for incoming moves linked to a PO:
- The provisional valuation is based on the PO price and is used temporarily until it can be replaced by a definitive valuation.
- The definitive valuation is based on the actual price determined by a bill received from the vendor. In a single stock move, some of its quantity can be provisionally validated and some of it can be definitively validated.

To keep a consistency in valuing the incoming moves, **all root SVLs will always use the PO price**, even if some bills were already received from the vendor. For every vendor bill, correction SVLs are created on the different root SVLs to definitively value some or all of the quantity of this move using this vendor bill. The correction SVLs are thus always unique to every SVL-AML pair.

This method of operation ensures that we have a clear overview of the current valuation state of any stock move at any time, independent of the order in which moves/bills were entered into the system:
- The different correction SVLs show which vendor bill was used to definitively value which quantities.
- For any remaining quantities, these are only provisionally valued using the root SVL, and we know they still have to be valued definitively later when we receive the bills from the vendor.

## New correction SVL structure
For every correction SVL, we now keep two new quantity fields: `qty_valued_in_stock` (A) & `qty_valued_already_out` (B). When definitively valuing some quantity of a stock move using a vendor bill, we make an explicit distinction between quantities that we value that (A) are still in stock or (B) have already left our stock. Case (B) occurs when we receive a vendor bill only after already shipping out goods to a customer.
For the quantity (A), we create SVLs that lead to AMLs to correct the stock value. For the quantity (B), we create AMLs directly as the stock already left our system, but we still want to correct the value it had when it came in.

## Dummy correction SVLs
To make sure that a full record of the valuation state is always kept, we also introduce the concept of "dummy" SVLs with zero values. These are used in cases where we use a vendor bill to definitively value some stock, but all of that stock has already left our system. Previously, this would not result in the creation of SVLs, but to keep a consistent record that we used this invoice to value a specific amount of already-out stock, we use these dummy SVLs to keep track of the `qty_valued_already_out` value. Dummy SVLs are also created in the case where there is no price difference between the invoiced unit price and the PO unit price. Again, an SVL would normally not be created in this case but we create a dummy one here to keep track of the quantity that was valued definitively using this bill.

## New root SVL aggregates
On the root SVLs, we introduce some new aggregate fields that show the valuation state of the linked stock move, based on the values that are saved in the linked correction layers. The `qty_to_value_in_stock` and `qty_to_value_already_out` describe the quantity of a move that is still available for getting valued definitively by some vendor bill, for both quantities still in or already out of stock respectively. Finally, special care is taken to handle cases correctly where some items are returned to the vendor and refunded afterward by using the `qty_overvalued` on the root SVL. This value is only positive when, due to a return of items to the vendor, the total quantity valued definitively has become larger than the net amount of items received after returns.

## Resulting refund flow
When later some vendor bill needs to be (partially) refunded, the info stored in the SVLs will make it possible to correctly perform the (partial) refund without needing to replay the entire valuation from scratch.
A distinction will then be made between the different quantities that each need their own approach:
1. Returned to the vendor in the meanwhile: no valuation change
2. The quantities still in stock: create inverse correction SVLs
3. The quantities moved out in the meanwhile: no valuation change
4. The quantities that were already-out: create correction AMLs (only if no quantities out in the meanwhile)

In case of a partial refund, the quantities to refund are taken in the order they are stated above, taking the maximum from a higher category before moving on to the next one.


Task: 3389738
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
