### PR TITLE
[FIX] web_editor: fix crash when element has no mobile order

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -5707,7 +5707,9 @@ registry.SnippetMove = SnippetOptionWidget.extend(ColumnLayoutMixin, {
             const targetOrder = parseInt(targetMobileOrder[1]);
 
             [...this.$target[0].parentElement.children].forEach(el => {
-                const elOrder = parseInt(this._getItemMobileOrder(el)[1]);
+                const elClassOrder = this._getItemMobileOrder(el);
+                if (!elClassOrder) return;
+                const elOrder = parseInt(elClassOrder[1]);
                 if (elOrder > targetOrder) {
                     el.classList.replace(`order-${elOrder}`, `order-${elOrder - 1}`);
                 }


### PR DESCRIPTION
__Current behavior before commit:__
`this._getItemMobileOrder(el)` can return `null` if `el` has no class of the form `order-x`.

__Description of the fix:__
Check if the value returned by `this._getItemMobileOrder(el)` is not `null` before parsing the integer in it.

__Example of steps to reproduce the issue on runbot:__
- Go to the website editor
- Add 2 Text blocks
- Set the Layout of the first block to Grid and the second one to Cols
- Set the number of columns of the second block to 2
- Activate the mobile view
- Change the order of the 2 columns
- Disable the mobile view
- Move one of the column to the first Text block
- Remove the first block --> `TypeError: null is not an object (evaluating 'this._getItemMobileOrder(el)[1]')`

([video](https://drive.google.com/file/d/1YdflzwODV7Lg0RtBZ9hPgT75JVZf_sI9/view?usp=drive_link))

opw-3689575
