### PR TITLE
[FIX] account: reset due date on reset draft

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3251,7 +3251,7 @@ class AccountMove(models.Model):
             move.mapped('line_ids.analytic_line_ids').unlink()
 
         self.mapped('line_ids').remove_move_reconcile()
-        self.write({'state': 'draft', 'is_move_sent': False})
+        self.write({'state': 'draft', 'is_move_sent': False, 'invoice_payment_term_id': False})
 
     def button_cancel(self):
         self.write({'auto_post': False, 'state': 'cancel'})


### PR DESCRIPTION
Steps to reproduce:
- create a bill
- set a due date
- confirm
- reset to draft -> you have the possibility to set both a date and a payment term
- create a bill
- set a payment term
- confirm
- reset to draft

Issue:
You only have the possiblity to set a payment term (no date)

Cause:
https://github.com/odoo/odoo/blob/2994edbd88fd283aef2e1843abc87611be0414e4/addons/account/views/account_move_views.xml#L840-L841 and no unset of invoice_payment_term_id during reset to draft flow

opw-3647444

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
