### PR TITLE
[FIX] web_editor: allow selection between links and before leading link

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1816,7 +1816,6 @@ export class OdooEditor extends EventTarget {
             if (zws.innerHTML.replaceAll('\u200B', '')) {
                 // The zws span has more than just a zws -> don't remove it.
                 zws.removeAttribute('data-o-link-zws');
-                zws.setAttribute('oe-zws-empty-inline', '');
             } else if (!zwsToPreserve.includes(zws)) {
                 // const restoreUpdate = prepareUpdate(
                 //     ...boundariesOut(zws.parentElement),
@@ -1827,7 +1826,7 @@ export class OdooEditor extends EventTarget {
                 this.observerActive('_resetLinkZws');
                 // restoreUpdate();
             } else if (zws === zwsInSelection) {
-                // setSelection(zws, 1);
+                setSelection(zws, 1);
             }
         }
         // const { anchorNode, focusNode } = this.document.getSelection();

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1819,8 +1819,10 @@ export class OdooEditor extends EventTarget {
         // const restoreCursor = zwsInSelection && preserveCursor(this.document);
         for (const zws of element.querySelectorAll('[data-o-link-zws]')) {
             if (zws.innerHTML.replaceAll('\u200B', '')) {
+                this.observerUnactive('_resetLinkZwsRemoveZws');
                 // The zws span has more than just a zws -> don't remove it.
                 zws.removeAttribute('data-o-link-zws');
+                // TODO: DO THIS PART IN "ON_INPUT > INSERT" INSTEAD:
                 // Remove the zws characters anyway and fix the selection accordingly.
                 const { anchorNode, anchorOffset, isCollapsed } = this.document.getSelection();
                 let newOffset = anchorOffset;
@@ -1834,23 +1836,20 @@ export class OdooEditor extends EventTarget {
                     }
                 }
                 if (isCollapsed && anchorOffset !== newOffset) {
-                    this._pauseSetLinkZws = true;
                     setSelection(anchorNode, newOffset);
-                    this._pauseSetLinkZws = false;
                 }
+                this.observerActive('_resetLinkZwsRemoveZws');
             } else if (!zwsToPreserve.includes(zws)) {
                 // const restoreUpdate = prepareUpdate(
                 //     ...boundariesOut(zws.parentElement),
                 //     { allowReenter: false, label: '_resetLinkZws' }
                 // );
-                this.observerUnactive('_resetLinkZws');
+                this.observerUnactive('_resetLinkZwsRemoveZwsSpan');
                 zws.remove();
-                this.observerActive('_resetLinkZws');
+                this.observerActive('_resetLinkZwsRemoveZwsSpan');
                 // restoreUpdate();
             } else if (zws === zwsInSelection) {
-                this._pauseSetLinkZws = true;
                 setSelection(zws, 1);
-                this._pauseSetLinkZws = false;
             }
         }
         // const { anchorNode, focusNode } = this.document.getSelection();
@@ -1858,9 +1857,9 @@ export class OdooEditor extends EventTarget {
         // focusNode && fillEmpty(focusNode);
         for (const link of element.querySelectorAll('.o_link_in_selection')) {
             if (link !== linkInSelection) {
-                this.observerUnactive('_resetLinkZws');
+                this.observerUnactive('_resetLinkZwsLinkInSelection');
                 link.classList.remove('o_link_in_selection');
-                this.observerActive('_resetLinkZws');
+                this.observerActive('_resetLinkZwsLinkInSelection');
             }
         }
         // restoreCursor && restoreCursor();

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/enter.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/enter.js
@@ -18,6 +18,9 @@ import {
 
 Text.prototype.oEnter = function (offset) {
     this.parentElement.oEnter(splitTextNode(this, offset), true);
+    if (this.textContent === '\u200B') {
+        this.remove();
+    }
 };
 /**
  * The whole logic can pretty much be described by this example:

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -507,6 +507,7 @@ export function setSelection(
     focusOffset = anchorOffset,
     normalize = true,
 ) {
+    console.warn('setSelection');
     if (
         !anchorNode ||
         !anchorNode.parentElement ||

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -3951,11 +3951,11 @@ X[]
                     contentBefore: '<p>ab[]<a href="#">cd</a>ef</p>',
                     contentBeforeEdit: '<p>ab[]' +
                         '<a href="#">' +
-                            '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                            '<span data-o-link-zws="start">\u200B</span>' + // start zws
                             'cd' + // content
                             // end zws is only there if the selection is in the link
                         '</a>' +
-                        '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
+                        '<span data-o-link-zws="after">\u200B</span>' + // after zws
                     'ef</p>',
                     stepFunction: async editor => {
                         await keydown(editor.editable, 'ArrowRight');
@@ -3970,11 +3970,10 @@ X[]
                     },
                     contentAfterEdit: '<p>ab' +
                         '<a href="#" class="o_link_in_selection">' +
-                            '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                            '<span data-o-link-zws="start">\u200B</span>' + // start zws
                             '[]cd' + // content
-                            '<span data-o-link-zws="end">\u200B</span>' + // end zws
                         '</a>' +
-                        '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
+                        '<span data-o-link-zws="after">\u200B</span>' + // after zws
                     'ef</p>',
                     contentAfter: '<p>ab<a href="#">[]cd</a>ef</p>',
                 });
@@ -3984,31 +3983,30 @@ X[]
                     contentBefore: '<p>ab<a href="#">cd[]</a>ef</p>',
                     contentBeforeEdit: '<p>ab' +
                         '<a href="#" class="o_link_in_selection">' +
-                            '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                            '<span data-o-link-zws="start">\u200B</span>' + // start zws
                             'cd[]' + // content
-                            '<span data-o-link-zws="end">\u200B</span>' + // end zws
                         '</a>' +
-                        '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
+                        '<span data-o-link-zws="after">\u200B</span>' + // after zws
                     'ef</p>',
                     stepFunction: async editor => {
                         await keydown(editor.editable, 'ArrowRight');
                         // Set the selection to mimick that which keydown would
                         // have set, were it not blocked when triggered
                         // programmatically.
-                        const endZws = editor.editable.querySelector('a > span[data-o-link-zws="end"]');
+                        const afterZws = editor.editable.querySelector('span[data-o-link-zws="after"]');
                         await setTestSelection({
-                            anchorNode: endZws, anchorOffset: 1,
-                            focusNode: endZws, focusOffset: 1,
+                            anchorNode: afterZws, anchorOffset: 1,
+                            focusNode: afterZws, focusOffset: 1,
                         }, editor.document);
                     },
                     contentAfterEdit: '<p>ab' +
                         '<a href="#" class="">' +
-                            '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                            '<span data-o-link-zws="start">\u200B</span>' + // start zws
                             'cd' + // content
                             // end zws is only there if the selection is in the link
                         '</a>' +
-                        '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
-                    '[]ef</p>',
+                        '<span data-o-link-zws="after">\u200B[]</span>' + // after zws
+                    'ef</p>',
                     contentAfter: '<p>ab<a href="#">cd</a>[]ef</p>',
                 });
             });
@@ -4141,11 +4139,10 @@ X[]
                     contentBefore: '<p>ab<a href="#">[]cd</a>ef</p>',
                     contentBeforeEdit: '<p>ab' +
                         '<a href="#" class="o_link_in_selection">' +
-                            '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                            '<span data-o-link-zws="start">\u200B</span>' + // start zws
                             '[]cd' + // content
-                            '<span data-o-link-zws="end">\u200B</span>' + // end zws
                         '</a>' +
-                        '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
+                        '<span data-o-link-zws="after">\u200B</span>' + // after zws
                     'ef</p>',
                     stepFunction: async editor => {
                         await keydown(editor.editable, 'ArrowLeft');
@@ -4160,11 +4157,11 @@ X[]
                     },
                     contentAfterEdit: '<p>ab[]' +
                         '<a href="#" class="">' +
-                            '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                            '<span data-o-link-zws="start">\u200B</span>' + // start zws
                             'cd' + // content
                             // end zws is only there if the selection is in the link
                         '</a>' +
-                        '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
+                        '<span data-o-link-zws="after">\u200B</span>' + // after zws
                     'ef</p>',
                     contentAfter: '<p>ab[]<a href="#">cd</a>ef</p>',
                 });
@@ -4174,11 +4171,11 @@ X[]
                     contentBefore: '<p>ab<a href="#">cd</a>[]ef</p>',
                     contentBeforeEdit: '<p>ab' +
                         '<a href="#">' +
-                            '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                            '<span data-o-link-zws="start">\u200B</span>' + // start zws
                             'cd' + // content
                             // end zws is only there if the selection is in the link
                         '</a>' +
-                        '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
+                        '<span data-o-link-zws="after">\u200B</span>' + // after zws
                     '[]ef</p>',
                     stepFunction: async editor => {
                         await keydown(editor.editable, 'ArrowLeft');
@@ -4193,11 +4190,10 @@ X[]
                     },
                     contentAfterEdit: '<p>ab' +
                         '<a href="#" class="o_link_in_selection">' +
-                            '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                            '<span data-o-link-zws="start">\u200B</span>' + // start zws
                             'cd[]' + // content
-                            '<span data-o-link-zws="end">\u200B</span>' + // end zws
                         '</a>' +
-                        '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
+                        '<span data-o-link-zws="after">\u200B</span>' + // after zws
                     'ef</p>',
                     contentAfter: '<p>ab<a href="#">cd[]</a>ef</p>',
                 });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
@@ -563,11 +563,10 @@ describe('Link', () => {
                     await deleteBackward(editor);
                 },
                 contentAfterEdit: '<p>a<a href="#/" oe-zws-empty-inline="" class="o_link_in_selection">' +
-                        '<span data-o-link-zws="start" contenteditable="false">\u200B</span>' + // start zws
+                        '<span data-o-link-zws="start">\u200B</span>' + // start zws
                         '[]\u200B' + // content: empty inline zws
-                        '<span data-o-link-zws="end">\u200B</span>' + // end zws
                     '</a>' +
-                    '<span data-o-link-zws="after" contenteditable="false">\u200B</span>' + // after zws
+                    '<span data-o-link-zws="after">\u200B</span>' + // after zws
                     'c</p>',
                 contentAfter: '<p>a[]c</p>',
             });

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -604,7 +604,8 @@ QUnit.module('web_editor', {}, function () {
                 }
             });
 
-            let pText = $field.find('.note-editable p').first().contents()[0];
+            $field[0].querySelectorAll('[data-o-link-zws').forEach(el => el.remove()); // Make sure to just target the text
+            const pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText.firstChild, 0, pText.firstChild, pText.firstChild.length);
             await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'click');
             // load static xml file (dialog, link dialog)
@@ -653,7 +654,8 @@ QUnit.module('web_editor', {}, function () {
                 }
             });
 
-            let pText = $field.find('.note-editable p').first().contents()[0];
+            $field[0].querySelectorAll('[data-o-link-zws').forEach(el => el.remove()); // Make sure to just target the text
+            const pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText.firstChild, 0, pText.firstChild, pText.firstChild.length);
             await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'click');
             // load static xml file (dialog, link dialog)
@@ -703,7 +705,8 @@ QUnit.module('web_editor', {}, function () {
                 }
             });
 
-            let pText = $field.find('.note-editable p').first().contents()[0];
+            $field[0].querySelectorAll('[data-o-link-zws').forEach(el => el.remove()); // Make sure to just target the text
+            const pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText.firstChild, 0, pText.firstChild, pText.firstChild.length);
             await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'click');
             // load static xml file (dialog, link dialog)
@@ -756,7 +759,8 @@ QUnit.module('web_editor', {}, function () {
                 }
             });
 
-            let pText = $field.find('.note-editable p').first().contents()[0];
+            $field[0].querySelectorAll('[data-o-link-zws').forEach(el => el.remove()); // Make sure to just target the text
+            const pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText, 0, pText, pText.length);
             await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'click');
             // load static xml file (dialog, link dialog)
@@ -806,6 +810,7 @@ QUnit.module('web_editor', {}, function () {
                 }
             });
 
+            $field[0].querySelectorAll('[data-o-link-zws').forEach(el => el.remove()); // Make sure to just target the text
             let pText = $field.find('.note-editable p').first().contents()[0];
             Wysiwyg.setRange(pText, 0, pText, pText.length);
             await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'click');
@@ -829,6 +834,7 @@ QUnit.module('web_editor', {}, function () {
             await promise;
 
             $field = form.$('.oe_form_field[name="body"]');
+            $field[0].querySelectorAll('[data-o-link-zws').forEach(el => el.remove()); // Make sure to just target the text
             pText = $field.find('.note-editable a').eq(0).contents()[0];
             Wysiwyg.setRange(pText, 0, pText, pText.length);
             await testUtils.dom.triggerEvent($('#toolbar #create-link'), 'click');


### PR DESCRIPTION
Commit [1] introduced a mechanism to handle the selection around links, so the user can navigate in and out of them with the arrow keys. However, it was not working properly in the case of two adjacent links, or when the link was at the beginning of a block. This commit fixes that. A key change here has been to stop removing all the link zws to introduce the new ones at each selection change, and instead preserving the link zws that are relevant to the current selection and remove the rest.

task-3620897
task-3604728

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
