### PR TITLE
[FIX] account: ignore missing data when loading branch's chart template

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -426,7 +426,8 @@ class AccountChartTemplate(models.AbstractModel):
                     or (field.type in ('integer', 'many2one_reference') and not value.isdigit())
                 ):
                     try:
-                        values[fname] = self.ref(value).id if value not in ('', 'False', 'None') else False
+                        record = self.ref(value, not self.env.company.parent_id)
+                        values[fname] = record.id if record and value not in ('', 'False', 'None') else False
                     except ValueError as e:
                         _logger.warning("Failed when trying to recover %s for field=%s", value, field)
                         raise e


### PR DESCRIPTION
### Steps to reproduce

* switch to a company that uses the generic COA
* delete a default account. For example, "Foreign Exchange Gain" (`income_currency_exchange`)
* attempt to create a branch of your company

You should be met with a traceback.

### Cause

When a company in created, the system loads default configurations. These configurations can be defined using XML IDs. In this example, in order to set the `Company.income_currency_exchange_account_id` field, the system will try to get the account with the XML ID `income_currency_exchange`. This will throw an error, because that XML ID points to the account we just deleted.



opw-3675249