### PR TITLE
[FIX] point_of_sale: show product name with variant on display

### DIFF
--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -164,7 +164,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'taxes_id': False,
             'barcode': '2300002000007',
         })
-        configurable_chair = env['product.product'].create({
+        cls.configurable_chair = env['product.product'].create({
             'name': 'Configurable Chair',
             'available_in_pos': True,
             'list_price': 10,
@@ -201,7 +201,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'html_color': '#0000ff',
         })
         chair_color_line = env['product.template.attribute.line'].create({
-            'product_tmpl_id': configurable_chair.product_tmpl_id.id,
+            'product_tmpl_id': cls.configurable_chair.product_tmpl_id.id,
             'attribute_id': chair_color_attribute.id,
             'value_ids': [(6, 0, [chair_color_red.id, chair_color_blue.id])]
         })
@@ -221,7 +221,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'attribute_id': chair_legs_attribute.id,
         })
         chair_legs_line = env['product.template.attribute.line'].create({
-            'product_tmpl_id': configurable_chair.product_tmpl_id.id,
+            'product_tmpl_id': cls.configurable_chair.product_tmpl_id.id,
             'attribute_id': chair_legs_attribute.id,
             'value_ids': [(6, 0, [chair_legs_metal.id, chair_legs_wood.id])]
         })
@@ -241,7 +241,7 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
             'is_custom': True,
         })
         chair_fabrics_line = env['product.template.attribute.line'].create({
-            'product_tmpl_id': configurable_chair.product_tmpl_id.id,
+            'product_tmpl_id': cls.configurable_chair.product_tmpl_id.id,
             'attribute_id': chair_fabrics_attribute.id,
             'value_ids': [(6, 0, [chair_fabrics_leather.id, chair_fabrics_other.id])]
         })


### PR DESCRIPTION
Current behavior:
When you create a product with some variant (Never create option), and add them to be displayed on the pos_preparation_display they appear without the variant name.

Steps to reproduce:
- Create a product with some variant (Never create option), and add them to a pos category.
- Setup a pos_preparation_display with the pos category you selected before.
- Open a PoS linked to the pos_preparation_display.
- Add a product with variant to the order.
- Validate the order.
- Check the display, the product name is shown without the variant name.

opw-3671479

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
