### PR TITLE
[FIX] l10n_pt: Minor fixes to CoA

### DIFF
--- a/addons/l10n_pt/data/account.account.template.csv
+++ b/addons/l10n_pt/data/account.account.template.csv
@@ -230,7 +230,7 @@ chart_4151,4151,234,Detained to maturity,asset_non_current,l10n_pt.pt_chart_temp
 chart_4158,4158,235,Others,asset_non_current,l10n_pt.pt_chart_template,False
 chart_41611,41611,236,Subsidiary investments - Goodwill,asset_non_current,l10n_pt.pt_chart_template,False
 chart_41612,41612,237,Investments in associates - Goodwill,asset_non_current,l10n_pt.pt_chart_template,False
-chart_41613,41613,238,Investments in associates - Goodwill,asset_non_current,l10n_pt.pt_chart_template,False
+chart_41613,41613,238,Investments in jointly controlled entities - Goodwill,asset_non_current,l10n_pt.pt_chart_template,False
 chart_419111,419111,239,Capital participation,asset_non_current,l10n_pt.pt_chart_template,False
 chart_419112,419112,240,Goodwill,asset_non_current,l10n_pt.pt_chart_template,False
 chart_41912,41912,241,Capital Participations - Other methods,asset_non_current,l10n_pt.pt_chart_template,False
@@ -630,7 +630,7 @@ chart_7915,7915,635,Of financing obtained,income,l10n_pt.pt_chart_template,False
 chart_7918,7918,636,Other financing granted,income,l10n_pt.pt_chart_template,False
 chart_7921,7921,637,Of applications of net financial means,income,l10n_pt.pt_chart_template,False
 chart_7922,7922,638,Of associates and joint enterprises,income,l10n_pt.pt_chart_template,False
-chart_7923,7923,639,Subsidiary,income,l10n_pt.pt_chart_template,False
+chart_7923,7923,639,Of subsidiaries,income,l10n_pt.pt_chart_template,False
 chart_7928,7928,640,Others,income,l10n_pt.pt_chart_template,False
 chart_793,793,641,Favorable exchange rate differences,income,l10n_pt.pt_chart_template,False
 chart_798,798,642,Other similar income,income,l10n_pt.pt_chart_template,False

--- a/addons/l10n_pt/data/l10n_pt_chart_data.xml
+++ b/addons/l10n_pt/data/l10n_pt_chart_data.xml
@@ -5,7 +5,7 @@
             <field name="name">Portugal - Chart of Accounts</field>
             <field name="cash_account_code_prefix">11</field>
             <field name="bank_account_code_prefix">12</field>
-            <field name="transfer_account_code_prefix">15</field>
+            <field name="transfer_account_code_prefix">1431</field>
             <field name="currency_id" ref="base.EUR"/>
             <field name="country_id" ref="base.pt"/>
             <field name="spoken_languages" eval="'pt_PT'"/>

--- a/addons/l10n_pt/i18n/l10n_pt.pot
+++ b/addons/l10n_pt/i18n/l10n_pt.pot
@@ -1960,18 +1960,22 @@ msgstr ""
 
 #. module: l10n_pt
 #: model:account.account,name:l10n_pt.2_chart_41612
-#: model:account.account,name:l10n_pt.2_chart_41613
 #: model:account.account,name:l10n_pt.2_chart_41712
-#: model:account.account,name:l10n_pt.2_chart_41713
 #: model:account.account,name:l10n_pt.2_chart_41812
-#: model:account.account,name:l10n_pt.2_chart_41813
 #: model:account.account.template,name:l10n_pt.chart_41612
-#: model:account.account.template,name:l10n_pt.chart_41613
 #: model:account.account.template,name:l10n_pt.chart_41712
-#: model:account.account.template,name:l10n_pt.chart_41713
 #: model:account.account.template,name:l10n_pt.chart_41812
-#: model:account.account.template,name:l10n_pt.chart_41813
 msgid "Investments in associates - Goodwill"
+msgstr ""
+
+#. module: l10n_pt
+#: model:account.account,name:l10n_pt.2_chart_41613
+#: model:account.account,name:l10n_pt.2_chart_41713
+#: model:account.account,name:l10n_pt.2_chart_41813
+#: model:account.account.template,name:l10n_pt.chart_41613
+#: model:account.account.template,name:l10n_pt.chart_41713
+#: model:account.account.template,name:l10n_pt.chart_41813
+msgid "Investments in jointly controlled entities - Goodwill"
 msgstr ""
 
 #. module: l10n_pt
@@ -3370,7 +3374,7 @@ msgstr ""
 #: model:account.account.template,name:l10n_pt.chart_332
 #: model:account.account.template,name:l10n_pt.chart_3392
 #: model:account.account.template,name:l10n_pt.chart_7923
-msgid "Subsidiary"
+msgid "Of subsidiaries"
 msgstr ""
 
 #. module: l10n_pt

--- a/addons/l10n_pt/i18n/pt.po
+++ b/addons/l10n_pt/i18n/pt.po
@@ -1961,19 +1961,23 @@ msgstr "Investimentos em associadas"
 
 #. module: l10n_pt
 #: model:account.account,name:l10n_pt.2_chart_41612
-#: model:account.account,name:l10n_pt.2_chart_41613
 #: model:account.account,name:l10n_pt.2_chart_41712
-#: model:account.account,name:l10n_pt.2_chart_41713
 #: model:account.account,name:l10n_pt.2_chart_41812
-#: model:account.account,name:l10n_pt.2_chart_41813
 #: model:account.account.template,name:l10n_pt.chart_41612
-#: model:account.account.template,name:l10n_pt.chart_41613
 #: model:account.account.template,name:l10n_pt.chart_41712
-#: model:account.account.template,name:l10n_pt.chart_41713
 #: model:account.account.template,name:l10n_pt.chart_41812
-#: model:account.account.template,name:l10n_pt.chart_41813
 msgid "Investments in associates - Goodwill"
 msgstr "Investimentos em associadas - Goodwill"
+
+#. module: l10n_pt
+#: model:account.account,name:l10n_pt.2_chart_41613
+#: model:account.account,name:l10n_pt.2_chart_41713
+#: model:account.account,name:l10n_pt.2_chart_41813
+#: model:account.account.template,name:l10n_pt.chart_41613
+#: model:account.account.template,name:l10n_pt.chart_41713
+#: model:account.account.template,name:l10n_pt.chart_41813
+msgid "Investments in jointly controlled entities - Goodwill"
+msgstr "Investimentos em entidades conjuntamente controladas - Goodwill"
 
 #. module: l10n_pt
 #: model:account.group,name:l10n_pt.2_chart_group_413
@@ -3371,8 +3375,8 @@ msgstr "Subsidiárias, associadas e empr. Conjuntos (NÃO CORRENTE)"
 #: model:account.account.template,name:l10n_pt.chart_332
 #: model:account.account.template,name:l10n_pt.chart_3392
 #: model:account.account.template,name:l10n_pt.chart_7923
-msgid "Subsidiary"
-msgstr "Matérias subsidiárias"
+msgid "Of subsidiaries"
+msgstr "De subsidiárias"
 
 #. module: l10n_pt
 #: model:account.account,name:l10n_pt.2_chart_41611


### PR DESCRIPTION
In #87572, the CoA was refactored to follow the regulation for companies under the general regime, which can be found at https://www.occ.pt/fotos/editor2/taxonomiasplanocontas_fev2019.pdf.

This commit fixes minor discrepancies between our version and the published regulation.

Enterprise PR: https://github.com/odoo/enterprise/pull/54918

taskid:3060790