### PR TITLE
[IMP] various: display search filter from contact stat button

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -695,12 +695,16 @@ class ResPartner(models.Model):
     def action_view_partner_invoices(self):
         self.ensure_one()
         action = self.env["ir.actions.actions"]._for_xml_id("account.action_move_out_invoice_type")
-        all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
         action['domain'] = [
             ('move_type', 'in', ('out_invoice', 'out_refund')),
-            ('partner_id', 'in', all_child.ids)
+            ('partner_id', 'child_of', self.ids),
         ]
-        action['context'] = {'default_move_type': 'out_invoice', 'move_type': 'out_invoice', 'journal_type': 'sale', 'search_default_unpaid': 1}
+        action['context'] = {
+            'default_move_type': 'out_invoice',
+            'move_type': 'out_invoice',
+            'journal_type': 'sale',
+            'search_default_partner_id': self.id,
+        }
         return action
 
     def _has_invoice(self, partner_domain):

--- a/addons/calendar/models/res_partner.py
+++ b/addons/calendar/models/res_partner.py
@@ -99,6 +99,8 @@ class ResPartner(models.Model):
         action = self.env["ir.actions.actions"]._for_xml_id("calendar.action_calendar_event")
         action['context'] = {
             'default_partner_ids': partner_ids,
+            'meetings_parent_partner': self.id,
+            'search_default_invite_partner': 1,
         }
         action['domain'] = ['|', ('id', 'in', self._compute_meeting()[self.id]), ('partner_ids', 'in', self.ids)]
         return action

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -448,6 +448,8 @@
                     <separator/>
                     <filter string="Date" name="group_by_start" domain="[]" context="{'group_by': 'start'}"/>
                 </group>
+                <filter string="Attendees" name="invite_partner" domain="[('partner_ids', 'child_of', context.get('meetings_parent_partner'))]" context="{'active_test': False}" invisible="1"/>
+                <separator/>
             </search>
         </field>
     </record>

--- a/addons/crm/models/res_partner.py
+++ b/addons/crm/models/res_partner.py
@@ -75,6 +75,8 @@ class ResPartner(models.Model):
             'search_default_filter_ongoing': 1,
             'search_default_filter_lost': 1,
             'active_test': False,
+            'lead_parent_partner': self.ids,
+            'search_default_partner_filter': 1,
         }
         # we want the list view first
         action['views'] = sorted(action['views'], key=lambda view: view[1] != 'list')

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -1016,6 +1016,7 @@
                         <filter string="Closed Date" name="date_closed" context="{'group_by':'date_closed'}"/>
                         <separator/>
                         <filter string="Properties" name="group_by_lead_properties" context="{'group_by':'lead_properties'}"/>
+                        <filter name="partner_filter" string="Contact" domain="[('partner_id', 'child_of', context.get('lead_parent_partner'))]" context="{'active_test': False}" invisible="1"/>
                     </group>
                 </search>
             </field>

--- a/addons/loyalty/models/res_partner.py
+++ b/addons/loyalty/models/res_partner.py
@@ -35,7 +35,10 @@ class ResPartner(models.Model):
 
     def action_view_loyalty_cards(self):
         action = self.env['ir.actions.act_window']._for_xml_id('loyalty.loyalty_card_action')
-        all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        action['domain'] = [('partner_id', 'in', all_child.ids)]
-        action['context'] = {'search_default_active' : True, 'create': False}
+        action['domain'] = [('partner_id', 'child_of', self.ids)]
+        action['context'] = {
+            'create': False,
+            'search_default_active': True,
+            'search_default_partner_id': self.ids,
+        }
         return action

--- a/addons/loyalty/views/loyalty_card_views.xml
+++ b/addons/loyalty/views/loyalty_card_views.xml
@@ -62,7 +62,7 @@
         <field name="arch" type="xml">
             <search>
                 <field name="code"/>
-                <field name="partner_id"/>
+                <field name="partner_id" operator="child_of"/>
                 <field name="program_id"/>
                 <separator/>
                 <filter name="active" string="Active" domain="['&amp;', ('program_id.active', '=', True), '&amp;', ('points', '>', 0), '|', ('expiration_date', '>=', 'today'), ('expiration_date', '=', False)]"/>

--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -107,10 +107,8 @@ class ResPartner(models.Model):
         This function returns an action that displays the pos orders from partner.
         '''
         action = self.env['ir.actions.act_window']._for_xml_id('point_of_sale.action_pos_pos_form')
-        if self.is_company:
-            action['domain'] = [('partner_id.commercial_partner_id', '=', self.id)]
-        else:
-            action['domain'] = [('partner_id', '=', self.id)]
+        action['domain'] = [('partner_id', 'child_of', self.ids)]
+        action['context'] = {'search_default_partner_id': self.ids}
         return action
 
     def open_commercial_entity(self):

--- a/addons/point_of_sale/views/pos_order_view.xml
+++ b/addons/point_of_sale/views/pos_order_view.xml
@@ -416,7 +416,7 @@
                 <field name="date_order"/>
                 <field name="tracking_number"/>
                 <field name="user_id"/>
-                <field name="partner_id"/>
+                <field name="partner_id" operator="child_of"/>
                 <field name="session_id"/>
                 <field name="config_id"/>
                 <field name="lines" string="Product" filter_domain="[('lines.product_id', 'ilike', self)]"/>

--- a/addons/project/models/res_partner.py
+++ b/addons/project/models/res_partner.py
@@ -69,10 +69,10 @@ class ResPartner(models.Model):
             'display_name': _("%(partner_name)s's Tasks", partner_name=self.name),
             'context': {
                 'default_partner_id': self.id,
+                'search_default_partner_id': self.id,
             },
         }
-        all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])
-        search_domain = [('partner_id', 'in', (self | all_child).ids)]
+        search_domain = [('partner_id', 'child_of', self.ids)]
         if self.task_count <= 1:
             task_id = self.env['project.task'].search(search_domain, limit=1)
             action['res_id'] = task_id.id

--- a/addons/sale/views/res_partner_views.xml
+++ b/addons/sale/views/res_partner_views.xml
@@ -6,7 +6,7 @@
         <field name="res_model">sale.order</field>
         <field name="view_mode">list,kanban,form,graph</field>
         <field name="domain">[('partner_id', 'child_of', active_ids)]</field>
-        <field name="context">{'default_partner_id': active_id}</field>
+        <field name="context">{'default_partner_id': active_id, 'search_default_partner_id': active_id}</field>
         <field name="group_ids" eval="[(4, ref('sales_team.group_sale_salesman'))]"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -81,3 +81,11 @@ class ResPartner(models.Model):
                 assign_partner = assign_partner.parent_id
                 partner = partner.parent_id
 
+    def action_view_opportunity(self):
+        self.ensure_one()  # especially here as we are doing an id, in, IDS domain
+        action = super().action_view_opportunity()
+        action['context'].update({
+            'assign_partner_id': self.id,
+            'search_default_assign_partner': 1,
+        })
+        return action

--- a/addons/website_crm_partner_assign/views/crm_lead_views.xml
+++ b/addons/website_crm_partner_assign/views/crm_lead_views.xml
@@ -61,6 +61,9 @@
                 <field name="phone_mobile_search" position="after">
                     <field name="partner_assigned_id"/>
                 </field>
+                <filter name="partner_filter" position="after">
+                    <filter name="assign_partner" string="Assigned partner" domain="[('partner_assigned_id', 'child_of', context.get('assign_partner_id'))]" invisible="1"/>
+                </filter>
             </field>
         </record>
 


### PR DESCRIPTION
Purpose
=======
Currently, when we open records of various models through the stat button from
the contact form  view, records are filtered based on the domain given on action,
but the filter is not set so the user might find this confusing.

Specification
==============
 Adds a search filter to search the record so that the user
can visualize the query.

Task-2671192