### PR TITLE
[16.0] [FIX] privacy_lookup: Hide the action from users without access to the wizard

### DIFF
--- a/addons/privacy_lookup/wizard/privacy_lookup_wizard_views.xml
+++ b/addons/privacy_lookup/wizard/privacy_lookup_wizard_views.xml
@@ -92,6 +92,7 @@
         <field name="model_id" ref="base.model_res_partner"/>
         <field name="binding_model_id" ref="base.model_res_partner"/>
         <field name="binding_view_types">form</field>
+        <field name="groups_id" eval="[Command.link(ref('base.group_system'))]" />
         <field name="state">code</field>
         <field name="code">
 action = record.action_privacy_lookup()
@@ -103,6 +104,7 @@ action = record.action_privacy_lookup()
         <field name="model_id" ref="base.model_res_users"/>
         <field name="binding_model_id" ref="base.model_res_users"/>
         <field name="binding_view_types">form</field>
+        <field name="groups_id" eval="[Command.link(ref('base.group_system'))]" />
         <field name="state">code</field>
         <field name="code">
 action = record.partner_id.action_privacy_lookup()


### PR DESCRIPTION
**Steps to reproduce:**

1. Log in with a non-admin users
2. Open any Partner from
3. Click on Actions > Privacy Lookup

**Bug:**

```
You are not allowed to access 'Privacy Lookup Wizard' (privacy.lookup.wizard)
records.

This operation is allowed for the following groups:
	- Administration/Settings

Contact your administrator to request access if necessary.
```

**Expected behavior:**

The error message is correct. This feature should only be available to Administrator users. Therefore, the action should be hidden accordingly.

See: 

- https://github.com/odoo/odoo/blob/16.0/addons/privacy_lookup/security/ir.model.access.csv#L2

---

ping @tivisse 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
