### PR TITLE
[15.0][IMP] purchase_stock: hook methods for price difference journal items

### DIFF
--- a/doc/cla/corporate/forgeflow.md
+++ b/doc/cla/corporate/forgeflow.md
@@ -12,7 +12,7 @@ Jordi Ballester jordi.ballester@forgeflow.com https://github.com/JordiBForgeFlow
 
 List of contributors:
 
-Aarón Henríquez ahenriquez@forgeflow.com https://github.com/AaronHForgeFlow
+Aarón Henríquez aaron.henriquez@forgeflow.com https://github.com/AaronHForgeFlow
 Lois Rilo lois.rilo@forgeflow.com https://github.com/LoisRForgeFlow
 Miquel Raich miquel.raich@forgeflow.com https://github.com/MiquelRForgeFlow
 Jordi Ballester jordi.ballester@forgeflow.com https://github.com/JordiBForgeFlow


### PR DESCRIPTION
The main goal is to be able to customize the price difference journal items by adding new information. For example, If we reconcile the account "Interim received" by purchase order we will need to add the purchase line information in the journal items for the price difference for this account.

![interim_journals_by_purchase_order_line](https://github.com/odoo/odoo/assets/19620251/1c3bbee7-ed31-452a-89be-b76f3357776d)

Also that allows to add a custom description, for example add the Purchase difference in the name (see image above).

Also it allows to modify the standard behavior where price difference journals are created. Example: Confirm a PO in USD and create a BILL in EUR. The price difference journals are created and then the products are received at the price in the PO. Possible change: do not create price difference if the products are not received. Change the price in the PO instead.

cc @ForgeFlow

