### PR TITLE
[IMP] tools+many: replace html2plaintext

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-from odoo import models, _
-from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, float_repr, is_html_empty, html2plaintext, cleanup_xml_node
-from lxml import etree
-
+import logging
 from datetime import datetime
 
-import logging
+from lxml import etree
+
+from odoo import models, _
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, float_repr, is_html_empty, html_to_plaintext, cleanup_xml_node
 
 _logger = logging.getLogger(__name__)
 
@@ -109,7 +109,7 @@ class AccountEdiXmlCII(models.AbstractModel):
             'id': invoice.name,
             'type_code': '380' if invoice.move_type == 'out_invoice' else '381',
             'issue_date_time': invoice.invoice_date,
-            'included_note': html2plaintext(invoice.narration) if invoice.narration else "",
+            'included_note': html_to_plaintext(invoice.narration),
         }
 
     def _export_invoice_vals(self, invoice):

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 from collections import defaultdict
+
 from lxml import etree
 
 from odoo import models, _
-from odoo.tools import html2plaintext, cleanup_xml_node
+from odoo.tools import html_to_plaintext, cleanup_xml_node
 
 
 class AccountEdiXmlUBL20(models.AbstractModel):
@@ -162,7 +163,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         payment_term = invoice.invoice_payment_term_id
         if payment_term:
             # The payment term's note is automatically embedded in a <p> tag in Odoo
-            return [{'note_vals': [{'note': html2plaintext(payment_term.note)}]}]
+            return [{'note_vals': [{'note': html_to_plaintext(payment_term.note)}]}]
         else:
             return []
 
@@ -521,7 +522,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 'id': invoice.name,
                 'issue_date': invoice.invoice_date,
                 'due_date': invoice.invoice_date_due,
-                'note_vals': [{'note': html2plaintext(invoice.narration)}] if invoice.narration else [],
+                'note_vals': [{'note': html_to_plaintext(invoice.narration)}] if invoice.narration else [],
                 'order_reference': order_reference,
                 'sales_order_id': sales_order_id,
                 'accounting_supplier_party_vals': {

--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -24,7 +24,7 @@ from odoo.addons.calendar.models.calendar_recurrence import (
 )
 from odoo.tools.translate import _
 from odoo.tools.misc import get_lang
-from odoo.tools import pycompat, html2plaintext, is_html_empty, single_email_re
+from odoo.tools import pycompat, html_to_plaintext, is_html_empty, single_email_re
 from odoo.exceptions import UserError, ValidationError
 
 _logger = logging.getLogger(__name__)
@@ -1361,7 +1361,7 @@ class Meeting(models.Model):
 
     def _get_customer_description(self):
         """:return (str): The description to include in calendar exports"""
-        return html2plaintext(self.description) if self.description else ''
+        return html_to_plaintext(self.description)
 
     def _get_customer_summary(self):
         """:return (str): The summary to include in calendar exports"""

--- a/addons/crm_livechat/models/discuss_channel.py
+++ b/addons/crm_livechat/models/discuss_channel.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import models, _
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 
 class DiscussChannel(models.Model):
@@ -36,7 +36,7 @@ class DiscussChannel(models.Model):
 
         utm_source = self.env.ref('crm_livechat.utm_source_livechat', raise_if_not_found=False)
         return self.env['crm.lead'].create({
-            'name': html2plaintext(key[5:]),
+            'name': html_to_plaintext(key[5:]),
             'partner_id': customers[0].id if customers else False,
             'user_id': False,
             'team_id': False,

--- a/addons/crm_mail_plugin/controllers/crm_client.py
+++ b/addons/crm_mail_plugin/controllers/crm_client.py
@@ -3,7 +3,7 @@
 
 from odoo import http
 from odoo.http import request
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 from .mail_plugin import MailPluginController
 
@@ -46,7 +46,7 @@ class CrmClient(MailPluginController):
             return {'error': 'partner_not_found'}
 
         record = request.env['crm.lead'].with_company(partner.company_id).create({
-            'name': html2plaintext(email_subject),
+            'name': html_to_plaintext(email_subject),
             'partner_id': partner_id,
             'description': email_body,
         })

--- a/addons/hr_skills_slides/models/slide_channel.py
+++ b/addons/hr_skills_slides/models/slide_channel.py
@@ -4,7 +4,7 @@
 from markupsafe import Markup
 
 from odoo import fields, models, _
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 
 class SlideChannelPartner(models.Model):
@@ -39,7 +39,7 @@ class SlideChannelPartner(models.Model):
                         'name': channel.name,
                         'date_start': fields.Date.today(),
                         'date_end': fields.Date.today(),
-                        'description': html2plaintext(channel.description),
+                        'description': html_to_plaintext(channel.description),
                         'line_type_id': line_type_id,
                         'display_type': 'course',
                         'channel_id': channel.id

--- a/addons/hr_skills_survey/models/survey_user.py
+++ b/addons/hr_skills_survey/models/survey_user.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 
 class SurveyUserInput(models.Model):
@@ -27,7 +27,7 @@ class SurveyUserInput(models.Model):
                 'name': survey.title,
                 'date_start': fields.Date.today(),
                 'date_end': fields.Date.today(),
-                'description': html2plaintext(survey.description),
+                'description': html_to_plaintext(survey.description),
                 'line_type_id': line_type and line_type.id,
                 'display_type': 'certification',
                 'survey_id': survey.id

--- a/addons/im_livechat/models/chatbot_script.py
+++ b/addons/im_livechat/models/chatbot_script.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import _, api, models, fields
-from odoo.tools import email_normalize, html2plaintext, is_html_empty, plaintext2html
+from odoo.tools import email_normalize, html_to_plaintext, is_html_empty, plaintext2html
 
 
 class ChatbotScript(models.Model):
@@ -197,7 +197,7 @@ class ChatbotScript(models.Model):
         }
 
     def _validate_email(self, email_address, discuss_channel):
-        email_address = html2plaintext(email_address)
+        email_address = html_to_plaintext(email_address)
         email_normalized = email_normalize(email_address)
 
         posted_message = False

--- a/addons/im_livechat/models/chatbot_script_step.py
+++ b/addons/im_livechat/models/chatbot_script_step.py
@@ -5,7 +5,7 @@ from odoo import _, api, models, fields
 from odoo.exceptions import ValidationError
 from odoo.fields import Command
 from odoo.osv import expression
-from odoo.tools import html2plaintext, is_html_empty, email_normalize, plaintext2html
+from odoo.tools import html_to_plaintext, is_html_empty, email_normalize, plaintext2html
 
 from collections import defaultdict
 from markupsafe import Markup
@@ -281,7 +281,7 @@ class ChatbotScriptStep(models.Model):
 
         self.ensure_one()
 
-        user_text_answer = html2plaintext(message_body)
+        user_text_answer = html_to_plaintext(message_body)
         if self.step_type == 'question_email' and not email_normalize(user_text_answer):
             # if this error is raised, display an error message but do not go to next step
             raise ValidationError(_('"%s" is not a valid email.', user_text_answer))

--- a/addons/l10n_dk_oioubl/models/account_edi_xml_oioubl_201.py
+++ b/addons/l10n_dk_oioubl/models/account_edi_xml_oioubl_201.py
@@ -1,5 +1,5 @@
 from odoo import _, models, tools
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 DANISH_NATIONAL_IT_AND_TELECOM_AGENCY_ID = '320'
 
@@ -223,7 +223,7 @@ class AccountEdiXmlOIOUBL201(models.AbstractModel):
                 'amount': sign * line.amount_currency,
                 'currency_name': line.currency_id.name,
                 'currency_dp': self._get_currency_decimal_places(line.currency_id),
-                'note_vals': [{'note_vals': [{'note': html2plaintext(invoice.invoice_payment_term_id.note)}]}],
+                'note_vals': [{'note_vals': [{'note': html_to_plaintext(invoice.invoice_payment_term_id.note)}]}],
                 'settlement_period': {
                     'start_date': invoice.invoice_date,
                     'end_date': line.date_maturity,

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -450,7 +450,7 @@ class MailMail(models.Model):
             results.append({
                 'attachments': email_attachments,
                 'body': body_personalized,
-                'body_alternative': tools.html2plaintext(body_personalized),
+                'body_alternative': tools.html_to_plaintext(body_personalized),
                 'email_cc': email_values['email_cc'],
                 'email_from': self.email_from,
                 'email_to': email_values['email_to'],

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1229,7 +1229,7 @@ class Message(models.Model):
         Default `max_char` is the longest known mail client preview length (Outlook 2013)."""
         self.ensure_one()
 
-        plaintext_ct = tools.html_to_inner_content(self.body)
+        plaintext_ct = tools.html_to_plaintext(self.body)
         return textwrap.shorten(plaintext_ct, max_char) if max_char else plaintext_ct
 
     @api.model

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -30,7 +30,7 @@ from odoo.addons.mail.tools.web_push import push_to_end_point, DeviceUnreachable
 from odoo.exceptions import MissingError, AccessError
 from odoo.osv import expression
 from odoo.tools import (
-    is_html_empty, html_escape, html2plaintext, parse_contact_from_email,
+    is_html_empty, html_escape, html_to_plaintext, parse_contact_from_email,
     clean_context, split_every, Query, SQL,
 )
 
@@ -763,7 +763,7 @@ class MailThread(models.AbstractModel):
                     ('mail_message_id', '=', bounced_message.id),
                     ('res_partner_id', 'in', bounced_partner.ids)]
                 ).write({
-                    'failure_reason': html2plaintext(message_dict.get('body') or ''),
+                    'failure_reason': html_to_plaintext(message_dict.get('body') or ''),
                     'failure_type': 'mail_bounce',
                     'notification_status': 'bounce',
                 })
@@ -3667,7 +3667,7 @@ class MailThread(models.AbstractModel):
                 }
             }
         }
-        payload['options']['body'] = tools.html2plaintext(body)
+        payload['options']['body'] = tools.html_to_plaintext(body)
         payload['options']['body'] += self._generate_tracking_message(message)
 
         return payload

--- a/addons/mass_mailing/models/mail_thread.py
+++ b/addons/mass_mailing/models/mail_thread.py
@@ -63,7 +63,7 @@ class MailThread(models.AbstractModel):
         if bounced_msg_ids:
             self.env['mailing.trace'].set_bounced(
                 domain=[('message_id', 'in', bounced_msg_ids)],
-                bounce_message=tools.html2plaintext(message_dict.get('body') or ''))
+                bounce_message=tools.html_to_plaintext(message_dict.get('body') or ''))
         if bounced_email:
             three_months_ago = fields.Datetime.to_string(datetime.datetime.now() - datetime.timedelta(weeks=13))
             stats = self.env['mailing.trace'].search(['&', '&', ('trace_status', '=', 'bounce'), ('write_date', '>', three_months_ago), ('email', '=ilike', bounced_email)]).mapped('write_date')

--- a/addons/project_todo/models/project_task.py
+++ b/addons/project_todo/models/project_task.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, _, _lt, Command
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 class Task(models.Model):
     _inherit = 'project.task'
@@ -13,7 +13,7 @@ class Task(models.Model):
             if not vals.get('name') and not vals.get('project_id') and not vals.get('parent_id'):
                 if vals.get('description'):
                     # Generating name from first line of the description
-                    text = html2plaintext(vals['description'])
+                    text = html_to_plaintext(vals['description'])
                     name = text.strip().replace('*', '').partition("\n")[0]
                     vals['name'] = (name[:97] + '...') if len(name) > 100 else name
                 else:

--- a/addons/sale_mrp/tests/test_sale_mrp_report.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_report.py
@@ -4,7 +4,7 @@
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import common
 
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 
 @common.tagged('post_install', '-at_install')
@@ -67,5 +67,5 @@ class TestSaleMrpInvoices(AccountTestInvoicingCommon):
 
         html = self.env['ir.actions.report']._render_qweb_html(
             'account.report_invoice_with_payments', invoice.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By Lot\n1.00Units\nLOT0001', "There should be a line that specifies 1 x LOT0001")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n1.00 Units\nLOT0001', "There should be a line that specifies 1 x LOT0001")

--- a/addons/sale_stock/tests/test_sale_stock_report.py
+++ b/addons/sale_stock/tests/test_sale_stock_report.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from datetime import datetime, timedelta
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 from odoo.tests import Form, tagged
 from odoo.addons.stock.tests.test_report import TestReportsCommon
@@ -153,8 +153,8 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         html = self.env['ir.actions.report']._render_qweb_html(
             'account.report_invoice_with_payments', invoice.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By Lot\n2.00Units\nLOT0001', "There should be a line that specifies 2 x LOT0001")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n2.00 Units\nLOT0001', "There should be a line that specifies 2 x LOT0001")
 
     def test_invoice_before_delivery(self):
         """
@@ -186,8 +186,8 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         html = self.env['ir.actions.report']._render_qweb_html(
             'account.report_invoice_with_payments', invoice.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By Lot\n4.00Units\nLOT0001', "There should be a line that specifies 4 x LOT0001")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n4.00 Units\nLOT0001', "There should be a line that specifies 4 x LOT0001")
 
     def test_backorder_and_several_invoices(self):
         """
@@ -224,33 +224,33 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         IrActionsReport = self.env['ir.actions.report']
         html = IrActionsReport._render_qweb_html('account.report_invoice_with_payments', invoice01.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0001', "There should be a line that specifies 1 x USN0001")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00 Units\nUSN0001', "There should be a line that specifies 1 x USN0001")
         self.assertNotIn('USN0002', text)
 
         invoice02 = so._create_invoices()
         invoice02.action_post()
         html = IrActionsReport._render_qweb_html('account.report_invoice_with_payments', invoice02.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0002', "There should be a line that specifies 1 x USN0002")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00 Units\nUSN0002', "There should be a line that specifies 1 x USN0002")
         self.assertNotIn('USN0001', text)
 
         # Posting the second invoice shouldn't change the result of the first one
         html = IrActionsReport._render_qweb_html('account.report_invoice_with_payments', invoice01.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0001', "There should still be a line that specifies 1 x USN0001")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00 Units\nUSN0001', "There should still be a line that specifies 1 x USN0001")
         self.assertNotIn('USN0002', text)
 
         # Resetting and posting again the first invoice shouldn't change the results
         invoice01.button_draft()
         invoice01.action_post()
         html = IrActionsReport._render_qweb_html('account.report_invoice_with_payments', invoice01.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0001', "There should still be a line that specifies 1 x USN0001")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00 Units\nUSN0001', "There should still be a line that specifies 1 x USN0001")
         self.assertNotIn('USN0002', text)
         html = IrActionsReport._render_qweb_html('account.report_invoice_with_payments', invoice02.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0002', "There should be a line that specifies 1 x USN0002")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By USN\n1.00 Units\nUSN0002', "There should be a line that specifies 1 x USN0002")
         self.assertNotIn('USN0001', text)
 
     def test_invoice_with_several_returns(self):
@@ -333,8 +333,8 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         html = self.env['ir.actions.report']._render_qweb_html(
             'account.report_invoice_with_payments', invoice01.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By Lot\n2.00Units\nLOT0002', "There should be a line that specifies 2 x LOT0002")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n2.00 Units\nLOT0002', "There should be a line that specifies 2 x LOT0002")
         self.assertNotIn('LOT0001', text)
 
         # Deliver 5 x LOT0002 + 2 x LOT0003
@@ -357,9 +357,9 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         html = self.env['ir.actions.report']._render_qweb_html(
             'account.report_invoice_with_payments', invoice02.ids)[0]
-        text = html2plaintext(html)
-        self.assertRegex(text, r'Product By Lot\n6.00Units\nLOT0002', "There should be a line that specifies 6 x LOT0002")
-        self.assertRegex(text, r'Product By Lot\n2.00Units\nLOT0003', "There should be a line that specifies 2 x LOT0003")
+        text = html_to_plaintext(html)
+        self.assertRegex(text, r'Product By Lot\n6.00 Units\nLOT0002', "There should be a line that specifies 6 x LOT0002")
+        self.assertRegex(text, r'Product By Lot\n2.00 Units\nLOT0003', "There should be a line that specifies 2 x LOT0003")
         self.assertNotIn('LOT0001', text)
 
     def test_refund_cancel_invoices(self):
@@ -391,7 +391,7 @@ class TestSaleStockInvoices(TestSaleCommon):
         invoice01.action_post()
 
         html = self.env['ir.actions.report']._render_qweb_html('account.report_invoice_with_payments', invoice01.ids)[0]
-        text = html2plaintext(html)
+        text = html_to_plaintext(html)
         self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0001', "There should be a line that specifies 1 x USN0001")
         self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0002', "There should be a line that specifies 1 x USN0002")
 
@@ -422,7 +422,7 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         # reversed invoice
         html = self.env['ir.actions.report']._render_qweb_html('account.report_invoice_with_payments', refund_invoice.ids)[0]
-        text = html2plaintext(html)
+        text = html_to_plaintext(html)
         self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0001', "There should be a line that specifies 1 x USN0001")
         self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0002', "There should be a line that specifies 1 x USN0002")
 
@@ -454,7 +454,7 @@ class TestSaleStockInvoices(TestSaleCommon):
         invoice01.action_post()
 
         html = self.env['ir.actions.report']._render_qweb_html('account.report_invoice_with_payments', invoice01.ids)[0]
-        text = html2plaintext(html)
+        text = html_to_plaintext(html)
         self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0001', "There should be a line that specifies 1 x USN0001")
 
         # Refund the invoice with full refund and new draft invoice
@@ -467,5 +467,5 @@ class TestSaleStockInvoices(TestSaleCommon):
 
         # new draft invoice
         html = self.env['ir.actions.report']._render_qweb_html('account.report_invoice_with_payments', invoice02.ids)[0]
-        text = html2plaintext(html)
+        text = html_to_plaintext(html)
         self.assertRegex(text, r'Product By USN\n1.00Units\nUSN0001', "There should be a line that specifies 1 x USN0001")

--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -4,7 +4,7 @@
 import logging
 
 from odoo import api, Command, models, fields
-from odoo.tools import html2plaintext, plaintext2html
+from odoo.tools import html_to_plaintext, plaintext2html
 
 _logger = logging.getLogger(__name__)
 
@@ -201,7 +201,8 @@ class MailThread(models.AbstractModel):
             subtype_id = self.env['ir.model.data']._xmlid_to_res_id('mail.mt_note')
 
         return self.message_post(
-            body=plaintext2html(html2plaintext(body)), partner_ids=partner_ids or [],  # TDE FIXME: temp fix otherwise crash mail_thread.py
+            body=plaintext2html(html_to_plaintext(body)),
+            partner_ids=partner_ids or [],  # TDE FIXME: temp fix otherwise crash mail_thread.py
             message_type='sms', subtype_id=subtype_id,
             sms_numbers=sms_numbers, sms_pid_to_number=sms_pid_to_number,
             **kwargs
@@ -250,7 +251,7 @@ class MailThread(models.AbstractModel):
         # pre-compute SMS data
         body = msg_vals['body'] if msg_vals and 'body' in msg_vals else message.body
         sms_base_vals = {
-            'body': html2plaintext(body),
+            'body': html_to_plaintext(body),
             'mail_message_id': message.id,
             'state': 'outgoing',
         }

--- a/addons/sms/tests/common.py
+++ b/addons/sms/tests/common.py
@@ -253,14 +253,14 @@ class SMSCase(MockSMS):
 
         if messages is not None:
             for message in messages:
-                self.assertEqual(content, tools.html2plaintext(message.body).rstrip('\n'))
+                self.assertEqual(content, tools.html_to_plaintext(message.body).rstrip('\n'))
 
     def assertSMSLogged(self, records, body):
         for record in records:
             message = record.message_ids[-1]
             self.assertEqual(message.subtype_id, self.env.ref('mail.mt_note'))
             self.assertEqual(message.message_type, 'sms')
-            self.assertEqual(tools.html2plaintext(message.body).rstrip('\n'), body)
+            self.assertEqual(tools.html_to_plaintext(message.body).rstrip('\n'), body)
 
 
 class SMSCommon(MailCommon, SMSCase):

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
-from odoo.tools import html2plaintext, plaintext2html
+from odoo.tools import html_to_plaintext, plaintext2html
 
 
 class SendSMS(models.TransientModel):
@@ -333,7 +333,7 @@ class SendSMS(models.TransientModel):
     def _prepare_log_body_values(self, sms_records_values):
         result = {}
         for record_id, sms_values in sms_records_values.items():
-            result[record_id] = plaintext2html(html2plaintext(sms_values['body']))
+            result[record_id] = plaintext2html(html_to_plaintext(sms_values['body']))
         return result
 
     def _prepare_mass_log_values(self, records, sms_records_values):

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -11,7 +11,7 @@ from odoo.exceptions import UserError
 from odoo.osv import expression
 from odoo.tools import float_is_zero, check_barcode_encoding
 from odoo.tools.float_utils import float_round
-from odoo.tools.mail import html2plaintext, is_html_empty
+from odoo.tools.mail import html_to_plaintext
 
 OPERATORS = {
     '<': py_operator.lt,
@@ -236,7 +236,7 @@ class Product(models.Model):
         """
         self.ensure_one()
         picking_code = picking_type_id.code
-        description = html2plaintext(self.description) if not is_html_empty(self.description) else self.name
+        description = html_to_plaintext(self.description) or self.name
         if picking_code == 'incoming':
             return self.description_pickingin or description
         if picking_code == 'outgoing':

--- a/addons/stock_account/views/report_invoice.xml
+++ b/addons/stock_account/views/report_invoice.xml
@@ -17,8 +17,8 @@
                     <tr t-foreach="lot_values" t-as="snln_line">
                         <td><t t-esc="snln_line['product_name']">Bacon</t></td>
                         <td class="text-end">
-                            <t t-esc="snln_line['quantity']">6.00</t>
-                            <t t-esc="snln_line['uom_name']" groups="uom.group_uom">units</t>
+                            <span t-esc="snln_line['quantity']">6.00</span>
+                            <span t-esc="snln_line['uom_name']" groups="uom.group_uom">units</span>
                         </td>
                         <td><t class="text-end" t-esc="snln_line['lot_name']">BC46282798</t></td>
                     </tr>

--- a/addons/web/models/base_document_layout.py
+++ b/addons/web/models/base_document_layout.py
@@ -5,7 +5,7 @@ from markupsafe import Markup
 from odoo import api, fields, models, tools
 
 from odoo.addons.base.models.ir_qweb_fields import nl2br
-from odoo.tools import html2plaintext, is_html_empty
+from odoo.tools import html_to_plaintext, is_html_empty
 from odoo.tools.misc import file_path
 
 try:
@@ -308,4 +308,4 @@ class BaseDocumentLayout(models.TransientModel):
         # In recent change when an html field is empty a <p> balise remains with a <br> in it,
         # but when company details is empty we want to put the info of the company
         for record in self:
-            record.is_company_details_empty = not html2plaintext(record.company_details or '')
+            record.is_company_details_empty = not html_to_plaintext(record.company_details or '')

--- a/addons/website_blog/controllers/main.py
+++ b/addons/website_blog/controllers/main.py
@@ -13,7 +13,7 @@ from odoo.addons.website.controllers.main import QueryURL
 from odoo.addons.portal.controllers.portal import _build_url_w_params
 from odoo.http import request
 from odoo.osv import expression
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 from odoo.tools.misc import get_lang
 from odoo.tools import sql
 
@@ -223,7 +223,7 @@ class WebsiteBlog(http.Controller):
         v['blog'] = blog
         v['base_url'] = blog.get_base_url()
         v['posts'] = request.env['blog.post'].search([('blog_id', '=', blog.id)], limit=min(int(limit), 50), order="post_date DESC")
-        v['html2plaintext'] = html2plaintext
+        v['html_to_plaintext'] = html_to_plaintext
         r = request.render("website_blog.blog_feed", v, headers=[('Content-Type', 'application/atom+xml')])
         return r
 

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -470,7 +470,7 @@ list of filtered posts (by date or tag).
         <link t-att-href="'%s%s' % (base_url, post.website_url)"/>
         <id t-esc="'%s%s' % (base_url, post.website_url)"/>
         <author><name t-esc="post.sudo().author_id.name"/></author>
-        <summary t-esc="html2plaintext(post.teaser)"/>
+        <summary t-esc="html_to_plaintext(post.teaser)"/>
         <updated t-esc="str(post.post_date).replace(' ', 'T') + 'Z'"/>
     </entry>
 </feed>

--- a/addons/website_forum/models/forum_post.py
+++ b/addons/website_forum/models/forum_post.py
@@ -169,7 +169,7 @@ class Post(models.Model):
     @api.depends('content')
     def _compute_plain_content(self):
         for post in self:
-            post.plain_content = tools.html2plaintext(post.content)[0:500] if post.content else False
+            post.plain_content = tools.html_to_plaintext(post.content)[0:500] if post.content else False
 
     @api.depends('name')
     def _compute_website_url(self):

--- a/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
+++ b/addons/website_hr_recruitment/tests/test_website_hr_recruitment.py
@@ -3,7 +3,7 @@
 
 from odoo.api import Environment
 import odoo.tests
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
@@ -28,12 +28,12 @@ class TestWebsiteHrRecruitmentForm(odoo.tests.HttpCase):
         self.assertEqual(guru_applicant.partner_name, 'John Smith')
         self.assertEqual(guru_applicant.email_from, 'john@smith.com')
         self.assertEqual(guru_applicant.partner_mobile, '118.218')
-        self.assertEqual(html2plaintext(guru_applicant.description), '### [GURU] HR RECRUITMENT TEST DATA ###')
+        self.assertEqual(html_to_plaintext(guru_applicant.description), '### [GURU] HR RECRUITMENT TEST DATA ###')
         self.assertEqual(guru_applicant.job_id, job_guru)
 
         internship_applicant = capt.records[1]
         self.assertEqual(internship_applicant.partner_name, 'Jack Doe')
         self.assertEqual(internship_applicant.email_from, 'jack@doe.com')
         self.assertEqual(internship_applicant.partner_mobile, '118.712')
-        self.assertEqual(html2plaintext(internship_applicant.description), '### HR [INTERN] RECRUITMENT TEST DATA ###')
+        self.assertEqual(html_to_plaintext(internship_applicant.description), '### HR [INTERN] RECRUITMENT TEST DATA ###')
         self.assertEqual(internship_applicant.job_id, job_intern)

--- a/addons/website_project/controllers/main.py
+++ b/addons/website_project/controllers/main.py
@@ -5,7 +5,7 @@ from odoo.addons.website.controllers import form
 
 from odoo import _
 from odoo.addons.base.models.ir_qweb_fields import nl2br_enclose
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 class WebsiteForm(form.WebsiteForm):
     def insert_record(self, request, model, values, custom, meta=None):
@@ -25,7 +25,7 @@ class WebsiteForm(form.WebsiteForm):
         custom_label = "<h4>%s</h4>\n\n" % _("Other Information")  # Title for custom fields
         default_field = model.website_form_default_field_id
         default_field_data = values.get(default_field.name, '')
-        default_field_content = "<h4>%s</h4>\n<p>%s</p>" % (default_field.name.capitalize(), html2plaintext(default_field_data))
+        default_field_content = "<h4>%s</h4>\n<p>%s</p>" % (default_field.name.capitalize(), html_to_plaintext(default_field_data))
         custom_content = (f"{default_field_content} \n\n\n" if default_field_data else '') \
                         + (f"{custom_label} {custom} \n\n " if custom else '') \
                         + (self._meta_label + meta if meta else '')

--- a/addons/website_sale/models/product_ribbon.py
+++ b/addons/website_sale/models/product_ribbon.py
@@ -11,7 +11,7 @@ class ProductRibbon(models.Model):
     @api.depends('html')
     def _compute_display_name(self):
         for ribbon in self:
-            ribbon.display_name = f'{tools.html2plaintext(ribbon.html)} (#{ribbon.id})'
+            ribbon.display_name = f'{tools.html_to_plaintext(ribbon.html)} (#{ribbon.id})'
 
     html = fields.Html(string='Ribbon html', required=True, translate=True, sanitize=False)
     bg_color = fields.Char(string='Ribbon background color', required=False)

--- a/addons/website_sale_autocomplete/controllers/main.py
+++ b/addons/website_sale_autocomplete/controllers/main.py
@@ -4,7 +4,7 @@ import requests
 
 from odoo import http
 from odoo.http import request
-from odoo.tools import html2plaintext
+from odoo.tools import html_to_plaintext
 
 import logging
 _logger = logging.getLogger(__name__)
@@ -150,7 +150,7 @@ class AutoCompleteController(http.Controller):
             standard_address['number'] = self._guess_number_from_input(address, standard_address)
             standard_address['formatted_street_number'] = f'{standard_address["number"]} {standard_address.get("street", "")}'
         else:
-            formatted_from_html = html2plaintext(html_address.split(',')[0])
+            formatted_from_html = html_to_plaintext(html_address.split(',')[0])
             formatted_manually = f'{standard_address["number"]} {standard_address.get("street", "")}'
             # Sometimes, the google api sends back abbreviated data :
             # "52 High Road Street" becomes "52 HR St" for example. We usually take the result from google, but if it's an abbreviation, take our guess instead.

--- a/addons/website_slides/controllers/mail.py
+++ b/addons/website_slides/controllers/mail.py
@@ -8,7 +8,7 @@ from werkzeug.exceptions import NotFound, Forbidden
 from odoo import http, _
 from odoo.http import request
 from odoo.addons.portal.controllers.mail import _check_special_access, PortalChatter
-from odoo.tools import plaintext2html, html2plaintext
+from odoo.tools import plaintext2html, html_to_plaintext
 
 
 class SlidesPortalChatter(PortalChatter):
@@ -80,12 +80,12 @@ class SlidesPortalChatter(PortalChatter):
             rating = request.env['rating.rating'].sudo().search(domain, order='write_date DESC', limit=1)
             rating.write({
                 'rating': float(post['rating_value']),
-                'feedback': html2plaintext(message.body),
+                'feedback': html_to_plaintext(message.body),
             })
         channel = request.env[res_model].browse(res_id)
         return {
             'default_message_id': message.id,
-            'default_message': html2plaintext(message.body),
+            'default_message': html_to_plaintext(message.body),
             'default_rating_value': message.rating_value,
             'rating_avg': channel.rating_avg,
             'rating_count': channel.rating_count,

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -766,7 +766,7 @@ class WebsiteSlides(WebsiteProfile):
 
             values.update({
                 'last_message_id': last_message_values.get('id'),
-                'last_message': tools.html2plaintext(last_message_values.get('body', '')),
+                'last_message': tools.html_to_plaintext(last_message_values.get('body', '')),
                 'last_rating_value': last_message_values.get('rating_value'),
                 'last_message_attachment_ids': last_message_attachment_ids,
             })

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -17,7 +17,7 @@ from odoo import api, fields, models, _
 from odoo.addons.http_routing.models.ir_http import slug, url_for
 from odoo.exceptions import RedirectWarning, UserError, AccessError
 from odoo.http import request
-from odoo.tools import html2plaintext, sql
+from odoo.tools import html_to_plaintext, sql
 
 _logger = logging.getLogger(__name__)
 
@@ -1320,9 +1320,9 @@ class Slide(models.Model):
     def _default_website_meta(self):
         res = super(Slide, self)._default_website_meta()
         res['default_opengraph']['og:title'] = res['default_twitter']['twitter:title'] = self.name
-        res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = html2plaintext(self.description)
+        res['default_opengraph']['og:description'] = res['default_twitter']['twitter:description'] = html_to_plaintext(self.description)
         res['default_opengraph']['og:image'] = res['default_twitter']['twitter:image'] = self.env['website'].image_url(self, 'image_1024')
-        res['default_meta_description'] = html2plaintext(self.description)
+        res['default_meta_description'] = html_to_plaintext(self.description)
         return res
 
     # ---------------------------------------------------------

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -505,7 +505,7 @@ class IrMailServer(models.Model):
         email_body = ustr(body)
         if subtype == 'html' and not body_alternative:
             msg['MIME-Version'] = '1.0'
-            msg.add_alternative(tools.html2plaintext(email_body), subtype='plain', charset='utf-8')
+            msg.add_alternative(tools.html_to_plaintext(email_body, skip_sanitation=True), subtype='plain', charset='utf-8')
             msg.add_alternative(email_body, subtype=subtype, charset='utf-8')
         elif body_alternative:
             msg['MIME-Version'] = '1.0'

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -7,7 +7,7 @@ import warnings
 
 from odoo import api, fields, models, tools, _, Command, SUPERUSER_ID
 from odoo.exceptions import ValidationError, UserError
-from odoo.tools import html2plaintext, file_open, ormcache
+from odoo.tools import html_to_plaintext, file_open, ormcache
 
 _logger = logging.getLogger(__name__)
 
@@ -261,7 +261,7 @@ class Company(models.Model):
         # In recent change when an html field is empty a <p> balise remains with a <br> in it,
         # but when company details is empty we want to put the info of the company
         for record in self:
-            record.is_company_details_empty = not html2plaintext(record.company_details or '')
+            record.is_company_details_empty = html_to_plaintext(record.company_details)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/odoo/addons/base/tests/test_ir_mail_server.py
+++ b/odoo/addons/base/tests/test_ir_mail_server.py
@@ -113,8 +113,8 @@ class TestIrMailServer(TransactionCase, MockSmtplibCase):
             'content',
             'content',
             'content',
-            "test1\n*test2*\ntest3\ntest4\ntest5\ntest6   test7\ntest8    test9\ntest10\ntest11\ntest12\ngoogle [1]\ntest link [2]\n\n\n[1] http://google.com\n[2] javascript:alert('malicious code')",
-            'On 01/05/2016 10:24 AM, Raoul\nPoilvache wrote:\n\n* Test reply. The suite. *\n\n--\nRaoul Poilvache\n\nTop cool !!!\n\n--\nRaoul Poilvache',
+            "test1\n**test2**\n*test3*\n*test4*\n~~test5~~\ntest6\n  * test7\n  * test8\n  1. test9\n  2. test10\n> test11\n> > test12\n>> \n\n[google][1] [test link][2]\n\n   [1]: http://google.com\n   [2]: javascript:alert('malicious code')",
+            'On 01/05/2016 10:24 AM, Raoul Poilvache wrote:\n> **Test reply. The suite.**\n> \n> -- \n> Raoul Poilvache\n\n--\nRaoul Poilvache\n',
         ]
         for body, expected in zip(bodies, expected_list):
             message = self.env['ir.mail_server'].build_email(

--- a/odoo/tools/__init__.py
+++ b/odoo/tools/__init__.py
@@ -12,6 +12,7 @@ from .config import config
 from .date_utils import *
 from .float_utils import *
 from .func import *
+from .html_to_md import html_to_md
 from .image import *
 from .mail import *
 from .misc import *

--- a/odoo/tools/html_to_md/BaseNode.py
+++ b/odoo/tools/html_to_md/BaseNode.py
@@ -1,0 +1,64 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import json
+from typing import Callable
+
+
+class BaseNode:
+    def __init__(
+        self,
+        get_node: Callable,
+        options: dict,
+        indentation_level: int = 0,
+        induce_indent: bool = False,
+        induce_markup: str = "",
+        require_before: str = "",
+        require_after: str = "",
+        starts_with_whitespace: bool = False,
+        ends_with_whitespace: bool = False,
+        cancels_previous_whitespace: bool = False,
+        cancels_leading_tail_whitespace: bool = False,
+        force_cancel_whitespace: bool = False,
+        verbose: bool = False,
+        position=None,
+    ):
+        self.get_node = get_node
+        self.options = options
+        self.induce_indent = induce_indent
+        self.induce_markup = induce_markup
+        self.require_before = require_before  # Also means discarding whitespace before it
+        self.require_after = require_after
+        self.starts_with_whitespace = starts_with_whitespace
+        self.ends_with_whitespace = ends_with_whitespace
+        self.position = position
+        self.cancels_previous_whitespace = cancels_previous_whitespace or force_cancel_whitespace
+        self.cancels_leading_tail_whitespace = cancels_leading_tail_whitespace
+        self.verbose = verbose
+        self.indentation_level = indentation_level
+
+    def __str__(self):
+        return json.dumps(
+            {self.__class__.__name__: self.get_str_components()},
+            indent=2,
+        )
+
+    def get_str_components(self):
+        components = {}
+        if self.starts_with_whitespace:
+            components.update(starts_with_whitespace=True)
+        if self.ends_with_whitespace:
+            components.update(ends_with_whitespace=True)
+        if self.require_after:
+            components.update(require_after=self.require_after)
+        if self.require_before:
+            components.update(require_before=self.require_before)
+        if self.indentation_level:
+            components.update(indentation_level=self.indentation_level)
+        return components
+
+    def to_text_node(self, converter_state):
+        raise NotImplementedError
+
+    def to_markdown(self, converter_state) -> str:
+        raise NotImplementedError

--- a/odoo/tools/html_to_md/Converter.py
+++ b/odoo/tools/html_to_md/Converter.py
@@ -1,0 +1,115 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+import textwrap
+from typing import Collection, List
+
+import lxml
+
+from .NodeWithChildren import RootNode
+from .constants import LINK_TAG_REGEX
+
+
+class MarkdownConverter:
+    # noinspection PyProtectedMember
+    def __init__(self, root_html_node: lxml.etree._Element, get_node):
+        self.root_html = root_html_node
+        self.get_node = get_node
+        self.inline_tags = {}  # current default Odoo behavior for links
+        self.state = MarkdownConverterState()
+
+    def render_markdown(self, verbose=False, options=None, flags=None) -> str:
+        self.state.reset()
+
+        options = self.merge_and_apply_options(options, flags)
+
+        root_converter_node = self._get_converter_root_node(options, verbose=verbose)
+        if verbose:
+            print(str(root_converter_node))
+
+        markdown = root_converter_node.to_markdown(self.state).strip()
+        if self.state.has_links:
+            markdown = self._convert_links(markdown)
+
+        if max_width := options.get("line_width"):
+            new_markdown_lines = []
+            for line in markdown.splitlines():
+                new_markdown_lines += self._wrap_line(line, max_width)
+            return "\n".join(new_markdown_lines)
+
+        return markdown
+
+    def merge_and_apply_options(self, options: dict = None, flags: Collection[str] = None):
+        options = options or {}
+
+        self.inline_tags["a"] = options.get("inline_links", False)
+        self.inline_tags["img"] = options.get("inline_images", False)
+
+        if options.get("inline_images"):
+            options["keep_images"] = True
+
+        if flags:
+            if "SIMPLE_LINE_ENDING" in flags:
+                options["line_ending"] = ""
+            if "INLINE_LINKS" in flags:
+                self.inline_tags["a"] = True
+            if "KEEP_IMAGES" in flags:
+                options["keep_images"] = True
+            if "INLINE_IMAGES" in flags:
+                options["keep_images"] = True
+                options["inline_images"] = True
+                self.inline_tags["img"] = True
+            if "80_CHARS" in flags:
+                options["line_width"] = 80
+            if "72_CHARS" in flags:
+                options["line_width"] = 72
+
+        return options
+
+    def _convert_links(self, markdown) -> str:
+        footnote_links = []
+        position = 1
+        # Make sure we convert links in order of reading
+        for match in re.finditer(LINK_TAG_REGEX, markdown):
+            link_key = match.group()
+            link = self.state.get_link(link_key)
+            inline, footnote = link.render(self.inline_tags[link.tag], position)
+            markdown = markdown.replace(link_key, inline)
+            if not self.inline_tags[link.tag]:
+                footnote_links.append("   " + footnote)
+                position += 1
+
+        if footnote_links:
+            markdown += "\n\n" + "  \n".join(footnote_links)
+
+        return markdown
+
+    def _get_converter_root_node(self, options: dict = None, verbose: bool = False) -> RootNode:
+        return RootNode(self.get_node, options or {}, self.root_html, verbose)
+
+    @staticmethod
+    def _wrap_line(line: str, max_width: int) -> List[str]:
+        if len(line) <= max_width:
+            return [line]
+        without_leading_whitespace = line.lstrip()
+        indent_chars = len(line) - len(without_leading_whitespace)
+        return textwrap.wrap(line, width=max_width, initial_indent="", subsequent_indent=" " * indent_chars)
+
+
+class MarkdownConverterState:
+    def __init__(self):
+        self._links = {}
+
+    def reset(self):
+        self._links = {}
+
+    def add_link(self, link):
+        self._links[link.key] = link
+
+    def get_link(self, key):
+        return self._links[key]
+
+    @property
+    def has_links(self):
+        return bool(len(self._links))

--- a/odoo/tools/html_to_md/EmptyNode.py
+++ b/odoo/tools/html_to_md/EmptyNode.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from .NodeWithChildren import NodeWithChildren
+from .TextNode import text_to_text_node
+from .constants import LINE_ENDING
+
+
+class EmptyNode(NodeWithChildren):
+    def __init__(self, get_node, options, content, **kwargs):
+        super().__init__(
+            get_node, options, cancels_previous_whitespace=True, cancels_leading_tail_whitespace=True, **kwargs
+        )
+        self._children.append(text_to_text_node(content, verbose=self.verbose))
+
+
+class HrNode(EmptyNode):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(get_node, options, content="---", require_before="\n", require_after="\n", **kwargs)
+
+
+class BrNode(EmptyNode):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(
+            get_node,
+            options,
+            content="",
+            require_before=options.get("line_ending", LINE_ENDING),
+            require_after="\n",
+            **kwargs,
+        )

--- a/odoo/tools/html_to_md/InlineNode.py
+++ b/odoo/tools/html_to_md/InlineNode.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from .NodeWithChildren import NodeWithChildren
+from .constants import ALL_WHITESPACE
+
+
+class InlineNode(NodeWithChildren):
+    def __init__(self, get_node, options, element="", **kwargs):
+        super().__init__(get_node, options, skip_whitespace_tails=False, **kwargs)
+        self.fix = element
+
+    def _get_child_prefix(self, child, position=0):
+        """
+
+        :param child: TextNode
+        :param int position: Order of child element
+        """
+        return (self.fix if child.content and not ALL_WHITESPACE.match(child.content) else ""), True
+
+    def _get_child_suffix(self, child):
+        """
+
+        :param child: TextNode
+        """
+        return self.fix if child.content and not ALL_WHITESPACE.match(child.content) else ""
+
+
+class EmphasisNode(InlineNode):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(get_node, options, element="*", **kwargs)
+
+
+class BoldNode(InlineNode):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(get_node, options, element="**", **kwargs)
+
+
+class StrikeNode(InlineNode):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(get_node, options, element="~~", **kwargs)

--- a/odoo/tools/html_to_md/Link.py
+++ b/odoo/tools/html_to_md/Link.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from uuid import uuid4
+
+from .constants import LINK_TAG_PREFIX
+
+INLINE_FORMATS = {
+    "a": "[{label}]({target})",
+    "img": "![{label}]({target})",
+}
+
+
+class Link:
+    def __init__(self, target: str = "", label: str = "", tag: str = "") -> None:
+        self.target = target
+        self.label = label
+        self.key = LINK_TAG_PREFIX + uuid4().hex
+        self.tag = tag
+
+    def render(self, inline: bool = True, position: int = None) -> (str, str):
+        """Render the link inline and footnote parts as tuple.
+
+        :param inline:
+          If `True`, the inline part will include the href:
+          [label](href) and the footnote part will be empty.
+          If `False`, the link will be rendered as
+          [label][POSITION], with POSITION being the order of the link
+          in the footnote reference table, and  the footnote part will
+          be rendered as `[POSITION]: href`
+        :param position: Only relevant if inline=False, the POSITION of the link
+        """
+        if inline:
+            return INLINE_FORMATS[self.tag].format(label=self.label, target=self.target), ""
+
+        return f"[{self.label}][{position}]", f"[{position}]: {self.target}"

--- a/odoo/tools/html_to_md/LinkNode.py
+++ b/odoo/tools/html_to_md/LinkNode.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from .Link import Link
+from .NodeWithChildren import NodeWithChildren
+
+
+class LinkNode(NodeWithChildren):
+    def __init__(self, get_node, options, tag, link_attribute, check_content=True, **kwargs):
+        super().__init__(get_node, options, **kwargs)
+        self.link_attribute = link_attribute
+        self.check_content = check_content
+        self.tag = tag
+        self.default_label = "LINK"
+
+    def _reduce(self, converter_state):
+        merged_node = super()._reduce(converter_state)
+        if not self.check_content or merged_node.content:
+            target = self.node.get(self.link_attribute)
+            if target is not None:
+                link = Link(target, merged_node.content if self.check_content else self.default_label, self.tag)
+                merged_node._content = link.key
+                converter_state.add_link(link)
+        return merged_node
+
+
+class ANode(LinkNode):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(get_node, options, "a", "href", **kwargs)
+
+
+class ImgNode(LinkNode):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(get_node, options, "img", "src", check_content=False, **kwargs)
+        self.default_label = "Image"

--- a/odoo/tools/html_to_md/ListNode.py
+++ b/odoo/tools/html_to_md/ListNode.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from .NodeWithChildren import NodeWithChildren
+from .constants import LINE_ENDING
+
+
+class ListNode(NodeWithChildren):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(
+            get_node,
+            options,
+            skip_whitespace_tails=True,
+            require_after="\n" if kwargs.get("indentation_level", False) else "\n\n",
+            require_before="\n"
+            if kwargs.get("indentation_level", False)
+            else options.get("line_ending", LINE_ENDING) + "\n",
+            induce_indent=True,
+            cancels_previous_whitespace=True,
+            **kwargs,
+        )
+
+
+class LiNode(NodeWithChildren):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(
+            get_node,
+            options,
+            require_before="\n",
+            require_after="\n",
+            cancels_previous_whitespace=True,
+            **kwargs,
+        )
+
+
+class OlNode(ListNode):
+    @staticmethod
+    def _get_child_prefix(child, position=0):
+        if not child.induce_indent:
+            return f"{position+1}. ", True
+        return "", False
+
+
+class UlNode(ListNode):
+    @staticmethod
+    def _get_child_prefix(child, position=0):
+        if not child.induce_indent:
+            return "* ", True
+        return "", False

--- a/odoo/tools/html_to_md/NodeWithChildren.py
+++ b/odoo/tools/html_to_md/NodeWithChildren.py
@@ -1,0 +1,165 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from typing import Optional
+
+import lxml.etree
+
+from .BaseNode import BaseNode
+from .TextNode import merge_required, text_to_text_node
+from .constants import ALL_WHITESPACE, INDENT, LINE_ENDING
+
+
+class NodeWithChildren(BaseNode):
+    # noinspection PyProtectedMember
+    def __init__(
+        self,
+        get_node,
+        options,
+        node=None,
+        skip_whitespace_in_first_child: bool = False,
+        skip_whitespace_tails: bool = True,
+        children_cancel_whitespace: bool = False,
+        **kwargs,
+    ):
+        super().__init__(get_node, options, **kwargs)
+        self.node: Optional[lxml.etree._Element] = node
+        self.skip_whitespace_tails = skip_whitespace_tails
+        self.skip_whitespace_in_first_child = skip_whitespace_in_first_child
+        self.children_cancel_whitespace = children_cancel_whitespace
+        self._children: list[BaseNode] = []
+
+        self._make_children()
+
+    def get_str_components(self):
+        components = super().get_str_components()
+        components.update(
+            node_tag=self.node.tag if self.node is not None else None,
+            children=[child.get_str_components() for child in self._children],
+        )
+        return components
+
+    def _make_children(self):
+        if self.verbose:
+            print(f"shaping node {self.node} {self.node.text if self.node is not None else ''}")
+
+        common_child_values = dict(
+            verbose=self.verbose,
+            indentation_level=self.indentation_level + 1 if self.induce_indent else self.indentation_level,
+            force_cancel_whitespace=self.children_cancel_whitespace,
+        )
+        next_position = 0
+
+        if self.node.text and not ALL_WHITESPACE.match(self.node.text):
+            child = text_to_text_node(self.node.text, **common_child_values)
+            next_position = self._add_child(child, next_position)
+
+        for child_node in self.node:
+            child = self.get_node(
+                child_node.tag, self.options, node=child_node, position=next_position, **common_child_values
+            )
+            next_position = self._add_child(child, next_position)
+
+            if child_node.tail and (not self.skip_whitespace_tails or not ALL_WHITESPACE.match(child_node.tail)):
+                content = child_node.tail if not child.cancels_leading_tail_whitespace else child_node.tail.lstrip()
+                child = text_to_text_node(content, position=next_position, **common_child_values)
+                next_position = self._add_child(child, next_position)
+
+    def _add_child(self, child, current_position):
+        self._children.append(child)
+        return current_position + 1
+
+    def _reduce(self, converter_state):
+        first_child = self._children[0] if self._children else None
+
+        if not first_child:
+            return text_to_text_node("")
+
+        merged_node = first_child.to_text_node(converter_state)
+
+        self._merge_start_requirements(first_child, merged_node)
+
+        first_prefix, next_position = self._get_child_prefix(first_child, 0)
+        first_child_suffix = self._get_child_suffix(first_child)
+        merged_node.prepend(first_prefix)
+        merged_node.append(first_child_suffix)
+
+        if self.verbose:
+            print("First child to text: ", merged_node)
+
+        for next_sibling in self._children[1:]:
+            self._merge_next_child(next_sibling, converter_state, merged_node, next_position)
+            if self.verbose:
+                print("After additional node", merged_node)
+
+        merged_node.ends_with_whitespace = merged_node.ends_with_whitespace or self.ends_with_whitespace
+        merged_node.require_after = merge_required(merged_node.require_after, self.require_after)
+
+        if self.induce_indent and self.indentation_level:
+            merged_node.induce_indent = True
+            merged_node.prepend_lines(INDENT)
+        return merged_node
+
+    def _merge_start_requirements(self, merged_node, first_child):
+        merged_node.starts_with_whitespace = not self.skip_whitespace_in_first_child and (
+            self.starts_with_whitespace or first_child.starts_with_whitespace
+        )
+        merged_node.cancels_previous_whitespace = (
+            first_child.cancels_previous_whitespace
+            or self.cancels_previous_whitespace
+            or self.children_cancel_whitespace
+        )
+        merged_node.require_before = merge_required(self.require_before, merged_node.require_before)
+
+    def _merge_next_child(self, next_child, converter_state, merged_node, prefixed_position):
+        next_text_node = next_child.to_text_node(converter_state)
+        prefix, _ = self._get_child_prefix(next_child, prefixed_position)
+        suffix = self._get_child_suffix(next_child)
+        merged_node.concatenate(next_text_node, separator=prefix, suffix=suffix)
+
+    @staticmethod
+    def _get_child_prefix(child, position=0) -> (str, bool):
+        """Provide child prefix and position to assign next child.
+
+        `Prefix` should be added before child text node content,
+        `position` to assign the following child is used in overrides,
+        namely <Ol> to skip incrementing the prefix.
+        """
+        return "", True
+
+    @staticmethod
+    def _get_child_suffix(child) -> str:
+        """Generate suffix to add after child node content."""
+        return ""
+
+    def to_markdown(self, converter_state) -> str:
+        text_node = self.to_text_node(converter_state)
+        return text_node.content
+
+    def to_text_node(self, converter_state):
+        self._children = [child.to_text_node(converter_state) for child in self._children]
+        return self._reduce(converter_state)
+
+
+class BlockNode(NodeWithChildren):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(
+            get_node,
+            options,
+            require_before="\n",
+            require_after=kwargs.pop("require_after", options.get("line_ending", LINE_ENDING) + "\n"),
+            skip_whitespace_in_first_child=True,
+            **kwargs,
+        )
+
+
+class PNode(BlockNode):
+    def __init__(self, get_node, options, **kwargs):
+        super().__init__(get_node, options, require_after="\n\n", **kwargs)
+
+
+class RootNode(NodeWithChildren):
+    def __init__(self, get_node, options, node, verbose):
+        super().__init__(
+            get_node, options, node, verbose=verbose, children_cancel_whitespace=True, skip_whitespace_tails=True
+        )

--- a/odoo/tools/html_to_md/TextNode.py
+++ b/odoo/tools/html_to_md/TextNode.py
@@ -1,0 +1,108 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from .BaseNode import BaseNode
+from .constants import ALL_WHITESPACE, SURROUNDING_WHITESPACE_REGEX
+
+
+class TextNode(BaseNode):
+    def __init__(self, content: str, **kwargs):
+        super().__init__(lambda: False, {}, **kwargs)
+        self._content: str = content
+
+    @property
+    def content(self):
+        return self._content
+
+    def get_str_components(self):
+        components = super().get_str_components()
+        components.update(content=self._content)
+        return components
+
+    def to_text_node(self, converter_state) -> "TextNode":
+        if self.require_after:
+            self.ends_with_whitespace = False
+        return self
+
+    def concatenate(self, other: "TextNode", separator="", suffix=""):
+        between = get_separator(self, other, separator)
+        self._content += f"{between}{other.content}{suffix}"
+        self.ends_with_whitespace = other.ends_with_whitespace
+        self.require_after = other.require_after
+        return self
+
+    def prepend(self, prefix):
+        self._content = prefix + self._content
+
+    def append(self, suffix):
+        self._content += suffix
+
+    def prepend_lines(self, prefix) -> None:
+        """Prepend prefix on each line of self's content.
+
+        :param prefix: Generally whitespace
+        """
+        trailing_newline = "\n" if self._content.endswith("\n") else ""
+        content = self._content.rstrip("\n")
+        self._content = prefix + f"\n{prefix}".join(content.split("\n")) + trailing_newline
+
+
+def get_separator(a: TextNode, b: TextNode, separator=""):
+    first = (
+        " "
+        if (not a._content or not a._content[-1].isspace())
+        and (not b._content or not b._content[-1].isspace())
+        and (not b.cancels_previous_whitespace and (a.ends_with_whitespace or b.starts_with_whitespace))
+        else ""
+    )
+    second = (
+        "\n\n"
+        if a.require_after == "\n\n" or b.require_before == "\n\n"
+        else merge_required(a.require_after, b.require_before)
+        if not a.content.endswith("\n\n")
+        else ""
+    )
+    return first + second + separator
+
+
+def merge_required(a_required_after: str, b_required_before: str, start="", end="") -> str:
+    if not a_required_after or b_required_before.startswith(a_required_after):
+        return start + b_required_before + end
+    if not b_required_before or a_required_after.endswith(b_required_before):
+        return start + a_required_after + end
+
+    if (a0 := a_required_after[0]) != b_required_before[0]:
+        if (bl := b_required_before[-1]) != a_required_after[-1]:
+            return merge_required(a_required_after[1:], b_required_before[:-1], start=start + a0, end=bl + end)
+        return merge_required(a_required_after[1:], b_required_before, start=start + a0, end=end)
+
+    bl = b_required_before[-1]
+    return merge_required(a_required_after, b_required_before[:-1], start=start, end=bl + end)
+
+
+def text_to_text_node(
+    start_text,
+    position=0,
+    indentation_level=0,
+    force_cancel_whitespace=False,
+    verbose=False,
+):
+    all_whitespace = ALL_WHITESPACE.match(start_text)
+    if all_whitespace:
+        pre, text, post = "", "", start_text
+    else:
+        with_whitespace = SURROUNDING_WHITESPACE_REGEX.match(start_text)
+        if with_whitespace:
+            pre, text, post = with_whitespace.groups()
+        else:
+            raise ValueError("Match Not Found with text", start_text)
+
+    return TextNode(
+        content=text,
+        position=position,
+        starts_with_whitespace=bool(len(pre)),
+        ends_with_whitespace=bool(len(post)),
+        indentation_level=indentation_level,
+        verbose=verbose,
+        force_cancel_whitespace=force_cancel_whitespace,
+    )

--- a/odoo/tools/html_to_md/__init__.py
+++ b/odoo/tools/html_to_md/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import html_to_md

--- a/odoo/tools/html_to_md/constants.py
+++ b/odoo/tools/html_to_md/constants.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import re
+
+SURROUNDING_WHITESPACE_REGEX = re.compile(r"^(\s*)(.*?)(\s*)$", flags=re.MULTILINE)
+ALL_WHITESPACE = re.compile(r"^\s+$")
+
+LINK_TAG_PREFIX = r"LINK#"
+UUID_REGEX = r"[0-9a-fA-F]{8}([0-9a-fA-F]{4}){3}[0-9a-fA-F]{12}"  # adapted from pyparsing to remove "-"
+LINK_TAG_REGEX = LINK_TAG_PREFIX + UUID_REGEX
+
+INDENT = " " * 2
+LINE_ENDING = "  "

--- a/odoo/tools/html_to_md/html_to_md.py
+++ b/odoo/tools/html_to_md/html_to_md.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from typing import Union
+
+import lxml
+
+from .Converter import MarkdownConverter
+from .EmptyNode import BrNode, HrNode
+from .InlineNode import EmphasisNode, BoldNode, StrikeNode, InlineNode
+from .LinkNode import ANode, ImgNode
+from .ListNode import LiNode, OlNode, UlNode
+from .NodeWithChildren import NodeWithChildren, BlockNode, PNode
+from .TextNode import TextNode
+
+TAG_TO_NODE_CLASS = {
+    "hr": HrNode,
+    "br": BrNode,
+    "i": EmphasisNode,
+    "em": EmphasisNode,
+    "u": EmphasisNode,
+    "b": BoldNode,
+    "strong": BoldNode,
+    "strike": StrikeNode,
+    "del": StrikeNode,
+    "p": PNode,
+    "div": BlockNode,
+    "span": InlineNode,
+    "ol": OlNode,
+    "ul": UlNode,
+    "li": LiNode,
+    "a": ANode,
+    "img": ImgNode,
+}
+
+
+# noinspection PyProtectedMember
+def get_converter(root_node: lxml.etree._Element) -> MarkdownConverter:
+    return MarkdownConverter(root_node, get_node)
+
+
+def get_node(tag: str, options, **kwargs) -> Union[NodeWithChildren, TextNode]:
+    node_class = TAG_TO_NODE_CLASS.get(tag, NodeWithChildren)
+    if tag == "img" and not options.get("keep_images"):
+        node_class = NodeWithChildren
+    return node_class(get_node, options, **kwargs)

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -3,15 +3,14 @@
 
 import base64
 import collections
+import html as htmllib
 import logging
 import random
 import re
 import socket
-import threading
 import time
 from email.utils import getaddresses
 from urllib.parse import urlparse
-import html as htmllib
 
 import idna
 import markupsafe
@@ -19,9 +18,8 @@ from lxml import etree, html
 from lxml.html import clean
 from werkzeug import urls
 
-import odoo
 from odoo.loglevels import ustr
-from odoo.tools import misc
+from odoo.tools import misc, html_to_md
 
 _logger = logging.getLogger(__name__)
 
@@ -331,85 +329,59 @@ def html_keep_url(text):
     return final
 
 
-def html_to_inner_content(html):
-    """Returns unformatted text after removing html tags and excessive whitespace from a
-    string/Markup. Passed strings will first be sanitized.
+def html_to_plaintext(html, convert_entities=False, skip_sanitation=False, **kwargs):
     """
+    Returns formatted text from an HTML string/Markup with markdown-like markup.
+
+    :param str|markupsafe.Markup html: Text/Markup to process
+    :param convert_entities: Unescape resulting string
+    :param skip_sanitation: Set True to skip string sanitation
+    :param kwargs: additional formatting options available when formatted=True.
+      See _html2text.HTML2Text
+    :rtype: str
+    """
+    # Exclude non-string-like falsy cases first as `ustr` converts them.
+    if not html:
+        return ''
+
+    html = ustr(html)
+
     if is_html_empty(html):
         return ''
-    if not isinstance(html, markupsafe.Markup):
+
+    if not isinstance(html, markupsafe.Markup) and not skip_sanitation:
         html = html_sanitize(html)
-    processed = re.sub(HTML_NEWLINES_REGEX, ' ', html)
-    processed = re.sub(HTML_TAGS_REGEX, '', processed)
-    processed = re.sub(r' {2,}|\t', ' ', processed)
-    processed = htmllib.unescape(processed)
+
+    tree = etree.fromstring(html, parser=etree.HTMLParser())
+    root = tree.xpath('//body')[0]
+
+    processed = _html_to_plaintext(root, **kwargs)
+    if convert_entities:
+        processed = htmllib.unescape(processed)
     processed = processed.strip()
     return processed
 
 
-def html2plaintext(html, body_id=None, encoding='utf-8'):
-    """ From an HTML text, convert the HTML to plain text.
-    If @param body_id is provided then this is the tag where the
-    body (not necessarily <body>) starts.
+def _html_to_plaintext(root, markdown_newlines=False, markdown_pre=False, **kwargs):
     """
-    ## (c) Fry-IT, www.fry-it.com, 2007
-    ## <peter@fry-it.com>
-    ## download here: http://www.peterbe.com/plog/html2plaintext
+    :param markdown_newlines: Use double newlines and/or end lines with double space.
+      Added as argument to avoid changing HTML2Text too much.
+    :param kwargs: see HTML2Text docstring.
+    """
+    flags = kwargs.pop('flags', set())
+    if not markdown_newlines:
+        flags.add("SIMPLE_LINE_ENDING")
+    converter = html_to_md.get_converter(root)
+    processed = converter.render_markdown(flags=flags, **kwargs)
+    return processed
 
-    html = ustr(html)
 
-    if not html.strip():
-        return ''
+def style_to_dict(style):
+    return dict(
+        map(str.strip, rule.split(":", 1))
+        for rule in style.split(";") if ":" in rule
+    )
 
-    tree = etree.fromstring(html, parser=etree.HTMLParser())
-
-    if body_id is not None:
-        source = tree.xpath('//*[@id=%s]' % (body_id,))
-    else:
-        source = tree.xpath('//body')
-    if len(source):
-        tree = source[0]
-
-    url_index = []
-    i = 0
-    for link in tree.findall('.//a'):
-        url = link.get('href')
-        if url:
-            i += 1
-            link.tag = 'span'
-            link.text = '%s [%s]' % (link.text, i)
-            url_index.append(url)
-
-    html = ustr(etree.tostring(tree, encoding=encoding))
-    # \r char is converted into &#13;, must remove it
-    html = html.replace('&#13;', '')
-
-    html = html.replace('<strong>', '*').replace('</strong>', '*')
-    html = html.replace('<b>', '*').replace('</b>', '*')
-    html = html.replace('<h3>', '*').replace('</h3>', '*')
-    html = html.replace('<h2>', '**').replace('</h2>', '**')
-    html = html.replace('<h1>', '**').replace('</h1>', '**')
-    html = html.replace('<em>', '/').replace('</em>', '/')
-    html = html.replace('<tr>', '\n')
-    html = html.replace('</p>', '\n')
-    html = re.sub('<br\s*/?>', '\n', html)
-    html = re.sub('<.*?>', ' ', html)
-    html = html.replace(' ' * 2, ' ')
-    html = html.replace('&gt;', '>')
-    html = html.replace('&lt;', '<')
-    html = html.replace('&amp;', '&')
-    html = html.replace('&nbsp;', '\N{NO-BREAK SPACE}')
-
-    # strip all lines
-    html = '\n'.join([x.strip() for x in html.splitlines()])
-    html = html.replace('\n' * 2, '\n')
-
-    for i, url in enumerate(url_index):
-        if i == 0:
-            html += '\n\n'
-        html += ustr('[%s] %s\n') % (i + 1, url)
-
-    return html.strip()
 
 def plaintext2html(text, container_tag=None):
     r"""Convert plaintext into html. Content of the text is escaped to manage
@@ -443,8 +415,10 @@ def plaintext2html(text, container_tag=None):
     final += text[idx:] + '</p>'
 
     # 5. container
-    if container_tag: # FIXME: validate that container_tag is just a simple tag?
-        final = '<%s>%s</%s>' % (container_tag, final, container_tag)
+    if container_tag:
+        if not re.match(r'^[a-zA-Z]+$', container_tag):
+            raise ValueError('`container_tag` should be a simple tag.')
+        final = f'<{container_tag}>{final}</{container_tag}>'
     return markupsafe.Markup(final)
 
 def append_content_to_html(html, content, plaintext=True, preserve=False, container_tag=None):


### PR DESCRIPTION
To get more robustness and possibilities for customization as well as solve a licensing question, we here
* replace html2plaintext with another library
* replace calls to explicitly choose plaintext with formatting or a   more compact end result.

While keeping the current existing tests as models for the expected transformations to plaintext, we
* updated the bold mark to ** instead of *
* Used * and numbers for unordered and ordered lists, respectively for simplicity and trying to stay somehow close to markdown when possible.

Task-2817604
