### PR TITLE
[IMP] sale_timesheet: link timesheets of services not invoiced on timesheets

### DIFF
--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -2,7 +2,7 @@
 
 from collections import defaultdict
 
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 from odoo.fields import Domain
 
 
@@ -41,32 +41,13 @@ class AccountMove(models.Model):
         for invoice in self:
             invoice.timesheet_count = mapped_data.get(invoice.id, 0)
 
-    def action_view_timesheet(self):
-        self.ensure_one()
-        return {
-            'type': 'ir.actions.act_window',
-            'name': _('Timesheets'),
-            'domain': [('project_id', '!=', False)],
-            'res_model': 'account.analytic.line',
-            'view_id': False,
-            'view_mode': 'list,form',
-            'help': _("""
-                <p class="o_view_nocontent_smiling_face">
-                    Record timesheets
-                </p><p>
-                    You can register and track your workings hours by project every
-                    day. Every time spent on a project will become a cost and can be re-invoiced to
-                    customers if required.
-                </p>
-            """),
-            'limit': 80,
-            'context': {
-                'default_project_id': self.id,
-                'search_default_project_id': [self.id]
-            }
-        }
+    def _has_timesheet_portal(self):
+        Timesheet = self.env['account.analytic.line']
+        initial_domain = Timesheet._timesheet_get_portal_domain()
+        domain = Domain.AND([initial_domain, self.env['account.analytic.line']._timesheet_get_sale_domain(self.invoice_line_ids.sale_line_ids, self)])
+        return Timesheet.sudo().search(domain, limit=1)
 
-    def _link_timesheets_to_invoice(self, start_date=None, end_date=None):
+    def _link_timesheets_to_invoice(self, start_date=None, end_date=None, service_policies=['delivered_timesheet']):
         """ Search timesheets from given period and link this timesheets to the invoice
 
             When we create an invoice from a sale order, we need to
@@ -74,18 +55,28 @@ class AccountMove(models.Model):
             Then, we can know which timesheets are invoiced in the sale order.
             :param start_date: the start date of the period
             :param end_date: the end date of the period
+            :param service_policies: the service policies of the sol products to consider
         """
-        for line in self.filtered(lambda i: i.move_type == 'out_invoice' and i.state == 'draft').invoice_line_ids:
-            sale_line_delivery = line.sale_line_ids.filtered(lambda sol: sol.product_id.invoice_policy == 'delivery' and sol.product_id.service_type == 'timesheet')
-            if not start_date and not end_date:
-                start_date, end_date = self._get_range_dates(sale_line_delivery.order_id)
-            if sale_line_delivery:
-                domain = Domain(line._timesheet_domain_get_invoiced_lines(sale_line_delivery))
+        for line in self.filtered(lambda i: i.move_type in ['out_invoice', 'out_refund'] and i.state == 'draft').invoice_line_ids:
+            sale_line_delivery = line.sale_line_ids.filtered(lambda sol: sol.product_id.service_policy in service_policies)
+            if not sale_line_delivery:
+                continue
+            domain = Domain(line._timesheet_domain_get_invoiced_lines(sale_line_delivery))
+            timesheets_per_domain = dict()
+            for sale_line in sale_line_delivery:
+                sale_line_domain = domain
+                if not start_date and not end_date:
+                    start_date, end_date = self._get_range_dates(sale_line.order_id)
+                if sale_line.product_id.service_policy == 'delivered_manual':
+                    end_date = line.move_id.invoice_date or fields.Date.today()
                 if start_date:
-                    domain &= Domain('date', '>=', start_date)
+                    sale_line_domain &= Domain('date', '>=', start_date)
                 if end_date:
-                    domain &= Domain('date', '<=', end_date)
-                timesheets = self.env['account.analytic.line'].sudo().search(domain)
+                    sale_line_domain &= Domain('date', '<=', end_date)
+                repr_domain = repr(sale_line_domain)  # Normalize the domain to make it hashable
+                if repr_domain not in timesheets_per_domain:
+                    timesheets_per_domain[repr_domain] = self.env['account.analytic.line'].sudo().search(sale_line_domain)
+                timesheets = timesheets_per_domain[repr_domain]
                 timesheets.write({'timesheet_invoice_id': line.move_id.id})
 
     def _get_range_dates(self, order):
@@ -103,3 +94,22 @@ class AccountMove(models.Model):
         ])
         timesheets_sudo.write({'timesheet_invoice_id': False})
         return result
+
+    def _unlink_timesheets_from_invoice(self, service_policies):
+        for move in self:
+            if move.move_type in ['out_invoice', 'out_refund'] and move.state == 'posted':
+                timesheets = move.timesheet_ids.filtered(lambda t: t.service_policy in service_policies)
+                timesheets.timesheet_invoice_id = False
+
+    def _post(self, soft=True):
+        self._link_timesheets_to_invoice(service_policies=['delivered_milestones', 'delivered_manual'])
+        return super()._post(soft)
+
+    def button_draft(self):
+        self._unlink_timesheets_from_invoice(['ordered_prepaid', 'delivered_milestones', 'delivered_manual'])
+        return super().button_draft()
+
+    def _reverse_moves(self, default_values_list=None, cancel=False):
+        reverse_moves = super()._reverse_moves(default_values_list, cancel)
+        (self | reverse_moves)._unlink_timesheets_from_invoice(['ordered_prepaid', 'delivered_milestones', 'delivered_manual'])
+        return reverse_moves

--- a/addons/sale_timesheet/models/sale_order.py
+++ b/addons/sale_timesheet/models/sale_order.py
@@ -81,6 +81,12 @@ class SaleOrder(models.Model):
             created_records.with_context(disable_project_task_generation=True).action_confirm()
         return created_records
 
+    def _has_timesheet_portal(self):
+        Timesheet = self.env['account.analytic.line']
+        initial_domain = Timesheet._timesheet_get_portal_domain()
+        domain = Domain.AND([initial_domain, [('order_id', '=', self.id)]])
+        return Timesheet.sudo().search(domain, limit=1)
+
     def _get_order_with_valid_service_product(self):
         SaleOrderLine = self.env['sale.order.line']
         return SaleOrderLine._read_group(Domain.AND([

--- a/addons/sale_timesheet/tests/test_sale_timesheet.py
+++ b/addons/sale_timesheet/tests/test_sale_timesheet.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import date, timedelta
+from freezegun import freeze_time
 
 from odoo import Command
 from odoo.fields import Date
@@ -182,6 +183,16 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
 
         # timesheet can still be modified
         timesheet1.write({'unit_amount': 13})
+
+        timesheet5 = self.env['account.analytic.line'].create({
+            'name': 'Test Line',
+            'project_id': task_serv2.project_id.id,
+            'task_id': task_serv2.id,
+            'unit_amount': 5,
+            'employee_id': self.employee_user.id,
+            'so_line': so_line_ordered_global_project.id,
+        })
+        self.assertEqual(timesheet5.timesheet_invoice_id, invoice1, "After creating timesheet5, it should be linked to invoice1, since the service policy is ordered_prepaid and invoice1 is the last posted invoice linked to the SOL of timesheet5")
 
     def test_timesheet_delivery(self):
         """ Test timesheet invoicing with 'invoice on delivery' timetracked products
@@ -382,8 +393,8 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         # validate the invoice
         invoice1.action_post()
 
-        self.assertFalse(timesheet1.timesheet_invoice_id, "The timesheet1 should not be linked to the invoice, even after invoice validation")
-        self.assertFalse(timesheet2.timesheet_invoice_id, "The timesheet2 should not be linked to the invoice, even after invoice validation")
+        self.assertEqual(timesheet1.timesheet_invoice_id, invoice1, "After validating the invoice1, the timesheet1 should be linked to it, since the service policy of the sol product of the timesheet is delivered_manual")
+        self.assertFalse(timesheet2.timesheet_invoice_id, "After validating the invoice1, the timesheet2 should still not be linked to it, since the timesheet is non-billable")
 
     def test_timesheet_invoice(self):
         """ Test to create invoices for the sale order with timesheets
@@ -1197,6 +1208,117 @@ class TestSaleTimesheet(TestCommonSaleTimesheet):
         credit_note.action_post()
         self.assertFalse(timesheet1.timesheet_invoice_id, "Timesheet1 should be cleared after partial refund of its task")
         self.assertEqual(timesheet2.timesheet_invoice_id, invoice2, "Timesheet2 should still be linked to the original invoice")
+
+    def test_timesheet_ordered_prepaid_link_to_invoice(self):
+        sale_order = self.env['sale.order'].create({
+            'name': 'SO Test',
+            'partner_id': self.partner_a.id,
+        })
+        so_line = self.env['sale.order.line'].create({
+            'product_id': self.product_order_timesheet2.id,
+            'product_uom_qty': 10,
+            'order_id': sale_order.id,
+        })
+        sale_order.action_confirm()
+        self.env['account.analytic.line'].create({
+            'name': 'Timesheet 1',
+            'project_id': self.project_global.id,
+            'unit_amount': 10,
+            'employee_id': self.employee_manager.id,
+            'so_line': so_line.id,
+            'is_so_line_edited': True,
+        })
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Timesheet 2',
+            'project_id': self.project_global.id,
+            'unit_amount': 20,
+            'employee_id': self.employee_manager.id,
+            'so_line': so_line.id,
+        })
+        self.assertEqual(
+            timesheet.timesheet_invoice_id,
+            invoice,
+            "For ordered prepaid services, the created timesheet should be linked to the most recent posted invoice "
+            "linked to the SOL of the timesheet.",
+        )
+        invoice._reverse_moves()
+        self.assertFalse(
+            timesheet.timesheet_invoice_id,
+            "Reversing the invoice should unlink timesheets of that type from the invoice.",
+        )
+
+    def test_timesheet_delivered_milestones_link_to_invoice(self):
+        self.product_milestone.service_tracking = 'project_only'
+        sale_order = self.env['sale.order'].create({
+            'name': 'SO Test',
+            'partner_id': self.partner_a.id,
+        })
+        so_line = self.env['sale.order.line'].create({
+            'product_id': self.product_milestone.id,
+            'product_uom_qty': 10,
+            'order_id': sale_order.id,
+        })
+        sale_order.action_confirm()
+        sale_order.project_id.milestone_ids.is_reached = True
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Timesheet',
+            'project_id': sale_order.project_id.id,
+            'unit_amount': 10,
+            'employee_id': self.employee_manager.id,
+            'so_line': so_line.id,
+            'is_so_line_edited': True,
+        })
+        invoice = sale_order._create_invoices()
+        invoice.action_post()
+        self.assertEqual(
+            invoice.timesheet_ids,
+            timesheet,
+            "For milestones services, the timesheet should be linked to the invoice as the milestone was marked as reached.",
+        )
+        invoice._reverse_moves()
+        self.assertFalse(
+            timesheet.timesheet_invoice_id,
+            "Reversing the invoice should unlink timesheets of that type from the invoice.",
+        )
+
+    @freeze_time('2023-10-03')
+    def test_timesheet_delivered_manual_link_to_invoice(self):
+        sale_order = self.env['sale.order'].create({
+            'name': 'SO Test',
+            'partner_id': self.partner_a.id,
+        })
+        so_line = self.env['sale.order.line'].create({
+            'product_id': self.product_delivery_manual2.id,
+            'product_uom_qty': 10,
+            'order_id': sale_order.id,
+        })
+        sale_order.action_confirm()
+        timesheet = self.env['account.analytic.line'].create({
+            'name': 'Timesheet',
+            'project_id': self.project_global.id,
+            'unit_amount': 10,
+            'employee_id': self.employee_manager.id,
+            'so_line': so_line.id,
+            'is_so_line_edited': True,
+            'date': Date.today() - timedelta(days=1),
+        })
+        so_line.qty_delivered = 10
+        invoice = sale_order._create_invoices()
+        invoice.invoice_date = Date.today()
+        invoice.action_post()
+        self.assertEqual(
+            invoice.timesheet_ids,
+            timesheet,
+            "For delivered manual services, the timesheet should be linked to the invoice as the timesheets's date is before "
+            "or equal to the invoice's date.",
+        )
+        invoice._reverse_moves()
+        self.assertFalse(
+            timesheet.timesheet_invoice_id,
+            "Reversing the invoice should unlink timesheets of that type from the invoice.",
+        )
 
 
 @tagged('-at_install', 'post_install')

--- a/addons/sale_timesheet/views/account_invoice_views.xml
+++ b/addons/sale_timesheet/views/account_invoice_views.xml
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
+    <record id="view_kanban_account_analytic_line" model="ir.ui.view">
+        <field name="name">account.analytic.line.kanban.inherit.sale_timesheet</field>
+        <field name="model">account.analytic.line</field>
+        <field name="inherit_id" ref="hr_timesheet.view_kanban_account_analytic_line"/>
+        <field name="arch" type="xml">
+            <xpath expr="//kanban" position="attributes">
+                <attribute name="js_class" remove="timesheet_timer_kanban"/>
+            </xpath>
+        </field>
+    </record>
+
     <record id="action_timesheet_from_invoice" model="ir.actions.act_window">
         <field name="name">Timesheets</field>
         <field name="res_model">account.analytic.line</field>
         <field name="view_mode">list,form,graph,pivot,kanban</field>
         <field name="context">{
             'create': False,
-            'edit': False,
             'delete': False,
             "is_timesheet": 1,
         }</field>
@@ -25,7 +35,7 @@
     <record id="action_timesheet_from_invoice_view_tree" model="ir.actions.act_window.view">
         <field name="sequence" eval="1"/>
         <field name="view_mode">list</field>
-        <field name="view_id" ref="hr_timesheet.hr_timesheet_line_tree"/>
+        <field name="view_id" ref="hr_timesheet.timesheet_view_tree_user"/>
         <field name="act_window_id" ref="action_timesheet_from_invoice"/>
     </record>
 
@@ -39,7 +49,7 @@
     <record id="action_timesheet_from_invoice_view_kanban" model="ir.actions.act_window.view">
         <field name="sequence" eval="5"/>
         <field name="view_mode">kanban</field>
-        <field name="view_id" ref="hr_timesheet.view_kanban_account_analytic_line"/>
+        <field name="view_id" ref="view_kanban_account_analytic_line"/>
         <field name="act_window_id" ref="action_timesheet_from_invoice"/>
     </record>
 

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -43,6 +43,8 @@
                 <field name="is_so_line_edited" column_invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="allow_billable" column_invisible="True" groups="sales_team.group_sale_salesman"/>
                 <field name="so_line" widget="so_line_field" optional="show" options="{'no_create': True, 'no_open': True}" context="{'create': False, 'edit': False, 'delete': False}" invisible="not allow_billable" readonly="readonly_timesheet" column_invisible="context.get('hide_so_line')" placeholder="Non-billable" groups="sales_team.group_sale_salesman"/>
+                <field name="service_policy" column_invisible="True" groups="sales_team.group_sale_salesman"/>
+                <field name="timesheet_invoice_id" optional="hide" invisible="not allow_billable" readonly="readonly_timesheet or not so_line or service_policy == 'delivered_timesheet'" options="{'no_create': True, 'no_open': True}" groups="account.group_account_invoice"/>
             </xpath>
         </field>
     </record>

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -3,7 +3,7 @@
 
     <template id="sale_order_portal_content_inherit" inherit_id="sale.sale_order_portal_template">
         <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="inside">
-            <t t-if="sale_order.timesheet_count > 0 and sale_order.state == 'sale' and sale_order.env['account.analytic.line']._show_portal_timesheets()">
+            <t t-if="sale_order._has_timesheet_portal() and sale_order.state == 'sale' and sale_order.env['account.analytic.line']._show_portal_timesheets()">
                 <a class="btn btn-light flex-grow-1" t-att-href="'/my/timesheets?search_in=so&amp;search=%s' % sale_order.name" title="View Timesheets" target="_blank" role="button">View Timesheets</a>
             </t>
         </xpath>
@@ -73,10 +73,10 @@
 
     <template id="portal_invoice_page_inherit" inherit_id="account.portal_invoice_page">
         <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="after">
-            <t t-if="invoice.timesheet_count > 0 and invoice.env['account.analytic.line']._show_portal_timesheets()">
+            <t t-if="invoice._has_timesheet_portal() and invoice.env['account.analytic.line']._show_portal_timesheets()">
                 <t t-set="search_value" t-value="invoice.name"/>
                 <t t-if="invoice.state == 'draft'" t-set="search_value" t-value="invoice.id"/>
-                <a t-if="invoice.move_type == 'out_invoice' and invoice.state in ('draft', 'posted') and invoice.timesheet_count > 0"
+                <a t-if="invoice.move_type == 'out_invoice' and invoice.state in ('draft', 'posted')"
                     target="_blank" t-att-href="'/my/timesheets?search_in=invoice&amp;search=%s' % search_value" class="btn btn-light" role="button" title="View Timesheet">View Timesheets</a>
             </t>
         </xpath>


### PR DESCRIPTION
The rationale behind this commit is that, normally, only timesheets of services with invoicing policy based on timesheets can be linked to an invoice.
After this commit, we allow timesheets of other types of invoicing policy to be able to get linked to invoices.
Doing so, we improve the timesheets reporting.

This commit introduces the following changes:

- For timesheets of services with prepaid/fixed price invoicing policy:
At timesheet creation, it is now automatically linked to one of the invoices of the SOL of the timesheet.
By default, we choose the most recent posted invoice (that is not a credit note).

- For timesheets of services with milestones invoicing policy:
At invoice confirmation, the timesheets from the SO are now automatically linked to the invoice under the following conditions:
    - The timesheets must be timesheeted in a task that has been set as reached
    - The timesheets must not already be linked to another invoice

- For timesheets of services with delivered quantity (manual) invoicing policy:
At invoice confirmation, the timesheet from the SO are now automatically linked to the invoice under the following conditions:
    - The timesheets's date must be before or equal to the invoice's date
    - The timesheets must not already be linked to another invoice

- When a confirmed invoice is set back to draft or reversed by a credit note, the timesheets of types mentioned above are
unlinked from the invoice.

- From the "Recorded" stat button of invoices, it is no longer possible to create new timesheets using the "Start" button.
Instead, we can create them using the "New" button (regular record creation). When creating new timesheets this way, it will
prefill some fields based on the first SOL of services of types mentioned above.

- It's now possible to edit the invoice field of a timesheet in the list view for timesheets of types mentioned above.
The domain excludes draft invoices but includes credit notes and regular posted invoices.
The edition of the invoice field is available under the following conditions:
    - The SOL must be defined
    - The project must be billable

- The button "View Timesheets" of sale orders and invoices in portal is hidden if there is no timesheet linked to the SO/Invoice.

- The tests have been adapted to match the new specifications.

task-3619757