### PR TITLE
[FIX] mrp: maintain By-Products on changing Work Orders

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -736,10 +736,13 @@ class MrpProduction(models.Model):
                     ]
                 continue
             # delete to remove existing moves from database and clear to remove new records
-            production.move_finished_ids = [Command.delete(m) for m in production.move_finished_ids.ids]
+            byproducts = production.move_byproduct_ids
+            byproduct_ids = production.move_byproduct_ids.mapped(lambda m: m.product_id)
+            production.move_finished_ids = [Command.delete(m) for m in production.move_finished_ids.filtered(lambda m: m.product_id not in byproduct_ids).ids]
             production.move_finished_ids = [Command.clear()]
             if production.product_id:
                 production._create_update_move_finished()
+                production.move_finished_ids += byproducts
             else:
                 production.move_finished_ids = [
                     Command.delete(move.id) for move in production.move_finished_ids if move.bom_line_id


### PR DESCRIPTION
### Steps to reproduce
- Install **Manufacturing**
- Go to **Settings** > **Manufacturing** > **Operations** and activate **By-Products** option
- In Manufacturing, Go to **Operations** > **Manufacturing Orders** and create a New MO
- In the **By-Products** tab, add a product
- In the **Work Orders** tab, add a WO
- Go back to the **By-Products** tab, the by-product is gone
- Same thing happens on deleting the WO, the by-products are gone

### Investigation
- Changing the WO, triggers `_compute_move_finished_ids` method which clears the `move_finished_ids` https://github.com/odoo/odoo/blob/67bbf31e57959631d98586f5a4d22f981b344066/addons/mrp/models/mrp_production.py#L739-L740
- Which triggers `_compute_move_byproduct_ids` mehtod resulting in an empty set https://github.com/odoo/odoo/blob/67bbf31e57959631d98586f5a4d22f981b344066/addons/mrp/models/mrp_production.py#L614-L616

### Discussion
- Personally I would say that it's a normal behavior as the products are to be related with the WO. SO we just add the WOs first then the by-product. However it was mentioned in the ticket that the PO confirms it's a bug
- I am concerned it that would miss up some other parts that need the move_finished_ids to fully cleared out.

opw-3693285