### PR TITLE
[IMP] web_editor: add shortcuts toolbar buttons in the placeholder

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -191,22 +191,8 @@ export class HtmlField extends Component {
                         name: _t('Dynamic Placeholder'),
                         priority: 10,
                         description: _t('Insert personalized content'),
-                        fontawesome: 'fa-magic',
-                        callback: () => {
-                            this.wysiwygRangePosition = getRangePosition(document.createElement('x'), this.wysiwyg.options.document || document);
-                            this.dynamicPlaceholder.updateModel(this.props.dynamicPlaceholderModelReferenceField);
-                            // The method openDynamicPlaceholder need to be triggered
-                            // after the focus from powerBox prevalidate.
-                            setTimeout(async () => {
-                                await this.dynamicPlaceholder.open(
-                                    {
-                                        validateCallback: this.onDynamicPlaceholderValidate.bind(this),
-                                        closeCallback: this.onDynamicPlaceholderClose.bind(this),
-                                        positionCallback: this.positionDynamicPlaceholder.bind(this),
-                                    }
-                                );
-                            });
-                        },
+                        fontawesome: 'fa-hashtag',
+                        callback: this.placeholderCallback,
                     }
                 ],
                 powerboxFilters: [this._filterPowerBoxCommands.bind(this)],
@@ -227,6 +213,10 @@ export class HtmlField extends Component {
             onWysiwygBlur: this._onWysiwygBlur.bind(this),
             ...wysiwygOptions,
             ...dynamicPlaceholderOptions,
+            dynamicPlaceholder: {
+                show: this.props.dynamicPlaceholder,
+                placeholderCallback: this.placeholderCallback,
+            },
             recordInfo: {
                 res_model: this.props.record.resModel,
                 res_id: this.props.record.resId,
@@ -340,6 +330,22 @@ export class HtmlField extends Component {
             this.props.record.update({ [this.props.name]: value });
 
         }
+    }
+    /**
+     * Dynamic Placeholder Callback.
+     */
+    placeholderCallback = () => {
+        this.wysiwygRangePosition = getRangePosition(document.createElement('x'), this.wysiwyg.options.document || document);
+        this.dynamicPlaceholder.updateModel(this.props.dynamicPlaceholderModelReferenceField);
+        // The method openDynamicPlaceholder need to be triggered
+        // after the focus from powerBox prevalidate.
+        setTimeout(async () => {
+            await this.dynamicPlaceholder.open({
+                validateCallback: this.onDynamicPlaceholderValidate.bind(this),
+                closeCallback: this.onDynamicPlaceholderClose.bind(this),
+                positionCallback: this.positionDynamicPlaceholder.bind(this),
+            });
+        });
     }
     onDynamicPlaceholderValidate(chain, defaultValue) {
         if (chain) {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -84,6 +84,8 @@ import {
     ZERO_WIDTH_CHARS_REGEX,
     getAdjacentCharacter,
     isLinkEligibleForZwnbsp,
+    chooseForeground,
+    ancestorsBackground,
 } from './utils/utils.js';
 import { editorCommands } from './commands/commands.js';
 import { Powerbox } from './powerbox/Powerbox.js';
@@ -3488,6 +3490,7 @@ export class OdooEditor extends EventTarget {
             block &&
             block.closest('P') &&
             block.classList.contains('oe-command-temporary-hint') &&
+            !block.classList.contains('display-1') && 
             !block.closest('TD, .o_editor_banner, div.o_text_columns') &&
             !block.style.textAlign &&
             !this.isMobile &&
@@ -4675,6 +4678,18 @@ export class OdooEditor extends EventTarget {
             block.classList.add('oe-hint');
             if (temporary) {
                 block.classList.add('oe-command-temporary-hint');
+            }
+            const color = ancestorsBackground(block, this.editable);
+            const foregroundColor = color ? chooseForeground(color) : false;
+            if (foregroundColor === "light") {
+                block.style.setProperty("--placeholder-text", "white");
+                this.magicButtonUiContainer.style.color = "white";
+            } else if (this.magicButtonUiContainer.style.color) {
+                this.magicButtonUiContainer.style.color = "";
+            }
+        } else {
+            if (block.style.getPropertyValue("--placeholder-text")) {
+                block.style.removeProperty("--placeholder-text");
             }
         }
         this._positionMagicButtons();

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -398,7 +398,7 @@ i.oe-powerbox-commandImg {
         top: 0;
         left: 0;
         display: block;
-        color: inherit;
+        color: var(--placeholder-text, inherit);
         opacity: 0.4;
         pointer-events: none;
         text-align: inherit;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/tablepicker/TablePicker.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/tablepicker/TablePicker.js
@@ -84,6 +84,10 @@ export class TablePicker extends EventTarget {
         this.el.style.display = 'none';
     }
 
+    visible() {
+        return this.el.style.display === 'none';
+    }
+
     reset() {
         this.rowNumber = this.options.minRowCount;
         this.colNumber = this.options.minColCount;

--- a/addons/web_editor/static/src/js/editor/toolbar.js
+++ b/addons/web_editor/static/src/js/editor/toolbar.js
@@ -26,6 +26,7 @@ export class Toolbar extends Component {
         useFontSizeInput: { type: Boolean, optional: true },
         showHistory: { type: Boolean, optional: true },
         showRemoveFormat: { type: Boolean, optional: true },
+        showDynamicplaceholder: { type: Boolean, optional: true },
 
         showStyle: { type: Boolean, optional: true },
         showJustify: { type: Boolean, optional: true },
@@ -60,6 +61,7 @@ export class Toolbar extends Component {
         useFontSizeInput: false,
         showHistory: false,
         showRemoveFormat: true,
+        showDynamicplaceholder: false,
 
         showStyle: true,
         showJustify: true,

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -991,3 +991,13 @@ code.o_inline_code {
     font-size: 85%;
     color: $gray-900;
 }
+
+.o_we_magic_button_container {
+    z-index: 1;
+    opacity: 0.30;
+
+    .magic_button:hover {
+        background-color: var(--o-cc2-btn-secondary);
+        border-radius: 5px;
+    }
+}

--- a/addons/web_editor/static/src/xml/editor.xml
+++ b/addons/web_editor/static/src/xml/editor.xml
@@ -297,6 +297,12 @@
                 <div id="redo" data-call="redo" class="btn fa fa-repeat"/>
             </div>
 
+            <div t-if="props.showDynamicplaceholder" id="dynamic-placeholder" class="btn-group">
+                <div id="open-dynamic-placeholder" class="btn editor-ignore" title="Use dynamic placeholders for personalization">
+                    <span class="fa fa-hashtag fa-fw" />
+                </div>
+            </div>
+
             <t t-slot="default"/>
         </div>
     </t>

--- a/addons/website/static/src/js/editor/odoo_editor.js
+++ b/addons/website/static/src/js/editor/odoo_editor.js
@@ -35,4 +35,12 @@ patch(OdooEditor.prototype, {
             e.clipboardData.setData("text/odoo-editor", html);
         }
     },
+    /**
+     * Since we do not want to show the magic buttons,
+     * we just return from here.
+     * @override
+     */
+    _positionMagicButtons() {
+        return;
+    }
 });


### PR DESCRIPTION
### Purpose of this PR:

This PR adds placeholder buttons for certain toolbar options to enhance
user experience and functionality.

1. **Placeholder Buttons**
    1. For backend HTML fields and knowledge:
          - Numbered lists
          - Bullet lists
          - Checklists
          - Tables
          - Images
          - Links
      2. In the case of mass-mailing add the following options:
         - Numbered lists
         - Bullet lists
         - Checklists
         - Tables
         - Images
         - Links
         - DynamicPlaceholder

2. **Dynamic Placeholder**
    1. Updated dynamic placeholder icon to use 'fa-hashtag' for consistency.
    2. Added 'dynamic placeholder' button to the sidebar.

3. **Excluded these buttons from display on the website.**

### Desired Output:

1. **For HTMLFields:**
![image](https://github.com/odoo/odoo/assets/120459796/77eeccdb-3afb-43be-ad30-723ca199a037)

2. **For Mass-mailing:**
![image](https://github.com/odoo/odoo/assets/120459796/b4571c1b-39e4-40eb-8f48-c90b6e5d6013)

4. **Dynamic Placeholder:**
     - Sidebar
![image](https://github.com/odoo/odoo/assets/120459796/4af9e71b-e781-417e-8732-a19bc03870e1)
     - Floating Toolbar
![image](https://github.com/odoo/odoo/assets/120459796/46f73f3a-70ba-45b1-9bef-d63899cb23d5)

**task-3644644**
