### PR TITLE
[FIX] l10n_it: empties the l10n_tax_representative_partner_id if the …

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -382,7 +382,7 @@ class AccountMove(models.Model):
             'sender': sender,
             'buyer': buyer,
             'seller': seller,
-            'representative': company.l10n_it_tax_representative_partner_id,
+            'representative': company.l10n_it_has_tax_representative and company.l10n_it_tax_representative_partner_id,
             'sender_info': sender_info_values,
             'buyer_info': buyer_info_values,
             'seller_info': seller_info_values,

--- a/addons/l10n_it_edi/tests/export_xmls/tax_representative_unchecked.xml
+++ b/addons/l10n_it_edi/tests/export_xmls/tax_representative_unchecked.xml
@@ -1,0 +1,58 @@
+<p:FatturaElettronicaSemplificata xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                                  xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+                                  xmlns:p="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.0"
+                                  xsi:schemaLocation="http://ivaservizi.agenziaentrate.gov.it/docs/xsd/fatture/v1.0 http://www.fatturapa.gov.it/export/fatturazione/sdi/fatturapa/v1.0/Schema_del_file_xml_FatturaPA_versione_1.0.xsd"
+                                  versione="FSM10">
+    <FatturaElettronicaHeader>
+        <DatiTrasmissione>
+            <IdTrasmittente>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdTrasmittente>
+            <ProgressivoInvio>V202400001</ProgressivoInvio>
+            <FormatoTrasmissione>FSM10</FormatoTrasmissione>
+            <CodiceDestinatario>0000000</CodiceDestinatario>
+        </DatiTrasmissione>
+        <CedentePrestatore>
+            <IdFiscaleIVA>
+                <IdPaese>IT</IdPaese>
+                <IdCodice>01234560157</IdCodice>
+            </IdFiscaleIVA>
+            <CodiceFiscale>01234560157</CodiceFiscale>
+            <Denominazione>company_2_data</Denominazione>
+            <Sede>
+                <Indirizzo>1234 Test Street</Indirizzo>
+                <CAP>12345</CAP>
+                <Comune>Prova</Comune>
+                <Nazione>IT</Nazione>
+            </Sede>
+            <RegimeFiscale>RF01</RegimeFiscale>
+        </CedentePrestatore>
+        <CessionarioCommittente>
+            <IdentificativiFiscali>
+                <CodiceFiscale>00465840031</CodiceFiscale>
+            </IdentificativiFiscali>
+        </CessionarioCommittente>
+    </FatturaElettronicaHeader>
+    <FatturaElettronicaBody>
+        <DatiGenerali>
+            <DatiGeneraliDocumento>
+
+                <TipoDocumento>TD07</TipoDocumento>
+                <Divisa>EUR</Divisa>
+                <Data>2024-01-31</Data>
+                <Numero>INV/2024/00001</Numero>
+            </DatiGeneraliDocumento>
+        </DatiGenerali>
+
+        <DatiBeniServizi>
+            <Descrizione>
+                invoice_line
+            </Descrizione>
+            <Importo>122.00</Importo>
+            <DatiIVA>
+                <Imposta>22.00</Imposta>
+            </DatiIVA>
+        </DatiBeniServizi>
+    </FatturaElettronicaBody>
+</p:FatturaElettronicaSemplificata>

--- a/addons/l10n_it_edi/tests/test_edi_export.py
+++ b/addons/l10n_it_edi/tests/test_edi_export.py
@@ -338,3 +338,23 @@ class TestItEdiExport(TestItEdi):
 
         with self.subTest('credit note'):
             self._assert_export_invoice(credit_note, 'credit_note_negative_price.xml')
+
+    def test_tax_representative(self):
+        # Test to check for l10n_it_edi_tax_representive if l10n_it_has_tax_representative is not set.
+        self.company.l10n_it_has_tax_representative = False
+        invoice = self.env['account.move'].with_company(self.company).create({
+            'move_type': 'out_invoice',
+            'invoice_date': '2024-01-31',
+            'invoice_date_due': '2024-01-31',
+            'partner_id': self.italian_partner_no_address_codice.id,
+            'invoice_line_ids': [
+                Command.create({
+                    'name': 'invoice_line',
+                    'price_unit': 100.00,
+                    'tax_ids': [Command.set(self.default_tax.ids)],
+                }),
+            ],
+        })
+
+        invoice.action_post()
+        self._assert_export_invoice(invoice, 'tax_representative_unchecked.xml')


### PR DESCRIPTION
[FIX] l10n_it: empties the l10n_tax_representative_partner_id if the l10n_it_has_tax_representative field is unchecked.

When a xml file is generated from the invoice, the company tax code is used and not the previous tax representative, after the setting has changed. 

Current behavior before PR:
Tax representative is still assigned even if the setting to use a tax representative is unchecked.

Desired behavior after PR is merged:
Have the tax representative field emptied when the setting to use representative is unchecked. 

opw-3694076
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
