### PR TITLE
[FIX] base, base_import: don't increment sequence on test import

### DIFF
--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1330,7 +1330,8 @@ class Import(models.TransientModel):
             name_create_enabled_fields=name_create_enabled_fields,
             import_set_empty_fields=options.get('import_set_empty_fields', []),
             import_skip_records=options.get('import_skip_records', []),
-            _import_limit=import_limit)
+            _import_limit=import_limit,
+            dryrun=dryrun)
         import_result = model.load(import_fields, merged_data)
         _logger.info('done')
 

--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -268,6 +268,8 @@ class IrSequence(models.Model):
     def next_by_id(self, sequence_date=None):
         """ Draw an interpolated string using the specified sequence."""
         self.check_access_rights('read')
+        if self.env.context.get('dryrun'):
+            return False
         return self._next(sequence_date=sequence_date)
 
     @api.model
@@ -282,6 +284,8 @@ class IrSequence(models.Model):
         seq_ids = self.search([('code', '=', sequence_code), ('company_id', 'in', [company_id, False])], order='company_id')
         if not seq_ids:
             _logger.debug("No ir.sequence has been found for code '%s'. Please make sure a sequence is set for current company." % sequence_code)
+            return False
+        if self.env.context.get('dryrun'):
             return False
         seq_id = seq_ids[0]
         return seq_id._next(sequence_date=sequence_date)


### PR DESCRIPTION
Before this commit, when doing a test import, the model's sequence was incremented. This is because sequences are not affected by savepoints and rollbacks. This is undesirable behavior as records are not actually imported, creating gaps in the sequence.

To fix this, we pass a context to prevent `next_by_code` and `next_by_id` from getting the next sequence when doing a test import.

opw-3650734