### PR TITLE
[FIX] stock: decrease delivered quantities on SO when a return is validated

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -1297,6 +1297,7 @@ class StockMove(models.Model):
                 move.picking_type_id = move.picking_type_id.return_picking_type_id
             # We are returning some products, we must take them in the source location
             move.procure_method = 'make_to_stock'
+            move.to_refund = True
         neg_r_moves._assign_picking()
 
         # call `_action_assign` on every confirmed move which location_id bypasses the reservation + those expected to be auto-assigned


### PR DESCRIPTION
Current behavior:
---
Creating an SO with negative quantities for a storable product with an invoicing policy of type "delivered quantities" automatically generates a return move for the stocks. However, when this delivery is validated, the quantities are not updated on the SO. This is problematic as these quantities are therefore not taken into account on the associated invoice.

Expected behavior:
---
The behavior should be the same as when you create an SO with positive quantities and create a "classic" return with a quantity greater than the one delivered, that is, the delivered quantities should be updated negatively on the SO.

Steps to reproduce:
---
- Create a storable product with an invoicing policy of type "delivered quantities".
- Create an SO with 2 lines:
  - a line with positive quantities for any other product.
  - a line with negative quantities for the product you created.

- Confirm and validate the corresponding deliveries. Return to the SO. The quantities for the second line are not updated. 
- Create an invoice. The second line is not taken into account.

Cause of the issue:
---
When the to_refund field of the stock.move model is set to true it triggers a decrease of the delivered/received quantity in the associated Sale Order. This field is set to True for "classic" returns but not for stock moves generated from negative quantities in SO's.

Fix:
---
We set the value of the to_refund field to true for moves generated from negative quantities on SO's.


opw-3676045
-
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
