### PR TITLE
[IMP] l10_in_pos: GST instead of VAT in receipt with tax bifurcation

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
+++ b/addons/l10n_in_pos/static/src/overrides/components/pos_receipt.xml
@@ -26,6 +26,29 @@
                 </div>
             </t>
         </xpath>
+        <xpath expr="//div[hasclass('pos-receipt-taxes')]" position="replace">
+            <div t-if="props.data.tax_details.length > 0" class="pos-receipt-taxes justify-content-between">
+                <span>GST%</span>
+                <span>SGST</span>
+                <span>CGST</span>
+                <span>ExGST</span>
+                <span>Total</span>
+                <t t-foreach="props.data.tax_details" t-as="tax" t-key="tax.tax.id">
+                    <span><t t-esc="tax.tax.amount"/> %</span>
+                    <span t-esc="props.formatCurrency(tax.amount / 2, false)" />
+                    <span t-esc="props.formatCurrency(tax.amount / 2, false)" />
+                    <span t-esc="props.formatCurrency(tax.base, false)" />
+                    <span t-esc="props.formatCurrency(tax.amount + tax.base, false)" />
+                </t>
+                <t t-if="props.data.tax_details.length > 1">
+                    <span />
+                    <span t-esc="props.formatCurrency(props.data.amount_tax / 2, false)" />
+                    <span t-esc="props.formatCurrency(props.data.amount_tax / 2, false)" />
+                    <span t-esc="props.formatCurrency(props.data.total_without_tax, false)" />
+                    <span t-esc="props.formatCurrency(props.data.amount_total, false)" />
+                </t>
+            </div>
+        </xpath>
         <xpath expr="//div[@class='before-footer']" position="after">
             <br/>
             <table t-if="props.data?.l10n_in_hsn_summary and props.data.headerData.company.country_id?.code === 'IN'" style="width:100%;">


### PR DESCRIPTION
**Before this commit:**
The product price calculation in the POS was based on the VAT tax system. 
Consequently, the taxes calculated on the bill amount were also determined 
by VAT.

**After this commit:**
With GST now implemented as the tax system, we calculate the bill amount 
based on the GST tax system. Subsequently, the tax breakdown is displayed 
accordingly.

task-3653060
