### PR TITLE
[IMP] base: report_render() to render PDF using API

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -921,10 +921,27 @@ class IrActionsReport(models.Model):
     @api.model
     def _render(self, report_ref, res_ids, data=None):
         report = self._get_report(report_ref)
-        report_type = report.report_type.lower().replace('-', '_')
+        report_type = report.report_type.replace('-', '_')
         render_func = getattr(self, '_render_' + report_type, None)
         if not render_func:
             return None
+        return render_func(report_ref, res_ids, data=data)
+
+    def report_render(self, report_ref, res_ids, data=None, converter=None):
+        """Return the rendered report
+
+        :param report_ref: The report id, record or name
+        :param res_ids: ids of the records to print
+        :param data:
+        :param converter: The requested output like pdf, html or text
+        :rtype: bytes, str
+        """
+        report = self._get_report(report_ref)
+        report_type = 'qweb_' + converter if converter else report.report_type.replace('-', '_')
+        try:
+            render_func = getattr(self, '_render_' + report_type)
+        except AttributeError:
+            raise ValueError('Invalid report type: %s' % report_type) from None
         return render_func(report_ref, res_ids, data=data)
 
     def report_action(self, docids, data=None, config=True):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Add a method to be able to render ir.actions.report using the RPC API.

Current behavior before PR:
The existing methods to render the reports are private.

Desired behavior after PR is merged:
Have a public method that can be called via RPC.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
