### PR TITLE
[IMP] l10n_in: add hsn summary in invoice report

### DIFF
--- a/addons/l10n_in/models/__init__.py
+++ b/addons/l10n_in/models/__init__.py
@@ -1,7 +1,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from . import template_in
-from . import account
 from . import account_invoice
+from . import account_move_line
+from . import account_tax
 from . import company
 from . import product_template
 from . import port_code

--- a/addons/l10n_in/models/account_move_line.py
+++ b/addons/l10n_in/models/account_move_line.py
@@ -8,6 +8,12 @@ class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     l10n_in_hsn_code = fields.Char(string="HSN/SAC Code", compute="_compute_l10n_in_hsn_code", store=True, readonly=False, copy=False)
+    l10n_in_gst_rate = fields.Float('GST Rate', compute="_compute_l10n_in_tax_details", store=False, readonly=False)
+    l10n_in_cgst_amount_currency = fields.Monetary('CGST', compute="_compute_l10n_in_tax_details", store=False, readonly=True, currency_field='company_currency_id')
+    l10n_in_sgst_amount_currency = fields.Monetary('SGST', compute='_compute_l10n_in_tax_details', store=False, readonly=True, currency_field='company_currency_id')
+    l10n_in_igst_amount_currency = fields.Monetary('IGST', compute='_compute_l10n_in_tax_details', store=False, readonly=True, currency_field='company_currency_id')
+    l10n_in_cess_amount_currency = fields.Monetary('CESS', compute="_compute_l10n_in_tax_details", store=False, readonly=True, currency_field='company_currency_id')
+    vat = fields.Char(related="partner_id.vat")
 
     @api.depends('product_id')
     def _compute_l10n_in_hsn_code(self):
@@ -29,3 +35,88 @@ class AccountMoveLine(models.Model):
         remaining_aml = self - aml
         if remaining_aml:
             return super(AccountMoveLine, remaining_aml)._compute_tax_base_amount()
+
+    def _format_l10n_in_tax_detail_by_move_line_id(self, tax_data):
+        formatted_data = {}
+        for data in tax_data:
+            base_line_id = data['base_line_id']
+            tax_type = data['tax_type']
+            if not formatted_data.get(base_line_id):
+                formatted_data.setdefault(base_line_id, {'gst_tax_rate': data['gst_tax_rate']})
+            if not formatted_data[base_line_id].get(tax_type):
+                formatted_data[base_line_id].setdefault(tax_type, 0)
+            formatted_data[base_line_id][tax_type] += data['tax_amount']
+        return formatted_data
+
+    def _compute_l10n_in_tax_details(self):
+        domain = [
+            ("move_id.id", "in", self.move_id.ids)
+        ]
+        tax_query, tax_params = self._get_l10n_in_tax_details_query(domain)
+        self._cr.execute(tax_query, tax_params)
+        tax_data = self._cr.dictfetchall()
+        data_by_aml_id = self._format_l10n_in_tax_detail_by_move_line_id(tax_data)
+        for record in self:
+            sign = record.move_id.is_inbound() and -1 or 1
+            tax_details = data_by_aml_id.get(record.id, {})
+            record.l10n_in_gst_rate = tax_details.get('gst_tax_rate', 0)
+            record.l10n_in_sgst_amount_currency = sign*tax_details.get('SGST', 0)
+            record.l10n_in_cgst_amount_currency = sign*tax_details.get('CGST', 0)
+            record.l10n_in_igst_amount_currency = sign*tax_details.get('IGST', 0)
+            record.l10n_in_cess_amount_currency = sign*tax_details.get('CESS', 0)
+
+    @api.model
+    def _get_l10n_in_tax_details_query(self, domain):
+        igst_tag_id = self.env.ref("l10n_in.tax_tag_igst").id
+        cgst_tag_id = self.env.ref("l10n_in.tax_tag_cgst").id
+        sgst_tag_id = self.env.ref("l10n_in.tax_tag_sgst").id
+        cess_tag_id = self.env.ref("l10n_in.tax_tag_cess").id
+        all_gst_tag = (igst_tag_id, cgst_tag_id, sgst_tag_id)
+        tax_details_query, tax_details_params = self._get_query_tax_details_from_domain(domain=domain)
+        return f'''
+             WITH RECURSIVE tax_child_tree(id, child_ids) AS (
+                SELECT tax_fil_rel.parent_tax,
+                       ARRAY_AGG(tax_fil_rel.child_tax)
+                  FROM account_tax_filiation_rel tax_fil_rel
+              GROUP BY tax_fil_rel.parent_tax
+             UNION ALL
+                SELECT tax_fil_rel.parent_tax, ARRAY_APPEND(ct.child_ids, tax_fil_rel.parent_tax)
+                  FROM account_tax_filiation_rel tax_fil_rel
+                  JOIN tax_child_tree ct ON ct.id = tax_fil_rel.child_tax
+            ),
+            base_line_with_gst_rate AS (
+                SELECT aml.id, sum(CASE WHEN at.amount_type != 'group' THEN at.amount ELSE 0 END) as gst_rate
+                FROM account_move_line aml
+                JOIN account_move_line_account_tax_rel aml_taxs ON aml_taxs.account_move_line_id = aml.id
+                LEFT JOIN tax_child_tree tax_child ON aml_taxs.account_tax_id = tax_child.id
+                JOIN account_tax at ON at.id = aml_taxs.account_tax_id or at.id = any(tax_child.child_ids)
+                WHERE EXISTS(SELECT 1
+                    FROM account_tax_repartition_line at_rl
+                    JOIN account_account_tag_account_tax_repartition_line_rel tax_tag ON tax_tag.account_tax_repartition_line_id = at_rl.id
+                   where (at_rl.tax_id = at.id OR at_rl.tax_id = aml_taxs.account_tax_id)
+                     and tax_tag.account_account_tag_id in {all_gst_tag}
+                )
+                GROUP BY aml.id
+            ),
+            tax_line_with_tags AS (
+                SELECT aml.id, array_agg(aml_tag.account_account_tag_id) as tag_ids
+                FROM account_move_line aml
+                JOIN account_account_tag_account_move_line_rel aml_tag ON aml_tag.account_move_line_id = aml.id
+                GROUP BY aml.id
+            )
+            SELECT
+                COALESCE(aml_gst_rate.gst_rate, 0) as gst_tax_rate,
+                aml_tags.tag_ids,
+                at.l10n_in_reverse_charge,
+                CASE
+                    WHEN {igst_tag_id} = any(aml_tags.tag_ids) THEN 'IGST'
+                    WHEN {cgst_tag_id} = any(aml_tags.tag_ids) THEN 'CGST'
+                    WHEN {sgst_tag_id} = any(aml_tags.tag_ids) THEN 'SGST'
+                    WHEN {cess_tag_id} = any(aml_tags.tag_ids) THEN 'CESS'
+                END as tax_type,
+                tax_detail.*
+            FROM ({tax_details_query}) AS tax_detail
+        LEFT JOIN account_tax at ON at.id = tax_detail.tax_id
+        LEFT JOIN base_line_with_gst_rate aml_gst_rate ON aml_gst_rate.id = tax_detail.base_line_id
+        LEFT JOIN tax_line_with_tags aml_tags ON aml_tags.id = tax_detail.tax_line_id
+        ''', tax_details_params

--- a/addons/l10n_in/models/account_move_line.py
+++ b/addons/l10n_in/models/account_move_line.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
-from odoo.exceptions import ValidationError
+from odoo import api, fields, models
 from odoo import tools
-
 
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
@@ -31,35 +29,3 @@ class AccountMoveLine(models.Model):
         remaining_aml = self - aml
         if remaining_aml:
             return super(AccountMoveLine, remaining_aml)._compute_tax_base_amount()
-
-
-class AccountTax(models.Model):
-    _inherit = 'account.tax'
-
-    l10n_in_reverse_charge = fields.Boolean("Reverse charge", help="Tick this if this tax is reverse charge. Only for Indian accounting")
-
-    @api.model
-    def _get_generation_dict_from_base_line(self, line_vals, tax_vals, force_caba_exigibility=False):
-        # EXTENDS account
-        # Group taxes also by product.
-        res = super()._get_generation_dict_from_base_line(line_vals, tax_vals, force_caba_exigibility=force_caba_exigibility)
-        record = line_vals['record']
-        if isinstance(record, models.Model)\
-                and record._name == 'account.move.line'\
-                and record.company_id.account_fiscal_country_id.code == 'IN':
-            res['product_id'] = record.product_id.id
-            res['product_uom_id'] = record.product_uom_id.id
-        return res
-
-    @api.model
-    def _get_generation_dict_from_tax_line(self, line_vals):
-        # EXTENDS account
-        # Group taxes also by product.
-        res = super()._get_generation_dict_from_tax_line(line_vals)
-        record = line_vals['record']
-        if isinstance(record, models.Model)\
-                and record._name == 'account.move.line'\
-                and record.company_id.account_fiscal_country_id.code == 'IN':
-            res['product_id'] = record.product_id.id
-            res['product_uom_id'] = record.product_uom_id.id
-        return res

--- a/addons/l10n_in/models/account_tax.py
+++ b/addons/l10n_in/models/account_tax.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+class AccountTax(models.Model):
+    _inherit = 'account.tax'
+
+    l10n_in_reverse_charge = fields.Boolean("Reverse charge", help="Tick this if this tax is reverse charge. Only for Indian accounting")
+
+    @api.model
+    def _get_generation_dict_from_base_line(self, line_vals, tax_vals, force_caba_exigibility=False):
+        # EXTENDS account
+        # Group taxes also by product.
+        res = super()._get_generation_dict_from_base_line(line_vals, tax_vals, force_caba_exigibility=force_caba_exigibility)
+        record = line_vals['record']
+        if isinstance(record, models.Model)\
+                and record._name == 'account.move.line'\
+                and record.company_id.account_fiscal_country_id.code == 'IN':
+            res['product_id'] = record.product_id.id
+            res['product_uom_id'] = record.product_uom_id.id
+        return res
+
+    @api.model
+    def _get_generation_dict_from_tax_line(self, line_vals):
+        # EXTENDS account
+        # Group taxes also by product.
+        res = super()._get_generation_dict_from_tax_line(line_vals)
+        record = line_vals['record']
+        if isinstance(record, models.Model)\
+                and record._name == 'account.move.line'\
+                and record.company_id.account_fiscal_country_id.code == 'IN':
+            res['product_id'] = record.product_id.id
+            res['product_uom_id'] = record.product_uom_id.id
+        return res

--- a/addons/l10n_in/views/report_invoice.xml
+++ b/addons/l10n_in/views/report_invoice.xml
@@ -58,6 +58,47 @@
             </h2>
         </xpath>
 
+        <xpath expr="//div[@id='payment_term']" position="before">
+            <t t-if="o.company_id.account_fiscal_country_id.code == 'IN'">
+                <t t-set="l10n_in_hsn_summary_details" t-value="o._l10n_in_get_hsn_summary()"/>
+                <t t-set="l10n_in_tax_details" t-value="l10n_in_hsn_summary_details['hsn_tax_details'].values()"/>
+                <t t-set="l10n_in_hsn_columns_details" t-value="l10n_in_hsn_summary_details['column_details']"/>
+                <t t-if="l10n_in_tax_details">
+                    <div name="l10n_in_hsn_summary" class="mt-3">
+                        <table id="l10n_in_hsn_table" class="table table-sm table-borderless col-6" style="page-break-inside: avoid;">
+                            <thead>
+                                <th t-attf-colspan="l10n_in_hsn_columns_details['nb_columns']"><h3>HSN Summary</h3></th>
+                            </thead>
+                            <thead>
+                                <th>HSN/SAC</th>
+                                <th class="text-end">Quantity</th>
+                                <th class="text-end">Rate %</th>
+                                <th class="text-end">Taxable Value</th>
+                                <t t-if="l10n_in_hsn_columns_details['display_gst']">
+                                    <th class="text-end">SGST</th>
+                                    <th class="text-end">CGST</th>
+                                </t>
+                                <th t-if="l10n_in_hsn_columns_details['display_igst']" class="text-end">IGST</th>
+                                <th class="text-end" t-if="l10n_in_hsn_columns_details['display_cess']">CESS</th>
+                            </thead>
+                            <tr t-foreach="l10n_in_tax_details" t-as="tax_detail">
+                                <td><span t-esc="tax_detail['l10n_in_hsn_code']"/></td>
+                                <td class="text-end"><span t-esc="tax_detail['quantity']"/><span t-if="tax_detail['uom']">(<t t-esc="tax_detail['uom']"/>)</span></td>
+                                <td class="text-end"><span t-esc="tax_detail['gst_tax_rate']"/></td>
+                                <td class="text-end"><span t-esc="tax_detail['base_amount_currency']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                                <t t-if="l10n_in_hsn_columns_details['display_gst']">
+                                    <td class="text-end"><span t-esc="tax_detail['SGST_amount_currency']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                                    <td class="text-end"><span t-esc="tax_detail['CGST_amount_currency']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                                </t>
+                                <td class="text-end" t-if="l10n_in_hsn_columns_details['display_igst']"><span t-esc="tax_detail['IGST_amount_currency']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                                <td class="text-end" t-if="l10n_in_hsn_columns_details['display_cess']"><span t-esc="tax_detail['CESS_amount_currency']" t-options='{"widget": "monetary", "display_currency": o.currency_id}'/></td>
+                            </tr>
+                        </table>
+                    </div>
+                </t>
+            </t>
+        </xpath>
+
     </template>
 
 </odoo>


### PR DESCRIPTION
In this PR
------------
- #### [REF] l10n_in*: move l10n_in gst tax query to `odoo/addons/l10n_in/account_move_line.py`

  Before this commit:
  The gst tax  detail query which computes
  the CGST, SGST, IGST and CESS for each
  account move line was only used
  for l10n_in_reports_gstr module
  
  After this commit:
  The gst tax detail query has now moved to
  `odoo/addons/l10n_in/account_move_line.py`,
  after which the query is now reusable,
  and can be used for multiple purposes

    task-3196107,3539187

- #### [IMP] l10n_in: add hsn summary in invoice report
  Added HSN summary for showing taxes rate and amount according to the HSN
  task-3196107

Related PR- https://github.com/odoo/enterprise/pull/53775
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
