### PR TITLE
[IMP] odoo: make comparison to empty string complementary

### DIFF
--- a/odoo/addons/base/tests/test_search.py
+++ b/odoo/addons/base/tests/test_search.py
@@ -292,7 +292,7 @@ class test_search(TransactionCase):
         """, """
             SELECT "res_country"."id"
             FROM "res_country"
-            WHERE "res_country"."code" IS NULL
+            WHERE FALSE
             ORDER BY "res_country"."name"->>%s
         """]):
             Model.search([('code', 'ilike', '')])

--- a/odoo/addons/test_new_api/tests/test_domain.py
+++ b/odoo/addons/test_new_api/tests/test_domain.py
@@ -52,15 +52,15 @@ class TestDomain(common.TransactionCase):
         self.assertListEqual(EmptyChar.search([('name', 'ilike', 'name')]).mapped('name'), ['name'])
         self.assertListEqual(EmptyChar.search([('name', 'not ilike', 'name')]).mapped('name'), ['', False])
 
-        self.assertListEqual(EmptyChar.search([('name', '=', '')]).mapped('name'), [''])
+        self.assertListEqual(EmptyChar.search([('name', '=', '')]).mapped('name'), ['', False])
         self.assertListEqual(EmptyChar.search([('name', '!=', '')]).mapped('name'), ['name'])
         self.assertListEqual(EmptyChar.search([('name', 'ilike', '')]).mapped('name'), ['name', '', False])
-        self.assertListEqual(EmptyChar.search([('name', 'not ilike', '')]).mapped('name'), [False])
+        self.assertListEqual(EmptyChar.search([('name', 'not ilike', '')]).mapped('name'), [])
 
         self.assertListEqual(EmptyChar.search([('name', '=', False)]).mapped('name'), [False])
         self.assertListEqual(EmptyChar.search([('name', '!=', False)]).mapped('name'), ['name', ''])
         self.assertListEqual(EmptyChar.search([('name', 'ilike', False)]).mapped('name'), ['name', '', False])
-        self.assertListEqual(EmptyChar.search([('name', 'not ilike', False)]).mapped('name'), [False])
+        self.assertListEqual(EmptyChar.search([('name', 'not ilike', False)]).mapped('name'), [])
 
         values = ['name', '', False]
         for length in range(len(values) + 1):
@@ -87,15 +87,15 @@ class TestDomain(common.TransactionCase):
         self.assertListEqual(records_fr.search([('name', 'ilike', 'name')]).mapped('name'), ['name'])
         self.assertListEqual(records_fr.search([('name', 'not ilike', 'name')]).mapped('name'), ['', False])
 
-        self.assertListEqual(records_fr.search([('name', '=', '')]).mapped('name'), [''])
+        self.assertListEqual(records_fr.search([('name', '=', '')]).mapped('name'), ['', False])
         self.assertListEqual(records_fr.search([('name', '!=', '')]).mapped('name'), ['name'])
         self.assertListEqual(records_fr.search([('name', 'ilike', '')]).mapped('name'), ['name', '', False])
-        self.assertListEqual(records_fr.search([('name', 'not ilike', '')]).mapped('name'), [False])
+        self.assertListEqual(records_fr.search([('name', 'not ilike', '')]).mapped('name'), [])
 
         self.assertListEqual(records_fr.search([('name', '=', False)]).mapped('name'), [False])
         self.assertListEqual(records_fr.search([('name', '!=', False)]).mapped('name'), ['name', ''])
         self.assertListEqual(records_fr.search([('name', 'ilike', False)]).mapped('name'), ['name', '', False])
-        self.assertListEqual(records_fr.search([('name', 'not ilike', False)]).mapped('name'), [False])
+        self.assertListEqual(records_fr.search([('name', 'not ilike', False)]).mapped('name'), [])
 
         values = ['name', '', False]
         for length in range(len(values) + 1):

--- a/odoo/addons/test_new_api/tests/test_indexed_translation.py
+++ b/odoo/addons/test_new_api/tests/test_indexed_translation.py
@@ -62,7 +62,7 @@ class TestIndexedTranslation(odoo.tests.TransactionCase):
         """, """
             SELECT "test_new_api_indexed_translation"."id"
             FROM "test_new_api_indexed_translation"
-            WHERE "test_new_api_indexed_translation"."name" IS NULL
+            WHERE FALSE
             ORDER BY "test_new_api_indexed_translation"."id"
         """]):
             record_en.search([('name', 'ilike', 'foo')])

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3047,10 +3047,10 @@ class BaseModel(metaclass=MetaModel):
             sql_value = self.env.registry.unaccent(sql_value)
 
         if need_wildcard and not value:
-            return SQL("%s IS NULL", sql_field) if operator in expression.NEGATIVE_TERM_OPERATORS else SQL("TRUE")
+            return SQL("FALSE") if operator in expression.NEGATIVE_TERM_OPERATORS else SQL("TRUE")
 
         sql = SQL("(%s %s %s)", sql_left, sql_operator, sql_value)
-        if value and operator in expression.NEGATIVE_TERM_OPERATORS:
+        if (value and operator in expression.NEGATIVE_TERM_OPERATORS) or (not value and operator == '=' and isinstance(value, str)):
             sql = SQL("(%s OR %s IS NULL)", sql, sql_field)
 
         return sql

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1397,13 +1397,13 @@ class expression(object):
                     need_wildcard = operator in WILDCARD_OPERATORS
 
                     if need_wildcard and not right:
-                        push_result(SQL("%s IS NULL", sql_field) if operator in NEGATIVE_TERM_OPERATORS else SQL("TRUE"))
+                        push_result(SQL("FALSE") if operator in NEGATIVE_TERM_OPERATORS else SQL("TRUE"))
                         continue
 
                     if not need_wildcard:
                         right = field.convert_to_column(right, model, validate=False).adapted['en_US']
 
-                    if (need_wildcard and not right) or (right and operator in NEGATIVE_TERM_OPERATORS):
+                    if (need_wildcard and not right) or (right and operator in NEGATIVE_TERM_OPERATORS) or (not right and operator == '=' and isinstance(right, str)):
                         sql_exprs.append(SQL("%s IS NULL OR", sql_field))
 
                     if self._has_trigram and field.index == 'trigram' and operator in ('=', 'like', 'ilike', '=like', '=ilike'):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When comparing string fields to empty values, the results are should be complementary. So if you negate the condition, you get the complementary result.

Current behavior before PR:
For example, searching `('name', '=', '')` and the complementary condition, does not result in all records, the ones where the value is False are not resturned.

Desired behavior after PR is merged:
`model.search([('name', '=', '')]) | model.search([('name', '!=', '')]) == model.search([])`



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
