### PR TITLE
[FIX] website: prevent content selection of an empty #wrap container

### DIFF
--- a/addons/website/static/src/scss/website.edit_mode.scss
+++ b/addons/website/static/src/scss/website.edit_mode.scss
@@ -107,6 +107,7 @@ $-editor-messages-margin-x: 2%;
             padding: 112px 0px;
             margin: 20px $-editor-messages-margin-x;
             color: #999999;
+            user-select: none;
         }
 
         // Exception 2: empty wrap during drag & drop (override of base case)


### PR DESCRIPTION
Steps to reproduce:

- Go to the website (“Edit” mode with an empty page) > Try to select the
default text on the page (“DRAG BUILDING BLOCKS HERE”)
- The text goes up, and the style of the whole dropzone is affected.

This happens because the powerbox hint preview function (see `OdooEditor`
 `_handleCommandHint()`) is trying to set the hint on the empty `#wrap`
container on every `selectionchange`.

The goal of this commit to fix this behaviour by simply making the empty
`#wrap` element not selectable.