### PR TITLE
remove_delivery_line_on_return_from_checkout

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -38,12 +38,12 @@ class WebsiteSale(main.WebsiteSale):
 
     @http.route()
     def cart(self, **post):
-        order = request.website.sale_get_order()
+        order = request.website.sale_get_order() # this returns 2 (order + delivery) (BUG)
+        res = super().cart(**post) # When going back to "Confirm Order" -> "Review Order") Delivery must be removed first, before calculating coupons. Otherwise couponse include delivery into calculation
         if order:
             order._update_programs_and_rewards()
             order._auto_apply_rewards()
 
-        res = super().cart(**post)
 
         # TODO in master: remove and pass delete=True to the methods fetching the error/success
         # messages in _get_website_sale_extra_values


### PR DESCRIPTION
[[FIX] website_sale_loyalty: returning from checkout rm delivery line](https://github.com/odoo/odoo/pull/149058/commits/f37993ccd8e98ef753d26bb0bd8102efb2ad03f0) 

Prior to this commit, (after https://github.com/odoo-dev/odoo/commit/74a17c1b2664cab2860306b84d542741a33953f9)
there was an issue where the Standard Delivery line was added to the Sales Order
during the transition from the "Review Order" screen to the "Confirm Order" screen.
This addition caused loyalty programs to incorrectly count an extra order line when
calculating loyalty points, in happens when navigating back to "Review Order" screen.

This commit addresses the problem by rearranging the sequence of operations.
Now, the delivery line is removed from the sales order before the loyalty points are calculated.

[Reproduce]
- Install Odoo with modules:   sale_management,website_sale
- Create a loyalty program:
    - Enable "Discounts, Loyalty & Gift Card."
    - Create a program with type "Promotions."
    - Set program conditions:
        - Minimum Quantity: 2
        - Minimum Purchase: 0
        - Grant 1 point per order
        - Among Product Domain "Match all records."
    - Set program Rewards:
        - Type: Discount
        - In exchange for 1 promo point.
- Navigate to the front-end shop:
    - Select 1 item.
    - Add it to the cart.
    - Proceed to Checkout.
    - In the "Review Order" screen:
        - Ensure there is one item (you need 2 for the discount).
        - Click "Proceed to Checkout" (delivery is added to the Sales Order at this point).
        - Click "Review Order" to go back.
        - BUG: The discount is shown in the "Review Order" screen.
opw-3675387