### PR TITLE
[REF] sale_expense: Refactor re-invoicing of expenses

### DIFF
--- a/addons/sale_expense/models/__init__.py
+++ b/addons/sale_expense/models/__init__.py
@@ -7,3 +7,4 @@ from . import hr_expense_sheet
 from . import hr_expense_split
 from . import product_template
 from . import sale_order
+from . import sale_order_line

--- a/addons/sale_expense/models/__init__.py
+++ b/addons/sale_expense/models/__init__.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import account_move
 from . import account_move_line
 from . import hr_expense
 from . import hr_expense_sheet

--- a/addons/sale_expense/models/account_move.py
+++ b/addons/sale_expense/models/account_move.py
@@ -1,0 +1,17 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    def _reverse_moves(self, default_values_list=None, cancel=False):
+        # EXTENDS sale
+        self.expense_sheet_id._sale_expense_reset_sol_quantities()
+        return super()._reverse_moves(default_values_list, cancel)
+
+    def button_draft(self):
+        # EXTENDS sale
+        self.expense_sheet_id._sale_expense_reset_sol_quantities()
+        return super().button_draft()

--- a/addons/sale_expense/models/account_move.py
+++ b/addons/sale_expense/models/account_move.py
@@ -15,3 +15,8 @@ class AccountMove(models.Model):
         # EXTENDS sale
         self.expense_sheet_id._sale_expense_reset_sol_quantities()
         return super().button_draft()
+
+    def unlink(self):
+        # EXTENDS sale
+        self.expense_sheet_id._sale_expense_reset_sol_quantities()
+        return super().unlink()

--- a/addons/sale_expense/models/account_move_line.py
+++ b/addons/sale_expense/models/account_move_line.py
@@ -41,17 +41,3 @@ class AccountMoveLine(models.Model):
         res = super(AccountMoveLine, self - expensed_lines)._sale_create_reinvoice_sale_line()
         res.update(super(AccountMoveLine, expensed_lines.with_context({'force_split_lines': True}))._sale_create_reinvoice_sale_line())
         return res
-
-
-class AccountMove(models.Model):
-    _inherit = 'account.move'
-
-    def _reverse_moves(self, default_values_list=None, cancel=False):
-        self.expense_sheet_id._sale_expense_reset_sol_quantities()
-        res = super()._reverse_moves(default_values_list, cancel)
-        return res
-
-    def button_draft(self):
-        res = super().button_draft()
-        self.expense_sheet_id._sale_expense_reset_sol_quantities()
-        return res

--- a/addons/sale_expense/models/hr_expense.py
+++ b/addons/sale_expense/models/hr_expense.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
@@ -7,11 +6,26 @@ from odoo import api, fields, models
 class HrExpense(models.Model):
     _inherit = "hr.expense"
 
-    sale_order_id = fields.Many2one('sale.order', compute='_compute_sale_order_id', store=True, index='btree_not_null', string='Customer to Reinvoice', readonly=False, tracking=True,
+    sale_order_id = fields.Many2one(
+        'sale.order',
+        string='Customer to Reinvoice',
+        compute='_compute_sale_order_id',
+        store=True,
+        readonly=False,
+        index='btree_not_null',
+        tracking=True,
         # NOTE: only confirmed SO can be selected, but this domain in activated throught the name search with the `sale_expense_all_order`
         # context key. So, this domain is not the one applied.
-        domain="[('state', '=', 'sale'), ('company_id', '=', company_id)]",
+        domain="[('state', '=', 'sale')]",
+        check_company=True,
         help="If the category has an expense policy, it will be reinvoiced on this sales order")
+    sale_order_line_id = fields.Many2one(
+        comodel_name='sale.order.line',
+        compute='_compute_sale_order_id',
+        store=True,
+        readonly=True,
+        index='btree_not_null',
+    )
     can_be_reinvoiced = fields.Boolean("Can be reinvoiced", compute='_compute_can_be_reinvoiced')
 
     @api.depends('product_id.expense_policy')
@@ -23,6 +37,7 @@ class HrExpense(models.Model):
     def _compute_sale_order_id(self):
         for expense in self.filtered(lambda e: not e.can_be_reinvoiced):
             expense.sale_order_id = False
+            expense.sale_order_line_id = False
 
     @api.onchange('sale_order_id')
     def _onchange_sale_order_id(self):
@@ -31,6 +46,7 @@ class HrExpense(models.Model):
         self.env.add_to_compute(self._fields['analytic_distribution'], to_reset)
 
     def _get_split_values(self):
+        # EXTENDS hr_expense
         vals = super()._get_split_values()
         for split_value in vals:
             split_value['sale_order_id'] = self.sale_order_id.id

--- a/addons/sale_expense/models/hr_expense_sheet.py
+++ b/addons/sale_expense/models/hr_expense_sheet.py
@@ -1,7 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from collections import Counter
-
-from odoo import fields, models, _
+from odoo import fields, models, _, Command
 
 
 class HrExpenseSheet(models.Model):
@@ -13,69 +11,20 @@ class HrExpenseSheet(models.Model):
         for sheet in self:
             sheet.sale_order_count = len(sheet.expense_line_ids.sale_order_id)
 
-    def _get_sale_order_lines(self):
-        """
-            This method is used to try to find the sale order lines created by expense sheets.
-            It is used to reset the quantities of the sale order lines when the expense sheet is reset.
-            It uses several shared fields to try to find the sale order lines:
-                - order_id
-                - product_id
-                - product_uom_qty
-                - sale order line's price_unit (computed from the product_id, then rounded to the currency's rounding)
-                - name
-        """
-        # Get the product account move lines created by an expense
-        expensed_amls = self.account_move_ids.line_ids.filtered(lambda aml: aml.expense_id.sale_order_id and aml.balance >= 0 and not aml.tax_line_id)
-        if not expensed_amls:
-            return self.env['sale.order.line']
-
-        # Get the sale orders linked to the related expenses
-        aml_to_so_map = expensed_amls._sale_determine_order()
-
-        self.env['sale.order.line'].flush_model(['order_id', 'product_id', 'product_uom_qty', 'price_unit', 'name'])
-        self.env['res.company'].flush_model(['currency_id'])
-        self.env['res.currency'].flush_model(['rounding'])
-        query = """
-              WITH aml(key_id, key_count, order_id, product_id, product_uom_qty, price_unit, name) AS (VALUES %s)
-            SELECT ARRAY_AGG(sol.id ORDER BY sol.id), aml.key_count
-              FROM aml,
-                   sale_order_line AS sol
-              JOIN res_company AS company ON sol.company_id = company.id
-              JOIN res_currency AS company_currency ON company.currency_id = company_currency.id
-         LEFT JOIN res_currency AS currency ON sol.currency_id = currency.id
-             WHERE sol.is_expense = TRUE
-               AND sol.order_id = aml.order_id
-               AND sol.product_id = aml.product_id
-               AND sol.product_uom_qty = aml.product_uom_qty
-               AND sol.name = aml.name
-               AND ROUND(sol.price_unit::numeric, COALESCE(currency.rounding, company_currency.rounding)::int)
-                   = ROUND(aml.price_unit::numeric, COALESCE(currency.rounding, company_currency.rounding)::int)
-               GROUP BY aml.key_id, aml.key_count
-        """
-
-        # Get the keys used to fetch the corresponding sale order lines, and the number of times they are used
-        # We need the occurrences count to filter out the sale order lines so that we keep exactly one per expense
-        expense_keys_counter = Counter(expensed_amls.mapped(lambda aml: (
-            aml.expense_id.sale_order_id.id,
-            aml.product_id.id,
-            aml.quantity,
-            aml.currency_id.round(aml._sale_get_invoice_price(aml_to_so_map[aml.id])),
-            aml.name,
-        )))
-        expensed_amls_keys_and_count = tuple(
-            (key_id, key_count, *key) for key_id, (key, key_count) in enumerate(expense_keys_counter.items())
-        )
-        self.env.cr.execute_values(query, expensed_amls_keys_and_count)
-
-        # Filters out the sale order lines so that we only keep one per expense
-        sol_ids = []
-        for all_sol_ids_per_key, expense_count_per_key in self.env.cr.fetchall():
-            sol_ids += all_sol_ids_per_key[:expense_count_per_key]
-        return self.env['sale.order.line'].browse(sol_ids)
-
     def _sale_expense_reset_sol_quantities(self):
-        sale_order_lines = self._get_sale_order_lines()
-        sale_order_lines.write({'qty_delivered': 0.0, 'product_uom_qty': 0.0})
+        """
+        Resets the quantity of a SOL created by a reinvoiced expense to 0 when the expense or its move is reset to an unfinished state
+
+        Note: Resetting the qty_delivered will raise if the product is a storable product and sale_stock is installed,
+              but it's fine as it doesn't make much sense to have a stored product in an expense.
+        """
+        self.check_access('write')
+        # If we can edit the sheet, we may not be able to edit the sol without sudoing.
+        self.sudo().expense_line_ids.sale_order_line_id.write({
+            'qty_delivered': 0.0,
+            'product_uom_qty': 0.0,
+            'expense_ids': [Command.clear()],
+        })
 
     def action_reset_expense_sheets(self):
         super().action_reset_expense_sheets()

--- a/addons/sale_expense/models/hr_expense_split.py
+++ b/addons/sale_expense/models/hr_expense_split.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api
@@ -6,13 +5,6 @@ from odoo import fields, models, api
 
 class HrExpenseSplit(models.TransientModel):
     _inherit = "hr.expense.split"
-
-    def default_get(self, fields):
-        result = super(HrExpenseSplit, self).default_get(fields)
-        if 'expense_id' in result:
-            expense = self.env['hr.expense'].browse(result['expense_id'])
-            result['sale_order_id'] = expense.sale_order_id
-        return result
 
     sale_order_id = fields.Many2one('sale.order', string="Customer to Reinvoice", compute='_compute_sale_order_id', readonly=False, store=True, domain="[('state', '=', 'sale'), ('company_id', '=', company_id)]")
     can_be_reinvoiced = fields.Boolean("Can be reinvoiced", compute='_compute_can_be_reinvoiced')

--- a/addons/sale_expense/models/sale_order.py
+++ b/addons/sale_expense/models/sale_order.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, fields, models
@@ -8,7 +7,13 @@ from odoo.osv import expression
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    expense_ids = fields.One2many('hr.expense', 'sale_order_id', string='Expenses', domain=[('state', '=', 'done')], readonly=True, copy=False)
+    expense_ids = fields.One2many(
+        comodel_name='hr.expense',
+        inverse_name='sale_order_id',
+        string='Expenses',
+        domain=[('state', '=', 'done')],
+        readonly=True,
+    )
     expense_count = fields.Integer("# of Expenses", compute='_compute_expense_count', compute_sudo=True)
 
     @api.model
@@ -31,7 +36,5 @@ class SaleOrder(models.Model):
 
     @api.depends('expense_ids')
     def _compute_expense_count(self):
-        expense_data = self.env['hr.expense']._read_group([('sale_order_id', 'in', self.ids)], ['sale_order_id'], ['__count'])
-        mapped_data = {sale_order.id: count for sale_order, count in expense_data}
         for sale_order in self:
-            sale_order.expense_count = mapped_data.get(sale_order.id, 0)
+            sale_order.expense_count = len(sale_order.order_line.expense_ids)

--- a/addons/sale_expense/models/sale_order_line.py
+++ b/addons/sale_expense/models/sale_order_line.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    expense_ids = fields.One2many(
+        comodel_name='hr.expense',
+        inverse_name='sale_order_line_id',
+        string='Expenses',
+        readonly=True,
+    )

--- a/addons/sale_expense/tests/test_reinvoice.py
+++ b/addons/sale_expense/tests/test_reinvoice.py
@@ -127,9 +127,7 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
         cls.expense_sale_order.action_confirm()
 
         # Create an expense sheet with 6 expenses, covering all the expense & invoicing policies combinaisons
-        cls.sale_expenses = cls.env['hr.expense'].create([
-            {
-                # exp_order_sale_1
+        cls.sale_exp_order_sale_1 = cls.env['hr.expense'].create({
                 'name': 'expense_1 invoicing=order, expense=sales_price',
                 'date': '2016-01-01',
                 'product_id': cls.company_data['service_order_sales_price'].id,
@@ -137,18 +135,16 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
                 'analytic_distribution': {cls.analytic_account_1.id: 100},
                 'employee_id': cls.expense_employee.id,
                 'sale_order_id': cls.expense_sale_order.id,
-            },
-            {
-                # exp_order_sale_2
+        })
+        cls.sale_exp_order_sale_2 = cls.env['hr.expense'].create({
                 'name': 'expense_2 invoicing=order, expense=sales_price',
                 'date': '2016-01-02',
                 'product_id': cls.company_data['service_order_sales_price'].id,
                 'total_amount': 100.21,
                 'employee_id': cls.expense_employee.id,
                 'sale_order_id': cls.expense_sale_order.id,
-            },
-            {
-                # exp_deliv_sale_3
+        })
+        cls.sale_exp_deliv_sale_3 = cls.env['hr.expense'].create({
                 'name': 'expense_3 invoicing=delivery, expense=sales_price',
                 'date': '2016-01-03',
                 'product_id': cls.company_data['service_delivery_sales_price'].id,
@@ -156,9 +152,8 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
                 'analytic_distribution': {cls.analytic_account_1.id: 100},
                 'employee_id': cls.expense_employee.id,
                 'sale_order_id': cls.expense_sale_order.id,
-            },
-            {
-                # exp_deliv_sale_4
+        })
+        cls.sale_exp_deliv_sale_4 = cls.env['hr.expense'].create({
                 'name': 'expense_4 invoicing=delivery, expense=sales_price',
                 'date': '2016-01-03',
                 'product_id': cls.company_data['service_delivery_sales_price'].id,
@@ -166,18 +161,16 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
                 'total_amount': 10012.49,
                 'employee_id': cls.expense_employee.id,
                 'sale_order_id': cls.expense_sale_order.id,
-            },
-            {
-                # exp_deliv_cost_5
+        })
+        cls.sale_exp_deliv_cost_5 = cls.env['hr.expense'].create({
                 'name': 'expense_5 invoicing=delivery, expense=cost',
                 'date': '2016-01-03',
                 'product_id': cls.company_data['service_delivery_cost_price'].id,
                 'quantity': 5,
                 'employee_id': cls.expense_employee.id,
                 'sale_order_id': cls.expense_sale_order.id,
-            },
-            {
-                # exp_order_cost_6
+        })
+        cls.sale_exp_order_cost_6 = cls.env['hr.expense'].create({
                 'name': 'expense_6 invoicing=order, expense=cost',
                 'date': '2016-01-03',
                 'product_id': cls.company_data['service_order_cost_price'].id,
@@ -185,15 +178,25 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
                 'employee_id': cls.expense_employee.id,
                 'sale_order_id': cls.expense_sale_order.id,
             },
-        ]).sorted()
+        )
         cls.sale_expense_sheet = cls.env['hr.expense.sheet'].create({
             'name': 'Reset expense test',
             'employee_id': cls.expense_employee.id,
             'journal_id': cls.company_data['default_journal_purchase'].id,
             'accounting_date': '2017-01-01',
-            'expense_line_ids': [Command.set(cls.sale_expenses.ids)],
+            'expense_line_ids': [
+                Command.link(expense.id)
+                for expense in (
+                    cls.sale_exp_order_sale_1,
+                    cls.sale_exp_order_sale_2,
+                    cls.sale_exp_deliv_sale_3,
+                    cls.sale_exp_deliv_sale_4,
+                    cls.sale_exp_deliv_cost_5,
+                    cls.sale_exp_order_cost_6,
+                )
+            ],
         })
-        cls.sale_expense_sheet.action_submit_sheet()
+        cls.sale_expense_sheet._do_submit()
 
     def test_expenses_reinvoice_case_1_create_moves(self):
         """
@@ -204,14 +207,14 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
 
         self.assertRecordValues(self.expense_sale_order.order_line, [
             # [0] Line not created from a re-invoiced, should never be changed
-            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'is_expense': False, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'is_expense': False, 'expense_ids': []},
             # [1-6] SHEET 1 Lines: created with the correct quantities and linked to the expense
-            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'is_expense':  True, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},  # noqa: E272
-            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'is_expense':  True, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},  # noqa: E272
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'is_expense':  True, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},  # noqa: E272
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'is_expense':  True, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},  # noqa: E272
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'is_expense':  True, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},  # noqa: E272
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'is_expense':  True, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},  # noqa: E272
+            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'is_expense':  True, 'expense_ids': [self.sale_exp_order_cost_6.id]},  # noqa: E272
+            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'is_expense':  True, 'expense_ids': [self.sale_exp_deliv_cost_5.id]},  # noqa: E272
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'is_expense':  True, 'expense_ids': [self.sale_exp_deliv_sale_4.id]},  # noqa: E272
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'is_expense':  True, 'expense_ids': [self.sale_exp_deliv_sale_3.id]},  # noqa: E272
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'is_expense':  True, 'expense_ids': [self.sale_exp_order_sale_2.id]},  # noqa: E272
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'is_expense':  True, 'expense_ids': [self.sale_exp_order_sale_1.id]},  # noqa: E272
         ])
 
     def test_expenses_reinvoice_case_2_reset_sheet_to_draft(self):
@@ -227,14 +230,14 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
 
         self.assertRecordValues(self.expense_sale_order.order_line, [
             # [0] Line not created from a re-invoiced, should never be changed
-            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'expense_ids': []},
             # [1-6] SHEET Lines: quantities are reset to 0 and expenses are unlinked
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
         ])
 
     def test_expenses_reinvoice_case_3_recreate_move_after_reset(self):
@@ -249,27 +252,27 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
         self.sale_expense_sheet.action_reset_expense_sheets()
 
         # CASE 3 steps
-        self.sale_expense_sheet.action_submit_sheet()
+        self.sale_expense_sheet._do_submit()
         self.sale_expense_sheet._do_approve()
         self.sale_expense_sheet.action_sheet_move_post()
 
         self.assertRecordValues(self.expense_sale_order.order_line, [
             # [0] Line not created from a re-invoiced, should never be changed
-            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'expense_ids': []},
             # [1-6] SHEET CASE 2 Lines: no change
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
             # [7-12] SHEET CASE 3 Lines: created with the correct quantities and linked to the expense
-            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'expense_ids': [self.sale_exp_order_cost_6.id]},
+            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'expense_ids': [self.sale_exp_deliv_cost_5.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_deliv_sale_4.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_deliv_sale_3.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_order_sale_2.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_order_sale_1.id]},
         ])
 
     def test_expenses_reinvoice_case_4_reset_sheet_move_to_draft(self):
@@ -285,14 +288,14 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
 
         self.assertRecordValues(self.expense_sale_order.order_line, [
             # [0] Line not created from a re-invoiced, should never be changed
-            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'expense_ids': []},
             # [1-6] SHEET Lines: quantities are reset to 0 and expenses are unlinked
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
         ])
 
     def test_expenses_reinvoice_case_5_repost_sheet_move_after_reset_to_draft(self):
@@ -311,21 +314,21 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
 
         self.assertRecordValues(self.expense_sale_order.order_line, [
             # [0] Line not created from a re-invoiced, should never be changed
-            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'expense_ids': []},
             # [1-6] SHEET CASE 4 Lines: no change
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
             # [7-12] SHEET CASE 5 Lines: created with the correct quantities and linked to the expense
-            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'expense_ids': [self.sale_exp_order_cost_6.id]},
+            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'expense_ids': [self.sale_exp_deliv_cost_5.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_deliv_sale_4.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_deliv_sale_3.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_order_sale_2.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_order_sale_1.id]},
         ])
 
     def test_expenses_reinvoice_case_6_reverse_expense_move(self):
@@ -341,85 +344,115 @@ class TestReInvoice(TestExpenseCommon, TestSaleCommon):
 
         self.assertRecordValues(self.expense_sale_order.order_line, [
             # [0] Line not created from a re-invoiced, should never be changed
-            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'expense_ids': []},
             # [1-6] SHEET Lines: quantities are reset to 0 and expenses are unlinked
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
         ])
 
     def test_expenses_reinvoice_case_7_ensure_one2one_relationship(self):
         """
         CASE 7: Test that two exact same sols are not reset to 0 when the expense of one of them is resetting the quantities to 0
         """
-        original_expenses = self.sale_expenses
+        # For every expense, we duplicate it twice.
+        # - the former will be linked to the same expense sheet
+        # - the latter will go on a different
+        sale_exp_order_sale_1_copy_same, sale_exp_order_sale_1_copy_diff = (self.sale_exp_order_sale_1.copy() for _i in range(2))
+        sale_exp_order_sale_2_copy_same, sale_exp_order_sale_2_copy_diff = (self.sale_exp_order_sale_2.copy() for _i in range(2))
+        sale_exp_deliv_sale_3_copy_same, sale_exp_deliv_sale_3_copy_diff = (self.sale_exp_deliv_sale_3.copy() for _i in range(2))
+        sale_exp_deliv_sale_4_copy_same, sale_exp_deliv_sale_4_copy_diff = (self.sale_exp_deliv_sale_4.copy() for _i in range(2))
+        sale_exp_deliv_cost_5_copy_same, sale_exp_deliv_cost_5_copy_diff = (self.sale_exp_deliv_cost_5.copy() for _i in range(2))
+        sale_exp_order_cost_6_copy_same, sale_exp_order_cost_6_copy_diff = (self.sale_exp_order_cost_6.copy() for _i in range(2))
+        copied_expenses_same_sheet = (
+            sale_exp_order_cost_6_copy_same,
+            sale_exp_deliv_cost_5_copy_same,
+            sale_exp_deliv_sale_4_copy_same,
+            sale_exp_deliv_sale_3_copy_same,
+            sale_exp_order_sale_2_copy_same,
+            sale_exp_order_sale_1_copy_same,
+        )
+        copied_expenses_diff_sheet = (
+            sale_exp_order_cost_6_copy_diff,
+            sale_exp_deliv_cost_5_copy_diff,
+            sale_exp_deliv_sale_4_copy_diff,
+            sale_exp_deliv_sale_3_copy_diff,
+            sale_exp_order_sale_2_copy_diff,
+            sale_exp_order_sale_1_copy_diff,
+        )
+
+        # Link the first batch of duplicated expense to the first expense sheet and process the sheet up to the post step
         self.sale_expense_sheet.write({
-            'expense_line_ids': [Command.link(expense.copy().id) for expense in original_expenses],  # Duplicates of the expenses IN the reset sheet
-            'accounting_date': '2017-01-01',  # To avoid "duplicate vendor reference raised" in the move
+            'expense_line_ids': [Command.link(expense.id) for expense in copied_expenses_same_sheet],
+            'accounting_date': '2017-01-01',  # To avoid "duplicate vendor reference" raised in the move
         })
-        self.sale_expense_sheet.action_submit_sheet()
+        self.sale_expense_sheet._do_submit()
         self.sale_expense_sheet._do_approve()
         self.sale_expense_sheet.action_sheet_move_post()
+
+        # Create a duplicated sheet and link the second batch, then go to posted
         sheet_2 = self.sale_expense_sheet.copy({
-            'expense_line_ids': [Command.set([expense.copy().id for expense in original_expenses])],  # Duplicates of the expenses OUTSIDE the reset sheet
+            'expense_line_ids': [Command.link(expense.id) for expense in copied_expenses_diff_sheet],
             'accounting_date': '2017-01-02',
         })
-        sheet_2.action_submit_sheet()
+        sheet_2._do_submit()
         sheet_2._do_approve()
         sheet_2.action_sheet_move_post()
+
+        # Check that all the expenses can be found on the sale order
         self.assertRecordValues(self.expense_sale_order.order_line, [
             # [0] Line not created from a re-invoiced, should never be changed
-            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'expense_ids': []},
             # [1-12] SHEET 1 Lines: Created with the correct quantities
-            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'expense_ids': [self.sale_exp_order_cost_6.id]},
+            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'expense_ids': [self.sale_exp_deliv_cost_5.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_deliv_sale_4.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_deliv_sale_3.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_order_sale_2.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [self.sale_exp_order_sale_1.id]},
+            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'expense_ids': [sale_exp_order_cost_6_copy_same.id]},
+            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'expense_ids': [sale_exp_deliv_cost_5_copy_same.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_deliv_sale_4_copy_same.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_deliv_sale_3_copy_same.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_order_sale_2_copy_same.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_order_sale_1_copy_same.id]},
             # [13-18] SHEET 2 Lines: Created with the correct quantities
-            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'expense_ids': [sale_exp_order_cost_6_copy_diff.id]},
+            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'expense_ids': [sale_exp_deliv_cost_5_copy_diff.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_deliv_sale_4_copy_diff.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_deliv_sale_3_copy_diff.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_order_sale_2_copy_diff.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_order_sale_1_copy_diff.id]},
         ])
 
+        # Reset the first sheet to draft and check that only its expense are unlinked
         self.sale_expense_sheet.account_move_ids.button_draft()
-
         self.assertRecordValues(self.expense_sale_order.order_line, [
             # [0] Line not created from a re-invoiced, should never be changed
-            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
-            # [1-12] SHEET 1 Lines: quantities are reset to 0 and expenses are unlinked (because they are the oldest)
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 0.0, 'product_uom_qty': 3.0, 'expense_ids': []},
+            # [1-12] SHEET 1 Lines: quantities are reset to 0 and expenses are unlinked
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
+            {'qty_delivered': 0.0, 'product_uom_qty': 0.0, 'expense_ids': []},
             # [13-18] SHEET 2 Lines: Not caught by the reset
-            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'name': 'expense_employee: expense_6 invoicing=order, expense=cost'},
-            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'name': 'expense_employee: expense_5 invoicing=delivery, expense=cost'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_4 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_3 invoicing=delivery, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_2 invoicing=order, expense=sales_price'},
-            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'name': 'expense_employee: expense_1 invoicing=order, expense=sales_price'},
+            {'qty_delivered': 6.0, 'product_uom_qty': 6.0, 'expense_ids': [sale_exp_order_cost_6_copy_diff.id]},
+            {'qty_delivered': 5.0, 'product_uom_qty': 5.0, 'expense_ids': [sale_exp_deliv_cost_5_copy_diff.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_deliv_sale_4_copy_diff.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_deliv_sale_3_copy_diff.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_order_sale_2_copy_diff.id]},
+            {'qty_delivered': 1.0, 'product_uom_qty': 1.0, 'expense_ids': [sale_exp_order_sale_1_copy_diff.id]},
         ])
 
     def test_expenses_reinvoice_analytic_distribution(self):


### PR DESCRIPTION
In https://github.com/odoo/odoo/commit/b073350cb2afcc162a11dc9a1972078838712953 a fix was made to create a more robust link between
sale order lines and the expenses that generated them, but as it was
in stable a related field wasn't possible.

This replaces the fields used as an relational ID and the query matching
the two models by a proper related-field.

In addition
- splits account_move_line.py into one file per model
- remove deprecated coding utf-8 instructions

task-3458826



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
