### PR TITLE
[FIX] partner_autocomplete: fix quick creation issue

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -18,7 +18,12 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
     }
 
     get sources() {
-        return super.sources.concat(
+        const sources = super.sources;
+        if (!this.props.quickCreate)
+        {
+            return sources;
+        }
+        return sources.concat(
             {
                 options: async (request) => {
                     if (this.validateSearchTerm(request)) {

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -358,4 +358,24 @@ QUnit.module('partner_autocomplete', {
         await triggerEvent(input, null, "blur");
         assert.containsOnce(target, ".modal-open");
     });
+
+    QUnit.test("Hide auto complate suggestion for no create", async function (assert) {
+        const partnerMakeViewParams = {
+            ...makeViewParams,
+            arch:
+                `<form>
+                    <field name="company_type"/>
+                    <field name="parent_id" widget="res_partner_many2one" options="{'no_create': True}"/>
+                </form>`
+        }
+        await makeView(partnerMakeViewParams);
+        const input = target.querySelector("[name='parent_id'] input");
+        await editInputNoChangeEvent(input, "blabla");
+        const autocompleteContainer = input.parentElement;
+        assert.containsNone(
+            autocompleteContainer,
+            ".o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one",
+            "There should be no option when partner field has no_create attribute"
+        );
+    });
 });

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -198,23 +198,23 @@ QUnit.module('partner_autocomplete', {
         assert.doesNotHaveClass(nameInput, 'o-autocomplete--input', "The input for field 'name' should be a regular input");
 
         const companyInput = target.querySelector("[name='parent_id'] input");
+        const autocompleteContainer = companyInput.parentElement;
 
         await click(companyInput, null);
         assert.containsNone(
-            companyInput,
-            ".o-autocomplete--dropdown-menu",
+            autocompleteContainer,
+            ".o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one",
             "There should be no option when input is empty"
         );
 
         await editInputNoChangeEvent(companyInput, "od");
         assert.containsNone(
-            companyInput,
-            ".o-autocomplete--dropdown-menu",
+            autocompleteContainer,
+            ".o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one",
             "There should be no option when the length of the query is < 3"
         );
 
         await editInputNoChangeEvent(companyInput, "company");
-        const autocompleteContainer = companyInput.parentElement;
         assert.containsN(
             autocompleteContainer,
             ".o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one",
@@ -251,23 +251,23 @@ QUnit.module('partner_autocomplete', {
         await editSelect(target, "[name='company_type'] > select", '"company"');
 
         const input = target.querySelector("[name='name'] .dropdown input");
+        const autocompleteContainer = input.parentElement;
 
         await click(input, null);
         assert.containsNone(
-            input,
-            ".o-autocomplete--dropdown-menu",
+            autocompleteContainer,
+            ".o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one",
             "There should be no option when input is empty"
         );
 
         await editInputNoChangeEvent(input, "od");
         assert.containsNone(
-            input,
-            ".o-autocomplete--dropdown-menu",
+            autocompleteContainer,
+            ".o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one",
             "There should be no option when the length of the query is < 3"
         );
 
         await editInputNoChangeEvent(input, "company");
-        const autocompleteContainer = input.parentElement;
         assert.containsN(
             autocompleteContainer,
             ".o-autocomplete--dropdown-item",
@@ -304,23 +304,23 @@ QUnit.module('partner_autocomplete', {
         await editSelect(target, "[name='company_type'] > select", '"company"');
 
         const input = target.querySelector("[name='vat'] .dropdown input");
+        const autocompleteContainer = input.parentElement;
 
         await click(input, null);
         assert.containsNone(
-            input,
-            ".o-autocomplete--dropdown-menu",
+            autocompleteContainer,
+            ".o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one",
             "There should be no option when input is empty"
         );
 
         await editInputNoChangeEvent(input, "blabla");
         assert.containsNone(
-            input,
-            ".o-autocomplete--dropdown-menu",
+            autocompleteContainer,
+            ".o-autocomplete--dropdown-item.partner_autocomplete_dropdown_many2one",
             "There should be no option when the value doesn't have a valid VAT number format"
         );
 
         await editInputNoChangeEvent(input, "BE0477472701");
-        const autocompleteContainer = input.parentElement;
         assert.containsN(
             autocompleteContainer,
             ".o-autocomplete--dropdown-item",


### PR DESCRIPTION
Before this commit auto complete suggestion were showing on partner field even though there is no_create attribute on partner field and because of that user can create partner record from that field even though user is not allow to create record from it and also it gives trackback in partner portal field because of access_token.

This commit prevent auto complete suggestion when partner field has no_create attribute set on them to avoid unnecessary partner creation from that field.

task-3690532
