### PR TITLE
[IMP] utm: ignore capital letter

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -102,7 +102,7 @@ class LinkTracker(models.Model):
                 continue
 
             utms = {}
-            for key, field_name, cook in self.env['utm.mixin'].tracking_fields():
+            for key, field_name, __, __ in self.env['utm.mixin'].tracking_fields():
                 field = self._fields[field_name]
                 attr = tracker[field_name]
                 if field.type == 'many2one':
@@ -172,7 +172,7 @@ class LinkTracker(models.Model):
                 vals['title'] = self._get_title_from_url(vals['url'])
 
             # Prevent the UTMs to be set by the values of UTM cookies
-            for (__, fname, __) in self.env['utm.mixin'].tracking_fields():
+            for (__, fname, __, __) in self.env['utm.mixin'].tracking_fields():
                 if fname not in vals:
                     vals[fname] = False
 

--- a/addons/mass_mailing/tests/common.py
+++ b/addons/mass_mailing/tests/common.py
@@ -174,7 +174,7 @@ class MassMailCase(MailCase, MockLinkTracker):
             if link_info:
                 trace_mail = self._find_mail_mail_wrecord(record)
                 for (anchor_id, url, is_shortened, add_link_params) in link_info:
-                    link_params = {'utm_medium': 'Email', 'utm_source': mailing.name}
+                    link_params = {'utm_medium': 'email', 'utm_source': mailing.name}
                     if add_link_params:
                         link_params.update(**add_link_params)
                     self.assertLinkShortenedHtml(

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -449,20 +449,20 @@ class TestMassMailValues(MassMailCommon):
             'subject': 'Second subject',
         }])
 
-        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)')
-        self.assertEqual(mailing_1.name, 'First subject (Mass Mailing created on 2022-01-02) [2]')
-        self.assertEqual(mailing_2.name, 'First subject (Mass Mailing created on 2022-01-02) [3]')
-        self.assertEqual(mailing_3.name, 'Custom Source')
-        self.assertEqual(mailing_4.name, 'Mailing')
-        self.assertEqual(mailing_5.name, 'Mailing [2]')
-        self.assertEqual(mailing_6.name, 'Second subject (Mass Mailing created on 2022-01-02)')
+        self.assertEqual(mailing_0.name, 'first subject (mass mailing created on 2022-01-02)')
+        self.assertEqual(mailing_1.name, 'first subject (mass mailing created on 2022-01-02) [2]')
+        self.assertEqual(mailing_2.name, 'first subject (mass mailing created on 2022-01-02) [3]')
+        self.assertEqual(mailing_3.name, 'custom source')
+        self.assertEqual(mailing_4.name, 'mailing')
+        self.assertEqual(mailing_5.name, 'mailing [2]')
+        self.assertEqual(mailing_6.name, 'second subject (mass mailing created on 2022-01-02)')
 
         mailing_0.subject = 'First subject'
-        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02) [4]',
+        self.assertEqual(mailing_0.name, 'first subject (mass mailing created on 2022-01-02) [4]',
             msg='The name must have been re-generated')
 
-        mailing_0.name = 'Second subject (Mass Mailing created on 2022-01-02)'
-        self.assertEqual(mailing_0.name, 'Second subject (Mass Mailing created on 2022-01-02) [2]',
+        mailing_0.name = 'second subject (mass mailing created on 2022-01-02)'
+        self.assertEqual(mailing_0.name, 'second subject (mass mailing created on 2022-01-02) [2]',
             msg='The name must be unique')
 
 
@@ -658,7 +658,7 @@ Email: <a id="url5" href="mailto:test@odoo.com">test@odoo.com</a></div>""",
                               ('url4', 'https://www.example.com/foo/bar?baz=qux', True),
                               ('url5', 'mailto:test@odoo.com', False)]:
                 # TDE FIXME: why going to mail message id ? mail.body_html seems to fail, check
-                link_params = {'utm_medium': 'Email', 'utm_source': mailing.name}
+                link_params = {'utm_medium': 'email', 'utm_source': mailing.name}
                 if link_info[0] == 'url4':
                     link_params['baz'] = 'qux'
                 self.assertLinkShortenedHtml(

--- a/addons/mass_mailing_sms/tests/common.py
+++ b/addons/mass_mailing_sms/tests/common.py
@@ -113,7 +113,7 @@ class MassSMSCase(SMSCase, MockLinkTracker):
                 for (url, is_shortened, add_link_params) in link_info:
                     if url == 'unsubscribe':
                         url = '%s/sms/%d/%s' % (mailing.get_base_url(), mailing.id, trace.sms_code)
-                    link_params = {'utm_medium': 'SMS', 'utm_source': mailing.name}
+                    link_params = {'utm_medium': 'sms', 'utm_source': mailing.name}
                     if add_link_params:
                         link_params.update(**add_link_params)
                     self.assertLinkShortenedText(

--- a/addons/utm/data/utm_medium_data.xml
+++ b/addons/utm/data/utm_medium_data.xml
@@ -1,33 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record model="utm.medium" id="utm_medium_website">
-        <field name="name">Website</field>
+        <field name="name">website</field>
     </record>
     <record model="utm.medium" id="utm_medium_phone">
-        <field name="name">Phone</field>
+        <field name="name">phone</field>
     </record>
     <record model="utm.medium" id="utm_medium_direct">
-        <field name="name">Direct</field>
+        <field name="name">direct</field>
     </record>
     <record model="utm.medium" id="utm_medium_email">
-        <field name="name">Email</field>
+        <field name="name">email</field>
     </record>
     <record model="utm.medium" id="utm_medium_banner">
-        <field name="name">Banner</field>
+        <field name="name">banner</field>
     </record>
     <record model="utm.medium" id="utm_medium_twitter">
-        <field name="name">Twitter</field>
+        <field name="name">twitter</field>
     </record>
     <record model="utm.medium" id="utm_medium_facebook">
-        <field name="name">Facebook</field>
+        <field name="name">facebook</field>
     </record>
     <record model="utm.medium" id="utm_medium_linkedin">
-        <field name="name">LinkedIn</field>
+        <field name="name">linkedIn</field>
     </record>
     <record model="utm.medium" id="utm_medium_television">
-        <field name="name">Television</field>
+        <field name="name">television</field>
     </record>
     <record model="utm.medium" id="utm_medium_google_adwords">
-        <field name="name">Google Adwords</field>
+        <field name="name">google adwords</field>
     </record>
 </odoo>

--- a/addons/utm/data/utm_source_data.xml
+++ b/addons/utm/data/utm_source_data.xml
@@ -1,30 +1,30 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <record model="utm.source" id="utm_source_search_engine">
-        <field name="name">Search engine</field>
+        <field name="name">search engine</field>
     </record>
     <record model="utm.source" id="utm_source_mailing">
-        <field name="name">Lead Recall</field>
+        <field name="name">lead Recall</field>
     </record>
     <record model="utm.source" id="utm_source_newsletter">
-        <field name="name">Newsletter</field>
+        <field name="name">newsletter</field>
     </record>
     <record model="utm.source" id="utm_source_facebook">
-        <field name="name">Facebook</field>
+        <field name="name">facebook</field>
     </record>
     <record model="utm.source" id="utm_source_twitter">
-        <field name="name">Twitter</field>
+        <field name="name">twitter</field>
     </record>
     <record model="utm.source" id="utm_source_linkedin">
-        <field name="name">LinkedIn</field>
+        <field name="name">linkedIn</field>
     </record>
     <record model="utm.source" id="utm_source_monster">
-        <field name="name">Monster</field>
+        <field name="name">monster</field>
     </record>
     <record model="utm.source" id="utm_source_glassdoor">
-        <field name="name">Glassdoor</field>
+        <field name="name">glassdoor</field>
     </record>
     <record model="utm.source" id="utm_source_craigslist">
-        <field name="name">Craigslist</field>
+        <field name="name">craigslist</field>
     </record>
 </odoo>

--- a/addons/utm/models/ir_http.py
+++ b/addons/utm/models/ir_http.py
@@ -16,7 +16,7 @@ class IrHttp(models.AbstractModel):
         # Make sure response is an odoo Response.
         response = Response.load(response)
         domain = cls.get_utm_domain_cookies()
-        for url_parameter, __, cookie_name in request.env['utm.mixin'].tracking_fields():
+        for url_parameter, __, cookie_name, __ in request.env['utm.mixin'].tracking_fields():
             if url_parameter in request.params and request.httprequest.cookies.get(cookie_name) != request.params[url_parameter]:
                 response.set_cookie(cookie_name, request.params[url_parameter], max_age=31 * 24 * 3600, domain=domain, cookie_type='optional')
 

--- a/addons/utm/models/utm_campaign.py
+++ b/addons/utm/models/utm_campaign.py
@@ -34,7 +34,7 @@ class UtmCampaign(models.Model):
 
     @api.depends('title')
     def _compute_name(self):
-        new_names = self.env['utm.mixin']._get_unique_names(self._name, [c.title for c in self])
+        new_names = self.env['utm.mixin']._get_unique_names(self._name, [c.title for c in self], lowercase=False)
         for campaign, new_name in zip(self, new_names):
             campaign.name = new_name
 
@@ -43,7 +43,7 @@ class UtmCampaign(models.Model):
         for vals in vals_list:
             if not vals.get('title') and vals.get('name'):
                 vals['title'] = vals['name']
-        new_names = self.env['utm.mixin']._get_unique_names(self._name, [vals.get('name') for vals in vals_list])
+        new_names = self.env['utm.mixin']._get_unique_names(self._name, [vals.get('name') for vals in vals_list], lowercase=False)
         for vals, new_name in zip(vals_list, new_names):
             if new_name:
                 vals['name'] = new_name

--- a/addons/utm/models/utm_source.py
+++ b/addons/utm/models/utm_source.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import re
 
 from odoo import _, api, fields, models, tools
+from odoo.exceptions import ValidationError
 
 
 class UtmSource(models.Model):
@@ -17,10 +19,15 @@ class UtmSource(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        new_names = self.env['utm.mixin']._get_unique_names(self._name, [vals.get('name') for vals in vals_list])
-        for vals, new_name in zip(vals_list, new_names):
-            vals['name'] = new_name
-        return super().create(vals_list)
+        for vals in vals_list:
+            if name := vals.get('name'):
+                vals['name'] = name.lower()
+        try:
+            return super().create(vals_list)
+        except Exception as e:
+            pattern = r"Key \(name\)=\((.*?)\)"
+            match = re.search(pattern, str(e))
+            raise ValidationError(f'The operation cannot be completed: The Source "{match.group(1)}" already exists!')
 
     def _generate_name(self, record, content):
         """Generate the UTM source name based on the content of the source."""
@@ -54,11 +61,13 @@ class UtmSourceMixin(models.AbstractModel):
     def create(self, vals_list):
         """Create the UTM sources if necessary, generate the name based on the content in batch."""
         # Create all required <utm.source>
-        utm_sources = self.env['utm.source'].create([
-            {'name': values.get('name') or self.env['utm.source']._generate_name(self, values.get(self._rec_name))}
+        source_names = [
+            values.get('name') or self.env['utm.source']._generate_name(self, values.get(self._rec_name))
             for values in vals_list
             if not values.get('source_id')
-        ])
+        ]
+        unique_source_names = self.env['utm.mixin']._get_unique_names('utm.source', [name.lower() for name in source_names])
+        utm_sources = self.env['utm.source'].create([{'name': name} for name in unique_source_names])
 
         # Update "vals_list" to add the ID of the newly created source
         vals_list_missing_source = [values for values in vals_list if not values.get('source_id')]

--- a/addons/utm/tests/test_utm.py
+++ b/addons/utm/tests/test_utm.py
@@ -2,6 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.utm.tests.common import TestUTMCommon
+from odoo.tools import mute_logger
+from odoo.exceptions import ValidationError
 
 
 class TestUtm(TestUTMCommon):
@@ -12,14 +14,23 @@ class TestUtm(TestUTMCommon):
             'name': 'Source 2',
         }])
 
+        # created UTMs should be lowercase
+        self.assertEqual(source_1.name, 'source 1')
+        self.assertEqual(source_2.name, 'source 2')
+
         # Find the record based on the given name
-        source = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 1')
+        source = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 1', lowercase=True)
         self.assertEqual(source, source_1)
 
         # Create a new record
-        source_4 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 3')
+        source_4 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 3', lowercase=True)
+
         self.assertNotIn(source_4, source_1 | source_2)
-        self.assertEqual(source_4.name, 'Source 3')
+        self.assertEqual(source_4.name, 'source 3')
+
+        # Test case insensitivity
+        source_5 = self.env['utm.mixin']._find_or_create_record('utm.source', 'SoURcE 3', lowercase=True)
+        self.assertEqual(source_5, source_4)
 
     def test_find_or_create_with_archived_record(self):
         archived_campaign = self.env['utm.campaign'].create([{
@@ -29,46 +40,76 @@ class TestUtm(TestUTMCommon):
         campaign = self.env['utm.mixin']._find_or_create_record('utm.campaign', 'Archived Campaign')
         self.assertEqual(archived_campaign, campaign, "An archived record must be found instead of re-created.")
 
-    def test_name_generation(self):
+    def test_medium_source_name_generation(self):
         """Test that the name is always unique.
 
         A counter must be added at the end of the name if it's not the case.
         """
-        for utm_model in ('utm.source', 'utm.medium', 'utm.campaign'):
-            utm_0 = self.env[utm_model].create({'name': 'UTM dup'})
-
-            utm_1, utm_2, utm_3, utm_4, utm_5 = self.env[utm_model].create([{
+        for utm_model in ('utm.source', 'utm.medium'):
+            utm_1, utm_2, utm_3 = self.env[utm_model].create([{
                 'name': 'UTM 1',
             }, {
                 'name': 'UTM 2',
             }, {
-                'name': 'UTM dup',
-            }, {
-                # UTM record 4 has the same name of the previous UTM record
-                'name': 'UTM dup',
-            }, {
-                # UTM record 5 has the same name of the previous UTM record
-                # but with a wrong counter part, it will be removed and updated
-                'name': 'UTM dup [0]',
+                'name': 'UTM 3',
             }])
 
-            self.assertEqual(utm_0.name, 'UTM dup', msg='The first "UTM dup" should be left unchanged since it is unique')
-            self.assertEqual(utm_1.name, 'UTM 1', msg='This name is already unique')
-            self.assertEqual(utm_2.name, 'UTM 2', msg='This name is already unique')
-            self.assertEqual(utm_3.name, 'UTM dup [2]', msg='Must add a counter as suffix to ensure uniqueness')
-            self.assertEqual(utm_4.name, 'UTM dup [3]', msg='Must add a counter as suffix to ensure uniqueness')
-            self.assertEqual(utm_5.name, 'UTM dup [4]', msg='Must add a counter as suffix to ensure uniqueness')
+            self.assertEqual(utm_1.name, 'utm 1')
+            self.assertEqual(utm_2.name, 'utm 2')
+            self.assertEqual(utm_3.name, 'utm 3')
+            with mute_logger('odoo.sql_db'):
+                with self.assertRaises(ValidationError):
+                    # create method should raise the ValidationError
+                    self.env[utm_model].create({'name': 'UTM 1'})
 
-            (utm_0 | utm_3 | utm_4).unlink()
+            (utm_1 | utm_3).unlink()
 
-            utm_6 = self.env[utm_model].create({'name': 'UTM dup'})
-            self.assertEqual(utm_6.name, 'UTM dup [5]')
+            utm_4 = self.env[utm_model].create({'name': 'utm 1'})
+            self.assertEqual(utm_4.name, 'utm 1')
+            with mute_logger('odoo.sql_db'):
+                with self.assertRaises(ValidationError):
+                    _ = utm_4.copy()
 
-            utm_7 = self.env[utm_model].create({'name': 'UTM d'})
-            self.assertEqual(utm_7.name, 'UTM d', msg='Even if this name has the same prefix as the other, it is still unique')
+    def test_campaign_name_generation(self):
+        """Test that the name is always unique.
 
-            utm_8 = utm_7.copy()
-            self.assertEqual(utm_8.name, 'UTM d [2]', msg='Must add a counter as suffix to ensure uniqueness')
+        A counter must be added at the end of the name if it's not the case.
+        """
+
+        utm_0 = self.env['utm.campaign'].create({'name': 'UTM dup'})
+
+        utm_1, utm_2, utm_3, utm_4, utm_5 = self.env['utm.campaign'].create([{
+            'name': 'UTM 1',
+        }, {
+            'name': 'UTM 2',
+        }, {
+            'name': 'UTM dup',
+        }, {
+            # UTM record 4 has the same name of the previous UTM record
+            'name': 'UTM dup',
+        }, {
+            # UTM record 5 has the same name of the previous UTM record
+            # but with a wrong counter part, it will be removed and updated
+            'name': 'UTM dup [0]',
+        }])
+
+        self.assertEqual(utm_0.name, 'UTM dup', msg='The first "UTM dup" should be left unchanged since it is unique')
+        self.assertEqual(utm_1.name, 'UTM 1', msg='This name is already unique')
+        self.assertEqual(utm_2.name, 'UTM 2', msg='This name is already unique')
+        self.assertEqual(utm_3.name, 'UTM dup [2]', msg='Must add a counter as suffix to ensure uniqueness')
+        self.assertEqual(utm_4.name, 'UTM dup [3]', msg='Must add a counter as suffix to ensure uniqueness')
+        self.assertEqual(utm_5.name, 'UTM dup [4]', msg='Must add a counter as suffix to ensure uniqueness')
+
+        (utm_0 | utm_3 | utm_4).unlink()
+
+        utm_6 = self.env['utm.campaign'].create({'name': 'UTM dup'})
+        self.assertEqual(utm_6.name, 'UTM dup [5]')
+
+        utm_7 = self.env['utm.campaign'].create({'name': 'UTM d'})
+        self.assertEqual(utm_7.name, 'UTM d', msg='Even if this name has the same prefix as the other, it is still unique')
+
+        utm_8 = utm_7.copy()
+        self.assertEqual(utm_8.name, 'UTM d [2]', msg='Must add a counter as suffix to ensure uniqueness')
 
         # Test name uniqueness when creating a campaign using a title (quick creation)
         utm_9 = self.env['utm.campaign'].create({'title': 'UTM dup'})

--- a/addons/utm/views/utm_source_views.xml
+++ b/addons/utm/views/utm_source_views.xml
@@ -4,7 +4,7 @@
         <field name="name">utm.source.view.tree</field>
         <field name="model">utm.source</field>
         <field name="arch" type="xml">
-            <tree string="Source" editable="bottom" sample="1">
+            <tree string="Source" editable="bottom" sample="1" duplicate="0">
                 <field name="name" placeholder='e.g. "Christmas Mailing"'/>
             </tree>
         </field>

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -64,7 +64,7 @@ wTourUtils.changeOption('ConditionalVisibility', 'we-toggler'),
     run: 'text Email',
 },
 {
-    trigger: '[data-save-attribute="visibilityValueUtmMedium"] we-selection-items [data-add-record="Email"]',
+    trigger: '[data-save-attribute="visibilityValueUtmMedium"] we-selection-items [data-add-record="email"]',
     content: 'click on Email',
     run: 'click',
 },

--- a/addons/website/static/tests/tours/conditional_visibility_frontend.js
+++ b/addons/website/static/tests/tours/conditional_visibility_frontend.js
@@ -4,7 +4,7 @@ import { registry } from "@web/core/registry";
 
 registry.category("web_tour.tours").add('conditional_visibility_2', {
     test: true,
-    url: '/?utm_medium=Email',
+    url: '/?utm_medium=email',
     steps: () => [{
     content: 'The content previously hidden should now be visible',
     trigger: 'body #wrap',

--- a/addons/website_links/static/tests/tours/website_links.js
+++ b/addons/website_links/static/tests/tours/website_links.js
@@ -25,12 +25,12 @@ registry.category("web_tour.tours").add('website_links_tour', {
                 document.querySelector(".o_website_links_utm_forms input#campaign-select").value = campaignId;
                 const channelId = Object.entries(document.querySelector("#s2id_channel-select"))
                     .find(([key, value]) => value.select2)[1]
-                    .select2.opts.data.find((d) => d.text === "Website").id;
+                    .select2.opts.data.find((d) => d.text === "test website").id;
                 document.querySelector(".o_website_links_utm_forms input#channel-select").value =
                     channelId;
                 const sourceId = Object.entries(document.querySelector("#s2id_source-select"))
                     .find(([key, value]) => value.select2)[1]
-                    .select2.opts.data.find((d) => d.text === "Search engine").id;
+                    .select2.opts.data.find((d) => d.text === "test search engine").id;
                 document.querySelector(".o_website_links_utm_forms input#source-select").value =
                     sourceId;
                 // Patch and ignore write on clipboard in tour as we don't have permissions
@@ -55,7 +55,7 @@ registry.category("web_tour.tours").add('website_links_tour', {
             content: "check that we landed on correct page with correct query strings",
             trigger: ".s_title h1:contains(/^Contact us$/)",
             run: function () {
-                var expectedUrl = "/contactus?utm_campaign=Sale&utm_source=Search+engine&utm_medium=Website";
+                var expectedUrl = "/contactus?utm_campaign=Sale&utm_source=test+search+engine&utm_medium=test+website";
                 if (window.location.pathname + window.location.search !== expectedUrl) {
                     console.error("The link was not correctly created. " + window.location.search);
                 }

--- a/addons/website_links/tests/test_ui.py
+++ b/addons/website_links/tests/test_ui.py
@@ -20,8 +20,8 @@ class TestUi(odoo.tests.HttpCase):
     def test_01_test_ui(self):
         self.env['link.tracker'].search_or_create([{
             'campaign_id': self.env['utm.campaign'].create({'name': 'Sale'}).id,
-            'medium_id': self.env['utm.medium'].create({'name': 'Website'}).id,
-            'source_id': self.env['utm.source'].create({'name': 'Search'}).id,
+            'medium_id': self.env['utm.medium'].create({'name': 'Test Website'}).id,
+            'source_id': self.env['utm.source'].create({'name': 'Test Search Engine'}).id,
             'url': self.env["ir.config_parameter"].sudo().get_param("web.base.url") + '/contactus',
         }])
         self.start_tour("/", 'website_links_tour', login="admin")


### PR DESCRIPTION
To avoid creating duplicates repeatedly sources and mediums won't be
created automatically if there's a case-insensitive match in the
existing records.

We also update the name for case-incensitive duplicates for records
created in the back end so users should notice if they create a
case-incensitive duplicate the same way they did if they created an
exact duplicate

Some tests were also modified to test the updated functionality.

task-3329888

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
