### PR TITLE
[FIX] hr_holidays: manage accrual plan over years

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -198,47 +198,55 @@ class AccrualPlanLevel(models.Model):
         Returns the next date with the given last call
         """
         self.ensure_one()
+        next_date = False
         if self.frequency == 'daily':
-            return last_call + relativedelta(days=1)
+            next_date = last_call + relativedelta(days=1)
         elif self.frequency == 'weekly':
             daynames = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun']
             weekday = daynames.index(self.week_day)
-            return last_call + relativedelta(days=1, weekday=weekday)
+            next_date = last_call + relativedelta(days=1, weekday=weekday)
         elif self.frequency == 'bimonthly':
             first_date = last_call + relativedelta(day=self.first_day)
             second_date = last_call + relativedelta(day=self.second_day)
             if last_call < first_date:
-                return first_date
+                next_date = first_date
             elif last_call < second_date:
-                return second_date
+                next_date = second_date
             else:
-                return last_call + relativedelta(months=1, day=self.first_day)
+                next_date = last_call + relativedelta(months=1, day=self.first_day)
         elif self.frequency == 'monthly':
             date = last_call + relativedelta(day=self.first_day)
             if last_call < date:
-                return date
+                next_date = date
             else:
-                return last_call + relativedelta(months=1, day=self.first_day)
+                next_date = last_call + relativedelta(months=1, day=self.first_day)
         elif self.frequency == 'biyearly':
             first_month = MONTHS.index(self.first_month) + 1
             second_month = MONTHS.index(self.second_month) + 1
             first_date = last_call + relativedelta(month=first_month, day=self.first_month_day)
             second_date = last_call + relativedelta(month=second_month, day=self.second_month_day)
             if last_call < first_date:
-                return first_date
+                next_date = first_date
             elif last_call < second_date:
-                return second_date
+                next_date = second_date
             else:
-                return last_call + relativedelta(years=1, month=first_month, day=self.first_month_day)
+                next_date = last_call + relativedelta(years=1, month=first_month, day=self.first_month_day)
         elif self.frequency == 'yearly':
             month = MONTHS.index(self.yearly_month) + 1
             date = last_call + relativedelta(month=month, day=self.yearly_day)
             if last_call < date:
-                return date
+                next_date = date
             else:
-                return last_call + relativedelta(years=1, month=month, day=self.yearly_day)
+                next_date = last_call + relativedelta(years=1, month=month, day=self.yearly_day)
         else:
-            return False
+            return next_date
+        # If the new year occurs between the `last_call` and the `next_date`
+        # and we are in the year of the `last_call`,
+        # return the first day of the next year.
+        if next_date.year > last_call.year and fields.Date.today().year == last_call.year:
+            return next_date + relativedelta(month=1, day=1)
+        else:
+            return next_date
 
     def _get_previous_date(self, last_call):
         """

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -5,6 +5,7 @@ from freezegun import freeze_time
 from dateutil.relativedelta import relativedelta
 
 from odoo.tests import tagged
+from odoo.tools import float_compare
 
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
 
@@ -575,7 +576,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         accrual_cron.lastcall = datetime.date(2021, 9, 1)
         with freeze_time('2022-01-01'):
             allocation._update_accrual()
-            self.assertEqual(allocation.number_of_days, 1, 'The number of days should be reset')
+            self.assertEqual(allocation.number_of_days, 0, 'The number of days should be reset')
 
     def test_unused_accrual_postponed(self):
         # 1 accrual with 2 levels and level transition after
@@ -641,7 +642,91 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         accrual_cron.lastcall = datetime.date(2021, 1, 1)
         with freeze_time('2023-01-26'):
             allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 6, 'The maximum number of days should be reached and kept.')
+        self.assertEqual(allocation.number_of_days, 4, 'The maximum number of days should be reached and kept.')
+
+    def test_accrual_over_years(self):
+        hr_leave_allocation = self.env['hr.leave.allocation']
+        with freeze_time('2023-11-20'):
+            accrual_plan_postponed = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+                'name': 'Accrual Plan For Test',
+                'level_ids': [(0, 0, {
+                    'start_count': 0,
+                    'start_type': 'day',
+                    'added_value': 1,
+                    'added_value_type': 'days',
+                    'frequency': 'monthly',
+                    'first_day': 20,
+                    'maximum_leave': 100,
+                    'action_with_unused_accruals': 'postponed',
+                    'postpone_max_days': 10,
+                })],
+            })
+            accrual_plan_lost = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
+                'name': 'Accrual Plan For Test',
+                'level_ids': [(0, 0, {
+                    'start_count': 0,
+                    'start_type': 'day',
+                    'added_value': 1,
+                    'added_value_type': 'days',
+                    'frequency': 'monthly',
+                    'first_day': 20,
+                    'maximum_leave': 100,
+                    'action_with_unused_accruals': 'lost',
+                })],
+            })
+            allocation_postponed = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee (postponed)',
+                'accrual_plan_id': accrual_plan_postponed.id,
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+            })
+            allocation_lost = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
+                'name': 'Accrual allocation for employee (lost)',
+                'accrual_plan_id': accrual_plan_lost.id,
+                'employee_id': self.employee_emp.id,
+                'holiday_status_id': self.leave_type.id,
+                'number_of_days': 0,
+                'allocation_type': 'accrual',
+            })
+            allocation_postponed.action_confirm()
+            allocation_postponed.action_validate()
+            allocation_lost.action_confirm()
+            allocation_lost.action_validate()
+
+        accrual_cron = self.env['ir.cron'].sudo().env.ref('hr_holidays.hr_leave_allocation_cron_accrual')
+        accrual_cron.lastcall = datetime.date(2023, 11, 20)
+
+        with freeze_time('2023-12-21'):
+            hr_leave_allocation._update_accrual()
+        # One month has passed, 1 allocation has been given
+        self.assertEqual(allocation_postponed.number_of_days, 1)
+        self.assertEqual(allocation_lost.number_of_days, 1)
+        # `nextcall` dates must be the first day of the following year,
+        # as we do not yet know whether or not to postpone allocations.
+        self.assertEqual(allocation_postponed.nextcall, datetime.date(2024, 1, 1))
+        self.assertEqual(allocation_lost.nextcall, datetime.date(2024, 1, 1))
+
+        with freeze_time('2024-1-5'):
+            hr_leave_allocation._update_accrual()
+        # It's the following year, we receive the allocations
+        # for the end of the year if we have to postpone them.
+        self.assertEqual(float_compare(allocation_postponed.number_of_days, 1.39, 2), 0)
+        # 1.39 = 1 (because allocations are postponed) + 0.39 (because we receive the part between 20th December and 31st December)
+        self.assertEqual(allocation_lost.number_of_days, 0)
+        # `nextcall` dates must be the day defined in the accrual plan
+        self.assertEqual(allocation_postponed.nextcall, datetime.date(2024, 1, 20))
+        self.assertEqual(allocation_lost.nextcall, datetime.date(2024, 1, 20))
+
+        with freeze_time('2024-1-21'):
+            hr_leave_allocation._update_accrual()
+        self.assertEqual(allocation_postponed.number_of_days, 2) # We receive the second part between 1st January and 20th January
+        self.assertEqual(float_compare(allocation_lost.number_of_days, 0.61, 2), 0)
+        # We receive the second part between 1st January and 20th January
+        # The part between 20th December and 31st December is lost
+        self.assertEqual(allocation_postponed.nextcall, datetime.date(2024, 2, 20))
+        self.assertEqual(allocation_lost.nextcall, datetime.date(2024, 2, 20))
 
     def test_unused_accrual_postponed_limit(self):
         # 1 accrual with 2 levels and level transition after
@@ -838,7 +923,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         allocation.action_validate()
         with freeze_time('2022-4-4'):
             allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 4, "Invalid number of days")
+        self.assertEqual(allocation.number_of_days, 3, "Invalid number of days")
 
     def test_accrual_lost_first_january(self):
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
@@ -868,7 +953,10 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         allocation.action_validate()
         with freeze_time('2022-4-1'):
             allocation._update_accrual()
-        self.assertEqual(allocation.number_of_days, 3, "Invalid number of days")
+        self.assertEqual(allocation.number_of_days, 0, "Invalid number of days")
+        # Note:
+        # Receiving allocations at the beginning of the year calculated on the period of the previous year
+        # without postponing it will always be 0.
 
     def test_accrual_maximum_leaves(self):
         accrual_plan = self.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({


### PR DESCRIPTION
Steps to reproduce:
-------------------
Create an accrual plan with 1 days every last day of the month. At the end of the year, unused accruals is postponed.

Create an allocation that begins 1st November 2023. To be in mid-January 2024 and run the cron several times.

The number of days is incremented like: 0.00 -> 1.97 -> 2.00 -> 2.03 -> 2.06

Issue:
------
Increasing plans do not behave as expected when they are spread over several years. If we create an accrual plan that gives allocations every month in 2023 and in 2024 we run the cron (several times), the number of days allocated to the allocation will always increment.

Solution:
---------
Process the year change logic directly in the `_process_accrual_plans` method. The cron should only process the accrual plan if we are after the `nextcall`. If a year change is detected in `_get_next_date`, set the `nextcall` to the first day of the following year so that the allocation is correctly updated when the year changes (taking into account the `postponed`/`lost` values).

Note:
-----
The fix is invasive but simplifies the accrual plan logic for V16.0. The `_end_of_year_accrual` method is no longer used. The `date_to` and `force_period` parameters are no longer used.

opw-3669893