### PR TITLE
[FIX] hr: fix error on avatar computation in multi-comp

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -153,7 +153,7 @@ class HrEmployeePrivate(models.Model):
             avatar = employee._origin[image_field]
             if not avatar:
                 if employee.user_id:
-                    avatar = employee.user_id[avatar_field]
+                    avatar = employee.user_id.sudo()[avatar_field]
                 else:
                     avatar = base64.b64encode(employee._avatar_get_placeholder())
             employee[avatar_field] = avatar


### PR DESCRIPTION
The user associated to an employee doesn't need to be in the same
company of the employee. When this happens, we could get a multi company
issue when trying to _only_ display the employee form.

One way this issue is triggered is when the partner of the associated
user is marked as partner_share=True. We may get an access error due to
the rule `base.res_partner_rule`.

Steps to reproduce:
1. Install HR module
2. Create an extra company with a user (U) on it. Ensure the partner of
   U is also set as belonging to this second company.
3. Create an employee in the first company with associated user U.
4. Archive U (this makes the partner of U get partner_share=True)
5. Try to access the employee form from the first company.

We get an error:
```
Due to security restrictions, you are not allowed to access 'User' (res.users) records.

Records: U (id=11, company=COMP2)
User: Mitchell Admin (id=2)

This restriction is due to the following rules:
- user rule

Note: this might be a multi-company issue.

Contact your administrator to request access if necessary.

Implicitly accessed through 'User' (res.users).
```

Since we allow hr.employee records to keep the associated archived user,
to avoid this issue (potentially triggered differently) we opt to
compute the avatar placeholder as sudo.

The issue has been observed in multiple upgrade requests.

