### PR TITLE
[FIX] website_sale amount of reviews on product

### DIFF
--- a/addons/portal_rating/static/src/js/portal_composer.js
+++ b/addons/portal_rating/static/src/js/portal_composer.js
@@ -36,7 +36,7 @@ PortalComposer.include({
         this.options = _.defaults(this.options, {
             'default_message': false,
             'default_message_id': false,
-            'default_rating_value': 0.0,
+            'default_rating_value': 5.0,
             'force_submit_url': false,
         });
         // star input widget


### PR DESCRIPTION
Description of the issue/feature this PR addresses: 
Correct computation of the amount of reviews of products on the website_sale app.

Current behavior before PR: On the website_sale app, the amount of reviews on a product is computed as the sum of all reviews with are strictly positive rating. However, it is possible to post a review without any rating (default 0 rating that do not impact average and amount of reviews). In particular, the displayed amount of reviews is not correct.

Desired behavior after PR is merged: The amount of reviews displayed should be equal to the amount of reviews given to the product.

Fix : I set the default value of the rating to 5.0 to force the existence of a rating on reviews. On Odoo 16.0 and 17.0 the default value is set to 4.0 but doing so in 15.0 shows the fifth star in grey and the first 4 in gold.  

Ticket 3670156 
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
