### PR TITLE
[FIX] mrp: compute date stock move

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -721,12 +721,14 @@ class MrpProduction(models.Model):
             else:
                 production.move_raw_ids = [Command.delete(move.id) for move in production.move_raw_ids.filtered(lambda m: m.bom_line_id)]
 
-    @api.depends('product_id', 'bom_id', 'product_qty', 'product_uom_id', 'location_dest_id', 'date_planned_finished', 'move_dest_ids')
+    @api.depends('product_id', 'bom_id', 'product_qty', 'product_uom_id', 'location_dest_id', 'date_planned_finished', 'date_finished', 'move_dest_ids')
     def _compute_move_finished_ids(self):
         for production in self:
             if production.state != 'draft':
                 updated_values = {}
-                if production.date_planned_finished:
+                if production.date_finished:
+                    updated_values['date'] = production.date_finished
+                elif production.date_planned_finished:
                     updated_values['date'] = production.date_planned_finished
                 if production.date_deadline:
                     updated_values['date_deadline'] = production.date_deadline


### PR DESCRIPTION
Step:
+ Create MO, produce delay of product = 2 day, date planned start on MO
= 2024/01/19 => date planned finished = 2024/01/18 + 2 days =
2024/01/20.
+ Done MO in 2024/01/19, check move finished has date = 2024/01/20 ->
Wrong date ??

After done the MO, the processing date of move finished
should be date_finished of MO instead of compute =
date planned finished of MO

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
