### PR TITLE
[FIX] delivery: fix memory error

### DIFF
--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -37,9 +37,8 @@ class StockPicking(models.Model):
         for package in self:
             packs = set()
             if self.env['stock.move.line'].search_count([('picking_id', '=', package.id), ('result_package_id', '!=', False)]):
-                for move_line in package.move_line_ids:
-                    if move_line.result_package_id:
-                        packs.add(move_line.result_package_id.id)
+                for move_line in self.env['stock.move.line'].search([('id', 'in', package.move_line_ids.ids), ('result_package_id', '!=', False)]):
+                    packs.add(move_line.result_package_id.id)
             package.package_ids = list(packs)
 
     @api.depends('move_line_ids', 'move_line_ids.result_package_id', 'move_line_ids.product_uom_id', 'move_line_ids.qty_done')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Blocking request 

Current behavior before PR:

```py
Traceback (most recent call last):
   File "/tmp/tmpkidg4rcd/migrations/base/tests/test_mock_crawl.py", line 238, in crawl_menu
    self.mock_action(action_vals)
   File "/tmp/tmpkidg4rcd/migrations/base/tests/test_mock_crawl.py", line 394, in mock_action
    mock_method(model, view, fields_list, domain, group_by)
   File "/tmp/tmpkidg4rcd/migrations/base/tests/test_mock_crawl.py", line 522, in mock_view_tree
    self.mock_web_search_read(model, view, [domain], fields_list)
   File "/tmp/tmpkidg4rcd/migrations/base/tests/test_mock_crawl.py", line 556, in mock_web_search_read
    data = model.search_read(domain=domain, fields=fields_list, limit=80)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 5730, in search_read
    return records._read_format(fnames=fields, **read_kwargs)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3742, in _read_format
    vals[name] = convert(record[name], record, use_display_name)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 6577, in __getitem__
    return self._fields[key].__get__(self, type(self))
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1206, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/17.0/addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 4858, in _compute_field_value
    fields.determine(field.compute, self)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 101, in determine
    return needle(*args)
   File "/home/odoo/src/odoo/17.0/addons/stock_delivery/models/stock_picking.py", line 66, in _compute_shipping_weight
    picking.shipping_weight = picking.weight_bulk + sum([pack.shipping_weight or pack.weight for pack in picking.package_ids])
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 2886, in __get__
    return super().__get__(records, owner)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1206, in __get__
    self.compute_value(recs)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
   File "/home/odoo/src/odoo/17.0/addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 4858, in _compute_field_value
    fields.determine(field.compute, self)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 101, in determine
    return needle(*args)
   File "/home/odoo/src/odoo/17.0/addons/stock_delivery/models/stock_picking.py", line 41, in _compute_packages
    if move_line.result_package_id:
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 2886, in __get__
    return super().__get__(records, owner)
   File "/home/odoo/src/odoo/17.0/odoo/fields.py", line 1181, in __get__
    recs._fetch_field(self)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3768, in _fetch_field
    self.fetch(fnames)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3818, in fetch
    fetched = self._fetch_query(query, fields_to_fetch)
   File "/home/odoo/src/odoo/17.0/odoo/models.py", line 3923, in _fetch_query
    self.env.cache.insert_missing(fetched, field, values)
   File "/home/odoo/src/odoo/17.0/odoo/api.py", line 1093, in insert_missing
    field_cache.setdefault(id_, val)
 MemoryError

```

Desired behavior after PR is merged:

Causes a MemoryError if there are many stock move line with unique ```result_package_id``` values for ```packs``` to add
Preventing iteration for stock move line which didn't have ```result_package_id```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
