### PR TITLE
[FIX] event_sale: set default value as free for sale status 

### DIFF
--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -15,7 +15,7 @@ class EventRegistration(models.Model):
             ('to_pay', 'Not Sold'),
             ('sold', 'Sold'),
             ('free', 'Free'),
-        ], compute="_compute_registration_status", compute_sudo=True, store=True)
+        ], compute="_compute_registration_status", compute_sudo=True, store=True, default="free")
     state = fields.Selection(default=None, compute="_compute_registration_status", store=True, readonly=False)
     utm_campaign_id = fields.Many2one(compute='_compute_utm_campaign_id', readonly=False,
         store=True, ondelete="set null")

--- a/addons/event_sale/tests/__init__.py
+++ b/addons/event_sale/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_event_internals
+from . import test_event_registration
 from . import test_event_sale
 from . import test_event_sale_ui
 from . import test_event_specific

--- a/addons/event_sale/tests/test_event_registration.py
+++ b/addons/event_sale/tests/test_event_registration.py
@@ -1,0 +1,20 @@
+from odoo.addons.event_sale.tests.common import TestEventSaleCommon
+
+class TestEventRegistration(TestEventSaleCommon):
+
+    def test_event_registration_without_sale_order_id(self):
+        """
+        Test the creation of an event registration without a sale order.
+        """
+        # Create a registration and generate a QR code for the existing event
+        registration = self.env['event.registration'].create({
+            'name': 'Test',
+            'event_id': self.event_0.id,
+            'state': 'draft'
+        })
+        registration_summary = registration._get_registration_summary()
+
+        self.assertEqual(registration_summary['event_display_name'], 'TestEvent')
+        self.assertEqual(registration_summary['name'], 'Test')
+        self.assertEqual(registration_summary['ticket_name'], 'None')
+        self.assertEqual(registration_summary['sale_status_value'], 'Free')


### PR DESCRIPTION
Currently an error occurs when the user is scanning a badge that is not linked
to a sale order.

Steps to Reproduce:
- Install 'event_sale' module.
- Go to Events > Registration Desk ; click on Select Attendee >> New.
- Select any Event and then save it, A pdf having QR code would be generated.
- Now download that pdf.
- Go back to Events > Registration Desk ; click on Scan a Badge(Tap to scan) and
  scan your QR Code.
- The error would be generated.

Traceback on sentry:
```
KeyError: False
  File "odoo/http.py", line 2150, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1722, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1749, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1953, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 464, in call_kw
    result = _call_kw_model(method, model, args, kwargs)
  File "odoo/api.py", line 435, in _call_kw_model
    result = method(recs, *args, **kwargs)
  File "addons/event/models/event_registration.py", line 161, in register_attendee
    res = attendee._get_registration_summary()
  File "addons/event_sale/models/event_registration.py", line 136, in _get_registration_summary
    'sale_status_value': dict(self._fields['sale_status']._description_selection(self.env))[self.sale_status],
```
This error arises at [1] when it attempts to access the dictionary with the key
'self.sale_status', but when 'self.sale_status' was False or not set, it
resulted in a KeyError.

This commit fixes the above issue by giving 'free' as the default value of sale
status as there is no sale order available. 

Link: [1]-https://github.com/odoo/odoo/blob/c1d250fcbc178eaee1694197b759d3717e3b50e6/addons/event_sale/models/event_registration.py#L136

sentry-4620674401


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
