### PR TITLE
[FIX] hr_holidays : wrong specials days displayed on dashboard

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -505,10 +505,14 @@ class HrEmployeePrivate(models.Model):
     def _get_unusual_days(self, date_from, date_to=None):
         # Checking the calendar directly allows to not grey out the leaves taken
         # by the employee or fallback to the company calendar
-        return (self.resource_calendar_id or self.env.company.resource_calendar_id)._get_unusual_days(
-            datetime.combine(fields.Date.from_string(date_from), time.min).replace(tzinfo=UTC),
-            datetime.combine(fields.Date.from_string(date_to), time.max).replace(tzinfo=UTC)
-        )
+        domain_company = self.company_id or self.env.company
+        domain = ['|', ('company_id', '=', False), ('company_id', '=', domain_company.id)]
+        return (self.resource_calendar_id or self.env.company.resource_calendar_id)\
+                .with_context({'domain': domain})\
+                ._get_unusual_days(
+                    datetime.combine(fields.Date.from_string(date_from), time.min).replace(tzinfo=UTC),
+                    datetime.combine(fields.Date.from_string(date_to), time.max).replace(tzinfo=UTC)
+            )
 
     # ---------------------------------------------------------
     # Messaging

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -318,11 +318,11 @@ class HrEmployee(models.Model):
     def _get_public_holidays(self, date_start, date_end):
         domain = [
             ('resource_id', '=', False),
-            ('company_id', 'in', self.env.companies.ids),
             ('date_from', '<=', date_end),
             ('date_to', '>=', date_start),
         ]
-
+        domain_company = self.company_id or self.env.company
+        domain += ['|', ('company_id', '=', False), ('company_id', '=', domain_company.id)]
         # a user with hr_holidays permissions will be able to see all public holidays from his calendar
         if not self._is_leave_user():
             domain += [
@@ -352,9 +352,9 @@ class HrEmployee(models.Model):
         domain = [
             ('start_date', '<=', end_date),
             ('end_date', '>=', start_date),
-            ('company_id', 'in', self.env.companies.ids),
         ]
-
+        domain_company = self.company_id or self.env.company
+        domain += [('company_id', '=', domain_company.id)]
         # a user with hr_holidays permissions will be able to see all stress days from his calendar
         if not self._is_leave_user():
             domain += [

--- a/addons/hr_holidays/tests/test_global_leaves.py
+++ b/addons/hr_holidays/tests/test_global_leaves.py
@@ -48,14 +48,14 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
 
         cls.global_leave = cls.env['resource.calendar.leaves'].create({
             'name': 'Global Leave',
-            'date_from': date(2022, 3, 7),
-            'date_to': date(2022, 3, 7),
+            'date_from': "2022-03-07 00:00:00",
+            'date_to': "2022-03-07 23:59:59",
         })
 
         cls.calendar_leave = cls.env['resource.calendar.leaves'].create({
             'name': 'Global Leave',
-            'date_from': date(2022, 3, 8),
-            'date_to': date(2022, 3, 8),
+            'date_from': "2022-03-08 00:00:00",
+            'date_to': "2022-03-08 23:59:59",
             'calendar_id': cls.calendar_1.id,
         })
 
@@ -63,38 +63,38 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
         with self.assertRaises(ValidationError):
             self.env['resource.calendar.leaves'].create({
                 'name': 'Wrong Leave',
-                'date_from': date(2022, 3, 7),
-                'date_to': date(2022, 3, 7),
+                'date_from': "2022-03-07 00:00:00",
+                'date_to': "2022-03-07 23:59:59",
                 'calendar_id': self.calendar_1.id,
             })
 
         with self.assertRaises(ValidationError):
             self.env['resource.calendar.leaves'].create({
                 'name': 'Wrong Leave',
-                'date_from': date(2022, 3, 7),
-                'date_to': date(2022, 3, 7),
+                'date_from': "2022-03-07 00:00:00",
+                'date_to': "2022-03-07 23:59:59",
             })
 
     def test_leave_on_calendar_leave(self):
         self.env['resource.calendar.leaves'].create({
                 'name': 'Correct Leave',
-                'date_from': date(2022, 3, 8),
-                'date_to': date(2022, 3, 8),
+                'date_from': "2022-03-08 00:00:00",
+                'date_to': "2022-03-08 23:59:59",
                 'calendar_id': self.calendar_2.id,
             })
 
         with self.assertRaises(ValidationError):
             self.env['resource.calendar.leaves'].create({
                 'name': 'Wrong Leave',
-                'date_from': date(2022, 3, 8),
-                'date_to': date(2022, 3, 8),
+                'date_from': "2022-03-08 00:00:00",
+                'date_to': "2022-03-08 23:59:59",
             })
 
         with self.assertRaises(ValidationError):
             self.env['resource.calendar.leaves'].create({
                 'name': 'Wrong Leave',
-                'date_from': date(2022, 3, 8),
-                'date_to': date(2022, 3, 8),
+                'date_from': "2022-03-08 00:00:00",
+                'date_to': "2022-03-08 23:59:59",
                 'calendar_id': self.calendar_1.id,
             })
 
@@ -125,3 +125,45 @@ class TestGlobalLeaves(TestHrHolidaysCommon):
         # Note:
         # The user in Europe/Brussels timezone see 4:30 and not 2:30 because he is in UTC +02:00.
         # The user in Asia/Calcutta timezone (determined via the browser) see 8:00 because he is in UTC +05:30
+
+    def test_global_leave_multi_companies(self):
+        other_company = self.env['res.company'].create({'name': 'Other company'})
+        calendar_other_company = self.env['resource.calendar'].create({
+            'name': 'Classic 40h/week Other company',
+            'tz': 'UTC',
+            'company_id': other_company.id,
+            'hours_per_day': 8.0,
+            'attendance_ids': [
+                (0, 0, {'name': 'Monday Morning', 'dayofweek': '0', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Monday Afternoon', 'dayofweek': '0', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Tuesday Morning', 'dayofweek': '1', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Tuesday Afternoon', 'dayofweek': '1', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Wednesday Morning', 'dayofweek': '2', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Wednesday Afternoon', 'dayofweek': '2', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Thursday Morning', 'dayofweek': '3', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Thursday Afternoon', 'dayofweek': '3', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'}),
+                (0, 0, {'name': 'Friday Morning', 'dayofweek': '4', 'hour_from': 8, 'hour_to': 12, 'day_period': 'morning'}),
+                (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 17, 'day_period': 'afternoon'})
+            ]
+        })
+        other_company.resource_calendar_id = calendar_other_company
+        self.env['resource.calendar.leaves'].with_company(other_company).create({
+            'name': 'Global Leave Other company',
+            'date_from': "2022-03-15 00:00:00",
+            'date_to': "2022-03-15 23:59:59",
+        })
+        list_days = self.employee_emp.with_context(allowed_company_ids=[self.env.company.id, other_company.id], company_id=self.env.company.id)._get_unusual_days(date(2022, 3, 1), date(2022, 3, 30))
+        self.assertTrue(list_days['2022-03-07']) #global leave from Yourcompany
+        self.assertFalse(list_days['2022-03-15']) #global leave from Other company
+
+        holidays = self.employee_emp.with_context(allowed_company_ids=[self.env.company.id, other_company.id], company_id=self.env.company.id)._get_public_holidays(date(2022, 3, 1), date(2022, 3, 30))
+        self.assertEqual(len(holidays), 1)
+        self.assertEqual(holidays.name, 'Global Leave')
+
+        list_days = self.env['hr.employee'].with_context(allowed_company_ids=[self.env.company.id, other_company.id]).with_company(other_company)._get_unusual_days(date(2022, 3, 1), date(2022, 3, 30))
+        self.assertFalse(list_days['2022-03-07']) #global leave from Yourcompany
+        self.assertTrue(list_days['2022-03-15']) #global leave from Other company
+
+        holidays = self.env['hr.employee'].with_context(allowed_company_ids=[self.env.company.id, other_company.id]).with_company(other_company)._get_public_holidays(date(2022, 3, 1), date(2022, 3, 30))
+        self.assertEqual(len(holidays), 1)
+        self.assertEqual(holidays.name, 'Global Leave Other company')

--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -672,8 +672,12 @@ class ResourceCalendar(models.Model):
             start_dt = start_dt.replace(tzinfo=utc)
         if not end_dt.tzinfo:
             end_dt = end_dt.replace(tzinfo=utc)
-
-        works = {d[0].date() for d in self._work_intervals_batch(start_dt, end_dt)[False]}
+        if 'domain' in self.env.context:
+            ctx_domain = self.env.context.get('domain')
+            works_intervals = self._work_intervals_batch(start_dt, end_dt, domain=ctx_domain)[False]
+        else:
+            works_intervals = self._work_intervals_batch(start_dt, end_dt)[False]
+        works = {d[0].date() for d in works_intervals}
         return {fields.Date.to_string(day.date()): (day.date() not in works) for day in rrule(DAILY, start_dt, until=end_dt)}
 
     # --------------------------------------------------


### PR DESCRIPTION
STEP TO REPRODUCE:
	1- You need to have 2 companies and select multi-companies
	2- Create different public holiday/ mandatory day for each company
	3- go on mitchell admin dashboard
	4- you will see all ph/md
Expected behaviour = you want to see only ph/md related to main company.

task : 3677469

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
