### PR TITLE
[IMP] hr_timesheet: include sub-tasks hours spent in portal list tasks view

### DIFF
--- a/addons/hr_timesheet/views/project_task_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_task_portal_templates.xml
@@ -55,11 +55,11 @@
             <td t-if="not project or project.allow_timesheets" class="text-end">
                 <t t-if="task.allow_timesheets">
                     <t t-if="is_uom_day">
-                        <t t-out="timesheet_ids._convert_hours_to_days(task.effective_hours)"/>
+                        <t t-out="timesheet_ids._convert_hours_to_days(task.total_hours_spent)"/>
                         <span t-if="task.allocated_hours > 0"> / <t t-out="timesheet_ids._convert_hours_to_days(task.allocated_hours)"/></span>
                     </t>
                     <t t-else="">
-                        <span t-field="task.effective_hours" t-options='{"widget": "float_time"}'/>
+                        <span t-field="task.total_hours_spent" t-options='{"widget": "float_time"}'/>
                         <t t-if="task.allocated_hours > 0">
                             /
                             <span t-field="task.allocated_hours" t-options='{"widget": "float_time"}'/>


### PR DESCRIPTION
Before this commit, in the portal list view of tasks, the hours spent displayed for each task were only the hours timesheeted for the task without taking into account the timesheets of the sub-tasks. As a consequence, this could give customers a false sense that there is more time remaining on their task than there is.

After this commit, the hours spent for each task take the timesheets of the sub-tasks into account.

task-3693453

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
