### PR TITLE
[FIX] l10n_be_pos_sale: remove debbugers

### DIFF
--- a/addons/l10n_be_pos_sale/static/src/js/models.js
+++ b/addons/l10n_be_pos_sale/static/src/js/models.js
@@ -6,9 +6,7 @@ import { patch } from "@web/core/utils/patch";
 patch(Order.prototype, "l10n_be_pos_sale.order", {
     async pay() {
         const _super = this._super;
-        debugger;
         const has_origin_order = this.get_orderlines().some(line => line.sale_order_origin_id);
-        debugger;
         if (this.pos.company.country && this.pos.company.country.code === "BE" && has_origin_order) {
             this.to_invoice = true;
         }


### PR DESCRIPTION
Debuggers where left in the code and not detected by the linter. https://github.com/odoo/odoo/pull/147950

opw-3574913
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
