### PR TITLE
[FIX] base: fix 413 error when `web.max_file_upload_size` ICP is set

### DIFF
--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -180,7 +180,7 @@ class IrHttp(models.AbstractModel):
         # takes over.
         try:
             key = 'web.max_file_upload_size'
-            if value := (ICP.get_param(key, None) is not None):
+            if (value := ICP.get_param(key, None)) is not None:
                 request.httprequest.max_content_length = int(value)
         except ValueError:  # better not crash on ALL requests
             _logger.error("invalid %s: %r, using %s instead",


### PR DESCRIPTION
Following odoo/odoo@2a8dd6011, if a db has `web.max_file_upload_size` ICP set to any value, the request would have been wrongly limited to 1 byte

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
