### PR TITLE
[FIX] event_crm: prevent error whenever modify questions in attendees form view

### DIFF
--- a/addons/event_crm/models/event_registration.py
+++ b/addons/event_crm/models/event_registration.py
@@ -61,7 +61,7 @@ class EventRegistration(models.Model):
         if not event_lead_rule_skip:
             to_update = self.filtered(lambda reg: reg.lead_count)
         if to_update:
-            lead_tracked_vals = to_update._get_lead_tracked_values()
+            lead_tracked_vals = to_update._get_lead_tracked_values(vals)
 
         res = super(EventRegistration, self).write(vals)
 
@@ -279,7 +279,7 @@ class EventRegistration(models.Model):
             f" {line_suffix}" if line_suffix else "",
         ) + Markup("</li>")
 
-    def _get_lead_tracked_values(self):
+    def _get_lead_tracked_values(self, new_vals):
         """ Tracked values are based on two subset of fields to track in order
         to fill or update leads. Two main use cases are
 
@@ -292,7 +292,9 @@ class EventRegistration(models.Model):
             not rewrite partner values from registration values.
 
         Tracked values are therefore the union of those two field sets. """
-        tracked_fields = list(set(self._get_lead_contact_fields()) or set(self._get_lead_description_fields()))
+        tracked_fields = list(set(self._get_lead_contact_fields()))
+        if 'registration_answer_ids' in new_vals:
+            tracked_fields.append('registration_answer_ids')
         return dict(
             (registration.id,
              dict((field, self._convert_value(registration[field], field)) for field in tracked_fields)


### PR DESCRIPTION
Currently, the error occurs when trying to update question answers in the attendees form view

Steps to reproduce:

- Install a 'website_event_questions' and 'event_crm' modules.
- Create a record in the 'Lead Generation Rule' without any match conditions and add values for 'Rules Name' and 'Event' in which registrations are open.
- After that go to that Event which is added in the 'Event' field and add a question answer in the 'Questions' page.
- In Event Click on 'Go to Website' and proceed an event registration.
- Return to the event, And click on the 'Attendees' button to open a registered attendee.
- Try to add any 'Question' on the Questions page.

Stack Trace:

```
KeyError: 'registration_answer_ids'
  File "odoo/http.py", line 2150, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1722, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1749, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1953, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 71, in web_save
    self.write(vals)
  File "addons/event_sale/models/event_registration.py", line 103, in write
    return super(EventRegistration, self).write(vals)
  File "addons/event_crm/models/event_registration.py", line 68, in write
    to_update.sudo()._update_leads(vals, lead_tracked_vals)
  File "addons/event_crm/models/event_registration.py", line 133, in _update_leads
    if any(new_vals[field] != old_vals[field] for field in upd_description_fields):
  File "addons/event_crm/models/event_registration.py", line 133, in <genexpr>
    if any(new_vals[field] != old_vals[field] for field in upd_description_fields):
```

When modifying questions or answers in the attendees' form view, There's an issue where the system attempts to retrieve the 'registration_answer_ids' key from the 'old_vals' dictionary [1]. But, This key is not present. because the value of 'registration_answer_ids' is only returned by the method '_get_lead_description_fields' [2], and this method is not executed in the entire flow. As we can see at this point [3] 'self._get_lead_contact_fields()' always returns a static value so method '_get_lead_description_fields' is never executed.

[1]https://github.com/odoo/odoo/blob/8a60ee5076adeec54169243f804ef1362eb3744c/addons/event_crm/models/event_registration.py#L135
[2]https://github.com/odoo/odoo/blob/8a60ee5076adeec54169243f804ef1362eb3744c/addons/website_event_crm_questions/models/event_registration.py#L24-L27
[3]https://github.com/odoo/odoo/blob/8a60ee5076adeec54169243f804ef1362eb3744c/addons/event_crm/models/event_registration.py#L295

This commit solves this issue by appending 'registration_answer_ids' values based on new values in method name '_get_lead_tracked_values' to ensure that the 'registration_answer_ids' key is present in the 'old_vals' dictionary during the
process of modifying questions or answers in the attendees' form view.

sentry-4874260136

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
