### PR TITLE
[FIX] website_sale: count reviews of product

### DIFF
--- a/addons/portal_rating/static/src/js/portal_composer.js
+++ b/addons/portal_rating/static/src/js/portal_composer.js
@@ -36,7 +36,7 @@ PortalComposer.include({
         this.options = _.defaults(this.options, {
             'default_message': false,
             'default_message_id': false,
-            'default_rating_value': 0.0,
+            'default_rating_value': 5.0,
             'force_submit_url': false,
         });
         // star input widget


### PR DESCRIPTION
Current behaviour :

On the website_sale application, the "count of review" displayed for a product is computed as the sum of all reviews with a strictly positive rating. However, it is possible to leave a review without any rating (efault rating is 0: a values that does not affect the average and the count of reviews).
-> The count of reviews displayed for any product is incorrect if reviews without rating are provided.

Desired behaviour after PR is merged:

Every review posted on the e-commerce has a positive default rating of 5.0. This forces reviews to provide a rating with their review.

Rmk:

In Odoo 16.0 and 17.0 the default is set to 4.0, but, such a change in 15.0 display the fifth star in grey and the first 4 in yellow during review creation. To keep the changes to a minimal, we set the default value to 5.0 and all the stars appear in yellow.

opw-3670156
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
