### PR TITLE
[FIX] website_sale_wishlist: prevent wishlist caching

### DIFF
--- a/addons/website_sale_wishlist/controllers/main.py
+++ b/addons/website_sale_wishlist/controllers/main.py
@@ -47,7 +47,10 @@ class WebsiteSaleWishlist(WebsiteSale):
     def get_wishlist(self, count=False, **kw):
         values = request.env['product.wishlist'].with_context(display_default_code=False).current()
         if count:
-            return request.make_response(json.dumps(values.mapped('product_id').ids))
+            return request.make_response(
+                json.dumps(values.mapped('product_id').ids),
+                [('Content-type', 'application/json')]
+            )
 
         if not len(values):
             return request.redirect("/shop")

--- a/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/src/js/website_sale_wishlist.js
@@ -41,8 +41,8 @@ publicWidget.registry.ProductWishlist = publicWidget.Widget.extend(VariantMixin,
             wishDef = $.get('/shop/wishlist', {
                 count: 1,
             }).then(function (res) {
-                self.wishlistProductIDs = JSON.parse(res);
-                sessionStorage.setItem('website_sale_wishlist_product_ids', res);
+                self.wishlistProductIDs = res;
+                sessionStorage.setItem('website_sale_wishlist_product_ids', JSON.stringify(res));
             });
 
         }


### PR DESCRIPTION
Steps to reproduce:
-------------------
- add products to the wishlist;
- click on the wishlist button;
- remove a product from the wishlist;
- click on the shop;
- click on the back arrow in the browser.

Issue:
------
The wishlist still contains the item that has been removed.

Cause:
------
The `get_wishlist` controller can return two different types of response `html` and `json`. By default, the response will be of the `html` type, and will therefore be cached by the browser.

Solution:
---------
Force the response type to `json` when necessary.

opw-3659181