### PR TITLE
[FIX] documents, web: manage access to ir.model with context

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -2509,11 +2509,19 @@ var BasicModel = AbstractModel.extend({
                 resourceRef.hasChanged = false;
                 return Promise.resolve(resourceRef);
             } else {
-                const result = await this._rpc({
-                    model: 'ir.model',
-                    method: 'read',
-                    args: [modelId, ['id', 'model']],
-                });
+                let result;
+                if ('default_model_id' in record.context && 'default_model_name' in record.context) {
+                    result = [{
+                        id: record.context.default_model_id,
+                        model: record.context.default_model_name,
+                    }];
+                } else {
+                    result = await this._rpc({
+                        model: 'ir.model',
+                        method: 'read',
+                        args: [modelId, ['id', 'model']],
+                    });
+                }
                 // Checks the case where the data on the backend side are not synchronized
                 // (modelFieldName != referenceFieldName) when opening the edit view (!_changes).
                 // We want to avoid resynchronization in order not to modify the data 


### PR DESCRIPTION
Steps to reproduce:
-------------------
- install documents and fleet apps;
- be a user who is not in the `base.user_admin` group;
- have admin rights to fleet and document;
- put a document in the "Fleet" workspace;
- click on "Link to a vehicle" button;

Issue:
------
- First issue: An access error is triggered when we want to get the `model` field for an `ir.model` record.
- Second issue: When a `Reference` field has the `model_field` option, a read on `ir.model` is triggered and as we don't have the rights, this causes an access error.

Solution:
---------
Work on the `ir.model` record in sudo.
If the context lets us know the model id and name, there is no need to perform a read request.

Note:
-----
This solution avoids adding a new access right for `ir.model` as follows:
```csv
access_ir_model,access_ir_model,base.model_ir_model,documents.group_documents_user,1,0,0,0
```

opw-3502558