### PR TITLE
[FIX] l10n_sa_invoice: prevent OverflowError while print invoice

### DIFF
--- a/addons/l10n_sa_invoice/models/account_move.py
+++ b/addons/l10n_sa_invoice/models/account_move.py
@@ -30,7 +30,8 @@ class AccountMove(models.Model):
         def get_qr_encoding(tag, field):
             company_name_byte_array = field.encode()
             company_name_tag_encoding = tag.to_bytes(length=1, byteorder='big')
-            company_name_length_encoding = len(company_name_byte_array).to_bytes(length=1, byteorder='big')
+            company_name_len = len(company_name_byte_array)
+            company_name_length_encoding = company_name_len.to_bytes(length=(company_name_len.bit_length() + 7) // 8, byteorder='big')
             return company_name_tag_encoding + company_name_length_encoding + company_name_byte_array
 
         for record in self:


### PR DESCRIPTION
When  user  enter very large company name  and try to generate invoice and click send&print button a traceback will be appear.

Steps to reproduce error:

-Download `l10n_sa_invoice` module
-Switch to `SA COMPANY`
-Update Company Name that exceed the length of `255` char & add QR Codes from invoice setings. 
-Go to invoicing app and create a customer invoice add a line and save the record.
-Click the `Send & Print` button
-Error will be generated

Traceback:
```OverflowError: int too big to convert
  File "<845>", line 2230, in template_845
  File "<845>", line 2212, in template_845_content
  File "<845>", line 154, in template_845_t_call_0
  File "<845>", line 109, in template_845_t_set_2
  File "odoo/fields.py", line 1206, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4858, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/l10n_sa/models/account_move.py", line 38, in _compute_qr_code_str
    seller_name_enc = get_qr_encoding(1, record.company_id.display_name)
  File "addons/l10n_sa/models/account_move.py", line 32, in get_qr_encoding
    company_name_length_encoding = len(company_name_byte_array).to_bytes(length=1, byteorder='big')
QWebException: Error while render the template
OverflowError: int too big to convert
Template: ir.ui.view(845,)
Path: /t/t/t[4]/p/img
Node: <img t-if="o.l10n_sa_qr_code_str" style="display:block;" t-att-src="\'/report/barcode/?barcode_type=%s&amp;value=%s&amp;width=%s&amp;height=%s\'%(\'QR\', quote_plus(o.l10n_sa_qr_code_str), 200, 200)"/>
  File "odoo/http.py", line 2150, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1722, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1749, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1953, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/account/wizard/account_move_send.py", line 712, in action_send_and_print
    return self._process_send_and_print(
  File "addons/account/wizard/account_move_send.py", line 657, in _process_send_and_print
    self._generate_invoice_documents(moves_data, allow_fallback_pdf=allow_fallback_pdf)
  File "addons/account/wizard/account_move_send.py", line 583, in _generate_invoice_documents
    self._prepare_invoice_pdf_report(invoice, invoice_data)
  File "addons/account/wizard/account_move_send.py", line 375, in _prepare_invoice_pdf_report
    content, _report_format = self.env['ir.actions.report']._render('account.account_invoices', invoice.ids)
  File "odoo/addons/base/models/ir_actions_report.py", line 948, in _render
    return render_func(report_ref, res_ids, data=data)
  File "addons/account/models/ir_actions_report.py", line 58, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "odoo/addons/base/models/ir_actions_report.py", line 839, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "addons/account/models/ir_actions_report.py", line 20, in _render_qweb_pdf_prepare_streams
    return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "odoo/addons/base/models/ir_actions_report.py", line 727, in _render_qweb_pdf_prepare_streams
    html = self.with_context(**additional_context)._render_qweb_html(report_ref, res_ids_wo_stream, data=data)[0]
  File "odoo/addons/base/models/ir_actions_report.py", line 916, in _render_qweb_html
    return self._render_template(report.report_name, data), 'html'
  File "odoo/addons/base/models/ir_actions_report.py", line 653, in _render_template
    return view_obj._render_template(template, values).encode()
  File "odoo/addons/base/models/ir_ui_view.py", line 2048, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "odoo/tools/profiler.py", line 292, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "odoo/addons/base/models/ir_qweb.py", line 593, in _render
    result = ''.join(rendering)
  File "<740>", line 38, in template_740
  File "<740>", line 27, in template_740_content
  File "<739>", line 107, in template_739
  File "<739>", line 89, in template_739_content
  File "<739>", line 77, in template_739_t_call_0
  File "<845>", line 2236, in template_845
```
This is because when company name exceed its length and at [1] try to convert in `to_bytes`.

This commit solve the above issue by calculating the required length of `to_bytes` function.

https://github.com/odoo/odoo/blob/00d0a2d2df3537587af8f153f26ccd972ffacdfe/addons/l10n_sa_invoice/models/account_move.py#L33

sentry-4737012151
