### PR TITLE
[FIX] web_editor: shift+enter correct cursor position

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -1937,12 +1937,12 @@ export class OdooEditor extends EventTarget {
                         link.classList.add('o_link_in_selection');
                         this.observerActive('_setLinkZws_o_link_in_selection');
                         didAddZwsInLinkInSelection = true;
-                    }
-                    const zwsAfter = this._insertLinkZws('after', link);
-                    if (!zwsAfter.parentElement || !zwsAfter.parentElement.isContentEditable) {
-                        this.observerUnactive('_setLinkZws_zwsAfter_remove');
-                        zwsAfter.remove();
-                        this.observerActive('_setLinkZws_zwsAfter_remove');
+                        const zwsAfter = this._insertLinkZws('after', link);
+                        if (!zwsAfter.parentElement || !zwsAfter.parentElement.isContentEditable) {
+                            this.observerUnactive('_setLinkZws_zwsAfter_remove');
+                            zwsAfter.remove();
+                            this.observerActive('_setLinkZws_zwsAfter_remove');
+                        }
                     }
                 }
             }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -7019,5 +7019,17 @@ X[]
                 });
             });
         });
+        describe('shiftEnter command', () => {
+            it('should place cursor correctly after br element', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>text <a href="http://test.com">http://test.com</a> text[]</p>',
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', {key: 'Enter', shiftKey: true});
+                        await triggerEvent(editor.editable, 'keyup', {key: 'Enter', shiftKey: true});
+                    },
+                    contentAfterEdit: `<p>text <a href="http://test.com"><span data-o-link-zws="start" contenteditable="false">\u200B</span>http://test.com</a> text<br>[]<br></p>`,
+                });
+            });
+        });
     });
 });


### PR DESCRIPTION
Issue:
======
Pressing shift+enter at the end of the text when the text has a link inside it , it will place the cursor at wrong position.

Steps to reproduce the issue:
=============================
- Go to to do app and create a new to do
- Insert some text then add a link `https://www.google.com/` for example and add some other text
- Press shift+enter
- The cursor is misplaced

Origin of the issue:
====================
The insertion and delection of `ZWS` affect the position of the cursor and produce weird behavior when calling `_setLinkZws` in `_onSelectionChange`.

Solution:
=========
To avoid the problem we only add an after `ZWS` to the link in selection

task-3613107