### PR TITLE
[IMP] {website_}mass_mailing: repaint the wall of mailing subscriptions

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -143,7 +143,6 @@
             'mass_mailing/static/src/builder/snippet_viewer/*.scss',
         ],
         'mass_mailing.mailing_assets': [
-            'mass_mailing/static/src/scss/mailing_portal.scss',
             'mass_mailing/static/src/interactions/subscribe.js',
             'mass_mailing/static/src/xml/mailing_portal_subscription_blocklist.xml',
             'mass_mailing/static/src/xml/mailing_portal_subscription_feedback.xml',
@@ -173,6 +172,7 @@
         ],
         'web.assets_frontend': [
             'mass_mailing/static/src/js/tours/**/*',
+            'mass_mailing/static/src/scss/mailing_portal.scss',
         ],
         'web.assets_tests': [
             'mass_mailing/static/tests/tours/**/*',

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -6,12 +6,12 @@ import urllib.parse
 
 from datetime import timedelta
 from markupsafe import Markup, escape
-from lxml import etree
 from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 
 from odoo import _, fields, http, tools
 from odoo.http import request, Response
 from odoo.tools import consteq
+from odoo.tools.mail import is_html_empty
 
 
 class MassMailController(http.Controller):
@@ -167,17 +167,8 @@ class MassMailController(http.Controller):
         # Unsubscribe directly + Let the user choose their subscriptions
 
         mailing.contact_list_ids._update_subscription_from_email(email, opt_out=True)
-        # compute name of unsubscribed list: hide non public lists
-        if all(not mlist.is_public for mlist in mailing.contact_list_ids):
-            lists_unsubscribed_name = _('You are no longer part of our mailing list(s).')
-        elif len(mailing.contact_list_ids) == 1:
-            lists_unsubscribed_name = _('You are no longer part of the %(mailing_name)s mailing list.',
-                                        mailing_name=mailing.contact_list_ids.name)
-        else:
-            lists_unsubscribed_name = _(
-                'You are no longer part of the %(mailing_names)s mailing list.',
-                mailing_names=', '.join(mlist.name for mlist in mailing.contact_list_ids if mlist.is_public)
-            )
+        # compute name of unsubscribed list: hide non public lists. (resolves to False is no list is public)
+        lists_unsubscribed_name = ', '.join(mlist.name for mlist in mailing.contact_list_ids if mlist.is_public)
 
         return request.render(
             'mass_mailing.page_mailing_unsubscribe',
@@ -186,6 +177,7 @@ class MassMailController(http.Controller):
                     mailing, document_id, email, hash_token
                 ),
                 last_action='subscription_updated',
+                unsubscribed=True,
                 unsubscribed_name=lists_unsubscribed_name,
             )
         )
@@ -262,16 +254,20 @@ class MassMailController(http.Controller):
             'is_blocklisted': mail_blocklist.active if mail_blocklist else False,
             # mailing lists
             'contacts': contacts,
-            'lists_contacts': contacts.subscription_ids.list_id.filtered('active'),
             'lists_optin': lists_optin,
             'lists_optout': lists_optout,
             'lists_public': lists_public,
+            # display
+            'is_html_empty': is_html_empty,
+            'lists_optin_public': lists_optin.filtered('is_public'),
+            'lists_optout_public': lists_optout.filtered('is_public'),
+            'show_subscription_form': any(mlist.is_public for mlist in lists_optin + lists_optout) or lists_public,
         }
 
     @http.route('/mailing/list/update', type='jsonrpc', auth='public', csrf=True)
     def mailing_update_list_subscription(self, mailing_id=None, document_id=None,
                                          email=None, hash_token=None,
-                                         lists_optin_ids=None, **post):
+                                         lists_optin_ids=None, opt_out_reason_id=None, **post):
         email_found, hash_token_found = self._fetch_user_information(email, hash_token)
         try:
             _mailing_sudo = self._check_mailing_email_token(
@@ -285,10 +281,14 @@ class MassMailController(http.Controller):
 
         contacts = self._fetch_contacts(email_found)
         lists_optin = request.env['mailing.list'].sudo().browse(lists_optin_ids or []).exists()
-        # opt-out all not chosen lists
-        lists_to_optout = contacts.subscription_ids.filtered(
-            lambda sub: not sub.opt_out and sub.list_id not in lists_optin
-        ).list_id
+        lists_optin_private = contacts.subscription_ids.filtered(
+            lambda sub: not sub.opt_out and not sub.list_id.is_public
+        ).mapped("list_id")
+        # opt-out all not chosen lists (except hidden lists)
+        subscriptions_to_optout = contacts.subscription_ids.filtered(
+            lambda sub: not sub.opt_out and sub.list_id not in (lists_optin + lists_optin_private)
+        )
+        lists_to_optout = subscriptions_to_optout.list_id
         # opt-in in either already member, either public (to avoid trying to opt-in
         # in private lists)
         lists_to_optin = lists_optin.filtered(
@@ -296,6 +296,9 @@ class MassMailController(http.Controller):
         )
         lists_to_optout._update_subscription_from_email(email_found, opt_out=True)
         lists_to_optin._update_subscription_from_email(email_found, opt_out=False)
+
+        if subscriptions_to_optout and opt_out_reason_id:
+            subscriptions_to_optout.opt_out_reason_id = opt_out_reason_id
 
         return len(lists_to_optout)
 

--- a/addons/mass_mailing/models/mailing_list.py
+++ b/addons/mass_mailing/models/mailing_list.py
@@ -31,6 +31,8 @@ class MailingList(models.Model):
     contact_ids = fields.Many2many(
         'mailing.contact', 'mailing_subscription', 'list_id', 'contact_id',
         string='Mailing Lists', copy=False)
+    description = fields.Text('Description', translate=True,
+        help="Summary of Mailing List contents. This will appear on the subscription management page.")
     mailing_count = fields.Integer(compute="_compute_mailing_count", string="Number of Mailing")
     mailing_ids = fields.Many2many(
         'mailing.mailing', 'mail_mass_mailing_list_rel',
@@ -166,7 +168,7 @@ class MailingList(models.Model):
                 'default_model_id': self.env['ir.model']._get_id('mailing.list'),
             },
             'target': 'current',
-            'view_type': 'form',
+            'views': [[False, 'form']],
         })
 
         return action
@@ -398,12 +400,12 @@ class MailingList(models.Model):
                 body = force_message
             elif opt_out:
                 body = Markup('<p>%s</p><ul>%s</ul>') % (
-                    _('%(contact_name)s unsubscribed from the following mailing list(s)', contact_name=contact.display_name),
+                    _('%(contact_name)s unsubscribed from the following mailing list(s):', contact_name=contact.display_name),
                     Markup().join(Markup('<li>%s</li>') % name for name in updated.mapped('name')),
                 )
             else:
                 body = Markup('<p>%s</p><ul>%s</ul>') % (
-                    _('%(contact_name)s subscribed to the following mailing list(s)', contact_name=contact.display_name),
+                    _('%(contact_name)s subscribed to the following mailing list(s):', contact_name=contact.display_name),
                     Markup().join(Markup('<li>%s</li>') % name for name in updated.mapped('name')),
                 )
             contact.with_context(mail_post_autofollow_author_skip=True).message_post(

--- a/addons/mass_mailing/static/src/scss/mailing_portal.scss
+++ b/addons/mass_mailing/static/src/scss/mailing_portal.scss
@@ -1,16 +1,30 @@
 .o_mailing_portal_body {
     // Taken from webclient.scss to copy backend styling
-    // Uppercase primary and secondary except when secondary is used as a dropdown
-    // toggler.
-    .btn-primary,
-    .btn-secondary:not(.dropdown-toggle):not(.dropdown-item),
-    .btn-secondary.o_arrow_button:not(.dropdown-item) {
-      text-transform: uppercase;
+    .o_mailing_subscription_form_list_toggle {
+        > span:last-of-type {
+            color: $green-700;
+        }
+        &:hover {
+            opacity: 1;
+            cursor: pointer;
+        }
+    }
+    .o_mailing_subscription_form_list_description {
+        margin-left: 54px;
+        overflow: hidden;
+    }
+    li {
+        border-radius: 0.5em;
     }
 
-    .o_mailing_list_unsubscribed {
-        margin-left: 20px;
-        color: #005326;
-        font-size: 90%;
+    &.editor_enable {
+        .o_mailing_portal_alert, #o_mailing_subscription_feedback_info, #o_mailing_subscription_feedback,
+        #o_mailing_subscription_form_manage, #o_mailing_subscription_form_blocklisted,
+        #button_subscription_update_preferences {
+            display: block !important;
+        }
+        .o_mailing_subscription_form_list_description {
+            margin-bottom: 16px;
+        }
     }
 }

--- a/addons/mass_mailing/static/src/xml/mailing_portal_subscription_blocklist.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_portal_subscription_blocklist.xml
@@ -4,15 +4,15 @@
     <t t-name="mass_mailing.portal.blocklist_update_info">
         <span>
             <t t-if="infoKey == 'blocklist_add'">
-                <i class="fa fa-check me-1"/>
+                <i class="fa fa-check me-2"/>
                 <span>Email added to our blocklist</span>
             </t>
             <t t-elif="infoKey == 'blocklist_remove'">
-                <i class="fa fa-check me-1"/>
+                <i class="fa fa-check me-2"/>
                 <span>Email removed from our blocklist</span>
             </t>
             <t t-else="">
-                <i class="fa fa-exclamation-triangle me-1"/>
+                <i class="fa fa-exclamation-triangle me-2"/>
                 <span>An error occurred. Please retry later.</span>
             </t>
         </span>

--- a/addons/mass_mailing/static/src/xml/mailing_portal_subscription_feedback.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_portal_subscription_feedback.xml
@@ -4,11 +4,12 @@
     <t t-name="mass_mailing.portal.feedback_update_info">
         <span>
             <t t-if="infoKey == 'feedback_sent'">
-                <i class="fa fa-check me-1"/>
-                <span>Sent. Thanks you for your feedback!</span>
+                <i class="fa fa-check me-2"/>
+                <span>Thank you for your feedback!</span>
             </t>
+            <t t-elif="infoKey == 'idle'"/>
             <t t-else="">
-                <i class="fa fa-exclamation-triangle me-1"/>
+                <i class="fa fa-exclamation-triangle me-2"/>
                 <span>An error occurred. Please retry later or contact us.</span>
             </t>
         </span>

--- a/addons/mass_mailing/static/src/xml/mailing_portal_subscription_form.xml
+++ b/addons/mass_mailing/static/src/xml/mailing_portal_subscription_form.xml
@@ -3,84 +3,41 @@
 <templates xml:space="preserve">
     <!-- Re-render lists form as no reload is done on portal page -->
     <t t-name="mass_mailing.portal.list_form_content">
-        <p t-if="listsMember.length">
-            Choose your mailing subscriptions
-        </p>
         <ul id="o_mailing_subscription_form_lists"
-            t-if="listsMember.length"
+            t-if="listsMemberOrPoposal.length"
             class="list-group">
-            <li t-foreach="listsMember"
+            <li t-foreach="listsMemberOrPoposal"
                 t-as="mailing_list"
                 t-key="mailing_list_key"
-                class="list-group-item d-flex align-items-center">
-                <input type="checkbox"
-                       name="mailing_list_ids"
-                       t-att-data-member="1"
-                       t-att-value="mailing_list['id']"
-                       t-att-checked="mailing_list['opt_out'] ? undefined : 'checked'"
-                       t-att-title="mailing_list['name']"/>
-                <span class="ms-1" t-out="mailing_list['name']"/>
-                <span class="o_mailing_list_unsubscribed ms-auto">
-                    <t t-if="mailing_list['opt_out']">
-                        Not subscribed
-                    </t>
-                    <t t-else="">
-                        Subscribed
-                    </t>
-                </span>
+                class="list-group-item p-0">
+                <label class="o_mailing_subscription_form_list_toggle checkbox-group d-flex align-items-center px-3">
+                    <input class="mailing_lists_checkboxes checkbox-input mx-2"
+                           type="checkbox"
+                           role="switch"
+                           name="mailing_list_ids"
+                           t-att-id="'mailing_list_id' + mailing_list['id']"
+                           t-att-data-description="mailing_list['description']"
+                           t-att-data-member="mailing_list['member'] ? '1' : undefined"
+                           t-att-value="mailing_list['id']"
+                           t-att-checked="mailing_list['opt_out'] ? undefined : 'checked'"
+                           t-att-title="mailing_list['name']"/>
+                    <span class="mx-2 py-3" t-out="mailing_list['name']"/>
+                </label>
+                <div t-attf-class="pe-3 o_mailing_subscription_form_list_description #{mailing_list['description'] ? 'mb-3' : ''}"
+                     t-att-data-description="mailing_list['description']"/>
             </li>
-        </ul>
-        <p t-if="listsProposal.length">
-            You may also be interested in
-        </p>
-        <ul id="o_mailing_subscription_form_lists_additional"
-            t-if="listsProposal.length"
-            class="list-group">
-            <li t-foreach="listsProposal"
-                t-as="mailing_list"
-                t-key="mailing_list_key"
-                class="list-group-item">
-                <input type="checkbox"
-                       name="mailing_list_ids"
-                       t-att-value="mailing_list['id']"
-                       t-att-title="mailing_list['name']"/>
-                <span class="ms-1" t-out="mailing_list['name']"/>
-            </li>
-        </ul>
-    </t>
-
-    <!-- Re-render lists (in readonly mode) as no reload is done on portal page -->
-    <t t-name="mass_mailing.portal.list_form_content_readonly">
-        <p>
-            Your email is currently <strong>in our block list</strong>.
-            <t t-if="listsOptin.length">
-                You will not receive any news from those mailing lists you are a member of:
-            </t>
-            <t t-else="">
-                You will not hear from us anymore.
-            </t>
-        </p>
-        <ul class="list-group mb-4"
-            t-if="listsOptin.length">
-            <t t-foreach="listsOptin"
-               t-as="mailing_list"
-               t-key="mailing_list_key">
-                <li class="list-group-item d-flex align-items-center">
-                    <strong t-out="mailing_list['name']"/>
-                </li>
-            </t>
         </ul>
     </t>
 
     <!-- Post action informative span -->
-    <t t-name="mass_mailing.portal.list_form_update_info">
-        <t t-if="infoKey == 'subscription_updated'">
-            <i class="fa fa-check me-1"/>
-            <span>Membership updated</span>
+    <t t-name="mass_mailing.portal.list_form_update_status">
+        <t t-if="infoKey === 'error'">
+            <i class="fa fa-exclamation-triangle me-2"/>
+            <span>An error occurred. Please retry later.</span>
         </t>
         <t t-else="">
-            <i class="fa fa-exclamation-triangle me-1"/>
-            <span>An error occurred. Please retry later.</span>
+            <i class="fa fa-check me-2"/>
+            <span>Your preferences have been updated</span>
         </t>
     </t>
 </templates>

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_document.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_document.js
@@ -5,80 +5,21 @@ import { registry } from "@web/core/registry";
  * mailing lists). We assume email is not member of any mailing list in this test.
  */
 registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_document', {
+    // add new steps, as the tour will now begin on another page
     steps: () => [
         {
-            content: "Confirmation unsubscribe is done",
-            trigger: "div#o_mailing_subscription_info span:contains('You are no longer part of our services and will not be contacted again.')",
+            content: "Click on unsubscription button to unsubscribe",
+            trigger: "form button#button_confirm_unsubscribe",
             run: "click",
-        }, {
-            content: "No warning should be displayed",
-            trigger: "div#o_mailing_subscription_form_blocklisted:not(:has(p:contains('You will not receive any news from those mailing lists you are a member of')))",
-            run: "click",
-        }, {
-            content: "Warning will not receive anything anymore",
-            trigger: "div#o_mailing_subscription_form_blocklisted p:contains('You will not hear from us anymore.')",
-            run: "click",
-        }, {
-            content: "Feedback textarea not displayed (see data)",
-            trigger: "div#o_mailing_portal_subscription:not(textarea)",
-            run: "click",
-        }, {
-            content: "Choose 'Other' reason",
-            trigger: "fieldset label:contains('Other')",
-            run: "click",
-        }, {
-            content: "This should display the Feedback area",
-            trigger: "div#o_mailing_portal_subscription textarea",
-        }, {
-            content: "Write feedback reason",
-            trigger: "textarea[name='feedback']",
-            run: "edit My feedback",
-        }, {
-            content: "Hit Send",
-            trigger: "button#button_feedback",
-            run: "click",
-        }, {
-            content: "Confirmation feedback is sent",
-            trigger: "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
-            run: "click",
-        }, {
-            content: "Revert exclusion list",
-            trigger: "div#button_blocklist_remove",
-            run: "click",
-        }, {
-            content: "Confirmation exclusion list is removed",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Email removed from our blocklist')",
-            run: "click",
-        }, {
-            content: "Now exclude me (again)",
-            trigger: "div#button_blocklist_add",
-            run: "click",
-        }, {
-            content: "Confirmation exclusion is done",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
+            expectUnloadPage: true,
         },
-    ],
-});
-
-
-/*
- * Tour: unsubscribe from a mailing done on documents (aka not on contacts or
- * mailing lists). We assume email is member of mailing lists in this test.
- */
-registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_document_with_lists', {
-    steps: () => [
         {
             content: "Confirmation unsubscribe is done",
             trigger: "div#o_mailing_subscription_info span:contains('You are no longer part of our services and will not be contacted again.')",
             run: "click",
         }, {
-            content: "Display warning about mailing lists",
-            trigger: "div#o_mailing_subscription_form_blocklisted p:contains('You will not receive any news from those mailing lists you are a member of')",
-            run: "click",
-        }, {
-            content: "Warning should contain reference to memberships",
-            trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List1')",
-            run: "click",
+            content: "Warning you will not receive anything anymore",
+            trigger: "div#o_mailing_subscription_form_blocklisted div:contains('You won't receive marketing emails.')",
         }, {
             content: "Feedback textarea not displayed (see data)",
             trigger: "div#o_mailing_portal_subscription:not(textarea)",
@@ -100,8 +41,7 @@ registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_documen
             run: "click",
         }, {
             content: "Confirmation feedback is sent",
-            trigger: "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
-            run: "click",
+            trigger: "div#o_mailing_subscription_feedback_info span:contains('Thank you for your feedback!')",
         }, {
             content: "Revert exclusion list",
             trigger: "div#button_blocklist_remove",

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_list.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_list.js
@@ -7,9 +7,14 @@ import { registry } from "@web/core/registry";
 registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list", {
     steps: () => [
         {
+            content: "Click on unsubscription button to unsubscribe",
+            trigger: "form button#button_confirm_unsubscribe",
+            run: "click",
+            expectUnloadPage: true,
+        },
+        {
             content: "Confirmation unsubscribe is done",
-            trigger:
-                "div#o_mailing_subscription_info span:contains('You are no longer part of the List1, List2 mailing list')",
+            trigger: "div#o_mailing_subscription_info span:contains('You have successfully unsubscribed from List1, List2')",
             run: "click",
         },
         {
@@ -34,8 +39,7 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list", 
         },
         {
             content: "Confirmation feedback is sent",
-            trigger:
-                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
+            trigger: "div#o_mailing_subscription_feedback_info span:contains('Thank you for your feedback!')",
             run: "click",
         },
         {
@@ -60,34 +64,30 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list", 
 registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_with_update", {
     steps: () => [
         {
-            content: "Confirmation unsubscribe is done",
-            trigger:
-                "div#o_mailing_subscription_info span:contains('You are no longer part of the List1, List2 mailing list')",
+            content: "Click on unsubscription button to unsubscribe",
+            trigger: "form button#button_confirm_unsubscribe",
             run: "click",
+            expectUnloadPage: true,
+        },
+        {
+            content: "Confirmation unsubscribe is done",
+            trigger: "div#o_mailing_subscription_info span:contains('You have successfully unsubscribed from List1, List2')",
         },
         {
             content: "List1 is present, just opt-outed",
-            trigger:
-                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') span:contains('Not subscribed')",
-            run: "click",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') input:not(:checked)",
         },
         {
             content: "List3 is present, opt-outed (test starting data)",
-            trigger:
-                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Not subscribed')",
-            run: "click",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') input:not(:checked)",
         },
         {
             content: "List2 is proposed (not member -> proposal to join)",
-            trigger:
-                "ul#o_mailing_subscription_form_lists_additional li.list-group-item:contains('List2')",
-            run: "click",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List2') input:not(:checked)",
         },
         {
-            content: "List4 is not proposed (not member but not private)",
-            trigger:
-                "ul#o_mailing_subscription_form_lists_additional:not(:has(li.list-group-item:contains('List4')))",
-            run: "click",
+            content: "List4 is not proposed (not member but not public)",
+            trigger: "ul#o_mailing_subscription_form_lists:not(:has(li.list-group-item:contains('List4')))",
         },
         {
             content: "Feedback textarea not displayed (see data)",
@@ -111,8 +111,7 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_wi
         },
         {
             content: "Confirmation feedback is sent",
-            trigger:
-                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
+            trigger: "div#o_mailing_subscription_feedback_info span:contains('Thank you for your feedback!')",
             run: "click",
         },
         {
@@ -122,13 +121,22 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_wi
         },
         {
             content: "Confirmation exclusion is done",
-            trigger:
-                "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
+            trigger: "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
             run: "click",
         },
         {
-            content: "This should disable the 'Update my subscriptions' (Apply changes) button",
-            trigger: "div#o_mailing_subscription_blocklist:not(button#button_form_send)",
+            content: "This should hide the subscription management panel",
+            trigger: "body",
+            run: function () {
+                const elements = this.anchor.querySelectorAll('div#o_mailing_subscription_form_manage:has(.d-none)');
+                if (elements.length === 1) {
+                    this.anchor.classList.add('manage_panel_hidden');
+                }
+            },
+        },
+        {
+            content: "Verify previous step",
+            trigger: "body.manage_panel_hidden",
         },
         {
             content: "Revert exclusion list",
@@ -137,13 +145,7 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_wi
         },
         {
             content: "Confirmation exclusion list is removed",
-            trigger:
-                "div#o_mailing_subscription_update_info span:contains('Email removed from our blocklist')",
-            run: "click",
-        },
-        {
-            content: "'Update my subscriptions' button usable again",
-            trigger: "button#button_form_send:not([disabled])",
+            trigger: "div#o_mailing_subscription_update_info span:contains('Email removed from our blocklist')",
         },
         {
             content: "Choose the mailing list 3 to come back",
@@ -151,44 +153,38 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_wi
             run: "click",
         },
         {
-            content: "Add list 2",
-            trigger: "ul#o_mailing_subscription_form_lists_additional input[title='List2']",
-            run: "click",
-        },
-        {
-            content: "Update subscription",
-            trigger: "button#button_form_send",
-            run: "click",
-        },
-        {
-            content: "Confirmation changes are done",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Membership updated')",
+            content: "Update Preferences",
+            trigger: "#button_subscription_update_preferences",
             run: "click",
         },
         {
             content: "List 3 is noted as subscribed again",
-            trigger:
-                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Subscribed')",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') input:checked",
+        },
+        {
+            content: "Add list 2",
+            trigger: "ul#o_mailing_subscription_form_lists input[title='List2']",
             run: "click",
+        },
+        {
+            content: "Update Preferences",
+            trigger: "#button_subscription_update_preferences",
+            run: "click",
+        },
+        {
+            content: "Info message confirms update",
+            trigger: "#o_mailing_subscription_update_info:contains('Your preferences have been updated')",
         },
         {
             content: "List 2 has joined the subscriptions",
-            trigger:
-                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List2') span:contains('Subscribed')",
-            run: "click",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List2') input:checked",
         },
         {
-            content: "No list in proposals",
-            trigger:
-                "div#o_mailing_subscription_form_manage:not(:has(ul#o_mailing_subscription_form_lists_additional))",
-            run: "click",
+            content: "List 3 is still noted as subscribed",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') input:checked",
         },
         {
-            trigger: "div#o_mailing_portal_subscription:not(fieldset)",
-        },
-        {
-            content:
-                "Feedback area is not displayed (nothing opt-out or no blocklist done, no feedback required)",
+            content: "Feedback area is not displayed (nothing opt-out or no blocklist done, no feedback required)",
             trigger: "div#o_mailing_portal_subscription:not(textarea)",
             run: "click",
         },
@@ -199,23 +195,11 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_wi
         },
         {
             content: "Confirmation exclusion is done",
-            trigger:
-                "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
-            run: "click",
+            trigger: "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
         },
         {
-            content: "Should display warning about mailing lists",
-            trigger:
-                "div#o_mailing_subscription_form_blocklisted p:contains('You will not receive any news from those mailing lists you are a member of')",
-            run: "click",
-        },
-        {
-            trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List3')",
-        },
-        {
-            content: "Warning should contain reference to memberships",
-            trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List2')",
-            run: "click",
+            content: "Should display warning about marketing emails",
+            trigger: "div#o_mailing_subscription_form_blocklisted div:contains('You won't receive marketing emails.')",
         },
         {
             content: "Give a reason for blocklist (first one)",
@@ -229,8 +213,7 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_list_wi
         },
         {
             content: "Confirmation feedback is sent",
-            trigger:
-                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
-        },
+            trigger: "div#o_mailing_subscription_feedback_info span:contains('Thank you for your feedback!')",
+        }
     ],
 });

--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
@@ -8,26 +8,20 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_my", {
     steps: () => [
         {
             content: "List1 is present, opt-in member",
-            trigger:
-                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') span:contains('Subscribed')",
-            run: "click",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') input:checked",
         },
         {
             content: "List3 is present, opt-outed (test starting data)",
-            trigger:
-                "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') span:contains('Not subscribed')",
-            run: "click",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') input:not(:checked)",
         },
         {
             content: "List2 is proposed (not member -> proposal to join)",
-            trigger:
-                "ul#o_mailing_subscription_form_lists_additional li.list-group-item:contains('List2')",
-            run: "click",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List2') input:not(:checked)",
         },
         {
             content: "List4 is not proposed (not member but not private)",
             trigger:
-                "ul#o_mailing_subscription_form_lists_additional:not(:has(li.list-group-item:contains('List4')))",
+                "ul#o_mailing_subscription_form_lists:not(:has(li.list-group-item:contains('List4')))",
             run: "click",
         },
         {
@@ -52,9 +46,42 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_my", {
             run: "click",
         },
         {
-            content: "List2: join (opt-in, not already member)",
-            trigger: "ul#o_mailing_subscription_form_lists_additional input[title='List2']",
+            content: "Update Preferences",
+            trigger: "#button_subscription_update_preferences",
             run: "click",
+        },
+        {
+            content: "Check that subscriptions have been updated after the RPC call",
+            trigger: "#o_mailing_subscription_update_info:visible",
+            run: function (args = {}) {
+                this.anchor.classList.add("d-none");
+            }
+        },
+        {
+            content: "List3 is noted as subscribed again",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List3') input:checked",
+        },
+        {
+            content: "List2: join (opt-in, not already member)",
+            trigger: "ul#o_mailing_subscription_form_lists input[title='List2']",
+            run: "click",
+        },
+        {
+            content: "Update Preferences",
+            trigger: "#button_subscription_update_preferences",
+            run: "click",
+        },
+        {
+            content: "Check that subscriptions have been updated after the RPC call",
+            trigger: "#o_mailing_subscription_update_info:visible",
+            run: function () {
+                // Make it invisible again to prevent future race conditions
+                this.anchor.classList.add("d-none");
+            }
+        },
+        {
+            content: "List2 is noted as subscribed ",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List2') input:checked",
         },
         {
             content: "List1: opt-out",
@@ -62,98 +89,55 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_my", {
             run: "click",
         },
         {
-            content: "Update subscription",
-            trigger: "button#button_form_send",
+            content: "Update Preferences",
+            trigger: "#button_subscription_update_preferences",
             run: "click",
         },
         {
-            content: "Confirmation changes are done",
-            trigger: "div#o_mailing_subscription_update_info span:contains('Membership updated')",
-            run: "click",
+            content: "Check that subscriptions have been updated after the RPC call",
+            trigger: "#o_mailing_subscription_update_info:visible",
+            run: function () {
+                // Make it invisible again to prevent future race conditions
+                this.anchor.classList.add("d-none");
+            }
         },
         {
-            trigger: "div#o_mailing_portal_subscription:not(textarea)",
+            content: "List1 is noted as unsubscribed ",
+            trigger: "ul#o_mailing_subscription_form_lists li.list-group-item:contains('List1') input:not(:checked)",
         },
         {
-            content:
-                "Should make feedback reasons choice appear (feedback still not displayed, linked to reasons)",
-            trigger: "div#o_mailing_portal_subscription fieldset",
-            run: "click",
-        },
-        {
-            content: "Choose first reason, which should not display feedback (see data)",
-            trigger: "fieldset input.o_mailing_subscription_opt_out_reason:first",
-            run: "click",
-        },
-        {
-            content: "Feedback textarea not displayed (see data)",
-            trigger: "div#o_mailing_portal_subscription:not(textarea)",
-            run: "click",
-        },
-        {
-            content: "Choose 'Other' reason",
-            trigger: "fieldset label:contains('Other')",
-            run: "click",
-        },
-        {
-            content: "This should display the Feedback area",
-            trigger: "div#o_mailing_portal_subscription textarea",
-        },
-        {
-            content: "Write feedback reason",
-            trigger: "textarea[name='feedback']",
-            run: "edit My feedback",
-        },
-        {
-            content: "Hit Send",
-            trigger: "button#button_feedback",
-            run: "click",
-        },
-        {
-            content: "Confirmation feedback is sent",
-            trigger:
-                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
-            run: "click",
-        },
-        {
-            trigger: "textarea[disabled]",
-        },
-        {
-            content: "Once sent feedback area is readonly",
-            trigger: "fieldset input.o_mailing_subscription_opt_out_reason[disabled]",
+            content: "Should not make feedback reasons choice appear",
+            trigger: "div#o_mailing_subscription_feedback:not(:visible)",
+            run: function () {
+                document.querySelector("body").classList.add("feedback_panel_hidden");
+            },
         },
         {
             content: "Now exclude me",
-            trigger: "div#button_blocklist_add",
+            trigger: "div#button_blocklist_add:not(.d-none)",
             run: "click",
         },
         {
             content: "Confirmation exclusion is done",
-            trigger:
-                "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
-            run: "click",
+            trigger: "div#o_mailing_subscription_update_info span:contains('Email added to our blocklist')",
         },
         {
-            content: "This should disable the 'Update my subscriptions' (Apply changes) button",
-            trigger: "div#o_mailing_subscription_blocklist:not(button#button_form_send)",
+            content: "This should hide the subscription management panel",
+            trigger: "div#o_mailing_subscription_form_manage:not(:visible)",
+            run: function () {
+                document.querySelector("body").classList.add("manage_panel_hidden");
+            },
         },
         {
-            content: "This should enabled Feedback again",
-            trigger: "div#o_mailing_portal_subscription textarea",
+            content: "This should show the feedback form",
+            trigger: "div#o_mailing_portal_subscription textarea:not(:visible)",
+            run: function () {
+                document.querySelector("body").classList.add("feedback_enabled");
+            },
         },
         {
-            content: "Display warning about mailing lists",
-            trigger:
-                "div#o_mailing_subscription_form_blocklisted p:contains('You will not receive any news from those mailing lists you are a member of')",
-            run: "click",
-        },
-        {
-            trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List3')",
-        },
-        {
-            content: "Warning should contain reference to memberships",
-            trigger: "div#o_mailing_subscription_form_blocklisted li strong:contains('List2')",
-            run: "click",
+            content: "Warning you will not receive anything anymore",
+            trigger: "div#o_mailing_subscription_form_blocklisted div:contains('You won't receive marketing emails.')",
         },
         {
             content: "Give a reason for blocklist (first one)",
@@ -167,8 +151,7 @@ registry.category("web_tour.tours").add("mailing_portal_unsubscribe_from_my", {
         },
         {
             content: "Confirmation feedback is sent",
-            trigger:
-                "div#o_mailing_subscription_feedback_info span:contains('Sent. Thanks you for your feedback!')",
+            trigger: "div#o_mailing_subscription_feedback_info span:contains('Thank you for your feedback!')",
         },
     ],
 });

--- a/addons/mass_mailing/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing/tests/test_mailing_controllers.py
@@ -174,9 +174,6 @@ class TestMailingControllers(TestMailingControllersCommon):
         mailing lists or contacts). Primary effect is to automatically exclude
         the email (see tour).
 
-        Two tests are performed (with and without existing list subscriptions)
-        as it triggers the display of the mailing list part of the UI.
-
         Tour effects
           * unsubscribe from mailing based on a document = blocklist;
           * add feedback (block list): Other reason, with 'My feedback' feedback;
@@ -281,29 +278,65 @@ class TestMailingControllers(TestMailingControllersCommon):
             'email': tools.formataddr(("Déboulonneur", "fleurus@example.com")),
             'group_ids': [(3, self.env.ref('mass_mailing.group_mass_mailing_user').id)],
         })
-        test_mailing = self.test_mailing_on_documents.with_env(self.env)
-        self.authenticate('user_marketing', 'user_marketing')
+        self.assertFalse(test_partner.is_blacklisted)
+        previous_messages = test_partner.message_ids
+        test_email_normalized = tools.email_normalize(self.test_email)
+        hash_token = test_mailing._generate_mailing_recipient_token(test_partner.id, test_partner.email_normalized)
 
-        # no group -> no direct access to /unsubscribe
-        res = self.url_open(
-            tools.urls.urljoin(
-                test_mailing.get_base_url(),
-                f'mailing/{test_mailing.id}/unsubscribe',
-            )
+        # launch request on mailing/test_mailing.id/unsubscribe (GET) and check that this doesn't unsubscribe
+        self.url_open(
+            f'/mailing/{test_mailing.id}/unsubscribe?email={test_partner.email_normalized}&document_id={test_partner.id}&hash_token={hash_token}'
         )
-        self.assertEqual(res.status_code, 400)
+        self.assertFalse(test_partner.is_blacklisted)
 
-        # group -> direct access to /unsubscribe should wokr
-        self.user_marketing.write({
-            'group_ids': [(4, self.env.ref('mass_mailing.group_mass_mailing_user').id)],
-        })
         # launch unsubscription tour
         with freeze_time(self._reference_now):
             self.start_tour(
-                f"/mailing/{test_mailing.id}/unsubscribe",
-                "mailing_portal_unsubscribe_from_document_with_lists",
-                login=self.user_marketing.login,
+                f"/mailing/{test_mailing.id}/confirm_unsubscribe?email={test_partner.email_normalized}&document_id={test_partner.id}&hash_token={hash_token}",
+                'mailing_portal_unsubscribe_from_document',
+                login=None,
             )
+
+        # status update check
+        self.assertTrue(test_partner.is_blacklisted)
+
+        # partner (document): new message for blocklist addition with feedback
+        self.assertEqual(len(test_partner.message_ids), len(previous_messages) + 1)
+        msg_fb = test_partner.message_ids[0]
+        self.assertEqual(
+            msg_fb.body,
+            Markup(f'<p>Feedback from {test_email_normalized}<br>{test_feedback}</p>'),
+        )
+
+        # posted messages on exclusion list record: activated, feedback, deactivated, activated again
+        bl_record = self.env['mail.blacklist'].search([('email', '=', test_partner.email_normalized)])
+        self.assertEqual(len(bl_record.message_ids), 5)
+        self.assertEqual(bl_record.opt_out_reason_id, opt_out_reasons[-1])
+        msg_bl2, msg_unbl, msg_fb, msg_bl, msg_create = bl_record.message_ids
+        self.assertEqual(
+            msg_bl2.body,
+            Markup(f'<p>Blocklist request from portal of mailing <a href="#" data-oe-model="{test_mailing._name}" '
+                    f'data-oe-id="{test_mailing.id}">{test_mailing.subject}</a> (document <a href="#" '
+                    f'data-oe-model="{test_partner._name}" data-oe-id="{test_partner.id}">Contact</a>)</p>'),
+        )
+        self.assertEqual(
+            msg_unbl.body,
+            Markup(f'<p>Blocklist removal request from portal of mailing <a href="#" data-oe-model="{test_mailing._name}" '
+                    f'data-oe-id="{test_mailing.id}">{test_mailing.subject}</a> (document <a href="#" '
+                    f'data-oe-model="{test_partner._name}" data-oe-id="{test_partner.id}">Contact</a>)</p>'),
+        )
+        self.assertEqual(
+            msg_fb.body,
+            Markup(f'<p>Feedback from {test_email_normalized}<br>{test_feedback}</p>'),
+        )
+        self.assertTracking(msg_fb, [('opt_out_reason_id', 'many2one', False, opt_out_reasons[-1])])
+        self.assertEqual(
+            msg_bl.body,
+            Markup(f'<p>Blocklist request from unsubscribe link of mailing <a href="#" data-oe-model="{test_mailing._name}" '
+                    f'data-oe-id="{test_mailing.id}">{test_mailing.subject}</a> (document <a href="#" '
+                    f'data-oe-model="{test_partner._name}" data-oe-id="{test_partner.id}">Contact</a>)</p>'),
+        )
+        self.assertEqual(msg_create.body, Markup('<p>Mail Blacklist created</p>'))
 
     def test_mailing_unsubscribe_from_list_tour(self):
         """ Test portal unsubscribe on mailings performed on mailing lists. Their
@@ -330,7 +363,7 @@ class TestMailingControllers(TestMailingControllersCommon):
         hash_token = test_mailing._generate_mailing_recipient_token(contact_l1.id, contact_l1.email)
         with freeze_time(self._reference_now):
             self.start_tour(
-                f"/mailing/{test_mailing.id}/unsubscribe?email={self.test_email_normalized}&document_id={contact_l1.id}&hash_token={hash_token}",
+                f"/mailing/{test_mailing.id}/confirm_unsubscribe?email={self.test_email_normalized}&document_id={contact_l1.id}&hash_token={hash_token}",
                 "mailing_portal_unsubscribe_from_list",
                 login=None,
             )
@@ -406,7 +439,7 @@ class TestMailingControllers(TestMailingControllersCommon):
         hash_token = test_mailing._generate_mailing_recipient_token(contact_l1.id, contact_l1.email)
         with freeze_time(self._reference_now):
             self.start_tour(
-                f"/mailing/{test_mailing.id}/unsubscribe?email={contact_l1.email}&document_id={contact_l1.id}&hash_token={hash_token}",
+                f"/mailing/{test_mailing.id}/confirm_unsubscribe?email={contact_l1.email}&document_id={contact_l1.id}&hash_token={hash_token}",
                 "mailing_portal_unsubscribe_from_list_with_update",
                 login=None,
             )
@@ -508,7 +541,6 @@ class TestMailingControllers(TestMailingControllersCommon):
           * add email in block list;
           * add feedback (as block list addition): First reason (hence no feedback);
         """
-        test_feedback = "My feedback"
         portal_user = mail_new_test_user(
             self.env,
             email=tools.formataddr(("Déboulonneur", "fleurus@example.com")),
@@ -572,7 +604,8 @@ class TestMailingControllers(TestMailingControllersCommon):
         self.assertTrue(subscription_l1.opt_out)
         self.assertEqual(subscription_l1.opt_out_datetime, self._reference_now,
                          'Subscription: opt-outed during test, datetime should have been set')
-        self.assertEqual(subscription_l1.opt_out_reason_id, opt_out_reasons[-1])
+        # No feedback when going to mailing/my to unsubscribe
+        self.assertFalse(subscription_l1.opt_out_reason_id)
         self.assertFalse(subscription_l2.opt_out)
         self.assertFalse(subscription_l2.opt_out_datetime)
         self.assertFalse(subscription_l2.opt_out_reason_id)
@@ -596,12 +629,13 @@ class TestMailingControllers(TestMailingControllersCommon):
             f'<p>{contact_l1.name} unsubscribed from the following mailing list(s)</p>'
             f'<ul><li>{self.mailing_list_1.name}</li></ul>'
         )
-        # message on contact for list 2: opt-in L3 and L2
-        msg_fb, msg_sub = contact_l3.message_ids
+        # messages on contact for list 2: opt-in L3 and L2 - as from toggle button is directly sub/unsub, no common message anymore.
+        msg_sub_l2, msg_sub_l3 = contact_l3.message_ids
         self.assertEqual(
             msg_fb.body,
             f'<p>Feedback from {portal_user.name} ({test_email_normalized})<br>{test_feedback}</p>'
         )
+
         self.assertEqual(
             msg_sub.body,
             f'<p>{contact_l3.name} subscribed to the following mailing list(s)</p>'

--- a/addons/mass_mailing/views/mailing_list_views.xml
+++ b/addons/mass_mailing/views/mailing_list_views.xml
@@ -85,6 +85,12 @@
                             <field name="color" widget="color_picker"/>
                         </group>
                     </group>
+                    <notebook>
+                        <page name="Description">
+                            <field name="description" class="oe-bordered-editor"
+                                placeholder="e.g. &quot;Keep an Eye Out for our latest Deals...&quot;"/>
+                        </page>
+                    </notebook>
                 </sheet>
             </form>
         </field>

--- a/addons/mass_mailing/views/mailing_templates_portal_layouts.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_layouts.xml
@@ -15,7 +15,6 @@
                         <img t-if="not res_company.uses_default_logo" t-attf-src="/web/binary/company_logo?company={{ res_company.id }}"/>
                     </div>
                 </header>
-                <div id="wrap" class="oe_structure oe_empty"/>
                 <main>
                     <t t-out="0"/>
                 </main>

--- a/addons/mass_mailing/views/mailing_templates_portal_layouts.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_layouts.xml
@@ -12,7 +12,7 @@
                 <header>
                     <div><title>Odoo</title></div>
                     <div class="text-center">
-                        <img t-attf-src="/web/binary/company_logo?company={{ res_company.id }}"/>
+                        <img t-if="not res_company.uses_default_logo" t-attf-src="/web/binary/company_logo?company={{ res_company.id }}"/>
                     </div>
                 </header>
                 <div id="wrap" class="oe_structure oe_empty"/>
@@ -20,6 +20,12 @@
                     <t t-out="0"/>
                 </main>
             </body>
+            <xpath expr="//head/t[@t-call-assets][last()]" position="after">
+                <t t-call-assets="mass_mailing.mailing_assets" lazy_load="True"/>
+            </xpath>
+            <xpath expr="//header" position="before">
+                <t t-if="not website" t-set="no_header" t-value="True"/>
+            </xpath>
          </t>
      </template>
 </odoo>

--- a/addons/mass_mailing/views/mailing_templates_portal_management.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_management.xml
@@ -2,6 +2,7 @@
 <odoo>
     <template id="mailing_report_deactivated" name="Report Unsubscribed">
         <t t-call="mass_mailing.layout">
+            <div id="wrap" class="oe_structure oe_empty"/>
             <div class="container mt8">
                 <div class="row">
                     <div class="col-lg-6 offset-lg-3">

--- a/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
@@ -2,6 +2,7 @@
 <odoo>
     <template id="page_mailing_confirm_unsubscribe" name="Confirm Unsubscription">
         <t t-call="mass_mailing.layout">
+            <div id="wrap" class="oe_structure oe_empty"/>
             <div class="container o_unsubscribe_form">
                 <div class="row">
                     <div class="col-lg-6 offset-lg-3 mt-4">
@@ -37,6 +38,7 @@
 
     <template id="page_mailing_unsubscribe" name="Unsubscribe">
         <t t-call="mass_mailing.layout">
+            <div id="wrap" class="oe_structure oe_empty"/>
             <t t-call="mass_mailing.unsubscribe_form"/>
         </t>
     </template>

--- a/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
@@ -1,13 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="page_mailing_confirm_unsubscribe">
+    <template id="page_mailing_confirm_unsubscribe" name="Confirm Unsubscription">
         <t t-call="mass_mailing.layout">
             <div class="container o_unsubscribe_form">
                 <div class="row">
                     <div class="col-lg-6 offset-lg-3 mt-4">
                         <div id="info_state"  class="alert alert-success">
                             <div class="text-center">
-                                <form action="/mailing/confirm_unsubscribe" method="POST">
+                                <form t-att-action="form_target" method="POST">
+                                    <div id="o_mailing_portal_subscription_editor_1" class="oe_structure oe_empty"/>
+                                    <div id="o_mailing_portal_subscription_editor_2" class="oe_structure oe_empty"/>
                                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
                                     <input type="hidden" name="mailing_id" t-att-value="mailing_id"/>
                                     <input type="hidden" name="document_id" t-att-value="document_id"/>
@@ -19,30 +21,17 @@
                                     <p t-else="">
                                         Are you sure you want to unsubscribe from our mailing list?
                                     </p>
-                                    <button type="submit" class="btn btn-primary">Unsubscribe</button>
+                                    <button id="button_confirm_unsubscribe" type="submit" class="btn btn-primary o-paragraph oe_structure oe_empty">
+                                        <div>Unsubscribe</div>
+                                    </button>
                                 </form>
+                                <div id="o_mailing_portal_subscription_editor_3" class="oe_structure oe_empty"/>
                             </div>
                         </div>
                     </div>
                 </div>
             </div>
-        </t>
-    </template>
-
-    <template id="page_mailing_has_unsubscribed">
-        <t t-call="mass_mailing.layout">
-            <div class="container o_unsubscribe_form">
-                <div class="row">
-                    <div class="col-lg-6 offset-lg-3 mt-4">
-                        <div id="info_state"  class="alert alert-success">
-                            <div class="text-center">
-                                <p>Successfully unsubscribed!</p>
-                                <a t-att-href="settings_url" class="btn btn-primary">Manage Subscriptions</a>
-                            </div>
-                        </div>
-                    </div>
-                </div>
-            </div>
+            <div id="o_mailing_portal_subscription_editor_4" class="oe_structure oe_empty"/>
         </t>
     </template>
 
@@ -54,7 +43,7 @@
 
     <template id="unsubscribe_form">
         <div id="o_mailing_portal_subscription"
-             class="container o_mailing_portal_body"
+             class="o_mailing_portal_body"
              t-att-data-blocklist-enabled="blocklist_enabled"
              t-att-data-blocklist-possible="blocklist_possible"
              t-att-data-document-id="document_id"
@@ -66,147 +55,112 @@
              t-att-data-email-valid="email_valid"
              t-att-data-is-blocklisted="is_blocklisted"
              t-att-data-mailing-id="mailing_id">
-            <div class="row">
-                <div class="col-lg-6 offset-lg-3 mt-4">
-                    <div id="o_mailing_subscription_form">
-                        <form action="/mailing/list/update" method="POST">
-                            <h1 class="o_page_header">Mailing Subscriptions</h1>
-
-                            <div id="o_mailing_subscription_form_blocklisted"
-                                 t-att-class="'' if is_blocklisted else 'd-none'">
-                                <p>
-                                    Your email is currently <strong>in our block list</strong>.
-                                    <t t-if="lists_optin">
-                                        You will not receive any news from those mailing lists you are a member of:
-                                    </t>
-                                    <t t-else="">
-                                        You will not hear from us anymore.
-                                    </t>
-                                </p>
-                                <ul class="list-group mb-4"
-                                    t-if="lists_optin">
-                                    <t t-foreach="lists_optin" t-as="mailing_list">
-                                        <li class="list-group-item d-flex align-items-center">
-                                            <strong>
-                                                <t t-if="mailing_list.is_public" t-out="mailing_list.name"/>
-                                                <t t-else="">Mailing List #<t t-out="mailing_list.id"/></t>
-                                            </strong>
-                                        </li>
-                                    </t>
-                                </ul>
-                            </div>
-
-                            <div id="o_mailing_subscription_form_manage"
-                                 t-att-class="'d-none' if is_blocklisted else ''">
-                                <p t-if="lists_optin + lists_optout">
-                                    Choose your mailing subscriptions
-                                </p>
-                                <ul id="o_mailing_subscription_form_lists"
-                                    t-if="lists_optin + lists_optout"
-                                    class="list-group">
-                                    <li t-foreach="(lists_optin + lists_optout)"
-                                        t-as="mailing_list"
-                                        class="list-group-item d-flex align-items-center"
-                                        t-if="mailing_list not in lists_optout or mailing_list.is_public">
-                                        <t t-set="title" t-value="mailing_list.name"/>
-                                        <input type="checkbox"
-                                               name="mailing_list_ids"
-                                               t-att-data-member="1"
-                                               t-att-disabled="'disabled' if is_blocklisted else None"
-                                               t-att-value="mailing_list.id"
-                                               t-att-checked="None if mailing_list in lists_optout else 'checked'"
-                                               t-att-title="title"/>
-                                        <span class="ms-1" t-out="title"/>
-                                        <span class="o_mailing_list_unsubscribed ms-auto">
-                                            <t t-if="mailing_list in lists_optout">
-                                                Not subscribed
-                                            </t>
-                                            <t t-else="">
-                                                Subscribed
-                                            </t>
-                                        </span>
-                                    </li>
-                                </ul>
-                                <p t-if="lists_public">
-                                    You may also be interested in
-                                </p>
-                                <ul id="o_mailing_subscription_form_lists_additional"
-                                    t-if="lists_public"
-                                    class="list-group">
-                                    <li t-foreach="lists_public"
-                                        t-as="mailing_list"
-                                        class="list-group-item">
-                                        <input type="checkbox"
-                                               name="mailing_list_ids"
-                                               t-att-disabled="'disabled' if is_blocklisted else None"
-                                               t-att-value="mailing_list.id"
-                                               t-att-title="mailing_list.name"/>
-                                        <span class="ms-1" t-out="mailing_list.name"/>
-                                    </li>
-                                </ul>
-                                <p t-if="not lists_optin and not lists_optout and not lists_public">
-                                    You are not subscribed to any of our mailing list.
-                                </p>
-                            </div>
-                            <div id="o_mailing_subscription_blocklist"
-                                 class="d-flex align-items-center mb-4 pt-3">
-                                <button type="submit" id="button_form_send"
-                                        t-att-disabled="'disabled' if is_blocklisted else None"
-                                        t-att-class="'btn btn-primary ' + ('' if lists_optin or lists_optout or lists_public else 'd-none')">
-                                    Apply changes
-                                </button>
-                                <div class="btn btn-link me-2 text-uppercase d-none"
-                                     t-if="blocklist_enabled and blocklist_possible"
-                                     id="button_blocklist_add">Exclude Me</div>
-                                <div class="btn btn-link text-uppercase d-none"
-                                     id="button_blocklist_remove">Come Back</div>
-                                <div id="o_mailing_subscription_update_info" class="d-none"/>
-                            </div>
+            <div class="o_container_small">
+                <div id="o_mailing_portal_subscription_editor_1" class="oe_structure oe_empty"/>
+                <div id="o_mailing_subscription_info" class="mt64 mb-5" role="status">
+                    <div id="o_mailing_unsubscribed_alert" role="alert"
+                         t-attf-class="alert alert-success d-flex align-items-center #{'' if unsubscribed or unsubscribed_name or unsubscribed_name else 'd-none'}">
+                        <i class="fa fa-check-circle float-start me-3"/>
+                        <span t-if="unsubscribed_name">You have successfully unsubscribed from <b t-out="unsubscribed_name"/>!</span>
+                        <span t-elif="unsubscribed_name"><b t-out="unsubscribed_name"/></span>
+                        <span t-else="">You have successfully unsubscribed from our mailing list!</span>
+                    </div>
+                    <!-- todo guce: rework to "feedback_request" on route merge? ?-->
+                    <div id="o_mailing_subscription_feedback" t-attf-class="#{'' if last_action in ['subscription_updated', 'blocklist_add'] else 'd-none'}">
+                        <form action="/mail/mailing/feedback" method="POST" class="my-3" autocomplete="off">
+                            <p t-if="last_action == 'blocklist_add'">
+                                Please let us know why you want to be in our block list.
+                            </p>
+                            <p t-else="">
+                                Please let us know why you updated your subscription.
+                            </p>
+                            <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
+                            <fieldset>
+                                <div class="form-check"
+                                     t-foreach="opt_out_reasons"
+                                     t-as="opt_out_reason">
+                                    <input class="form-check-input o_mailing_subscription_opt_out_reason"
+                                           type="radio"
+                                           name="opt_out_reason_id"
+                                           t-att-id="'opt_out_reason_id' + str(opt_out_reason.id)"
+                                           t-att-data-is-feedback="opt_out_reason.is_feedback"
+                                           t-att-value="opt_out_reason.id"/>
+                                    <label class="form-check-label"
+                                           t-att-for="'opt_out_reason_id' + str(opt_out_reason.id)"
+                                           t-out="opt_out_reason.name"/>
+                                </div>
+                            </fieldset>
+                            <textarea id="o_mailing_subscription_feedback_textarea" class="form-control mt-1 d-none" name="feedback" cols="60" rows="3"></textarea>
+                            <button id="button_feedback"
+                                    type="submit"
+                                    class="btn btn-primary text-start mt-3"
+                                    disabled="">Send</button>
                         </form>
                     </div>
-
-                    <div id="o_mailing_subscription_info"
-                         class="mb-4"
-                         role="status">
-                        <t t-if="unsubscribed_name">
-                            <h1 class="o_page_header">Successfully Unsubscribed</h1>
-                            <span t-out="unsubscribed_name"/>
-                        </t>
-                        <div id="o_mailing_subscription_feedback"
-                             t-att-class="'' if feedback_enabled else 'd-none'">
-                            <form action="/mail/mailing/feedback" method="POST"
-                                  class="mt-3">
-                                <p>
-                                    Please let us know why you updated your subscription.
-                                </p>
-                                <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-                                <fieldset>
-                                    <div class="form-check"
-                                         t-foreach="opt_out_reasons"
-                                         t-as="opt_out_reason">
-                                        <input class="form-check-input o_mailing_subscription_opt_out_reason"
-                                               type="radio"
-                                               name="opt_out_reason_id"
-                                               t-att-id="'opt_out_reason_id' + str(opt_out_reason.id)"
-                                               t-att-data-is-feedback="opt_out_reason.is_feedback"
-                                               t-att-value="opt_out_reason.id"/>
-                                        <label class="form-check-label"
-                                               t-att-for="'opt_out_reason_id' + str(opt_out_reason.id)"
-                                               t-out="opt_out_reason.name"/>
-                                    </div>
-                                </fieldset>
-                                <textarea class="form-control d-none" name="feedback" cols="60" rows="3"></textarea>
-                                <div class="d-flex align-items-center mt-2">
-                                    <button type="submit" id="button_feedback"
-                                            class="btn btn-primary text-start me-2">Send</button>
-                                    <div id="o_mailing_subscription_feedback_info" class="d-none"/>
-                                </div>
-                            </form>
-                        </div>
-                    </div>
+                    <div id="o_mailing_subscription_feedback_info" class="pt-2 my-3 d-none"/>
                 </div>
+                <div id="o_mailing_portal_subscription_editor_2" class="oe_structure oe_empty"/>
+                <div id="o_mailing_subscription_form" class="mb-5">
+                    <form action="/mailing/list/update" method="POST" autocomplete="off">
+                        <h5 class="mb-3">
+                            <span>Your subscriptions for</span>
+                            <b t-out="email"/>
+                        </h5>
+                        <div id="o_mailing_subscription_form_blocklisted" t-attf-class="#{'' if is_blocklisted else 'd-none'}">
+                            <div class="alert alert-danger my-2">
+                                Your email address is currently in our <strong>blocklist</strong>.
+                                You will not receive marketing emails. <br/>
+                                However, you will continue to receive updates related to your account.
+                            </div>
+                        </div>
+                        <div id="o_mailing_subscription_form_manage" t-attf-class="#{'d-none' if is_blocklisted else '' }">
+                            <ul id="o_mailing_subscription_form_lists"
+                                t-if="lists_optin_public + lists_optout_public + lists_public"
+                                class="list-group">
+                                <li t-foreach="lists_optin_public + lists_optout_public + lists_public"
+                                    t-as="mailing_list"
+                                    class="list-group-item p-0">
+                                    <label class="o_mailing_subscription_form_list_toggle checkbox-group d-flex align-items-center px-3">
+                                        <input class="check-input mailing_lists_checkboxes mx-2"
+                                               type="checkbox" role="switch"
+                                               name="mailing_list_ids"
+                                               t-att-id="'mailing_list_id' + str(mailing_list.id)"
+                                               t-att-data-member="'1' if mailing_list in (lists_optin_public + lists_optout_public) else None"
+                                               t-att-data-description="mailing_list.description"
+                                               t-att-disabled="'disabled' if is_blocklisted else None"
+                                               t-att-value="mailing_list.id"
+                                               t-att-checked="'checked' if mailing_list in lists_optin_public else None"
+                                               t-att-title="mailing_list.name"/>
+                                        <span class="mx-2 py-3" t-out="mailing_list.name"/><br/>
+                                    </label>
+                                    <div t-attf-class="o_mailing_subscription_form_list_description pe-3 {{'oe-hint' if is_html_empty(mailing_list.description) else 'mb-3'}}"
+                                         t-field="mailing_list.description"
+                                         t-att-data-description="mailing_list.description"
+                                         placeholder="Add a description..."/>
+                                </li>
+                            </ul>
+                            <p t-if="not lists_optin and not lists_optout and not lists_public" class="o_editable">
+                                You are not subscribed to any of our mailing list.
+                            </p>
+                        </div>
+                        <div class="o_mailing_subscription_buttons my-3 d-flex align-items-center">
+                            <div id="button_subscription_update_preferences"
+                                t-attf-class="btn btn-primary me-2 #{'d-none' if is_blocklisted else ''}">
+                                Update Preferences
+                            </div>
+                            <div id="o_mailing_subscription_blocklist" class="d-flex">
+                                <div t-attf-class="btn btn-secondary me-2 #{'d-none' if is_blocklisted else ''}"
+                                     t-if="blocklist_enabled and blocklist_possible"
+                                     id="button_blocklist_add">I don't want emails</div>
+                                <div t-attf-class="btn btn-secondary #{'' if is_blocklisted else 'd-none'}"
+                                     id="button_blocklist_remove">Unblock me</div>
+                            </div>
+                        </div>
+                    </form>
+                    <div id="o_mailing_subscription_update_info" class="my-2"/>
+                </div>
+                <div id="o_mailing_portal_subscription_editor_3" class="oe_structure oe_empty"/>
             </div>
-            <div id="o_mailing_portal_subscription_editor" class="oe_structure oe_empty"/>
         </div>
     </template>
 </odoo>

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -15,7 +15,7 @@
                             <setting name="contact_naming" title="Contact Naming" help="Separate Mailing Contact Names into two fields">
                                 <field name="mass_mailing_split_contact_name"/>
                             </setting>
-                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page. The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to blacklist themselves">
+                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'I don't want emails' button will be present on the unsubscription page. The 'I want emails' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to exclude themselves from future mailings">
                                 <field name="show_blacklist_buttons"/>
                             </setting>
                             <setting name="mass_mailing_reports_setting_container" title="Send a report to the mailing responsible one day after the mailing has been sent." help="Check how well your mailing is doing a day after it has been sent">

--- a/addons/website_mass_mailing/__manifest__.py
+++ b/addons/website_mass_mailing/__manifest__.py
@@ -12,6 +12,7 @@ On a simple click, your visitors can subscribe to mailing lists managed in the E
     'data': [
         'security/ir.model.access.csv',
         'data/ir_model_data.xml',
+        'views/mailing_templates_portal_unsubscribe.xml',
         'views/snippets_templates.xml',
         'views/snippets/s_newsletter_benefits_popup.xml',
     ],

--- a/addons/website_mass_mailing/views/mailing_templates_portal_unsubscribe.xml
+++ b/addons/website_mass_mailing/views/mailing_templates_portal_unsubscribe.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="unsubscribe_form" inherit_id="mass_mailing.unsubscribe_form">
+        <xpath expr="//div[hasclass('o_container_small')]" position="inside">
+            <div class="mb-5 py-4 w-100 text-start oe_structure">
+                <div class="container">
+                    <h5>Not a fan of emails ?</h5>
+                    <p>Follow us on Social Media</p>
+                    <div class="s_social_media o_not_editable text-start" data-snippet="s_social_media" data-name="Social Media">
+                        <h5 class="s_social_media_title d-none o_default_snippet_text">Social Media</h5>
+                        <a href="/website/social/facebook" class="s_social_media_facebook" target="_blank">
+                            <i class="fa fa-facebook rounded shadow-sm o_editable_media"></i>
+                        </a>
+                        <a href="/website/social/twitter" class="s_social_media_twitter" target="_blank">
+                            <i class="fa fa-twitter rounded shadow-sm o_editable_media"></i>
+                        </a>
+                        <a href="/website/social/linkedin" class="s_social_media_linkedin" target="_blank">
+                            <i class="fa fa-linkedin rounded shadow-sm o_editable_media"></i>
+                        </a>
+                        <a href="/website/social/youtube" class="s_social_media_youtube" target="_blank">
+                            <i class="fa fa-youtube rounded shadow-sm o_editable_media"></i>
+                        </a>
+                        <a href="/website/social/instagram" class="s_social_media_instagram" target="_blank">
+                            <i class="fa fa-instagram rounded shadow-sm o_editable_media"></i>
+                        </a>
+                        <a href="/website/social/github" class="s_social_media_github" target="_blank">
+                            <i class="fa fa-github rounded shadow-sm o_editable_media"></i>
+                        </a>
+                        <a href="/website/social/tiktok" class="s_social_media_tiktok" target="_blank">
+                            <i class="fa fa-tiktok rounded shadow-sm o_editable_media"></i>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </xpath>
+    </template>
+</odoo>


### PR DESCRIPTION
Purpose
=======

Make the opt-out page easier to customize as well as easier to use.
Modernize / clean the design of the page as well.

MAIN CHANGES
============

1. Redesign, regroup information into a few blocks:

A clear alert on unsubscribing, displayed when landing on the page

Feedback form (showed when adding the email to blacklist)
- Will appear at the top of the page
- Will disappear on submission, replaced by a confirmation msg
- Only when unsubscribing from document or mailing, not when opting
on or out mailing lists from the list block. Will appear if using
the 'I don't want emails' button though.

A single block displaying all public mailing lists
- Will contain
    -first the lists the mailing contact is opt in
    - Then the ones it is opt out
    - Then the other public ones
- Will now have simple checkbox and large clickable area
- Will now have a description displayed below the list name (*)

A simple message + alert when on blocklist
- Will replace the mailing list form.

Buttons Update Preferences, Unblock me, I don't want emails
- Will dynamically be displayed or hidden
- Always below the displayed block in (list display, blocklist msg)
- Note that the default value for the OPTION displaying
the "I don't want emails" button is now False

Information message
- Updated on action, dispalayed below buttons.

Social media block (with website)
- At the end of the page

A placeholder if no public list exists

2. A new description field on mailing lists (*)

Add a description field on the mailing.list model, that can be used
to hint its content when on the subscription page. It should be
editable from the form view, and from the website editor as well.

3. Make the page editable and customizable

Before, the edition of the page lead to an empty page, very hard to
read and customize.

The page is now easy to customize (a few in-between editable blocks
have been added) and content will be displayed on edition so that
one sees what the page would look like in actual use.

A few things are necessary to make it work:

- SCSS TRICK

Force display of potentially hidden elements when in edition. This is not
perfect but good enough for the edition we want.

4. Updating tours

Side Notes
==========

- Placeholder on t-field seems broken except on html fields (unrelated to this task)
- Using 'I don't want emails' several times while on the same page and
using the textarea in the feedback form several times with different contents
will not generate tracking messages in the backend mailing contact chatter.
This is an acceptable limitation to me, just noticing passing by. Maybe to handle.

Co-authored by Noé Antoine <nan@odoo.com>
Co-authored by guce <guce@odoo.com>

task-3546018