### PR TITLE
[FIX] web_editor: image content type issue

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -401,6 +401,15 @@ class Web_Editor(http.Controller):
                 'type': 'url',
                 'url': url,
             })
+            # The code issues a HEAD request to retrieve headers from the URL.
+            # This approach is beneficial when the URL doesn't conclude with an
+            # image extension. By verifying the MIME type, the code ensures that
+            # only supported image types are incorporated into the data.
+            response = requests.head(url, timeout=10)
+            if response.status_code == 200:
+                mime_type = response.headers['content-type']
+                if mime_type in SUPPORTED_IMAGE_MIMETYPES:
+                    attachment_data['mimetype'] = mime_type
         else:
             raise UserError(_("You need to specify either data or url to create an attachment."))
 

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.js
@@ -117,8 +117,10 @@ export class FileSelectorControlPanel extends Component {
             showUrlInput: false,
             urlInput: '',
             isValidUrl: false,
-            isValidFileFormat: false
+            isValidFileFormat: false,
+            isValidatingUrl: false,
         });
+        this.debouncedValidateUrl = useDebounced(this.props.validateUrl, 500);
 
         this.fileInput = useRef('file-input');
     }
@@ -140,10 +142,12 @@ export class FileSelectorControlPanel extends Component {
         }
     }
 
-    onUrlInput(ev) {
-        const { isValidUrl, isValidFileFormat } = this.props.validateUrl(ev.target.value);
+    async onUrlInput(ev) {
+        this.state.isValidatingUrl = true;
+        const { isValidUrl, isValidFileFormat } = await this.debouncedValidateUrl(ev.target.value);
         this.state.isValidFileFormat = isValidFileFormat;
         this.state.isValidUrl = isValidUrl;
+        this.state.isValidatingUrl = false;
     }
 
     onClickUpload() {

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.xml
@@ -22,9 +22,10 @@
                     <t t-esc="props.addText"/>
             </button>
             <div class="d-flex align-items-center">
-                <span t-if="state.urlInput and state.isValidUrl and state.isValidFileFormat" class="o_we_url_success text-success mx-2 fa fa-lg fa-check" title="The URL seems valid."/>
-                <span t-if="state.urlInput and !state.isValidUrl" class="o_we_url_error text-danger mx-2 fa fa-lg fa-times" title="The URL does not seem to work."/>
-                <span t-if="props.urlWarningTitle and state.urlInput and state.isValidUrl and !state.isValidFileFormat" class="o_we_url_warning text-warning mx-2 fa fa-lg fa-warning" t-att-title="props.urlWarningTitle"/>
+                <span t-if="state.urlInput and state.isValidatingUrl" class="o_we_url_loading mx-2 fa fa-lg fa-spinner" title="Loading..."/>
+                <span t-elif="state.urlInput and state.isValidUrl and state.isValidFileFormat" class="o_we_url_success text-success mx-2 fa fa-lg fa-check" title="The URL seems valid."/>
+                <span t-elif="state.urlInput and !state.isValidUrl" class="o_we_url_error text-danger mx-2 fa fa-lg fa-times" title="The URL does not seem to work."/>
+                <span t-elif="props.urlWarningTitle and state.urlInput and state.isValidUrl and !state.isValidFileFormat" class="o_we_url_warning text-warning mx-2 fa fa-lg fa-warning" t-att-title="props.urlWarningTitle"/>
             </div>
         </div>
         <input type="file" class="d-none o_file_input" t-on-change="onChangeFileInput" t-ref="file-input" t-att-accept="props.accept" t-att-multiple="props.multiSelect and 'multiple'"/>

--- a/addons/web_editor/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/image_selector.js
@@ -187,10 +187,15 @@ export class ImageSelector extends FileSelector {
         });
     }
 
-    validateUrl(...args) {
+    async validateUrl(...args) {
         const { isValidUrl, path } = super.validateUrl(...args);
-        const isValidFileFormat = IMAGE_EXTENSIONS.some(format => path.endsWith(format));
-        return { isValidFileFormat, isValidUrl };
+        const isValidFileFormat = isValidUrl && await new Promise(resolve => {
+            const img = new Image();
+            img.src = path;
+            img.onload = () => resolve(true);
+            img.onerror = () => resolve(false);
+        });
+        return { isValidUrl, isValidFileFormat };
     }
 
     isInitialMedia(attachment) {


### PR DESCRIPTION
Description:

Previously, when attempting to insert an image via URL, the system incorrectly
flagged certain valid image URLs as unsupported due to a limited validation
method based solely on file extensions. This resulted in users being unable to
insert valid images into the editor even when the URLs contained valid image content.

This PR addresses the problem by enhancing the URL validation process on the
client side. The system now checks whether the URL actually loads an image when
used as an image source. In cases where this method fails the URLs are validated
based on their content type. Only if both validation methods fail will the URL be
considered invalid for image insertion.

Desired behavior after PR is merged:

Users are now able to successfully insert images from valid URLs.

task-3323862

Co-authored-by: Deependra Solanki <deso@odoo.com>