### PR TITLE
[FIX] account, l10n_cl : move_type invisible condition eval

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -435,7 +435,7 @@
                            attrs="{'invisible': ['|', '|', ('payment_state', 'in', ('invoicing_legacy')), ('state', '!=', 'posted'), ('move_type', '=', 'entry')]}"
                            optional="show"/>
                     <field name="state" widget="badge" decoration-success="state == 'posted'" decoration-info="state == 'draft'" optional="show"/>
-                    <field name="move_type" invisible="context.get('default_move_type', True)"/>
+                    <field name="move_type" invisible="bool(context.get('default_move_type', True))"/>
                   </tree>
             </field>
         </record>

--- a/addons/l10n_cl/views/account_move_view.xml
+++ b/addons/l10n_cl/views/account_move_view.xml
@@ -63,7 +63,7 @@
                 <field name="company_currency_id" invisible="1"/>
                 <field name="state" optional="show"/>
                 <field name="payment_state" optional="hide"/>
-                <field name="move_type" invisible="context.get('default_move_type', True)"/>
+                <field name="move_type" invisible="bool(context.get('default_move_type', True))"/>
             </tree>
         </field>
     </record>


### PR DESCRIPTION
steps:
with studio, try adding a field to the invoice tree view -> traceback

This is due to the 'default_move_type' context being a string but trying to be evaluated as a boolean.

opw-3703559
opw-3702620
opw-3702360
opw-3698111
opw-3698108
opw-3702084