### PR TITLE
[IMP] sale: remove down payment products

### DIFF
--- a/addons/repair/models/sale_order.py
+++ b/addons/repair/models/sale_order.py
@@ -66,16 +66,18 @@ class SaleOrderLine(models.Model):
         res.filtered(lambda line: line.state in ('sale', 'done'))._create_repair_order()
         return res
 
-    def write(self, vals_list):
-        old_product_uom_qty = {line.id: line.product_uom_qty for line in self}
-        res = super().write(vals_list)
-        for line in self:
-            if line.state in ('sale', 'done') and line.product_id:
-                if float_compare(old_product_uom_qty[line.id], 0, precision_rounding=line.product_uom.rounding) <= 0 and float_compare(line.product_uom_qty, 0, precision_rounding=line.product_uom.rounding) > 0:
-                    self._create_repair_order()
-                if float_compare(old_product_uom_qty[line.id], 0, precision_rounding=line.product_uom.rounding) > 0 and float_compare(line.product_uom_qty, 0, precision_rounding=line.product_uom.rounding) <= 0:
-                    self._cancel_repair_order()
-        return res
+    def write(self, vals):
+        if 'product_uom_qty' in vals:
+            old_product_uom_qty = {line.id: line.product_uom_qty for line in self}
+            res = super().write(vals)
+            for line in self:
+                if line.state in ('sale', 'done') and line.product_id:
+                    if float_compare(old_product_uom_qty[line.id], 0, precision_rounding=line.product_uom.rounding) <= 0 and float_compare(line.product_uom_qty, 0, precision_rounding=line.product_uom.rounding) > 0:
+                        self._create_repair_order()
+                    if float_compare(old_product_uom_qty[line.id], 0, precision_rounding=line.product_uom.rounding) > 0 and float_compare(line.product_uom_qty, 0, precision_rounding=line.product_uom.rounding) <= 0:
+                        self._cancel_repair_order()
+            return res
+        return super().write(vals)
 
     def _action_launch_stock_rule(self, previous_product_uom_qty=False):
         # Picking must be generated for products created from the SO but not for parts added from the RO, as they're already handled there

--- a/addons/sale/models/res_company.py
+++ b/addons/sale/models/res_company.py
@@ -37,16 +37,6 @@ class ResCompany(models.Model):
         help="Default product used for discounts",
         check_company=True,
     )
-    sale_down_payment_product_id = fields.Many2one(
-        comodel_name='product.product',
-        string="Deposit Product",
-        domain=[
-            ('type', '=', 'service'),
-            ('invoice_policy', '=', 'order'),
-        ],
-        help="Default product used for down payments",
-        check_company=True,
-    )
 
     # sale onboarding
     sale_onboarding_payment_method = fields.Selection(

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -22,7 +22,7 @@ class SaleOrderLine(models.Model):
 
     _sql_constraints = [
         ('accountable_required_fields',
-            "CHECK(display_type IS NOT NULL OR (product_id IS NOT NULL AND product_uom IS NOT NULL))",
+            "CHECK(display_type IS NOT NULL OR is_downpayment OR (product_id IS NOT NULL AND product_uom IS NOT NULL))",
             "Missing required fields on accountable sale order line."),
         ('non_accountable_null_fields',
             "CHECK(display_type IS NULL OR (product_id IS NULL AND price_unit = 0 AND product_uom_qty = 0 AND product_uom IS NULL AND customer_lead = 0))",

--- a/addons/sale/tests/test_credit_limit.py
+++ b/addons/sale/tests/test_credit_limit.py
@@ -69,7 +69,6 @@ class TestSaleOrderCreditLimit(TestSaleCommon):
         }).create({
             'advance_payment_method': 'percentage',
             'amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id,
         }).create_invoices()
 
         invoice = sale_order.invoice_ids

--- a/addons/sale/tests/test_sale_order_down_payment.py
+++ b/addons/sale/tests/test_sale_order_down_payment.py
@@ -94,7 +94,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'percentage',
             'amount': 50,
-            'deposit_account_id': cls.revenue_account.id,
             **kwargs,
         }
         downpayment = cls.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
@@ -442,7 +441,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'fixed',
             'fixed_amount': 550.0,
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         downpayment.create_invoices()
@@ -496,7 +494,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'fixed',
             'fixed_amount': 200.0,
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         action = downpayment.create_invoices()
@@ -521,7 +518,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         # final invoice which is a credit note as there ar no deliveries to invoice and there already is 200 paid
         payment_params = {
             'advance_payment_method': 'delivered',
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context({**so_context, 'raise_if_nothing_to_invoice': False}).create(payment_params)
         action = downpayment.create_invoices()
@@ -604,7 +600,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'fixed',
             'fixed_amount': 200.0,
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         action = downpayment.create_invoices()
@@ -627,10 +622,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         self.assertEqual(downpayment.amount_invoiced, 200.0, "Amount invoiced is not equal to downpayment amount")
 
         # final invoice which is a credit note as there ar no deliveries to invoice and there already is 200 paid
-        payment_params = {
-            'advance_payment_method': 'delivered',
-            'deposit_account_id': self.revenue_account.id,
-        }
+        payment_params = {'advance_payment_method': 'delivered'}
         downpayment = self.env['sale.advance.payment.inv'].with_context({**so_context, 'raise_if_nothing_to_invoice': False}).create(payment_params)
         action = downpayment.create_invoices()
         invoice = self.env['account.move'].browse(action['res_id'])
@@ -735,7 +727,6 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         payment_params = {
             'advance_payment_method': 'fixed',
             'fixed_amount': 500.0,
-            'deposit_account_id': self.revenue_account.id,
         }
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         action = downpayment.create_invoices()
@@ -764,10 +755,7 @@ class TestSaleOrderDownPayment(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         self.assertEqual(downpayment.amount_invoiced, 500.0, "Amount invoiced is not equal to downpayment amount")
         # final invoice
-        payment_params = {
-            'advance_payment_method': 'delivered',
-            'deposit_account_id': self.revenue_account.id,
-        }
+        payment_params = {'advance_payment_method': 'delivered'}
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
         action = downpayment.create_invoices()
         invoice = self.env['account.move'].browse(action['res_id'])

--- a/addons/sale/tests/test_sale_refund.py
+++ b/addons/sale/tests/test_sale_refund.py
@@ -289,7 +289,6 @@ class TestSaleRefund(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create({
             'advance_payment_method': 'percentage',
             'amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         # order_line[1] is the down payment section
@@ -308,9 +307,7 @@ class TestSaleRefund(TestSaleCommon):
             'qty_to_invoice': -1.0,
         }])
 
-        payment = self.env['sale.advance.payment.inv'].with_context(so_context).create({
-            'deposit_account_id': self.company_data['default_account_revenue'].id
-        })
+        payment = self.env['sale.advance.payment.inv'].with_context(so_context).create({})
         payment.create_invoices()
 
         so_invoice = max(sale_order_refund.invoice_ids)

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -240,8 +240,6 @@ class TestSaleToInvoice(TestSaleCommon):
             'price_include': True,
         })
         # Let's do an invoice for a deposit of 100
-        product_id = self.env.company.sale_down_payment_product_id
-        product_id.taxes_id = tax_downpayment.ids
         payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'percentage',
             'amount': 50,

--- a/addons/sale/tests/test_sale_to_invoice.py
+++ b/addons/sale/tests/test_sale_to_invoice.py
@@ -96,13 +96,11 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         downpayment2 = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment2.create_invoices()
         self._check_order_search(self.sale_order, [('invoice_ids', '=', False)], self.env['sale.order'])
@@ -116,9 +114,7 @@ class TestSaleToInvoice(TestSaleCommon):
         self.sol_prod_deliver.write({'qty_delivered': 2.0})
 
         # Let's do an invoice with refunds
-        payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
-            'deposit_account_id': self.company_data['default_account_revenue'].id
-        })
+        payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({})
         payment.create_invoices()
 
         self.assertEqual(len(self.sale_order.invoice_ids), 3, 'Invoice should be created for the SO')
@@ -142,7 +138,6 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'percentage',
             'amount': 10,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         self._check_order_search(self.sale_order, [('invoice_ids', '=', False)], self.env['sale.order'])
@@ -183,13 +178,10 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(context).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         # Let's do the invoice
-        payment = self.env['sale.advance.payment.inv'].with_context(context).create({
-            'deposit_account_id': self.company_data['default_account_revenue'].id
-        })
+        payment = self.env['sale.advance.payment.inv'].with_context(context).create({})
         payment.create_invoices()
         # Confirm all invoices
         for invoice in sale_order.invoice_ids:
@@ -223,7 +215,6 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(context).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         # Create invoice
         downpayment.create_invoices()
@@ -243,7 +234,6 @@ class TestSaleToInvoice(TestSaleCommon):
         payment = self.env['sale.advance.payment.inv'].with_context(self.context).create({
             'advance_payment_method': 'percentage',
             'amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id,
         })
         payment.create_invoices()
 
@@ -546,7 +536,6 @@ class TestSaleToInvoice(TestSaleCommon):
         downpayment = self.env['sale.advance.payment.inv'].with_context(context_for_downpayment).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 50,
-            'deposit_account_id': self.company_data['default_account_revenue'].id
         })
         downpayment.create_invoices()
         self.assertEqual(so_for_downpayment.invoice_ids[0].company_id.id, so_company_id, "The company of the downpayment invoice should be the same as the one from the SO")

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -35,11 +35,6 @@ class ResConfigSettings(models.TransientModel):
              "and not after the delivery.",
         config_parameter='sale.automatic_invoice',
     )
-    deposit_default_product_id = fields.Many2one(
-        related='company_id.sale_down_payment_product_id',
-        readonly=False,
-        # previously config_parameter='sale.default_deposit_product_id',
-    )
 
     invoice_mail_template_id = fields.Many2one(
         comodel_name='mail.template',

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -154,13 +154,6 @@
                                 <field name="invoice_mail_template_id" class="oe_inline" options="{'no_create': True}"/>
                             </div>
                         </setting>
-                        <setting id="down_payments"
-                            string="Down Payments"
-                            help="Product used for down payments"
-                            documentation="/applications/sales/sales/invoicing/down_payment.html"
-                            company_dependent="1">
-                            <field name="deposit_default_product_id" context="{'default_detailed_type': 'service'}"/>
-                        </setting>
                     </block>
                     <block title="Connectors" id="connectors_setting_container">
                         <setting id="amazon_connector" documentation="/applications/sales/sales/amazon_connector/setup.html" help="Import Amazon orders and sync deliveries">

--- a/addons/sale/wizard/sale_make_invoice_advance_views.xml
+++ b/addons/sale/wizard/sale_make_invoice_advance_views.xml
@@ -25,7 +25,6 @@
                 <group name="down_payment_specification"
                     invisible="advance_payment_method not in ('fixed', 'percentage')">
                     <field name="company_id" invisible="1"/>
-                    <field name="product_id" invisible="1"/>
                     <label for="amount"/>
                     <div id="payment_method_details">
                         <field name="currency_id" invisible="1"/>
@@ -46,13 +45,6 @@
                             <i class="fa fa-warning"/>
                         </span>
                     </div>
-                    <field name="deposit_account_id"
-                        options="{'no_create': True}"
-                        invisible="product_id"
-                        groups="account.group_account_manager"/>
-                    <field name="deposit_taxes_id"
-                        widget="many2many_tags"
-                        invisible="product_id"/>
                 </group>
                 <group invisible="not has_down_payments">
                     <field name="amount_invoiced"/>

--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -425,7 +425,7 @@ class Project(models.Model):
             domain = []
         return expression.AND([
             [
-                ('product_id', '!=', False),
+                '|', ('product_id', '!=', False), ('is_downpayment', '=', True),
                 ('is_expense', '=', False),
                 ('state', '=', 'sale'),
                 '|', ('qty_to_invoice', '>', 0), ('qty_invoiced', '>', 0),

--- a/addons/sale_project/tests/test_project_profitability.py
+++ b/addons/sale_project/tests/test_project_profitability.py
@@ -589,7 +589,6 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
         downpayment = self.env['sale.advance.payment.inv'].with_context(Downpayment).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 115,
-            'deposit_account_id': self.company_data['default_account_revenue'].id,
         })
         # When a down payment is created, the default 15% tax is included. The SOL associated it then created by removing the taxed amount.
         # Therefore, the amount of the dp is higher than the amount of the sol created.
@@ -603,7 +602,6 @@ class TestSaleProjectProfitability(TestProjectProfitabilityCommon, TestSaleCommo
         downpayment = self.env['sale.advance.payment.inv'].with_context(Downpayment).create({
             'advance_payment_method': 'fixed',
             'fixed_amount': 115,
-            'deposit_account_id': self.company_data['default_account_revenue'].id,
         })
         down_payment_invoiced = 2 * down_payment_invoiced
         downpayment.create_invoices()

--- a/addons/sale_stock/tests/test_sale_stock.py
+++ b/addons/sale_stock/tests/test_sale_stock.py
@@ -144,15 +144,9 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         self.assertTrue(self.so.picking_ids, 'Sale Stock: no picking created for "invoice on order" storable products')
         # let's do an invoice for a deposit of 5%
 
-        advance_product = self.env['product.product'].create({
-            'name': 'Deposit',
-            'type': 'service',
-            'invoice_policy': 'order',
-        })
         adv_wiz = self.env['sale.advance.payment.inv'].with_context(active_ids=[self.so.id]).create({
             'advance_payment_method': 'percentage',
             'amount': 5.0,
-            'product_id': advance_product.id,
         })
         act = adv_wiz.with_context(open_invoices=True).create_invoices()
         inv = self.env['account.move'].browse(act['res_id'])
@@ -1412,16 +1406,9 @@ class TestSaleStock(TestSaleCommon, ValuationReconciliationTestCommon):
         })
         so.action_confirm()
 
-        advance_product = self.env['product.product'].create({
-            'name': 'Deposit',
-            'type': 'service',
-            'invoice_policy': 'order',
-        })
-
         adv_wiz = self.env['sale.advance.payment.inv'].with_context(active_ids=[so.id]).create({
             'advance_payment_method': 'percentage',
             'amount': 5.0,
-            'product_id': advance_product.id,
         })
 
         act = adv_wiz.with_context(open_invoices=True).create_invoices()


### PR DESCRIPTION
This commit removes down payment products from the settings (where it has become obsolete, dead field, never used since 16.2) and from the down payment wizard where the user creating the down payment has probably no idea of what should be entered there.

task-3618096






---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
