### PR TITLE
[FIX] project,web: fix the missing record error and scrollbar

### DIFF
--- a/addons/project/static/src/components/project_control_panel/project_control_panel.js
+++ b/addons/project/static/src/components/project_control_panel/project_control_panel.js
@@ -10,8 +10,9 @@ export class ProjectControlPanel extends ControlPanel {
     setup() {
         super.setup();
         this.orm = useService("orm");
-        const { active_id, show_project_update } = this.env.searchModel.globalContext;
-        this.showProjectUpdate = this.env.config.viewType === "form" || show_project_update;
+        const { active_model, active_id, show_project_update } = this.env.searchModel.globalContext;
+        this.showProjectUpdate = this.env.config.viewType === "form" ||
+            (show_project_update && active_model === "project.project");
         this.projectId = this.showProjectUpdate ? active_id : false;
 
         onWillStart(async () => {


### PR DESCRIPTION
In this PR fixes the following issue
----------------------------------------------------------
- The pull request addresses a mobile view issue where the context 'show_project_update' is False so 
  the showProjectUpdate method will not be called and the missing record error will not appear.

- As part of this pull request, the visible property will be set for the x and y so that the scroll bar will 
  appear at the bottom when fever records are displayed.

task-3681318