### PR TITLE
[FIX] project: fix session error while opening archive task in portal view

### DIFF
--- a/addons/project/controllers/project_sharing_chatter.py
+++ b/addons/project/controllers/project_sharing_chatter.py
@@ -25,7 +25,7 @@ class ProjectSharingChatter(PortalChatter):
         can_access = project_sudo and res_model == 'project.task' and project_sudo.with_user(request.env.user)._check_project_sharing_access()
         task = None
         if can_access:
-            task = request.env['project.task'].sudo().search([('id', '=', res_id), ('project_id', '=', project_sudo.id)])
+            task = request.env['project.task'].sudo().with_context(active_test=False).search([('id', '=', res_id), ('project_id', '=', project_sudo.id)])
         if not can_access or not task:
             raise Forbidden()
         return task[task._mail_post_token_field]

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -225,6 +225,9 @@
         <field name="priority">999</field>
         <field name="arch" type="xml">
             <search position="inside"/>
+            <xpath expr="//search/filter[@name='inactive']" position='attributes'>
+                <attribute name='invisible'>1</attribute>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
**Steps:**
- Go to project > task > archive a task
- Open portal view of project > go to the same project
- Filter the search view by choosing 'Archived'
- Click on the archived task

**Issue:**
- Session error when trying to open the archive task

**Cause:**
- By clicking on the archived task, page is refreshed and it tries to open the kanban view again and hence gives session expire error

**Fix:**
- Hiding the archived filter as suggested by the specs of the task because it seems to be irrelevant in project sharing
- Passing the correct context so that it will take all the tasks in counting and not just the active tasks.

**Affected version**: saas-16.3 - master

**Task**-3690536