### PR TITLE
[IMP] base: Enable duplicate context value in actions

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1121,7 +1121,7 @@ actual arch.
         is_base_model = self.env.context.get('base_model_name', model._name) == model._name
 
         if node.tag in ('kanban', 'tree', 'form', 'activity', 'calendar'):
-            for action, operation in (('create', 'create'), ('delete', 'unlink'), ('edit', 'write')):
+            for action, operation in (('create', 'create'), ('duplicate', 'create'), ('delete', 'unlink'), ('edit', 'write')):
                 if (not node.get(action) and
                         not model.check_access_rights(operation, raise_exception=False) or
                         not self._context.get(action, True) and is_base_model):


### PR DESCRIPTION
Of the four 'activeActions' of views, only three of them can be enabled/disabled using context values

This commit enables the use of a duplicate = True/False context to prevent copying in the action menu

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
