### PR TITLE
[FIX] portal, web, web_editor: list styles are consistent

### DIFF
--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -45,6 +45,7 @@ a dependency towards website editing and customization capabilities.""",
             'portal/static/src/xml/portal_signature.xml',
             'portal/static/src/js/portal_sidebar.js',
             'portal/static/src/xml/portal_security.xml',
+            'web/static/src/scss/lists_styles.scss',
         ],
         'web.assets_tests': [
             'portal/static/tests/**/*',

--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -86,53 +86,6 @@ a, .btn-link {
     margin-bottom: 0;
 }
 
-// Typography
-ul {
-    list-style-type: disc;
-}
-ul ul {
-    list-style-type: circle;
-}
-ul ul ul {
-    list-style-type: square;
-}
-ul ul ul ul {
-    list-style-type: disc;
-}
-ul ul ul ul ul {
-    list-style-type: circle;
-}
-ul ul ul ul ul ul {
-    list-style-type: square;
-}
-ul ul ul ul ul ul ul {
-    list-style-type: disc;
-}
-ol {
-    list-style-type: decimal;
-}
-ol ol {
-    list-style-type: lower-alpha;
-}
-ol ol ol {
-    list-style-type: lower-greek;
-}
-ol ol ol ol {
-    list-style-type: decimal;
-}
-ol ol ol ol ol {
-    list-style-type: lower-alpha;
-}
-ol ol ol ol ol ol {
-    list-style-type: lower-greek;
-}
-ol ol ol ol ol ol ol {
-    list-style-type: decimal;
-}
-li > p {
-    margin: 0;
-}
-
 // Bootstrap hacks
 %o-double-container-no-padding {
     padding-right: 0;

--- a/addons/web/__manifest__.py
+++ b/addons/web/__manifest__.py
@@ -500,6 +500,7 @@ This module provides the core of the Odoo Web Client.
             'web/static/fonts/fonts.scss',
 
             'web/static/src/webclient/actions/reports/report.scss',
+            'web/static/src/scss/lists_styles.scss',
             'web/static/src/webclient/actions/reports/layout_assets/layout_standard.scss',
             'web/static/src/webclient/actions/reports/layout_assets/layout_background.scss',
             'web/static/src/webclient/actions/reports/layout_assets/layout_boxed.scss',

--- a/addons/web/static/src/scss/lists_styles.scss
+++ b/addons/web/static/src/scss/lists_styles.scss
@@ -1,0 +1,28 @@
+$max-depth: 25;
+@for $depth from 0 through $max-depth {
+    $selectorOl: "";
+    $selectorUl: "";
+    @for $i from 0 through $depth {
+        $selectorOl: $selectorOl + "ol ";
+        $selectorUl: $selectorUl + "ul ";
+    }
+    $remainder: $depth % 3;
+    #{$selectorOl} {
+        @if $remainder == 0 {
+            list-style-type: decimal;
+        } @else if $remainder == 1 {
+            list-style-type: lower-alpha;
+        } @else if $remainder == 2 {
+            list-style-type: lower-roman;
+        }
+    }
+    #{$selectorUl} {
+        @if $remainder == 0 {
+            list-style-type: disc;
+        } @else if $remainder == 1 {
+            list-style-type: circle;
+        } @else if $remainder == 2 {
+            list-style-type: square;
+        }
+    }
+}

--- a/addons/web_editor/__manifest__.py
+++ b/addons/web_editor/__manifest__.py
@@ -97,6 +97,7 @@ Odoo Web Editor widget.
         ],
         'web.assets_common': [
             'web_editor/static/src/js/editor/odoo-editor/src/base_style.scss',
+            'web/static/src/scss/lists_styles.scss',
             'web_editor/static/lib/vkbeautify/**/*',
             'web_editor/static/src/js/common/**/*',
             'web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js',


### PR DESCRIPTION
Issue:

The 'list-style-type' for our lists are not consistent in Odoo, this means that the style we have in portal is different from the one we have in the web_editor and different from what wkhtmltopdf generates, this will make the user to have a different style in the report printed, in the customer preview and what he sees when working in Odoo.

Solution:

By backporting this PR #128532 and adding it to the 2 other places needed we will get a more consistent behavior of the lists in Odoo.

opw-3265778
