### PR TITLE
[IMP] sale_project,_*: multi-company support for count values of stat buttons in project updates panel

### DIFF
--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -15,7 +15,7 @@ class Project(models.Model):
     @api.depends('analytic_account_id')
     def _compute_purchase_orders_count(self):
         data = self.env['purchase.order.line']._read_group(
-            [('analytic_distribution', 'in', self.analytic_account_id.ids)],
+            [('analytic_distribution', 'in', self.analytic_account_id.ids), ('company_id', 'in', self.env.companies.ids)],
             ['analytic_distribution'],
             ['order_id:count_distinct'],
         )


### PR DESCRIPTION
Before this commit, the stat buttons count values in the project updates right-side panel were not updated when the user was changing companies in the company selector.
After this commit, the counts displayed in the stat buttons are updated based on the selected companies.

task-3689065

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
