### PR TITLE
[FIX] web_editor: set shortcut for link dialog

### DIFF
--- a/addons/web_editor/static/src/xml/wysiwyg.xml
+++ b/addons/web_editor/static/src/xml/wysiwyg.xml
@@ -101,8 +101,8 @@
                     </div>
                 </div>
                 <t t-set-slot="footer">
-                    <button class="btn btn-primary" t-on-click="this.onSave">Insert</button>
-                    <button class="btn btn-secondary" t-on-click="this.onDiscard">Discard</button>
+                    <button class="btn btn-primary" t-on-click="this.onSave" data-hotkey="q">Insert</button>
+                    <button class="btn btn-secondary" t-on-click="this.onDiscard" data-hotkey="x">Discard</button>
                 </t>
             </div>
         </Dialog>


### PR DESCRIPTION
The shortcut for the link dialog was not set, so it was not possible to insert or discard the creation of a link with the keyboard.

task-3677041





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
