### PR TITLE
[IMP] {website_}mass_mailing: split contact name into first and last name

### DIFF
--- a/addons/mass_mailing/models/res_config_settings.py
+++ b/addons/mass_mailing/models/res_config_settings.py
@@ -26,6 +26,9 @@ class ResConfigSettings(models.TransientModel):
         string='24H Stat Mailing Reports',
         config_parameter='mass_mailing.mass_mailing_reports',
         help='Check how well your mailing is doing a day after it has been sent.')
+    group_mass_mailing_split_contact_name = fields.Boolean(
+        string="Split First and Last Name",
+        implied_group='mass_mailing.group_split_contact_name')
 
     @api.onchange('mass_mailing_outgoing_mail_server')
     def _onchange_mass_mailing_outgoing_mail_server(self):

--- a/addons/mass_mailing/security/res_groups_data.xml
+++ b/addons/mass_mailing/security/res_groups_data.xml
@@ -18,4 +18,10 @@
             <field name="implied_ids" eval="[(4, ref('mail.group_mail_template_editor'))]"/>
         </record>
     </data>
+
+    <!-- Config groups -->
+    <record id="group_split_contact_name" model="res.groups">
+        <field name="name">Split Contact Name</field>
+        <field name="category_id" ref="base.module_category_hidden"/>
+    </record>
 </odoo>

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -49,7 +49,9 @@
                 </header>
                 <field name="create_date" optional="show"/>
                 <field name="title_id" optional="hide"/>
-                <field name="name" readonly="1"/>
+                <field name="name" readonly="1" groups="!mass_mailing.group_split_contact_name"/>
+                <field name="first_name" readonly="1" groups="mass_mailing.group_split_contact_name"/>
+                <field name="last_name" readonly="1" groups="mass_mailing.group_split_contact_name"/>
                 <field name="company_name"/>
                 <field name="email" readonly="1"/>
                 <field name="is_blacklisted" string="Email Blacklisted"/>
@@ -117,13 +119,25 @@
                 <sheet>
                     <div class="oe_title">
                         <label for="name" string="Contact Name"/>
-                        <h1>
+                        <h1 groups="mass_mailing.group_split_contact_name">
+                            <field class="text-break" name="name" placeholder="e.g. John Smith"
+                                   readonly="1" invisible="not name"/>
+                            <!-- simulate the placeholder on the readonly field -->
+                            <span class="oe_grey" invisible="name">e.g. "John Smith"</span>
+                        </h1>
+                        <h1 groups="!mass_mailing.group_split_contact_name">
                             <field class="text-break" name="name" placeholder="e.g. John Smith"/>
                         </h1>
-                        <div>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags" style="width: 100%"/>
-                        </div>
                     </div>
+                    <!-- Separate group in order to have the correct tabindex -->
+                    <group groups="mass_mailing.group_split_contact_name">
+                        <group>
+                            <field name="first_name" placeholder="e.g. &quot;John&quot;"/>
+                        </group>
+                        <group>
+                            <field name="last_name" placeholder="e.g. &quot;Smith&quot;"/>
+                        </group>
+                    </group>
                     <group>
                         <group>
                             <label for="email" class="oe_inline"/>

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -12,6 +12,15 @@
                             <setting title="This tool is advised if your marketing campaign is composed of several emails." help="Manage mass mailing campaigns">
                                 <field name="group_mass_mailing_campaign"/>
                             </setting>
+                            <setting name="contact_naming" title="Contact Naming" help="Separate Mailing Contact Names into two fields">
+                                <field name="group_mass_mailing_split_contact_name"/>
+                            </setting>
+                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page. The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to blacklist themselves">
+                                <field name="show_blacklist_buttons"/>
+                            </setting>
+                            <setting name="mass_mailing_reports_setting_container" title="Send a report to the mailing responsible one day after the mailing has been sent." help="Check how well your mailing is doing a day after it has been sent">
+                                <field name="mass_mailing_reports"/>
+                            </setting>
                             <setting name="dedicated_server_setting_container" title="Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails." help="Pick a dedicated outgoing mail server for your mass mailings">
                                 <field name="mass_mailing_outgoing_mail_server"/>
                                 <div class="content-group" invisible="not mass_mailing_outgoing_mail_server">
@@ -23,12 +32,6 @@
                                         <button type="action" name="base.action_ir_mail_server_list" string="Configure Outgoing Mail Servers" icon="oi-arrow-right" class="oe_link"/>
                                     </div>
                                 </div>
-                            </setting>
-                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page. The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to blacklist themselves">
-                                <field name="show_blacklist_buttons"/>
-                            </setting>
-                            <setting name="mass_mailing_reports_setting_container" title="Send a report to the mailing responsible one day after the mailing has been sent." help="Check how well your mailing is doing a day after it has been sent">
-                                <field name="mass_mailing_reports"/>
                             </setting>
                         </block>
                     </app>

--- a/addons/website_mass_mailing/data/ir_model_data.xml
+++ b/addons/website_mass_mailing/data/ir_model_data.xml
@@ -11,6 +11,8 @@
             <value>mailing.contact</value>
             <value eval="[
                 'name',
+                'first_name',
+                'last_name',
                 'company_name',
                 'title_id',
                 'email',

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -59,7 +59,27 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
             <form id="newsletter_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required"
                   data-mark="*" data-model_name="mailing.contact" data-success-mode="message" hide-change-model="true">
                 <div class="s_website_form_rows row s_col_no_bgcolor">
-                    <div class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
+                    <t t-if="request.env.user.has_group('mass_mailing.group_split_contact_name')">
+                        <div class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub1a">
+                                    <span class="s_website_form_label_content">Name</span>
+                                    <span class="s_website_form_mark"> *</span>
+                                </label>
+                                <div class="col-sm row">
+                                    <div class="col-sm-6">
+                                        <input id="mailing_sub1a" type="text" class="form-control s_website_form_input"
+                                               name="first_name" placeholder="First Name" required="1"/>
+                                    </div>
+                                    <div class="col-sm-6">
+                                        <input id="mailing_sub1b" type="text" class="form-control s_website_form_input"
+                                               name="last_name" placeholder="Last Name" required="1"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                    <div t-else="" class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub1">
                                 <span class="s_website_form_label_content">Your Name</span>


### PR DESCRIPTION
Add an option that allows to fill the contact name by providing a first and a
last name instead of a single name. This option is not set by default.

If the option is enabled, the name will automatically be filled when filling
the first and the last name (as first name followed by last name).
In the front-end, inserting the form subscription of the newsletter block,
insert a form with a first name and last name field instead of a single name
field. Unfortunately, when changing the option, it won't update the
subscription form automatically (it must be done manually).

A small inconvenient is that when updating first or last name, it will update
the name so that the other part of the name is lost. To mitigate that problem,
we have enabled the tracking on "name" so that any change on that field is
logged in the chatter.

If the option is not enabled, only names can be filled. First and last name
will remain empty. Enabling the option won't convert name to first and last
name; that works should be done manually (maybe using an export and an import).

When not enabled, we make the first and last name fields not searchable so that
they don't appears in custom filters or dynamic placeholder.

Notes:
- the first and last name are not alligned with the rest of the form because we
have set them in a different group to force the correct tabindex.
- the columns of the mailing contact list view change depending on the config
setting group_mass_mailing_split_contact_name implemented with a group:
mass_mailing.group_split_contact_name. If it is enabled, the "name" column is
replaced by a first and a last name column. We have implemented it with a group
because using a context variable and column_invisible implied to modify
multiple action to pass that context variable which is prone to error.

Task-3597124