### PR TITLE
[FIX] website_form_project: fixed chatter message irrelevant information

### DIFF
--- a/addons/website_form_project/controllers/main.py
+++ b/addons/website_form_project/controllers/main.py
@@ -17,22 +17,4 @@ class WebsiteForm(form.WebsiteForm):
             # When a task is created from the web editor, if the key 'user_ids' is not present, the user_ids is filled with the odoo bot. We set it to False to ensure it is not.
             values.setdefault('user_ids', False)
 
-        res = super().insert_record(request, model, values, custom, meta=meta)
-        if not (custom or meta) or model.model != 'project.task':
-            return res
-        task = request.env['project.task'].sudo().browse(res)
-        custom = "<b>" + custom.replace('email_from', 'Email').replace(' :', ':</b>').replace('\n', '\n<b>').replace('\r\n<b>', '\r\n')
-        custom_label = "<h4>%s</h4>\n\n" % _("Other Information")  # Title for custom fields
-        default_field = model.website_form_default_field_id
-        default_field_data = values.get(default_field.name, '')
-        default_field_content = "<h4>%s</h4>\n<p>%s</p>" % (default_field.name.capitalize(), html2plaintext(default_field_data))
-        custom_content = (f"{default_field_content} \n\n\n" if default_field_data else '') \
-                        + (f"{custom_label} {custom} \n\n " if custom else '') \
-                        + (self._meta_label + meta if meta else '')
-
-        if default_field.name:
-            task._message_log(
-                body=nl2br_enclose(custom_content, 'p'),
-                message_type='comment',
-            )
-        return res
+        return super().insert_record(request, model, values, custom, meta=meta)


### PR DESCRIPTION
Steps to reproduce:

- Open website and go to contact us
- Using web editor option click on existing form and change its action
- Select create task action and select a existing project
- Fill and submit the form
- Open Project app and go into the project given in create task action
- Open the task created from the website
- Scroll down to the bottom to the chatter

Issue:

- Chatter was showing irrelevant information. (namely html tags)

Cause:

- The message being posted in the project task chatter was not using Markup and tags being directly sent is causing the tags to be printed as it is.

Solution:

- Removal of message log from the chatter as the information is already available in the Description of the respective task.

task-3674768

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
