### PR TITLE
[FIX] web: Wait for notif to show

### DIFF
--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -6053,7 +6053,7 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(target.querySelector(".o_pager_value").textContent, "2");
         assert.strictEqual(router.current.hash.id, 2);
     });
-
+    
     QUnit.test("switching to non-existing record", async function (assert) {
         patchWithCleanup(browser, {
             setTimeout(fn) {
@@ -6074,6 +6074,7 @@ QUnit.module("Views", (hooks) => {
         assert.strictEqual(target.querySelector(".o_pager_limit").textContent, "3");
         assert.strictEqual(router.current.hash.id, 1);
         await click(target.querySelector(".o_pager_next"));
+        await nextTick();
 
         assert.containsOnce(target, ".o_notification_bar.bg-danger");
         assert.strictEqual(target.querySelector(".o_pager_value").textContent, "1");


### PR DESCRIPTION
Before this commit, the test "switching to non-existing record" was not waiting for the notification to show.

After this commit, it waits.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
