### PR TITLE
[FIX] pos_restaurant: prevent duplicate printing of automated receipts

### DIFF
--- a/addons/pos_restaurant/static/src/app/tip_receipt/tip_receipt.js
+++ b/addons/pos_restaurant/static/src/app/tip_receipt/tip_receipt.js
@@ -4,7 +4,7 @@ import { Component } from "@odoo/owl";
 import { ReceiptHeader } from "@point_of_sale/app/screens/receipt_screen/receipt/receipt_header/receipt_header";
 
 export class TipReceipt extends Component {
-    static template = "pos_restaurant.TipReceipt";
+    static template = "pos_restaurant.MultipleTipReceipt";
     static components = { ReceiptHeader };
     static props = ["headerData", "data", "total"];
 }

--- a/addons/pos_restaurant/static/src/app/tip_receipt/tip_receipt.xml
+++ b/addons/pos_restaurant/static/src/app/tip_receipt/tip_receipt.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
 
+    <t t-name="pos_restaurant.MultipleTipReceipt">
+        <div class="pos-receipt">
+            <t t-call="pos_restaurant.TipReceipt"/>
+            <p style="page-break-after:always;"/>
+            <t t-call="pos_restaurant.TipReceipt"/>
+        </div>
+    </t>
+
     <t t-name="pos_restaurant.TipReceipt">
         <div class="pos-receipt">
             <ReceiptHeader data="props.headerData" />

--- a/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js
+++ b/addons/pos_restaurant/static/src/app/tip_screen/tip_screen.js
@@ -109,22 +109,15 @@ export class TipScreen extends Component {
         return { name: "ReceiptScreen" };
     }
     async printTipReceipt() {
-        const order = this.currentOrder;
-        const receipts = [
-            order.get_selected_paymentline().ticket,
-            order.get_selected_paymentline().cashier_receipt,
-        ];
-        for (let i = 0; i < receipts.length; i++) {
-            await this.printer.print(
-                TipReceipt,
-                {
-                    headerData: this.pos.getReceiptHeaderData(order),
-                    data: receipts[i] || {},
-                    total: this.env.utils.formatCurrency(this.totalAmount),
-                },
-                { webPrintFallback: true }
-            );
-        }
+        await this.printer.print(
+            TipReceipt,
+            {
+                headerData: this.pos.getReceiptHeaderData(this.currentOrder),
+                data: this.currentOrder.get_selected_paymentline().ticket || {},
+                total: this.env.utils.formatCurrency(this.totalAmount),
+            },
+            { webPrintFallback: true }
+        );
     }
 }
 


### PR DESCRIPTION
Before this commit
================
The automated receipt printing functionality was causing receipts to be printed twice when payment was confirmed.

After this commit
================
With this commit, the issue of duplicated receipt printing on payment confirmation is resolved. Now, the automated receipt printing functionality ensures that receipts are printed only once.

task: 3568958