### PR TITLE
[FIX] website_sale: fix mobile scroll while changing variant

### DIFF
--- a/addons/website_sale/static/src/js/variant_mixin.js
+++ b/addons/website_sale/static/src/js/variant_mixin.js
@@ -58,6 +58,14 @@ VariantMixin._onChangeCombination = function (ev, $parent, combination) {
         product_unavailable.removeClass('d-flex').addClass('d-none')
     }
     originalOnChangeCombination.apply(this, [ev, $parent, combination]);
+
+    const $variantsContainer = ev.target.closest('.js_add_cart_variants');
+    if(ev.target.tagName === 'INPUT' && $variantsContainer){
+        $variantsContainer.scrollIntoView({
+            behavior: 'auto',
+            block: 'center',
+        });
+    }
 };
 
 const originalToggleDisable = VariantMixin._toggleDisable;


### PR DESCRIPTION
To reproduce
============
- add 3 or 4 images to a product
- add more images to a variant of this product
- go to the product page on website
- edit website and change the layout from Carousel to Grid and Columns to 1
- go to the product page on website on mobile
- switch between variants -> the page scrolls weirdly

Problem
=======
when updating the images, we add the new ones after the old one then remove the old ones. As the variant has more images, the page is longer and the scroll is not at the same place anymore.

Solution
========
when changing the variant we scroll to the container of variants as it's the element that the user interacted with.

opw-3628238


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
