### PR TITLE
[FIX] web: fix nested form views arch pieces in main view

### DIFF
--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -199,7 +199,9 @@ export class Field extends Component {
                     },
                     domain() {
                         if (fieldInfo.domain) {
-                            return new Domain(evaluateExpr(fieldInfo.domain, record.evalContext)).toList();
+                            return new Domain(
+                                evaluateExpr(fieldInfo.domain, record.evalContext)
+                            ).toList();
                         }
                         return getFieldDomain(record, fieldInfo.name);
                     },
@@ -330,7 +332,8 @@ Field.parseFieldNode = function (node, models, modelName, viewType, jsClass) {
         for (const child of node.children) {
             const viewType = child.tagName === "tree" ? "list" : child.tagName;
             const { ArchParser } = viewRegistry.get(viewType);
-            const archInfo = new ArchParser().parse(child, models, fields[name].relation);
+            const childCopy = child.cloneNode(true);
+            const archInfo = new ArchParser().parse(childCopy, models, fields[name].relation);
             views[viewType] = {
                 ...archInfo,
                 limit: archInfo.limit || 40,

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -533,14 +533,16 @@ export class X2ManyFieldDialog extends Component {
 
         this.canCreate = !this.record.resId;
 
-        if (this.archInfo.xmlDoc.querySelector("footer")) {
+        if (this.archInfo.xmlDoc.querySelector("footer:not(field footer)")) {
             this.footerArchInfo = Object.assign({}, this.archInfo);
             this.footerArchInfo.xmlDoc = createElement("t");
             this.footerArchInfo.xmlDoc.append(
-                ...[...this.archInfo.xmlDoc.querySelectorAll("footer")]
+                ...[...this.archInfo.xmlDoc.querySelectorAll("footer:not(field footer)")]
             );
             this.footerArchInfo.arch = this.footerArchInfo.xmlDoc.outerHTML;
-            [...this.archInfo.xmlDoc.querySelectorAll("footer")].forEach((x) => x.remove());
+            [...this.archInfo.xmlDoc.querySelectorAll("footer:not(field footer)")].forEach((x) =>
+                x.remove()
+            );
             this.archInfo.arch = this.archInfo.xmlDoc.outerHTML;
         }
 

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -178,7 +178,9 @@ export class FormController extends Component {
             this.archInfo.arch = this.archInfo.xmlDoc.outerHTML;
         }
 
-        const xmlDocButtonBox = this.archInfo.xmlDoc.querySelector("div[name='button_box']");
+        const xmlDocButtonBox = this.archInfo.xmlDoc.querySelector(
+            "div[name='button_box']:not(field div)"
+        );
         if (xmlDocButtonBox) {
             const buttonBoxTemplates = useViewCompiler(
                 this.props.Compiler || FormCompiler,

--- a/addons/web/static/tests/views/form/form_view_tests.js
+++ b/addons/web/static/tests/views/form/form_view_tests.js
@@ -14444,4 +14444,33 @@ QUnit.module("Views", (hooks) => {
             );
         }
     );
+
+    QUnit.test("nested form view doesn't parasite the main one", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                <form>
+                    <field name="p">
+                        <form>
+                            <div name="button_box" invisible="crash == True">
+                                <button name="somename" type="object" />
+                            </div>
+                            <footer>
+                                <button name="somename" type="object" />
+                            </footer>
+                        </form>
+                        <tree>
+                            <field name="display_name" />
+                        </tree>
+                    </field>
+                </form>`,
+            resId: 2,
+        });
+        assert.containsOnce(target, ".o_form_view");
+        assert.containsNone(target, ".o-form-buttonbox");
+        await click(target, ".o_field_x2many_list_row_add a");
+        assert.containsOnce(target, ".modal .modal-footer button[name='somename']");
+    });
 });


### PR DESCRIPTION
Since [1], the same document representing the arch of a view is used everywhere (as opposed to serializing/parsing a node).

Also, because of [2], the form view selected its button box with a naive selector that did not take into account the fact that there could be nested form views.

In practice, it means that some pieces of a nested view could be compiled and rendered in the scope of the main form view, inevitably leading to crashes because, among other things, the evaluation context was wrong.

This commit fixes this: the same arch document is used but, at some key points, nodes are cloned and selectors take nested views into account.

opw-3681966

[1]: cc3a3a328db913da76573404967e1190f40bcc98
[2]: 824024f8aaa4a5419646d4eec7f529277869ceac

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
