### PR TITLE
[REF] website_(sale_)slides: simplify _filter_add_members

### DIFF
--- a/addons/website_sale_slides/models/slide_channel.py
+++ b/addons/website_sale_slides/models/slide_channel.py
@@ -1,8 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
-from odoo.exceptions import AccessError
+from odoo import api, fields, models
 
 
 class SlideChannel(models.Model):
@@ -76,15 +75,3 @@ class SlideChannel(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("website_sale_slides.sale_report_action_slides")
         action['domain'] = [('product_id', 'in', self.product_id.ids)]
         return action
-
-    def _filter_add_members(self, target_partners, raise_on_access=False):
-        """ Overridden to add 'payment' channels to the filtered channels. People
-        that can write on payment-based channels can add members. """
-        result = super()._filter_add_members(target_partners, raise_on_access=raise_on_access)
-        on_payment = self.filtered(lambda channel: channel.enroll == 'payment')
-        if on_payment:
-            if on_payment.has_access('write'):
-                result |= on_payment
-            elif raise_on_access:
-                raise AccessError(_('You are not allowed to add members to this course. Please contact the course responsible or an administrator.'))
-        return result

--- a/addons/website_slides/tests/test_attendee.py
+++ b/addons/website_slides/tests/test_attendee.py
@@ -8,6 +8,7 @@ from odoo import fields
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
 from odoo.addons.website_slides.tests import common
+from odoo.exceptions import AccessError
 from odoo.tests import tagged, users
 
 @tagged('post_install', '-at_install')
@@ -162,6 +163,9 @@ class TestAttendee(common.SlidesCase):
         # Uninvited partner cannot join the course
         self.channel.with_user(self.user_portal)._action_add_members(user_portal_partner)
         self.assertFalse(user_portal_partner.id in self.channel.partner_ids.ids)
+
+        with self.assertRaises(AccessError):
+            self.channel.with_user(self.user_portal)._action_add_members(user_portal_partner, raise_on_access=True)
 
         user_portal_channel_partner = self.env['slide.channel.partner'].create({
             'channel_id': self.channel.id,


### PR DESCRIPTION
An argument wasn't used, and the override wasn't necessary.
If we do need to be able to filter differently, based on access rights,
we should probably split the current into a proper overridable filter
and a check-access-and-raise-or-not-method, but it isn't necessary
at this point.

Task-3299646