### PR TITLE
[FIX] web editor: color of whole cell should change

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -543,7 +543,7 @@ export const editorCommands = {
             node => closestElement(node).isContentEditable
         );
         let coloredTds = [];
-        if (selectedTds.length) {
+        if (selectedTds.length && mode === "backgroundColor") {
             for (const td of selectedTds) {
                 colorElement(td, color, mode);
             }
@@ -566,7 +566,9 @@ export const editorCommands = {
         if (isEmptyBlock(range.endContainer)) {
             selectionNodes.push(range.endContainer, ...descendants(range.endContainer));
         }
-        const selectedNodes = selectionNodes.filter(node => !closestElement(node, 'table.o_selected_table'))
+        const selectedNodes = mode === "backgroundColor"
+            ? selectionNodes.filter(node => !closestElement(node, 'table.o_selected_table'))
+            : selectionNodes;
         function getFonts(selectedNodes) {
             return selectedNodes.flatMap(node => {
                 let font = closestElement(node, 'font') || closestElement(node, 'span');

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -583,7 +583,7 @@ export const editorCommands = {
                     }
                 } else if (
                     (node.nodeType === Node.TEXT_NODE && isVisibleStr(node)) ||
-                    (isEmptyBlock(node.parentNode)) ||
+                    (node.nodeName === 'BR' && isEmptyBlock(node.parentNode)) ||
                     (node.nodeType === Node.ELEMENT_NODE &&
                     ['inline', 'inline-block'].includes(getComputedStyle(node).display) &&
                     isVisibleStr(node.textContent) &&

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
@@ -53,7 +53,7 @@ describe('applyColor', () => {
     it('should apply a background color on empty selection', async () => {
         await testEditor(BasicEditor, {
             contentBefore: '<p>[<br></p><p><br></p><p>]<br></p>',
-            stepFunction: setColor('rgb(255, 0, 0)', 'background-color'),
+            stepFunction: setColor('rgb(255, 0, 0)', 'backgroundColor'),
             contentAfterEdit: '<p>[<font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
                               '<p><font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
                               '<p>]<font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>',
@@ -95,7 +95,7 @@ describe('applyColor', () => {
                     <tr><td contenteditable="false">cd]</td></tr>
                 </tbody></table>
             `),
-            stepFunction: setColor('rgb(255, 0, 0)', 'background-color'),
+            stepFunction: setColor('rgb(255, 0, 0)', 'backgroundColor'),
             contentAfter: unformat(`
                 <table><tbody>
                     <tr><td style="background-color: rgb(255, 0, 0);">[]ab</td></tr>

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -5283,18 +5283,37 @@ X[]
                 describe('color', () => {
                     it('should apply a color to some characters and a table', async () => {
                         await testEditor(BasicEditor, {
-                            contentBefore: '<p>a[bc</p><table><tbody><tr>' +
-                                                '<td>a]b</td>' +
-                                                '<td>cd</td>' +
-                                                '<td>ef</td>' +
-                                            '</tr></tbody></table>',
+                            contentBefore: unformat(`
+                                <p>a[bc</p>
+                                <table>
+                                    <tbody>
+                                        <tr>
+                                            <td>a]b</td>
+                                            <td>cd</td>
+                                            <td>ef</td>
+                                        </tr>
+                                    </tbody>
+                                </table>`),
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<p>a<font style="color: aquamarine;">[bc</font></p>' +
-                                            '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">a]b</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ef</td>' +
-                                            '</tr></tbody></table>',
+                            contentAfterEdit: unformat(`
+                                <p>
+                                    a<font style="color: aquamarine;">[bc</font>
+                                </p>
+                                <table class="o_selected_table">
+                                    <tbody>
+                                        <tr>
+                                            <td class="o_selected_td">
+                                                <font style="color: aquamarine;">a]b</font>
+                                            </td>
+                                            <td class="o_selected_td">
+                                                <font style="color: aquamarine;">cd</font>
+                                            </td>
+                                            <td class="o_selected_td">
+                                                <font style="color: aquamarine;">ef</font>
+                                            </td>
+                                        </tr>
+                                    </tbody>
+                                </table>`),
                         });
                     });
                     it('should apply a color to a table and some characters', async () => {
@@ -5305,12 +5324,23 @@ X[]
                                                 '<td>e[f</td>' +
                                             '</tr></tbody></table><p>a]bc</p>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">e[f</td>' +
-                                            '</tr></tbody></table>' +
-                                            '<p><font style="color: aquamarine;">a]</font>bc</p>',
+                            contentAfterEdit: unformat(`
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">e[f</font>
+                                        </td>
+                                    </tr></tbody>
+                                </table>
+                                <p>
+                                    <font style="color: aquamarine;">a]</font>bc
+                                </p>`),
                         });
                     });
                     it('should apply a color to some characters, a table and some more characters', async () => {
@@ -5323,13 +5353,26 @@ X[]
                                         '</tr></tbody></table>' +
                                         '<p>a]bc</p>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<p>a<font style="color: aquamarine;">[bc</font></p>' +
-                                            '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ef</td>' +
-                                            '</tr></tbody></table>' +
-                                            '<p><font style="color: aquamarine;">a]</font>bc</p>',
+                            contentAfterEdit: unformat(`
+                                <p>
+                                    a<font style="color: aquamarine;">[bc</font>
+                                </p>
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ef</font>
+                                        </td>
+                                    </tr></tbody>
+                                </table>
+                                <p>
+                                    <font style="color: aquamarine;">a]</font>bc
+                                </p>`),
                         });
                     });
                     it('should apply a color to some characters, a table, some more characters and another table', async () => {
@@ -5347,18 +5390,39 @@ X[]
                                             '<td>ef</td>' +
                                         '</tr></tbody></table>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<p>a<font style="color: aquamarine;">[bc</font></p>' +
-                                            '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ef</td>' +
-                                            '</tr></tbody></table>' +
-                                            '<p><font style="color: aquamarine;">abc</font></p>' +
-                                            '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">a]b</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ef</td>' +
-                                            '</tr></tbody></table>',
+                            contentAfterEdit: unformat(`
+                                <p>
+                                    a<font style="color: aquamarine;">[bc</font>
+                                </p>
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ef</font>
+                                        </td>
+                                    </tr></tbody>
+                                </table>
+                                <p>
+                                    <font style="color: aquamarine;">abc</font>
+                                </p>
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">a]b</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ef</font>
+                                        </td>
+                                    </tr></tbody>
+                                </table>`),
                         });
                     });
                     it('should apply a color to some characters, a table, some more characters, another table and some more characters', async () => {
@@ -5377,19 +5441,38 @@ X[]
                                         '</tr></tbody></table>' +
                                         '<p>a]bc</p>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<p>a<font style="color: aquamarine;">[bc</font></p>' +
-                                            '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ef</td>' +
-                                            '</tr></tbody></table>' +
-                                            '<p><font style="color: aquamarine;">abc</font></p>' +
-                                            '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">ef</td>' +
-                                            '</tr></tbody></table>' +
-                                            '<p><font style="color: aquamarine;">a]</font>bc</p>',
+                            contentAfterEdit: unformat(`
+                                <p>
+                                    a<font style="color: aquamarine;">[bc</font>
+                                </p>
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ef</font>
+                                        </td>
+                                    </tr></tbody>
+                                </table>
+                                <p><font style="color: aquamarine;">abc</font></p>
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ef</font>
+                                        </td>
+                                    </tr></tbody>
+                                </table>
+                                <p><font style="color: aquamarine;">a]</font>bc</p>`),
                         });
                     });
                 });
@@ -5804,11 +5887,18 @@ X[]
                                             '<td>ef</td>' +
                                         '</tr></tbody></table>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">a[b</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">c]d</td>' +
-                                                '<td>ef</td>' +
-                                            '</tr></tbody></table>',
+                            contentAfterEdit: unformat(`
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">a[b</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">c]d</font>
+                                        </td>
+                                        <td>ef</td>
+                                    </tr></tbody>
+                                </table>`),
                         });
                     });
                     it('should apply a color to a whole row', async () => {
@@ -5819,11 +5909,25 @@ X[]
                                             '<td>e]f</td>' +
                                         '</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<table class="o_selected_table"><tbody><tr>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">a[b</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                '<td class="o_selected_td" style="color: aquamarine;">e]f</td>' +
-                                            '</tr><tr><td>ab</td><td>cd</td><td>ef</td></tr></tbody></table>',
+                            contentAfterEdit: unformat(`
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">a[b</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">e]f</font>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                    </tr></tbody>
+                                </table>`),
                         });
                     });
                     it('should apply a color to a whole column', async () => {
@@ -5846,23 +5950,30 @@ X[]
                                             '</tr>' +
                                         '</tbody></table>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<table class="o_selected_table"><tbody>' +
-                                                '<tr>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">a[b</td>' +
-                                                    '<td>cd</td>' +
-                                                    '<td>ef</td>' +
-                                                '</tr>' +
-                                                '<tr>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                    '<td>cd</td>' +
-                                                    '<td>ef</td>' +
-                                                '</tr>' +
-                                                '<tr>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">a]b</td>' +
-                                                    '<td>cd</td>' +
-                                                    '<td>ef</td>' +
-                                                '</tr>' +
-                                            '</tbody></table>',
+                            contentAfterEdit: unformat(`
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">a[b</font>
+                                        </td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">a]b</font>
+                                        </td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                    </tr></tbody>
+                                </table>`),
                         });
                     });
                     it('should apply a color from (0,0) to (1,1) in a 3x3 table', async () => {
@@ -5885,23 +5996,32 @@ X[]
                                             '</tr>' +
                                         '</tbody></table>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<table class="o_selected_table"><tbody>' +
-                                                '<tr>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">a[b</td>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                    '<td>ef</td>' +
-                                                '</tr>' +
-                                                '<tr>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">c]d</td>' +
-                                                    '<td>ef</td>' +
-                                                '</tr>' +
-                                                '<tr>' +
-                                                    '<td>ab</td>' +
-                                                    '<td>cd</td>' +
-                                                    '<td>ef</td>' +
-                                                '</tr>' +
-                                            '</tbody></table>',
+                            contentAfterEdit: unformat(`
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">a[b</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td>ef</td>
+                                    </tr>
+                                    <tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">c]d</font>
+                                        </td>
+                                        <td>ef</td>
+                                    </tr>
+                                    <tr>
+                                        <td>ab</td>
+                                        <td>cd</td>
+                                        <td>ef</td>
+                                    </tr></tbody>
+                                </table>`),
                         });
                     });
                     it('should apply a color to a whole table', async () => {
@@ -5924,23 +6044,42 @@ X[]
                                             '</tr>' +
                                         '</tbody></table>',
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
-                            contentAfterEdit: '<table class="o_selected_table"><tbody>' +
-                                                '<tr>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">a[b</td>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">ef</td>' +
-                                                '</tr>' +
-                                                '<tr>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">ef</td>' +
-                                                '</tr>' +
-                                                '<tr>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">ab</td>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">cd</td>' +
-                                                    '<td class="o_selected_td" style="color: aquamarine;">e]f</td>' +
-                                                '</tr>' +
-                                            '</tbody></table>',
+                            contentAfterEdit: unformat(`
+                                <table class="o_selected_table">
+                                    <tbody><tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">a[b</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ef</font>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ef</font>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">ab</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">cd</font>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <font style="color: aquamarine;">e]f</font>
+                                        </td>
+                                    </tr></tbody>
+                                </table>`),
                         });
                     });
                 });


### PR DESCRIPTION
This commit fixes the issue of partial coloring of table cells.

Before this commit, if one colors part of the text in the cell
and then seeks to color the whole cell, the last coloring
would not apply on the previously colored text.

We do that by preventing the cell coloring to be done differently
than other elements except if we want to change the
background color.

task-3454903

BackPort-Of: #130646