### PR TITLE
[IMP] mrp,web_gantt: enable 3 weeks mode in gantt view

### DIFF
--- a/addons/mrp/views/mrp_workorder_views.xml
+++ b/addons/mrp/views/mrp_workorder_views.xml
@@ -390,7 +390,8 @@
                 total_row="True"
                 js_class="mrp_workorder_gantt"
                 precision="{'day': 'hour:full', 'week': 'day:full', 'month': 'day:full', 'year': 'day:full'}"
-                form_view_id="mrp_production_workorder_form_view_inherit">
+                form_view_id="mrp_production_workorder_form_view_inherit"
+                default_scale="3weeks">
 
                 <field name="date_start"/>
                 <field name="state"/>


### PR DESCRIPTION
The Gantt view is not very useful for planning manufacturing orders, especially towards the end of your period.
We are introducing a 3-week mode: the current one and the following 2 weeks.
It is more usable for daily work.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
