### PR TITLE
[15.0][FIX] calendar: Select correct base event when current is archived

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -555,6 +555,14 @@ class Meeting(models.Model):
                     self.env.ref('calendar.calendar_template_meeting_changedate', raise_if_not_found=False)
                 )
 
+        # Change base event when the main base event is archived. If it isn't done when trying to modify
+        # all events of the recurrence an error can be thrown or all the recurrence can be deleted.
+        if values.get("active") is False:
+            recurrences = self.env["calendar.recurrence"].search([
+                ('base_event_id', 'in', self.ids)
+            ])
+            recurrences._select_new_base_event()
+
         return True
 
     def _check_private_event_conditions(self):

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -621,6 +621,48 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         self.assertTrue(self.recurrence)
         self.assertEqual(self.events.exists(), self.events[0])
 
+    def test_recurrence_update_all_first_archived(self):
+        """Test to check the flow when a calendar event is
+        created from a day that does not belong to the recurrence.
+        """
+        event = self.env['calendar.event'].create({
+            'name': 'Recurrent Event',
+            'start': datetime(2019, 10, 22, 1, 0),
+            'stop': datetime(2019, 10, 22, 2, 0),
+            'recurrency': True,
+            'rrule_type': 'weekly',
+            'tue': False,
+            'wed': True,
+            'fri': True,
+            'interval': 1,
+            'count': 3,
+            'event_tz': 'Etc/GMT-4',
+        })
+        # Tuesday datetime(2019, 10, 22, 1, 0) - Archived
+        # Wednesday datetime(2019, 10, 23, 1, 0)
+        # Friday datetime(2019, 10, 25, 1, 0)
+        # Wednesday datetime(2019, 10, 30, 1, 0)
+        recurrence = self.env['calendar.recurrence'].search([('id', '!=', self.recurrence.id)])
+        events = recurrence.calendar_event_ids.sorted('start')
+        # Check first event is archived
+        self.assertFalse(event.active)
+        # Check base_event is different than archived and it is first active event
+        self.assertNotEqual(recurrence.base_event_id, event)
+        self.assertEqual(recurrence.base_event_id, events[0])
+        # Update all events to check that error is not thrown
+        events[0].write({
+            'recurrence_update': 'all_events',
+            'fri': False,
+        })
+        events = self.env['calendar.recurrence'].search(
+            [('id', '!=', self.recurrence.id)]
+        ).calendar_event_ids.sorted('start')
+        self.assertEventDates(events, [
+            (datetime(2019, 10, 23, 1, 0), datetime(2019, 10, 23, 2, 0)),
+            (datetime(2019, 10, 30, 1, 0), datetime(2019, 10, 30, 2, 0)),
+            (datetime(2019, 11, 6, 1, 0), datetime(2019, 11, 6, 2, 0)),
+        ])
+
 
 class TestUpdateMultiDayWeeklyRecurrentEvents(TestRecurrentEvents):
 


### PR DESCRIPTION
When the base event is archived, it continues being the base event of the recurrence, and when trying to change the recurrence of all the events of the recurrence, an error is thrown or some inconsistencies occur.

To test the problem, you can follow these steps:

1. Create a recurrence of events from a non included day on the recurrence (example: recurrence on tuesday and friday and the start of the recurrence on monday). The first event will be archived automatically.
2. Open other event of the recurrence.
3. Modify the recurrence for all events (example: change the weekdays, set just tuesday instead of tuesday and friday)

An error will be thrown.

See next gif:
![ERROR](https://github.com/odoo/odoo/assets/35952655/6150e48a-5ef2-4e9b-89a8-7ca7c7969e3a)

By making these changes, the base event will be updated, as indicated in the `_select_new_base_event` method, so these inconsistencies will not occur when making the changes.

See next gif:
![Correct](https://github.com/odoo/odoo/assets/35952655/1d733320-e6d0-4405-a690-87b94a71c2de)

cc @Tecnativa TT46742

ping @pedrobaeza @chienandalu 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
