### PR TITLE
[IMP] base: add singular currency to invoice amount in letters

### DIFF
--- a/odoo/addons/base/data/res_currency_data.xml
+++ b/odoo/addons/base/data/res_currency_data.xml
@@ -11,6 +11,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="VEF" model="res.currency">
@@ -19,8 +21,10 @@
             <field name="symbol">Bs.F</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Bolivar</field>
+            <field name="currency_unit_label">Bolivares</field>
             <field name="currency_subunit_label">Centimos</field>
+            <field name="currency_unit_label_singular">Bolivar</field>
+            <field name="currency_subunit_label_singular">Centimo</field>
         </record>
 
         <record id="CAD" model="res.currency">
@@ -31,6 +35,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="CHF" model="res.currency">
@@ -40,8 +46,10 @@
             <field name="position">before</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
+            <field name="currency_unit_label">Francs</field>
             <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="BRL" model="res.currency">
@@ -51,8 +59,10 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
-            <field name="currency_unit_label">Real</field>
+            <field name="currency_unit_label">Reais</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Real</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="CNY" model="res.currency">
@@ -84,8 +94,10 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
-            <field name="currency_unit_label">Peso</field>
+            <field name="currency_unit_label">Pesos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="CZK" model="res.currency">
@@ -96,6 +108,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Koruna</field>
             <field name="currency_subunit_label">Halers</field>
+            <field name="currency_subunit_label_singular">Haler</field>
         </record>
 
         <record id="DKK" model="res.currency">
@@ -105,8 +118,9 @@
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Krone</field>
+            <field name="currency_unit_label">Kroner</field>
             <field name="currency_subunit_label">Ore</field>
+            <field name="currency_unit_label_singular">Krone</field>
         </record>
 
         <record id="HUF" model="res.currency">
@@ -147,8 +161,9 @@
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Krone</field>
+            <field name="currency_unit_label">Kroner</field>
             <field name="currency_subunit_label">Ore</field>
+            <field name="currency_unit_label_singular">Krone</field>
         </record>
 
         <record id="XPF" model="res.currency">
@@ -157,8 +172,10 @@
             <field name="symbol">XPF</field>
             <field name="rounding">1.00</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
+            <field name="currency_unit_label">Francs</field>
             <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="PAB" model="res.currency">
@@ -198,8 +215,10 @@
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Peso</field>
+            <field name="currency_unit_label">Pesos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="INR" model="res.currency">
@@ -211,6 +230,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupees</field>
             <field name="currency_subunit_label">Paise</field>
+            <field name="currency_unit_label_singular">Rupee</field>
         </record>
 
         <record id="AUD" model="res.currency">
@@ -222,6 +242,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="UAH" model="res.currency">
@@ -253,6 +275,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="JPY" model="res.currency">
@@ -272,8 +296,9 @@
             <field name="symbol">лв</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Lev</field>
+            <field name="currency_unit_label">Leva</field>
             <field name="currency_subunit_label">Stotinki</field>
+            <field name="currency_unit_label_singular">Lev</field>
         </record>
 
         <record id="LTL" model="res.currency">
@@ -284,6 +309,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Litas</field>
             <field name="currency_subunit_label">Centas</field>
+            <field name="currency_subunit_label_singular">Stotinka</field>
         </record>
 
         <record id="RON" model="res.currency">
@@ -292,8 +318,10 @@
             <field name="symbol">lei</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Leu</field>
+            <field name="currency_unit_label">Lei</field>
             <field name="currency_subunit_label">Bani</field>
+            <field name="currency_unit_label_singular">Leu</field>
+            <field name="currency_subunit_label_singular">Ban</field>
         </record>
 
         <record id="HRK" model="res.currency">
@@ -346,6 +374,8 @@
             <field name="position">before</field>
             <field name="currency_unit_label">Pesos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="MYR" model="res.currency">
@@ -368,6 +398,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="PHP" model="res.currency">
@@ -376,8 +408,10 @@
             <field name="symbol">₱</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Peso</field>
+            <field name="currency_unit_label">Pesos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="SGD" model="res.currency">
@@ -389,6 +423,8 @@
             <field name="position">before</field>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="ZAR" model="res.currency">
@@ -400,6 +436,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rand</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="CRC" model="res.currency">
@@ -409,8 +446,10 @@
             <field name="symbol">₡</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Colon</field>
+            <field name="currency_unit_label">Colones</field>
             <field name="currency_subunit_label">Centimos</field>
+            <field name="currency_unit_label_singular">Colón</field>
+            <field name="currency_subunit_label_singular">Centimo</field>
         </record>
 
         <record id="MUR" model="res.currency">
@@ -421,6 +460,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Rupees</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="XOF" model="res.currency">
@@ -429,8 +470,10 @@
             <field name="symbol">CFA</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
+            <field name="currency_unit_label">Francs</field>
             <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="XAF" model="res.currency">
@@ -439,8 +482,10 @@
             <field name="symbol">FCFA</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
+            <field name="currency_unit_label">Francs</field>
             <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="UGX" model="res.currency">
@@ -449,8 +494,10 @@
             <field name="symbol">USh</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Shilling</field>
+            <field name="currency_unit_label">Shillings</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Shilling</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="HNL" model="res.currency">
@@ -462,6 +509,8 @@
             <field name="position">before</field>
             <field name="currency_unit_label">Lempiras</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Lempira</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="CLP" model="res.currency">
@@ -471,8 +520,10 @@
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
-            <field name="currency_unit_label">Peso</field>
+            <field name="currency_unit_label">Pesos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="UYU" model="res.currency">
@@ -481,8 +532,10 @@
             <field name="symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Peso</field>
-            <field name="currency_subunit_label">Centesimos</field>
+            <field name="currency_unit_label">Pesos</field>
+            <field name="currency_subunit_label">Centésimos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centésimo</field>
         </record>
 
         <record id="AFN" model="res.currency">
@@ -491,8 +544,10 @@
             <field name="symbol">Afs</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Afghani</field>
+            <field name="currency_unit_label">Afghanis</field>
             <field name="currency_subunit_label">Puls</field>
+            <field name="currency_unit_label_singular">Afghani</field>
+            <field name="currency_subunit_label_singular">Pul</field>
         </record>
 
         <record id="AOA" model="res.currency">
@@ -501,8 +556,10 @@
             <field name="symbol">Kz</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Kwanza</field>
-            <field name="currency_subunit_label">Centimos</field>
+            <field name="currency_unit_label">Kwanzas</field>
+            <field name="currency_subunit_label">Cêntimos</field>
+            <field name="currency_unit_label_singular">Kwanza</field>
+            <field name="currency_subunit_label_singular">Cêntimo</field>
         </record>
 
         <record id="XCD" model="res.currency">
@@ -513,6 +570,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="AMD" model="res.currency">
@@ -533,6 +592,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Guilder</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="AZN" model="res.currency">
@@ -542,7 +602,8 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Manat</field>
-            <field name="currency_subunit_label">Qapik</field>
+            <field name="currency_subunit_label">Gapiks</field>
+            <field name="currency_subunit_label_singular">Gapik</field>
         </record>
 
         <record id="BSD" model="res.currency">
@@ -553,6 +614,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="BHD" model="res.currency">
@@ -561,8 +624,9 @@
             <field name="symbol">BD</field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Fils</field>
+            <field name="currency_unit_label_singular">Dinar</field>
         </record>
 
         <record id="BDT" model="res.currency">
@@ -583,6 +647,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="BYR" model="res.currency">
@@ -613,6 +679,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="BMD" model="res.currency">
@@ -623,6 +691,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="BTN" model="res.currency">
@@ -641,8 +711,10 @@
             <field name="symbol">Bs.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Boliviano</field>
+            <field name="currency_unit_label">Bolivianos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Boliviano</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="BAM" model="res.currency">
@@ -671,8 +743,10 @@
             <field name="symbol">FBu</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
-            <field name="currency_subunit_label">Centime</field>
+            <field name="currency_unit_label">Francs</field>
+            <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="KHR" model="res.currency">
@@ -693,6 +767,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="KMF" model="res.currency">
@@ -701,8 +777,10 @@
             <field name="symbol">CF</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
-            <field name="currency_subunit_label">Centime</field>
+            <field name="currency_unit_label">Francs</field>
+            <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="CDF" model="res.currency">
@@ -711,8 +789,10 @@
             <field name="symbol">Fr</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
-            <field name="currency_subunit_label">Centime</field>
+            <field name="currency_unit_label">Francs</field>
+            <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="CUP" model="res.currency">
@@ -721,8 +801,10 @@
             <field name="symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Peso</field>
+            <field name="currency_unit_label">Pesos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="ANG" model="res.currency">
@@ -731,8 +813,10 @@
             <field name="symbol">ƒ</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Guilder</field>
+            <field name="currency_unit_label">Guilders</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Guilder</field>
+            <field name="currency_subunit_label_singular">Cent</field>
             <field name="position">before</field>
         </record>
 
@@ -742,8 +826,10 @@
             <field name="symbol">Fdj</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
-            <field name="currency_subunit_label">Centime</field>
+            <field name="currency_unit_label">Francs</field>
+            <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="DOP" model="res.currency">
@@ -754,6 +840,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pesos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
             <field name="position">before</field>
         </record>
 
@@ -774,7 +862,9 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Colones</field>
-            <field name="currency_subunit_label">Centavo</field>
+            <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Colón</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="ERN" model="res.currency">
@@ -785,6 +875,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Nakfa</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_subunit_label_singular">Cent</field>
+
         </record>
 
         <record id="ETB" model="res.currency">
@@ -795,6 +887,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Birr</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="FKP" model="res.currency">
@@ -803,8 +896,10 @@
             <field name="symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Pound</field>
-            <field name="currency_subunit_label">Penny</field>
+            <field name="currency_unit_label">Pounds</field>
+            <field name="currency_subunit_label">Pence</field>
+            <field name="currency_unit_label_singular">Pound</field>
+            <field name="currency_subunit_label_singular">Penny</field>
         </record>
 
         <record id="FJD" model="res.currency">
@@ -815,6 +910,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="GEL" model="res.currency">
@@ -833,8 +930,10 @@
             <field name="symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Pound</field>
-            <field name="currency_subunit_label">Penny</field>
+            <field name="currency_unit_label">Pounds</field>
+            <field name="currency_subunit_label">Pence</field>
+            <field name="currency_unit_label_singular">Pound</field>
+            <field name="currency_subunit_label_singular">Penny</field>
         </record>
 
         <record id="GNF" model="res.currency">
@@ -843,8 +942,10 @@
             <field name="symbol">FG</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
-            <field name="currency_subunit_label">Centime</field>
+            <field name="currency_unit_label">Francs</field>
+            <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="GYD" model="res.currency">
@@ -855,6 +956,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="HTG" model="res.currency">
@@ -863,8 +966,10 @@
             <field name="symbol">G</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Gourde</field>
-            <field name="currency_subunit_label">Centime</field>
+            <field name="currency_unit_label">Gourdes</field>
+            <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Gourde</field>
+            <field name="currency_subunit_label_singular">Centime</field>
         </record>
 
         <record id="ISK" model="res.currency">
@@ -873,8 +978,10 @@
             <field name="symbol">kr</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Krona</field>
+            <field name="currency_unit_label">Krónur</field>
             <field name="currency_subunit_label">Aurar</field>
+            <field name="currency_unit_label_singular">Króna</field>
+            <field name="currency_subunit_label_singular">Eyrir</field>
         </record>
 
         <record id="IRR" model="res.currency">
@@ -883,8 +990,9 @@
             <field name="symbol">﷼</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Fils</field>
+            <field name="currency_unit_label_singular">Dinar</field>
         </record>
 
         <record id="IQD" model="res.currency">
@@ -893,8 +1001,9 @@
             <field name="symbol"> ع.د</field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Fils</field>
+            <field name="currency_unit_label_singular">Dinar</field>
         </record>
 
         <record id="ILS" model="res.currency">
@@ -906,6 +1015,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Shekel</field>
             <field name="currency_subunit_label">Agorot</field>
+            <field name="currency_subunit_label_singular">Agora</field>
         </record>
 
         <record id="JMD" model="res.currency">
@@ -916,6 +1026,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="JOD" model="res.currency">
@@ -924,8 +1036,9 @@
             <field name="symbol"> د.ا </field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Fils</field>
+            <field name="currency_unit_label_singular">Dinar</field>
         </record>
 
         <record id="KZT" model="res.currency">
@@ -944,8 +1057,10 @@
             <field name="symbol">KSh</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Shilling</field>
+            <field name="currency_unit_label">Shillings</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Shilling</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="KWD" model="res.currency">
@@ -954,8 +1069,9 @@
             <field name="symbol"> د.ك </field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Fils</field>
+            <field name="currency_unit_label_singular">Dinar</field>
         </record>
 
         <record id="KGS" model="res.currency">
@@ -984,7 +1100,7 @@
             <field name="symbol">ل.ل</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Pound</field>
+            <field name="currency_unit_label">Pounds</field>
             <field name="currency_subunit_label">Piastres</field>
         </record>
 
@@ -1006,6 +1122,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="LYD" model="res.currency">
@@ -1014,8 +1132,9 @@
             <field name="symbol"> ل.د </field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Dirham</field>
+            <field name="currency_unit_label_singular">Dinar</field>
         </record>
 
         <record id="MOP" model="res.currency">
@@ -1034,8 +1153,9 @@
             <field name="symbol">ден</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Denar</field>
+            <field name="currency_unit_label">Denari</field>
             <field name="currency_subunit_label">Deni</field>
+            <field name="currency_unit_label_singular">Denar</field>
         </record>
 
         <record id="MGA" model="res.currency">
@@ -1095,8 +1215,10 @@
             <field name="symbol">L</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Leu</field>
-            <field name="currency_subunit_label">Ban</field>
+            <field name="currency_unit_label">Lei</field>
+            <field name="currency_subunit_label">Bani</field>
+            <field name="currency_unit_label_singular">Leu</field>
+            <field name="currency_subunit_label_singular">Ban</field>
         </record>
 
         <record id="MNT" model="res.currency">
@@ -1127,6 +1249,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="DZD" model="res.currency">
@@ -1135,8 +1259,9 @@
             <field name="symbol">DA</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Dinar</field>
         </record>
 
         <record id="GHS" model="res.currency">
@@ -1147,6 +1272,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Cedi</field>
             <field name="currency_subunit_label">Pesewas</field>
+            <field name="currency_subunit_label_singular">Pesewa</field>
+
         </record>
 
         <record id="GMD" model="res.currency">
@@ -1165,8 +1292,10 @@
             <field name="symbol">MT</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Metical</field>
-            <field name="currency_subunit_label">Centavo</field>
+            <field name="currency_unit_label">Meticais</field>
+            <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Metical</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="MMK" model="res.currency">
@@ -1187,6 +1316,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="NPR" model="res.currency">
@@ -1197,6 +1328,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
             <field name="currency_subunit_label">Paisa</field>
+            <field name="currency_unit_label_singular">Rupees</field>
         </record>
 
         <record id="ALL" model="res.currency">
@@ -1205,8 +1337,10 @@
             <field name="symbol">L</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Lek</field>
-            <field name="currency_subunit_label">Qindarke</field>
+            <field name="currency_unit_label">Lekë</field>
+            <field name="currency_subunit_label">Qindarka</field>
+            <field name="currency_unit_label_singular">Lek</field>
+            <field name="currency_subunit_label_singular">Qindarkë</field>
         </record>
 
         <record id="NIO" model="res.currency">
@@ -1215,8 +1349,10 @@
             <field name="symbol">C$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Cordoba</field>
+            <field name="currency_unit_label">Cordobas</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Cordoba</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="NGN" model="res.currency">
@@ -1247,6 +1383,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="ZMW" model="res.currency">
@@ -1265,8 +1403,9 @@
             <field name="symbol">﷼</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Rial</field>
+            <field name="currency_unit_label">Rials</field>
             <field name="currency_subunit_label">Fils</field>
+            <field name="currency_unit_label_singular">Rial</field>
         </record>
 
         <record id="EUR" model="res.currency">
@@ -1277,6 +1416,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Euros</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Euro</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="VUV" model="res.currency">
@@ -1324,8 +1465,10 @@
             <field name="symbol">DT</field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Millimes</field>
+            <field name="currency_unit_label_singular">Dinar</field>
+            <field name="currency_subunit_label_singular">Millime</field>
         </record>
 
         <record id="TTD" model="res.currency">
@@ -1336,6 +1479,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="TOP" model="res.currency">
@@ -1364,8 +1509,9 @@
             <field name="symbol">TSh</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Shilling</field>
+            <field name="currency_unit_label">Shillings</field>
             <field name="currency_subunit_label">Senti</field>
+            <field name="currency_unit_label_singular">Shilling</field>
         </record>
 
         <record id="TJS" model="res.currency">
@@ -1375,7 +1521,8 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Somoni</field>
-            <field name="currency_subunit_label">Diram</field>
+            <field name="currency_subunit_label">Dirams</field>
+            <field name="currency_subunit_label_singular">Diram</field>
         </record>
 
         <record id="TWD" model="res.currency">
@@ -1386,6 +1533,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="SYP" model="res.currency">
@@ -1394,8 +1543,10 @@
             <field name="symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Pound</field>
-            <field name="currency_subunit_label">Piastrp</field>
+            <field name="currency_unit_label">Pounds</field>
+            <field name="currency_subunit_label">Piastres</field>
+            <field name="currency_unit_label_singular">Pound</field>
+            <field name="currency_subunit_label_singular">Piastre</field>
         </record>
 
         <record id="SZL" model="res.currency">
@@ -1404,8 +1555,10 @@
             <field name="symbol">E</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Lilangeni</field>
+            <field name="currency_unit_label">Emalangeni</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Lilangeni</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="SRD" model="res.currency">
@@ -1416,6 +1569,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="SDG" model="res.currency">
@@ -1434,6 +1589,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Rupees</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="SSP" model="res.currency">
@@ -1444,6 +1601,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Pounds</field>
             <field name="currency_subunit_label">Piasters</field>
+            <field name="currency_unit_label_singular">Pound</field>
         </record>
 
         <record id="GBP" model="res.currency">
@@ -1453,8 +1611,10 @@
             <field name="rounding">0.01</field>
             <field name="position">before</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Sterling</field>
-            <field name="currency_subunit_label">Penny</field>
+            <field name="currency_unit_label">Pounds</field>
+            <field name="currency_subunit_label">Pence</field>
+            <field name="currency_unit_label_singular">Pound</field>
+            <field name="currency_subunit_label_singular">Penny</field>
         </record>
 
         <record id="SOS" model="res.currency">
@@ -1465,6 +1625,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Shillings</field>
             <field name="currency_subunit_label">Senti</field>
+            <field name="currency_unit_label_singular">Shilling</field>
         </record>
 
         <record id="SBD" model="res.currency">
@@ -1475,6 +1636,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Dollars</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Dollar</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="SLL" model="res.currency">
@@ -1485,6 +1648,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Leone</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="SLE" model="res.currency">
@@ -1495,6 +1659,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Leone</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="SCR" model="res.currency">
@@ -1505,6 +1670,8 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
             <field name="currency_subunit_label">Cents</field>
+            <field name="currency_unit_label_singular">Rupees</field>
+            <field name="currency_subunit_label_singular">Cent</field>
         </record>
 
         <record id="RSD" model="res.currency">
@@ -1513,8 +1680,9 @@
             <field name="symbol">din.</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dinar</field>
+            <field name="currency_unit_label">Dinars</field>
             <field name="currency_subunit_label">Para</field>
+            <field name="currency_unit_label_singular">Dinar</field>
         </record>
 
         <record id="SAR" model="res.currency">
@@ -1523,8 +1691,10 @@
             <field name="symbol">SR</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Riyal</field>
-            <field name="currency_subunit_label">Halala</field>
+            <field name="currency_unit_label">Riyals</field>
+            <field name="currency_subunit_label">Halalas</field>
+            <field name="currency_unit_label_singular">Riyal</field>
+            <field name="currency_subunit_label_singular">Halalah</field>
         </record>
 
         <record id="STD" model="res.currency">
@@ -1533,8 +1703,10 @@
             <field name="symbol">Db</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dobra</field>
-            <field name="currency_subunit_label">Centimo</field>
+            <field name="currency_unit_label">Dobras</field>
+            <field name="currency_subunit_label">Cêntimos</field>
+            <field name="currency_unit_label_singular">Dobra</field>
+            <field name="currency_subunit_label_singular">Cêntimo</field>
         </record>
 
         <record id="WST" model="res.currency">
@@ -1553,8 +1725,10 @@
             <field name="symbol">£</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Pound</field>
-            <field name="currency_subunit_label">Penny</field>
+            <field name="currency_unit_label">Pounds</field>
+            <field name="currency_subunit_label">Pence</field>
+            <field name="currency_unit_label_singular">Pound</field>
+            <field name="currency_subunit_label_singular">Penny</field>
         </record>
 
         <record id="RWF" model="res.currency">
@@ -1563,8 +1737,11 @@
             <field name="symbol">RF</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Franc</field>
-            <field name="currency_subunit_label">Santime</field>
+            <field name="currency_unit_label">Francs</field>
+            <field name="currency_subunit_label">Centimes</field>
+            <field name="currency_unit_label_singular">Franc</field>
+            <field name="currency_subunit_label_singular">Centime</field>
+
         </record>
 
         <record id="QAR" model="res.currency">
@@ -1574,7 +1751,8 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rial</field>
-            <field name="currency_subunit_label">Dirham</field>
+            <field name="currency_subunit_label">Dirhams</field>
+            <field name="currency_subunit_label_singular">Dirham</field>
         </record>
 
         <record id="PEN" model="res.currency">
@@ -1586,6 +1764,8 @@
             <field name="position">before</field>
             <field name="currency_unit_label">Soles</field>
             <field name="currency_subunit_label">Centimos</field>
+            <field name="currency_unit_label_singular">Sol</field>
+            <field name="currency_subunit_label_singular">Centimo</field>
         </record>
 
         <record id="PYG" model="res.currency">
@@ -1594,8 +1774,10 @@
             <field name="symbol">₲</field>
             <field name="rounding">1</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Guarani</field>
+            <field name="currency_unit_label">Guaraní</field>
             <field name="currency_subunit_label">Centimos</field>
+            <field name="currency_unit_label_singular">Guaraníes</field>
+            <field name="currency_subunit_label_singular">Centimo</field>
         </record>
 
         <record id="PGK" model="res.currency">
@@ -1616,6 +1798,7 @@
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Rupee</field>
             <field name="currency_subunit_label">Paisa</field>
+            <field name="currency_unit_label_singular">Rupees</field>
         </record>
 
         <record id="OMR" model="res.currency">
@@ -1624,8 +1807,9 @@
             <field name="symbol">ر.ع.</field>
             <field name="rounding">0.001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Rial</field>
+            <field name="currency_unit_label">Rials</field>
             <field name="currency_subunit_label">Baisa</field>
+            <field name="currency_unit_label_singular">Rial</field>
         </record>
 
         <record id="CVE" model="res.currency">
@@ -1634,8 +1818,10 @@
             <field name="symbol">$</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Escudo</field>
-            <field name="currency_subunit_label">Centavo</field>
+            <field name="currency_unit_label">Escudos</field>
+            <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Escudo</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="COU" model="res.currency">
@@ -1645,8 +1831,10 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
-            <field name="currency_unit_label">Peso</field>
-            <field name="currency_subunit_label">centavo</field>
+            <field name="currency_unit_label">Pesos</field>
+            <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="CLF" model="res.currency">
@@ -1656,8 +1844,10 @@
             <field name="rounding">0.0001</field>
             <field name="active" eval="False"/>
             <field name="position">before</field>
-            <field name="currency_unit_label">Peso</field>
+            <field name="currency_unit_label">Pesos</field>
             <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="CUC" model="res.currency">
@@ -1676,7 +1866,9 @@
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
             <field name="currency_unit_label">Quetzales</field>
-            <field name="currency_subunit_label">Centavo</field>
+            <field name="currency_subunit_label">Centavos</field>
+            <field name="currency_unit_label_singular">Quetzal</field>
+            <field name="currency_subunit_label_singular">Centavo</field>
         </record>
 
         <record id="VES" model="res.currency">
@@ -1693,8 +1885,10 @@
             <field name="symbol">$</field>
             <field name="rounding">0.0001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">peso</field>
-            <field name="currency_subunit_label">centésimo</field>
+            <field name="currency_unit_label">Pesos</field>
+            <field name="currency_subunit_label">Centésimos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centésimo</field>
         </record>
 
         <record id="UYI" model="res.currency">
@@ -1703,8 +1897,10 @@
             <field name="symbol">$</field>
             <field name="rounding">0.0001</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Peso</field>
-            <field name="currency_subunit_label">centésimo</field>
+            <field name="currency_unit_label">Pesos</field>
+            <field name="currency_subunit_label">Centésimos</field>
+            <field name="currency_unit_label_singular">Peso</field>
+            <field name="currency_subunit_label_singular">Centésimo</field>
         </record>
 
         <record id="STN" model="res.currency">
@@ -1713,8 +1909,10 @@
             <field name="symbol">Db</field>
             <field name="rounding">0.01</field>
             <field name="active" eval="False"/>
-            <field name="currency_unit_label">Dobra</field>
-            <field name="currency_subunit_label">cêntimo</field>
+            <field name="currency_unit_label">Dobras</field>
+            <field name="currency_subunit_label">Cêntimos</field>
+            <field name="currency_unit_label_singular">Dobra</field>
+            <field name="currency_subunit_label_singular">Cêntimo</field>
         </record>
 
     </data>

--- a/odoo/addons/base/models/res_currency.py
+++ b/odoo/addons/base/models/res_currency.py
@@ -45,6 +45,8 @@ class Currency(models.Model):
     date = fields.Date(compute='_compute_date')
     currency_unit_label = fields.Char(string="Currency Unit")
     currency_subunit_label = fields.Char(string="Currency Subunit")
+    currency_unit_label_singular = fields.Char(string="Currency Unit - singular")
+    currency_subunit_label_singular = fields.Char(string="Currency Subunit - singular")
     is_current_company_currency = fields.Boolean(compute='_compute_is_current_company_currency')
 
     _sql_constraints = [
@@ -188,12 +190,14 @@ class Currency(models.Model):
         lang = tools.get_lang(self.env)
         amount_words = tools.ustr('{amt_value} {amt_word}').format(
                         amt_value=_num2words(integer_value, lang=lang.iso_code),
-                        amt_word=self.currency_unit_label,
+                        amt_word=self.currency_unit_label_singular
+                        if integer_value == 1 and self.currency_unit_label_singular else self.currency_unit_label,
                         )
         if not self.is_zero(amount - integer_value):
             amount_words += ' ' + _('and') + tools.ustr(' {amt_value} {amt_word}').format(
                         amt_value=_num2words(fractional_value, lang=lang.iso_code),
-                        amt_word=self.currency_subunit_label,
+                        amt_word=self.currency_subunit_label_singular
+                        if fractional_value == 1 and self.currency_subunit_label_singular else self.currency_subunit_label,
                         )
         return amount_words
 


### PR DESCRIPTION
For values such as $1,01 the amount in letters was shown as One Dollars and One Cents. This commit corrects this by displaying the singular unit or subunit name when amount equals to 1.

To do so, added singular unit and subunit names to several currencies in res_currency_data. Since not all languages have a difference between plural and singular, and not all plural are made by simply adding an -s at the end, this solution offers the flexibility needed.

task-3642672
