### PR TITLE
[FIX] hr_expense: prevent error when post hr expense sheets for journal entries

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1285,7 +1285,7 @@ class HrExpenseSheet(models.Model):
         self.ensure_one()
         return {
             'name': '/',
-            'date': self.accounting_date or max(self.expense_line_ids.mapped('date')) or fields.Date.context_today(self),
+            'date': self.accounting_date or max([expense_date for expense_date in self.expense_line_ids.mapped('date') if expense_date]) or fields.Date.context_today(self),
             'invoice_date': self.accounting_date or fields.Date.context_today(self),  # expense payment behave as bills
             'ref': self.name,
             'expense_sheet_id': [Command.set(self.ids)],


### PR DESCRIPTION
Currently, the error arises during the posting of HR expense sheets for the journal entries when an 'Expense Date' is not available in the HR expense.

Steps to reproduce:

- Install a 'hr_expense' module (with demo data).
- Navigate to Expense / Expense Reports and open any record.
- Add a line in the Expense section without entering an 'Expense Date.'
- Click the 'Approve' button and then proceed to click on 'POST JOURNAL ENTRIES.'

Stack Trace:

```
TypeError: '>' not supported between instances of 'datetime.date' and 'bool'
  File "odoo/http.py", line 2150, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1722, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1749, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1953, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 28, in call_button
    action = self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "home/odoo/src/enterprise/17.0/hr_expense_extract/models/hr_expense.py", line 194, in action_sheet_move_create
    return super().action_sheet_move_create()
  File "addons/hr_expense/models/hr_expense_sheet.py", line 538, in action_sheet_move_create
    self._do_create_moves()
  File "addons/sale_expense/models/hr_expense_sheet.py", line 98, in _do_create_moves
    return super()._do_create_moves()
  File "addons/hr_expense/models/hr_expense_sheet.py", line 680, in _do_create_moves
    payments = self.env['account.payment'].with_context(**skip_context).create([
  File "addons/hr_expense/models/hr_expense_sheet.py", line 681, in <listcomp>
    expense._prepare_payments_vals() for expense in company_account_sheets.expense_line_ids
  File "addons/hr_expense/models/hr_expense.py", line 779, in _prepare_payments_vals
    **self.sheet_id._prepare_move_vals(),
  File "addons/hr_expense/models/hr_expense_sheet.py", line 723, in _prepare_move_vals
    'date': self.accounting_date or max(self.expense_line_ids.mapped('date')) or fields.Date.context_today(self),
```

When posting the HR expenses sheet for journal entries without adding an expense date in 'Expense', There's an issue at 
 [1], Where the max() function is used to return highest expense date from 'expense_line_ids.' But one of the dates is marked as 'False,'

[1] : 
 https://github.com/odoo/odoo/blob/b1b94a075672067325ddcc125cbc57ae214b0a9a/addons/hr_expense/models/hr_expense.py#L1288

This commit fixes the above issue by adding a condition to eliminate date values that are marked as 'False.' This ensures that only valid dates are considered when determining the highest expense date.

sentry-4907496401

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
