### PR TITLE
[FIX] stock: filter company related product routes when getting rules

### DIFF
--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -488,7 +488,7 @@ class ProcurementGroup(models.Model):
             if packaging_routes:
                 res = Rule.search(expression.AND([[('route_id', 'in', packaging_routes.ids)], domain]), order='route_sequence, sequence', limit=1)
         if not res:
-            product_routes = product_id.route_ids | product_id.categ_id.total_route_ids
+            product_routes = product_id['route_ids'] | product_id['categ_id'].total_route_ids
             if product_routes:
                 res = Rule.search(expression.AND([[('route_id', 'in', product_routes.ids)], domain]), order='route_sequence, sequence', limit=1)
         if not res and warehouse_id:
@@ -504,6 +504,13 @@ class ProcurementGroup(models.Model):
         """
         result = self.env['stock.rule']
         location = location_id
+
+        if values.get('company_id'):
+            product_id = {
+                'route_ids': product_id.route_ids.filtered(lambda route: not route.company_id or route.company_id == values.get('company_id')),
+                'categ_id': product_id.categ_id,
+            }
+
         while (not result) and location:
             domain = self._get_rule_domain(location, values)
             result = self._search_rule(values.get('route_ids', False), values.get('product_packaging_id', False), product_id, values.get('warehouse_id', False), domain)


### PR DESCRIPTION
### Steps to reproduce:
- Create two companies: 
    - (ex. Daughter Company) 
    - (ex. Mother Company)
- Install Inventory and purchase app
- In the settings of both companies: 
    - enable **Multi-Step Routes** 
    - enable **Dropshipping** option 
    - enable **Inter-Company Transactions** with: 
        - **Synchronize sales and purchase order** checked
        - **Auto validation** turned on
- Using the **Daughter Company**, go to Routes, In the **Dropship** route, set Company to **Daughter Company**
- Create a new _Storable_ product
- Using the **Daughter Company**: 
    - In the **inventory** tab > **Operations**, Turn on **dropship** route 
    - In the **purchase** tab, set the **Mother Company** as the vendor
- Using the **Mother Company**: 
    - In the **purchase** tab, set a vendor 
    - Set a reordering rule
- Using the **Daughter Company**: 
    - create a new SO, with the our new product 
    - Confirm the SO 
    - Go to the associated PO - Notice how the Deliver To property is set to _Dropship_ -, the confirm it
- Using the **Mother Company**, U should find a newly created SO, with a PO related to it
- Notice how how the Deliver To property is set to _Dropship_, this is not correct as the PO should deliver the product to the warehouse of the Mother Company

### Investigation:
- When a SO is confirmed, a stock rule is matched in order to create a PO if needed
- As **auto validation** is turned on, the SO is auto validated within the **Daughter Company** environment, which means our product has _TWO_ routes: **buy** and **dropship** when it should have had only one: **buy** if we had validated it in the **Mother Company** -without auto validation-
- That leads to a confusion in the `_search_rule` method finding the Dropship rule instead of the buy one https://github.com/odoo/odoo/blob/0deb5f1e9150c1e178d92379877f9a401867c820/addons/stock/models/stock_rule.py#L490-L493

opw-3648535