### PR TITLE
[FIX] web: layout issue with binary fields in dialogs

### DIFF
--- a/addons/web/static/src/legacy/scss/attachment_preview.scss
+++ b/addons/web/static/src/legacy/scss/attachment_preview.scss
@@ -31,6 +31,9 @@ $o-attachment-margin: 5px;
         border-radius: 2px;
         padding: 4px 6px 0 4px;
         background-color: rgba($o-black, 0.05);
+        min-width:12rem;
+        max-width: 25rem;
+        width: 100%;
 
         .o_attachment_delete_cross {
             float: right;
@@ -60,6 +63,10 @@ $o-attachment-margin: 5px;
 
         a {
             @include o-hover-text-color($default-color: $o-main-text-color, $hover-color: $headings-color);
+            display: inline-block;
+            overflow: hidden;
+            width: 100%;
+            text-overflow: ellipsis;
         }
     }
 


### PR DESCRIPTION
When the user uploads the file with a long name in a binary field in dialog,
it will cause a layout issue in the view.

Steps to reproduce the issue:
- Open Marketing automation
- Create campaign > Add new activity
- Create and edit a "mail template"
- Open the options tab > upload an attachment with a long name

Observed behavior:
When the user uploads a file with a long name, It eats up the whole space and
shrinks the labels.

Expected behavior:
It should not shrink the labels and the view should appear properly.

Task-3644267

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
