### PR TITLE
[FIX] odoo: avoid JSON serialization of lazy translations

### DIFF
--- a/odoo/http.py
+++ b/odoo/http.py
@@ -717,7 +717,7 @@ def serialize_exception(e):
         "name": type(e).__module__ + "." + type(e).__name__ if type(e).__module__ else type(e).__name__,
         "debug": traceback.format_exc(),
         "message": ustr(e),
-        "arguments": e.args,
+        "arguments": [str(arg) for arg in e.args],
         "context": getattr(e, 'context', {}),
     }
 


### PR DESCRIPTION
# To reproduce:
Raise an exception with a lazy translation from a report E.g.: `raise UserError(_lt("Something went wrong."))`.

# Why it happens:
In the serialization of the exception, we simply return the arguments of the exception. However, at this point we are still using a lazy translation.
Later, when perfoming a JSON dumps, we get an exception: `TypeError: Object of type _lt is not JSON serializable`.

# Solution:
Convert all the exception arguments into strings.

task-id: none
