### PR TITLE
[REV] hr_holidays: Revert change on hr_leave's default_get state update

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -88,7 +88,7 @@ class HolidaysRequest(models.Model):
 
         if 'state' in fields_list and not defaults.get('state'):
             lt = self.env['hr.leave.type'].browse(defaults.get('holiday_status_id'))
-            defaults['state'] = 'confirm'
+            defaults['state'] = 'confirm' if lt and lt.leave_validation_type != 'no_validation' else 'draft'
 
         now = fields.Datetime.now()
         if 'date_from' not in defaults:


### PR DESCRIPTION
Ever since 14.0, from PR #45414, there has been a _compute_state function for recalculating the state on holiday_status_id change

The reverted commit becomes unnecessary and causes incorrect action buttons to be shown before creation

Note:
Reverts commit 015f8ecfa863ae2fcca983b6bb21e38577b220e7 from #82552

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
