### PR TITLE
[IMP] {website_}mass_mailing: split contact name into first and last name

### DIFF
--- a/addons/mass_mailing/__manifest__.py
+++ b/addons/mass_mailing/__manifest__.py
@@ -130,6 +130,8 @@
             'mass_mailing/static/src/js/mass_mailing_mobile_preview.js',
             'mass_mailing/static/src/js/mass_mailing_html_field.js',
             'mass_mailing/static/src/js/mailing_mailing_view_form_full_width.js',
+            'mass_mailing/static/src/js/mailing_contact_list_renderer.js',
+            'mass_mailing/static/src/js/mailing_contact_list_view.js',
             'mass_mailing/static/src/xml/mailing_filter_widget.xml',
             'mass_mailing/static/src/xml/mass_mailing.xml',
             'mass_mailing/static/src/xml/mass_mailing_mobile_preview.xml',

--- a/addons/mass_mailing/models/mailing_contact.py
+++ b/addons/mass_mailing/models/mailing_contact.py
@@ -1,6 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from ast import literal_eval
+
 from odoo import _, api, fields, models, tools
 from odoo.exceptions import UserError
 from odoo.osv import expression
@@ -29,7 +31,14 @@ class MassMailingContact(models.Model):
                     (0, 0, {'list_id': list_id}) for list_id in list_ids]
         return res
 
-    name = fields.Char()
+    name = fields.Char('Name', compute='_compute_name', readonly=False, store=True, tracking=True)
+    name_is_split = fields.Boolean(
+        'Name Is Split',
+        compute='_compute_name_is_split',
+        default=lambda self: self.get_name_is_split(),
+        help='Technical field indicating whether the name is split into first and last name or not.')
+    first_name = fields.Char('First Name')
+    last_name = fields.Char('Last Name')
     company_name = fields.Char(string='Company Name')
     title_id = fields.Many2one('res.partner.title', string='Title')
     email = fields.Char('Email')
@@ -47,6 +56,15 @@ class MassMailingContact(models.Model):
              'This field should not be used in a view without a unique and active mailing list context.')
 
     @api.model
+    def fields_get(self, allfields=None, attributes=None):
+        """ Hide first and last name field if the split name feature is not enabled. """
+        res = super().fields_get(allfields, attributes)
+        if not self.get_name_is_split():
+            res.get('first_name', {})['searchable'] = False
+            res.get('last_name', {})['searchable'] = False
+        return res
+
+    @api.model
     def _search_opt_out(self, operator, value):
         # Assumes operator is '=' or '!=' and value is True or False
         if operator != '=':
@@ -60,6 +78,17 @@ class MassMailingContact(models.Model):
             contacts = self.env['mailing.subscription'].search([('list_id', '=', active_list_id)])
             return [('id', 'in', [record.contact_id.id for record in contacts if record.opt_out == value])]
         return expression.FALSE_DOMAIN if value else expression.TRUE_DOMAIN
+
+    @api.depends('first_name', 'last_name')
+    def _compute_name(self):
+        for record in self:
+            if record.first_name or record.last_name:
+                record.name = ' '.join(name_part for name_part in (record.first_name, record.last_name) if name_part)
+
+    def _compute_name_is_split(self):
+        name_is_split = self.get_name_is_split()
+        for record in self:
+            record.name_is_split = name_is_split
 
     @api.depends('subscription_ids')
     @api.depends_context('default_list_ids')
@@ -164,3 +193,8 @@ class MassMailingContact(models.Model):
             'label': _('Import Template for Mailing List Contacts'),
             'template': '/mass_mailing/static/xls/mailing_contact.xls'
         }]
+
+    @api.model
+    def get_name_is_split(self):
+        return literal_eval(
+            self.env['ir.config_parameter'].sudo().get_param('mass_mailing.split_contact_name', 'False'))

--- a/addons/mass_mailing/models/res_config_settings.py
+++ b/addons/mass_mailing/models/res_config_settings.py
@@ -26,6 +26,10 @@ class ResConfigSettings(models.TransientModel):
         string='24H Stat Mailing Reports',
         config_parameter='mass_mailing.mass_mailing_reports',
         help='Check how well your mailing is doing a day after it has been sent.')
+    mass_mailing_split_contact_name = fields.Boolean(
+        string='Split First and Last Name',
+        config_parameter='mass_mailing.split_contact_name',
+        help='Separate Mailing Contact Names into two fields')
 
     @api.onchange('mass_mailing_outgoing_mail_server')
     def _onchange_mass_mailing_outgoing_mail_server(self):

--- a/addons/mass_mailing/static/src/js/mailing_contact_list_renderer.js
+++ b/addons/mass_mailing/static/src/js/mailing_contact_list_renderer.js
@@ -1,0 +1,36 @@
+/** @odoo-module */
+
+import { useService } from "@web/core/utils/hooks";
+import { ListRenderer } from "@web/views/list/list_renderer";
+import { onWillStart } from "@odoo/owl";
+
+export class MailingContactListRenderer extends ListRenderer {
+    setup() {
+        super.setup(...arguments);
+        this.orm = useService("orm");
+        onWillStart(async () => {
+            this.nameIsSplit = await this.orm.call("mailing.contact", "get_name_is_split", [], {});
+            // As the columns are processed before onWillStart, reprocess them if name is split.
+            if (this.nameIsSplit) {
+                this.allColumns = this.processAllColumn(
+                    this.props.archInfo.columns,
+                    this.props.list
+                );
+                this.state.columns = this.getActiveColumns(this.props.list);
+            }
+        });
+    }
+
+    processAllColumn(allColumns, list) {
+        const cols = super.processAllColumn(...arguments);
+        for (const col of cols) {
+            if (["first_name", "last_name"].includes(col.name)) {
+                col.column_invisible = this.nameIsSplit ? "0" : "1";
+            }
+            if (col.name === "name") {
+                col.column_invisible = this.nameIsSplit ? "1" : "0";
+            }
+        }
+        return cols;
+    }
+}

--- a/addons/mass_mailing/static/src/js/mailing_contact_list_view.js
+++ b/addons/mass_mailing/static/src/js/mailing_contact_list_view.js
@@ -1,0 +1,12 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+import { listView } from '@web/views/list/list_view';
+import { MailingContactListRenderer } from "./mailing_contact_list_renderer";
+
+export const mailingContactListView = {
+    ...listView,
+    Renderer: MailingContactListRenderer,
+};
+
+registry.category("views").add("mailing_contact_list", mailingContactListView);

--- a/addons/mass_mailing/views/mailing_contact_views.xml
+++ b/addons/mass_mailing/views/mailing_contact_views.xml
@@ -50,6 +50,8 @@
                 <field name="create_date" optional="show"/>
                 <field name="title_id" optional="hide"/>
                 <field name="name" readonly="1"/>
+                <field name="first_name" readonly="1"/>
+                <field name="last_name" readonly="1"/>
                 <field name="company_name"/>
                 <field name="email" readonly="1"/>
                 <field name="is_blacklisted" string="Email Blacklisted"/>
@@ -114,16 +116,26 @@
         <field name="arch" type="xml">
             <form string="Mailing List Contacts">
                 <field name="id" invisible="1"/>
+                <field name="name_is_split" invisible="1"/>
                 <sheet>
                     <div class="oe_title">
                         <label for="name" string="Contact Name"/>
                         <h1>
-                            <field class="text-break" name="name" placeholder="e.g. John Smith"/>
+                            <field class="text-break" name="name" placeholder="e.g. John Smith"
+                                   readonly="name_is_split" invisible="name_is_split and not name"/>
+                            <!-- simulate the placeholder on the readonly field -->
+                            <span class="oe_grey" invisible="not name_is_split or name">e.g. "John Smith"</span>
                         </h1>
-                        <div>
-                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags" style="width: 100%"/>
-                        </div>
                     </div>
+                    <!-- Separate group in order to have the correct tabindex -->
+                    <group invisible="not name_is_split">
+                        <group>
+                            <field name="first_name" placeholder="e.g. &quot;John&quot;"/>
+                        </group>
+                        <group>
+                            <field name="last_name" placeholder="e.g. &quot;Smith&quot;"/>
+                        </group>
+                    </group>
                     <group>
                         <group>
                             <label for="email" class="oe_inline"/>
@@ -142,6 +154,7 @@
                         <group>
                             <field name="create_date" readonly="1" invisible="not id"/>
                             <field name="message_bounce" readonly="1" invisible="not id"/>
+                            <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}" placeholder="Tags" style="width: 100%"/>
                         </group>
                     </group>
                     <field name="subscription_ids">

--- a/addons/mass_mailing/views/res_config_settings_views.xml
+++ b/addons/mass_mailing/views/res_config_settings_views.xml
@@ -12,6 +12,15 @@
                             <setting title="This tool is advised if your marketing campaign is composed of several emails." help="Manage mass mailing campaigns">
                                 <field name="group_mass_mailing_campaign"/>
                             </setting>
+                            <setting name="contact_naming" title="Contact Naming" help="Separate Mailing Contact Names into two fields">
+                                <field name="mass_mailing_split_contact_name"/>
+                            </setting>
+                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page. The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to blacklist themselves">
+                                <field name="show_blacklist_buttons"/>
+                            </setting>
+                            <setting name="mass_mailing_reports_setting_container" title="Send a report to the mailing responsible one day after the mailing has been sent." help="Check how well your mailing is doing a day after it has been sent">
+                                <field name="mass_mailing_reports"/>
+                            </setting>
                             <setting name="dedicated_server_setting_container" title="Use a specific mail server in priority. Otherwise Odoo relies on the first outgoing mail server available (based on their sequencing) as it does for normal mails." help="Pick a dedicated outgoing mail server for your mass mailings">
                                 <field name="mass_mailing_outgoing_mail_server"/>
                                 <div class="content-group" invisible="not mass_mailing_outgoing_mail_server">
@@ -23,12 +32,6 @@
                                         <button type="action" name="base.action_ir_mail_server_list" string="Configure Outgoing Mail Servers" icon="oi-arrow-right" class="oe_link"/>
                                     </div>
                                 </div>
-                            </setting>
-                            <setting name="allow_blacklist_setting_container" title="Allow the recipient to manage themselves their state in the blacklist via the unsubscription page. If the option is active, the 'Blacklist Me' button is hidden on the unsubscription page. The 'come Back' button will always be visible in any case to allow leads and partners to re-subscribe." help="Allow recipients to blacklist themselves">
-                                <field name="show_blacklist_buttons"/>
-                            </setting>
-                            <setting name="mass_mailing_reports_setting_container" title="Send a report to the mailing responsible one day after the mailing has been sent." help="Check how well your mailing is doing a day after it has been sent">
-                                <field name="mass_mailing_reports"/>
                             </setting>
                         </block>
                     </app>

--- a/addons/website_mass_mailing/data/ir_model_data.xml
+++ b/addons/website_mass_mailing/data/ir_model_data.xml
@@ -11,6 +11,8 @@
             <value>mailing.contact</value>
             <value eval="[
                 'name',
+                'first_name',
+                'last_name',
                 'company_name',
                 'title_id',
                 'email',

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -59,7 +59,27 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
             <form id="newsletter_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required"
                   data-mark="*" data-model_name="mailing.contact" data-success-mode="message" hide-change-model="true">
                 <div class="s_website_form_rows row s_col_no_bgcolor">
-                    <div class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
+                    <t t-if="request.env['mailing.contact'].get_name_is_split()">
+                        <div class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
+                            <div class="row s_col_no_resize s_col_no_bgcolor">
+                                <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub1a">
+                                    <span class="s_website_form_label_content">Name</span>
+                                    <span class="s_website_form_mark"> *</span>
+                                </label>
+                                <div class="col-sm row">
+                                    <div class="col-sm-6">
+                                        <input id="mailing_sub1a" type="text" class="form-control s_website_form_input"
+                                               name="first_name" placeholder="First Name" required="1"/>
+                                    </div>
+                                    <div class="col-sm-6">
+                                        <input id="mailing_sub1b" type="text" class="form-control s_website_form_input"
+                                               name="last_name" placeholder="Last Name" required="1"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                    <div t-else="" class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub1">
                                 <span class="s_website_form_label_content">Your Name</span>


### PR DESCRIPTION
[WIP] Alternative to group and context to configure visible columns of the list view using an override of the ListRenderer. Probably not the right solution but to be exhaustive. 

Add an option that allows to fill the contact name by providing a first and a last name instead of a single name. This option is not set by default.

If the option is enabled, the name will automatically be filled when filling the first and the last name (as first name followed by last name). In the front-end, inserting the form subscription of the newsletter block, insert a form with a first name and last name field instead of a single name field. Unfortunately, when changing the option, it won't update the subscription form automatically (it must be done manually).

A small inconvenient is that when updating first or last name, it will update the name so that the other part of the name is lost. To mitigate that problem, we have enabled the tracking on "name" so that any change on that field is logged in the chatter.

If the option is not enabled, only names can be filled. First and last name will remain empty. Enabling the option won't convert name to first and last name; that works should be done manually (maybe using an export and an import).

When not enabled, we make the first and last name fields not searchable so that they don't appears in custom filters or dynamic placeholder.

Notes:
- the first and last name are not alligned with the rest of the form because we have set them in a different group to force the correct tabindex.
- the columns of the mailing contact list view change depending of the system parameter mass_mailing.split_contact_name. If it is true, the "name" column is replaced by a first and a last name column. Technically, it has been implemented through a context variable (name_is_split) as it is not possible to use the system parameter directly. For the list view, to avoid redefining actions with that context variable, we override the list renderer to configure the columns.

Task-3597124
