### PR TITLE
[PERF] stock_account: add index on FKey `cogs_origin_id`

### DIFF
--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -236,7 +236,7 @@ class AccountMoveLine(models.Model):
 
     stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'account_move_line_id', string='Stock Valuation Layer')
     cogs_origin_id = fields.Many2one(  # technical field used to keep track in the originating line of the anglo-saxon lines
-        "account.move.line", copy=False,
+        "account.move.line", copy=False, index='btree_not_null',
     )
 
     def _compute_account_id(self):


### PR DESCRIPTION
## Description
Add missing index on `cogs_origin_id` to speed up triggers upon deletion of `account.move.line` entries. Noticeable during bank reconciliation.

## Reference
opw-3675176

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
