### PR TITLE
[FIX] web: fix footer wrapping in boxed layout

### DIFF
--- a/addons/web/static/src/legacy/scss/layout_boxed.scss
+++ b/addons/web/static/src/legacy/scss/layout_boxed.scss
@@ -23,7 +23,6 @@
 }
 .o_boxed_footer {
     margin-top: 200px;
-    white-space: nowrap;
     border-top: 3px solid $o-default-report-secondary-color;
     ul {
         margin: 4px 0;


### PR DESCRIPTION
This commit fixes the footer for the boxed layout. A CSS property is preventing the footer from wrapping

This was done in order to prevent TVA numbers or phone numbers from wrapping, because of the font. But this is obsolete as:

- the font is the same as in other layouts now
- other layouts don't prevent wrapping
- users can use a line break to prevent the numbers from wrapping

So we essentially align the footer's behavior with the other footers

opw-3658954