### PR TITLE
[FIX] hr_attendance: retain overtime adjustments after deactivation

### DIFF
--- a/addons/hr_attendance/i18n/hr_attendance.pot
+++ b/addons/hr_attendance/i18n/hr_attendance.pot
@@ -742,6 +742,12 @@ msgid "Officer"
 msgstr ""
 
 #. module: hr_attendance
+#: code:addons/hr_attendance/models/hr_attendance_overtime.py:0
+#, python-format
+msgid "Operation not supported"
+msgstr ""
+
+#. module: hr_attendance
 #: model:ir.model.fields,field_description:hr_attendance.field_hr_employee__overtime_ids
 msgid "Overtime"
 msgstr ""

--- a/addons/hr_attendance/models/hr_attendance_overtime.py
+++ b/addons/hr_attendance/models/hr_attendance_overtime.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models, fields
+from odoo import api, models, fields, _
+from odoo.exceptions import UserError
 
 
 class HrAttendanceOvertime(models.Model):
@@ -24,6 +25,7 @@ class HrAttendanceOvertime(models.Model):
         string='Extra Hours (Real)', default=0.0,
         help="Extra-hours including the threshold duration")
     adjustment = fields.Boolean(default=False)
+    active = fields.Boolean(compute='_compute_active', search='_search_active', store=False)
 
     def init(self):
         # Allows only 1 overtime record per employee per day unless it's an adjustment
@@ -31,3 +33,22 @@ class HrAttendanceOvertime(models.Model):
             CREATE UNIQUE INDEX IF NOT EXISTS hr_attendance_overtime_unique_employee_per_day
             ON %s (employee_id, date)
             WHERE adjustment is false""" % (self._table))
+
+    @api.depends('date', 'company_id.overtime_start_date')
+    def _compute_active(self):
+        for overtime in self:
+            start_date = overtime.company_id.overtime_start_date
+            overtime.active = start_date and overtime.date >= start_date
+
+    @api.model
+    def _search_active(self, operator, value):
+        if operator not in ('=', '!='):
+            raise UserError(_("Operation not supported"))
+        is_true = (operator, bool(value)) in (('=', True), ('!=', False))
+        operator = 'inselect' if is_true else 'not inselect'
+        subquery = """
+            SELECT ot.id FROM hr_attendance_overtime ot
+            LEFT JOIN hr_employee emp ON emp.id = ot.employee_id
+            LEFT JOIN res_company com ON com.id = emp.company_id
+            WHERE ot.date >= com.overtime_start_date"""
+        return [('id', operator, (subquery, []))]

--- a/addons/hr_attendance/models/res_company.py
+++ b/addons/hr_attendance/models/res_company.py
@@ -22,7 +22,9 @@ class ResCompany(models.Model):
         is_disabling_overtime = False
         # If we disable overtime
         if 'hr_attendance_overtime' in vals and not vals['hr_attendance_overtime'] and overtime_enabled_companies:
-            delete_domain = [('company_id', 'in', overtime_enabled_companies.ids)]
+            delete_domain = [
+                ('adjustment', '=', False),
+                ('company_id', 'in', overtime_enabled_companies.ids)]
             vals['overtime_start_date'] = False
             is_disabling_overtime = True
 
@@ -50,6 +52,7 @@ class ResCompany(models.Model):
                 # If we move the start date into the future
                 elif start_date and company.overtime_start_date < start_date:
                     delete_domain = OR([delete_domain, [
+                        ('adjustment', '=', False),
                         ('company_id', '=', company.id),
                         ('date', '<', start_date)]])
 


### PR DESCRIPTION
Versions
--------
- 15.0+

Steps
-----
1. Go to Attendances / Configuration;
2. enable Count Extra Hours;
3. go to Time Off / Configuration / Time Off Types;
4. create a new Time Off Type;
5. set yourself a Responsible Time Off Officer;
6. enable Deduct Extra Hours and save;
7. go to Attendances / Attendances;
8. create an attendance for an employee which adds overtime;
9. go to employee form and click Deduct Extra Hours;
10. deduct some hours;
11. go back to Attendances / Configuration;
12. disable Count Extra Hours and save;
13. enable Count Extra Hours (selecting same date as before) and save;
14. go back to employee form and click Deduct Extra Hours.

Issue
-----
Overtime hours were restored, but adjustments dissappeared.

Cause
-----
On disabling overtime from a company, it unlinks all relevant `hr.attendance.overtime` records. These can be partially be restored later on based on logged attendances, but manual adjustments are lost.

Solution
--------
Prevent the unlinking of any records where `adjustment` is set and add the non-stored field `active`, which gets computed by comparing the the `date` field to the company's `overtime_start_date`.

The `active` field is handled specially by the ORM, treating non-active records as if they're deleted while searching, except when `('active', '=', False)` is added to the query. This means existing views and methods dealing with these records don't require further modifications to ignore non-active overtime adjustments.

opw-3665133