### PR TITLE
[FIX] test_mass_mailing: update replied test

### DIFF
--- a/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
+++ b/addons/test_mass_mailing/tests/test_mailing_statistics_sms.py
@@ -61,9 +61,10 @@ class TestMailingStatistics(TestMassSMSCommon):
         # test body content: KPIs
         body_html = html.fromstring(mail.body_html)
         kpi_values = body_html.xpath('//div[@data-field="sms"]//*[hasclass("kpi_value")]/text()')
+
         self.assertEqual(
             [t.strip().strip('%') for t in kpi_values],
-            ['100', str(mailing.opened_ratio), str(mailing.replied_ratio)]
+            ['100', str(mailing.opened_ratio), str(mailing.bounced_ratio)]
         )
         # test body content: clicks (a bit hackish but hey we are in stable)
         kpi_click_values = body_html.xpath('//div[hasclass("global_layout")]/table//tr[contains(@style,"color: #888888")]/td[contains(@style,"width: 30%")]/text()')


### PR DESCRIPTION
`replied_ratio` shouldn't be tested against `bounced_ratio`. `_prepare_statistics_email_values` function returns list, whose last value is `bounced_ratio` instead of `replied_ratio`. Also `replied_ratio` doesn't make sense when testing sms.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
