### PR TITLE
[FIX] point_of_sale: traceback on backspace hit in tips

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.js
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/number_popup.js
@@ -101,6 +101,6 @@ export class NumberPopup extends Component {
         if (this.state.payload != startingPayload) {
             return this.state.payload;
         }
-        return this.numberBuffer.get();
+        return this.numberBuffer.get() ?? "";
     }
 }


### PR DESCRIPTION
**Before this PR:**
When a user adds a tip and removes it by hitting multiple backspaces then enter, a 
traceback occurs. The value passed as the tip was supposed to be an 
empty string if no tip is applied, but it received a null value, causing a traceback.

**After this PR:**
The tip value is checked to be a truthy value. If it is not a truthy value, then an 
empty string is passed, resolving the traceback.

task-3692849