### PR TITLE
[FIX] hr_skills: resume_o2m widget duplicate title

### DIFF
--- a/addons/hr_skills/i18n/hr_skills.pot
+++ b/addons/hr_skills/i18n/hr_skills.pot
@@ -1171,6 +1171,13 @@ msgid "Select Skills"
 msgstr ""
 
 #. module: hr_skills
+#. odoo-javascript
+#: code:addons/hr_skills/static/src/fields/skills_one2many/resume_one2many.js:0
+#, python-format
+msgid "Select Experience"
+msgstr ""
+
+#. module: hr_skills
 #: model:ir.model.fields,field_description:hr_skills.field_hr_resume_line_type__sequence
 #: model:ir.model.fields,field_description:hr_skills.field_hr_skill__sequence
 msgid "Sequence"

--- a/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.js
+++ b/addons/hr_skills/static/src/fields/resume_one2many/resume_one2many.js
@@ -2,7 +2,7 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
-
+import { _t } from "@web/core/l10n/translation";
 import { formatDate } from "@web/core/l10n/dates";
 
 import { SkillsX2ManyField, skillsX2ManyField } from "../skills_one2many/skills_one2many";
@@ -32,10 +32,11 @@ ResumeListRenderer.recordRowTemplate = "hr_skills.ResumeListRenderer.RecordRow";
 
 
 export class ResumeX2ManyField extends SkillsX2ManyField {
-    getWizardTitleName() {
-        return _t("Create a resume line");
+    get title() {
+        return _t("Select Experience");
     }
 }
+
 ResumeX2ManyField.components = {
     ...SkillsX2ManyField.components,
     ListRenderer: ResumeListRenderer,

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.js
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.js
@@ -85,12 +85,12 @@ export class SkillsX2ManyField extends X2ManyField {
         });
 
         this._openRecord = (params) => {
-            params.title = this.getWizardTitleName();
+            params.title = this.title;
             openRecord({...params});
         };
     }
 
-    getWizardTitleName() {
+    get title() {
         return _t("Select Skills")
     }
 


### PR DESCRIPTION
**Current behavior:**
Using the resume_one2many widget renders a view whose title is the same as the skills_one2many widget.

---

**Expected behavior:**
The resume_one2many widget will render a view with a more relevant title.

---

**Steps to reproduce:**
1. In the Employee application, select or create and employee

2. In the 'Resume' notebook tab, add a new entry in their 'Experience' section

3. The view rendered here is titled "Select Skills"

---

**Cause of the issue:**
The resumeX2ManyField class extends skillsX2ManyField, inheriting its title.

---

**Fix:**
Setup resumeX2ManyField independent of skillsX2ManyField and give it a unique title.

---

opw-3687865