### PR TITLE
[FIX] project: fix display of archive and state

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -152,7 +152,12 @@
                         <h1 class="d-flex flex-row justify-content-between">
                             <field name="priority" widget="priority" class="me-3"/>
                             <field name="name" class="o_task_name text-truncate" placeholder="Task Title..."/>
-                            <field name="state" widget="project_task_state_selection" options="{'is_toggle_mode': false}"/>
+                            <div class="d-flex justify-content-end o_state_container" invisible="not active">
+                                <field name="state" widget="project_task_state_selection" class="o_task_state_widget"/>
+                            </div>
+                            <div class="d-flex justify-content-start o_state_container w-100 w-md-50 w-lg-25" invisible="active">
+                                <field name="state" widget="project_task_state_selection" class="o_task_state_widget"/>
+                            </div>
                         </h1>
                     </div>
                     <group>


### PR DESCRIPTION
Steps:
- Install project.
- Create a project and share that project.
- Create a task and archive that task
- Open project sharing view in mobile device.
- Open that archive task.

Issue:
- State selection and archive badge is not displaying property in project sharing task form view.

Cause:
- Issue about this display was fix in backend but forgot to fix that in frontend,

Fix:
- Fix aligment issue by making state field display differently when task is archive in mobile like
we did in backend similer to this pr https://github.com/odoo/odoo/pull/125532

task-3690532
