### PR TITLE
[IMP] sale_project,_*: multi-company count of stat buttons in project updates

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -27,8 +27,7 @@ class ProjectProject(models.Model):
     timesheet_encode_uom_id = fields.Many2one('uom.uom', compute='_compute_timesheet_encode_uom_id', export_string_translation=False)
     total_timesheet_time = fields.Integer(
         compute='_compute_total_timesheet_time', groups='hr_timesheet.group_hr_timesheet_user',
-        string="Total amount of time (in the proper unit) recorded in the project, rounded to the unit.",
-        compute_sudo=True, export_string_translation=False)
+        string="Total amount of time (in the proper unit) recorded in the project, rounded to the unit.", export_string_translation=False)
     encode_uom_in_days = fields.Boolean(compute='_compute_encode_uom_in_days', export_string_translation=False)
     is_internal_project = fields.Boolean(compute='_compute_is_internal_project', search='_search_is_internal_project', export_string_translation=False)
     remaining_hours = fields.Float(compute='_compute_remaining_hours', string='Time Remaining', compute_sudo=True)

--- a/addons/hr_timesheet/models/project_update.py
+++ b/addons/hr_timesheet/models/project_update.py
@@ -34,6 +34,6 @@ class ProjectUpdate(models.Model):
             update.write({
                 "uom_id": encode_uom,
                 "allocated_time": round(project.allocated_hours / ratio),
-                "timesheet_time": round(project.total_timesheet_time / ratio),
+                "timesheet_time": round(project.sudo().total_timesheet_time / ratio),
             })
         return updates

--- a/addons/project_mrp/models/project_project.py
+++ b/addons/project_mrp/models/project_project.py
@@ -64,23 +64,22 @@ class ProjectProject(models.Model):
     def _get_stat_buttons(self):
         buttons = super()._get_stat_buttons()
         if self.env.user.has_group('mrp.group_mrp_user'):
-            self_sudo = self.sudo()
             buttons.extend([{
                 'icon': 'flask',
                 'text': self.env._('Bills of Materials'),
-                'number': self_sudo.bom_count,
+                'number': self.bom_count,
                 'action_type': 'object',
                 'action': 'action_view_mrp_bom',
-                'show': self_sudo.bom_count > 0,
+                'show': self.bom_count > 0,
                 'sequence': 35,
             },
             {
                 'icon': 'wrench',
                 'text': self.env._('Manufacturing Orders'),
-                'number': self_sudo.production_count,
+                'number': self.production_count,
                 'action_type': 'object',
                 'action': 'action_view_mrp_production',
-                'show': self_sudo.production_count > 0,
+                'show': self.production_count > 0,
                 'sequence': 46,
             }])
         return buttons

--- a/addons/project_purchase/models/project_project.py
+++ b/addons/project_purchase/models/project_project.py
@@ -106,14 +106,13 @@ class ProjectProject(models.Model):
     def _get_stat_buttons(self):
         buttons = super()._get_stat_buttons()
         if self.env.user.has_group('purchase.group_purchase_user'):
-            self_sudo = self.sudo()
             buttons.append({
                 'icon': 'credit-card',
                 'text': self.env._('Purchase Orders'),
-                'number': self_sudo.purchase_orders_count,
+                'number': self.purchase_orders_count,
                 'action_type': 'object',
                 'action': 'action_open_project_purchase_orders',
-                'show': self_sudo.purchase_orders_count > 0,
+                'show': self.purchase_orders_count > 0,
                 'sequence': 36,
             })
         return buttons

--- a/addons/sale_project/models/project_project.py
+++ b/addons/sale_project/models/project_project.py
@@ -38,7 +38,7 @@ class ProjectProject(models.Model):
     sale_order_count = fields.Integer(compute='_compute_sale_order_count', groups='sales_team.group_sale_salesman', export_string_translation=False)
     has_any_so_with_nothing_to_invoice = fields.Boolean('Has a SO with an invoice status of No', compute='_compute_has_any_so_with_nothing_to_invoice', export_string_translation=False)
     invoice_count = fields.Integer(compute='_compute_invoice_count', groups='account.group_account_readonly', export_string_translation=False)
-    vendor_bill_count = fields.Integer(related='account_id.vendor_bill_count', groups='account.group_account_readonly', export_string_translation=False)
+    vendor_bill_count = fields.Integer(related='account_id.vendor_bill_count', groups='account.group_account_readonly', compute_sudo=False, export_string_translation=False)
     partner_id = fields.Many2one(compute="_compute_partner_id", store=True, readonly=False)
     display_sales_stat_buttons = fields.Boolean(compute='_compute_display_sales_stat_buttons', export_string_translation=False)
     sale_order_state = fields.Selection(related='sale_order_id.state', export_string_translation=False)
@@ -752,17 +752,16 @@ class ProjectProject(models.Model):
     def _get_stat_buttons(self):
         buttons = super()._get_stat_buttons()
         if self.env.user.has_group('sales_team.group_sale_salesman_all_leads'):
-            self_sudo = self.sudo()
             buttons.append({
                 'icon': 'dollar',
                 'text': self.env._('Sales Orders'),
-                'number': self_sudo.sale_order_count,
+                'number': self.sale_order_count,
                 'action_type': 'object',
                 'action': 'action_view_sos',
                 'additional_context': json.dumps({
                     'create_for_project_id': self.id,
                 }),
-                'show': self_sudo.display_sales_stat_buttons and self_sudo.sale_order_count > 0,
+                'show': self.display_sales_stat_buttons and self.sale_order_count > 0,
                 'sequence': 27,
             })
         if self.env.user.has_group('sales_team.group_sale_salesman_all_leads'):
@@ -776,25 +775,23 @@ class ProjectProject(models.Model):
                 'sequence': 28,
             })
         if self.env.user.has_group('account.group_account_readonly'):
-            self_sudo = self.sudo()
             buttons.append({
                 'icon': 'pencil-square-o',
                 'text': self.env._('Invoices'),
-                'number': self_sudo.invoice_count,
+                'number': self.invoice_count,
                 'action_type': 'object',
                 'action': 'action_open_project_invoices',
-                'show': bool(self.account_id) and self_sudo.invoice_count > 0,
+                'show': bool(self.account_id) and self.invoice_count > 0,
                 'sequence': 30,
             })
         if self.env.user.has_group('account.group_account_readonly'):
-            self_sudo = self.sudo()
             buttons.append({
                 'icon': 'pencil-square-o',
                 'text': self.env._('Vendor Bills'),
-                'number': self_sudo.vendor_bill_count,
+                'number': self.vendor_bill_count,
                 'action_type': 'object',
                 'action': 'action_open_project_vendor_bills',
-                'show': self_sudo.vendor_bill_count > 0,
+                'show': self.vendor_bill_count > 0,
                 'sequence': 38,
             })
         return buttons


### PR DESCRIPTION
Before this commit, the stat buttons count values in the project updates right-side panel were not updated when the user was changing companies in the company selector.
After this commit, the counts displayed in the stat buttons are updated based on the selected companies.

task-3689065

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
