### PR TITLE
[FIX] resource: could not create company due to attendances overlap

### DIFF
--- a/addons/resource/models/resource.py
+++ b/addons/resource/models/resource.py
@@ -177,6 +177,8 @@ class ResourceCalendar(models.Model):
                         'hour_from': attendance.hour_from,
                         'hour_to': attendance.hour_to,
                         'day_period': attendance.day_period,
+                        'date_from': attendance.date_from,
+                        'date_to': attendance.date_to,
                     })
                     for attendance in company_attendance_ids
                 ]


### PR DESCRIPTION
### before this PR
When creating a new company, a new resource calendar is created by copying the default calendar of the current company. However, if the calendar of the current company contains the same periods (e.g. Saturday Afternoon) with different date_from and date_to, duplication error will raise, by the constrain `_check_attendance()` which calls the `_check_overlap()`. See https://github.com/odoo/odoo/blob/013a0391d5de84fda02d542760471f4c296b7f2b/addons/resource/models/resource.py#L362-L383

Here is a sample of the default calendar of the current company that caused error when creating a new company
![Selection_144](https://github.com/odoo/odoo/assets/7938973/89bf8a4d-43f7-4547-8a42-ffb9f2b5fce9)

### What this PR does
copying resource calendar should respect date_from and date_to to pass constraint

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
