### PR TITLE
[IMP] account: exclude legacy invoices from portal

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -31,7 +31,11 @@ class PortalAccount(CustomerPortal):
         return self._get_page_view_values(invoice, access_token, values, 'my_invoices_history', False, **kwargs)
 
     def _get_invoices_domain(self):
-        return [('state', 'not in', ('cancel', 'draft')), ('move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt'))]
+        return [
+            ('state', 'not in', ('cancel', 'draft')),
+            ('move_type', 'in', ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')),
+            ('payment_state', '!=', 'invoicing_legacy'),
+        ]
 
     def _get_account_searchbar_sortings(self):
         return {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Users are allowed to import invoices from their legacy system. These invoices are considered as fully closed and are normally created to have a reference inside of Odoo of the status of the old system. These invoices can/should be excluded from the portal's invoice, to not clutter the page.

Current behavior before PR:
- Import invoices from legacy system
- Grant access to one of your customers
- The customer will be able to see their old invoices in the portal

Desired behavior after PR is merged:
- When the portal access is granted the users shouldn't see the old invoices


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
