### PR TITLE
[FIX] stock_account: use income account when raising product price

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -267,7 +267,7 @@ class ProductProduct(models.Model):
                 credit_account_id = product_accounts[product.id]['stock_valuation'].id
             else:
                 debit_account_id = product_accounts[product.id]['stock_valuation'].id
-                credit_account_id = product_accounts[product.id]['expense'].id
+                credit_account_id = product_accounts[product.id]['income'].id
 
             move_vals = {
                 'journal_id': product_accounts[product.id]['stock_journal'].id,


### PR DESCRIPTION
Have a product having category configured with
- Costing Method: Average Cost (AVCO)
- Inventory Valuation: Automated Create a PO for the product to have an initial stock valuation Go to the product form and raise the cost
Save
Check the newly create Journal entry

Issue: for the credit account move line the expense account has been used instead of the income account

opw-3636211

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
