### PR TITLE
[FIX] sale,purchase: skip recomputation for matching quantities

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1305,6 +1305,9 @@ class PurchaseOrderLine(models.Model):
                 line.product_packaging_id = False
             # suggest biggest suitable packaging matching the PO's company
             if line.product_id and line.product_qty and line.product_uom:
+                # if a packaging already set, check if it still match the quantity
+                if line.product_packaging_id and line.product_packaging_id._check_qty(line.product_qty, line.product_uom) == line.product_qty:
+                    continue
                 suggested_packaging = line.product_id.packaging_ids\
                         .filtered(lambda p: p.purchase and (p.product_id.company_id <= p.company_id <= line.company_id))\
                         ._find_suitable_product_packaging(line.product_qty, line.product_uom)

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -647,6 +647,9 @@ class SaleOrderLine(models.Model):
                 line.product_packaging_id = False
             # suggest biggest suitable packaging matching the SO's company
             if line.product_id and line.product_uom_qty and line.product_uom:
+                # if a packaging already set, check if it still match the quantity
+                if line.product_packaging_id and line.product_packaging_id._check_qty(line.product_uom_qty, line.product_uom) == line.product_uom_qty:
+                    continue
                 suggested_packaging = line.product_id.packaging_ids\
                         .filtered(lambda p: p.sales and (p.product_id.company_id <= p.company_id <= line.company_id))\
                         ._find_suitable_product_packaging(line.product_uom_qty, line.product_uom)


### PR DESCRIPTION
**Issue Description**:
When you create a purchase order or sales order and select packaging as boxes and quantity, when you change the packaging to piece-by-piece and change the quantity, the packaging becomes boxes again.

This is due to the operation of the function ._find_suitable_product_packaging in suggested_packaging that's trying to come up with a better option.

https://github.com/odoo/odoo/blob/bfabb945348f0d044ac19a1c8bd130c1e37c5145/addons/purchase/models/purchase.py#L1301-L1311 https://github.com/odoo/odoo/blob/72c1a4f96a1219d98ce9b90ee54fd7297b9ab999/addons/sale/models/sale_order_line.py#L646-L656

**Steps to Reproduce**:
1. Create a new product in the `Purchase` or `Sale` app.
2. In the `Inventory` tab, add 2 new packaging options (for example, 'pack1' with a `Contained Quantity` of 1 and 'pack5' with a `Contained Quantity` of 5).
3. Open the `Purchase` or `Sale` app, create a Purchase Order (PO) or Sales Order (SO), and add this new product.
4. Change the `Quantity` to 5, select `Packaging` as pack5, and save.
5. Change the `Packaging` to pack1 and save.
6. Change the `Quantity` to 10, and you will notice that the packaging recalculates to the larger box, pack5.

**Proposed Solution**:
If a type of packaging is selected and then the product quantity is changed to an amount that is suitable for that packaging, the system should not recalculate to a different packaging option.

opw-3648476
