### PR TITLE
[FIX] l10n_es_pos: don't print customer details if none is selected

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml
+++ b/addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml
@@ -16,7 +16,7 @@
         </xpath>
         <xpath expr="//div[hasclass('pos-receipt-contact')]" position="inside">
             <t t-set="partner" t-value="props.data.partner"/>
-            <t t-if="props.data.is_spanish and partner?.id !== props.data.simplified_partner_id">
+            <t t-if="props.data.is_spanish and partner and partner?.id !== props.data.simplified_partner_id">
                 <div>Customer: <t t-esc="partner.name" /></div>
                 <div t-if="partner.vat"><t t-esc="props.data.company.country?.vat_label || 'Tax ID'"/>: <t t-esc="partner.vat" /></div>
                 <div t-if="partner.address" t-esc="partner.address"/>


### PR DESCRIPTION
### Steps to reproduce:
- Create a new company located in **Spain**.
- Install **Restaurant** app.
- Go to **Settings** > **Invoicing** and select **Spain - SMEs (2008)** in **Fiscal Localization**
- Go to **Settings** > **Point of Sale** and enable **Early Receipt Printing** under **Restaurant Mode**
- Open **Point of Sale** app, and open a Bar session
- Add a product
- Click on **Bill** button, an error arises

### Investigation
- When u click on **Bill**, no customer (partner) is selected yet and hence partner is `null` at the order https://github.com/odoo/odoo/blob/d0704a19de31e0251d343081ae6b3da9991a248e/addons/l10n_es_pos/static/src/overrides/models/pos_store.js#L12
- and so no properties of partner can be accessed in https://github.com/odoo/odoo/blob/d0704a19de31e0251d343081ae6b3da9991a248e/addons/l10n_es_pos/static/src/overrides/components/receipt_header/receipt_header.xml#L20-L22

opw-3652235
