### PR TITLE
[IMP] calendar: list view improvements

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -20,6 +20,25 @@ class Users(models.Model):
     def SELF_WRITEABLE_FIELDS(self):
         return super().SELF_READABLE_FIELDS + ['calendar_default_privacy']
 
+    def get_selected_calendars_partner_ids(self, include_user=True):
+        """
+        Retrieves the partner IDs of the attendees selected in the calendar view.
+
+        :param bool include_user: Determines whether to include the current user's partner ID in the results.
+        :return: A list of integer IDs representing the partners selected in the calendar view.
+                 If 'include_user' is True, the list will also include the current user's partner ID.
+        :rtype: list
+        """
+        self.ensure_one()
+        partner_ids = self.env['calendar.filters'].search([
+            ('user_id', '=', self.id),
+            ('partner_checked', '=', True)
+        ]).partner_id.ids
+
+        if include_user:
+            partner_ids += [self.env.user.partner_id.id]
+        return partner_ids
+
     def _systray_get_calendar_event_domain(self):
         # Determine the domain for which the users should be notified. This method sends notification to
         # events occurring between now and the end of the day. Note that "now" needs to be computed in the

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -66,8 +66,21 @@ export class AttendeeCalendarModel extends CalendarModel {
     }
 
     /**
+     * Load the filter section and add both 'user' and 'everybody' filters to the context.
      * @override
      */
+    async loadFilterSection(fieldName, filterInfo, previousSection) {
+        let result = await super.loadFilterSection(fieldName, filterInfo, previousSection);
+        if (result?.filters) {
+            user.updateContext({
+                calendar_filters: {
+                    all: result?.filters?.find((f) => f.type == "all")?.active ?? false,
+                    user: result?.filters?.find((f) => f.type == "user")?.active ?? false,
+                }
+            });
+        }
+        return result;
+    }
 
     /**
      * @override

--- a/addons/calendar/static/src/views/list_view/calendar_list_view.js
+++ b/addons/calendar/static/src/views/list_view/calendar_list_view.js
@@ -1,0 +1,42 @@
+import { listView } from "@web/views/list/list_view";
+import { registry } from "@web/core/registry";
+import { user } from "@web/core/user";
+
+export class CalendarListModel extends listView.Model {
+    setup(params, { action, dialog, notification, rpc, user, view, company }) {
+        super.setup(...arguments);
+    }
+
+    /**
+    * @override
+    * Add the calendar view's selected attendees to the list view's domain.
+    */
+    async load(params = {}) {
+        const filters = params?.context?.calendar_filters;
+        const emptyDomain = Array.isArray(params?.domain) && params.domain.length == 0;
+        if (filters && emptyDomain) {
+            const selectedPartnerIds = await this.orm.call(
+                "res.users",
+                "get_selected_calendars_partner_ids",
+                [[user.userId], filters["user"]]
+            );
+            // Filter attendees to be shown if 'everybody' filter isn't active.
+            if (!filters["all"])
+                params.domain.push(["partner_ids", "in", selectedPartnerIds]);
+        }
+        return super.load(params);
+    }
+}
+
+export const CalendarListView = {
+    ...listView,
+    Model: CalendarListModel,
+};
+
+function _mockGetCalendarPartnerIds(params) {
+    /* Mock function for when there aren't records to be shown. */
+    return [];
+}
+
+registry.category("views").add("calendar_list_view", CalendarListView);
+registry.category("sample_server").add("get_selected_calendars_partner_ids", _mockGetCalendarPartnerIds);

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -72,7 +72,7 @@
         <field name="name">calendar.event.tree</field>
         <field name="model">calendar.event</field>
         <field name="arch" type="xml">
-            <tree string="Meetings" sample="1" multi_edit="1">
+            <tree string="Meetings" sample="1" multi_edit="1" js_class="calendar_list_view">
                 <header>
                     <button name="action_open_composer" type="object" context="{'default_composition_mode':'mass_mail'}"
                             string="Send Mail"/>


### PR DESCRIPTION
Before this commit, all events from all calendars where being showed in the list view of the module while in the calendar view only the events from the selected attendees are shown, making the list view and calendar view not consisted with each other.

After this commit, by default, the events shown in the list view are the same as the ones shown in the module's calendar view (which are the events from the selected attendees on the right panel). This is done by adding into the user context the current status of both unstored filters: own calendar filter and everybody's calendar filter.

task-3606999