### PR TITLE
[FIX] mail: enforcing an active mail author

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1792,7 +1792,7 @@ class MailThread(models.AbstractModel):
             domain = expression.AND([domain, extra_domain])
         partners = self.env['res.users'].sudo().search(domain).mapped('partner_id')
         # return a search on partner to filter results current user should not see (multi company for example)
-        return self.env['res.partner'].search([('id', 'in', partners.ids)])
+        return self.env['res.partner'].search([('id', 'in', partners.ids), ('active', '=', True)])
 
     def _mail_search_on_partner(self, normalized_emails, extra_domain=False):
         domain = [('email_normalized', 'in', normalized_emails)]


### PR DESCRIPTION
Excludes archived partners from being selected by the '_mail_search_on_user' function.

OPW-3672143