### PR TITLE
[FIX] mail: prevent self call

### DIFF
--- a/addons/mail/static/src/discuss/call/common/thread_actions.js
+++ b/addons/mail/static/src/discuss/call/common/thread_actions.js
@@ -13,6 +13,7 @@ threadActionsRegistry
         condition(component) {
             return (
                 component.thread?.allowCalls &&
+                !component.thread?.isOnlySelf &&
                 !component.thread?.eq(component.rtc.state.channel) &&
                 !component.props.chatWindow?.hidden
             );

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -76,4 +76,7 @@ patch(Thread.prototype, {
     incrementUnreadCounter() {
         this.message_unread_counter++;
     },
+    get isOnlySelf() {
+        return this.channelMembers.length === 1 && this.channel_type === "chat";
+    }
 });

--- a/addons/mail/static/tests/discuss/call/call_tests.js
+++ b/addons/mail/static/tests/discuss/call/call_tests.js
@@ -52,6 +52,20 @@ QUnit.test("no call with odoobot", async () => {
     await contains("[title='Start a Call']", { count: 0 });
 });
 
+QUnit.test("should not make self call if there is only one memeber", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({
+        channel_member_ids: [
+            Command.create({ partner_id: pyEnv.currentPartnerId }),
+        ],
+        channel_type: "chat",
+    });
+    const { openDiscuss } = await start();
+    openDiscuss(channelId);
+    await contains(".o-mail-Discuss-header");
+    await contains("[title='Start a Call']", { count: 0 });
+});
+
 QUnit.test("should not display call UI when no more members (self disconnect)", async () => {
     mockGetMedia();
     const pyEnv = await startServer();


### PR DESCRIPTION
**Before this PR:**
When a user is in conversation with himself, the user had the option 
of calling as the call button is visible in that particular thread.

**After this PR:**
Now, the when the user is in conversation with himself, in that case, 
the self call is restricted for that thread.

task- 3502904
