### PR TITLE
[FIX] account: correctly fetch a branch's taxes in settings

### DIFF
--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -47,11 +47,11 @@
                                 <div class="content-group">
                                     <div class="row mt16">
                                         <label string="Sales Tax" for="sale_tax_id" class="col-lg-3 o_light_label"/>
-                                        <field name="sale_tax_id" domain="[('type_tax_use', 'in', ('sale', 'all')), ('company_id', '=', company_id)]"/>
+                                        <field name="sale_tax_id" domain="[('type_tax_use', 'in', ('sale', 'all'))]"/>
                                     </div>
                                     <div class="row">
                                         <label string="Purchase Tax" for="purchase_tax_id" class="col-lg-3 o_light_label"/>
-                                        <field name="purchase_tax_id" domain="[('type_tax_use', 'in', ('purchase', 'all')), ('company_id', '=', company_id)]"/>
+                                        <field name="purchase_tax_id" domain="[('type_tax_use', 'in', ('purchase', 'all'))]"/>
                                     </div>
                                 </div>
                             </setting>


### PR DESCRIPTION
### Steps to reproduce

* create a branch
* on that branch's settings, attempt to change the default taxes

You should see that the parent's taxes do not appear in the dropdown.

opw-3652138