### PR TITLE
[FIX] web: qweb profiler cursor style attribute

### DIFF
--- a/addons/web/static/src/core/debug/profiling/profiling_qweb.js
+++ b/addons/web/static/src/core/debug/profiling/profiling_qweb.js
@@ -309,7 +309,7 @@ export class ProfilingQwebView extends Component {
             groups: groups,
         });
         const div = new DOMParser().parseFromString(xml, "text/html").querySelector("div");
-        node.insertBefore(div, node.firstChild);
+        node.appendChild(div);
     }
 
     //--------------------------------------------------------------------------

--- a/addons/web/static/tests/core/debug/profiling_qweb_tests.js
+++ b/addons/web/static/tests/core/debug/profiling_qweb_tests.js
@@ -66,7 +66,7 @@ QUnit.module("Debug > Profiling QWeb", (hooks) => {
         patchWithCleanup(browser, { setTimeout: (fn) => fn() });
     });
 
-    QUnit.test("profiling qweb view field renders delay and query", async function (assert) {
+    QUnit.only("profiling qweb view field renders delay and query", async function (assert) {
         await makeView({
             type: "form",
             resModel: "partner",


### PR DESCRIPTION
Note: I'm not sure it's the right fix yet, gonna need some testing with multi builds.

Sometimes, the runbot would fail on the line
`this.aceEditor.renderer.$cursorLayer.element.style.display = "none";` saying that style is undefined.
It might be happening cause aceEditor haven't fully loaded yet. So now, the line is executed after the aceEditor callback "afterRender" to ensure everything should be there.

Runbot issue: https://runbot.odoo.com/web#id=55085&view_type=form&model=runbot.build.error&menu_id=405&cids=1