### PR TITLE
[FIX] crm: update new partner based on lead customer info

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -2027,6 +2027,9 @@ class Lead(models.Model):
                 lambda partner: partner.email == self.email_from or (self.email_normalized and partner.email_normalized == self.email_normalized)
             )
             if new_partner:
+                customer_info = self._get_customer_information().get(self.email_normalized or self.email_from, {})
+                if customer_info and new_partner[0].email == new_partner[0].name != customer_info.get('name'):
+                    new_partner[0].update(customer_info)
                 if new_partner[0].email_normalized:
                     email_domain = ('email_normalized', '=', new_partner[0].email_normalized)
                 else:


### PR DESCRIPTION
Steps to reproduce:

  - Install `crm` module
  - Create a new lead
  - Set an email address, phone number, company name and contact name
  - Save the lead
  - In the chatter, send a mail (with the default recipient checked)

Issue:

  - The partner has only the email address set (also set as name).
  - The `contact name` on the lead is updated with the partner name (who is the email address).

Cause:

  When sending a mail with the default recipient checked, the partner
  is created based only on the email address (therefore, name is same as
  email), and when assigning the new partner on the lead, the
  `contact name` is updated with the partner name (who is the email
  address).

Solution:

  In the post message hook, if the new partner has the same name as the
  email, and the name is different from the `contact name` on the lead,
  then get customer info on the lead and update the partner before
  assign it to the lead.

opw-3512045