### PR TITLE
[FIX] web : adjust dropdown interfered display in documents module

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -41,6 +41,8 @@
         thead {
             background-color: var(--ListRenderer-thead-bg-color);
             color: $headings-color;
+            position: sticky;
+            z-index: 1;
 
             th:not(.o_list_record_selector) {
                 border-left: $border-width solid var(--ListRenderer-thead-border-end-color);


### PR DESCRIPTION
**Steps to reproduce:**
	1- Install Documents module
	2- Go to documents list view
	3- Click on the dropdown menu for additional fields selection

**Current behavior before PR:**
The dropdown menu for additional fields selection in documents list view is interfered with the table cells so the user will not be able to select the wanted option.
![image](https://github.com/odoo/odoo/assets/145127917/48de24be-00a3-4522-b80a-cc253050b066)


**Desired behavior after PR is merged:**
The view has been adjusted by adding a z-index for the table head css that is less than the z-index for the dropdown menu so the dropdown menu will be visible over the table cells when opened.
![image](https://github.com/odoo/odoo/assets/145127917/2a3ed45b-fc07-49d9-a744-61bd161916cf)


opw-3682703