### PR TITLE
[IMP] l10n_in: add the hsn autocomplete widget

### DIFF
--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -55,4 +55,10 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
     ],
     'post_init_hook': 'post_init',
     'license': 'LGPL-3',
+    'assets': {
+        'web.assets_backend': [
+            'l10n_in/static/src/js/*',
+            'l10n_in/static/src/xml/*',
+        ],
+    },
 }

--- a/addons/l10n_in/demo/product_demo.xml
+++ b/addons/l10n_in/demo/product_demo.xml
@@ -2,127 +2,96 @@
 <odoo noupdate="1">
     <record id="product.product_product_1" model="product.product">
         <field name="l10n_in_hsn_code">998391</field>
-        <field name="l10n_in_hsn_description">Specialty Design Services Including Interior Design, Fashion Design, Industrial Design And Other Specialty Design Services</field>
     </record>
     <record id="product.product_product_2" model="product.product">
         <field name="l10n_in_hsn_code">998391</field>
-        <field name="l10n_in_hsn_description">Specialty Design Services Including Interior Design, Fashion Design, Industrial Design And Other Specialty Design Services</field>
     </record>
     <record id="product.product_product_3" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_4" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_4b" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_4c" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_5" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_6" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_7" model="product.product">
         <field name="l10n_in_hsn_code">48196000</field>
-        <field name="l10n_in_hsn_description">Box files, letter trays, storage boxes and similar articles, of a kind used in offices, shops or the like</field>
     </record>
     <record id="product.product_product_8" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_9" model="product.product">
         <field name="l10n_in_hsn_code">7323</field>
-        <field name="l10n_in_hsn_description">Table, kitchen or other household articles and parts thereof, of iron or steel; iron or steel wool; pot scourers and scouring or polishing pads, gloves and the like, of iron or steel.</field>
     </record>
     <record id="product.product_product_10" model="product.product">
         <field name="l10n_in_hsn_code">84185000</field>
-        <field name="l10n_in_hsn_description">Other furniture (chests, cabinets, display counters, show-cases and the like) for storage and display, incorporating refrigerating or freezing equipment</field>
     </record>
     <record id="product.product_product_11" model="product.product">
         <field name="l10n_in_hsn_code">94018000</field>
-        <field name="l10n_in_hsn_description">Seats (other than those of heading 9402), whether or not convertible into beds, and parts thereof</field>
     </record>
     <record id="product.product_product_11b" model="product.product">
         <field name="l10n_in_hsn_code">94018000</field>
-        <field name="l10n_in_hsn_description">Seats (other than those of heading 9402), whether or not convertible into beds, and parts thereof</field>
     </record>
     <record id="product.product_product_12" model="product.product">
         <field name="l10n_in_hsn_code">94018000</field>
-        <field name="l10n_in_hsn_description">Seats (other than those of heading 9402), whether or not convertible into beds, and parts thereof</field>
     </record>
     <record id="product.product_product_13" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_16" model="product.product">
         <field name="l10n_in_hsn_code">94031090</field>
-        <field name="l10n_in_hsn_description">Metal furniture of a kind used in offices</field>
     </record>
     <record id="product.product_product_20" model="product.product">
         <field name="l10n_in_hsn_code">37011090</field>
-        <field name="l10n_in_hsn_description">Photographic plates and film in the flat, sensitised, unexposed, of any material other than paper, paperboard or textiles; instant print film in the flat, sensitised, unexposed, whether or not in packs.</field>
     </record>
     <record id="product.product_product_22" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
     <record id="product.product_product_24" model="product.product">
         <field name="l10n_in_hsn_code">94031090</field>
-        <field name="l10n_in_hsn_description">Metal furniture of a kind used in offices</field>
     </record>
     <record id="product.product_product_25" model="product.product">
         <field name="l10n_in_hsn_code">94031090</field>
-        <field name="l10n_in_hsn_description">Metal furniture of a kind used in offices</field>
     </record>
     <record id="product.product_product_27" model="product.product">
         <field name="l10n_in_hsn_code">94031090</field>
-        <field name="l10n_in_hsn_description">Metal furniture of a kind used in offices</field>
     </record>
 
     <!-- Expensable products -->
     <record id="product.expense_product" model="product.product">
         <field name="l10n_in_hsn_code">9963.31</field>
-        <field name="l10n_in_hsn_description">Services provided by Restaurants, Cafes and similar eating facilities including takeaway services, Room services and door delivery of food.
-        </field>
     </record>
     <record id="product.expense_hotel" model="product.product">
         <field name="l10n_in_hsn_code">9963.32</field>
-        <field name="l10n_in_hsn_description">Services provided by Hotels, INN, Guest House, Club etc including Room services, takeaway services and door delivery of food.</field>
     </record>
 
     <!-- Physical Products -->
     <record id="product.product_delivery_01" model="product.product">
         <field name="l10n_in_hsn_code">94018000</field>
-        <field name="l10n_in_hsn_description">Seats (other than those of heading 9402), whether or not convertible into beds, and parts thereof</field>
     </record>
     <record id="product.product_delivery_02" model="product.product">
         <field name="l10n_in_hsn_code">94051090</field>
-        <field name="l10n_in_hsn_description">Lamps and lighting fittings including searchlights and spotlights and parts thereof, not elsewhere specified or included; illuminated signs, illuminated name-plates and the like, having a permanently fixed light source, and parts thereof not elsewhere specified or included</field>
     </record>
     <record id="product.product_order_01" model="product.product">
         <field name="l10n_in_hsn_code">4911.99.10</field>
-        <field name="l10n_in_hsn_description">Hard copy (printed) of computer software</field>
     </record>
     <record id="product.consu_delivery_01" model="product.product">
         <field name="l10n_in_hsn_code">9401.61.00</field>
-        <field name="l10n_in_hsn_description">Seats (other than those of heading 9402), whether or not convertible into beds, and parts thereof</field>
     </record>
     <record id="product.consu_delivery_02" model="product.product">
         <field name="l10n_in_hsn_code">9403.89.00</field>
-        <field name="l10n_in_hsn_description">Other Furniture</field>
     </record>
     <record id="product.consu_delivery_03" model="product.product">
         <field name="l10n_in_hsn_code">9403</field>
-        <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
     </record>
 </odoo>

--- a/addons/l10n_in/models/account.py
+++ b/addons/l10n_in/models/account.py
@@ -9,15 +9,7 @@ from odoo import tools
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    l10n_in_hsn_code = fields.Char(string="HSN/SAC Code", compute="_compute_l10n_in_hsn_code", store=True, readonly=False, copy=False)
-
-    @api.depends('product_id')
-    def _compute_l10n_in_hsn_code(self):
-        indian_lines = self.filtered(lambda line: line.company_id.account_fiscal_country_id.code == 'IN')
-        (self - indian_lines).l10n_in_hsn_code = False
-        for line in indian_lines:
-            if line.product_id:
-                line.l10n_in_hsn_code = line.product_id.l10n_in_hsn_code
+    l10n_in_hsn_code = fields.Char("HSN")
 
     def init(self):
         tools.create_index(self._cr, 'account_move_line_move_product_index', self._table, ['move_id', 'product_id'])
@@ -31,6 +23,7 @@ class AccountMoveLine(models.Model):
         remaining_aml = self - aml
         if remaining_aml:
             return super(AccountMoveLine, remaining_aml)._compute_tax_base_amount()
+
 
 
 class AccountTax(models.Model):

--- a/addons/l10n_in/models/account.py
+++ b/addons/l10n_in/models/account.py
@@ -9,7 +9,15 @@ from odoo import tools
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    l10n_in_hsn_code = fields.Char("HSN")
+    l10n_in_hsn_code = fields.Char(string="HSN/SAC Code", compute="_compute_l10n_in_hsn_code", store=True, readonly=False, copy=False)
+
+    @api.depends('product_id')
+    def _compute_l10n_in_hsn_code(self):
+        indian_lines = self.filtered(lambda line: line.company_id.account_fiscal_country_id.code == 'IN')
+        (self - indian_lines).l10n_in_hsn_code = False
+        for line in indian_lines:
+            if line.product_id:
+                line.l10n_in_hsn_code = line.product_id.l10n_in_hsn_code
 
     def init(self):
         tools.create_index(self._cr, 'account_move_line_move_product_index', self._table, ['move_id', 'product_id'])
@@ -23,7 +31,6 @@ class AccountMoveLine(models.Model):
         remaining_aml = self - aml
         if remaining_aml:
             return super(AccountMoveLine, remaining_aml)._compute_tax_base_amount()
-
 
 
 class AccountTax(models.Model):

--- a/addons/l10n_in/models/product_template.py
+++ b/addons/l10n_in/models/product_template.py
@@ -1,15 +1,19 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models, fields, _
 from odoo.exceptions import ValidationError
+import logging
+import requests
+from werkzeug.urls import url_encode
+from requests.exceptions import HTTPError, ConnectionError
+from odoo import api, models, fields, _
 
+_logger = logging.getLogger(__name__)
 
 class ProductTemplate(models.Model):
     _inherit = 'product.template'
 
     l10n_in_hsn_code = fields.Char(string="HSN/SAC Code", help="Harmonized System Nomenclature/Services Accounting Code")
-    l10n_in_hsn_description = fields.Char(string="HSN/SAC Description", help="HSN/SAC description is required if HSN/SAC code is not provided.")
 
     @api.constrains('l10n_in_hsn_code')
     def _check_hsn_code_validation(self):
@@ -20,3 +24,21 @@ class ProductTemplate(models.Model):
             if check_hsn and len(record.l10n_in_hsn_code) < int(minimum_hsn_len):
                 error_message = _("As per your HSN/SAC code validation, minimum %s digits HSN/SAC code is required.", minimum_hsn_len)
                 raise ValidationError(error_message)
+    @api.model
+    def get_hsn_suggestions(self, value):
+        response_json = {}
+        all_url_and_params = [
+            ('https://services.gst.gov.in/commonservices/hsn/search/qsearch', {'inputText': value, 'selectedType': 'byCode', 'category': 'null'}),
+            ('https://services.gst.gov.in/commonservices/hsn/search/qsearch', {'inputText': value, 'selectedType': 'byDesc', 'category': 'P'}),
+            ('https://services.gst.gov.in/commonservices/hsn/search/qsearch', {'inputText': value, 'selectedType': 'byDesc', 'category': 'S'}),
+        ]
+        for url, params in all_url_and_params:
+            try:
+                response = requests.get(url, params=url_encode(params))
+                response.raise_for_status()
+                response_json = response.json()
+                if response_json.get('data'):
+                    break
+            except (ConnectionError, HTTPError, ValueError) as e:
+                _logger.warning('HSN Autocomplete API error: %s', str(e))
+        return response_json.get('data', [])

--- a/addons/l10n_in/static/src/js/hsn_autocomplete.js
+++ b/addons/l10n_in/static/src/js/hsn_autocomplete.js
@@ -1,0 +1,65 @@
+/** @odoo-module **/
+
+import { AutoComplete } from "@web/core/autocomplete/autocomplete";
+import { registry } from "@web/core/registry";
+import { _t } from "@web/core/l10n/translation";
+import { useService } from "@web/core/utils/hooks";
+import { Component } from "@odoo/owl";
+
+export class HsnAutoComplete extends Component {
+    static template = "hsn_autocomplete.HsnAutoComplete";
+    static components = { AutoComplete };
+    setup() {
+        this.orm = useService("orm");
+    }
+
+    async validateSearchTerm(request) {
+        return request && request.length > 2;
+    }
+
+    get sources() {
+        return [
+            {
+                options: async (request) => {
+                    if (await this.validateSearchTerm(request)) {
+                        return await this.orm.call("product.template", "get_hsn_suggestions", [
+                            request,
+                        ]);
+                    } else {
+                        return [];
+                    }
+                },
+                optionTemplate: "hsn_autocomplete.DropdownOption",
+                placeholder: _t("Searching..."),
+            },
+        ];
+    }
+
+    onSelect(option) {
+        if (this.props.hsn_description_field) {
+            this.props.record.update({
+                [this.props.name]: option.c,
+                [this.props.hsn_description_field]: option.n,
+            });
+        } else {
+            this.props.record.update({ [this.props.name]: option.c });
+        }
+    }
+}
+
+export const hsnAutoComplete = {
+    component: HsnAutoComplete,
+    supportedOptions: [
+        {
+            label: _t("Hsn description field"),
+            name: "hsn_description_field",
+            type: "string",
+        },
+    ],
+    supportedTypes: ["char"],
+    extractProps: ({ options }) => ({
+        hsn_description_field: options.hsn_description_field,
+    }),
+};
+
+registry.category("fields").add("hsn_autocomplete", hsnAutoComplete);

--- a/addons/l10n_in/static/src/xml/hsn_autocomplete.xml
+++ b/addons/l10n_in/static/src/xml/hsn_autocomplete.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates>
+    <t t-name="hsn_autocomplete.HsnAutoComplete">
+        <AutoComplete
+            value="props.record.data[props.name] || ''"
+            sources="sources"
+            onSelect.bind="onSelect"
+            placeholder="props.placeholder || ''"
+        />
+    </t>
+
+    <t t-name="hsn_autocomplete.DropdownOption">
+        <div class="text-wrap">
+            <strong t-out="option.c"/>
+            <div t-out="option.n"/>
+        </div>
+    </t>
+</templates>

--- a/addons/l10n_in/static/src/xml/hsn_autocomplete.xml
+++ b/addons/l10n_in/static/src/xml/hsn_autocomplete.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
-    <t t-name="hsn_autocomplete.HsnAutoComplete">
+    <t t-name="hsn_autocomplete.L10nInHsnAutoComplete">
         <AutoComplete
             value="props.record.data[props.name] || ''"
             sources="sources"
             onSelect.bind="onSelect"
-            placeholder="props.placeholder || ''"
         />
     </t>
 

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -35,8 +35,8 @@
                        invisible="move_type not in ('out_invoice', 'out_refund') or country_code != 'IN' or move_type == 'entry'"
                        readonly="state != 'draft'"/>
             </xpath>
-            <xpath expr="//field[@name='invoice_line_ids']/tree//field[@name='product_id']" position="after">
-                <field name="l10n_in_hsn_code" optional="hide" column_invisible="parent.country_code != 'IN'"/>
+            <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='name']" position="after">
+                <field name="l10n_in_hsn_code" widget="hsn_autocomplete" options="{'hsn_description_field': 'name'}"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -36,7 +36,7 @@
                        readonly="state != 'draft'"/>
             </xpath>
             <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='name']" position="after">
-                <field name="l10n_in_hsn_code" widget="hsn_autocomplete" options="{'hsn_description_field': 'name'}"/>
+                <field name="l10n_in_hsn_code" widget="l10n_in_hsn_autocomplete" options="{'l10n_in_hsn_description': 'name'}"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_in/views/product_template_view.xml
+++ b/addons/l10n_in/views/product_template_view.xml
@@ -7,8 +7,7 @@
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
             <field name="categ_id" position="after">
-                <field name="l10n_in_hsn_code" invisible="'IN' not in fiscal_country_codes"/>
-                <field name="l10n_in_hsn_description" invisible="'IN' not in fiscal_country_codes"/>
+                <field name="l10n_in_hsn_code" widget="hsn_autocomplete" options="{'hsn_description_field':'description'}" invisible="'IN' not in fiscal_country_codes"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_in/views/product_template_view.xml
+++ b/addons/l10n_in/views/product_template_view.xml
@@ -7,7 +7,9 @@
         <field name="inherit_id" ref="product.product_template_form_view"/>
         <field name="arch" type="xml">
             <field name="categ_id" position="after">
-                <field name="l10n_in_hsn_code" widget="hsn_autocomplete" options="{'hsn_description_field':'description'}" invisible="'IN' not in fiscal_country_codes"/>
+                <field name="l10n_in_hsn_code" widget="l10n_in_hsn_autocomplete"
+                        options="{'l10n_in_hsn_description':'description'}"
+                        invisible="'IN' not in fiscal_country_codes"/>
             </field>
         </field>
     </record>

--- a/addons/l10n_in_pos/data/product_demo.xml
+++ b/addons/l10n_in_pos/data/product_demo.xml
@@ -2,52 +2,39 @@
     <data noupdate="1">
         <record id="point_of_sale.desk_organizer" model="product.product">
             <field name="l10n_in_hsn_code">9403</field>
-            <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
         </record>
         <record id="point_of_sale.desk_pad" model="product.product">
             <field name="l10n_in_hsn_code">9403</field>
-            <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
         </record>
         <record id="point_of_sale.led_lamp" model="product.product">
             <field name="l10n_in_hsn_code">8539.50.00</field>
-            <field name="l10n_in_hsn_description">Light-emitting diode (LED) lamps</field>
         </record>
         <record id="point_of_sale.letter_tray" model="product.product">
             <field name="l10n_in_hsn_code">4819.60.00</field>
-            <field name="l10n_in_hsn_description">Box files, letter trays, storage boxes and similar articles, of a kind used in offices, shops or the like</field>
         </record>
         <record id="point_of_sale.magnetic_board" model="product.product">
             <field name="l10n_in_hsn_code">3921.90.99</field>
-            <field name="l10n_in_hsn_description">Other plates, sheets film , foil and strip, of plastics</field>
         </record>
         <record id="point_of_sale.monitor_stand" model="product.product">
             <field name="l10n_in_hsn_code">9403</field>
-            <field name="l10n_in_hsn_description">Other furniture and parts thereof.</field>
         </record>
         <record id="point_of_sale.newspaper_rack" model="product.product">
             <field name="l10n_in_hsn_code">9403.10.90</field>
-            <field name="l10n_in_hsn_description">Metal furniture of a kind used in offices</field>
         </record>
         <record id="point_of_sale.small_shelf" model="product.product">
             <field name="l10n_in_hsn_code">9403.10.90</field>
-            <field name="l10n_in_hsn_description">Metal furniture of a kind used in offices</field>
         </record>
         <record id="point_of_sale.product_product_tip" model="product.product">
             <field name="l10n_in_hsn_code">8209.00.90</field>
-            <field name="l10n_in_hsn_description">Plates, sticks, tips and the like for tools, unmounted, of cermets.</field>
         </record>
         <record id="point_of_sale.wall_shelf" model="product.product">
             <field name="l10n_in_hsn_code">9403.10.90</field>
-            <field name="l10n_in_hsn_description">Metal furniture of a kind used in offices</field>
         </record>
         <record id="point_of_sale.whiteboard" model="product.product">
             <field name="l10n_in_hsn_code">3926.10.99</field>
-            <field name="l10n_in_hsn_description">Office supplies of a kind classified as stationary other than pins,clips, and writing instruments</field>
         </record>
         <record id="point_of_sale.whiteboard_pen" model="product.product">
             <field name="l10n_in_hsn_code">9608</field>
-            <field name="l10n_in_hsn_description">Ball point pens; felt tipped and other porous-tipped pens and markers; fountain pens, stylograph pens and other pens; duplicating stylos; propelling or sliding pencils; pen-holders, pencilholders and similar holders; parts (including caps and clips) of the foregoing articles, othe than those of heading 9609
-            </field>
         </record>
         <record model="pos.bill" id="500_00" forcecreate="0">
             <field name="name">500.00</field>

--- a/addons/l10n_in_sale/data/product_demo.xml
+++ b/addons/l10n_in_sale/data/product_demo.xml
@@ -2,8 +2,6 @@
     <data noupdate="1">
         <record id="sale.advance_product_0" model="product.product">
             <field name="l10n_in_hsn_code">8303.00.00</field>
-            <field name="l10n_in_hsn_description">Armoured or reinforced safes, strong boxes and doors and safe deposit lockers for strong rooms, cash or deed boxes and the like, of base metal
-            </field>
         </record>
     </data>
 </odoo>

--- a/addons/l10n_in_stock/data/product_demo.xml
+++ b/addons/l10n_in_stock/data/product_demo.xml
@@ -2,7 +2,6 @@
     <data noupdate="1">
         <record id="stock.product_cable_management_box" model="product.product">
             <field name="l10n_in_hsn_code">4819.60.00</field>
-            <field name="l10n_in_hsn_description">Box files, letter trays, storage boxes and similar articles, of a kind used in offices, shops or the like</field>
         </record>
     </data>
 </odoo>


### PR DESCRIPTION
- Add the hsn_autocomplete widget, also add the options attribute for the hsn_description which takes the field name, and then after selecting the hsn_code, the hsn_decription will be stored in that field.

- Remove the "l10n_in_hsn_description" field as there is no such purpose for the field, also remove that field from the demo data as well.

Task: 3646598