### PR TITLE
[FIX] web: fix progress bar behavior while the stage name same

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -290,10 +290,8 @@ class Base(models.AbstractModel):
             selection_labels = dict(self.fields_get()[group_by]['selection'])
 
         def adapt(value):
-            if field_type == 'selection':
-                value = selection_labels.get(value, False)
             if isinstance(value, tuple):
-                value = value[1]  # FIXME should use technical value (0)
+                value = value[0]
             return value
 
         result = {}

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -51,7 +51,7 @@ class ProgressBarState {
                     [group.groupByField.name]: group.serverValue,
                 });
             }
-            let groupValue = group.displayName || group.value;
+            let groupValue = !group.value.isLuxonDateTime?group.value:group.displayName
             if (groupValue === true) {
                 groupValue = "True";
             } else if (groupValue === false) {
@@ -265,7 +265,7 @@ class ProgressBarState {
             for (const group of this.model.root.groups) {
                 if (!group.isFolded) {
                     const groupInfo = this.getGroupInfo(group);
-                    let groupValue = group.displayName || group.value;
+                    let groupValue = !group.value.isLuxonDateTime?group.value:group.displayName
                     if (groupValue === true) {
                         groupValue = "True";
                     } else if (groupValue === false) {

--- a/odoo/addons/test_read_group/tests/test_read_progress_bar.py
+++ b/odoo/addons/test_read_group/tests/test_read_progress_bar.py
@@ -112,9 +112,9 @@ class TestReadProgressBar(common.TransactionCase):
         }
         result = self.env['x_progressbar'].read_progress_bar([], 'x_country_id', progress_bar)
         self.assertEqual(result, {
-            c1.display_name: {'foo': 3, 'bar': 1, 'baz': 1},
-            c2.display_name: {'foo': 1, 'bar': 2, 'baz': 1},
-            c3.display_name: {'foo': 2, 'bar': 0, 'baz': 4},
+            str(c1.id): {'foo': 3, 'bar': 1, 'baz': 1},
+            str(c2.id): {'foo': 1, 'bar': 2, 'baz': 1},
+            str(c3.id): {'foo': 2, 'bar': 0, 'baz': 4},
         })
 
         # check date aggregation and format
@@ -145,9 +145,9 @@ class TestReadProgressBar(common.TransactionCase):
         }
         result = self.env['x_progressbar'].read_progress_bar([], 'x_country_id', progress_bar)
         self.assertEqual(result, {
-            c1.display_name: {'foo': 3, 'bar': 1, 'baz': 1},
-            c2.display_name: {'foo': 1, 'bar': 2, 'baz': 1},
-            c3.display_name: {'foo': 2, 'bar': 0, 'baz': 4},
+            str(c1.id): {'foo': 3, 'bar': 1, 'baz': 1},
+            str(c2.id): {'foo': 1, 'bar': 2, 'baz': 1},
+            str(c3.id): {'foo': 2, 'bar': 0, 'baz': 4},
         })
 
         result = self.env['x_progressbar'].read_progress_bar([], 'x_date:week', progress_bar)


### PR DESCRIPTION
Steps to Reproduce :
 - Open Project Module
 - Open any Project
 - Create the same stage Name
 - Check the Progress Bar

https://drive.google.com/file/d/1hvLAmi0pIRLsiHGftD3Q0wTkJjYJhjTM/view

Observed behavior:
even though the data in the two stages are different, the stage with the same name displays the same progress bar

Expected behavior: 
When the stage name is the same, the progress bar shouldn't appear the same.

Task-3491897

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
