### PR TITLE
[FIX] l10n_sa_edi: format telephone value

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -402,3 +402,8 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
     def _get_invoice_payment_terms_vals_list(self, invoice):
         """ Override to include/update values specific to ZATCA's UBL 2.1 specs """
         return []
+
+    def _get_partner_contact_vals(self, partner):
+        res = super()._get_partner_contact_vals(partner)
+        res['telephone'] = res.get('telephone', '').replace(' ', '')
+        return res


### PR DESCRIPTION
Currently, when submitting an invoice to ZATCA, the phone number printed in the XML file includes spaces, which returns a warning from ZATCA. To fix this, we manually trim the spaces from the phone number value before printing it in the XML.

Description of the issue/feature this PR addresses:
Phone number included in the XML file submitted to ZATCA includes spaces, which returns a non-blocking warning from ZATCA

Current behavior before PR:
Phone number included in the XML file submitted to ZATCA includes spaces, which returns a non-blocking warning from ZATCA

Desired behavior after PR is merged:
Phone number is pre-formatted to remove spaces before submission to ZATCA



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
