### PR TITLE
[FIX] web: tooling: add paths to [web,web_studio]/../tests in jsconfig

### DIFF
--- a/addons/web/tooling/_jsconfig.json
+++ b/addons/web/tooling/_jsconfig.json
@@ -8,6 +8,7 @@
         "typeRoots": ["addons/web/tooling/types"],
         "paths": {
             "@web/*": ["addons/web/static/src/*"],
+            "@web/../tests/*": ["addons/web/static/tests/*"],
             "@web_enterprise/*": ["web_enterprise/static/src/*"],
             "@web_unsplash/*": ["addons/web_unsplash/static/src/*"],
             "@web_editor/*": ["addons/web_editor/static/src/*"],
@@ -18,6 +19,7 @@
             "@web_mobile/*": ["web_mobile/static/src/*"],
             "@web_grid/*": ["web_grid/static/src/*"],
             "@web_studio/*": ["web_studio/static/src/*"],
+            "@web_studio/../tests/*": ["web_studio/static/tests/*"],
             "@bus/*": ["addons/bus/static/src/*"],
             "@mail/*": ["addons/mail/static/src/*"],
             "@whatsapp/*": ["addons/whatsapp/static/src/*"],


### PR DESCRIPTION
Adds paths in jsconfig to resolve tests helpers of web and web_studio.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
