### PR TITLE
[FIX] stock: remove outposed element in report_picking

### DIFF
--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -64,7 +64,7 @@
                                         </div>
                                     </div>
                                 </div>
-                                <div class="oe_structure"></div>
+                                <div t-if="False" class="oe_structure"></div>
                             </div>
                             <h1 t-field="o.name" class="mt0">WH/OUT/00001</h1>
                             <div class="oe_structure"></div>


### PR DESCRIPTION
### Steps to reproduce issue:

1. Go to _Inventory>Operations>Deliveries_
2. Open a form and click on the Gear Icon then _Print>"Picking Operations"_
3. The text looks much smaller than on other documents

### Explanation:

div with class `oe-structure` is not wrapped in the browser used by `wkhtmltopdf` and misposed. https://github.com/odoo/odoo/blob/567b8d676b3b6dc747df4d9bf10e7a91b4cb61bb/addons/stock/report/report_stockpicking_operations.xml#L67 ![overflowing_element](https://github.com/odoo/odoo/assets/151827051/3eec530d-35fe-47e8-9ee2-18816cfee1ab) Becuse of this, every element is shrunk to fit in the pdf.

### Suggested fix:

Removing misposed element from display solves the issue.

opw-3685935
