### PR TITLE
[IMP] stock: keep MTO on relocate

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -765,11 +765,13 @@ class StockQuant(models.Model):
                 domain = expression.AND([[('package_id', '=', package_id.id)], domain])
             if owner_id:
                 domain = expression.AND([[('owner_id', '=', owner_id.id)], domain])
-            domain = expression.AND([[('location_id', 'child_of', location_id.id)], domain])
         else:
             domain = expression.AND([['|', ('lot_id', '=', lot_id.id), ('lot_id', '=', False)] if lot_id else [('lot_id', '=', False)], domain])
             domain = expression.AND([[('package_id', '=', package_id and package_id.id or False)], domain])
             domain = expression.AND([[('owner_id', '=', owner_id and owner_id.id or False)], domain])
+        if not strict or self.env.context.get('allow_child_locations'):
+            domain = expression.AND([[('location_id', 'child_of', location_id.id)], domain])
+        else:
             domain = expression.AND([[('location_id', '=', location_id.id)], domain])
         if self.env.context.get('with_expiration'):
             domain = expression.AND([['|', ('expiration_date', '>=', self.env.context['with_expiration']), ('expiration_date', '=', False)], domain])


### PR DESCRIPTION
When relocating an MTO reserverd product, the MTO link should be kept if possible.

task-3686855

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
