### PR TITLE
[I18N] l10n_be{_pos_sale}: sync translations

### DIFF
--- a/addons/l10n_be/i18n/de.po
+++ b/addons/l10n_be/i18n/de.po
@@ -4,72 +4,37 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-05 14:50+0000\n"
+"POT-Creation-Date: 2023-02-02 17:05+0000\n"
 "PO-Revision-Date: 2020-01-27 14:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
-"Language: nl_BE\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00
-msgid "0% Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-G
-msgid "0% Biens divers"
-msgstr ""
-
-#. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-CC
-msgid "0% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-CC
-msgid "0% Cocont. - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-CC
-msgid "0% Cocont. M."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-CC
-msgid "0% Cocont. S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-EU
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-EU
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-EU
-msgid "0% EU - Biens d'investissement"
+msgid "0% Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-EU-G
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-EU-G
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-G
-msgid "0% EU - Biens divers"
+msgid "0% EU G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-EU
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-EU
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-EU
+msgid "0% EU IG"
 msgstr ""
 
 #. module: l10n_be
@@ -79,7 +44,7 @@ msgstr ""
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-L
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-L
-msgid "0% EU M."
+msgid "0% EU M"
 msgstr ""
 
 #. module: l10n_be
@@ -89,49 +54,77 @@ msgstr ""
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-S
-msgid "0% EU S."
+msgid "0% EU S"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-EU-T
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-T
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-T
-msgid "0% EU T."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00
-msgid "0% M."
+msgid "0% EU T"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-ROW
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-ROW
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-ROW
-msgid "0% Non EU"
+msgid "0% EX"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-ROW-CC
-msgid "0% Non EU - Biens d'investissement"
+msgid "0% EX IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-ROW-CC
-msgid "0% Non EU M."
+msgid "0% EX M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-ROW-CC
-msgid "0% Non EU S."
+msgid "0% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-G
+msgid "0% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00
+msgid "0% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-CC
+msgid "0% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00
+msgid "0% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-CC
+msgid "0% M.Cocont"
 msgstr ""
 
 #. module: l10n_be
@@ -141,145 +134,173 @@ msgstr ""
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-S
-msgid "0% S."
+msgid "0% S"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_00
-msgid "00"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-CC
+msgid "0% S.Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_00
-msgid "00 - Opérations soumises à un régime particulier"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_01
-msgid "01"
-msgstr ""
+msgid "00 - Operations subject to a special regulation"
+msgstr "00 - Umsätze, die einer Sonderregelung unterliegen"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_01
-msgid "01 - Opérations avec TVA à 6%"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_02
-msgid "02"
-msgstr ""
+msgid "01 - Operations subject to 6% VAT"
+msgstr "01 - Umsätze, die 6 % MwSt. unterliegen "
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_02
-msgid "02 - Opérations avec TVA à 12%"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_03
-msgid "03"
-msgstr ""
+msgid "02 - Operations subject to 12% VAT"
+msgstr "02 - Umsätze, die 12 % MwSt. unterliegen "
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_03
-msgid "03 - Opérations avec TVA à 21%"
-msgstr ""
+msgid "03 - Operations subject to 21% VAT"
+msgstr "03 - Umsätze, die 21 % MwSt. unterliegen "
 
 #. module: l10n_be
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-L
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-L
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-12-L
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-12-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-12-L
 msgid "12%"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12
-msgid "12% Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-G
-msgid "12% Biens divers"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-CC
-msgid "12% Cocont. - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-CC
-msgid "12% Cocont. M."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-CC
-msgid "12% Cocont. S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-EU
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-EU
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-EU
-msgid "12% EU - Biens d'investissement"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-G
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-EU-G
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-G
-msgid "12% EU - Biens divers"
+msgid "12% EU G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-EU
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-EU
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-EU
+msgid "12% EU IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-EU
-msgid "12% EU M."
+msgid "12% EU M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-S
-msgid "12% EU S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12
-msgid "12% M."
+msgid "12% EU S"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-ROW-CC
-msgid "12% Non EU - Biens d'investissement"
+msgid "12% EX IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-ROW-CC
-msgid "12% Non EU M."
+msgid "12% EX M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-ROW-CC
-msgid "12% Non EU S."
+msgid "12% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-G
+msgid "12% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12
+msgid "12% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-CC
+msgid "12% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12
+msgid "12% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-CC
+msgid "12% M.Cocont"
 msgstr ""
 
 #. module: l10n_be
@@ -289,105 +310,166 @@ msgstr ""
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-12-S
-msgid "12% S."
+msgid "12% S"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-CC
+msgid "12% S.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,description:l10n_be.1_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-L
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-S
+#: model:account.tax,description:l10n_be.2_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-L
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-21-L
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-21-L
+#: model:account.tax.template,description:l10n_be.attn_TVA-21-inclus-dans-prix
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-21-L
 msgid "21%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21
-msgid "21% Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-G
-msgid "21% Biens divers"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-CC
-msgid "21% Cocont .S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-CC
-msgid "21% Cocont. - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-CC
-msgid "21% Cocont. M."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-EU
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-EU
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-EU
-msgid "21% EU - Biens d'investissement"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-CAR-EXC
+msgid "21% Car"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-EU-G
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-EU-G
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-EU-G
-msgid "21% EU - Biens divers"
+msgid "21% EU G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-EU
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-EU
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-EU
+msgid "21% EU IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-EU
-msgid "21% EU M."
+msgid "21% EU M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-EU-S
-msgid "21% EU S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21
-msgid "21% M."
+msgid "21% EU S"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-ROW-CC
-msgid "21% Non EU - Biens d'investissement"
+msgid "21% EX IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-ROW-CC
-msgid "21% Non EU M."
+msgid "21% EX M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-ROW-CC
-msgid "21% Non EU S."
+msgid "21% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-G
+msgid "21% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21
+msgid "21% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-CC
+msgid "21% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21
+msgid "21% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-CC
+msgid "21% M.Cocont"
 msgstr ""
 
 #. module: l10n_be
@@ -397,262 +479,189 @@ msgstr ""
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-21-S
-msgid "21% S."
+msgid "21% S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-CC
+msgid "21% S.Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_TVA-21-inclus-dans-prix
 #: model:account.tax,name:l10n_be.2_attn_TVA-21-inclus-dans-prix
 #: model:account.tax.template,name:l10n_be.attn_TVA-21-inclus-dans-prix
-msgid "21% S. TTC"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_44
-msgid "44"
+msgid "21% S.TTC"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_44
-msgid "44 - Services intra-communautaires"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_45
-msgid "45"
-msgstr ""
+msgid "44 - Intra-Community services"
+msgstr "44 - Innergemeinschaftliche Dienstleistungen"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_45
-msgid "45 - Opérations avec TVA due par le cocontractant"
-msgstr ""
+msgid "45 - Operations subject to VAT due by the co-contractor"
+msgstr "45 - Umsätze, auf die der Vertragspartner die MwSt. schuldet"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_46
-msgid "46 - Livraisons intra-communautaires exemptées"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_46L
-msgid "46L"
-msgstr ""
+msgid "46 - Exempted intra-Community deliveries and ABC sales"
+msgstr "46 - Steuerfreie innergemeinschaftliche Lieferungen und ABC-Geschäfte"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_46L
-msgid "46L - Livraisons biens intra-communautaires exemptées"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_46T
-msgid "46T"
-msgstr ""
+msgid "46L - Exempted intra-Community deliveries"
+msgstr "46L - Steuerfreie innergemeinschaftliche Lieferungen"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_46T
-msgid "46T - Livraisons biens intra-communautaire exemptées"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_47
-msgid "47"
-msgstr ""
+msgid "46T - ABC sales"
+msgstr "46T - ABC-Geschäfte"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_47
-msgid "47 - Autres opérations exemptées"
-msgstr ""
+msgid "47 - Other exempted operations and operations carried out abroad"
+msgstr "47 - Andere steuerfreie Umsätze und andere im Ausland bewirkte Umsätze"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_48
-msgid "48 - Notes de crédit aux opérations grilles [44] et [46]"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s44
-msgid "48s44"
-msgstr ""
+msgid "48 - Credit notes for operations in grids [44] and [46]"
+msgstr "48 - Gutschriften für Umsätze aus Raster [44] und [46]"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_48s44
-msgid "48s44 - Notes de crédit aux opérations grilles [44]"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46L
-msgid "48s46L"
-msgstr ""
+msgid "48s44 - Credit notes for operations in grid [44]"
+msgstr "48s44 - Gutschriften für Umsätze aus Raster [44]"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_48s46L
-msgid "48s46L - Notes de crédit aux opérations grilles [46L]"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46T
-msgid "48s46T"
-msgstr ""
+msgid "48s46L - Credit notes for operations in grid [46L]"
+msgstr "48s46L - Gutschriften für Umsätze aus Raster [46L]"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_48s46T
-msgid "48s46T - Notes de crédit aux opérations grilles [46T]"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_49
-msgid "49"
-msgstr ""
+msgid "48s46T - Credit notes for operations in grid [46T]"
+msgstr "48s46T - Gutschriften für Umsätze aus Raster [46T]"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_49
-msgid "49 - Notes de crédit aux opérations du point II"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-CAR-EXC
-msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_54
-msgid "54"
-msgstr ""
+msgid "49 - Credit notes for other operations in part II"
+msgstr "49 - Gutschriften für die übrigen Umsätze aus Rahmen II"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_54
-msgid "54 - TVA sur opérations des grilles [01], [02], [03]"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_55
-msgid "55"
-msgstr ""
+msgid "54 - VAT on operations in grids [01], [02] and [03]"
+msgstr "54 - MwSt. auf Umsätze aus den Rastern [01], [02] und [03]"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_55
-msgid "55 - TVA sur opérations des grilles [86] et [88]"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_56
-msgid "56"
-msgstr ""
+msgid "55 - VAT on operations in grids [86] and [88]"
+msgstr "55 - MwSt. auf Umsätze aus den Rastern [86] und [88]"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_56
-msgid "56 - TVA sur opérations de la grille [87]"
+msgid ""
+"56 - VAT on operations in grid [87], with the exception of imports with "
+"reverse charge"
 msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_57
-msgid "57"
-msgstr ""
+"56 - MwSt. auf Umsätze aus Raster [87], ausschließlich der Einfuhren mit "
+"Verlegung der Erhebung"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_57
-msgid "57 - TVA relatives aux importations"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_59
-msgid "59"
-msgstr ""
+msgid "57 - VAT on import with reverse charge"
+msgstr "57 - MwSt. auf Einfuhren mit Verlegung der Erhebung"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_59
-msgid "59 - TVA déductible"
-msgstr ""
+msgid "59 - Deductible VAT"
+msgstr "59 - Abzugsfähige MwSt."
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06
-msgid "6% Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-G
-msgid "6% Biens divers"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-CC
-msgid "6% Cocont. - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-CC
-msgid "6% Cocont. M."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-CC
-msgid "6% Cocont. S."
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-G
+msgid "6% EU G"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-EU
-msgid "6% EU - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-G
-msgid "6% EU - Biens divers"
+msgid "6% EU IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-EU
-msgid "6% EU M."
+msgid "6% EU M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-S
-msgid "6% EU S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06
-msgid "6% M."
+msgid "6% EU S"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-ROW-CC
-msgid "6% Non EU - Biens d'investissement"
+msgid "6% EX IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-ROW-CC
-msgid "6% Non EU M."
+msgid "6% EX M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-ROW-CC
-msgid "6% Non EU S."
+msgid "6% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-G
+msgid "6% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06
+msgid "6% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-CC
+msgid "6% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06
+msgid "6% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-CC
+msgid "6% M.Cocont"
 msgstr ""
 
 #. module: l10n_be
@@ -662,143 +671,94 @@ msgstr ""
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-06-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-06-S
-msgid "6% S."
+msgid "6% S"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_61
-msgid "61"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-CC
+msgid "6% S.Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_61
-msgid "61 - Diverses régularisations en faveur de l'Etat"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_62
-msgid "62"
-msgstr ""
+msgid "61 - Various VAT regularizations in favor of the State"
+msgstr "61 - Verschiedene MwSt.-Berichtigungen zugunsten des Staates"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_62
-msgid "62 - Diverses régularisations en faveur du déclarant"
+msgid "62 - Various VAT regularizations in favor of the declarant"
 msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_63
-msgid "63"
-msgstr ""
+"62 - Verschiedene MwSt.-Berichtigungen zugunsten des Anmeldepflichtigen"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_63
-msgid "63 - TVA à reverser sur notes de crédit recues"
+msgid "63 - VAT to be paid back on credit notes received"
 msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_64
-msgid "64"
-msgstr ""
+"63 - Zurückzuführende MwSt., die auf erhaltenen Gutschriften angegeben ist"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_64
-msgid "64 - TVA à récupérer sur notes de crédit delivrées"
-msgstr ""
+msgid "64 - VAT to be recovered on credit notes issued"
+msgstr "64 - Zurückzuerhaltende MwSt. infolge erteilter Gutschriften"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_71
-msgid "71 - Taxes dues à l'état"
-msgstr ""
+msgid "71 - Taxes due to the State"
+msgstr "71 - Dem Staat geschuldete Steuer"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_72
-msgid "72 - Somme due par l'état"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_81
-msgid "81"
-msgstr ""
+msgid "72 - Amount owed by the State"
+msgstr "72 - Vom Staat geschuldete Summen"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_81
-msgid "81 - Marchandises, matières premières et auxiliaires"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_82
-msgid "82"
-msgstr ""
+msgid "81 - Trade goods, raw materials and consumables"
+msgstr "81 - Handelsgüter, Roh- und Hilfsstoffe"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_82
-msgid "82 - Services et biens divers"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_83
-msgid "83"
-msgstr ""
+msgid "82 - Services and miscellaneous goods"
+msgstr "82 - Leistungen und verschiedene Güter"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_83
-msgid "83 - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_84
-msgid "84"
-msgstr ""
+msgid "83 - Investment goods"
+msgstr "83 - Investitionsgüter"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_84
-msgid "84 - Notes de crédits sur opérations case [86] et [88]"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_85
-msgid "85"
-msgstr ""
+msgid "84 - Credit notes for operations in grids [86] and [88]"
+msgstr "84 - Gutschriften für Umsätze aus Raster [86] und [88]"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_85
-msgid "85 - Notes de crédits autres opérations"
+msgid "85 - Credit notes received relating to other operations in part III"
 msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_86
-msgid "86"
-msgstr ""
+"85 - Erhaltene Gutschriften, die sich auf die übrigen Umsätze aus Rahmen III "
+"beziehen"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_86
-msgid "86 - Acquisition intra-communautaires et ventes ABC"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_87
-msgid "87"
-msgstr ""
+msgid "86 - Intra-Community acquisitions and ABC sales"
+msgstr "86 - Innergemeinschaftliche Erwerbe und ABC-Geschäfte"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_87
-msgid "87 - Autres opérations"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_88
-msgid "88"
-msgstr ""
+msgid "87 - Other operations subject to VAT"
+msgstr "87 - Sonstige Eingänge, die der MwSt. unterliegen "
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_line_88
-msgid "88 - Acquisition services intra-communautaires"
-msgstr ""
+msgid "88 - Intra-Community services with reverse charge"
+msgstr "88 - Innergemeinschaftliche Leistungen mit Verlegung der Erhebung"
 
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_chart_template
 msgid "Account Chart Template"
-msgstr ""
+msgstr "Kontenplanvorlage"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a052
@@ -875,6 +835,13 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_600
 #: model:account.group.template,name:l10n_be.be_group_600
 msgid "Achats de matières premières"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_602
+#: model:account.group,name:l10n_be.2_be_group_602
+#: model:account.group.template,name:l10n_be.be_group_602
+msgid "Achats de services, travaux et études"
 msgstr ""
 
 #. module: l10n_be
@@ -1062,6 +1029,16 @@ msgstr "Zu erhaltende Anzahlungen mit einer Restlaufzeit bis zu einem Jahr"
 #: model:account.group.template,name:l10n_be.be_group_691
 msgid "Affectations au capital et à la prime d'émission"
 msgstr ""
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_69
+#: model:account.group,name:l10n_be.1_be_group_79
+#: model:account.group,name:l10n_be.2_be_group_69
+#: model:account.group,name:l10n_be.2_be_group_79
+#: model:account.group.template,name:l10n_be.be_group_69
+#: model:account.group.template,name:l10n_be.be_group_79
+msgid "Affectations et prélèvements"
+msgstr "Affectations et prélèvements"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_660
@@ -1476,6 +1453,20 @@ msgid "Autres actions et parts"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_473
+#: model:account.group,name:l10n_be.2_be_group_473
+#: model:account.group.template,name:l10n_be.be_group_473
+msgid "Autres allocataires"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_697
+#: model:account.group,name:l10n_be.2_be_group_697
+#: model:account.group.template,name:l10n_be.be_group_697
+msgid "Autres applications"
+msgstr ""
+
+#. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_64
 #: model:account.group,name:l10n_be.2_be_group_64
 #: model:account.group.template,name:l10n_be.be_group_64
@@ -1590,6 +1581,11 @@ msgid "Available reserves"
 msgstr "Verfügbare Rücklagen"
 
 #. module: l10n_be
+#: model:account.report.column,name:l10n_be.tax_report_vat_balance
+msgid "Balance"
+msgstr "Saldo"
+
+#. module: l10n_be
 #: model:account.chart.template,name:l10n_be.l10nbe_chart_template
 msgid "Belgian PCMN"
 msgstr ""
@@ -1671,7 +1667,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
 #: model:ir.ui.menu,name:l10n_be.account_reports_be_statements_menu
 msgid "Belgium"
-msgstr ""
+msgstr "Belgien"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_07
@@ -1819,7 +1815,7 @@ msgstr "Eingefordertes, noch nicht eingezahltes Kapital"
 #: model:account.group,name:l10n_be.2_be_group_10
 #: model:account.group.template,name:l10n_be.be_group_10
 msgid "Capital"
-msgstr ""
+msgstr "Kapital"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_410
@@ -1955,7 +1951,7 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_6
 #: model:account.group.template,name:l10n_be.be_group_6
 msgid "Charges"
-msgstr ""
+msgstr "Kosten"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_653
@@ -2063,7 +2059,7 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_400
 #: model:account.group.template,name:l10n_be.be_group_400
 msgid "Clients"
-msgstr ""
+msgstr "Kunden"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_37
@@ -2082,12 +2078,7 @@ msgstr ""
 #. module: l10n_be
 #: model:ir.model.fields,field_description:l10n_be.field_account_journal__invoice_reference_model
 msgid "Communication Standard"
-msgstr ""
-
-#. module: l10n_be
-#: model:ir.model,name:l10n_be.model_res_company
-msgid "Companies"
-msgstr ""
+msgstr "Kommunikationsstandard"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a020
@@ -2136,6 +2127,14 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_550
 #: model:account.group.template,name:l10n_be.be_group_550
 msgid "Comptes ouverts auprès des divers établissements, à subdiviser en :"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_211
+#: model:account.group,name:l10n_be.2_be_group_211
+#: model:account.group.template,name:l10n_be.be_group_211
+msgid ""
+"Concessions, brevets, licences, savoir-faire, marques et droits similaires"
 msgstr ""
 
 #. module: l10n_be
@@ -2194,6 +2193,11 @@ msgstr "Hilfs- und Betriebsstoffe - Anschaffungswert"
 #: model:account.account.template,name:l10n_be.a319
 msgid "Consumables - amounts written down"
 msgstr "Hilfs- und Betriebsstoffe - Gebuchte Wertminderungen"
+
+#. module: l10n_be
+#: model:ir.model,name:l10n_be.model_res_partner
+msgid "Contact"
+msgstr "Kontakt"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a370
@@ -2777,6 +2781,20 @@ msgstr "Tantiemen für das Geschäftsjahr"
 #: model:account.account.template,name:l10n_be.a695
 msgid "Directors' or managers' entitlements"
 msgstr "Verteilung zugunsten der Verwalter oder Geschäftsführer"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a657000
+#: model:account.account,name:l10n_be.2_a657000
+#: model:account.account.template,name:l10n_be.a657000
+msgid "Discounts Given"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a757000
+#: model:account.account,name:l10n_be.2_a757000
+#: model:account.account.template,name:l10n_be.a757000
+msgid "Discounts Taken"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a608
@@ -3480,18 +3498,18 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie
-msgid "II A la sortie"
-msgstr ""
+msgid "II Outgoing"
+msgstr "II Ausgänge"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_operations_entree
-msgid "III A l'entrée"
-msgstr ""
+msgid "III Incoming"
+msgstr "III Eingänge"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_taxes_dues
-msgid "IV Dues"
-msgstr ""
+msgid "IV Due"
+msgstr "IV Geschuldet"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_35
@@ -3756,12 +3774,12 @@ msgstr "Gezeichnetes Kapital"
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_journal
 msgid "Journal"
-msgstr ""
+msgstr "Journal"
 
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "Buchungssatz"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a220
@@ -3844,7 +3862,7 @@ msgstr "Entliehen zurückzugebende Aktien"
 #: model:account.account,name:l10n_be.2_l10nbe_chart_template_liquidity_transfer
 #: model:account.account.template,name:l10n_be.l10nbe_chart_template_liquidity_transfer
 msgid "Liquidity Transfer"
-msgstr ""
+msgstr "Liquiditätstransfer"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a201
@@ -3878,8 +3896,15 @@ msgstr ""
 #: model:account.account,name:l10n_be.1_a690
 #: model:account.account,name:l10n_be.2_a690
 #: model:account.account.template,name:l10n_be.a690
-msgid "Loss brought forward"
-msgstr "Verlusvortrag aus dem Vorjahr"
+msgid "Loss brought forward from previous year"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a141
+#: model:account.account,name:l10n_be.2_a141
+#: model:account.account.template,name:l10n_be.a141
+msgid "Loss carried forward"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a641
@@ -4234,15 +4259,15 @@ msgstr ""
 "Ausgleichszahlungen"
 
 #. module: l10n_be
+#: model:account.report.line,name:l10n_be.tax_report_title_operations
+msgid "Operations"
+msgstr "Umsätze"
+
+#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a099
 #: model:account.account,name:l10n_be.2_a099
 #: model:account.account.template,name:l10n_be.a099
 msgid "Options (buy or sell) on securities issued."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.line,name:l10n_be.tax_report_title_operations
-msgid "Opérations"
 msgstr ""
 
 #. module: l10n_be
@@ -4929,8 +4954,15 @@ msgstr ""
 #: model:account.account,name:l10n_be.1_a790
 #: model:account.account,name:l10n_be.2_a790
 #: model:account.account.template,name:l10n_be.a790
-msgid "Profit brought forward"
-msgstr "Gewinnvortrag aus dem Vorjahr"
+msgid "Profit brought forward from previous year"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a140
+#: model:account.account,name:l10n_be.2_a140
+#: model:account.account.template,name:l10n_be.a140
+msgid "Profit carried forward"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a693
@@ -5102,6 +5134,16 @@ msgid "Provisions of a financial nature - Uses and write-backs"
 msgstr "Rückstellungen mit finanziellem Charakter - Verbrauch und Auflösungen"
 
 #. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_164
+#: model:account.group,name:l10n_be.1_be_group_638
+#: model:account.group,name:l10n_be.2_be_group_164
+#: model:account.group,name:l10n_be.2_be_group_638
+#: model:account.group.template,name:l10n_be.be_group_164
+#: model:account.group.template,name:l10n_be.be_group_638
+msgid "Provisions pour autres risques et charges"
+msgstr ""
+
+#. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_161
 #: model:account.group,name:l10n_be.2_be_group_161
 #: model:account.group.template,name:l10n_be.be_group_161
@@ -5116,6 +5158,33 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_162
 #: model:account.group.template,name:l10n_be.be_group_636
 msgid "Provisions pour grosses réparations et gros entretien"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_163
+#: model:account.group,name:l10n_be.1_be_group_637
+#: model:account.group,name:l10n_be.2_be_group_163
+#: model:account.group,name:l10n_be.2_be_group_637
+#: model:account.group.template,name:l10n_be.be_group_163
+#: model:account.group.template,name:l10n_be.be_group_637
+msgid "Provisions pour obligations environnementales"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_160
+#: model:account.group,name:l10n_be.1_be_group_635
+#: model:account.group,name:l10n_be.2_be_group_160
+#: model:account.group,name:l10n_be.2_be_group_635
+#: model:account.group.template,name:l10n_be.be_group_160
+#: model:account.group.template,name:l10n_be.be_group_635
+msgid "Provisions pour pensions et obligations similaires"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_662
+#: model:account.group,name:l10n_be.2_be_group_662
+#: model:account.group.template,name:l10n_be.be_group_662
+msgid "Provisions pour risques et charges non récurrents"
 msgstr ""
 
 #. module: l10n_be
@@ -5584,6 +5653,13 @@ msgid "Rémunérations et avantages sociaux directs"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_62
+#: model:account.group,name:l10n_be.2_be_group_62
+#: model:account.group.template,name:l10n_be.be_group_62
+msgid "Rémunérations, charges sociales et pensions"
+msgstr ""
+
+#. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_618
 #: model:account.group,name:l10n_be.2_be_group_618
 #: model:account.group.template,name:l10n_be.be_group_618
@@ -5833,6 +5909,13 @@ msgid "Subsides d'exploitation et montants compensatoires"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_15
+#: model:account.group,name:l10n_be.2_be_group_15
+#: model:account.group.template,name:l10n_be.be_group_15
+msgid "Subsides en capital"
+msgstr ""
+
+#. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_753
 #: model:account.group,name:l10n_be.2_be_group_753
 #: model:account.group.template,name:l10n_be.be_group_753
@@ -5877,292 +5960,23 @@ msgid "T.V.A. à récupérer"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_0
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-S
 msgid "TVA 0%"
-msgstr ""
+msgstr "MwSt. 0%"
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-CC
-msgid "TVA 0% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-T
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-T
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-T
-msgid "TVA 0% EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-ROW
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-ROW
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-ROW
-msgid "TVA 0% Non EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_12
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-S
 msgid "TVA 12%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-CC
-msgid "TVA 12% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-EU
-msgid "TVA 12% EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-ROW-CC
-msgid "TVA 12% Non EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_21
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-S
 msgid "TVA 21%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-CC
-msgid "TVA 21% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-EU
-msgid "TVA 21% EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-ROW-CC
-msgid "TVA 21% Non EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_TVA-21-inclus-dans-prix
-#: model:account.tax,description:l10n_be.2_attn_TVA-21-inclus-dans-prix
-#: model:account.tax.template,description:l10n_be.attn_TVA-21-inclus-dans-prix
-msgid "TVA 21% TTC"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-CAR-EXC
-msgid "TVA 50% Non Déductible - Frais de voiture (Prix Excl.)"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-06-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-06-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-06-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-06-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_6
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-06-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-06-S
 msgid "TVA 6%"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-CC
-msgid "TVA 6% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-EU
-msgid "TVA 6% EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-ROW-CC
-msgid "TVA 6% Non EU"
 msgstr ""
 
 #. module: l10n_be
@@ -6182,7 +5996,7 @@ msgstr ""
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_taxes
 msgid "Taxes"
-msgstr ""
+msgstr "Steuern"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a412
@@ -6437,6 +6251,13 @@ msgid "Transferts aux impôts différés et aux réserves immunisées"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_689
+#: model:account.group,name:l10n_be.2_be_group_689
+#: model:account.group.template,name:l10n_be.be_group_689
+msgid "Transferts aux réserves immunisées"
+msgstr ""
+
+#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a101
 #: model:account.account,name:l10n_be.2_a101
 #: model:account.account.template,name:l10n_be.a101
@@ -6498,8 +6319,8 @@ msgstr "Steuerfreie Rücklagen"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_taxes_deductibles
-msgid "V Déductibles"
-msgstr ""
+msgid "V Deductible"
+msgstr "V Abzugsfähig"
 
 #. module: l10n_be
 #: model:account.report,name:l10n_be.tax_report_vat
@@ -6592,8 +6413,8 @@ msgstr "Mehrwertsteuer erstattungsfähig - Girokonto"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_taxes_soldes
-msgid "VI Soldes"
-msgstr ""
+msgid "VI Balance"
+msgstr "VI Saldo"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_300
@@ -6635,6 +6456,13 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_71
 #: model:account.group.template,name:l10n_be.be_group_71
 msgid "Variation des stocks et des commandes en cours d'exécution"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_609
+#: model:account.group,name:l10n_be.2_be_group_609
+#: model:account.group.template,name:l10n_be.be_group_609
+msgid "Variations des stocks"
 msgstr ""
 
 #. module: l10n_be
@@ -6729,6 +6557,8 @@ msgid ""
 "You can choose different models for each type of reference. The default one "
 "is the Odoo reference."
 msgstr ""
+"Sie können für jede Art von Referenz verschiedene Modelle auswählen. Die "
+"Standardeinstellung ist die Odoo-Referenz."
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_755

--- a/addons/l10n_be/i18n/fr.po
+++ b/addons/l10n_be/i18n/fr.po
@@ -4,9 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-05 14:50+0000\n"
+"POT-Creation-Date: 2023-02-02 17:05+0000\n"
 "PO-Revision-Date: 2020-01-27 14:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,60 +17,25 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00
-msgid "0% Biens d'investissement"
-msgstr "0% Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-G
-msgid "0% Biens divers"
-msgstr "0% Biens divers"
-
-#. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-CC
-msgid "0% Cocont."
-msgstr "0% Cocont."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-CC
-msgid "0% Cocont. - Biens d'investissement"
-msgstr "0% Cocont. - Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-CC
-msgid "0% Cocont. M."
-msgstr "0% Cocont. M."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-CC
-msgid "0% Cocont. S."
-msgstr "0% Cocont. S."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-EU
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-EU
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-EU
-msgid "0% EU - Biens d'investissement"
-msgstr "0% EU - Biens d'investissement"
+msgid "0% Cocont"
+msgstr "0% Cocont"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-EU-G
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-EU-G
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-G
-msgid "0% EU - Biens divers"
-msgstr "0% EU - Biens divers"
+msgid "0% EU G"
+msgstr "0% EU G"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-EU
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-EU
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-EU
+msgid "0% EU IG"
+msgstr "0% EU IG"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-EU
@@ -79,8 +44,8 @@ msgstr "0% EU - Biens divers"
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-L
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-L
-msgid "0% EU M."
-msgstr "0% EU M."
+msgid "0% EU M"
+msgstr "0% EU M"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-EU-S
@@ -89,50 +54,78 @@ msgstr "0% EU M."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-S
-msgid "0% EU S."
-msgstr "0% EU S."
+msgid "0% EU S"
+msgstr "0% EU S"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-EU-T
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-T
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-T
-msgid "0% EU T."
-msgstr "0% EU T."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00
-msgid "0% M."
-msgstr "0% M."
+msgid "0% EU T"
+msgstr "0% EU T"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-ROW
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-ROW
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-ROW
-msgid "0% Non EU"
-msgstr "0% Non EU"
+msgid "0% EX"
+msgstr "0% EX"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-ROW-CC
-msgid "0% Non EU - Biens d'investissement"
-msgstr "0% Non EU - Biens d'investissement"
+msgid "0% EX IG"
+msgstr "0% EX IG"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-ROW-CC
-msgid "0% Non EU M."
-msgstr "0% Non EU M."
+msgid "0% EX M"
+msgstr "0% EX M"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-ROW-CC
-msgid "0% Non EU S."
-msgstr "0% Non EU S."
+msgid "0% EX S"
+msgstr "0% EX S"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-G
+msgid "0% G"
+msgstr "0% G"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00
+msgid "0% IG"
+msgstr "0% IG"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-CC
+msgid "0% IG.Cocont"
+msgstr "0% IG.Cocont"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00
+msgid "0% M"
+msgstr "0% M"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-CC
+msgid "0% M.Cocont"
+msgstr "0% M.Cocont"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-S
@@ -141,150 +134,174 @@ msgstr "0% Non EU S."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-S
-msgid "0% S."
-msgstr "0% S."
+msgid "0% S"
+msgstr "0% S"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_00
-msgid "00"
-msgstr "00"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-CC
+msgid "0% S.Cocont"
+msgstr "0% S.Cocont"
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_00_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_00
 msgid "00 - Operations subject to a special regulation"
 msgstr "00 - Opérations soumises à un régime particulier"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_01
-msgid "01"
-msgstr "01"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_01_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_01
 msgid "01 - Operations subject to 6% VAT"
 msgstr "01 - Opérations soumises à la TVA à 6%"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_02
-msgid "02"
-msgstr "02"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_02_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_02
 msgid "02 - Operations subject to 12% VAT"
 msgstr "02 - Opérations soumises à la TVA à 12%"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_03
-msgid "03"
-msgstr "03"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_03_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_03
 msgid "03 - Operations subject to 21% VAT"
 msgstr "03 - Opérations soumises à la TVA à 21%"
 
 #. module: l10n_be
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-L
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-L
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-12-L
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-12-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-12-L
 msgid "12%"
 msgstr "12%"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12
-msgid "12% Biens d'investissement"
-msgstr "12% Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-G
-msgid "12% Biens divers"
-msgstr "12% Biens divers"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-CC
-msgid "12% Cocont. - Biens d'investissement"
-msgstr "12% Cocont. - Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-CC
-msgid "12% Cocont. M."
-msgstr "12% Cocont. M."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-CC
-msgid "12% Cocont. S."
-msgstr "12% Cocont. S."
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-G
+msgid "12% EU G"
+msgstr "12% EU G"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-EU
-msgid "12% EU - Biens d'investissement"
-msgstr "12% EU - Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-G
-msgid "12% EU - Biens divers"
-msgstr "12% EU - Biens divers"
+msgid "12% EU IG"
+msgstr "12% EU IG"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-EU
-msgid "12% EU M."
-msgstr "12% EU M."
+msgid "12% EU M"
+msgstr "12% EU M"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-S
-msgid "12% EU S."
-msgstr "12% EU S."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12
-msgid "12% M."
-msgstr "12% M."
+msgid "12% EU S"
+msgstr "12% EU S"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-ROW-CC
-msgid "12% Non EU - Biens d'investissement"
-msgstr "12% Non EU - Biens d'investissement"
+msgid "12% EX IG"
+msgstr "12% EX IG"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-ROW-CC
-msgid "12% Non EU M."
-msgstr "12% Non EU M."
+msgid "12% EX M"
+msgstr "12% EX M"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-ROW-CC
-msgid "12% Non EU S."
-msgstr "12% Non EU S."
+msgid "12% EX S"
+msgstr "12% EX S"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-G
+msgid "12% G"
+msgstr "12% G"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12
+msgid "12% IG"
+msgstr "12% IG"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-CC
+msgid "12% IG.Cocont"
+msgstr "12% IG.Cocont"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12
+msgid "12% M"
+msgstr "12% M"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-CC
+msgid "12% M.Cocont"
+msgstr "12% M.Cocont"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-S
@@ -293,106 +310,167 @@ msgstr "12% Non EU S."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-12-S
-msgid "12% S."
-msgstr "12% S."
+msgid "12% S"
+msgstr "12% S"
 
 #. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-CC
+msgid "12% S.Cocont"
+msgstr "12% S.Cocont"
+
+#. module: l10n_be
+#: model:account.tax,description:l10n_be.1_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-L
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-S
+#: model:account.tax,description:l10n_be.2_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-L
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-21-L
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-21-L
+#: model:account.tax.template,description:l10n_be.attn_TVA-21-inclus-dans-prix
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-21-L
 msgid "21%"
 msgstr "21%"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21
-msgid "21% Biens d'investissement"
-msgstr "21% Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-G
-msgid "21% Biens divers"
-msgstr "21% Biens divers"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-CC
-msgid "21% Cocont .S."
-msgstr "21% Cocont .S."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-CC
-msgid "21% Cocont. - Biens d'investissement"
-msgstr "21% Cocont. - Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-CC
-msgid "21% Cocont. M."
-msgstr "21% Cocont. M."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-EU
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-EU
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-EU
-msgid "21% EU - Biens d'investissement"
-msgstr "21% EU - Biens d'investissement"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-CAR-EXC
+msgid "21% Car"
+msgstr "21% Car"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-EU-G
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-EU-G
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-EU-G
-msgid "21% EU - Biens divers"
-msgstr "21% EU - Biens divers"
+msgid "21% EU G"
+msgstr "21% EU G"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-EU
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-EU
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-EU
+msgid "21% EU IG"
+msgstr "21% EU IG"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-EU
-msgid "21% EU M."
-msgstr "21% EU M."
+msgid "21% EU M"
+msgstr "21% EU M"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-EU-S
-msgid "21% EU S."
-msgstr "21% EU S."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21
-msgid "21% M."
-msgstr "21% M."
+msgid "21% EU S"
+msgstr "21% EU S"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-ROW-CC
-msgid "21% Non EU - Biens d'investissement"
-msgstr "21% Non EU - Biens d'investissement"
+msgid "21% EX IG"
+msgstr "21% EX IG"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-ROW-CC
-msgid "21% Non EU M."
-msgstr "21% Non EU M."
+msgid "21% EX M"
+msgstr "21% EX M"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-ROW-CC
-msgid "21% Non EU S."
-msgstr "21% Non EU S."
+msgid "21% EX S"
+msgstr "21% EX S"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-G
+msgid "21% G"
+msgstr "21% G"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21
+msgid "21% IG"
+msgstr "21% IG"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-CC
+msgid "21% IG.Cocont"
+msgstr "21% IG.Cocont"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21
+msgid "21% M"
+msgstr "21% M"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-CC
+msgid "21% M.Cocont"
+msgstr "21% M.Cocont"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-S
@@ -401,34 +479,29 @@ msgstr "21% Non EU S."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-21-S
-msgid "21% S."
-msgstr "21% S."
+msgid "21% S"
+msgstr "21% S"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-CC
+msgid "21% S.Cocont"
+msgstr "21% S.Cocont"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_TVA-21-inclus-dans-prix
 #: model:account.tax,name:l10n_be.2_attn_TVA-21-inclus-dans-prix
 #: model:account.tax.template,name:l10n_be.attn_TVA-21-inclus-dans-prix
-msgid "21% S. TTC"
-msgstr "21% S. TTC"
+msgid "21% S.TTC"
+msgstr "21% S.TTC"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_44
-msgid "44"
-msgstr "44"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_44_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_44
 msgid "44 - Intra-Community services"
 msgstr "44 - Services intracommunautaires"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_45
-msgid "45"
-msgstr "45"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_45_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_45
 msgid "45 - Operations subject to VAT due by the co-contractor"
 msgstr "45 - Opérations pour lesquelles la TVA est due par le cocontractant"
@@ -439,239 +512,163 @@ msgid "46 - Exempted intra-Community deliveries and ABC sales"
 msgstr "46 - Livraisons intracommunautaires exemptées et ventes ABC"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_46L
-msgid "46L"
-msgstr "46L"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_46L_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_46L
 msgid "46L - Exempted intra-Community deliveries"
 msgstr "46L - Livraisons intracommunautaires exemptées"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_46T
-msgid "46T"
-msgstr "46T"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_46T_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_46T
 msgid "46T - ABC sales"
 msgstr "46T - Ventes ABC"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_47
-msgid "47"
-msgstr "47"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_47_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_47
 msgid "47 - Other exempted operations and operations carried out abroad"
-msgstr "47 - Autres opérations exemptées et autres opérations effectuées à l'étranger"
+msgstr ""
+"47 - Autres opérations exemptées et autres opérations effectuées à l'étranger"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_48
 msgid "48 - Credit notes for operations in grids [44] and [46]"
-msgstr "48 - Notes de crédit relatif aux opérations inscrites en grilles [44] et [46]"
+msgstr ""
+"48 - Notes de crédit relatif aux opérations inscrites en grilles [44] et [46]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s44
-msgid "48s44"
-msgstr "48s44"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s44_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s44
 msgid "48s44 - Credit notes for operations in grid [44]"
-msgstr "48s44 - Notes de crédit relatif aux opérations inscrites en grille [44]"
+msgstr ""
+"48s44 - Notes de crédit relatif aux opérations inscrites en grille [44]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46L
-msgid "48s46L"
-msgstr "48s46L"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s46L_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s46L
 msgid "48s46L - Credit notes for operations in grid [46L]"
-msgstr "48s46L - Notes de crédit relatif aux opérations inscrites en grille [46L]"
+msgstr ""
+"48s46L - Notes de crédit relatif aux opérations inscrites en grille [46L]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46T
-msgid "48s46T"
-msgstr "48s46T"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s46T_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s46T
 msgid "48s46T - Credit notes for operations in grid [46T]"
-msgstr "48s46T - Notes de crédit relatif aux opérations inscrites en grille [46T]"
+msgstr ""
+"48s46T - Notes de crédit relatif aux opérations inscrites en grille [46T]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_49
-msgid "49"
-msgstr "49"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_49_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_49
 msgid "49 - Credit notes for other operations in part II"
 msgstr "49 - Notes de crédit relatif aux autres opérations de la partie II"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-CAR-EXC
-msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
-msgstr "50% Non Déductible - Frais de voiture (Prix Excl.)"
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_54
-msgid "54"
-msgstr "54"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_54_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_54
 msgid "54 - VAT on operations in grids [01], [02] and [03]"
-msgstr "54 - TVA relative aux opérations déclarées en grilles [01], [02] et [03]"
+msgstr ""
+"54 - TVA relative aux opérations déclarées en grilles [01], [02] et [03]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_55
-msgid "55"
-msgstr "55"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_55_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_55
 msgid "55 - VAT on operations in grids [86] and [88]"
 msgstr "55 - TVA relative aux opérations déclarées en grilles [86] et [88]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_56
-msgid "56"
-msgstr "56"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_56_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_56
-msgid "56 - VAT on operations in grid [87], with the exception of imports with reverse charge"
-msgstr "56 - TVA relative aux opérations déclarées en grille [87], à l'exception des importations avec report de perception"
+msgid ""
+"56 - VAT on operations in grid [87], with the exception of imports with "
+"reverse charge"
+msgstr ""
+"56 - TVA relative aux opérations déclarées en grille [87], à l'exception des "
+"importations avec report de perception"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_57
-msgid "57"
-msgstr "57"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_57_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_57
 msgid "57 - VAT on import with reverse charge"
 msgstr "57 - TVA relative aux importations avec report de perception"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_59
-msgid "59"
-msgstr "59"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_59_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_59
 msgid "59 - Deductible VAT"
 msgstr "59 - TVA déductible"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06
-msgid "6% Biens d'investissement"
-msgstr "6% Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-G
-msgid "6% Biens divers"
-msgstr "6% Biens divers"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-CC
-msgid "6% Cocont. - Biens d'investissement"
-msgstr "6% Cocont. - Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-CC
-msgid "6% Cocont. M."
-msgstr "6% Cocont. M."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-CC
-msgid "6% Cocont. S."
-msgstr "6% Cocont. S."
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-G
+msgid "6% EU G"
+msgstr "6% EU G"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-EU
-msgid "6% EU - Biens d'investissement"
-msgstr "6% EU - Biens d'investissement"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-G
-msgid "6% EU - Biens divers"
-msgstr "6% EU - Biens divers"
+msgid "6% EU IG"
+msgstr "6% EU IG"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-EU
-msgid "6% EU M."
-msgstr "6% EU M."
+msgid "6% EU M"
+msgstr "6% EU M"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-S
-msgid "6% EU S."
-msgstr "6% EU S."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06
-msgid "6% M."
-msgstr "6% M."
+msgid "6% EU S"
+msgstr "6% EU S"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-ROW-CC
-msgid "6% Non EU - Biens d'investissement"
-msgstr "6% Non EU - Biens d'investissement"
+msgid "6% EX IG"
+msgstr "6% EX IG"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-ROW-CC
-msgid "6% Non EU M."
-msgstr "6% Non EU M."
+msgid "6% EX M"
+msgstr "6% EX M"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-ROW-CC
-msgid "6% Non EU S."
-msgstr "6% Non EU S."
+msgid "6% EX S"
+msgstr "6% EX S"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-G
+msgid "6% G"
+msgstr "6% G"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06
+msgid "6% IG"
+msgstr "6% IG"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-CC
+msgid "6% IG.Cocont"
+msgstr "6% IG.Cocont"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06
+msgid "6% M"
+msgstr "6% M"
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-CC
+msgid "6% M.Cocont"
+msgstr "6% M.Cocont"
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-S
@@ -680,173 +677,85 @@ msgstr "6% Non EU S."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-06-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-06-S
-msgid "6% S."
-msgstr "6% S."
+msgid "6% S"
+msgstr "6% S"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_61
-msgid "61"
-msgstr "61"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-CC
+msgid "6% S.Cocont"
+msgstr "6% S.Cocont"
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_61_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_61
 msgid "61 - Various VAT regularizations in favor of the State"
 msgstr "61 - Diverses régularisations TVA en faveur de l'Etat"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_62
-msgid "62"
-msgstr "62"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_62_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_62
 msgid "62 - Various VAT regularizations in favor of the declarant"
 msgstr "62 - Diverses régularisations TVA en faveur du déclarant"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_63
-msgid "63"
-msgstr "63"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_63_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_63
 msgid "63 - VAT to be paid back on credit notes received"
 msgstr "63 - TVA à reverser mentionnée sur les notes de crédit reçues"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_64
-msgid "64"
-msgstr "64"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_64_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_64
 msgid "64 - VAT to be recovered on credit notes issued"
 msgstr "64 - TVA à récupérer mentionnée sur les notes de crédit délivrées"
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_71_formula
 #: model:account.report.line,name:l10n_be.tax_report_line_71
 msgid "71 - Taxes due to the State"
 msgstr "71 - Taxe due à l'Etat"
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_72_formula
 #: model:account.report.line,name:l10n_be.tax_report_line_72
 msgid "72 - Amount owed by the State"
 msgstr "72 - Sommes dues par l'Etat"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_81
-msgid "81"
-msgstr "81"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_81
 msgid "81 - Trade goods, raw materials and consumables"
 msgstr "81 - Marchandises, matières premières et matières auxiliaires"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_82
-msgid "82"
-msgstr "82"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_82
 msgid "82 - Services and miscellaneous goods"
 msgstr "82 - Services et biens divers"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_83
-msgid "83"
-msgstr "83"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_83
 msgid "83 - Investment goods"
 msgstr "83 - Biens d'investissement"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_84
-msgid "84"
-msgstr "84"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_84_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_84
 msgid "84 - Credit notes for operations in grids [86] and [88]"
-msgstr "84 - Notes de crédits reçues relatif aux opérations inscrites en grilles [86] et [88]"
+msgstr ""
+"84 - Notes de crédits reçues relatif aux opérations inscrites en grilles "
+"[86] et [88]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_85
-msgid "85"
-msgstr "85"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_85_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_85
 msgid "85 - Credit notes received relating to other operations in part III"
-msgstr "85 - Notes de crédits reçues relatif aux autres opérations de la partie III"
+msgstr ""
+"85 - Notes de crédits reçues relatif aux autres opérations de la partie III"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_86
-msgid "86"
-msgstr "86"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_86
 msgid "86 - Intra-Community acquisitions and ABC sales"
 msgstr "86 - Acquisitions intracommunautaires et ventes ABC"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_87
-msgid "87"
-msgstr "87"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_87
 msgid "87 - Other operations subject to VAT"
 msgstr "87 - Autres opérations soumises à la TVA"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_88
-msgid "88"
-msgstr "88"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_88
 msgid "88 - Intra-Community services with reverse charge"
 msgstr "88 - Services intracommunautaires avec report de perception"
@@ -910,28 +819,42 @@ msgstr "Produits acquis"
 #: model:account.group,name:l10n_be.2_be_group_605
 #: model:account.group.template,name:l10n_be.be_group_605
 msgid "Achats d'immeubles destinés à la vente"
-msgstr ""
+msgstr "Achats d'immeubles destinés à la vente"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_601
 #: model:account.group,name:l10n_be.2_be_group_601
 #: model:account.group.template,name:l10n_be.be_group_601
 msgid "Achats de fournitures"
-msgstr ""
+msgstr "Achats de fournitures"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_604
 #: model:account.group,name:l10n_be.2_be_group_604
 #: model:account.group.template,name:l10n_be.be_group_604
 msgid "Achats de marchandises"
-msgstr ""
+msgstr "Achats de marchandises"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_600
+#: model:account.group,name:l10n_be.2_be_group_600
+#: model:account.group.template,name:l10n_be.be_group_600
+msgid "Achats de matières premières"
+msgstr "Achats de matières premières"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_602
+#: model:account.group,name:l10n_be.2_be_group_602
+#: model:account.group.template,name:l10n_be.be_group_602
+msgid "Achats de services, travaux et études"
+msgstr "Achats de services, travaux et études"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_19
 #: model:account.group,name:l10n_be.2_be_group_19
 #: model:account.group.template,name:l10n_be.be_group_19
 msgid "Acompte aux associés sur le partage de l'actif net (-)"
-msgstr ""
+msgstr "Acompte aux associés sur le partage de l'actif net (-)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_176
@@ -941,7 +864,7 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_176
 #: model:account.group.template,name:l10n_be.be_group_46
 msgid "Acomptes reçus sur commandes"
-msgstr ""
+msgstr "Acomptes reçus sur commandes"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_213
@@ -954,14 +877,14 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_360
 #: model:account.group.template,name:l10n_be.be_group_406
 msgid "Acomptes versés"
-msgstr ""
+msgstr "Acomptes versés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_36
 #: model:account.group,name:l10n_be.2_be_group_36
 #: model:account.group.template,name:l10n_be.be_group_36
 msgid "Acomptes versés sur achats pour stocks"
-msgstr ""
+msgstr "Acomptes versés sur achats pour stocks"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a050
@@ -981,14 +904,14 @@ msgstr "Engagements d’acquisition"
 #: model:account.group.template,name:l10n_be.be_group_5110
 #: model:account.group.template,name:l10n_be.be_group_5190
 msgid "Actions et parts"
-msgstr ""
+msgstr "Actions et parts"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_50
 #: model:account.group,name:l10n_be.2_be_group_50
 #: model:account.group.template,name:l10n_be.be_group_50
 msgid "Actions propres"
-msgstr ""
+msgstr "Actions propres"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_51
@@ -998,6 +921,8 @@ msgid ""
 "Actions, parts et placements de trésorerie autres que placements à revenu "
 "fixe"
 msgstr ""
+"Actions, parts et placements de trésorerie autres que placements à revenu "
+"fixe"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a021
@@ -1048,7 +973,7 @@ msgstr "Régularisations d'impôts et reprises de provisions fiscales"
 #: model:account.group,name:l10n_be.2_be_group_695
 #: model:account.group.template,name:l10n_be.be_group_695
 msgid "Administrateurs ou gérants"
-msgstr ""
+msgstr "Administrateurs ou gérants"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a360
@@ -1106,14 +1031,24 @@ msgstr "Avances et acomptes à recevoir à un an au plus"
 #: model:account.group,name:l10n_be.2_be_group_691
 #: model:account.group.template,name:l10n_be.be_group_691
 msgid "Affectations au capital et à la prime d'émission"
-msgstr ""
+msgstr "Affectations au capital et à la prime d'émission"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_69
+#: model:account.group,name:l10n_be.1_be_group_79
+#: model:account.group,name:l10n_be.2_be_group_69
+#: model:account.group,name:l10n_be.2_be_group_79
+#: model:account.group.template,name:l10n_be.be_group_69
+#: model:account.group.template,name:l10n_be.be_group_79
+msgid "Affectations et prélèvements"
+msgstr "Affectations et prélèvements"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_660
 #: model:account.group,name:l10n_be.2_be_group_660
 #: model:account.group.template,name:l10n_be.be_group_660
 msgid "Amortissements et réductions de valeur non récurrents (dotations)"
-msgstr ""
+msgstr "Amortissements et réductions de valeur non récurrents (dotations)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_63
@@ -1122,6 +1057,7 @@ msgstr ""
 msgid ""
 "Amortissements, réductions de valeur et provisions pour risques et charges"
 msgstr ""
+"Amortissements, réductions de valeur et provisions pour risques et charges"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a653
@@ -1477,63 +1413,97 @@ msgstr "Dotation aux autres réserves"
 #: model:account.group,name:l10n_be.2_be_group_31
 #: model:account.group.template,name:l10n_be.be_group_31
 msgid "Approvisionnements - Fournitures"
-msgstr ""
+msgstr "Approvisionnements - Fournitures"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_30
 #: model:account.group,name:l10n_be.2_be_group_30
 #: model:account.group.template,name:l10n_be.be_group_30
 msgid "Approvisionnements - Matières premières"
-msgstr ""
+msgstr "Approvisionnements - Matières premières"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_60
 #: model:account.group,name:l10n_be.2_be_group_60
 #: model:account.group.template,name:l10n_be.be_group_60
 msgid "Approvisionnements et marchandises"
-msgstr ""
+msgstr "Approvisionnements et marchandises"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_284
+#: model:account.group,name:l10n_be.2_be_group_284
+#: model:account.group.template,name:l10n_be.be_group_284
+msgid "Autres actions et parts"
+msgstr "Autres actions et parts"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_473
+#: model:account.group,name:l10n_be.2_be_group_473
+#: model:account.group.template,name:l10n_be.be_group_473
+msgid "Autres allocataires"
+msgstr "Autres allocataires"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_697
+#: model:account.group,name:l10n_be.2_be_group_697
+#: model:account.group.template,name:l10n_be.be_group_697
+msgid "Autres applications"
+msgstr "Autres applications"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_64
 #: model:account.group,name:l10n_be.2_be_group_64
 #: model:account.group.template,name:l10n_be.be_group_64
 msgid "Autres charges d'exploitation"
-msgstr ""
+msgstr "Autres charges d'exploitation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_664
 #: model:account.group,name:l10n_be.2_be_group_664
 #: model:account.group.template,name:l10n_be.be_group_664
 msgid "Autres charges d'exploitation non récurrentes"
-msgstr ""
+msgstr "Autres charges d'exploitation non récurrentes"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_668
 #: model:account.group,name:l10n_be.2_be_group_668
 #: model:account.group.template,name:l10n_be.be_group_668
 msgid "Autres charges financières non récurrentes"
-msgstr ""
+msgstr "Autres charges financières non récurrentes"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_285
+#: model:account.group,name:l10n_be.1_be_group_291
+#: model:account.group,name:l10n_be.1_be_group_41
+#: model:account.group,name:l10n_be.2_be_group_285
+#: model:account.group,name:l10n_be.2_be_group_291
+#: model:account.group,name:l10n_be.2_be_group_41
+#: model:account.group.template,name:l10n_be.be_group_285
+#: model:account.group.template,name:l10n_be.be_group_291
+#: model:account.group.template,name:l10n_be.be_group_41
+msgid "Autres créances"
+msgstr "Autres créances"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_489
 #: model:account.group,name:l10n_be.2_be_group_489
 #: model:account.group.template,name:l10n_be.be_group_489
 msgid "Autres dettes diverses"
-msgstr ""
+msgstr "Autres dettes diverses"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_459
 #: model:account.group,name:l10n_be.2_be_group_459
 #: model:account.group.template,name:l10n_be.be_group_459
 msgid "Autres dettes sociales"
-msgstr ""
+msgstr "Autres dettes sociales"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_223
 #: model:account.group,name:l10n_be.2_be_group_223
 #: model:account.group.template,name:l10n_be.be_group_223
 msgid "Autres droits réels sur des immeubles"
-msgstr ""
+msgstr "Autres droits réels sur des immeubles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_174
@@ -1543,49 +1513,49 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_174
 #: model:account.group.template,name:l10n_be.be_group_439
 msgid "Autres emprunts"
-msgstr ""
+msgstr "Autres emprunts"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_202
 #: model:account.group,name:l10n_be.2_be_group_202
 #: model:account.group.template,name:l10n_be.be_group_202
 msgid "Autres frais d'établissement"
-msgstr ""
+msgstr "Autres frais d'établissement"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_623
 #: model:account.group,name:l10n_be.2_be_group_623
 #: model:account.group.template,name:l10n_be.be_group_623
 msgid "Autres frais de personnel"
-msgstr ""
+msgstr "Autres frais de personnel"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_26
 #: model:account.group,name:l10n_be.2_be_group_26
 #: model:account.group.template,name:l10n_be.be_group_26
 msgid "Autres immobilisations corporelles"
-msgstr ""
+msgstr "Autres immobilisations corporelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_74
 #: model:account.group,name:l10n_be.2_be_group_74
 #: model:account.group.template,name:l10n_be.be_group_74
 msgid "Autres produits d'exploitation"
-msgstr ""
+msgstr "Autres produits d'exploitation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_764
 #: model:account.group,name:l10n_be.2_be_group_764
 #: model:account.group.template,name:l10n_be.be_group_764
 msgid "Autres produits d'exploitation non récurrents"
-msgstr ""
+msgstr "Autres produits d'exploitation non récurrents"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_769
 #: model:account.group,name:l10n_be.2_be_group_769
 #: model:account.group.template,name:l10n_be.be_group_769
 msgid "Autres produits financiers non récurrents"
-msgstr ""
+msgstr "Autres produits financiers non récurrents"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a133
@@ -1688,14 +1658,14 @@ msgstr "Belgium"
 #: model:account.group,name:l10n_be.2_be_group_07
 #: model:account.group.template,name:l10n_be.be_group_07
 msgid "Biens et valeurs de tiers détenus par l'entreprise"
-msgstr ""
+msgstr "Biens et valeurs de tiers détenus par l'entreprise"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_072
 #: model:account.group,name:l10n_be.2_be_group_072
 #: model:account.group.template,name:l10n_be.be_group_072
 msgid "Biens et valeurs de tiers reçus en dépôt, en consignation ou à façon"
-msgstr ""
+msgstr "Biens et valeurs de tiers reçus en dépôt, en consignation ou à façon"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_04
@@ -1708,6 +1678,8 @@ msgid ""
 "Biens et valeurs détenus par des tiers en leur nom mais aux risques et "
 "profits de l'entreprise"
 msgstr ""
+"Biens et valeurs détenus par des tiers en leur nom mais aux risques et "
+"profits de l'entreprise"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_074
@@ -1715,6 +1687,7 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_074
 msgid "Biens et valeurs détenus pour compte ou aux risques et profits de tiers"
 msgstr ""
+"Biens et valeurs détenus pour compte ou aux risques et profits de tiers"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1751
@@ -1771,49 +1744,49 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_371
 #: model:account.group.template,name:l10n_be.be_group_371
 msgid "Bénéfice pris en compte"
-msgstr ""
+msgstr "Bénéfice pris en compte"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_790
 #: model:account.group,name:l10n_be.2_be_group_790
 #: model:account.group.template,name:l10n_be.be_group_790
 msgid "Bénéfice reporté de l'exercice précédent"
-msgstr ""
+msgstr "Bénéfice reporté de l'exercice précédent"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_14
 #: model:account.group,name:l10n_be.2_be_group_14
 #: model:account.group.template,name:l10n_be.be_group_14
 msgid "Bénéfice reporté ou Perte reportée (–)"
-msgstr ""
+msgstr "Bénéfice reporté ou perte reportée (–)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_693
 #: model:account.group,name:l10n_be.2_be_group_693
 #: model:account.group.template,name:l10n_be.be_group_693
 msgid "Bénéfice à reporter"
-msgstr ""
+msgstr "Bénéfice à reporter"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_57
 #: model:account.group,name:l10n_be.2_be_group_57
 #: model:account.group.template,name:l10n_be.be_group_57
 msgid "Caisses"
-msgstr ""
+msgstr "Caisses"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_570
 #: model:account.group,name:l10n_be.2_be_group_570
 #: model:account.group.template,name:l10n_be.be_group_570
 msgid "Caisses-espèces"
-msgstr ""
+msgstr "Caisses-espèces"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_578
 #: model:account.group,name:l10n_be.2_be_group_578
 #: model:account.group.template,name:l10n_be.be_group_578
 msgid "Caisses-timbres"
-msgstr ""
+msgstr "Caisses-timbres"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a410
@@ -1827,14 +1800,14 @@ msgstr "Capital appelé, non versé"
 #: model:account.group,name:l10n_be.2_be_group_10
 #: model:account.group.template,name:l10n_be.be_group_10
 msgid "Capital"
-msgstr ""
+msgstr "Capital"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_410
 #: model:account.group,name:l10n_be.2_be_group_410
 #: model:account.group.template,name:l10n_be.be_group_410
 msgid "Capital appelé, non versé"
-msgstr ""
+msgstr "Capital appelé, non versé"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7631
@@ -1871,14 +1844,14 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_101
 #: model:account.group.template,name:l10n_be.be_group_101
 msgid "Capital non appelé (–)"
-msgstr ""
+msgstr "Capital non appelé (–)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_100
 #: model:account.group,name:l10n_be.2_be_group_100
 #: model:account.group.template,name:l10n_be.be_group_100
 msgid "Capital souscrit"
-msgstr ""
+msgstr "Capital souscrit"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6503
@@ -1944,7 +1917,7 @@ msgstr "Caisses-timbres"
 #: model:account.group.template,name:l10n_be.be_group_178
 #: model:account.group.template,name:l10n_be.be_group_488
 msgid "Cautionnements reçus en numéraire"
-msgstr ""
+msgstr "Cautionnements reçus en numéraire"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_288
@@ -1954,35 +1927,35 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_288
 #: model:account.group.template,name:l10n_be.be_group_418
 msgid "Cautionnements versés en numéraire"
-msgstr ""
+msgstr "Cautionnements versés en numéraire"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_6
 #: model:account.group,name:l10n_be.2_be_group_6
 #: model:account.group.template,name:l10n_be.be_group_6
 msgid "Charges"
-msgstr ""
+msgstr "Frais"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_653
 #: model:account.group,name:l10n_be.2_be_group_653
 #: model:account.group.template,name:l10n_be.be_group_653
 msgid "Charges d'escompte de créances"
-msgstr ""
+msgstr "Charges d'escompte de créances"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_643
 #: model:account.group,name:l10n_be.2_be_group_643
 #: model:account.group.template,name:l10n_be.be_group_643
 msgid "Charges d'exploitation diverses"
-msgstr ""
+msgstr "Charges d'exploitation diverses"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_66
 #: model:account.group,name:l10n_be.2_be_group_66
 #: model:account.group.template,name:l10n_be.be_group_66
 msgid "Charges d'exploitation ou financières non récurrentes"
-msgstr ""
+msgstr "Charges d'exploitation ou financières non récurrentes"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_649
@@ -1992,27 +1965,29 @@ msgid ""
 "Charges d'exploitation portées à l'actif au titre de frais de "
 "restructuration (–)"
 msgstr ""
+"Charges d'exploitation portées à l'actif au titre de frais de "
+"restructuration (–)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_650
 #: model:account.group,name:l10n_be.2_be_group_650
 #: model:account.group.template,name:l10n_be.be_group_650
 msgid "Charges des dettes"
-msgstr ""
+msgstr "Charges des dettes"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_65
 #: model:account.group,name:l10n_be.2_be_group_65
 #: model:account.group.template,name:l10n_be.be_group_65
 msgid "Charges financières"
-msgstr ""
+msgstr "Charges financières"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_657
 #: model:account.group,name:l10n_be.2_be_group_657
 #: model:account.group.template,name:l10n_be.be_group_657
 msgid "Charges financières diverses"
-msgstr ""
+msgstr "Charges financières diverses"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_659
@@ -2021,79 +1996,75 @@ msgstr ""
 msgid ""
 "Charges financières portées à l'actif au titre de frais de restructuration"
 msgstr ""
+"Charges financières portées à l'actif au titre de frais de restructuration"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_640
 #: model:account.group,name:l10n_be.2_be_group_640
 #: model:account.group.template,name:l10n_be.be_group_640
 msgid "Charges fiscales d'exploitation"
-msgstr ""
+msgstr "Charges fiscales d'exploitation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_669
 #: model:account.group,name:l10n_be.2_be_group_669
 #: model:account.group.template,name:l10n_be.be_group_669
 msgid "Charges portées à l'actif au titre de frais de restructuration (-)"
-msgstr ""
+msgstr "Charges portées à l'actif au titre de frais de restructuration (-)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_492
 #: model:account.group,name:l10n_be.2_be_group_492
 #: model:account.group.template,name:l10n_be.be_group_492
 msgid "Charges à imputer"
-msgstr ""
+msgstr "Charges à imputer"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_490
 #: model:account.group,name:l10n_be.2_be_group_490
 #: model:account.group.template,name:l10n_be.be_group_490
 msgid "Charges à reporter"
-msgstr ""
+msgstr "Charges à reporter"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_70
 #: model:account.group,name:l10n_be.2_be_group_70
 #: model:account.group.template,name:l10n_be.be_group_70
 msgid "Chiffre d'affaires"
-msgstr ""
+msgstr "Chiffre d'affaires"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_561
 #: model:account.group,name:l10n_be.2_be_group_561
 #: model:account.group.template,name:l10n_be.be_group_561
 msgid "Chèques émis (–)"
-msgstr ""
+msgstr "Chèques émis (–)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_400
 #: model:account.group,name:l10n_be.2_be_group_400
 #: model:account.group.template,name:l10n_be.be_group_400
 msgid "Clients"
-msgstr ""
+msgstr "Clients"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_37
 #: model:account.group,name:l10n_be.2_be_group_37
 #: model:account.group.template,name:l10n_be.be_group_37
 msgid "Commandes en cours d'exécution"
-msgstr ""
+msgstr "Commandes en cours d'exécution"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_073
 #: model:account.group,name:l10n_be.2_be_group_073
 #: model:account.group.template,name:l10n_be.be_group_073
 msgid "Commettants et déposants de biens et de valeurs"
-msgstr ""
+msgstr "Commettants et déposants de biens et de valeurs"
 
 #. module: l10n_be
 #: model:ir.model.fields,field_description:l10n_be.field_account_journal__invoice_reference_model
 msgid "Communication Standard"
-msgstr ""
-
-#. module: l10n_be
-#: model:ir.model,name:l10n_be.model_res_company
-msgid "Companies"
-msgstr ""
+msgstr "Standard de référence"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a020
@@ -2121,28 +2092,37 @@ msgstr "Montants compensatoires destinés à réduire le coût salarial"
 #: model:account.group,name:l10n_be.2_be_group_560
 #: model:account.group.template,name:l10n_be.be_group_560
 msgid "Compte courant"
-msgstr ""
+msgstr "Compte courant"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_499
 #: model:account.group,name:l10n_be.2_be_group_499
 #: model:account.group.template,name:l10n_be.be_group_499
 msgid "Comptes d'attente"
-msgstr ""
+msgstr "Comptes d'attente"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_49
 #: model:account.group,name:l10n_be.2_be_group_49
 #: model:account.group.template,name:l10n_be.be_group_49
 msgid "Comptes de régularisation et comptes d'attente"
-msgstr ""
+msgstr "Comptes de régularisation et comptes d'attente"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_550
 #: model:account.group,name:l10n_be.2_be_group_550
 #: model:account.group.template,name:l10n_be.be_group_550
 msgid "Comptes ouverts auprès des divers établissements, à subdiviser en :"
+msgstr "Comptes ouverts auprès des divers établissements, à subdiviser en :"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_211
+#: model:account.group,name:l10n_be.2_be_group_211
+#: model:account.group.template,name:l10n_be.be_group_211
+msgid ""
+"Concessions, brevets, licences, savoir-faire, marques et droits similaires"
 msgstr ""
+"Concessions, brevets, licences, savoir-faire, marques et droits similaires"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a211
@@ -2167,6 +2147,13 @@ msgid "Concordat resolution commitments"
 msgstr "Engagements de résolution de concordat"
 
 #. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_033
+#: model:account.group,name:l10n_be.2_be_group_033
+#: model:account.group.template,name:l10n_be.be_group_033
+msgid "Constituants de garanties"
+msgstr "Constituants de garanties"
+
+#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a033
 #: model:account.account,name:l10n_be.2_a033
 #: model:account.account.template,name:l10n_be.a033
@@ -2178,7 +2165,7 @@ msgstr "Constituants de garanties"
 #: model:account.group,name:l10n_be.2_be_group_221
 #: model:account.group.template,name:l10n_be.be_group_221
 msgid "Constructions"
-msgstr ""
+msgstr "Constructions"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a310
@@ -2193,6 +2180,11 @@ msgstr "Fournitures - Valeur d'acquisition"
 #: model:account.account.template,name:l10n_be.a319
 msgid "Consumables - amounts written down"
 msgstr "Fournitures - Réductions de valeur actées"
+
+#. module: l10n_be
+#: model:ir.model,name:l10n_be.model_res_partner
+msgid "Contact"
+msgstr "Contact"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a370
@@ -2255,7 +2247,7 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_621
 #: model:account.group.template,name:l10n_be.be_group_621
 msgid "Cotisations patronales d'assurances sociales"
-msgstr ""
+msgstr "Cotisations patronales d'assurances sociales"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a065
@@ -2347,14 +2339,14 @@ msgstr "Créanciers sous conditions concordataires"
 #: model:account.group.template,name:l10n_be.be_group_290
 #: model:account.group.template,name:l10n_be.be_group_40
 msgid "Créances commerciales"
-msgstr ""
+msgstr "Créances commerciales"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_416
 #: model:account.group,name:l10n_be.2_be_group_416
 #: model:account.group.template,name:l10n_be.be_group_416
 msgid "Créances diverses"
-msgstr ""
+msgstr "Créances diverses"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_407
@@ -2364,14 +2356,14 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_407
 #: model:account.group.template,name:l10n_be.be_group_417
 msgid "Créances douteuses"
-msgstr ""
+msgstr "Créances douteuses"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_4
 #: model:account.group,name:l10n_be.2_be_group_4
 #: model:account.group.template,name:l10n_be.be_group_4
 msgid "Créances et dettes à un an au plus"
-msgstr ""
+msgstr "Créances et dettes à un an au plus"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_283
@@ -2381,41 +2373,43 @@ msgid ""
 "Créances sur des entreprises avec lesquelles il existe un lien de "
 "participation"
 msgstr ""
+"Créances sur des entreprises avec lesquelles il existe un lien de "
+"participation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_281
 #: model:account.group,name:l10n_be.2_be_group_281
 #: model:account.group.template,name:l10n_be.be_group_281
 msgid "Créances sur des entreprises liées"
-msgstr ""
+msgstr "Créances sur des entreprises liées"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_29
 #: model:account.group,name:l10n_be.2_be_group_29
 #: model:account.group.template,name:l10n_be.be_group_29
 msgid "Créances à plus d'un an"
-msgstr ""
+msgstr "Créances à plus d'un an"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_013
 #: model:account.group,name:l10n_be.2_be_group_013
 #: model:account.group.template,name:l10n_be.be_group_013
 msgid "Créanciers d'autres garanties personnelles"
-msgstr ""
+msgstr "Créanciers d'autres garanties personnelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_051
 #: model:account.group,name:l10n_be.2_be_group_051
 #: model:account.group.template,name:l10n_be.be_group_051
 msgid "Créanciers d'engagements d'acquisition"
-msgstr ""
+msgstr "Créanciers d'engagements d'acquisition"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_011
 #: model:account.group,name:l10n_be.2_be_group_011
 #: model:account.group.template,name:l10n_be.be_group_011
 msgid "Créanciers d'engagements sur effets en circulation"
-msgstr ""
+msgstr "Créanciers d'engagements sur effets en circulation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_075
@@ -2425,41 +2419,50 @@ msgid ""
 "Créanciers de biens et valeurs détenus pour compte de tiers ou à leurs "
 "risques et profits"
 msgstr ""
+"Créanciers de biens et valeurs détenus pour compte de tiers ou à leurs "
+"risques et profits"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_000
 #: model:account.group,name:l10n_be.2_be_group_000
 #: model:account.group.template,name:l10n_be.be_group_000
 msgid "Créanciers de l'entreprise, bénéficiaires de garanties de tiers"
-msgstr ""
+msgstr "Créanciers de l'entreprise, bénéficiaires de garanties de tiers"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_020
 #: model:account.group,name:l10n_be.2_be_group_020
 #: model:account.group.template,name:l10n_be.be_group_020
 msgid "Créanciers de l'entreprise, bénéficiaires de garanties réelles"
-msgstr ""
+msgstr "Créanciers de l'entreprise, bénéficiaires de garanties réelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_071
 #: model:account.group,name:l10n_be.2_be_group_071
 #: model:account.group.template,name:l10n_be.be_group_071
 msgid "Créanciers de loyers et redevances"
-msgstr ""
+msgstr "Créanciers de loyers et redevances"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_022
+#: model:account.group,name:l10n_be.2_be_group_022
+#: model:account.group.template,name:l10n_be.be_group_022
+msgid "Créanciers de tiers, bénéficiaires de garanties réelles"
+msgstr "Créanciers de tiers, bénéficiaires de garanties réelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_065
 #: model:account.group,name:l10n_be.2_be_group_065
 #: model:account.group.template,name:l10n_be.be_group_065
 msgid "Créanciers pour devises achetées à terme"
-msgstr ""
+msgstr "Créanciers pour devises achetées à terme"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_061
 #: model:account.group,name:l10n_be.2_be_group_061
 #: model:account.group.template,name:l10n_be.be_group_061
 msgid "Créanciers pour marchandises achetées à terme"
-msgstr ""
+msgstr "Créanciers pour marchandises achetées à terme"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a509
@@ -2495,21 +2498,21 @@ msgstr "Clients (POS)"
 #: model:account.group,name:l10n_be.2_be_group_532
 #: model:account.group.template,name:l10n_be.be_group_532
 msgid "D'un mois au plus"
-msgstr ""
+msgstr "D'un mois au plus"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_530
 #: model:account.group,name:l10n_be.2_be_group_530
 #: model:account.group.template,name:l10n_be.be_group_530
 msgid "De plus d'un an"
-msgstr ""
+msgstr "De plus d'un an"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_531
 #: model:account.group,name:l10n_be.2_be_group_531
 #: model:account.group.template,name:l10n_be.be_group_531
 msgid "De plus d'un mois et à un an au plus"
-msgstr ""
+msgstr "De plus d'un mois et à un an au plus"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a096
@@ -2637,28 +2640,28 @@ msgstr "Dotations aux amortissements sur immobilisations corporelles"
 #: model:account.group,name:l10n_be.2_be_group_717
 #: model:account.group.template,name:l10n_be.be_group_717
 msgid "Des commandes en cours d'exécution"
-msgstr ""
+msgstr "Des commandes en cours d'exécution"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_712
 #: model:account.group,name:l10n_be.2_be_group_712
 #: model:account.group.template,name:l10n_be.be_group_712
 msgid "Des en-cours de fabrication"
-msgstr ""
+msgstr "Des en-cours de fabrication"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_715
 #: model:account.group,name:l10n_be.2_be_group_715
 #: model:account.group.template,name:l10n_be.be_group_715
 msgid "Des immeubles construits destinés à la vente"
-msgstr ""
+msgstr "Des immeubles construits destinés à la vente"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_713
 #: model:account.group,name:l10n_be.2_be_group_713
 #: model:account.group.template,name:l10n_be.be_group_713
 msgid "Des produits finis"
-msgstr ""
+msgstr "Des produits finis"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_175
@@ -2668,49 +2671,59 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_175
 #: model:account.group.template,name:l10n_be.be_group_44
 msgid "Dettes commerciales"
-msgstr ""
+msgstr "Dettes commerciales"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_172
 #: model:account.group,name:l10n_be.2_be_group_172
 #: model:account.group.template,name:l10n_be.be_group_172
 msgid "Dettes de location-financement et dettes assimilées"
-msgstr ""
+msgstr "Dettes de location-financement et dettes assimilées"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_179
+#: model:account.group,name:l10n_be.1_be_group_48
+#: model:account.group,name:l10n_be.2_be_group_179
+#: model:account.group,name:l10n_be.2_be_group_48
+#: model:account.group.template,name:l10n_be.be_group_179
+#: model:account.group.template,name:l10n_be.be_group_48
+msgid "Dettes diverses"
+msgstr "Dettes diverses"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_47
 #: model:account.group,name:l10n_be.2_be_group_47
 #: model:account.group.template,name:l10n_be.be_group_47
 msgid "Dettes découlant de l'affectation du résultat"
-msgstr ""
+msgstr "Dettes découlant de l'affectation du résultat"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_43
 #: model:account.group,name:l10n_be.2_be_group_43
 #: model:account.group.template,name:l10n_be.be_group_43
 msgid "Dettes financières"
-msgstr ""
+msgstr "Dettes financières"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_450
 #: model:account.group,name:l10n_be.2_be_group_450
 #: model:account.group.template,name:l10n_be.be_group_450
 msgid "Dettes fiscales estimées"
-msgstr ""
+msgstr "Dettes fiscales estimées"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_45
 #: model:account.group,name:l10n_be.2_be_group_45
 #: model:account.group.template,name:l10n_be.be_group_45
 msgid "Dettes fiscales, salariales et sociales"
-msgstr ""
+msgstr "Dettes fiscales, salariales et sociales"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_17
 #: model:account.group,name:l10n_be.2_be_group_17
 #: model:account.group.template,name:l10n_be.be_group_17
 msgid "Dettes à plus d'un an"
-msgstr ""
+msgstr "Dettes à plus d'un an"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_42
@@ -2719,6 +2732,8 @@ msgstr ""
 msgid ""
 "Dettes à plus d'un an échéant dans l'année 16 (même subdivision que le 17)"
 msgstr ""
+"Dettes à plus d'un an échéant dans l'année (même subdivision que le compte "
+"17)"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a222
@@ -2732,14 +2747,14 @@ msgstr "Terrains bâtis"
 #: model:account.group,name:l10n_be.2_be_group_064
 #: model:account.group.template,name:l10n_be.be_group_064
 msgid "Devises achetées à terme - à recevoir"
-msgstr ""
+msgstr "Devises achetées à terme - à recevoir"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_067
 #: model:account.group,name:l10n_be.2_be_group_067
 #: model:account.group.template,name:l10n_be.be_group_067
 msgid "Devises vendues à terme - à livrer"
-msgstr ""
+msgstr "Devises vendues à terme - à livrer"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_654
@@ -2749,7 +2764,7 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_654
 #: model:account.group.template,name:l10n_be.be_group_754
 msgid "Différences de change"
-msgstr ""
+msgstr "Différences de change"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a472
@@ -2764,6 +2779,20 @@ msgstr "Tantièmes de l'exercice"
 #: model:account.account.template,name:l10n_be.a695
 msgid "Directors' or managers' entitlements"
 msgstr "Distribution aux administrateurs ou gérants"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a657000
+#: model:account.account,name:l10n_be.2_a657000
+#: model:account.account.template,name:l10n_be.a657000
+msgid "Discounts Given"
+msgstr "Remises accordées"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a757000
+#: model:account.account,name:l10n_be.2_a757000
+#: model:account.account.template,name:l10n_be.a757000
+msgid "Discounts Taken"
+msgstr "Remises reçues"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a608
@@ -2788,14 +2817,14 @@ msgstr "Remises, ristournes et rabais accordés"
 #: model:account.group,name:l10n_be.2_be_group_471
 #: model:account.group.template,name:l10n_be.be_group_471
 msgid "Dividendes de l'exercice"
-msgstr ""
+msgstr "Dividendes de l'exercice"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_470
 #: model:account.group,name:l10n_be.2_be_group_470
 #: model:account.group.template,name:l10n_be.be_group_470
 msgid "Dividendes et tantièmes d'exercices antérieurs"
-msgstr ""
+msgstr "Dividendes et tantièmes d'exercices antérieurs"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a694
@@ -2823,7 +2852,7 @@ msgstr "Dividendes et tantièmes d'exercices antérieurs"
 #: model:account.group,name:l10n_be.2_be_group_692
 #: model:account.group.template,name:l10n_be.be_group_692
 msgid "Dotation aux réserves"
-msgstr ""
+msgstr "Dotation aux réserves"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_630
@@ -2832,27 +2861,28 @@ msgstr ""
 msgid ""
 "Dotations aux amortissements et aux réductions de valeur sur immobilisations"
 msgstr ""
+"Dotations aux amortissements et aux réductions de valeur sur immobilisations"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_070
 #: model:account.group,name:l10n_be.2_be_group_070
 #: model:account.group.template,name:l10n_be.be_group_070
 msgid "Droits d'usage à long terme"
-msgstr ""
+msgstr "Droits d'usage à long terme"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_09
 #: model:account.group,name:l10n_be.2_be_group_09
 #: model:account.group.template,name:l10n_be.be_group_09
 msgid "Droits et engagements divers"
-msgstr ""
+msgstr "Droits et engagements divers"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_0
 #: model:account.group,name:l10n_be.2_be_group_0
 #: model:account.group.template,name:l10n_be.be_group_0
 msgid "Droits et engagements hors bilan"
-msgstr ""
+msgstr "Droits et engagements hors bilan"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a093
@@ -2866,84 +2896,84 @@ msgstr "Droits sur conditions concordataires"
 #: model:account.group,name:l10n_be.2_be_group_012
 #: model:account.group.template,name:l10n_be.be_group_012
 msgid "Débiteurs pour autres garanties personnelles"
-msgstr ""
+msgstr "Débiteurs pour autres garanties personnelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_066
 #: model:account.group,name:l10n_be.2_be_group_066
 #: model:account.group.template,name:l10n_be.be_group_066
 msgid "Débiteurs pour devises vendues à terme"
-msgstr ""
+msgstr "Débiteurs pour devises vendues à terme"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_052
 #: model:account.group,name:l10n_be.2_be_group_052
 #: model:account.group.template,name:l10n_be.be_group_052
 msgid "Débiteurs pour engagements de cession"
-msgstr ""
+msgstr "Débiteurs pour engagements de cession"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_010
 #: model:account.group,name:l10n_be.2_be_group_010
 #: model:account.group.template,name:l10n_be.be_group_010
 msgid "Débiteurs pour engagements sur effets en circulation"
-msgstr ""
+msgstr "Débiteurs pour engagements sur effets en circulation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_062
 #: model:account.group,name:l10n_be.2_be_group_062
 #: model:account.group.template,name:l10n_be.be_group_062
 msgid "Débiteurs pour marchandises vendues à terme"
-msgstr ""
+msgstr "Débiteurs pour marchandises vendues à terme"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_031
 #: model:account.group,name:l10n_be.2_be_group_031
 #: model:account.group.template,name:l10n_be.be_group_031
 msgid "Déposants statutaires"
-msgstr ""
+msgstr "Déposants statutaires"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_030
 #: model:account.group,name:l10n_be.2_be_group_030
 #: model:account.group.template,name:l10n_be.be_group_030
 msgid "Dépôts statutaires"
-msgstr ""
+msgstr "Dépôts statutaires"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_53
 #: model:account.group,name:l10n_be.2_be_group_53
 #: model:account.group.template,name:l10n_be.be_group_53
 msgid "Dépôts à terme"
-msgstr ""
+msgstr "Dépôts à terme"
 
 #. module: l10n_be
 #: model:account.fiscal.position,name:l10n_be.1_fiscal_position_template_5
 #: model:account.fiscal.position,name:l10n_be.2_fiscal_position_template_5
 #: model:account.fiscal.position.template,name:l10n_be.fiscal_position_template_5
 msgid "EU privé"
-msgstr ""
+msgstr "EU privé"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_655
 #: model:account.group,name:l10n_be.2_be_group_655
 #: model:account.group.template,name:l10n_be.be_group_655
 msgid "Ecarts de conversion des devises"
-msgstr ""
+msgstr "Ecarts de conversion des devises"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_441
 #: model:account.group,name:l10n_be.2_be_group_441
 #: model:account.group.template,name:l10n_be.be_group_441
 msgid "Effets à payer"
-msgstr ""
+msgstr "Effets à payer"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_401
 #: model:account.group,name:l10n_be.2_be_group_401
 #: model:account.group.template,name:l10n_be.be_group_401
 msgid "Effets à recevoir"
-msgstr ""
+msgstr "Effets à recevoir"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a696
@@ -2971,49 +3001,49 @@ msgstr "Primes patronales pour assurances extralégales"
 #: model:account.group,name:l10n_be.2_be_group_696
 #: model:account.group.template,name:l10n_be.be_group_696
 msgid "Employés"
-msgstr ""
+msgstr "Employés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_171
 #: model:account.group,name:l10n_be.2_be_group_171
 #: model:account.group.template,name:l10n_be.be_group_171
 msgid "Emprunts obligataires non subordonnés"
-msgstr ""
+msgstr "Emprunts obligataires non subordonnés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_170
 #: model:account.group,name:l10n_be.2_be_group_170
 #: model:account.group.template,name:l10n_be.be_group_170
 msgid "Emprunts subordonnés"
-msgstr ""
+msgstr "Emprunts subordonnés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_32
 #: model:account.group,name:l10n_be.2_be_group_32
 #: model:account.group.template,name:l10n_be.be_group_32
 msgid "En-cours de fabrication"
-msgstr ""
+msgstr "En-cours de fabrication"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_050
 #: model:account.group,name:l10n_be.2_be_group_050
 #: model:account.group.template,name:l10n_be.be_group_050
 msgid "Engagements d'acquisition"
-msgstr ""
+msgstr "Engagements d'acquisition"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_05
 #: model:account.group,name:l10n_be.2_be_group_05
 #: model:account.group.template,name:l10n_be.be_group_05
 msgid "Engagements d'acquisition et de cession d'immobilisations"
-msgstr ""
+msgstr "Engagements d'acquisition et de cession d'immobilisations"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_053
 #: model:account.group,name:l10n_be.2_be_group_053
 #: model:account.group.template,name:l10n_be.be_group_053
 msgid "Engagements de cession"
-msgstr ""
+msgstr "Engagements de cession"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a450
@@ -3037,42 +3067,42 @@ msgstr "Dettes fiscales estimées - Impôts et taxes étrangers"
 #: model:account.group.template,name:l10n_be.be_group_173
 #: model:account.group.template,name:l10n_be.be_group_55
 msgid "Etablissements de crédit"
-msgstr ""
+msgstr "Etablissements de crédit"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_432
 #: model:account.group,name:l10n_be.2_be_group_432
 #: model:account.group.template,name:l10n_be.be_group_432
 msgid "Etablissements de crédit - Crédits d'acceptation"
-msgstr ""
+msgstr "Etablissements de crédit - Crédits d'acceptation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_433
 #: model:account.group,name:l10n_be.2_be_group_433
 #: model:account.group.template,name:l10n_be.be_group_433
 msgid "Etablissements de crédit - Dettes en compte courant"
-msgstr ""
+msgstr "Etablissements de crédit - Dettes en compte courant"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_430
 #: model:account.group,name:l10n_be.2_be_group_430
 #: model:account.group.template,name:l10n_be.be_group_430
 msgid "Etablissements de crédit - Emprunts en compte à terme fixe"
-msgstr ""
+msgstr "Etablissements de crédit - Emprunts en compte à terme fixe"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_431
 #: model:account.group,name:l10n_be.2_be_group_431
 #: model:account.group.template,name:l10n_be.be_group_431
 msgid "Etablissements de crédit - Promesses"
-msgstr ""
+msgstr "Etablissements de crédit - Promesses"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_444
 #: model:account.group,name:l10n_be.2_be_group_444
 #: model:account.group.template,name:l10n_be.be_group_444
 msgid "Factures à recevoir"
-msgstr ""
+msgstr "Factures à recevoir"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a654
@@ -3173,6 +3203,7 @@ msgstr "Dépôts à terme d'un mois au plus"
 msgid ""
 "Fonds propres, provisions pour risques et charges et dettes à plus d'un an"
 msgstr ""
+"Fonds propres, provisions pour risques et charges et dettes à plus d'un an"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a496
@@ -3249,42 +3280,49 @@ msgstr "Marché à terme - Marchandises vendues (à livrer)"
 #: model:account.group,name:l10n_be.2_be_group_440
 #: model:account.group.template,name:l10n_be.be_group_440
 msgid "Fournisseurs"
-msgstr ""
+msgstr "Fournisseurs"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_201
 #: model:account.group,name:l10n_be.2_be_group_201
 #: model:account.group.template,name:l10n_be.be_group_201
 msgid "Frais d'émission d'emprunts"
-msgstr ""
+msgstr "Frais d'émission d'emprunts"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_20
 #: model:account.group,name:l10n_be.2_be_group_20
 #: model:account.group.template,name:l10n_be.be_group_20
 msgid "Frais d'établissement"
-msgstr ""
+msgstr "Frais d'établissement"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_2
 #: model:account.group,name:l10n_be.2_be_group_2
 #: model:account.group.template,name:l10n_be.be_group_2
 msgid "Frais d'établissement, actifs immobilisés et créances à plus d'un an"
-msgstr ""
+msgstr "Frais d'établissement, actifs immobilisés et créances à plus d'un an"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_200
 #: model:account.group,name:l10n_be.2_be_group_200
 #: model:account.group.template,name:l10n_be.be_group_200
 msgid "Frais de constitution et d'augmentation de capital"
-msgstr ""
+msgstr "Frais de constitution et d'augmentation de capital"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_210
 #: model:account.group,name:l10n_be.2_be_group_210
 #: model:account.group.template,name:l10n_be.be_group_210
 msgid "Frais de recherche et de développement"
-msgstr ""
+msgstr "Frais de recherche et de développement"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_204
+#: model:account.group,name:l10n_be.2_be_group_204
+#: model:account.group.template,name:l10n_be.be_group_204
+msgid "Frais de restructuration"
+msgstr "Frais de restructuration"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a24
@@ -3330,35 +3368,45 @@ msgstr "Plus-values sur réalisation de créances commerciales"
 #: model:account.group,name:l10n_be.2_be_group_00
 #: model:account.group.template,name:l10n_be.be_group_00
 msgid "Garanties constituées par des tiers pour compte de l'entreprise"
-msgstr ""
+msgstr "Garanties constituées par des tiers pour compte de l'entreprise"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_01
 #: model:account.group,name:l10n_be.2_be_group_01
 #: model:account.group.template,name:l10n_be.be_group_01
 msgid "Garanties personnelles constituées pour compte de tiers"
-msgstr ""
+msgstr "Garanties personnelles constituées pour compte de tiers"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_03
+#: model:account.group,name:l10n_be.1_be_group_032
+#: model:account.group,name:l10n_be.2_be_group_03
+#: model:account.group,name:l10n_be.2_be_group_032
+#: model:account.group.template,name:l10n_be.be_group_03
+#: model:account.group.template,name:l10n_be.be_group_032
+msgid "Garanties reçues"
+msgstr "Garanties reçues"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_023
 #: model:account.group,name:l10n_be.2_be_group_023
 #: model:account.group.template,name:l10n_be.be_group_023
 msgid "Garanties réelles constituées pour compte de tiers"
-msgstr ""
+msgstr "Garanties réelles constituées pour compte de tiers"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_021
 #: model:account.group,name:l10n_be.2_be_group_021
 #: model:account.group.template,name:l10n_be.be_group_021
 msgid "Garanties réelles constituées pour compte propre"
-msgstr ""
+msgstr "Garanties réelles constituées pour compte propre"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_02
 #: model:account.group,name:l10n_be.2_be_group_02
 #: model:account.group.template,name:l10n_be.be_group_02
 msgid "Garanties réelles constituées sur avoirs propres"
-msgstr ""
+msgstr "Garanties réelles constituées sur avoirs propres"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a733
@@ -3469,35 +3517,35 @@ msgstr "IV Dues"
 #: model:account.group,name:l10n_be.2_be_group_35
 #: model:account.group.template,name:l10n_be.be_group_35
 msgid "Immeubles destinés à la vente"
-msgstr ""
+msgstr "Immeubles destinés à la vente"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_21
 #: model:account.group,name:l10n_be.2_be_group_21
 #: model:account.group.template,name:l10n_be.be_group_21
 msgid "Immobilisation incorporelles"
-msgstr ""
+msgstr "Immobilisation incorporelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_27
 #: model:account.group,name:l10n_be.2_be_group_27
 #: model:account.group.template,name:l10n_be.be_group_27
 msgid "Immobilisations corporelles en cours et acomptes versés"
-msgstr ""
+msgstr "Immobilisations corporelles en cours et acomptes versés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_25
 #: model:account.group,name:l10n_be.2_be_group_25
 #: model:account.group.template,name:l10n_be.be_group_25
 msgid "Immobilisations détenues en location-financement et droits similaires"
-msgstr ""
+msgstr "Immobilisations détenues en location-financement et droits similaires"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_28
 #: model:account.group,name:l10n_be.2_be_group_28
 #: model:account.group.template,name:l10n_be.be_group_28
 msgid "Immobilisations financières"
-msgstr ""
+msgstr "Immobilisations financières"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a350
@@ -3518,70 +3566,70 @@ msgstr "Immeubles destinés à la vente - Réductions de valeur actées"
 #: model:account.group,name:l10n_be.2_be_group_771
 #: model:account.group.template,name:l10n_be.be_group_771
 msgid "Impôts belges sur le résultat"
-msgstr ""
+msgstr "Impôts belges sur le résultat"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_671
 #: model:account.group,name:l10n_be.2_be_group_671
 #: model:account.group.template,name:l10n_be.be_group_671
 msgid "Impôts belges sur le résultat d'exercices antérieurs"
-msgstr ""
+msgstr "Impôts belges sur le résultat d'exercices antérieurs"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_670
 #: model:account.group,name:l10n_be.2_be_group_670
 #: model:account.group.template,name:l10n_be.be_group_670
 msgid "Impôts belges sur le résultat de l'exercice"
-msgstr ""
+msgstr "Impôts belges sur le résultat de l'exercice"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_168
 #: model:account.group,name:l10n_be.2_be_group_168
 #: model:account.group.template,name:l10n_be.be_group_168
 msgid "Impôts différés"
-msgstr ""
+msgstr "Impôts différés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_412
 #: model:account.group,name:l10n_be.2_be_group_412
 #: model:account.group.template,name:l10n_be.be_group_412
 msgid "Impôts et précomptes à récupérer"
-msgstr ""
+msgstr "Impôts et précomptes à récupérer"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_452
 #: model:account.group,name:l10n_be.2_be_group_452
 #: model:account.group.template,name:l10n_be.be_group_452
 msgid "Impôts et taxes à payer"
-msgstr ""
+msgstr "Impôts et taxes à payer"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_67
 #: model:account.group,name:l10n_be.2_be_group_67
 #: model:account.group.template,name:l10n_be.be_group_67
 msgid "Impôts sur le résultat"
-msgstr ""
+msgstr "Impôts sur le résultat"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_773
 #: model:account.group,name:l10n_be.2_be_group_773
 #: model:account.group.template,name:l10n_be.be_group_773
 msgid "Impôts étrangers sur le résultat"
-msgstr ""
+msgstr "Impôts étrangers sur le résultat"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_673
 #: model:account.group,name:l10n_be.2_be_group_673
 #: model:account.group.template,name:l10n_be.be_group_673
 msgid "Impôts étrangers sur le résultat d'exercices antérieurs"
-msgstr ""
+msgstr "Impôts étrangers sur le résultat d'exercices antérieurs"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_672
 #: model:account.group,name:l10n_be.2_be_group_672
 #: model:account.group.template,name:l10n_be.be_group_672
 msgid "Impôts étrangers sur le résultat de l'exercice"
-msgstr ""
+msgstr "Impôts étrangers sur le résultat de l'exercice"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a751
@@ -3658,7 +3706,7 @@ msgstr "Augmentation (diminution) des stocks d'en-cours de fabrication"
 #: model:account.group.template,name:l10n_be.be_group_23
 #: model:account.group.template,name:l10n_be.be_group_251
 msgid "Installations, machines et outillage"
-msgstr ""
+msgstr "Installations, machines et outillage"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a213
@@ -3679,7 +3727,7 @@ msgstr "Intérêts, commissions et frais afférents aux dettes"
 #: model:account.group,name:l10n_be.2_be_group_794
 #: model:account.group.template,name:l10n_be.be_group_794
 msgid "Intervention d'associés (ou du propriétaire) dans la perte"
-msgstr ""
+msgstr "Intervention d'associés (ou du propriétaire) dans la perte"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a15
@@ -3726,12 +3774,12 @@ msgstr "Capital souscrit"
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_journal
 msgid "Journal"
-msgstr ""
+msgstr "Journal"
 
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "Pièce comptable"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a220
@@ -3816,7 +3864,7 @@ msgstr "Titres empruntés à restituer"
 #: model:account.account,name:l10n_be.2_l10nbe_chart_template_liquidity_transfer
 #: model:account.account.template,name:l10n_be.l10nbe_chart_template_liquidity_transfer
 msgid "Liquidity Transfer"
-msgstr ""
+msgstr "Transfert de liquidités"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a201
@@ -3850,8 +3898,15 @@ msgstr "Droits d’usage à long terme - Sur terrains et constructions"
 #: model:account.account,name:l10n_be.1_a690
 #: model:account.account,name:l10n_be.2_a690
 #: model:account.account.template,name:l10n_be.a690
-msgid "Loss brought forward"
+msgid "Loss brought forward from previous year"
 msgstr "Perte reportée de l'exercice précédent"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a141
+#: model:account.account,name:l10n_be.2_a141
+#: model:account.account.template,name:l10n_be.a141
+msgid "Loss carried forward"
+msgstr "Perte reportée"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a641
@@ -3886,28 +3941,28 @@ msgstr "Perte à reporter"
 #: model:account.group,name:l10n_be.2_be_group_34
 #: model:account.group.template,name:l10n_be.be_group_34
 msgid "Marchandises"
-msgstr ""
+msgstr "Marchandises"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_060
 #: model:account.group,name:l10n_be.2_be_group_060
 #: model:account.group.template,name:l10n_be.be_group_060
 msgid "Marchandises achetées à terme - à recevoir"
-msgstr ""
+msgstr "Marchandises achetées à terme - à recevoir"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_063
 #: model:account.group,name:l10n_be.2_be_group_063
 #: model:account.group.template,name:l10n_be.be_group_063
 msgid "Marchandises vendues à terme - à livrer"
-msgstr ""
+msgstr "Marchandises vendues à terme - à livrer"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_06
 #: model:account.group,name:l10n_be.2_be_group_06
 #: model:account.group.template,name:l10n_be.be_group_06
 msgid "Marchés à terme"
-msgstr ""
+msgstr "Marchés à terme"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a429
@@ -3999,42 +4054,42 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_24
 #: model:account.group.template,name:l10n_be.be_group_252
 msgid "Mobilier et matériel roulant"
-msgstr ""
+msgstr "Mobilier et matériel roulant"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_652
 #: model:account.group,name:l10n_be.2_be_group_652
 #: model:account.group.template,name:l10n_be.be_group_652
 msgid "Moins-values sur réalisation d'actifs circulants"
-msgstr ""
+msgstr "Moins-values sur réalisation d'actifs circulants"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_663
 #: model:account.group,name:l10n_be.2_be_group_663
 #: model:account.group.template,name:l10n_be.be_group_663
 msgid "Moins-values sur réalisation d'actifs immobilisés"
-msgstr ""
+msgstr "Moins-values sur réalisation d'actifs immobilisés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_641
 #: model:account.group,name:l10n_be.2_be_group_641
 #: model:account.group.template,name:l10n_be.be_group_641
 msgid "Moins-values sur réalisations courantes d'immobilisations corporelles"
-msgstr ""
+msgstr "Moins-values sur réalisations courantes d'immobilisations corporelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_642
 #: model:account.group,name:l10n_be.2_be_group_642
 #: model:account.group.template,name:l10n_be.be_group_642
 msgid "Moins-values sur réalisations de créances commerciales"
-msgstr ""
+msgstr "Moins-values sur réalisations de créances commerciales"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_511
 #: model:account.group,name:l10n_be.2_be_group_511
 #: model:account.group.template,name:l10n_be.be_group_511
 msgid "Montants non appelés (-)"
-msgstr ""
+msgstr "Montants non appelés (-)"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a64012
@@ -4120,21 +4175,21 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_480
 #: model:account.group.template,name:l10n_be.be_group_480
 msgid "Obligations et coupons échus"
-msgstr ""
+msgstr "Obligations et coupons échus"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_56
 #: model:account.group,name:l10n_be.2_be_group_56
 #: model:account.group.template,name:l10n_be.be_group_56
 msgid "Office des chèques postaux"
-msgstr ""
+msgstr "Office des chèques postaux"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_454
 #: model:account.group,name:l10n_be.2_be_group_454
 #: model:account.group.template,name:l10n_be.be_group_454
 msgid "Office national de la sécurité sociale"
-msgstr ""
+msgstr "Office national de la Sécurité sociale"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a094
@@ -4187,16 +4242,16 @@ msgid "Operating subsidies and compensatory amounts"
 msgstr "Subsides d'exploitation et montants compensatoires"
 
 #. module: l10n_be
+#: model:account.report.line,name:l10n_be.tax_report_title_operations
+msgid "Operations"
+msgstr "Opérations"
+
+#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a099
 #: model:account.account,name:l10n_be.2_a099
 #: model:account.account.template,name:l10n_be.a099
 msgid "Options (buy or sell) on securities issued."
 msgstr "Options (d’achat ou de vente) sur titres émis."
-
-#. module: l10n_be
-#: model:account.report.line,name:l10n_be.tax_report_title_operations
-msgid "Operations"
-msgstr "Opérations"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a668
@@ -4613,20 +4668,22 @@ msgid ""
 "Participations dans des entreprises avec lesquelles il existe un lien de "
 "participation"
 msgstr ""
+"Participations dans des entreprises avec lesquelles il existe un lien de "
+"participation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_280
 #: model:account.group,name:l10n_be.2_be_group_280
 #: model:account.group.template,name:l10n_be.be_group_280
 msgid "Participations dans des entreprises liées"
-msgstr ""
+msgstr "Participations dans des entreprises liées"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_624
 #: model:account.group,name:l10n_be.2_be_group_624
 #: model:account.group.template,name:l10n_be.be_group_624
 msgid "Pensions de retraite et de survie"
-msgstr ""
+msgstr "Pensions de retraite et de survie"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_617
@@ -4635,20 +4692,21 @@ msgstr ""
 msgid ""
 "Personnel intérimaire et personnes mises à la disposition de l'entreprise"
 msgstr ""
+"Personnel intérimaire et personnes mises à la disposition de l'entreprise"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_690
 #: model:account.group,name:l10n_be.2_be_group_690
 #: model:account.group.template,name:l10n_be.be_group_690
 msgid "Perte reportée de l'exercice précédent"
-msgstr ""
+msgstr "Perte reportée de l'exercice précédent"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_793
 #: model:account.group,name:l10n_be.2_be_group_793
 #: model:account.group.template,name:l10n_be.be_group_793
 msgid "Perte à reporter"
-msgstr ""
+msgstr "Perte à reporter"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_5101
@@ -4658,14 +4716,14 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_5101
 #: model:account.group.template,name:l10n_be.be_group_5191
 msgid "Placements de trésorerie autres que placements à revenu fixe"
-msgstr ""
+msgstr "Placements de trésorerie autres que placements à revenu fixe"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_5
 #: model:account.group,name:l10n_be.2_be_group_5
 #: model:account.group.template,name:l10n_be.be_group_5
 msgid "Placements de trésorerie et valeurs disponibles"
-msgstr ""
+msgstr "Placements de trésorerie et valeurs disponibles"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a23
@@ -4690,77 +4748,77 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_12
 #: model:account.group.template,name:l10n_be.be_group_12
 msgid "Plus-values de réévaluation"
-msgstr ""
+msgstr "Plus-values de réévaluation"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_121
 #: model:account.group,name:l10n_be.2_be_group_121
 #: model:account.group.template,name:l10n_be.be_group_121
 msgid "Plus-values de réévaluation sur immobilisations corporelles"
-msgstr ""
+msgstr "Plus-values de réévaluation sur immobilisations corporelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_122
 #: model:account.group,name:l10n_be.2_be_group_122
 #: model:account.group.template,name:l10n_be.be_group_122
 msgid "Plus-values de réévaluation sur immobilisations financières"
-msgstr ""
+msgstr "Plus-values de réévaluation sur immobilisations financières"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_120
 #: model:account.group,name:l10n_be.2_be_group_120
 #: model:account.group.template,name:l10n_be.be_group_120
 msgid "Plus-values de réévaluation sur immobilisations incorporelles"
-msgstr ""
+msgstr "Plus-values de réévaluation sur immobilisations incorporelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_123
 #: model:account.group,name:l10n_be.2_be_group_123
 #: model:account.group.template,name:l10n_be.be_group_123
 msgid "Plus-values de réévaluation sur stocks"
-msgstr ""
+msgstr "Plus-values de réévaluation sur stocks"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_752
 #: model:account.group,name:l10n_be.2_be_group_752
 #: model:account.group.template,name:l10n_be.be_group_752
 msgid "Plus-values sur réalisation d'actifs circulants"
-msgstr ""
+msgstr "Plus-values sur réalisation d'actifs circulants"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_763
 #: model:account.group,name:l10n_be.2_be_group_763
 #: model:account.group.template,name:l10n_be.be_group_763
 msgid "Plus-values sur réalisation d'actifs immobilisés"
-msgstr ""
+msgstr "Plus-values sur réalisation d'actifs immobilisés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_742
 #: model:account.group,name:l10n_be.2_be_group_742
 #: model:account.group.template,name:l10n_be.be_group_742
 msgid "Plus-values sur réalisation de créances commerciales"
-msgstr ""
+msgstr "Plus-values sur réalisation de créances commerciales"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_741
 #: model:account.group,name:l10n_be.2_be_group_741
 #: model:account.group.template,name:l10n_be.be_group_741
 msgid "Plus-values sur réalisations courantes d'immobilisations corporelles"
-msgstr ""
+msgstr "Plus-values sur réalisations courantes d'immobilisations corporelles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_11
 #: model:account.group,name:l10n_be.2_be_group_11
 #: model:account.group.template,name:l10n_be.be_group_11
 msgid "Primes d'émission"
-msgstr ""
+msgstr "Primes d'émission"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_622
 #: model:account.group,name:l10n_be.2_be_group_622
 #: model:account.group.template,name:l10n_be.be_group_622
 msgid "Primes patronales pour assurances extra-légales"
-msgstr ""
+msgstr "Primes patronales pour assurances extra-légales"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a073
@@ -4774,63 +4832,63 @@ msgstr "Commettants et déposants de biens et de valeurs"
 #: model:account.group,name:l10n_be.2_be_group_72
 #: model:account.group.template,name:l10n_be.be_group_72
 msgid "Production immobilisée"
-msgstr ""
+msgstr "Production immobilisée"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_7
 #: model:account.group,name:l10n_be.2_be_group_7
 #: model:account.group.template,name:l10n_be.be_group_7
 msgid "Produits"
-msgstr ""
+msgstr "Produits"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_491
 #: model:account.group,name:l10n_be.2_be_group_491
 #: model:account.group.template,name:l10n_be.be_group_491
 msgid "Produits acquis"
-msgstr ""
+msgstr "Produits acquis"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_743
 #: model:account.group,name:l10n_be.2_be_group_743
 #: model:account.group.template,name:l10n_be.be_group_743
 msgid "Produits d'exploitation divers"
-msgstr ""
+msgstr "Produits d'exploitation divers"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_76
 #: model:account.group,name:l10n_be.2_be_group_76
 #: model:account.group.template,name:l10n_be.be_group_76
 msgid "Produits d'exploitation ou financiers non récurrents"
-msgstr ""
+msgstr "Produits d'exploitation ou financiers non récurrents"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_751
 #: model:account.group,name:l10n_be.2_be_group_751
 #: model:account.group.template,name:l10n_be.be_group_751
 msgid "Produits des actifs circulants"
-msgstr ""
+msgstr "Produits des actifs circulants"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_750
 #: model:account.group,name:l10n_be.2_be_group_750
 #: model:account.group.template,name:l10n_be.be_group_750
 msgid "Produits des immobilisations financières"
-msgstr ""
+msgstr "Produits des immobilisations financières"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_75
 #: model:account.group,name:l10n_be.2_be_group_75
 #: model:account.group.template,name:l10n_be.be_group_75
 msgid "Produits financiers"
-msgstr ""
+msgstr "Produits financiers"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_756
 #: model:account.group,name:l10n_be.2_be_group_756
 #: model:account.group.template,name:l10n_be.be_group_756
 msgid "Produits financiers divers"
-msgstr ""
+msgstr "Produits financiers divers"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_33
@@ -4840,7 +4898,7 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_33
 #: model:account.group.template,name:l10n_be.be_group_330
 msgid "Produits finis"
-msgstr ""
+msgstr "Produits finis"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_404
@@ -4850,21 +4908,28 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_404
 #: model:account.group.template,name:l10n_be.be_group_414
 msgid "Produits à recevoir"
-msgstr ""
+msgstr "Produits à recevoir"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_493
 #: model:account.group,name:l10n_be.2_be_group_493
 #: model:account.group.template,name:l10n_be.be_group_493
 msgid "Produits à reporter"
-msgstr ""
+msgstr "Produits à reporter"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a790
 #: model:account.account,name:l10n_be.2_a790
 #: model:account.account.template,name:l10n_be.a790
-msgid "Profit brought forward"
+msgid "Profit brought forward from previous year"
 msgstr "Bénéfice reporté de l'exercice précédent"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a140
+#: model:account.account,name:l10n_be.2_a140
+#: model:account.account.template,name:l10n_be.a140
+msgid "Profit carried forward"
+msgstr "Bénéfice reporté"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a693
@@ -4894,7 +4959,7 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_16
 #: model:account.group.template,name:l10n_be.be_group_16
 msgid "Provisions et impôts différés"
-msgstr ""
+msgstr "Provisions et impôts différés"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a163
@@ -5027,11 +5092,21 @@ msgid "Provisions of a financial nature - Uses and write-backs"
 msgstr "Provisions à caractère financier - Utilisations et reprises"
 
 #. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_164
+#: model:account.group,name:l10n_be.1_be_group_638
+#: model:account.group,name:l10n_be.2_be_group_164
+#: model:account.group,name:l10n_be.2_be_group_638
+#: model:account.group.template,name:l10n_be.be_group_164
+#: model:account.group.template,name:l10n_be.be_group_638
+msgid "Provisions pour autres risques et charges"
+msgstr "Provisions pour autres risques et charges"
+
+#. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_161
 #: model:account.group,name:l10n_be.2_be_group_161
 #: model:account.group.template,name:l10n_be.be_group_161
 msgid "Provisions pour charges fiscales"
-msgstr ""
+msgstr "Provisions pour charges fiscales"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_162
@@ -5041,56 +5116,83 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_162
 #: model:account.group.template,name:l10n_be.be_group_636
 msgid "Provisions pour grosses réparations et gros entretien"
-msgstr ""
+msgstr "Provisions pour grosses réparations et gros entretien"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_163
+#: model:account.group,name:l10n_be.1_be_group_637
+#: model:account.group,name:l10n_be.2_be_group_163
+#: model:account.group,name:l10n_be.2_be_group_637
+#: model:account.group.template,name:l10n_be.be_group_163
+#: model:account.group.template,name:l10n_be.be_group_637
+msgid "Provisions pour obligations environnementales"
+msgstr "Provisions pour obligations environnementales"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_160
+#: model:account.group,name:l10n_be.1_be_group_635
+#: model:account.group,name:l10n_be.2_be_group_160
+#: model:account.group,name:l10n_be.2_be_group_635
+#: model:account.group.template,name:l10n_be.be_group_160
+#: model:account.group.template,name:l10n_be.be_group_635
+msgid "Provisions pour pensions et obligations similaires"
+msgstr "Provisions pour pensions et obligations similaires"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_662
+#: model:account.group,name:l10n_be.2_be_group_662
+#: model:account.group.template,name:l10n_be.be_group_662
+msgid "Provisions pour risques et charges non récurrents"
+msgstr "Provisions pour risques et charges non récurrents"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_656
 #: model:account.group,name:l10n_be.2_be_group_656
 #: model:account.group.template,name:l10n_be.be_group_656
 msgid "Provisions à caractère financier"
-msgstr ""
+msgstr "Provisions à caractère financier"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_453
 #: model:account.group,name:l10n_be.2_be_group_453
 #: model:account.group.template,name:l10n_be.be_group_453
 msgid "Précomptes retenus"
-msgstr ""
+msgstr "Précomptes retenus"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_791
 #: model:account.group,name:l10n_be.2_be_group_791
 #: model:account.group.template,name:l10n_be.be_group_791
 msgid "Prélèvement sur le capital et les primes d'émission"
-msgstr ""
+msgstr "Prélèvement sur le capital et les primes d'émission"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_792
 #: model:account.group,name:l10n_be.2_be_group_792
 #: model:account.group.template,name:l10n_be.be_group_792
 msgid "Prélèvement sur les réserves"
-msgstr ""
+msgstr "Prélèvement sur les réserves"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_780
 #: model:account.group,name:l10n_be.2_be_group_780
 #: model:account.group.template,name:l10n_be.be_group_780
 msgid "Prélèvements sur les impôts différés"
-msgstr ""
+msgstr "Prélèvements sur les impôts différés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_789
 #: model:account.group,name:l10n_be.2_be_group_789
 #: model:account.group.template,name:l10n_be.be_group_789
 msgid "Prélèvements sur les réserves immunisées"
-msgstr ""
+msgstr "Prélèvements sur les réserves immunisées"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_78
 #: model:account.group,name:l10n_be.2_be_group_78
 #: model:account.group.template,name:l10n_be.be_group_78
 msgid "Prélèvements sur les réserves immunisées et les impôts différés"
-msgstr ""
+msgstr "Prélèvements sur les réserves immunisées et les impôts différés"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a601
@@ -5132,7 +5234,7 @@ msgstr "Achats de services, travaux et études"
 #: model:account.group,name:l10n_be.2_be_group_456
 #: model:account.group.template,name:l10n_be.be_group_456
 msgid "Pécules de vacances"
-msgstr ""
+msgstr "Pécules de vacances"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a300
@@ -5160,14 +5262,14 @@ msgstr "Garanties réelles constituées pour compte de tiers"
 #: model:account.group,name:l10n_be.2_be_group_708
 #: model:account.group.template,name:l10n_be.be_group_708
 msgid "Remises, ristournes et rabais accordés (–)"
-msgstr ""
+msgstr "Remises, ristournes et rabais accordés (–)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_608
 #: model:account.group,name:l10n_be.2_be_group_608
 #: model:account.group.template,name:l10n_be.be_group_608
 msgid "Remises, ristournes et rabais obtenus (–)"
-msgstr ""
+msgstr "Remises, ristournes et rabais obtenus (–)"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6200
@@ -5259,28 +5361,28 @@ msgstr "Créanciers de loyers et redevances"
 #: model:account.group,name:l10n_be.2_be_group_760
 #: model:account.group.template,name:l10n_be.be_group_760
 msgid "Reprises d'amortissements et de réductions de valeur"
-msgstr ""
+msgstr "Reprises d'amortissements et de réductions de valeur"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_762
 #: model:account.group,name:l10n_be.2_be_group_762
 #: model:account.group.template,name:l10n_be.be_group_762
 msgid "Reprises de provisions pour risques et charges non récurrents"
-msgstr ""
+msgstr "Reprises de provisions pour risques et charges non récurrents"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_761
 #: model:account.group,name:l10n_be.2_be_group_761
 #: model:account.group.template,name:l10n_be.be_group_761
 msgid "Reprises de réductions de valeur sur immobilisations financières"
-msgstr ""
+msgstr "Reprises de réductions de valeur sur immobilisations financières"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_124
 #: model:account.group,name:l10n_be.2_be_group_124
 #: model:account.group.template,name:l10n_be.be_group_124
 msgid "Reprises de réductions de valeur sur placements de trésorerie"
-msgstr ""
+msgstr "Reprises de réductions de valeur sur placements de trésorerie"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a210
@@ -5357,7 +5459,7 @@ msgstr "Droits sur garanties techniques"
 #: model:account.group,name:l10n_be.2_be_group_519
 #: model:account.group.template,name:l10n_be.be_group_519
 msgid "Réductions de valeur actées (-)"
-msgstr ""
+msgstr "Réductions de valeur actées (-)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_309
@@ -5397,49 +5499,49 @@ msgstr ""
 #: model:account.group.template,name:l10n_be.be_group_529
 #: model:account.group.template,name:l10n_be.be_group_539
 msgid "Réductions de valeur actées (–)"
-msgstr ""
+msgstr "Réductions de valeur actées (–)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_651
 #: model:account.group,name:l10n_be.2_be_group_651
 #: model:account.group.template,name:l10n_be.be_group_651
 msgid "Réductions de valeur sur actifs circulants"
-msgstr ""
+msgstr "Réductions de valeur sur actifs circulants"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_632
 #: model:account.group,name:l10n_be.2_be_group_632
 #: model:account.group.template,name:l10n_be.be_group_632
 msgid "Réductions de valeur sur commandes en cours"
-msgstr ""
+msgstr "Réductions de valeur sur commandes en cours"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_633
 #: model:account.group,name:l10n_be.2_be_group_633
 #: model:account.group.template,name:l10n_be.be_group_633
 msgid "Réductions de valeur sur créances commerciales à plus d'un an"
-msgstr ""
+msgstr "Réductions de valeur sur créances commerciales à plus d'un an"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_634
 #: model:account.group,name:l10n_be.2_be_group_634
 #: model:account.group.template,name:l10n_be.be_group_634
 msgid "Réductions de valeur sur créances commerciales à un an au plus"
-msgstr ""
+msgstr "Réductions de valeur sur créances commerciales à un an au plus"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_661
 #: model:account.group,name:l10n_be.2_be_group_661
 #: model:account.group.template,name:l10n_be.be_group_661
 msgid "Réductions de valeur sur immobilisations financières (dotations)"
-msgstr ""
+msgstr "Réductions de valeur sur immobilisations financières (dotations)"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_631
 #: model:account.group,name:l10n_be.2_be_group_631
 #: model:account.group.template,name:l10n_be.be_group_631
 msgid "Réductions de valeur sur stocks"
-msgstr ""
+msgstr "Réductions de valeur sur stocks"
 
 #. module: l10n_be
 #: model:account.fiscal.position,name:l10n_be.1_fiscal_position_template_4
@@ -5474,21 +5576,35 @@ msgstr "Régime National"
 #: model:account.group,name:l10n_be.2_be_group_77
 #: model:account.group.template,name:l10n_be.be_group_77
 msgid "Régularisations d'impôts et reprises de provisions fiscales"
-msgstr ""
+msgstr "Régularisations d'impôts et reprises de provisions fiscales"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_694
 #: model:account.group,name:l10n_be.2_be_group_694
 #: model:account.group.template,name:l10n_be.be_group_694
 msgid "Rémunération du capital"
-msgstr ""
+msgstr "Rémunération du capital"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_455
+#: model:account.group,name:l10n_be.2_be_group_455
+#: model:account.group.template,name:l10n_be.be_group_455
+msgid "Rémunérations"
+msgstr "Rémunérations"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_620
 #: model:account.group,name:l10n_be.2_be_group_620
 #: model:account.group.template,name:l10n_be.be_group_620
 msgid "Rémunérations et avantages sociaux directs"
-msgstr ""
+msgstr "Rémunérations et avantages sociaux directs"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_62
+#: model:account.group,name:l10n_be.2_be_group_62
+#: model:account.group.template,name:l10n_be.be_group_62
+msgid "Rémunérations, charges sociales et pensions"
+msgstr "Rémunérations, charges sociales et pensions"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_618
@@ -5499,41 +5615,44 @@ msgid ""
 "de survie des administrateurs, gérants et associés actifs qui ne sont pas "
 "attribuées en vertu d'un contrat de travail"
 msgstr ""
+"Rémunérations, primes pour assurances extralégales, pensions de retraite et "
+"de survie des administrateurs, gérants et associés actifs qui ne sont pas "
+"attribuées en vertu d'un contrat de travail"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_130
 #: model:account.group,name:l10n_be.2_be_group_130
 #: model:account.group.template,name:l10n_be.be_group_130
 msgid "Réserve légale"
-msgstr ""
+msgstr "Réserve légale"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_13
 #: model:account.group,name:l10n_be.2_be_group_13
 #: model:account.group.template,name:l10n_be.be_group_13
 msgid "Réserves"
-msgstr ""
+msgstr "Réserves"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_133
 #: model:account.group,name:l10n_be.2_be_group_133
 #: model:account.group.template,name:l10n_be.be_group_133
 msgid "Réserves disponibles"
-msgstr ""
+msgstr "Réserves disponibles"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_132
 #: model:account.group,name:l10n_be.2_be_group_132
 #: model:account.group.template,name:l10n_be.be_group_132
 msgid "Réserves immunisées"
-msgstr ""
+msgstr "Réserves immunisées"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_131
 #: model:account.group,name:l10n_be.2_be_group_131
 #: model:account.group.template,name:l10n_be.be_group_131
 msgid "Réserves indisponibles"
-msgstr ""
+msgstr "Réserves indisponibles"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a053
@@ -5589,6 +5708,13 @@ msgstr "Ventes dans l’UE (marchandises)"
 #: model:account.account,name:l10n_be.2_a61
 #: model:account.account.template,name:l10n_be.a61
 msgid "Services and other goods"
+msgstr "Services et biens divers"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_61
+#: model:account.group,name:l10n_be.2_be_group_61
+#: model:account.group.template,name:l10n_be.be_group_61
+msgid "Services et biens divers"
 msgstr "Services et biens divers"
 
 #. module: l10n_be
@@ -5657,7 +5783,7 @@ msgstr ""
 #: model:account.group,name:l10n_be.2_be_group_603
 #: model:account.group.template,name:l10n_be.be_group_603
 msgid "Sous-traitances générales"
-msgstr ""
+msgstr "Sous-traitances générales"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a031
@@ -5678,7 +5804,7 @@ msgstr "Dépôts statutaires"
 #: model:account.group,name:l10n_be.2_be_group_3
 #: model:account.group.template,name:l10n_be.be_group_3
 msgid "Stocks et commandes en cours d'exécution"
-msgstr ""
+msgstr "Stocks et commandes en cours d'exécution"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a603
@@ -5730,14 +5856,21 @@ msgstr "Emprunts subordonnés à plus d'un an - Non convertibles"
 #: model:account.group,name:l10n_be.2_be_group_740
 #: model:account.group.template,name:l10n_be.be_group_740
 msgid "Subsides d'exploitation et montants compensatoires"
-msgstr ""
+msgstr "Subsides d'exploitation et montants compensatoires"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_15
+#: model:account.group,name:l10n_be.2_be_group_15
+#: model:account.group.template,name:l10n_be.be_group_15
+msgid "Subsides en capital"
+msgstr "Subsides en capital"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_753
 #: model:account.group,name:l10n_be.2_be_group_753
 #: model:account.group.template,name:l10n_be.be_group_753
 msgid "Subsides en capital et en intérêts"
-msgstr ""
+msgstr "Subsides en capital et en intérêts"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1750
@@ -5765,303 +5898,34 @@ msgstr "Compte d'attente"
 #: model:account.group,name:l10n_be.2_be_group_451
 #: model:account.group.template,name:l10n_be.be_group_451
 msgid "T.V.A. à payer"
-msgstr ""
+msgstr "TVA à payer"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_411
 #: model:account.group,name:l10n_be.2_be_group_411
 #: model:account.group.template,name:l10n_be.be_group_411
 msgid "T.V.A. à récupérer"
-msgstr ""
+msgstr "TVA à récupérer"
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_0
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-S
 msgid "TVA 0%"
 msgstr "TVA 0%"
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-CC
-msgid "TVA 0% Cocont."
-msgstr "TVA 0% Cocont."
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-T
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-T
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-T
-msgid "TVA 0% EU"
-msgstr "TVA 0% EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-ROW
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-ROW
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-ROW
-msgid "TVA 0% Non EU"
-msgstr "TVA 0% Non EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_12
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-S
 msgid "TVA 12%"
 msgstr "TVA 12%"
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-CC
-msgid "TVA 12% Cocont."
-msgstr "TVA 12% Cocont."
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-EU
-msgid "TVA 12% EU"
-msgstr "TVA 12% EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-ROW-CC
-msgid "TVA 12% Non EU"
-msgstr "TVA 12% Non EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_21
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-S
 msgid "TVA 21%"
 msgstr "TVA 21%"
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-CC
-msgid "TVA 21% Cocont."
-msgstr "TVA 21% Cocont."
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-EU
-msgid "TVA 21% EU"
-msgstr "TVA 21% EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-ROW-CC
-msgid "TVA 21% Non EU"
-msgstr "TVA 21% Non EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_TVA-21-inclus-dans-prix
-#: model:account.tax,description:l10n_be.2_attn_TVA-21-inclus-dans-prix
-#: model:account.tax.template,description:l10n_be.attn_TVA-21-inclus-dans-prix
-msgid "TVA 21% TTC"
-msgstr "TVA 21% TTC"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-CAR-EXC
-msgid "TVA 50% Non Déductible - Frais de voiture (Prix Excl.)"
-msgstr "TVA 50% Non Déductible - Frais de voiture (Prix Excl.)"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-06-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-06-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-06-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-06-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_6
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-06-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-06-S
 msgid "TVA 6%"
 msgstr "TVA 6%"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-CC
-msgid "TVA 6% Cocont."
-msgstr "TVA 6% Cocont."
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-EU
-msgid "TVA 6% EU"
-msgstr "TVA 6% EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-ROW-CC
-msgid "TVA 6% Non EU"
-msgstr "TVA 6% Non EU"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a27
@@ -6075,7 +5939,7 @@ msgstr "Immobilisations corporelles en cours et acomptes versés"
 #: model:account.group,name:l10n_be.2_be_group_472
 #: model:account.group.template,name:l10n_be.be_group_472
 msgid "Tantièmes de l'exercice"
-msgstr ""
+msgstr "Tantièmes de l'exercice"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_taxes
@@ -6129,28 +5993,28 @@ msgstr "Précomptes retenus"
 #: model:account.group,name:l10n_be.2_be_group_220
 #: model:account.group.template,name:l10n_be.be_group_220
 msgid "Terrains"
-msgstr ""
+msgstr "Terrains"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_222
 #: model:account.group,name:l10n_be.2_be_group_222
 #: model:account.group.template,name:l10n_be.be_group_222
 msgid "Terrains bâtis"
-msgstr ""
+msgstr "Terrains bâtis"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_250
 #: model:account.group,name:l10n_be.2_be_group_250
 #: model:account.group.template,name:l10n_be.be_group_250
 msgid "Terrains et construction"
-msgstr ""
+msgstr "Terrains et constructions"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_22
 #: model:account.group,name:l10n_be.2_be_group_22
 #: model:account.group.template,name:l10n_be.be_group_22
 msgid "Terrains et constructions"
-msgstr ""
+msgstr "Terrains et constructions"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a040
@@ -6175,7 +6039,7 @@ msgstr "Tiers constituants de garanties pour compte de l’entreprise"
 #: model:account.group,name:l10n_be.2_be_group_001
 #: model:account.group.template,name:l10n_be.be_group_001
 msgid "Tiers constituants de garanties pour compte de l'entreprise"
-msgstr ""
+msgstr "Tiers constituants de garanties pour compte de l'entreprise"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_040
@@ -6185,13 +6049,15 @@ msgid ""
 "Tiers, détenteurs en leur nom mais aux risques et profits de l'entreprise de "
 "biens et de valeurs"
 msgstr ""
+"Tiers, détenteurs en leur nom mais aux risques et profits de l'entreprise de "
+"biens et de valeurs"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_52
 #: model:account.group,name:l10n_be.2_be_group_52
 #: model:account.group.template,name:l10n_be.be_group_52
 msgid "Titres à revenu fixe"
-msgstr ""
+msgstr "Titres à revenu fixe"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2906
@@ -6303,14 +6169,21 @@ msgstr "Transfert aux réserves immunisées"
 #: model:account.group,name:l10n_be.2_be_group_680
 #: model:account.group.template,name:l10n_be.be_group_680
 msgid "Transferts aux impôts différés"
-msgstr ""
+msgstr "Transferts aux impôts différés"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_68
 #: model:account.group,name:l10n_be.2_be_group_68
 #: model:account.group.template,name:l10n_be.be_group_68
 msgid "Transferts aux impôts différés et aux réserves immunisées"
-msgstr ""
+msgstr "Transferts aux impôts différés et aux réserves immunisées"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_689
+#: model:account.group,name:l10n_be.2_be_group_689
+#: model:account.group.template,name:l10n_be.be_group_689
+msgid "Transferts aux réserves immunisées"
+msgstr "Transferts aux réserves immunisées"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a101
@@ -6492,35 +6365,42 @@ msgstr "VI Soldes"
 #: model:account.group.template,name:l10n_be.be_group_510
 #: model:account.group.template,name:l10n_be.be_group_520
 msgid "Valeur d'acquisition"
-msgstr ""
+msgstr "Valeur d'acquisition"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_54
 #: model:account.group,name:l10n_be.2_be_group_54
 #: model:account.group.template,name:l10n_be.be_group_54
 msgid "Valeurs échues à l'encaissement"
-msgstr ""
+msgstr "Valeurs échues à l'encaissement"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_71
 #: model:account.group,name:l10n_be.2_be_group_71
 #: model:account.group.template,name:l10n_be.be_group_71
 msgid "Variation des stocks et des commandes en cours d'exécution"
-msgstr ""
+msgstr "Variation des stocks et des commandes en cours d'exécution"
+
+#. module: l10n_be
+#: model:account.group,name:l10n_be.1_be_group_609
+#: model:account.group,name:l10n_be.2_be_group_609
+#: model:account.group.template,name:l10n_be.be_group_609
+msgid "Variations des stocks"
+msgstr "Variations des stocks"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_700
 #: model:account.group,name:l10n_be.2_be_group_700
 #: model:account.group.template,name:l10n_be.be_group_700
 msgid "Ventes et prestations de services"
-msgstr ""
+msgstr "Ventes et prestations de services"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_58
 #: model:account.group,name:l10n_be.2_be_group_58
 #: model:account.group.template,name:l10n_be.be_group_58
 msgid "Virements internes"
-msgstr ""
+msgstr "Virements internes"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a792
@@ -6601,10 +6481,12 @@ msgid ""
 "You can choose different models for each type of reference. The default one "
 "is the Odoo reference."
 msgstr ""
+"Vous pouvez choisir différents modèles par type de référence. Le modèle par "
+"défaut est la référence Odoo."
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_755
 #: model:account.group,name:l10n_be.2_be_group_755
 #: model:account.group.template,name:l10n_be.be_group_755
 msgid "Écart de conversion des devises"
-msgstr ""
+msgstr "Écart de conversion des devises"

--- a/addons/l10n_be/i18n/l10n_be.pot
+++ b/addons/l10n_be/i18n/l10n_be.pot
@@ -4,7 +4,7 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server saas~15.2\n"
+"Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2022-04-11 08:16+0000\n"
 "PO-Revision-Date: 2022-04-11 08:16+0000\n"
@@ -16,365 +16,491 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00
-msgid "0% Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-G
-msgid "0% Biens divers"
-msgstr ""
-
-#. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-00-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-CC
 msgid "0% Cocont."
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-CC
-msgid "0% Cocont. - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-CC
-msgid "0% Cocont. M."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-CC
-msgid "0% Cocont. S."
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-EU-G
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-00-EU-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-G
+msgid "0% EU G"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-EU
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-00-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-EU
-msgid "0% EU - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-EU-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-G
-msgid "0% EU - Biens divers"
+msgid "0% EU IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-EU
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-EU-L
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-00-EU
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-00-EU-L
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-L
-msgid "0% EU M."
+msgid "0% EU M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-EU-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-EU-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-00-EU-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-00-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-S
-msgid "0% EU S."
+msgid "0% EU S"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-EU-T
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-00-EU-T
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-T
-msgid "0% EU T."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00
-msgid "0% M."
+msgid "0% EU T"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-ROW
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-00-ROW
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-ROW
-msgid "0% Non EU"
+msgid "0% EX"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-ROW-CC
-msgid "0% Non EU - Biens d'investissement"
+msgid "0% EX IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-ROW-CC
-msgid "0% Non EU M."
+msgid "0% EX M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-ROW-CC
-msgid "0% Non EU S."
+msgid "0% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-G
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-00-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-G
+msgid "0% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-00
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00
+msgid "0% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-CC
+msgid "0% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-00
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00
+msgid "0% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-CC
+msgid "0% M.Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-00-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-00-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-S
-msgid "0% S."
+msgid "0% S"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_00
-msgid "00"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-CC
+msgid "0% S.Cocont"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_00_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_00
 msgid "00 - Operations subject to a special regulation"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_01
-msgid "01"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_01_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_01
 msgid "01 - Operations subject to 6% VAT"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_02
-msgid "02"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_02_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_02
 msgid "02 - Operations subject to 12% VAT"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_03
-msgid "03"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_03_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_03
 msgid "03 - Operations subject to 21% VAT"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-L
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-S
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V81-12
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V81-12-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V81-12-EU
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-12-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-12-G
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-12-S
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V83-12
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V83-12-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V83-12-EU
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-OUT-12-L
+#: model:account.tax,description:l10n_be.3_attn_VAT-OUT-12-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-12-L
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-12-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-12-L
 msgid "12%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12
-msgid "12% Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-G
-msgid "12% Biens divers"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-CC
-msgid "12% Cocont. - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-CC
-msgid "12% Cocont. M."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-CC
-msgid "12% Cocont. S."
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-G
+msgid "12% EU G"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-EU
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-12-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-EU
-msgid "12% EU - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-G
-msgid "12% EU - Biens divers"
+msgid "12% EU IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-EU
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-12-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-EU
-msgid "12% EU M."
+msgid "12% EU M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-12-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-S
-msgid "12% EU S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12
-msgid "12% M."
+msgid "12% EU S"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-ROW-CC
-msgid "12% Non EU - Biens d'investissement"
+msgid "12% EX IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-ROW-CC
-msgid "12% Non EU M."
+msgid "12% EX M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-ROW-CC
-msgid "12% Non EU S."
+msgid "12% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-G
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-12-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-G
+msgid "12% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-12
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12
+msgid "12% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-CC
+msgid "12% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-12
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12
+msgid "12% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-CC
+msgid "12% M.Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-12-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-12-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-12-S
-msgid "12% S."
+msgid "12% S"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-CC
+msgid "12% S.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,description:l10n_be.1_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-L
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-S
+#: model:account.tax,description:l10n_be.3_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V81-21
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V81-21-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V81-21-EU
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-21-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-21-G
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-21-S
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V83-21
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V83-21-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V83-21-EU
+#: model:account.tax,description:l10n_be.3_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,description:l10n_be.3_attn_VAT-OUT-21-L
+#: model:account.tax,description:l10n_be.3_attn_VAT-OUT-21-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-21-L
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-21-L
+#: model:account.tax.template,description:l10n_be.attn_TVA-21-inclus-dans-prix
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-21-L
 msgid "21%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21
-msgid "21% Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-G
-msgid "21% Biens divers"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-CC
-msgid "21% Cocont .S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-CC
-msgid "21% Cocont. - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-CC
-msgid "21% Cocont. M."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-EU
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-EU
-msgid "21% EU - Biens d'investissement"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-CAR-EXC
+msgid "21% Car"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-21-EU-G
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-EU-G
-msgid "21% EU - Biens divers"
+msgid "21% EU G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-EU
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-21-EU
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-EU
+msgid "21% EU IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-EU
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-21-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-EU
-msgid "21% EU M."
+msgid "21% EU M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-21-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-EU-S
-msgid "21% EU S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21
-msgid "21% M."
+msgid "21% EU S"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-ROW-CC
-msgid "21% Non EU - Biens d'investissement"
+msgid "21% EX IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-ROW-CC
-msgid "21% Non EU M."
+msgid "21% EX M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-ROW-CC
-msgid "21% Non EU S."
+msgid "21% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-G
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-21-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-G
+msgid "21% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-21
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21
+msgid "21% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-CC
+msgid "21% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-21
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21
+msgid "21% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-CC
+msgid "21% M.Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-21-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-21-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-21-S
-msgid "21% S."
+msgid "21% S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-CC
+msgid "21% S.Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,name:l10n_be.3_attn_TVA-21-inclus-dans-prix
 #: model:account.tax.template,name:l10n_be.attn_TVA-21-inclus-dans-prix
-msgid "21% S. TTC"
+msgid "21% S.TTC"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_44
-msgid "44"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_44_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_44
 msgid "44 - Intra-Community services"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_45
-msgid "45"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_45_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_45
 msgid "45 - Operations subject to VAT due by the co-contractor"
 msgstr ""
@@ -385,34 +511,16 @@ msgid "46 - Exempted intra-Community deliveries and ABC sales"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46L
-msgid "46L"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_46L_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_46L
 msgid "46L - Exempted intra-Community deliveries"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_46T
-msgid "46T"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_46T_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_46T
 msgid "46T - ABC sales"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_47
-msgid "47"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_47_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_47
 msgid "47 - Other exempted operations and operations carried out abroad"
 msgstr ""
@@ -423,360 +531,219 @@ msgid "48 - Credit notes for operations in grids [44] and [46]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s44
-msgid "48s44"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s44_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s44
 msgid "48s44 - Credit notes for operations in grid [44]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46L
-msgid "48s46L"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s46L_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s46L
 msgid "48s46L - Credit notes for operations in grid [46L]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_48s46T
-msgid "48s46T"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s46T_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s46T
 msgid "48s46T - Credit notes for operations in grid [46T]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_49
-msgid "49"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_49_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_49
 msgid "49 - Credit notes for other operations in part II"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-CAR-EXC
-msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_54
-msgid "54"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_54_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_54
 msgid "54 - VAT on operations in grids [01], [02] and [03]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_55
-msgid "55"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_55_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_55
 msgid "55 - VAT on operations in grids [86] and [88]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_56
-msgid "56"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_56_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_56
-msgid "56 - VAT on operations in grid [87], with the exception of imports with reverse charge"
+msgid ""
+"56 - VAT on operations in grid [87], with the exception of imports with "
+"reverse charge"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_57
-msgid "57"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_57_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_57
 msgid "57 - VAT on import with reverse charge"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_59
-msgid "59"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_59_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_59
 msgid "59 - Deductible VAT"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06
-msgid "6% Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-G
-msgid "6% Biens divers"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-CC
-msgid "6% Cocont. - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-CC
-msgid "6% Cocont. M."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-CC
-msgid "6% Cocont. S."
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-G
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-06-EU-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-G
+msgid "6% EU G"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-EU
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-06-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-EU
-msgid "6% EU - Biens d'investissement"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-G
-msgid "6% EU - Biens divers"
+msgid "6% EU IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-EU
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-06-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-EU
-msgid "6% EU M."
+msgid "6% EU M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-06-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-S
-msgid "6% EU S."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06
-msgid "6% M."
+msgid "6% EU S"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-ROW-CC
-msgid "6% Non EU - Biens d'investissement"
+msgid "6% EX IG"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-ROW-CC
-msgid "6% Non EU M."
+msgid "6% EX M"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-ROW-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-ROW-CC
-msgid "6% Non EU S."
+msgid "6% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-G
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-06-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-G
+msgid "6% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-06
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06
+msgid "6% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V83-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-CC
+msgid "6% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-06
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06
+msgid "6% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V81-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-CC
+msgid "6% M.Cocont"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-06-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-06-S
+#: model:account.tax,name:l10n_be.3_attn_VAT-OUT-06-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-06-S
-msgid "6% S."
+msgid "6% S"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_61
-msgid "61"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-CC
+#: model:account.tax,name:l10n_be.3_attn_VAT-IN-V82-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-CC
+msgid "6% S.Cocont"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_61_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_61
 msgid "61 - Various VAT regularizations in favor of the State"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_62
-msgid "62"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_62_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_62
 msgid "62 - Various VAT regularizations in favor of the declarant"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_63
-msgid "63"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_63_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_63
 msgid "63 - VAT to be paid back on credit notes received"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_64
-msgid "64"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_64_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_64
 msgid "64 - VAT to be recovered on credit notes issued"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_71_formula
 #: model:account.report.line,name:l10n_be.tax_report_line_71
 msgid "71 - Taxes due to the State"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_72_formula
 #: model:account.report.line,name:l10n_be.tax_report_line_72
 msgid "72 - Amount owed by the State"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_81
-msgid "81"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_81
 msgid "81 - Trade goods, raw materials and consumables"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_82
-msgid "82"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_82
 msgid "82 - Services and miscellaneous goods"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_83
-msgid "83"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_83
 msgid "83 - Investment goods"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_84
-msgid "84"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_84_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_84
 msgid "84 - Credit notes for operations in grids [86] and [88]"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_85
-msgid "85"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_85_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_85
 msgid "85 - Credit notes received relating to other operations in part III"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_86
-msgid "86"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_86
 msgid "86 - Intra-Community acquisitions and ABC sales"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_87
-msgid "87"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_87
 msgid "87 - Other operations subject to VAT"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax.report.line,tag_name:l10n_be.tax_report_line_88
-msgid "88"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_88
 msgid "88 - Intra-Community services with reverse charge"
 msgstr ""
@@ -788,78 +755,91 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a052
+#: model:account.account,name:l10n_be.3_a052
 #: model:account.account.template,name:l10n_be.a052
 msgid "Accounts receivable for assignment commitments"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a010
+#: model:account.account,name:l10n_be.3_a010
 #: model:account.account.template,name:l10n_be.a010
 msgid "Accounts receivable for commitments on bills in circulation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a066
+#: model:account.account,name:l10n_be.3_a066
 #: model:account.account.template,name:l10n_be.a066
 msgid "Accounts receivable for currencies sold forward"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a062
+#: model:account.account,name:l10n_be.3_a062
 #: model:account.account.template,name:l10n_be.a062
 msgid "Accounts receivable for goods sold forward"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a012
+#: model:account.account,name:l10n_be.3_a012
 #: model:account.account.template,name:l10n_be.a012
 msgid "Accounts receivable for other personal guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a492
+#: model:account.account,name:l10n_be.3_a492
 #: model:account.account.template,name:l10n_be.a492
 msgid "Accrued charges"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a491
+#: model:account.account,name:l10n_be.3_a491
 #: model:account.account.template,name:l10n_be.a491
 msgid "Accrued income"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_605
+#: model:account.group,name:l10n_be.3_be_group_605
 #: model:account.group.template,name:l10n_be.be_group_605
 msgid "Achats d'immeubles destinés à la vente"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_601
+#: model:account.group,name:l10n_be.3_be_group_601
 #: model:account.group.template,name:l10n_be.be_group_601
 msgid "Achats de fournitures"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_604
+#: model:account.group,name:l10n_be.3_be_group_604
 #: model:account.group.template,name:l10n_be.be_group_604
 msgid "Achats de marchandises"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_600
+#: model:account.group,name:l10n_be.3_be_group_600
 #: model:account.group.template,name:l10n_be.be_group_600
 msgid "Achats de matières premières"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_602
+#: model:account.group,name:l10n_be.3_be_group_602
 #: model:account.group.template,name:l10n_be.be_group_602
 msgid "Achats de services, travaux et études"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_19
+#: model:account.group,name:l10n_be.3_be_group_19
 #: model:account.group.template,name:l10n_be.be_group_19
 msgid "Acompte aux associés sur le partage de l'actif net (-)"
 msgstr ""
@@ -867,6 +847,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_176
 #: model:account.group,name:l10n_be.1_be_group_46
+#: model:account.group,name:l10n_be.3_be_group_176
+#: model:account.group,name:l10n_be.3_be_group_46
 #: model:account.group.template,name:l10n_be.be_group_176
 #: model:account.group.template,name:l10n_be.be_group_46
 msgid "Acomptes reçus sur commandes"
@@ -876,6 +858,9 @@ msgstr ""
 #: model:account.group,name:l10n_be.1_be_group_213
 #: model:account.group,name:l10n_be.1_be_group_360
 #: model:account.group,name:l10n_be.1_be_group_406
+#: model:account.group,name:l10n_be.3_be_group_213
+#: model:account.group,name:l10n_be.3_be_group_360
+#: model:account.group,name:l10n_be.3_be_group_406
 #: model:account.group.template,name:l10n_be.be_group_213
 #: model:account.group.template,name:l10n_be.be_group_360
 #: model:account.group.template,name:l10n_be.be_group_406
@@ -884,12 +869,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_36
+#: model:account.group,name:l10n_be.3_be_group_36
 #: model:account.group.template,name:l10n_be.be_group_36
 msgid "Acomptes versés sur achats pour stocks"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a050
+#: model:account.account,name:l10n_be.3_a050
 #: model:account.account.template,name:l10n_be.a050
 msgid "Acquisition commitments"
 msgstr ""
@@ -898,6 +885,9 @@ msgstr ""
 #: model:account.group,name:l10n_be.1_be_group_5100
 #: model:account.group,name:l10n_be.1_be_group_5110
 #: model:account.group,name:l10n_be.1_be_group_5190
+#: model:account.group,name:l10n_be.3_be_group_5100
+#: model:account.group,name:l10n_be.3_be_group_5110
+#: model:account.group,name:l10n_be.3_be_group_5190
 #: model:account.group.template,name:l10n_be.be_group_5100
 #: model:account.group.template,name:l10n_be.be_group_5110
 #: model:account.group.template,name:l10n_be.be_group_5190
@@ -906,12 +896,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_50
+#: model:account.group,name:l10n_be.3_be_group_50
 #: model:account.group.template,name:l10n_be.be_group_50
 msgid "Actions propres"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_51
+#: model:account.group,name:l10n_be.3_be_group_51
 #: model:account.group.template,name:l10n_be.be_group_51
 msgid ""
 "Actions, parts et placements de trésorerie autres que placements à revenu "
@@ -920,60 +912,70 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a021
+#: model:account.account,name:l10n_be.3_a021
 #: model:account.account.template,name:l10n_be.a021
 msgid "Actual guarantees established for own account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7711
+#: model:account.account,name:l10n_be.3_a7711
 #: model:account.account.template,name:l10n_be.a7711
 msgid "Adjustment of Belgian income taxes - Estimated taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7712
+#: model:account.account,name:l10n_be.3_a7712
 #: model:account.account.template,name:l10n_be.a7712
 msgid "Adjustment of Belgian income taxes - Tax provisions written back"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7710
+#: model:account.account,name:l10n_be.3_a7710
 #: model:account.account.template,name:l10n_be.a7710
 msgid "Adjustment of Belgian income taxes - Taxes due or paid"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a773
+#: model:account.account,name:l10n_be.3_a773
 #: model:account.account.template,name:l10n_be.a773
 msgid "Adjustment of foreign income taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a77
+#: model:account.account,name:l10n_be.3_a77
 #: model:account.account.template,name:l10n_be.a77
 msgid "Adjustment of income taxes and write-back of tax provisions"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_695
+#: model:account.group,name:l10n_be.3_be_group_695
 #: model:account.group.template,name:l10n_be.be_group_695
 msgid "Administrateurs ou gérants"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a360
+#: model:account.account,name:l10n_be.3_a360
 #: model:account.account.template,name:l10n_be.a360
 msgid "Advance payments on purchases for stocks - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a369
+#: model:account.account,name:l10n_be.3_a369
 #: model:account.account.template,name:l10n_be.a369
 msgid "Advance payments on purchases for stocks - amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a426
+#: model:account.account,name:l10n_be.3_a426
 #: model:account.account.template,name:l10n_be.a426
 msgid ""
 "Advance payments received on contract in progress payable after more than "
@@ -982,30 +984,35 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a19
+#: model:account.account,name:l10n_be.3_a19
 #: model:account.account.template,name:l10n_be.a19
 msgid "Advance to associates on the sharing out of the assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a461
+#: model:account.account,name:l10n_be.3_a461
 #: model:account.account.template,name:l10n_be.a461
 msgid "Advances received"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a176
+#: model:account.account,name:l10n_be.3_a176
 #: model:account.account.template,name:l10n_be.a176
 msgid "Advances received on contracts in progress (more than one year)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a460
+#: model:account.account,name:l10n_be.3_a460
 #: model:account.account.template,name:l10n_be.a460
 msgid "Advances to be received within one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_691
+#: model:account.group,name:l10n_be.3_be_group_691
 #: model:account.group.template,name:l10n_be.be_group_691
 msgid "Affectations au capital et à la prime d'émission"
 msgstr ""
@@ -1013,6 +1020,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_69
 #: model:account.group,name:l10n_be.1_be_group_79
+#: model:account.group,name:l10n_be.3_be_group_69
+#: model:account.group,name:l10n_be.3_be_group_79
 #: model:account.group.template,name:l10n_be.be_group_69
 #: model:account.group.template,name:l10n_be.be_group_79
 msgid "Affectations et prélèvements"
@@ -1020,12 +1029,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_660
+#: model:account.group,name:l10n_be.3_be_group_660
 #: model:account.group.template,name:l10n_be.be_group_660
 msgid "Amortissements et réductions de valeur non récurrents (dotations)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_63
+#: model:account.group,name:l10n_be.3_be_group_63
 #: model:account.group.template,name:l10n_be.be_group_63
 msgid ""
 "Amortissements, réductions de valeur et provisions pour risques et charges"
@@ -1033,6 +1044,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a653
+#: model:account.account,name:l10n_be.3_a653
 #: model:account.account.template,name:l10n_be.a653
 msgid ""
 "Amount of the discount borne by the enterprise, as a result of negotiating "
@@ -1041,6 +1053,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a428
+#: model:account.account,name:l10n_be.3_a428
 #: model:account.account.template,name:l10n_be.a428
 msgid ""
 "Amounts payable after more than one year falling due within one year - "
@@ -1049,6 +1062,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4232
+#: model:account.account,name:l10n_be.3_a4232
 #: model:account.account.template,name:l10n_be.a4232
 msgid ""
 "Amounts payable after more than one year falling due within one year to "
@@ -1057,6 +1071,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4230
+#: model:account.account,name:l10n_be.3_a4230
 #: model:account.account.template,name:l10n_be.a4230
 msgid ""
 "Amounts payable after more than one year falling due within one year to "
@@ -1065,6 +1080,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4231
+#: model:account.account,name:l10n_be.3_a4231
 #: model:account.account.template,name:l10n_be.a4231
 msgid ""
 "Amounts payable after more than one year falling due within one year to "
@@ -1073,6 +1089,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4250
+#: model:account.account,name:l10n_be.3_a4250
 #: model:account.account.template,name:l10n_be.a4250
 msgid ""
 "Amounts payable after more than one year falling due within one year to "
@@ -1081,6 +1098,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1732
+#: model:account.account,name:l10n_be.3_a1732
 #: model:account.account.template,name:l10n_be.a1732
 msgid ""
 "Amounts payable to credit institutions with a remaining term of more than "
@@ -1089,6 +1107,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1730
+#: model:account.account,name:l10n_be.3_a1730
 #: model:account.account.template,name:l10n_be.a1730
 msgid ""
 "Amounts payable to credit institutions with a remaining term of more than "
@@ -1097,6 +1116,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1731
+#: model:account.account,name:l10n_be.3_a1731
 #: model:account.account.template,name:l10n_be.a1731
 msgid ""
 "Amounts payable to credit institutions with a remaining term of more than "
@@ -1105,6 +1125,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a178
+#: model:account.account,name:l10n_be.3_a178
 #: model:account.account.template,name:l10n_be.a178
 msgid ""
 "Amounts payable with a remaining term of more than one year - Guarantees "
@@ -1113,6 +1134,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a432
+#: model:account.account,name:l10n_be.3_a432
 #: model:account.account.template,name:l10n_be.a432
 msgid ""
 "Amounts payable within one year to credit institutions - Bank acceptances"
@@ -1120,6 +1142,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a433
+#: model:account.account,name:l10n_be.3_a433
 #: model:account.account.template,name:l10n_be.a433
 msgid ""
 "Amounts payable within one year to credit institutions - Current account "
@@ -1128,6 +1151,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a430
+#: model:account.account,name:l10n_be.3_a430
 #: model:account.account.template,name:l10n_be.a430
 msgid ""
 "Amounts payable within one year to credit institutions - Fixed term loans"
@@ -1135,6 +1159,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a431
+#: model:account.account,name:l10n_be.3_a431
 #: model:account.account.template,name:l10n_be.a431
 msgid ""
 "Amounts payable within one year to credit institutions - Promissory notes"
@@ -1142,24 +1167,28 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2819
+#: model:account.account,name:l10n_be.3_a2819
 #: model:account.account.template,name:l10n_be.a2819
 msgid "Amounts receivable from affiliated enterprises - Amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2811
+#: model:account.account,name:l10n_be.3_a2811
 #: model:account.account.template,name:l10n_be.a2811
 msgid "Amounts receivable from affiliated enterprises - Bills receivable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2810
+#: model:account.account,name:l10n_be.3_a2810
 #: model:account.account.template,name:l10n_be.a2810
 msgid "Amounts receivable from affiliated enterprises - Current account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2812
+#: model:account.account,name:l10n_be.3_a2812
 #: model:account.account.template,name:l10n_be.a2812
 msgid ""
 "Amounts receivable from affiliated enterprises - Fixed income securities"
@@ -1167,6 +1196,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2839
+#: model:account.account,name:l10n_be.3_a2839
 #: model:account.account.template,name:l10n_be.a2839
 msgid ""
 "Amounts receivable from other enterprises linked by participating interests "
@@ -1175,6 +1205,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2831
+#: model:account.account,name:l10n_be.3_a2831
 #: model:account.account.template,name:l10n_be.a2831
 msgid ""
 "Amounts receivable from other enterprises linked by participating interests "
@@ -1183,6 +1214,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2830
+#: model:account.account,name:l10n_be.3_a2830
 #: model:account.account.template,name:l10n_be.a2830
 msgid ""
 "Amounts receivable from other enterprises linked by participating interests "
@@ -1191,6 +1223,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2837
+#: model:account.account,name:l10n_be.3_a2837
 #: model:account.account.template,name:l10n_be.a2837
 msgid ""
 "Amounts receivable from other enterprises linked by participating interests "
@@ -1199,6 +1232,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2832
+#: model:account.account,name:l10n_be.3_a2832
 #: model:account.account.template,name:l10n_be.a2832
 msgid ""
 "Amounts receivable from other enterprises linked by participating interests "
@@ -1207,18 +1241,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6320
+#: model:account.account,name:l10n_be.3_a6320
 #: model:account.account.template,name:l10n_be.a6320
 msgid "Amounts written off contracts in progress - Appropriations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6321
+#: model:account.account,name:l10n_be.3_a6321
 #: model:account.account.template,name:l10n_be.a6321
 msgid "Amounts written off contracts in progress - Write-backs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6510
+#: model:account.account,name:l10n_be.3_a6510
 #: model:account.account.template,name:l10n_be.a6510
 msgid ""
 "Amounts written off current assets except stocks, contracts in progress and "
@@ -1227,6 +1264,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6511
+#: model:account.account,name:l10n_be.3_a6511
 #: model:account.account.template,name:l10n_be.a6511
 msgid ""
 "Amounts written off current assets except stocks, contracts in progress and "
@@ -1235,36 +1273,42 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a661
+#: model:account.account,name:l10n_be.3_a661
 #: model:account.account.template,name:l10n_be.a661
 msgid "Amounts written off financial fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6308
+#: model:account.account,name:l10n_be.3_a6308
 #: model:account.account.template,name:l10n_be.a6308
 msgid "Amounts written off intangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6310
+#: model:account.account,name:l10n_be.3_a6310
 #: model:account.account.template,name:l10n_be.a6310
 msgid "Amounts written off stocks - Appropriations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6311
+#: model:account.account,name:l10n_be.3_a6311
 #: model:account.account.template,name:l10n_be.a6311
 msgid "Amounts written off stocks - Write-backs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6309
+#: model:account.account,name:l10n_be.3_a6309
 #: model:account.account.template,name:l10n_be.a6309
 msgid "Amounts written off tangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6330
+#: model:account.account,name:l10n_be.3_a6330
 #: model:account.account.template,name:l10n_be.a6330
 msgid ""
 "Amounts written off trade debtors (more than one year) - Appropriations"
@@ -1272,90 +1316,105 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6331
+#: model:account.account,name:l10n_be.3_a6331
 #: model:account.account.template,name:l10n_be.a6331
 msgid "Amounts written off trade debtors (more than one year) - Write-backs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6340
+#: model:account.account,name:l10n_be.3_a6340
 #: model:account.account.template,name:l10n_be.a6340
 msgid "Amounts written off trade debtors (within one year) - Appropriations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6341
+#: model:account.account,name:l10n_be.3_a6341
 #: model:account.account.template,name:l10n_be.a6341
 msgid "Amounts written off trade debtors (within one year) - Write-backs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a691
+#: model:account.account,name:l10n_be.3_a691
 #: model:account.account.template,name:l10n_be.a691
 msgid "Appropriations to capital and share premium account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6920
+#: model:account.account,name:l10n_be.3_a6920
 #: model:account.account.template,name:l10n_be.a6920
 msgid "Appropriations to legal reserve"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6921
+#: model:account.account,name:l10n_be.3_a6921
 #: model:account.account.template,name:l10n_be.a6921
 msgid "Appropriations to other reserves"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_31
+#: model:account.group,name:l10n_be.3_be_group_31
 #: model:account.group.template,name:l10n_be.be_group_31
 msgid "Approvisionnements - Fournitures"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_30
+#: model:account.group,name:l10n_be.3_be_group_30
 #: model:account.group.template,name:l10n_be.be_group_30
 msgid "Approvisionnements - Matières premières"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_60
+#: model:account.group,name:l10n_be.3_be_group_60
 #: model:account.group.template,name:l10n_be.be_group_60
 msgid "Approvisionnements et marchandises"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_284
+#: model:account.group,name:l10n_be.3_be_group_284
 #: model:account.group.template,name:l10n_be.be_group_284
 msgid "Autres actions et parts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_473
+#: model:account.group,name:l10n_be.3_be_group_473
 #: model:account.group.template,name:l10n_be.be_group_473
 msgid "Autres allocataires"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_697
+#: model:account.group,name:l10n_be.3_be_group_697
 #: model:account.group.template,name:l10n_be.be_group_697
 msgid "Autres applications"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_64
+#: model:account.group,name:l10n_be.3_be_group_64
 #: model:account.group.template,name:l10n_be.be_group_64
 msgid "Autres charges d'exploitation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_664
+#: model:account.group,name:l10n_be.3_be_group_664
 #: model:account.group.template,name:l10n_be.be_group_664
 msgid "Autres charges d'exploitation non récurrentes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_668
+#: model:account.group,name:l10n_be.3_be_group_668
 #: model:account.group.template,name:l10n_be.be_group_668
 msgid "Autres charges financières non récurrentes"
 msgstr ""
@@ -1364,6 +1423,9 @@ msgstr ""
 #: model:account.group,name:l10n_be.1_be_group_285
 #: model:account.group,name:l10n_be.1_be_group_291
 #: model:account.group,name:l10n_be.1_be_group_41
+#: model:account.group,name:l10n_be.3_be_group_285
+#: model:account.group,name:l10n_be.3_be_group_291
+#: model:account.group,name:l10n_be.3_be_group_41
 #: model:account.group.template,name:l10n_be.be_group_285
 #: model:account.group.template,name:l10n_be.be_group_291
 #: model:account.group.template,name:l10n_be.be_group_41
@@ -1372,18 +1434,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_489
+#: model:account.group,name:l10n_be.3_be_group_489
 #: model:account.group.template,name:l10n_be.be_group_489
 msgid "Autres dettes diverses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_459
+#: model:account.group,name:l10n_be.3_be_group_459
 #: model:account.group.template,name:l10n_be.be_group_459
 msgid "Autres dettes sociales"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_223
+#: model:account.group,name:l10n_be.3_be_group_223
 #: model:account.group.template,name:l10n_be.be_group_223
 msgid "Autres droits réels sur des immeubles"
 msgstr ""
@@ -1391,6 +1456,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_174
 #: model:account.group,name:l10n_be.1_be_group_439
+#: model:account.group,name:l10n_be.3_be_group_174
+#: model:account.group,name:l10n_be.3_be_group_439
 #: model:account.group.template,name:l10n_be.be_group_174
 #: model:account.group.template,name:l10n_be.be_group_439
 msgid "Autres emprunts"
@@ -1398,42 +1465,49 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_202
+#: model:account.group,name:l10n_be.3_be_group_202
 #: model:account.group.template,name:l10n_be.be_group_202
 msgid "Autres frais d'établissement"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_623
+#: model:account.group,name:l10n_be.3_be_group_623
 #: model:account.group.template,name:l10n_be.be_group_623
 msgid "Autres frais de personnel"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_26
+#: model:account.group,name:l10n_be.3_be_group_26
 #: model:account.group.template,name:l10n_be.be_group_26
 msgid "Autres immobilisations corporelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_74
+#: model:account.group,name:l10n_be.3_be_group_74
 #: model:account.group.template,name:l10n_be.be_group_74
 msgid "Autres produits d'exploitation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_764
+#: model:account.group,name:l10n_be.3_be_group_764
 #: model:account.group.template,name:l10n_be.be_group_764
 msgid "Autres produits d'exploitation non récurrents"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_769
+#: model:account.group,name:l10n_be.3_be_group_769
 #: model:account.group.template,name:l10n_be.be_group_769
 msgid "Autres produits financiers non récurrents"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a133
+#: model:account.account,name:l10n_be.3_a133
 #: model:account.account.template,name:l10n_be.a133
 msgid "Available reserves"
 msgstr ""
@@ -1450,12 +1524,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6703
+#: model:account.account,name:l10n_be.3_a6703
 #: model:account.account.template,name:l10n_be.a6703
 msgid "Belgian and foreign income taxes - Income taxes - Other income taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6701
+#: model:account.account,name:l10n_be.3_a6701
 #: model:account.account.template,name:l10n_be.a6701
 msgid ""
 "Belgian and foreign income taxes - Income taxes - Withholding taxes on "
@@ -1464,6 +1540,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6702
+#: model:account.account,name:l10n_be.3_a6702
 #: model:account.account.template,name:l10n_be.a6702
 msgid ""
 "Belgian and foreign income taxes - Income taxes - Withholding taxes on "
@@ -1472,6 +1549,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6711
+#: model:account.account,name:l10n_be.3_a6711
 #: model:account.account.template,name:l10n_be.a6711
 msgid ""
 "Belgian income taxes on the result of prior periods - Additional charges for"
@@ -1480,6 +1558,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6710
+#: model:account.account,name:l10n_be.3_a6710
 #: model:account.account.template,name:l10n_be.a6710
 msgid ""
 "Belgian income taxes on the result of prior periods - Additional charges for"
@@ -1488,6 +1567,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6712
+#: model:account.account,name:l10n_be.3_a6712
 #: model:account.account.template,name:l10n_be.a6712
 msgid ""
 "Belgian income taxes on the result of prior periods - Additional charges for"
@@ -1496,6 +1576,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6700
+#: model:account.account,name:l10n_be.3_a6700
 #: model:account.account.template,name:l10n_be.a6700
 msgid ""
 "Belgian income taxes on the result of the current period - Income taxes paid"
@@ -1510,12 +1591,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_07
+#: model:account.group,name:l10n_be.3_be_group_07
 #: model:account.group.template,name:l10n_be.be_group_07
 msgid "Biens et valeurs de tiers détenus par l'entreprise"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_072
+#: model:account.group,name:l10n_be.3_be_group_072
 #: model:account.group.template,name:l10n_be.be_group_072
 msgid "Biens et valeurs de tiers reçus en dépôt, en consignation ou à façon"
 msgstr ""
@@ -1523,6 +1606,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_04
 #: model:account.group,name:l10n_be.1_be_group_041
+#: model:account.group,name:l10n_be.3_be_group_04
+#: model:account.group,name:l10n_be.3_be_group_041
 #: model:account.group.template,name:l10n_be.be_group_04
 #: model:account.group.template,name:l10n_be.be_group_041
 msgid ""
@@ -1532,6 +1617,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_074
+#: model:account.group,name:l10n_be.3_be_group_074
 #: model:account.group.template,name:l10n_be.be_group_074
 msgid ""
 "Biens et valeurs détenus pour compte ou aux risques et profits de tiers"
@@ -1539,12 +1625,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1751
+#: model:account.account,name:l10n_be.3_a1751
 #: model:account.account.template,name:l10n_be.a1751
 msgid "Bills of exchange payable after more than one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4251
+#: model:account.account,name:l10n_be.3_a4251
 #: model:account.account.template,name:l10n_be.a4251
 msgid ""
 "Bills of exchange payable after more than one year falling due within one "
@@ -1553,24 +1641,28 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a441
+#: model:account.account,name:l10n_be.3_a441
 #: model:account.account.template,name:l10n_be.a441
 msgid "Bills of exchange payable within one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2211
+#: model:account.account,name:l10n_be.3_a2211
 #: model:account.account.template,name:l10n_be.a2211
 msgid "Building owned by the association or the foundation in full property"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a221
+#: model:account.account,name:l10n_be.3_a221
 #: model:account.account.template,name:l10n_be.a221
 msgid "Buildings"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2221
+#: model:account.account,name:l10n_be.3_a2221
 #: model:account.account.template,name:l10n_be.a2221
 msgid ""
 "Built-up lands owned by the association or the foundation in full property"
@@ -1578,144 +1670,168 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_371
+#: model:account.group,name:l10n_be.3_be_group_371
 #: model:account.group.template,name:l10n_be.be_group_371
 msgid "Bénéfice pris en compte"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_790
+#: model:account.group,name:l10n_be.3_be_group_790
 #: model:account.group.template,name:l10n_be.be_group_790
 msgid "Bénéfice reporté de l'exercice précédent"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_14
+#: model:account.group,name:l10n_be.3_be_group_14
 #: model:account.group.template,name:l10n_be.be_group_14
 msgid "Bénéfice reporté ou Perte reportée (–)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_693
+#: model:account.group,name:l10n_be.3_be_group_693
 #: model:account.group.template,name:l10n_be.be_group_693
 msgid "Bénéfice à reporter"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_57
+#: model:account.group,name:l10n_be.3_be_group_57
 #: model:account.group.template,name:l10n_be.be_group_57
 msgid "Caisses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_570
+#: model:account.group,name:l10n_be.3_be_group_570
 #: model:account.group.template,name:l10n_be.be_group_570
 msgid "Caisses-espèces"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_578
+#: model:account.group,name:l10n_be.3_be_group_578
 #: model:account.group.template,name:l10n_be.be_group_578
 msgid "Caisses-timbres"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a410
+#: model:account.account,name:l10n_be.3_a410
 #: model:account.account.template,name:l10n_be.a410
 msgid "Called up capital, unpaid"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_10
+#: model:account.group,name:l10n_be.3_be_group_10
 #: model:account.group.template,name:l10n_be.be_group_10
 msgid "Capital"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_410
+#: model:account.group,name:l10n_be.3_be_group_410
 #: model:account.group.template,name:l10n_be.be_group_410
 msgid "Capital appelé, non versé"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7631
+#: model:account.account,name:l10n_be.3_a7631
 #: model:account.account.template,name:l10n_be.a7631
 msgid "Capital gains on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7630
+#: model:account.account,name:l10n_be.3_a7630
 #: model:account.account.template,name:l10n_be.a7630
 msgid "Capital gains on disposal of intangible and tangible fixed asset"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6631
+#: model:account.account,name:l10n_be.3_a6631
 #: model:account.account.template,name:l10n_be.a6631
 msgid "Capital losses on disposal of financial fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6630
+#: model:account.account,name:l10n_be.3_a6630
 #: model:account.account.template,name:l10n_be.a6630
 msgid "Capital losses on disposal of intangible and tangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_101
+#: model:account.group,name:l10n_be.3_be_group_101
 #: model:account.group.template,name:l10n_be.be_group_101
 msgid "Capital non appelé (–)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_100
+#: model:account.group,name:l10n_be.3_be_group_100
 #: model:account.group.template,name:l10n_be.be_group_100
 msgid "Capital souscrit"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6503
+#: model:account.account,name:l10n_be.3_a6503
 #: model:account.account.template,name:l10n_be.a6503
 msgid "Capitalized Interests"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a54
+#: model:account.account,name:l10n_be.3_a54
 #: model:account.account.template,name:l10n_be.a54
 msgid "Cash at bank - Amounts overdue and in the process of collection"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a55
+#: model:account.account,name:l10n_be.3_a55
 #: model:account.account.template,name:l10n_be.a55
 msgid "Cash at bank - Credit institutions"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a560
+#: model:account.account,name:l10n_be.3_a560
 #: model:account.account.template,name:l10n_be.a560
 msgid "Cash at bank - Giro account - Bank account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a561
+#: model:account.account,name:l10n_be.3_a561
 #: model:account.account.template,name:l10n_be.a561
 msgid "Cash at bank - Giro account - Cheques issued"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a58
+#: model:account.account,name:l10n_be.3_a58
 #: model:account.account.template,name:l10n_be.a58
 msgid "Cash at bank and in hand - Internal transfers of funds"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a57
+#: model:account.account,name:l10n_be.3_a57
 #: model:account.account.template,name:l10n_be.a57
 msgid "Cash in hand"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a578
+#: model:account.account,name:l10n_be.3_a578
 #: model:account.account.template,name:l10n_be.a578
 msgid "Cash in hand - Stamps"
 msgstr ""
@@ -1723,6 +1839,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_178
 #: model:account.group,name:l10n_be.1_be_group_488
+#: model:account.group,name:l10n_be.3_be_group_178
+#: model:account.group,name:l10n_be.3_be_group_488
 #: model:account.group.template,name:l10n_be.be_group_178
 #: model:account.group.template,name:l10n_be.be_group_488
 msgid "Cautionnements reçus en numéraire"
@@ -1731,6 +1849,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_288
 #: model:account.group,name:l10n_be.1_be_group_418
+#: model:account.group,name:l10n_be.3_be_group_288
+#: model:account.group,name:l10n_be.3_be_group_418
 #: model:account.group.template,name:l10n_be.be_group_288
 #: model:account.group.template,name:l10n_be.be_group_418
 msgid "Cautionnements versés en numéraire"
@@ -1738,30 +1858,35 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_6
+#: model:account.group,name:l10n_be.3_be_group_6
 #: model:account.group.template,name:l10n_be.be_group_6
 msgid "Charges"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_653
+#: model:account.group,name:l10n_be.3_be_group_653
 #: model:account.group.template,name:l10n_be.be_group_653
 msgid "Charges d'escompte de créances"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_643
+#: model:account.group,name:l10n_be.3_be_group_643
 #: model:account.group.template,name:l10n_be.be_group_643
 msgid "Charges d'exploitation diverses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_66
+#: model:account.group,name:l10n_be.3_be_group_66
 #: model:account.group.template,name:l10n_be.be_group_66
 msgid "Charges d'exploitation ou financières non récurrentes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_649
+#: model:account.group,name:l10n_be.3_be_group_649
 #: model:account.group.template,name:l10n_be.be_group_649
 msgid ""
 "Charges d'exploitation portées à l'actif au titre de frais de "
@@ -1770,24 +1895,28 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_650
+#: model:account.group,name:l10n_be.3_be_group_650
 #: model:account.group.template,name:l10n_be.be_group_650
 msgid "Charges des dettes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_65
+#: model:account.group,name:l10n_be.3_be_group_65
 #: model:account.group.template,name:l10n_be.be_group_65
 msgid "Charges financières"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_657
+#: model:account.group,name:l10n_be.3_be_group_657
 #: model:account.group.template,name:l10n_be.be_group_657
 msgid "Charges financières diverses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_659
+#: model:account.group,name:l10n_be.3_be_group_659
 #: model:account.group.template,name:l10n_be.be_group_659
 msgid ""
 "Charges financières portées à l'actif au titre de frais de restructuration"
@@ -1795,54 +1924,63 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_640
+#: model:account.group,name:l10n_be.3_be_group_640
 #: model:account.group.template,name:l10n_be.be_group_640
 msgid "Charges fiscales d'exploitation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_669
+#: model:account.group,name:l10n_be.3_be_group_669
 #: model:account.group.template,name:l10n_be.be_group_669
 msgid "Charges portées à l'actif au titre de frais de restructuration (-)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_492
+#: model:account.group,name:l10n_be.3_be_group_492
 #: model:account.group.template,name:l10n_be.be_group_492
 msgid "Charges à imputer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_490
+#: model:account.group,name:l10n_be.3_be_group_490
 #: model:account.group.template,name:l10n_be.be_group_490
 msgid "Charges à reporter"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_70
+#: model:account.group,name:l10n_be.3_be_group_70
 #: model:account.group.template,name:l10n_be.be_group_70
 msgid "Chiffre d'affaires"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_561
+#: model:account.group,name:l10n_be.3_be_group_561
 #: model:account.group.template,name:l10n_be.be_group_561
 msgid "Chèques émis (–)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_400
+#: model:account.group,name:l10n_be.3_be_group_400
 #: model:account.group.template,name:l10n_be.be_group_400
 msgid "Clients"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_37
+#: model:account.group,name:l10n_be.3_be_group_37
 #: model:account.group.template,name:l10n_be.be_group_37
 msgid "Commandes en cours d'exécution"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_073
+#: model:account.group,name:l10n_be.3_be_group_073
 #: model:account.group.template,name:l10n_be.be_group_073
 msgid "Commettants et déposants de biens et de valeurs"
 msgstr ""
@@ -1853,54 +1991,57 @@ msgid "Communication Standard"
 msgstr ""
 
 #. module: l10n_be
-#: model:ir.model,name:l10n_be.model_res_company
-msgid "Companies"
-msgstr ""
-
-#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a020
+#: model:account.account,name:l10n_be.3_a020
 #: model:account.account.template,name:l10n_be.a020
 msgid "Company creditors, beneficiaries of real guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a000
+#: model:account.account,name:l10n_be.3_a000
 #: model:account.account.template,name:l10n_be.a000
 msgid "Company creditors, beneficiaries of third party guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a738
+#: model:account.account,name:l10n_be.3_a738
 #: model:account.account.template,name:l10n_be.a738
 msgid "Compensatory amounts meant to reduce wage costs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_560
+#: model:account.group,name:l10n_be.3_be_group_560
 #: model:account.group.template,name:l10n_be.be_group_560
 msgid "Compte courant"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_499
+#: model:account.group,name:l10n_be.3_be_group_499
 #: model:account.group.template,name:l10n_be.be_group_499
 msgid "Comptes d'attente"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_49
+#: model:account.group,name:l10n_be.3_be_group_49
 #: model:account.group.template,name:l10n_be.be_group_49
 msgid "Comptes de régularisation et comptes d'attente"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_550
+#: model:account.group,name:l10n_be.3_be_group_550
 #: model:account.group.template,name:l10n_be.be_group_550
 msgid "Comptes ouverts auprès des divers établissements, à subdiviser en :"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_211
+#: model:account.group,name:l10n_be.3_be_group_211
 #: model:account.group.template,name:l10n_be.be_group_211
 msgid ""
 "Concessions, brevets, licences, savoir-faire, marques et droits similaires"
@@ -1908,84 +2049,103 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a211
+#: model:account.account,name:l10n_be.3_a211
 #: model:account.account.template,name:l10n_be.a211
 msgid "Concessions, patents, licences, know-how, brands and similar rights"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a091
+#: model:account.account,name:l10n_be.3_a091
 #: model:account.account.template,name:l10n_be.a091
 msgid "Concordat resolution claims"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a090
+#: model:account.account,name:l10n_be.3_a090
 #: model:account.account.template,name:l10n_be.a090
 msgid "Concordat resolution commitments"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_033
+#: model:account.group,name:l10n_be.3_be_group_033
 #: model:account.group.template,name:l10n_be.be_group_033
 msgid "Constituants de garanties"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a033
+#: model:account.account,name:l10n_be.3_a033
 #: model:account.account.template,name:l10n_be.a033
 msgid "Constituents of guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_221
+#: model:account.group,name:l10n_be.3_be_group_221
 #: model:account.group.template,name:l10n_be.be_group_221
 msgid "Constructions"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a310
+#: model:account.account,name:l10n_be.3_a310
 #: model:account.account.template,name:l10n_be.a310
 msgid "Consumables - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a319
+#: model:account.account,name:l10n_be.3_a319
 #: model:account.account.template,name:l10n_be.a319
 msgid "Consumables - amounts written down"
 msgstr ""
 
 #. module: l10n_be
+#: model:ir.model,name:l10n_be.model_res_partner
+msgid "Contact"
+msgstr ""
+
+#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a370
+#: model:account.account,name:l10n_be.3_a370
 #: model:account.account.template,name:l10n_be.a370
 msgid "Contracts in progress - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a371
+#: model:account.account,name:l10n_be.3_a371
 #: model:account.account.template,name:l10n_be.a371
 msgid "Contracts in progress - Profit recognised"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a379
+#: model:account.account,name:l10n_be.3_a379
 #: model:account.account.template,name:l10n_be.a379
 msgid "Contracts in progress - amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a730
+#: model:account.account,name:l10n_be.3_a730
 #: model:account.account.template,name:l10n_be.a730
 msgid "Contributions from effective members"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a731
+#: model:account.account,name:l10n_be.3_a731
 #: model:account.account.template,name:l10n_be.a731
 msgid "Contributions from members"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a736
+#: model:account.account,name:l10n_be.3_a736
 #: model:account.account.template,name:l10n_be.a736
 msgid ""
 "Contributions, gifts, legacies and grants - Investment grants and interest "
@@ -1994,6 +2154,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a617
+#: model:account.account,name:l10n_be.3_a617
 #: model:account.account.template,name:l10n_be.a617
 msgid ""
 "Costs of hired temporary staff and persons placed at the enterprise's "
@@ -2002,30 +2163,35 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_621
+#: model:account.group,name:l10n_be.3_be_group_621
 #: model:account.group.template,name:l10n_be.be_group_621
 msgid "Cotisations patronales d'assurances sociales"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a065
+#: model:account.account,name:l10n_be.3_a065
 #: model:account.account.template,name:l10n_be.a065
 msgid "Creditors for forward currency purchases"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a061
+#: model:account.account,name:l10n_be.3_a061
 #: model:account.account.template,name:l10n_be.a061
 msgid "Creditors for goods purchased at term"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a051
+#: model:account.account,name:l10n_be.3_a051
 #: model:account.account.template,name:l10n_be.a051
 msgid "Creditors of acquisition commitments"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a0110
+#: model:account.account,name:l10n_be.3_a0110
 #: model:account.account.template,name:l10n_be.a0110
 msgid ""
 "Creditors of commitments on bills in circulation - Bids ceded by the company"
@@ -2034,6 +2200,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a0111
+#: model:account.account,name:l10n_be.3_a0111
 #: model:account.account.template,name:l10n_be.a0111
 msgid ""
 "Creditors of commitments on notes in circulation - Other commitments on "
@@ -2042,18 +2209,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a013
+#: model:account.account,name:l10n_be.3_a013
 #: model:account.account.template,name:l10n_be.a013
 msgid "Creditors of other personal guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a095
+#: model:account.account,name:l10n_be.3_a095
 #: model:account.account.template,name:l10n_be.a095
 msgid "Creditors of pending litigation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a075
+#: model:account.account,name:l10n_be.3_a075
 #: model:account.account.template,name:l10n_be.a075
 msgid ""
 "Creditors of property and securities held on behalf of third parties or at "
@@ -2062,12 +2232,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a022
+#: model:account.account,name:l10n_be.3_a022
 #: model:account.account.template,name:l10n_be.a022
 msgid "Creditors of third parties, beneficiaries of real guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a092
+#: model:account.account,name:l10n_be.3_a092
 #: model:account.account.template,name:l10n_be.a092
 msgid "Creditors under debt restructuring conditions"
 msgstr ""
@@ -2075,6 +2247,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_290
 #: model:account.group,name:l10n_be.1_be_group_40
+#: model:account.group,name:l10n_be.3_be_group_290
+#: model:account.group,name:l10n_be.3_be_group_40
 #: model:account.group.template,name:l10n_be.be_group_290
 #: model:account.group.template,name:l10n_be.be_group_40
 msgid "Créances commerciales"
@@ -2082,6 +2256,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_416
+#: model:account.group,name:l10n_be.3_be_group_416
 #: model:account.group.template,name:l10n_be.be_group_416
 msgid "Créances diverses"
 msgstr ""
@@ -2089,6 +2264,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_407
 #: model:account.group,name:l10n_be.1_be_group_417
+#: model:account.group,name:l10n_be.3_be_group_407
+#: model:account.group,name:l10n_be.3_be_group_417
 #: model:account.group.template,name:l10n_be.be_group_407
 #: model:account.group.template,name:l10n_be.be_group_417
 msgid "Créances douteuses"
@@ -2096,12 +2273,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_4
+#: model:account.group,name:l10n_be.3_be_group_4
 #: model:account.group.template,name:l10n_be.be_group_4
 msgid "Créances et dettes à un an au plus"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_283
+#: model:account.group,name:l10n_be.3_be_group_283
 #: model:account.group.template,name:l10n_be.be_group_283
 msgid ""
 "Créances sur des entreprises avec lesquelles il existe un lien de "
@@ -2110,36 +2289,42 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_281
+#: model:account.group,name:l10n_be.3_be_group_281
 #: model:account.group.template,name:l10n_be.be_group_281
 msgid "Créances sur des entreprises liées"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_29
+#: model:account.group,name:l10n_be.3_be_group_29
 #: model:account.group.template,name:l10n_be.be_group_29
 msgid "Créances à plus d'un an"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_013
+#: model:account.group,name:l10n_be.3_be_group_013
 #: model:account.group.template,name:l10n_be.be_group_013
 msgid "Créanciers d'autres garanties personnelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_051
+#: model:account.group,name:l10n_be.3_be_group_051
 #: model:account.group.template,name:l10n_be.be_group_051
 msgid "Créanciers d'engagements d'acquisition"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_011
+#: model:account.group,name:l10n_be.3_be_group_011
 #: model:account.group.template,name:l10n_be.be_group_011
 msgid "Créanciers d'engagements sur effets en circulation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_075
+#: model:account.group,name:l10n_be.3_be_group_075
 #: model:account.group.template,name:l10n_be.be_group_075
 msgid ""
 "Créanciers de biens et valeurs détenus pour compte de tiers ou à leurs "
@@ -2148,42 +2333,49 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_000
+#: model:account.group,name:l10n_be.3_be_group_000
 #: model:account.group.template,name:l10n_be.be_group_000
 msgid "Créanciers de l'entreprise, bénéficiaires de garanties de tiers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_020
+#: model:account.group,name:l10n_be.3_be_group_020
 #: model:account.group.template,name:l10n_be.be_group_020
 msgid "Créanciers de l'entreprise, bénéficiaires de garanties réelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_071
+#: model:account.group,name:l10n_be.3_be_group_071
 #: model:account.group.template,name:l10n_be.be_group_071
 msgid "Créanciers de loyers et redevances"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_022
+#: model:account.group,name:l10n_be.3_be_group_022
 #: model:account.group.template,name:l10n_be.be_group_022
 msgid "Créanciers de tiers, bénéficiaires de garanties réelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_065
+#: model:account.group,name:l10n_be.3_be_group_065
 #: model:account.group.template,name:l10n_be.be_group_065
 msgid "Créanciers pour devises achetées à terme"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_061
+#: model:account.group,name:l10n_be.3_be_group_061
 #: model:account.group.template,name:l10n_be.be_group_061
 msgid "Créanciers pour marchandises achetées à terme"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a509
+#: model:account.account,name:l10n_be.3_a509
 #: model:account.account.template,name:l10n_be.a509
 msgid ""
 "Current investments other than shares, fixed income securities and term "
@@ -2192,6 +2384,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a500
+#: model:account.account,name:l10n_be.3_a500
 #: model:account.account.template,name:l10n_be.a500
 msgid ""
 "Current investments other than shares, fixed income securities and term "
@@ -2200,84 +2393,98 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4001
+#: model:account.account,name:l10n_be.3_a4001
 #: model:account.account.template,name:l10n_be.a4001
 msgid "Customer (POS)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_532
+#: model:account.group,name:l10n_be.3_be_group_532
 #: model:account.group.template,name:l10n_be.be_group_532
 msgid "D'un mois au plus"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_530
+#: model:account.group,name:l10n_be.3_be_group_530
 #: model:account.group.template,name:l10n_be.be_group_530
 msgid "De plus d'un an"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_531
+#: model:account.group,name:l10n_be.3_be_group_531
 #: model:account.group.template,name:l10n_be.be_group_531
 msgid "De plus d'un mois et à un an au plus"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a096
+#: model:account.account,name:l10n_be.3_a096
 #: model:account.account.template,name:l10n_be.a096
 msgid "Debtors on technical guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6095
+#: model:account.account,name:l10n_be.3_a6095
 #: model:account.account.template,name:l10n_be.a6095
 msgid "Decrease (increase) in immovable property for resale"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6091
+#: model:account.account,name:l10n_be.3_a6091
 #: model:account.account.template,name:l10n_be.a6091
 msgid "Decrease (increase) in stocks of consumables"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6094
+#: model:account.account,name:l10n_be.3_a6094
 #: model:account.account.template,name:l10n_be.a6094
 msgid "Decrease (increase) in stocks of goods purchased for resale"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6090
+#: model:account.account,name:l10n_be.3_a6090
 #: model:account.account.template,name:l10n_be.a6090
 msgid "Decrease (increase) in stocks of raw materials"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a124
+#: model:account.account,name:l10n_be.3_a124
 #: model:account.account.template,name:l10n_be.a124
 msgid "Decrease in amounts written down current investments"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a490
+#: model:account.account,name:l10n_be.3_a490
 #: model:account.account.template,name:l10n_be.a490
 msgid "Deferred charges"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a493
+#: model:account.account,name:l10n_be.3_a493
 #: model:account.account.template,name:l10n_be.a493
 msgid "Deferred income"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1681
+#: model:account.account,name:l10n_be.3_a1681
 #: model:account.account.template,name:l10n_be.a1681
 msgid "Deferred taxes on gain on disposal of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1687
+#: model:account.account,name:l10n_be.3_a1687
 #: model:account.account.template,name:l10n_be.a1687
 msgid ""
 "Deferred taxes on gain on disposal of securities issued by Belgian public "
@@ -2286,60 +2493,70 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1682
+#: model:account.account,name:l10n_be.3_a1682
 #: model:account.account.template,name:l10n_be.a1682
 msgid "Deferred taxes on gain on disposal of tangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1680
+#: model:account.account,name:l10n_be.3_a1680
 #: model:account.account.template,name:l10n_be.a1680
 msgid "Deferred taxes on investment grants"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6300
+#: model:account.account,name:l10n_be.3_a6300
 #: model:account.account.template,name:l10n_be.a6300
 msgid "Depreciation of formation expenses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6301
+#: model:account.account,name:l10n_be.3_a6301
 #: model:account.account.template,name:l10n_be.a6301
 msgid "Depreciation of intangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6501
+#: model:account.account,name:l10n_be.3_a6501
 #: model:account.account.template,name:l10n_be.a6501
 msgid "Depreciation of loan issue expenses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6302
+#: model:account.account,name:l10n_be.3_a6302
 #: model:account.account.template,name:l10n_be.a6302
 msgid "Depreciation of tangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_717
+#: model:account.group,name:l10n_be.3_be_group_717
 #: model:account.group.template,name:l10n_be.be_group_717
 msgid "Des commandes en cours d'exécution"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_712
+#: model:account.group,name:l10n_be.3_be_group_712
 #: model:account.group.template,name:l10n_be.be_group_712
 msgid "Des en-cours de fabrication"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_715
+#: model:account.group,name:l10n_be.3_be_group_715
 #: model:account.group.template,name:l10n_be.be_group_715
 msgid "Des immeubles construits destinés à la vente"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_713
+#: model:account.group,name:l10n_be.3_be_group_713
 #: model:account.group.template,name:l10n_be.be_group_713
 msgid "Des produits finis"
 msgstr ""
@@ -2347,6 +2564,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_175
 #: model:account.group,name:l10n_be.1_be_group_44
+#: model:account.group,name:l10n_be.3_be_group_175
+#: model:account.group,name:l10n_be.3_be_group_44
 #: model:account.group.template,name:l10n_be.be_group_175
 #: model:account.group.template,name:l10n_be.be_group_44
 msgid "Dettes commerciales"
@@ -2354,6 +2573,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_172
+#: model:account.group,name:l10n_be.3_be_group_172
 #: model:account.group.template,name:l10n_be.be_group_172
 msgid "Dettes de location-financement et dettes assimilées"
 msgstr ""
@@ -2361,6 +2581,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_179
 #: model:account.group,name:l10n_be.1_be_group_48
+#: model:account.group,name:l10n_be.3_be_group_179
+#: model:account.group,name:l10n_be.3_be_group_48
 #: model:account.group.template,name:l10n_be.be_group_179
 #: model:account.group.template,name:l10n_be.be_group_48
 msgid "Dettes diverses"
@@ -2368,36 +2590,42 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_47
+#: model:account.group,name:l10n_be.3_be_group_47
 #: model:account.group.template,name:l10n_be.be_group_47
 msgid "Dettes découlant de l'affectation du résultat"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_43
+#: model:account.group,name:l10n_be.3_be_group_43
 #: model:account.group.template,name:l10n_be.be_group_43
 msgid "Dettes financières"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_450
+#: model:account.group,name:l10n_be.3_be_group_450
 #: model:account.group.template,name:l10n_be.be_group_450
 msgid "Dettes fiscales estimées"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_45
+#: model:account.group,name:l10n_be.3_be_group_45
 #: model:account.group.template,name:l10n_be.be_group_45
 msgid "Dettes fiscales, salariales et sociales"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_17
+#: model:account.group,name:l10n_be.3_be_group_17
 #: model:account.group.template,name:l10n_be.be_group_17
 msgid "Dettes à plus d'un an"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_42
+#: model:account.group,name:l10n_be.3_be_group_42
 #: model:account.group.template,name:l10n_be.be_group_42
 msgid ""
 "Dettes à plus d'un an échéant dans l'année 16 (même subdivision que le 17)"
@@ -2405,18 +2633,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a222
+#: model:account.account,name:l10n_be.3_a222
 #: model:account.account.template,name:l10n_be.a222
 msgid "Developed land"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_064
+#: model:account.group,name:l10n_be.3_be_group_064
 #: model:account.group.template,name:l10n_be.be_group_064
 msgid "Devises achetées à terme - à recevoir"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_067
+#: model:account.group,name:l10n_be.3_be_group_067
 #: model:account.group.template,name:l10n_be.be_group_067
 msgid "Devises vendues à terme - à livrer"
 msgstr ""
@@ -2424,6 +2655,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_654
 #: model:account.group,name:l10n_be.1_be_group_754
+#: model:account.group,name:l10n_be.3_be_group_654
+#: model:account.group,name:l10n_be.3_be_group_754
 #: model:account.group.template,name:l10n_be.be_group_654
 #: model:account.group.template,name:l10n_be.be_group_754
 msgid "Différences de change"
@@ -2431,18 +2664,35 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a472
+#: model:account.account,name:l10n_be.3_a472
 #: model:account.account.template,name:l10n_be.a472
 msgid "Director's fees - Current financial period"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a695
+#: model:account.account,name:l10n_be.3_a695
 #: model:account.account.template,name:l10n_be.a695
 msgid "Directors' or managers' entitlements"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.account,name:l10n_be.1_a657000
+#: model:account.account,name:l10n_be.3_a657000
+#: model:account.account.template,name:l10n_be.a657000
+msgid "Discounts Given"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a757000
+#: model:account.account,name:l10n_be.3_a757000
+#: model:account.account.template,name:l10n_be.a757000
+msgid "Discounts Taken"
+msgstr ""
+
+#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a608
+#: model:account.account,name:l10n_be.3_a608
 #: model:account.account.template,name:l10n_be.a608
 msgid ""
 "Discounts, allowance and rebates received on purchase of raw materials, "
@@ -2451,48 +2701,56 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a708
+#: model:account.account,name:l10n_be.3_a708
 #: model:account.account.template,name:l10n_be.a708
 msgid "Discounts, allowances and rebates allowed"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_471
+#: model:account.group,name:l10n_be.3_be_group_471
 #: model:account.group.template,name:l10n_be.be_group_471
 msgid "Dividendes de l'exercice"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_470
+#: model:account.group,name:l10n_be.3_be_group_470
 #: model:account.group.template,name:l10n_be.be_group_470
 msgid "Dividendes et tantièmes d'exercices antérieurs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a694
+#: model:account.account,name:l10n_be.3_a694
 #: model:account.account.template,name:l10n_be.a694
 msgid "Dividends"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a471
+#: model:account.account,name:l10n_be.3_a471
 #: model:account.account.template,name:l10n_be.a471
 msgid "Dividends - Current financial period"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a470
+#: model:account.account,name:l10n_be.3_a470
 #: model:account.account.template,name:l10n_be.a470
 msgid "Dividends and director's fees relating to prior financial periods"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_692
+#: model:account.group,name:l10n_be.3_be_group_692
 #: model:account.group.template,name:l10n_be.be_group_692
 msgid "Dotation aux réserves"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_630
+#: model:account.group,name:l10n_be.3_be_group_630
 #: model:account.group.template,name:l10n_be.be_group_630
 msgid ""
 "Dotations aux amortissements et aux réductions de valeur sur immobilisations"
@@ -2500,168 +2758,196 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_070
+#: model:account.group,name:l10n_be.3_be_group_070
 #: model:account.group.template,name:l10n_be.be_group_070
 msgid "Droits d'usage à long terme"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_09
+#: model:account.group,name:l10n_be.3_be_group_09
 #: model:account.group.template,name:l10n_be.be_group_09
 msgid "Droits et engagements divers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_0
+#: model:account.group,name:l10n_be.3_be_group_0
 #: model:account.group.template,name:l10n_be.be_group_0
 msgid "Droits et engagements hors bilan"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a093
+#: model:account.account,name:l10n_be.3_a093
 #: model:account.account.template,name:l10n_be.a093
 msgid "Duties on loan conditions"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_012
+#: model:account.group,name:l10n_be.3_be_group_012
 #: model:account.group.template,name:l10n_be.be_group_012
 msgid "Débiteurs pour autres garanties personnelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_066
+#: model:account.group,name:l10n_be.3_be_group_066
 #: model:account.group.template,name:l10n_be.be_group_066
 msgid "Débiteurs pour devises vendues à terme"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_052
+#: model:account.group,name:l10n_be.3_be_group_052
 #: model:account.group.template,name:l10n_be.be_group_052
 msgid "Débiteurs pour engagements de cession"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_010
+#: model:account.group,name:l10n_be.3_be_group_010
 #: model:account.group.template,name:l10n_be.be_group_010
 msgid "Débiteurs pour engagements sur effets en circulation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_062
+#: model:account.group,name:l10n_be.3_be_group_062
 #: model:account.group.template,name:l10n_be.be_group_062
 msgid "Débiteurs pour marchandises vendues à terme"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_031
+#: model:account.group,name:l10n_be.3_be_group_031
 #: model:account.group.template,name:l10n_be.be_group_031
 msgid "Déposants statutaires"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_030
+#: model:account.group,name:l10n_be.3_be_group_030
 #: model:account.group.template,name:l10n_be.be_group_030
 msgid "Dépôts statutaires"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_53
+#: model:account.group,name:l10n_be.3_be_group_53
 #: model:account.group.template,name:l10n_be.be_group_53
 msgid "Dépôts à terme"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.fiscal.position,name:l10n_be.1_fiscal_position_template_5
+#: model:account.fiscal.position,name:l10n_be.3_fiscal_position_template_5
 #: model:account.fiscal.position.template,name:l10n_be.fiscal_position_template_5
 msgid "EU privé"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_655
+#: model:account.group,name:l10n_be.3_be_group_655
 #: model:account.group.template,name:l10n_be.be_group_655
 msgid "Ecarts de conversion des devises"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_441
+#: model:account.group,name:l10n_be.3_be_group_441
 #: model:account.group.template,name:l10n_be.be_group_441
 msgid "Effets à payer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_401
+#: model:account.group,name:l10n_be.3_be_group_401
 #: model:account.group.template,name:l10n_be.be_group_401
 msgid "Effets à recevoir"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a696
+#: model:account.account,name:l10n_be.3_a696
 #: model:account.account.template,name:l10n_be.a696
 msgid "Employees' entitlements"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a621
+#: model:account.account,name:l10n_be.3_a621
 #: model:account.account.template,name:l10n_be.a621
 msgid "Employers' contribution for social security"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a622
+#: model:account.account,name:l10n_be.3_a622
 #: model:account.account.template,name:l10n_be.a622
 msgid "Employers' premiums for extra statutory insurance"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_696
+#: model:account.group,name:l10n_be.3_be_group_696
 #: model:account.group.template,name:l10n_be.be_group_696
 msgid "Employés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_171
+#: model:account.group,name:l10n_be.3_be_group_171
 #: model:account.group.template,name:l10n_be.be_group_171
 msgid "Emprunts obligataires non subordonnés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_170
+#: model:account.group,name:l10n_be.3_be_group_170
 #: model:account.group.template,name:l10n_be.be_group_170
 msgid "Emprunts subordonnés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_32
+#: model:account.group,name:l10n_be.3_be_group_32
 #: model:account.group.template,name:l10n_be.be_group_32
 msgid "En-cours de fabrication"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_050
+#: model:account.group,name:l10n_be.3_be_group_050
 #: model:account.group.template,name:l10n_be.be_group_050
 msgid "Engagements d'acquisition"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_05
+#: model:account.group,name:l10n_be.3_be_group_05
 #: model:account.group.template,name:l10n_be.be_group_05
 msgid "Engagements d'acquisition et de cession d'immobilisations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_053
+#: model:account.group,name:l10n_be.3_be_group_053
 #: model:account.group.template,name:l10n_be.be_group_053
 msgid "Engagements de cession"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a450
+#: model:account.account,name:l10n_be.3_a450
 #: model:account.account.template,name:l10n_be.a450
 msgid "Estimated taxes payable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4508
+#: model:account.account,name:l10n_be.3_a4508
 #: model:account.account.template,name:l10n_be.a4508
 msgid "Estimated taxes payable - Foreign taxes"
 msgstr ""
@@ -2669,6 +2955,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_173
 #: model:account.group,name:l10n_be.1_be_group_55
+#: model:account.group,name:l10n_be.3_be_group_173
+#: model:account.group,name:l10n_be.3_be_group_55
 #: model:account.group.template,name:l10n_be.be_group_173
 #: model:account.group.template,name:l10n_be.be_group_55
 msgid "Etablissements de crédit"
@@ -2676,114 +2964,133 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_432
+#: model:account.group,name:l10n_be.3_be_group_432
 #: model:account.group.template,name:l10n_be.be_group_432
 msgid "Etablissements de crédit - Crédits d'acceptation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_433
+#: model:account.group,name:l10n_be.3_be_group_433
 #: model:account.group.template,name:l10n_be.be_group_433
 msgid "Etablissements de crédit - Dettes en compte courant"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_430
+#: model:account.group,name:l10n_be.3_be_group_430
 #: model:account.group.template,name:l10n_be.be_group_430
 msgid "Etablissements de crédit - Emprunts en compte à terme fixe"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_431
+#: model:account.group,name:l10n_be.3_be_group_431
 #: model:account.group.template,name:l10n_be.be_group_431
 msgid "Etablissements de crédit - Promesses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_444
+#: model:account.group,name:l10n_be.3_be_group_444
 #: model:account.group.template,name:l10n_be.be_group_444
 msgid "Factures à recevoir"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a654
+#: model:account.account,name:l10n_be.3_a654
 #: model:account.account.template,name:l10n_be.a654
 msgid "Financial charges - Exchange differences"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a655
+#: model:account.account,name:l10n_be.3_a655
 #: model:account.account.template,name:l10n_be.a655
 msgid "Financial charges - Foreign currency translation differences"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a659
+#: model:account.account,name:l10n_be.3_a659
 #: model:account.account.template,name:l10n_be.a659
 msgid "Financial charges carried to assets as restructuring costs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a754
+#: model:account.account,name:l10n_be.3_a754
 #: model:account.account.template,name:l10n_be.a754
 msgid "Financial income - Exchange differences"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a755
+#: model:account.account,name:l10n_be.3_a755
 #: model:account.account.template,name:l10n_be.a755
 msgid "Financial income - Foreign currency translation differences"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a330
+#: model:account.account,name:l10n_be.3_a330
 #: model:account.account.template,name:l10n_be.a330
 msgid "Finished goods - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a339
+#: model:account.account,name:l10n_be.3_a339
 #: model:account.account.template,name:l10n_be.a339
 msgid "Finished goods - amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a520
+#: model:account.account,name:l10n_be.3_a520
 #: model:account.account.template,name:l10n_be.a520
 msgid "Fixed income securities - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a529
+#: model:account.account,name:l10n_be.3_a529
 #: model:account.account.template,name:l10n_be.a529
 msgid "Fixed income securities - Amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a539
+#: model:account.account,name:l10n_be.3_a539
 #: model:account.account.template,name:l10n_be.a539
 msgid "Fixed term deposit - Amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a531
+#: model:account.account,name:l10n_be.3_a531
 #: model:account.account.template,name:l10n_be.a531
 msgid "Fixed term deposit between one month and one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a530
+#: model:account.account,name:l10n_be.3_a530
 #: model:account.account.template,name:l10n_be.a530
 msgid "Fixed term deposit over one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a532
+#: model:account.account,name:l10n_be.3_a532
 #: model:account.account.template,name:l10n_be.a532
 msgid "Fixed term deposit up to one month"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_1
+#: model:account.group,name:l10n_be.3_be_group_1
 #: model:account.group.template,name:l10n_be.be_group_1
 msgid ""
 "Fonds propres, provisions pour risques et charges et dettes à plus d'un an"
@@ -2791,114 +3098,133 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a496
+#: model:account.account,name:l10n_be.3_a496
 #: model:account.account.template,name:l10n_be.a496
 msgid "Foreign currency translation differences - Assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a497
+#: model:account.account,name:l10n_be.3_a497
 #: model:account.account.template,name:l10n_be.a497
 msgid "Foreign currency translation differences - Liabilities"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1688
+#: model:account.account,name:l10n_be.3_a1688
 #: model:account.account.template,name:l10n_be.a1688
 msgid "Foreign deferred taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a673
+#: model:account.account,name:l10n_be.3_a673
 #: model:account.account.template,name:l10n_be.a673
 msgid "Foreign income taxes on the result of prior periods"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a672
+#: model:account.account,name:l10n_be.3_a672
 #: model:account.account.template,name:l10n_be.a672
 msgid "Foreign income taxes on the result of the current period"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a200
+#: model:account.account,name:l10n_be.3_a200
 #: model:account.account.template,name:l10n_be.a200
 msgid "Formation or capital increase expenses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a064
+#: model:account.account,name:l10n_be.3_a064
 #: model:account.account.template,name:l10n_be.a064
 msgid "Forward transactions - Currencies purchased (to be received)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a067
+#: model:account.account,name:l10n_be.3_a067
 #: model:account.account.template,name:l10n_be.a067
 msgid "Forward transactions - Currencies sold (to be delivered)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a060
+#: model:account.account,name:l10n_be.3_a060
 #: model:account.account.template,name:l10n_be.a060
 msgid "Forward transactions - Goods purchased (to be received)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a063
+#: model:account.account,name:l10n_be.3_a063
 #: model:account.account.template,name:l10n_be.a063
 msgid "Forward transactions - Goods sold (to be delivered)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_440
+#: model:account.group,name:l10n_be.3_be_group_440
 #: model:account.group.template,name:l10n_be.be_group_440
 msgid "Fournisseurs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_201
+#: model:account.group,name:l10n_be.3_be_group_201
 #: model:account.group.template,name:l10n_be.be_group_201
 msgid "Frais d'émission d'emprunts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_20
+#: model:account.group,name:l10n_be.3_be_group_20
 #: model:account.group.template,name:l10n_be.be_group_20
 msgid "Frais d'établissement"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_2
+#: model:account.group,name:l10n_be.3_be_group_2
 #: model:account.group.template,name:l10n_be.be_group_2
 msgid "Frais d'établissement, actifs immobilisés et créances à plus d'un an"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_200
+#: model:account.group,name:l10n_be.3_be_group_200
 #: model:account.group.template,name:l10n_be.be_group_200
 msgid "Frais de constitution et d'augmentation de capital"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_210
+#: model:account.group,name:l10n_be.3_be_group_210
 #: model:account.group.template,name:l10n_be.be_group_210
 msgid "Frais de recherche et de développement"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_204
+#: model:account.group,name:l10n_be.3_be_group_204
 #: model:account.group.template,name:l10n_be.be_group_204
 msgid "Frais de restructuration"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a24
+#: model:account.account,name:l10n_be.3_a24
 #: model:account.account.template,name:l10n_be.a24
 msgid "Furniture and vehicles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a241
+#: model:account.account,name:l10n_be.3_a241
 #: model:account.account.template,name:l10n_be.a241
 msgid ""
 "Furniture and vehicles owned by the association or the foundation in full "
@@ -2907,30 +3233,35 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a752
+#: model:account.account,name:l10n_be.3_a752
 #: model:account.account.template,name:l10n_be.a752
 msgid "Gain on disposal of current assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a741
+#: model:account.account,name:l10n_be.3_a741
 #: model:account.account.template,name:l10n_be.a741
 msgid "Gain on ordinary disposal of tangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a742
+#: model:account.account,name:l10n_be.3_a742
 #: model:account.account.template,name:l10n_be.a742
 msgid "Gain on ordinary disposal of trade debtors"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_00
+#: model:account.group,name:l10n_be.3_be_group_00
 #: model:account.group.template,name:l10n_be.be_group_00
 msgid "Garanties constituées par des tiers pour compte de l'entreprise"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_01
+#: model:account.group,name:l10n_be.3_be_group_01
 #: model:account.group.template,name:l10n_be.be_group_01
 msgid "Garanties personnelles constituées pour compte de tiers"
 msgstr ""
@@ -2938,6 +3269,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_03
 #: model:account.group,name:l10n_be.1_be_group_032
+#: model:account.group,name:l10n_be.3_be_group_03
+#: model:account.group,name:l10n_be.3_be_group_032
 #: model:account.group.template,name:l10n_be.be_group_03
 #: model:account.group.template,name:l10n_be.be_group_032
 msgid "Garanties reçues"
@@ -2945,36 +3278,42 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_023
+#: model:account.group,name:l10n_be.3_be_group_023
 #: model:account.group.template,name:l10n_be.be_group_023
 msgid "Garanties réelles constituées pour compte de tiers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_021
+#: model:account.group,name:l10n_be.3_be_group_021
 #: model:account.group.template,name:l10n_be.be_group_021
 msgid "Garanties réelles constituées pour compte propre"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_02
+#: model:account.group,name:l10n_be.3_be_group_02
 #: model:account.group.template,name:l10n_be.be_group_02
 msgid "Garanties réelles constituées sur avoirs propres"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a733
+#: model:account.account,name:l10n_be.3_a733
 #: model:account.account.template,name:l10n_be.a733
 msgid "Gifts with a recovery right"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a732
+#: model:account.account,name:l10n_be.3_a732
 #: model:account.account.template,name:l10n_be.a732
 msgid "Gifts without any recovery right"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a041
+#: model:account.account,name:l10n_be.3_a041
 #: model:account.account.template,name:l10n_be.a041
 msgid ""
 "Goods and securities held by third parties on their behalf but at the risk "
@@ -2983,6 +3322,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a074
+#: model:account.account,name:l10n_be.3_a074
 #: model:account.account.template,name:l10n_be.a074
 msgid ""
 "Goods and securities held for accounts or at the risk and profit of third "
@@ -2991,6 +3331,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a072
+#: model:account.account,name:l10n_be.3_a072
 #: model:account.account.template,name:l10n_be.a072
 msgid ""
 "Goods and values ​​from third parties received on deposit, consignment or "
@@ -2999,38 +3340,45 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a340
+#: model:account.account,name:l10n_be.3_a340
 #: model:account.account.template,name:l10n_be.a340
 msgid "Goods purchased for resale - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a349
+#: model:account.account,name:l10n_be.3_a349
 #: model:account.account.template,name:l10n_be.a349
 msgid "Goods purchased for resale - amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a212
+#: model:account.account,name:l10n_be.3_a212
 #: model:account.account.template,name:l10n_be.a212
 #: model:account.group,name:l10n_be.1_be_group_212
+#: model:account.group,name:l10n_be.3_be_group_212
 #: model:account.group.template,name:l10n_be.be_group_212
 msgid "Goodwill"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a413
+#: model:account.account,name:l10n_be.3_a413
 #: model:account.account.template,name:l10n_be.a413
 msgid "Grants receivable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a032
+#: model:account.account,name:l10n_be.3_a032
 #: model:account.account.template,name:l10n_be.a032
 msgid "Guarantees received"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a098
+#: model:account.account,name:l10n_be.3_a098
 #: model:account.account.template,name:l10n_be.a098
 msgid "Holders of options (buying or selling securities)"
 msgstr ""
@@ -3052,138 +3400,161 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_35
+#: model:account.group,name:l10n_be.3_be_group_35
 #: model:account.group.template,name:l10n_be.be_group_35
 msgid "Immeubles destinés à la vente"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_21
+#: model:account.group,name:l10n_be.3_be_group_21
 #: model:account.group.template,name:l10n_be.be_group_21
 msgid "Immobilisation incorporelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_27
+#: model:account.group,name:l10n_be.3_be_group_27
 #: model:account.group.template,name:l10n_be.be_group_27
 msgid "Immobilisations corporelles en cours et acomptes versés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_25
+#: model:account.group,name:l10n_be.3_be_group_25
 #: model:account.group.template,name:l10n_be.be_group_25
 msgid "Immobilisations détenues en location-financement et droits similaires"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_28
+#: model:account.group,name:l10n_be.3_be_group_28
 #: model:account.group.template,name:l10n_be.be_group_28
 msgid "Immobilisations financières"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a350
+#: model:account.account,name:l10n_be.3_a350
 #: model:account.account.template,name:l10n_be.a350
 msgid "Immovable property intended for sale - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a359
+#: model:account.account,name:l10n_be.3_a359
 #: model:account.account.template,name:l10n_be.a359
 msgid "Immovable property intended for sale - amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_771
+#: model:account.group,name:l10n_be.3_be_group_771
 #: model:account.group.template,name:l10n_be.be_group_771
 msgid "Impôts belges sur le résultat"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_671
+#: model:account.group,name:l10n_be.3_be_group_671
 #: model:account.group.template,name:l10n_be.be_group_671
 msgid "Impôts belges sur le résultat d'exercices antérieurs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_670
+#: model:account.group,name:l10n_be.3_be_group_670
 #: model:account.group.template,name:l10n_be.be_group_670
 msgid "Impôts belges sur le résultat de l'exercice"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_168
+#: model:account.group,name:l10n_be.3_be_group_168
 #: model:account.group.template,name:l10n_be.be_group_168
 msgid "Impôts différés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_412
+#: model:account.group,name:l10n_be.3_be_group_412
 #: model:account.group.template,name:l10n_be.be_group_412
 msgid "Impôts et précomptes à récupérer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_452
+#: model:account.group,name:l10n_be.3_be_group_452
 #: model:account.group.template,name:l10n_be.be_group_452
 msgid "Impôts et taxes à payer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_67
+#: model:account.group,name:l10n_be.3_be_group_67
 #: model:account.group.template,name:l10n_be.be_group_67
 msgid "Impôts sur le résultat"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_773
+#: model:account.group,name:l10n_be.3_be_group_773
 #: model:account.group.template,name:l10n_be.be_group_773
 msgid "Impôts étrangers sur le résultat"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_673
+#: model:account.group,name:l10n_be.3_be_group_673
 #: model:account.group.template,name:l10n_be.be_group_673
 msgid "Impôts étrangers sur le résultat d'exercices antérieurs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_672
+#: model:account.group,name:l10n_be.3_be_group_672
 #: model:account.group.template,name:l10n_be.be_group_672
 msgid "Impôts étrangers sur le résultat de l'exercice"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a751
+#: model:account.account,name:l10n_be.3_a751
 #: model:account.account.template,name:l10n_be.a751
 msgid "Income from current assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a750
+#: model:account.account,name:l10n_be.3_a750
 #: model:account.account.template,name:l10n_be.a750
 msgid "Income from financial fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7170
+#: model:account.account,name:l10n_be.3_a7170
 #: model:account.account.template,name:l10n_be.a7170
 msgid "Increase (decrease) in contracts in progress - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7171
+#: model:account.account,name:l10n_be.3_a7171
 #: model:account.account.template,name:l10n_be.a7171
 msgid "Increase (decrease) in contracts in progress - Profit recognized"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a713
+#: model:account.account,name:l10n_be.3_a713
 #: model:account.account.template,name:l10n_be.a713
 msgid "Increase (decrease) in stocks of finished goods"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a71
+#: model:account.account,name:l10n_be.3_a71
 #: model:account.account.template,name:l10n_be.a71
 msgid ""
 "Increase (decrease) in stocks of finished goods and work and contracts in "
@@ -3192,6 +3563,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a715
+#: model:account.account,name:l10n_be.3_a715
 #: model:account.account.template,name:l10n_be.a715
 msgid ""
 "Increase (decrease) in stocks of immovable property constructed for resale"
@@ -3199,6 +3571,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a712
+#: model:account.account,name:l10n_be.3_a712
 #: model:account.account.template,name:l10n_be.a712
 msgid "Increase (decrease) in work in progress"
 msgstr ""
@@ -3206,6 +3579,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_23
 #: model:account.group,name:l10n_be.1_be_group_251
+#: model:account.group,name:l10n_be.3_be_group_23
+#: model:account.group,name:l10n_be.3_be_group_251
 #: model:account.group.template,name:l10n_be.be_group_23
 #: model:account.group.template,name:l10n_be.be_group_251
 msgid "Installations, machines et outillage"
@@ -3213,54 +3588,63 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a213
+#: model:account.account,name:l10n_be.3_a213
 #: model:account.account.template,name:l10n_be.a213
 msgid "Intangible fixed assets - Advance payments"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6500
+#: model:account.account,name:l10n_be.3_a6500
 #: model:account.account.template,name:l10n_be.a6500
 msgid "Interests, commissions and other charges relating to debts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_794
+#: model:account.group,name:l10n_be.3_be_group_794
 #: model:account.group.template,name:l10n_be.be_group_794
 msgid "Intervention d'associés (ou du propriétaire) dans la perte"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a15
+#: model:account.account,name:l10n_be.3_a15
 #: model:account.account.template,name:l10n_be.a15
 msgid "Investment grants"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a753
+#: model:account.account,name:l10n_be.3_a753
 #: model:account.account.template,name:l10n_be.a753
 msgid "Investment grants and interest subsidies"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a151
+#: model:account.account,name:l10n_be.3_a151
 #: model:account.account.template,name:l10n_be.a151
 msgid "Investment grants received in cash"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a152
+#: model:account.account,name:l10n_be.3_a152
 #: model:account.account.template,name:l10n_be.a152
 msgid "Investment grants received in kind"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a444
+#: model:account.account,name:l10n_be.3_a444
 #: model:account.account.template,name:l10n_be.a444
 msgid "Invoices to be received payable within one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a100
+#: model:account.account,name:l10n_be.3_a100
 #: model:account.account.template,name:l10n_be.a100
 msgid "Issued capital"
 msgstr ""
@@ -3277,18 +3661,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a220
+#: model:account.account,name:l10n_be.3_a220
 #: model:account.account.template,name:l10n_be.a220
 msgid "Land"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2201
+#: model:account.account,name:l10n_be.3_a2201
 #: model:account.account.template,name:l10n_be.a2201
 msgid "Land owned by the association or the foundation in full property"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a422
+#: model:account.account,name:l10n_be.3_a422
 #: model:account.account.template,name:l10n_be.a422
 msgid ""
 "Leasing and similar obligations payable after more than one year falling due"
@@ -3297,139 +3684,161 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a252
+#: model:account.account,name:l10n_be.3_a252
 #: model:account.account.template,name:l10n_be.a252
 msgid "Leasing and similar rights - Furniture and vehicles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a250
+#: model:account.account,name:l10n_be.3_a250
 #: model:account.account.template,name:l10n_be.a250
 msgid "Leasing and similar rights - Land and buildings"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a251
+#: model:account.account,name:l10n_be.3_a251
 #: model:account.account.template,name:l10n_be.a251
 msgid "Leasing and similar rights - Plant, machinery and equipment"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a735
+#: model:account.account,name:l10n_be.3_a735
 #: model:account.account.template,name:l10n_be.a735
 msgid "Legacies with a recovery right"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a734
+#: model:account.account,name:l10n_be.3_a734
 #: model:account.account.template,name:l10n_be.a734
 msgid "Legacies without any recovery right"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a130
+#: model:account.account,name:l10n_be.3_a130
 #: model:account.account.template,name:l10n_be.a130
 msgid "Legal reserve"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a487
+#: model:account.account,name:l10n_be.3_a487
 #: model:account.account.template,name:l10n_be.a487
 msgid "Lent securities to return"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_l10nbe_chart_template_liquidity_transfer
+#: model:account.account,name:l10n_be.3_l10nbe_chart_template_liquidity_transfer
 #: model:account.account.template,name:l10n_be.l10nbe_chart_template_liquidity_transfer
 msgid "Liquidity Transfer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a201
+#: model:account.account,name:l10n_be.3_a201
 #: model:account.account.template,name:l10n_be.a201
 msgid "Loan issue expenses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a0702
+#: model:account.account,name:l10n_be.3_a0702
 #: model:account.account.template,name:l10n_be.a0702
 msgid "Long-term usage rights - On furniture and rolling stock"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a0701
+#: model:account.account,name:l10n_be.3_a0701
 #: model:account.account.template,name:l10n_be.a0701
 msgid "Long-term usage rights - On installations, machines and tools"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a0700
+#: model:account.account,name:l10n_be.3_a0700
 #: model:account.account.template,name:l10n_be.a0700
 msgid "Long-term usage rights - On land and buildings"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a690
+#: model:account.account,name:l10n_be.3_a690
 #: model:account.account.template,name:l10n_be.a690
 msgid "Loss brought forward from previous year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a141
-#: model:account.account,name:l10n_be.2_a141
+#: model:account.account,name:l10n_be.3_a141
 #: model:account.account.template,name:l10n_be.a141
 msgid "Loss carried forward"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a641
+#: model:account.account,name:l10n_be.3_a641
 #: model:account.account.template,name:l10n_be.a641
 msgid "Loss on ordinary disposal of tangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a642
+#: model:account.account,name:l10n_be.3_a642
 #: model:account.account.template,name:l10n_be.a642
 msgid "Loss on ordinary disposal of trade debtors"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a652
+#: model:account.account,name:l10n_be.3_a652
 #: model:account.account.template,name:l10n_be.a652
 msgid "Losses on disposal of current assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a793
+#: model:account.account,name:l10n_be.3_a793
 #: model:account.account.template,name:l10n_be.a793
 msgid "Losses to be carried forward"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_34
+#: model:account.group,name:l10n_be.3_be_group_34
 #: model:account.group.template,name:l10n_be.be_group_34
 msgid "Marchandises"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_060
+#: model:account.group,name:l10n_be.3_be_group_060
 #: model:account.group.template,name:l10n_be.be_group_060
 msgid "Marchandises achetées à terme - à recevoir"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_063
+#: model:account.group,name:l10n_be.3_be_group_063
 #: model:account.group.template,name:l10n_be.be_group_063
 msgid "Marchandises vendues à terme - à livrer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_06
+#: model:account.group,name:l10n_be.3_be_group_06
 #: model:account.group.template,name:l10n_be.be_group_06
 msgid "Marchés à terme"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a429
+#: model:account.account,name:l10n_be.3_a429
 #: model:account.account.template,name:l10n_be.a429
 msgid ""
 "Miscellaneous amounts payable after more than one year falling due within "
@@ -3438,6 +3847,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1792
+#: model:account.account,name:l10n_be.3_a1792
 #: model:account.account.template,name:l10n_be.a1792
 msgid ""
 "Miscellaneous amounts payable with a remaining term of more than one year - "
@@ -3446,6 +3856,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1790
+#: model:account.account,name:l10n_be.3_a1790
 #: model:account.account.template,name:l10n_be.a1790
 msgid ""
 "Miscellaneous amounts payable with a remaining term of more than one year - "
@@ -3454,6 +3865,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1791
+#: model:account.account,name:l10n_be.3_a1791
 #: model:account.account.template,name:l10n_be.a1791
 msgid ""
 "Miscellaneous amounts payable with a remaining term of more than one year - "
@@ -3462,6 +3874,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a480
+#: model:account.account,name:l10n_be.3_a480
 #: model:account.account.template,name:l10n_be.a480
 msgid ""
 "Miscellaneous amounts payable within one year - Debentures and matured "
@@ -3470,12 +3883,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a483
+#: model:account.account,name:l10n_be.3_a483
 #: model:account.account.template,name:l10n_be.a483
 msgid "Miscellaneous amounts payable within one year - Grants to repay"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a488
+#: model:account.account,name:l10n_be.3_a488
 #: model:account.account.template,name:l10n_be.a488
 msgid ""
 "Miscellaneous amounts payable within one year - Guarantees received in cash"
@@ -3483,6 +3898,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4890
+#: model:account.account,name:l10n_be.3_a4890
 #: model:account.account.template,name:l10n_be.a4890
 msgid ""
 "Miscellaneous amounts payable within one year - Sundry interest-bearing "
@@ -3491,6 +3907,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4891
+#: model:account.account,name:l10n_be.3_a4891
 #: model:account.account.template,name:l10n_be.a4891
 msgid ""
 "Miscellaneous amounts payable within one year - Sundry non interest-bearing "
@@ -3500,6 +3917,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_24
 #: model:account.group,name:l10n_be.1_be_group_252
+#: model:account.group,name:l10n_be.3_be_group_24
+#: model:account.group,name:l10n_be.3_be_group_252
 #: model:account.group.template,name:l10n_be.be_group_24
 #: model:account.group.template,name:l10n_be.be_group_252
 msgid "Mobilier et matériel roulant"
@@ -3507,42 +3926,49 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_652
+#: model:account.group,name:l10n_be.3_be_group_652
 #: model:account.group.template,name:l10n_be.be_group_652
 msgid "Moins-values sur réalisation d'actifs circulants"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_663
+#: model:account.group,name:l10n_be.3_be_group_663
 #: model:account.group.template,name:l10n_be.be_group_663
 msgid "Moins-values sur réalisation d'actifs immobilisés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_641
+#: model:account.group,name:l10n_be.3_be_group_641
 #: model:account.group.template,name:l10n_be.be_group_641
 msgid "Moins-values sur réalisations courantes d'immobilisations corporelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_642
+#: model:account.group,name:l10n_be.3_be_group_642
 #: model:account.group.template,name:l10n_be.be_group_642
 msgid "Moins-values sur réalisations de créances commerciales"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_511
+#: model:account.group,name:l10n_be.3_be_group_511
 #: model:account.group.template,name:l10n_be.be_group_511
 msgid "Montants non appelés (-)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a64012
+#: model:account.account,name:l10n_be.3_a64012
 #: model:account.account.template,name:l10n_be.a64012
 msgid "Non deductible taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2915
+#: model:account.account,name:l10n_be.3_a2915
 #: model:account.account.template,name:l10n_be.a2915
 msgid ""
 "Non interest-bearing amounts receivable after more than one year or with an "
@@ -3551,6 +3977,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a415
+#: model:account.account,name:l10n_be.3_a415
 #: model:account.account.template,name:l10n_be.a415
 msgid ""
 "Non interest-bearing amounts receivable within one year or with an "
@@ -3559,6 +3986,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6600
+#: model:account.account,name:l10n_be.3_a6600
 #: model:account.account.template,name:l10n_be.a6600
 msgid ""
 "Non-recurring depreciation of and amounts written off formation expenses"
@@ -3566,6 +3994,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6601
+#: model:account.account,name:l10n_be.3_a6601
 #: model:account.account.template,name:l10n_be.a6601
 msgid ""
 "Non-recurring depreciation of and amounts written off intangible fixed "
@@ -3574,6 +4003,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6602
+#: model:account.account,name:l10n_be.3_a6602
 #: model:account.account.template,name:l10n_be.a6602
 msgid ""
 "Non-recurring depreciation of and amounts written off tangible fixed assets"
@@ -3581,6 +4011,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6691
+#: model:account.account,name:l10n_be.3_a6691
 #: model:account.account.template,name:l10n_be.a6691
 msgid ""
 "Non-recurring financial charges carried to assets as restructuring costs"
@@ -3588,6 +4019,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6690
+#: model:account.account,name:l10n_be.3_a6690
 #: model:account.account.template,name:l10n_be.a6690
 msgid ""
 "Non-recurring operating charges carried to assets as restructuring costs"
@@ -3595,68 +4027,72 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_480
+#: model:account.group,name:l10n_be.3_be_group_480
 #: model:account.group.template,name:l10n_be.be_group_480
 msgid "Obligations et coupons échus"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_56
+#: model:account.group,name:l10n_be.3_be_group_56
 #: model:account.group.template,name:l10n_be.be_group_56
 msgid "Office des chèques postaux"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_454
+#: model:account.group,name:l10n_be.3_be_group_454
 #: model:account.group.template,name:l10n_be.be_group_454
 msgid "Office national de la sécurité sociale"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a094
+#: model:account.account,name:l10n_be.3_a094
 #: model:account.account.template,name:l10n_be.a094
 msgid "Ongoing litigation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a737
+#: model:account.account,name:l10n_be.3_a737
 #: model:account.account.template,name:l10n_be.a737
 msgid "Operating Subsidies"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a643
+#: model:account.account,name:l10n_be.3_a643
 #: model:account.account.template,name:l10n_be.a643
 msgid "Operating charges - Gifts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6431
+#: model:account.account,name:l10n_be.3_a6431
 #: model:account.account.template,name:l10n_be.a6431
 msgid "Operating charges - Gifts with a recovery right"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6432
+#: model:account.account,name:l10n_be.3_a6432
 #: model:account.account.template,name:l10n_be.a6432
 msgid "Operating charges - Gifts without any recovery right"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a649
+#: model:account.account,name:l10n_be.3_a649
 #: model:account.account.template,name:l10n_be.a649
 msgid "Operating charges carried to assets as restructuring costs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a740
+#: model:account.account,name:l10n_be.3_a740
 #: model:account.account.template,name:l10n_be.a740
 msgid "Operating subsidies and compensatory amounts"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.account,name:l10n_be.1_a099
-#: model:account.account.template,name:l10n_be.a099
-msgid "Options (buy or sell) on securities issued."
 msgstr ""
 
 #. module: l10n_be
@@ -3665,31 +4101,43 @@ msgid "Operations"
 msgstr ""
 
 #. module: l10n_be
+#: model:account.account,name:l10n_be.1_a099
+#: model:account.account,name:l10n_be.3_a099
+#: model:account.account.template,name:l10n_be.a099
+msgid "Options (buy or sell) on securities issued."
+msgstr ""
+
+#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a668
+#: model:account.account,name:l10n_be.3_a668
 #: model:account.account.template,name:l10n_be.a668
 msgid "Other  non-recurring financial charges"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a769
+#: model:account.account,name:l10n_be.3_a769
 #: model:account.account.template,name:l10n_be.a769
 msgid "Other  non-recurring financial income"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a473
+#: model:account.account,name:l10n_be.3_a473
 #: model:account.account.template,name:l10n_be.a473
 msgid "Other allocations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a697
+#: model:account.account,name:l10n_be.3_a697
 #: model:account.account.template,name:l10n_be.a697
 msgid "Other allocations entitlements"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2919
+#: model:account.account,name:l10n_be.3_a2919
 #: model:account.account.template,name:l10n_be.a2919
 msgid ""
 "Other amounts receivable after more than one year - Amounts written down"
@@ -3697,24 +4145,28 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2911
+#: model:account.account,name:l10n_be.3_a2911
 #: model:account.account.template,name:l10n_be.a2911
 msgid "Other amounts receivable after more than one year - Bills receivable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2910
+#: model:account.account,name:l10n_be.3_a2910
 #: model:account.account.template,name:l10n_be.a2910
 msgid "Other amounts receivable after more than one year - Current account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2917
+#: model:account.account,name:l10n_be.3_a2917
 #: model:account.account.template,name:l10n_be.a2917
 msgid "Other amounts receivable after more than one year - Doubtful amounts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2817
+#: model:account.account,name:l10n_be.3_a2817
 #: model:account.account.template,name:l10n_be.a2817
 msgid ""
 "Other amounts receivable from affiliated enterprises - Doubtful amounts"
@@ -3722,108 +4174,126 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a419
+#: model:account.account,name:l10n_be.3_a419
 #: model:account.account.template,name:l10n_be.a419
 msgid "Other amounts receivable within one year - Amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a417
+#: model:account.account,name:l10n_be.3_a417
 #: model:account.account.template,name:l10n_be.a417
 msgid "Other amounts receivable within one year - Doubtful amounts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a418
+#: model:account.account,name:l10n_be.3_a418
 #: model:account.account.template,name:l10n_be.a418
 msgid "Other amounts receivable within one year - Guarantees paid in cash"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a414
+#: model:account.account,name:l10n_be.3_a414
 #: model:account.account.template,name:l10n_be.a414
 msgid "Other amounts receivable within one year - Income receivable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a416
+#: model:account.account,name:l10n_be.3_a416
 #: model:account.account.template,name:l10n_be.a416
 msgid "Other amounts receivable within one year - Sundry amounts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2212
+#: model:account.account,name:l10n_be.3_a2212
 #: model:account.account.template,name:l10n_be.a2212
 msgid "Other building"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2222
+#: model:account.account,name:l10n_be.3_a2222
 #: model:account.account.template,name:l10n_be.a2222
 msgid "Other built-up lands"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6502
+#: model:account.account,name:l10n_be.3_a6502
 #: model:account.account.template,name:l10n_be.a6502
 msgid "Other debt charges"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2859
+#: model:account.account,name:l10n_be.3_a2859
 #: model:account.account.template,name:l10n_be.a2859
 msgid "Other financial assets - Amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2851
+#: model:account.account,name:l10n_be.3_a2851
 #: model:account.account.template,name:l10n_be.a2851
 msgid "Other financial assets - Bills receivable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a288
+#: model:account.account,name:l10n_be.3_a288
 #: model:account.account.template,name:l10n_be.a288
 msgid "Other financial assets - Cash Guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2850
+#: model:account.account,name:l10n_be.3_a2850
 #: model:account.account.template,name:l10n_be.a2850
 msgid "Other financial assets - Current account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2857
+#: model:account.account,name:l10n_be.3_a2857
 #: model:account.account.template,name:l10n_be.a2857
 msgid "Other financial assets - Doubtful amounts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2852
+#: model:account.account,name:l10n_be.3_a2852
 #: model:account.account.template,name:l10n_be.a2852
 msgid "Other financial assets - Fixed income securities"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a202
+#: model:account.account,name:l10n_be.3_a202
 #: model:account.account.template,name:l10n_be.a202
 msgid "Other formation expenses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a242
+#: model:account.account,name:l10n_be.3_a242
 #: model:account.account.template,name:l10n_be.a242
 msgid "Other furniture and vehicles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2202
+#: model:account.account,name:l10n_be.3_a2202
 #: model:account.account.template,name:l10n_be.a2202
 msgid "Other land"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a424
+#: model:account.account,name:l10n_be.3_a424
 #: model:account.account.template,name:l10n_be.a424
 msgid ""
 "Other loans payable after more than one year falling due within one year"
@@ -3831,72 +4301,84 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a439
+#: model:account.account,name:l10n_be.3_a439
 #: model:account.account.template,name:l10n_be.a439
 msgid "Other loans payable within one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a174
+#: model:account.account,name:l10n_be.3_a174
 #: model:account.account.template,name:l10n_be.a174
 msgid "Other loans with a remaining term of more than one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2840
+#: model:account.account,name:l10n_be.3_a2840
 #: model:account.account.template,name:l10n_be.a2840
 msgid "Other participating interests and shares - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2849
+#: model:account.account,name:l10n_be.3_a2849
 #: model:account.account.template,name:l10n_be.a2849
 msgid "Other participating interests and shares - Amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2848
+#: model:account.account,name:l10n_be.3_a2848
 #: model:account.account.template,name:l10n_be.a2848
 msgid "Other participating interests and shares - Revaluation surpluses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2841
+#: model:account.account,name:l10n_be.3_a2841
 #: model:account.account.template,name:l10n_be.a2841
 msgid "Other participating interests and shares - Uncalled amounts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a623
+#: model:account.account,name:l10n_be.3_a623
 #: model:account.account.template,name:l10n_be.a623
 msgid "Other personnel costs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a232
+#: model:account.account,name:l10n_be.3_a232
 #: model:account.account.template,name:l10n_be.a232
 msgid "Other plant, machinery and equipment"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1311
+#: model:account.account,name:l10n_be.3_a1311
 #: model:account.account.template,name:l10n_be.a1311
 msgid "Other reserves not available"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a223
+#: model:account.account,name:l10n_be.3_a223
 #: model:account.account.template,name:l10n_be.a223
 msgid "Other rights to immovable property"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2232
+#: model:account.account,name:l10n_be.3_a2232
 #: model:account.account.template,name:l10n_be.a2232
 msgid "Other rights to immovable property - Other"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2231
+#: model:account.account,name:l10n_be.3_a2231
 #: model:account.account.template,name:l10n_be.a2231
 msgid ""
 "Other rights to immovable property belonging to the association or the "
@@ -3905,18 +4387,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a26
+#: model:account.account,name:l10n_be.3_a26
 #: model:account.account.template,name:l10n_be.a26
 msgid "Other tangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a262
+#: model:account.account,name:l10n_be.3_a262
 #: model:account.account.template,name:l10n_be.a262
 msgid "Other tangible fixed assets - Other"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a261
+#: model:account.account,name:l10n_be.3_a261
 #: model:account.account.template,name:l10n_be.a261
 msgid ""
 "Other tangible fixed assets owned by the association or the foundation in "
@@ -3925,18 +4410,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a72
+#: model:account.account,name:l10n_be.3_a72
 #: model:account.account.template,name:l10n_be.a72
 msgid "Own work capitalised"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a794
+#: model:account.account,name:l10n_be.3_a794
 #: model:account.account.template,name:l10n_be.a794
 msgid "Owners' contribution in respect of losses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2800
+#: model:account.account,name:l10n_be.3_a2800
 #: model:account.account.template,name:l10n_be.a2800
 msgid ""
 "Participating interests and shares in associated enterprises - Acquisition "
@@ -3945,6 +4433,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2809
+#: model:account.account,name:l10n_be.3_a2809
 #: model:account.account.template,name:l10n_be.a2809
 msgid ""
 "Participating interests and shares in associated enterprises - Amounts "
@@ -3953,6 +4442,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2808
+#: model:account.account,name:l10n_be.3_a2808
 #: model:account.account.template,name:l10n_be.a2808
 msgid ""
 "Participating interests and shares in associated enterprises - Revaluation "
@@ -3961,6 +4451,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2801
+#: model:account.account,name:l10n_be.3_a2801
 #: model:account.account.template,name:l10n_be.a2801
 msgid ""
 "Participating interests and shares in associated enterprises - Uncalled "
@@ -3969,6 +4460,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2820
+#: model:account.account,name:l10n_be.3_a2820
 #: model:account.account.template,name:l10n_be.a2820
 msgid ""
 "Participating interests and shares in enterprises linked by a participating "
@@ -3977,6 +4469,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2829
+#: model:account.account,name:l10n_be.3_a2829
 #: model:account.account.template,name:l10n_be.a2829
 msgid ""
 "Participating interests and shares in enterprises linked by a participating "
@@ -3985,6 +4478,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2828
+#: model:account.account,name:l10n_be.3_a2828
 #: model:account.account.template,name:l10n_be.a2828
 msgid ""
 "Participating interests and shares in enterprises linked by a participating "
@@ -3993,6 +4487,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2821
+#: model:account.account,name:l10n_be.3_a2821
 #: model:account.account.template,name:l10n_be.a2821
 msgid ""
 "Participating interests and shares in enterprises linked by a participating "
@@ -4001,6 +4496,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_282
+#: model:account.group,name:l10n_be.3_be_group_282
 #: model:account.group.template,name:l10n_be.be_group_282
 msgid ""
 "Participations dans des entreprises avec lesquelles il existe un lien de "
@@ -4009,18 +4505,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_280
+#: model:account.group,name:l10n_be.3_be_group_280
 #: model:account.group.template,name:l10n_be.be_group_280
 msgid "Participations dans des entreprises liées"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_624
+#: model:account.group,name:l10n_be.3_be_group_624
 #: model:account.group.template,name:l10n_be.be_group_624
 msgid "Pensions de retraite et de survie"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_617
+#: model:account.group,name:l10n_be.3_be_group_617
 #: model:account.group.template,name:l10n_be.be_group_617
 msgid ""
 "Personnel intérimaire et personnes mises à la disposition de l'entreprise"
@@ -4028,12 +4527,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_690
+#: model:account.group,name:l10n_be.3_be_group_690
 #: model:account.group.template,name:l10n_be.be_group_690
 msgid "Perte reportée de l'exercice précédent"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_793
+#: model:account.group,name:l10n_be.3_be_group_793
 #: model:account.group.template,name:l10n_be.be_group_793
 msgid "Perte à reporter"
 msgstr ""
@@ -4041,6 +4542,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_5101
 #: model:account.group,name:l10n_be.1_be_group_5191
+#: model:account.group,name:l10n_be.3_be_group_5101
+#: model:account.group,name:l10n_be.3_be_group_5191
 #: model:account.group.template,name:l10n_be.be_group_5101
 #: model:account.group.template,name:l10n_be.be_group_5191
 msgid "Placements de trésorerie autres que placements à revenu fixe"
@@ -4048,18 +4551,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_5
+#: model:account.group,name:l10n_be.3_be_group_5
 #: model:account.group.template,name:l10n_be.be_group_5
 msgid "Placements de trésorerie et valeurs disponibles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a23
+#: model:account.account,name:l10n_be.3_a23
 #: model:account.account.template,name:l10n_be.a23
 msgid "Plant, machinery and equipment"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a231
+#: model:account.account,name:l10n_be.3_a231
 #: model:account.account.template,name:l10n_be.a231
 msgid ""
 "Plant, machinery and equipment owned by the association or the foundation in"
@@ -4068,126 +4574,147 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_12
+#: model:account.group,name:l10n_be.3_be_group_12
 #: model:account.group.template,name:l10n_be.be_group_12
 msgid "Plus-values de réévaluation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_121
+#: model:account.group,name:l10n_be.3_be_group_121
 #: model:account.group.template,name:l10n_be.be_group_121
 msgid "Plus-values de réévaluation sur immobilisations corporelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_122
+#: model:account.group,name:l10n_be.3_be_group_122
 #: model:account.group.template,name:l10n_be.be_group_122
 msgid "Plus-values de réévaluation sur immobilisations financières"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_120
+#: model:account.group,name:l10n_be.3_be_group_120
 #: model:account.group.template,name:l10n_be.be_group_120
 msgid "Plus-values de réévaluation sur immobilisations incorporelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_123
+#: model:account.group,name:l10n_be.3_be_group_123
 #: model:account.group.template,name:l10n_be.be_group_123
 msgid "Plus-values de réévaluation sur stocks"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_752
+#: model:account.group,name:l10n_be.3_be_group_752
 #: model:account.group.template,name:l10n_be.be_group_752
 msgid "Plus-values sur réalisation d'actifs circulants"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_763
+#: model:account.group,name:l10n_be.3_be_group_763
 #: model:account.group.template,name:l10n_be.be_group_763
 msgid "Plus-values sur réalisation d'actifs immobilisés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_742
+#: model:account.group,name:l10n_be.3_be_group_742
 #: model:account.group.template,name:l10n_be.be_group_742
 msgid "Plus-values sur réalisation de créances commerciales"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_741
+#: model:account.group,name:l10n_be.3_be_group_741
 #: model:account.group.template,name:l10n_be.be_group_741
 msgid "Plus-values sur réalisations courantes d'immobilisations corporelles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_11
+#: model:account.group,name:l10n_be.3_be_group_11
 #: model:account.group.template,name:l10n_be.be_group_11
 msgid "Primes d'émission"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_622
+#: model:account.group,name:l10n_be.3_be_group_622
 #: model:account.group.template,name:l10n_be.be_group_622
 msgid "Primes patronales pour assurances extra-légales"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a073
+#: model:account.account,name:l10n_be.3_a073
 #: model:account.account.template,name:l10n_be.a073
 msgid "Principals and depositors of goods and securities"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_72
+#: model:account.group,name:l10n_be.3_be_group_72
 #: model:account.group.template,name:l10n_be.be_group_72
 msgid "Production immobilisée"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_7
+#: model:account.group,name:l10n_be.3_be_group_7
 #: model:account.group.template,name:l10n_be.be_group_7
 msgid "Produits"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_491
+#: model:account.group,name:l10n_be.3_be_group_491
 #: model:account.group.template,name:l10n_be.be_group_491
 msgid "Produits acquis"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_743
+#: model:account.group,name:l10n_be.3_be_group_743
 #: model:account.group.template,name:l10n_be.be_group_743
 msgid "Produits d'exploitation divers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_76
+#: model:account.group,name:l10n_be.3_be_group_76
 #: model:account.group.template,name:l10n_be.be_group_76
 msgid "Produits d'exploitation ou financiers non récurrents"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_751
+#: model:account.group,name:l10n_be.3_be_group_751
 #: model:account.group.template,name:l10n_be.be_group_751
 msgid "Produits des actifs circulants"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_750
+#: model:account.group,name:l10n_be.3_be_group_750
 #: model:account.group.template,name:l10n_be.be_group_750
 msgid "Produits des immobilisations financières"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_75
+#: model:account.group,name:l10n_be.3_be_group_75
 #: model:account.group.template,name:l10n_be.be_group_75
 msgid "Produits financiers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_756
+#: model:account.group,name:l10n_be.3_be_group_756
 #: model:account.group.template,name:l10n_be.be_group_756
 msgid "Produits financiers divers"
 msgstr ""
@@ -4195,6 +4722,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_33
 #: model:account.group,name:l10n_be.1_be_group_330
+#: model:account.group,name:l10n_be.3_be_group_33
+#: model:account.group,name:l10n_be.3_be_group_330
 #: model:account.group.template,name:l10n_be.be_group_33
 #: model:account.group.template,name:l10n_be.be_group_330
 msgid "Produits finis"
@@ -4203,6 +4732,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_404
 #: model:account.group,name:l10n_be.1_be_group_414
+#: model:account.group,name:l10n_be.3_be_group_404
+#: model:account.group,name:l10n_be.3_be_group_414
 #: model:account.group.template,name:l10n_be.be_group_404
 #: model:account.group.template,name:l10n_be.be_group_414
 msgid "Produits à recevoir"
@@ -4210,61 +4741,70 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_493
+#: model:account.group,name:l10n_be.3_be_group_493
 #: model:account.group.template,name:l10n_be.be_group_493
 msgid "Produits à reporter"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a790
+#: model:account.account,name:l10n_be.3_a790
 #: model:account.account.template,name:l10n_be.a790
 msgid "Profit brought forward from previous year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a140
-#: model:account.account,name:l10n_be.2_a140
+#: model:account.account,name:l10n_be.3_a140
 #: model:account.account.template,name:l10n_be.a140
 msgid "Profit carried forward"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a693
+#: model:account.account,name:l10n_be.3_a693
 #: model:account.account.template,name:l10n_be.a693
 msgid "Profits to be carried forward"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6360
+#: model:account.account,name:l10n_be.3_a6360
 #: model:account.account.template,name:l10n_be.a6360
 msgid "Provision for major repairs and maintenance - Appropriations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6361
+#: model:account.account,name:l10n_be.3_a6361
 #: model:account.account.template,name:l10n_be.a6361
 msgid "Provision for major repairs and maintenance - Uses and write-backs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_16
+#: model:account.group,name:l10n_be.3_be_group_16
 #: model:account.group.template,name:l10n_be.be_group_16
 msgid "Provisions et impôts différés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a163
+#: model:account.account,name:l10n_be.3_a163
 #: model:account.account.template,name:l10n_be.a163
 msgid "Provisions for environmental obligations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a162
+#: model:account.account,name:l10n_be.3_a162
 #: model:account.account.template,name:l10n_be.a162
 msgid "Provisions for major repairs and maintenance"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a66210
+#: model:account.account,name:l10n_be.3_a66210
 #: model:account.account.template,name:l10n_be.a66210
 msgid ""
 "Provisions for non-recurring financial liabilities and charges - "
@@ -4273,12 +4813,14 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a66211
+#: model:account.account,name:l10n_be.3_a66211
 #: model:account.account.template,name:l10n_be.a66211
 msgid "Provisions for non-recurring financial liabilities and charges - Uses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a66200
+#: model:account.account,name:l10n_be.3_a66200
 #: model:account.account.template,name:l10n_be.a66200
 msgid ""
 "Provisions for non-recurring operating liabilities and charges - "
@@ -4287,18 +4829,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a66201
+#: model:account.account,name:l10n_be.3_a66201
 #: model:account.account.template,name:l10n_be.a66201
 msgid "Provisions for non-recurring operating liabilities and charges - Uses"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6370
+#: model:account.account,name:l10n_be.3_a6370
 #: model:account.account.template,name:l10n_be.a6370
 msgid "Provisions for other risks and charges - Appropriations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6380
+#: model:account.account,name:l10n_be.3_a6380
 #: model:account.account.template,name:l10n_be.a6380
 msgid ""
 "Provisions for other risks and charges - Provisions for environmental "
@@ -4307,6 +4852,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6381
+#: model:account.account,name:l10n_be.3_a6381
 #: model:account.account.template,name:l10n_be.a6381
 msgid ""
 "Provisions for other risks and charges - Provisions for environmental "
@@ -4315,42 +4861,49 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6371
+#: model:account.account,name:l10n_be.3_a6371
 #: model:account.account.template,name:l10n_be.a6371
 msgid "Provisions for other risks and charges - Uses (write-back)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a160
+#: model:account.account,name:l10n_be.3_a160
 #: model:account.account.template,name:l10n_be.a160
 msgid "Provisions for pensions and similar obligations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6350
+#: model:account.account,name:l10n_be.3_a6350
 #: model:account.account.template,name:l10n_be.a6350
 msgid "Provisions for pensions and similar obligations - Appropriations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6351
+#: model:account.account,name:l10n_be.3_a6351
 #: model:account.account.template,name:l10n_be.a6351
 msgid "Provisions for pensions and similar obligations - Uses and write-backs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a161
+#: model:account.account,name:l10n_be.3_a161
 #: model:account.account.template,name:l10n_be.a161
 msgid "Provisions for taxation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6560
+#: model:account.account,name:l10n_be.3_a6560
 #: model:account.account.template,name:l10n_be.a6560
 msgid "Provisions of a financial nature - Appropriations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6561
+#: model:account.account,name:l10n_be.3_a6561
 #: model:account.account.template,name:l10n_be.a6561
 msgid "Provisions of a financial nature - Uses and write-backs"
 msgstr ""
@@ -4358,6 +4911,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_164
 #: model:account.group,name:l10n_be.1_be_group_638
+#: model:account.group,name:l10n_be.3_be_group_164
+#: model:account.group,name:l10n_be.3_be_group_638
 #: model:account.group.template,name:l10n_be.be_group_164
 #: model:account.group.template,name:l10n_be.be_group_638
 msgid "Provisions pour autres risques et charges"
@@ -4365,6 +4920,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_161
+#: model:account.group,name:l10n_be.3_be_group_161
 #: model:account.group.template,name:l10n_be.be_group_161
 msgid "Provisions pour charges fiscales"
 msgstr ""
@@ -4372,6 +4928,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_162
 #: model:account.group,name:l10n_be.1_be_group_636
+#: model:account.group,name:l10n_be.3_be_group_162
+#: model:account.group,name:l10n_be.3_be_group_636
 #: model:account.group.template,name:l10n_be.be_group_162
 #: model:account.group.template,name:l10n_be.be_group_636
 msgid "Provisions pour grosses réparations et gros entretien"
@@ -4380,6 +4938,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_163
 #: model:account.group,name:l10n_be.1_be_group_637
+#: model:account.group,name:l10n_be.3_be_group_163
+#: model:account.group,name:l10n_be.3_be_group_637
 #: model:account.group.template,name:l10n_be.be_group_163
 #: model:account.group.template,name:l10n_be.be_group_637
 msgid "Provisions pour obligations environnementales"
@@ -4388,6 +4948,8 @@ msgstr ""
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_160
 #: model:account.group,name:l10n_be.1_be_group_635
+#: model:account.group,name:l10n_be.3_be_group_160
+#: model:account.group,name:l10n_be.3_be_group_635
 #: model:account.group.template,name:l10n_be.be_group_160
 #: model:account.group.template,name:l10n_be.be_group_635
 msgid "Provisions pour pensions et obligations similaires"
@@ -4395,174 +4957,203 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_662
+#: model:account.group,name:l10n_be.3_be_group_662
 #: model:account.group.template,name:l10n_be.be_group_662
 msgid "Provisions pour risques et charges non récurrents"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_656
+#: model:account.group,name:l10n_be.3_be_group_656
 #: model:account.group.template,name:l10n_be.be_group_656
 msgid "Provisions à caractère financier"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_453
+#: model:account.group,name:l10n_be.3_be_group_453
 #: model:account.group.template,name:l10n_be.be_group_453
 msgid "Précomptes retenus"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_791
+#: model:account.group,name:l10n_be.3_be_group_791
 #: model:account.group.template,name:l10n_be.be_group_791
 msgid "Prélèvement sur le capital et les primes d'émission"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_792
+#: model:account.group,name:l10n_be.3_be_group_792
 #: model:account.group.template,name:l10n_be.be_group_792
 msgid "Prélèvement sur les réserves"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_780
+#: model:account.group,name:l10n_be.3_be_group_780
 #: model:account.group.template,name:l10n_be.be_group_780
 msgid "Prélèvements sur les impôts différés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_789
+#: model:account.group,name:l10n_be.3_be_group_789
 #: model:account.group.template,name:l10n_be.be_group_789
 msgid "Prélèvements sur les réserves immunisées"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_78
+#: model:account.group,name:l10n_be.3_be_group_78
 #: model:account.group.template,name:l10n_be.be_group_78
 msgid "Prélèvements sur les réserves immunisées et les impôts différés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a601
+#: model:account.account,name:l10n_be.3_a601
 #: model:account.account.template,name:l10n_be.a601
 msgid "Purchases of consumables"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a604
+#: model:account.account,name:l10n_be.3_a604
 #: model:account.account.template,name:l10n_be.a604
 msgid "Purchases of goods for resale"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a605
+#: model:account.account,name:l10n_be.3_a605
 #: model:account.account.template,name:l10n_be.a605
 msgid "Purchases of immovable property for resale"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a600
+#: model:account.account,name:l10n_be.3_a600
 #: model:account.account.template,name:l10n_be.a600
 msgid "Purchases of raw materials"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a602
+#: model:account.account,name:l10n_be.3_a602
 #: model:account.account.template,name:l10n_be.a602
 msgid "Purchases of services, works and studies"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_456
+#: model:account.group,name:l10n_be.3_be_group_456
 #: model:account.group.template,name:l10n_be.be_group_456
 msgid "Pécules de vacances"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a300
+#: model:account.account,name:l10n_be.3_a300
 #: model:account.account.template,name:l10n_be.a300
 msgid "Raw materials - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a309
+#: model:account.account,name:l10n_be.3_a309
 #: model:account.account.template,name:l10n_be.a309
 msgid "Raw materials - amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a023
+#: model:account.account,name:l10n_be.3_a023
 #: model:account.account.template,name:l10n_be.a023
 msgid "Real guarantees provided on behalf of third parties"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_708
+#: model:account.group,name:l10n_be.3_be_group_708
 #: model:account.group.template,name:l10n_be.be_group_708
 msgid "Remises, ristournes et rabais accordés (–)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_608
+#: model:account.group,name:l10n_be.3_be_group_608
 #: model:account.group.template,name:l10n_be.be_group_608
 msgid "Remises, ristournes et rabais obtenus (–)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6200
+#: model:account.account,name:l10n_be.3_a6200
 #: model:account.account.template,name:l10n_be.a6200
 msgid "Remuneration and direct social benefits - Directors and managers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6202
+#: model:account.account,name:l10n_be.3_a6202
 #: model:account.account.template,name:l10n_be.a6202
 msgid "Remuneration and direct social benefits - Employees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6201
+#: model:account.account,name:l10n_be.3_a6201
 #: model:account.account.template,name:l10n_be.a6201
 msgid "Remuneration and direct social benefits - Executive"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6203
+#: model:account.account,name:l10n_be.3_a6203
 #: model:account.account.template,name:l10n_be.a6203
 msgid "Remuneration and direct social benefits - Manual workers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6204
+#: model:account.account,name:l10n_be.3_a6204
 #: model:account.account.template,name:l10n_be.a6204
 msgid "Remuneration and direct social benefits - Other staff members"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a456
+#: model:account.account,name:l10n_be.3_a456
 #: model:account.account.template,name:l10n_be.a456
 msgid "Remuneration and social security - Holiday pay"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a454
+#: model:account.account,name:l10n_be.3_a454
 #: model:account.account.template,name:l10n_be.a454
 msgid "Remuneration and social security - National Social Security Office"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a459
+#: model:account.account,name:l10n_be.3_a459
 #: model:account.account.template,name:l10n_be.a459
 msgid "Remuneration and social security - Other social obligations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a455
+#: model:account.account,name:l10n_be.3_a455
 #: model:account.account.template,name:l10n_be.a455
 msgid "Remuneration and social security - Remuneration"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a618
+#: model:account.account,name:l10n_be.3_a618
 #: model:account.account.template,name:l10n_be.a618
 msgid ""
 "Remuneration, premiums for extra statutory insurance, pensions of the "
@@ -4572,96 +5163,112 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a071
+#: model:account.account,name:l10n_be.3_a071
 #: model:account.account.template,name:l10n_be.a071
 msgid "Rent and royalty creditors"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_760
+#: model:account.group,name:l10n_be.3_be_group_760
 #: model:account.group.template,name:l10n_be.be_group_760
 msgid "Reprises d'amortissements et de réductions de valeur"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_762
+#: model:account.group,name:l10n_be.3_be_group_762
 #: model:account.group.template,name:l10n_be.be_group_762
 msgid "Reprises de provisions pour risques et charges non récurrents"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_761
+#: model:account.group,name:l10n_be.3_be_group_761
 #: model:account.group.template,name:l10n_be.be_group_761
 msgid "Reprises de réductions de valeur sur immobilisations financières"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_124
+#: model:account.group,name:l10n_be.3_be_group_124
 #: model:account.group.template,name:l10n_be.be_group_124
 msgid "Reprises de réductions de valeur sur placements de trésorerie"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a210
+#: model:account.account,name:l10n_be.3_a210
 #: model:account.account.template,name:l10n_be.a210
 msgid "Research and development costs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1310
+#: model:account.account,name:l10n_be.3_a1310
 #: model:account.account.template,name:l10n_be.a1310
 msgid "Reserves not available in respect of own shares held"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a204
+#: model:account.account,name:l10n_be.3_a204
 #: model:account.account.template,name:l10n_be.a204
 msgid "Restructuring costs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6240
+#: model:account.account,name:l10n_be.3_a6240
 #: model:account.account.template,name:l10n_be.a6240
 msgid "Retirement and survivors' pensions - Directors and managers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6241
+#: model:account.account,name:l10n_be.3_a6241
 #: model:account.account.template,name:l10n_be.a6241
 msgid "Retirement and survivors' pensions - Personnel"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a122
+#: model:account.account,name:l10n_be.3_a122
 #: model:account.account.template,name:l10n_be.a122
 msgid "Revaluation surpluses on financial fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a120
+#: model:account.account,name:l10n_be.3_a120
 #: model:account.account.template,name:l10n_be.a120
 msgid "Revaluation surpluses on intangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a123
+#: model:account.account,name:l10n_be.3_a123
 #: model:account.account.template,name:l10n_be.a123
 msgid "Revaluation surpluses on stocks"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a121
+#: model:account.account,name:l10n_be.3_a121
 #: model:account.account.template,name:l10n_be.a121
 msgid "Revaluation surpluses on tangible fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a097
+#: model:account.account,name:l10n_be.3_a097
 #: model:account.account.template,name:l10n_be.a097
 msgid "Rights on technical guarantees"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_519
+#: model:account.group,name:l10n_be.3_be_group_519
 #: model:account.group.template,name:l10n_be.be_group_519
 msgid "Réductions de valeur actées (-)"
 msgstr ""
@@ -4679,6 +5286,18 @@ msgstr ""
 #: model:account.group,name:l10n_be.1_be_group_419
 #: model:account.group,name:l10n_be.1_be_group_529
 #: model:account.group,name:l10n_be.1_be_group_539
+#: model:account.group,name:l10n_be.3_be_group_309
+#: model:account.group,name:l10n_be.3_be_group_319
+#: model:account.group,name:l10n_be.3_be_group_329
+#: model:account.group,name:l10n_be.3_be_group_339
+#: model:account.group,name:l10n_be.3_be_group_349
+#: model:account.group,name:l10n_be.3_be_group_359
+#: model:account.group,name:l10n_be.3_be_group_369
+#: model:account.group,name:l10n_be.3_be_group_379
+#: model:account.group,name:l10n_be.3_be_group_409
+#: model:account.group,name:l10n_be.3_be_group_419
+#: model:account.group,name:l10n_be.3_be_group_529
+#: model:account.group,name:l10n_be.3_be_group_539
 #: model:account.group.template,name:l10n_be.be_group_309
 #: model:account.group.template,name:l10n_be.be_group_319
 #: model:account.group.template,name:l10n_be.be_group_329
@@ -4696,96 +5315,112 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_651
+#: model:account.group,name:l10n_be.3_be_group_651
 #: model:account.group.template,name:l10n_be.be_group_651
 msgid "Réductions de valeur sur actifs circulants"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_632
+#: model:account.group,name:l10n_be.3_be_group_632
 #: model:account.group.template,name:l10n_be.be_group_632
 msgid "Réductions de valeur sur commandes en cours"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_633
+#: model:account.group,name:l10n_be.3_be_group_633
 #: model:account.group.template,name:l10n_be.be_group_633
 msgid "Réductions de valeur sur créances commerciales à plus d'un an"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_634
+#: model:account.group,name:l10n_be.3_be_group_634
 #: model:account.group.template,name:l10n_be.be_group_634
 msgid "Réductions de valeur sur créances commerciales à un an au plus"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_661
+#: model:account.group,name:l10n_be.3_be_group_661
 #: model:account.group.template,name:l10n_be.be_group_661
 msgid "Réductions de valeur sur immobilisations financières (dotations)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_631
+#: model:account.group,name:l10n_be.3_be_group_631
 #: model:account.group.template,name:l10n_be.be_group_631
 msgid "Réductions de valeur sur stocks"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.fiscal.position,name:l10n_be.1_fiscal_position_template_4
+#: model:account.fiscal.position,name:l10n_be.3_fiscal_position_template_4
 #: model:account.fiscal.position.template,name:l10n_be.fiscal_position_template_4
 msgid "Régime Cocontractant"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.fiscal.position,name:l10n_be.1_fiscal_position_template_2
+#: model:account.fiscal.position,name:l10n_be.3_fiscal_position_template_2
 #: model:account.fiscal.position.template,name:l10n_be.fiscal_position_template_2
 msgid "Régime Extra-Communautaire"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.fiscal.position,name:l10n_be.1_fiscal_position_template_3
+#: model:account.fiscal.position,name:l10n_be.3_fiscal_position_template_3
 #: model:account.fiscal.position.template,name:l10n_be.fiscal_position_template_3
 msgid "Régime Intra-Communautaire"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.fiscal.position,name:l10n_be.1_fiscal_position_template_1
+#: model:account.fiscal.position,name:l10n_be.3_fiscal_position_template_1
 #: model:account.fiscal.position.template,name:l10n_be.fiscal_position_template_1
 msgid "Régime National"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_77
+#: model:account.group,name:l10n_be.3_be_group_77
 #: model:account.group.template,name:l10n_be.be_group_77
 msgid "Régularisations d'impôts et reprises de provisions fiscales"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_694
+#: model:account.group,name:l10n_be.3_be_group_694
 #: model:account.group.template,name:l10n_be.be_group_694
 msgid "Rémunération du capital"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_455
+#: model:account.group,name:l10n_be.3_be_group_455
 #: model:account.group.template,name:l10n_be.be_group_455
 msgid "Rémunérations"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_620
+#: model:account.group,name:l10n_be.3_be_group_620
 #: model:account.group.template,name:l10n_be.be_group_620
 msgid "Rémunérations et avantages sociaux directs"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_62
+#: model:account.group,name:l10n_be.3_be_group_62
 #: model:account.group.template,name:l10n_be.be_group_62
 msgid "Rémunérations, charges sociales et pensions"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_618
+#: model:account.group,name:l10n_be.3_be_group_618
 #: model:account.group.template,name:l10n_be.be_group_618
 msgid ""
 "Rémunérations, primes pour assurances extralégales, pensions de retraite et "
@@ -4795,114 +5430,133 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_130
+#: model:account.group,name:l10n_be.3_be_group_130
 #: model:account.group.template,name:l10n_be.be_group_130
 msgid "Réserve légale"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_13
+#: model:account.group,name:l10n_be.3_be_group_13
 #: model:account.group.template,name:l10n_be.be_group_13
 msgid "Réserves"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_133
+#: model:account.group,name:l10n_be.3_be_group_133
 #: model:account.group.template,name:l10n_be.be_group_133
 msgid "Réserves disponibles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_132
+#: model:account.group,name:l10n_be.3_be_group_132
 #: model:account.group.template,name:l10n_be.be_group_132
 msgid "Réserves immunisées"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_131
+#: model:account.group,name:l10n_be.3_be_group_131
 #: model:account.group.template,name:l10n_be.be_group_131
 msgid "Réserves indisponibles"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a053
+#: model:account.account,name:l10n_be.3_a053
 #: model:account.account.template,name:l10n_be.a053
 msgid "Sale commitment"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7012
+#: model:account.account,name:l10n_be.3_a7012
 #: model:account.account.template,name:l10n_be.a7012
 msgid "Sales rendered for export (finished goods)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7002
+#: model:account.account,name:l10n_be.3_a7002
 #: model:account.account.template,name:l10n_be.a7002
 msgid "Sales rendered for export (marchandises)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7010
+#: model:account.account,name:l10n_be.3_a7010
 #: model:account.account.template,name:l10n_be.a7010
 msgid "Sales rendered in Belgium (finished goods)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7000
+#: model:account.account,name:l10n_be.3_a7000
 #: model:account.account.template,name:l10n_be.a7000
 msgid "Sales rendered in Belgium (marchandises)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7011
+#: model:account.account,name:l10n_be.3_a7011
 #: model:account.account.template,name:l10n_be.a7011
 msgid "Sales rendered in E.E.C. (finished goods)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7001
+#: model:account.account,name:l10n_be.3_a7001
 #: model:account.account.template,name:l10n_be.a7001
 msgid "Sales rendered in E.E.C. (marchandises)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a61
+#: model:account.account,name:l10n_be.3_a61
 #: model:account.account.template,name:l10n_be.a61
 msgid "Services and other goods"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_61
+#: model:account.group,name:l10n_be.3_be_group_61
 #: model:account.group.template,name:l10n_be.be_group_61
 msgid "Services et biens divers"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7052
+#: model:account.account,name:l10n_be.3_a7052
 #: model:account.account.template,name:l10n_be.a7052
 msgid "Services rendered for export"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7050
+#: model:account.account,name:l10n_be.3_a7050
 #: model:account.account.template,name:l10n_be.a7050
 msgid "Services rendered in Belgium"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7051
+#: model:account.account,name:l10n_be.3_a7051
 #: model:account.account.template,name:l10n_be.a7051
 msgid "Services rendered in E.E.C."
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a11
+#: model:account.account,name:l10n_be.3_a11
 #: model:account.account.template,name:l10n_be.a11
 msgid "Share premium account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a510
+#: model:account.account,name:l10n_be.3_a510
 #: model:account.account.template,name:l10n_be.a510
 msgid ""
 "Shares and current investments other than fixed income investments - "
@@ -4911,6 +5565,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a519
+#: model:account.account,name:l10n_be.3_a519
 #: model:account.account.template,name:l10n_be.a519
 msgid ""
 "Shares and current investments other than fixed income investments - Amounts"
@@ -4919,6 +5574,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a511
+#: model:account.account,name:l10n_be.3_a511
 #: model:account.account.template,name:l10n_be.a511
 msgid ""
 "Shares and current investments other than fixed income investments - "
@@ -4927,36 +5583,42 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_603
+#: model:account.group,name:l10n_be.3_be_group_603
 #: model:account.group.template,name:l10n_be.be_group_603
 msgid "Sous-traitances générales"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a031
+#: model:account.account,name:l10n_be.3_a031
 #: model:account.account.template,name:l10n_be.a031
 msgid "Statutory applicants"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a030
+#: model:account.account,name:l10n_be.3_a030
 #: model:account.account.template,name:l10n_be.a030
 msgid "Statutory deposits"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_3
+#: model:account.group,name:l10n_be.3_be_group_3
 #: model:account.group.template,name:l10n_be.be_group_3
 msgid "Stocks et commandes en cours d'exécution"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a603
+#: model:account.account,name:l10n_be.3_a603
 #: model:account.account.template,name:l10n_be.a603
 msgid "Sub-contracting"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4200
+#: model:account.account,name:l10n_be.3_a4200
 #: model:account.account.template,name:l10n_be.a4200
 msgid ""
 "Subordinated loans payable after more than one year falling due within one "
@@ -4965,6 +5627,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4201
+#: model:account.account,name:l10n_be.3_a4201
 #: model:account.account.template,name:l10n_be.a4201
 msgid ""
 "Subordinated loans payable after more than one year falling due within one "
@@ -4973,6 +5636,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1700
+#: model:account.account,name:l10n_be.3_a1700
 #: model:account.account.template,name:l10n_be.a1700
 msgid ""
 "Subordinated loans with a remaining term of more than one year - Convertible"
@@ -4981,6 +5645,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1701
+#: model:account.account,name:l10n_be.3_a1701
 #: model:account.account.template,name:l10n_be.a1701
 msgid ""
 "Subordinated loans with a remaining term of more than one year - Non "
@@ -4989,278 +5654,90 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_740
+#: model:account.group,name:l10n_be.3_be_group_740
 #: model:account.group.template,name:l10n_be.be_group_740
 msgid "Subsides d'exploitation et montants compensatoires"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_15
+#: model:account.group,name:l10n_be.3_be_group_15
 #: model:account.group.template,name:l10n_be.be_group_15
 msgid "Subsides en capital"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_753
+#: model:account.group,name:l10n_be.3_be_group_753
 #: model:account.group.template,name:l10n_be.be_group_753
 msgid "Subsides en capital et en intérêts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1750
+#: model:account.account,name:l10n_be.3_a1750
 #: model:account.account.template,name:l10n_be.a1750
 msgid "Suppliers (more than one year)"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a440
+#: model:account.account,name:l10n_be.3_a440
 #: model:account.account.template,name:l10n_be.a440
 msgid "Suppliers payable within one year"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a499
+#: model:account.account,name:l10n_be.3_a499
 #: model:account.account.template,name:l10n_be.a499
 msgid "Suspense account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_451
+#: model:account.group,name:l10n_be.3_be_group_451
 #: model:account.group.template,name:l10n_be.be_group_451
 msgid "T.V.A. à payer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_411
+#: model:account.group,name:l10n_be.3_be_group_411
 #: model:account.group.template,name:l10n_be.be_group_411
 msgid "T.V.A. à récupérer"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_0
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-S
 msgid "TVA 0%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-CC
-msgid "TVA 0% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-T
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-T
-msgid "TVA 0% EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-ROW
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-ROW
-msgid "TVA 0% Non EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_12
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-S
 msgid "TVA 12%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-CC
-msgid "TVA 12% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-EU
-msgid "TVA 12% EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-ROW-CC
-msgid "TVA 12% Non EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_21
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-S
 msgid "TVA 21%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-CC
-msgid "TVA 21% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-EU
-msgid "TVA 21% EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-ROW-CC
-msgid "TVA 21% Non EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_TVA-21-inclus-dans-prix
-#: model:account.tax.template,description:l10n_be.attn_TVA-21-inclus-dans-prix
-msgid "TVA 21% TTC"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-CAR-EXC
-msgid "TVA 50% Non Déductible - Frais de voiture (Prix Excl.)"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-06-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-06-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_6
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-06-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-06-S
 msgid "TVA 6%"
 msgstr ""
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-CC
-msgid "TVA 6% Cocont."
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-EU
-msgid "TVA 6% EU"
-msgstr ""
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-ROW-CC
-msgid "TVA 6% Non EU"
-msgstr ""
-
-#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a27
+#: model:account.account,name:l10n_be.3_a27
 #: model:account.account.template,name:l10n_be.a27
 msgid "Tangible fixed assets under construction and advance payments"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_472
+#: model:account.group,name:l10n_be.3_be_group_472
 #: model:account.group.template,name:l10n_be.be_group_472
 msgid "Tantièmes de l'exercice"
 msgstr ""
@@ -5272,66 +5749,77 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a412
+#: model:account.account,name:l10n_be.3_a412
 #: model:account.account.template,name:l10n_be.a412
 msgid "Taxes and withholdings taxes to be recovered"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4128
+#: model:account.account,name:l10n_be.3_a4128
 #: model:account.account.template,name:l10n_be.a4128
 msgid "Taxes and withholdings taxes to be recovered - Foreign taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a452
+#: model:account.account,name:l10n_be.3_a452
 #: model:account.account.template,name:l10n_be.a452
 msgid "Taxes payable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4528
+#: model:account.account,name:l10n_be.3_a4528
 #: model:account.account.template,name:l10n_be.a4528
 msgid "Taxes payable - Foreign taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a640
+#: model:account.account,name:l10n_be.3_a640
 #: model:account.account.template,name:l10n_be.a640
 msgid "Taxes related to operation"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a453
+#: model:account.account,name:l10n_be.3_a453
 #: model:account.account.template,name:l10n_be.a453
 msgid "Taxes withheld"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_220
+#: model:account.group,name:l10n_be.3_be_group_220
 #: model:account.group.template,name:l10n_be.be_group_220
 msgid "Terrains"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_222
+#: model:account.group,name:l10n_be.3_be_group_222
 #: model:account.group.template,name:l10n_be.be_group_222
 msgid "Terrains bâtis"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_250
+#: model:account.group,name:l10n_be.3_be_group_250
 #: model:account.group.template,name:l10n_be.be_group_250
 msgid "Terrains et construction"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_22
+#: model:account.group,name:l10n_be.3_be_group_22
 #: model:account.group.template,name:l10n_be.be_group_22
 msgid "Terrains et constructions"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a040
+#: model:account.account,name:l10n_be.3_a040
 #: model:account.account.template,name:l10n_be.a040
 msgid ""
 "Third parties, holders in their name but at the risks and profits of the "
@@ -5340,18 +5828,21 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a001
+#: model:account.account,name:l10n_be.3_a001
 #: model:account.account.template,name:l10n_be.a001
 msgid "Third party guarantees on behalf of the company"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_001
+#: model:account.group,name:l10n_be.3_be_group_001
 #: model:account.group.template,name:l10n_be.be_group_001
 msgid "Tiers constituants de garanties pour compte de l'entreprise"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_040
+#: model:account.group,name:l10n_be.3_be_group_040
 #: model:account.group.template,name:l10n_be.be_group_040
 msgid ""
 "Tiers, détenteurs en leur nom mais aux risques et profits de l'entreprise de"
@@ -5360,126 +5851,147 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_52
+#: model:account.group,name:l10n_be.3_be_group_52
 #: model:account.group.template,name:l10n_be.be_group_52
 msgid "Titres à revenu fixe"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2906
+#: model:account.account,name:l10n_be.3_a2906
 #: model:account.account.template,name:l10n_be.a2906
 msgid "Trade debtors after more than one year - Advance payments"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2909
+#: model:account.account,name:l10n_be.3_a2909
 #: model:account.account.template,name:l10n_be.a2909
 msgid "Trade debtors after more than one year - Amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2901
+#: model:account.account,name:l10n_be.3_a2901
 #: model:account.account.template,name:l10n_be.a2901
 msgid "Trade debtors after more than one year - Bills receivable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2900
+#: model:account.account,name:l10n_be.3_a2900
 #: model:account.account.template,name:l10n_be.a2900
 msgid "Trade debtors after more than one year - Customer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a2907
+#: model:account.account,name:l10n_be.3_a2907
 #: model:account.account.template,name:l10n_be.a2907
 msgid "Trade debtors after more than one year - Doubtful amounts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a406
+#: model:account.account,name:l10n_be.3_a406
 #: model:account.account.template,name:l10n_be.a406
 msgid "Trade debtors within one year - Advance payments"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a409
+#: model:account.account,name:l10n_be.3_a409
 #: model:account.account.template,name:l10n_be.a409
 msgid "Trade debtors within one year - Amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a401
+#: model:account.account,name:l10n_be.3_a401
 #: model:account.account.template,name:l10n_be.a401
 msgid "Trade debtors within one year - Bills receivable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a400
+#: model:account.account,name:l10n_be.3_a400
 #: model:account.account.template,name:l10n_be.a400
 msgid "Trade debtors within one year - Customer"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a407
+#: model:account.account,name:l10n_be.3_a407
 #: model:account.account.template,name:l10n_be.a407
 msgid "Trade debtors within one year - Doubtful amounts"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a404
+#: model:account.account,name:l10n_be.3_a404
 #: model:account.account.template,name:l10n_be.a404
 msgid "Trade debtors within one year - Income receivable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a780
+#: model:account.account,name:l10n_be.3_a780
 #: model:account.account.template,name:l10n_be.a780
 msgid "Transfer from deferred taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a789
+#: model:account.account,name:l10n_be.3_a789
 #: model:account.account.template,name:l10n_be.a789
 msgid "Transfer from untaxed reserves"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a680
+#: model:account.account,name:l10n_be.3_a680
 #: model:account.account.template,name:l10n_be.a680
 msgid "Transfer to deferred taxes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a689
+#: model:account.account,name:l10n_be.3_a689
 #: model:account.account.template,name:l10n_be.a689
 msgid "Transfer to untaxed reserves"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_680
+#: model:account.group,name:l10n_be.3_be_group_680
 #: model:account.group.template,name:l10n_be.be_group_680
 msgid "Transferts aux impôts différés"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_68
+#: model:account.group,name:l10n_be.3_be_group_68
 #: model:account.group.template,name:l10n_be.be_group_68
 msgid "Transferts aux impôts différés et aux réserves immunisées"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_689
+#: model:account.group,name:l10n_be.3_be_group_689
 #: model:account.group.template,name:l10n_be.be_group_689
 msgid "Transferts aux réserves immunisées"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a101
+#: model:account.account,name:l10n_be.3_a101
 #: model:account.account.template,name:l10n_be.a101
 msgid "Uncalled capital"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4210
+#: model:account.account,name:l10n_be.3_a4210
 #: model:account.account.template,name:l10n_be.a4210
 msgid ""
 "Unsubordinated debentures payable after more than one year falling due "
@@ -5488,6 +6000,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4211
+#: model:account.account,name:l10n_be.3_a4211
 #: model:account.account.template,name:l10n_be.a4211
 msgid ""
 "Unsubordinated debentures payable after more than one year falling due "
@@ -5496,6 +6009,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1710
+#: model:account.account,name:l10n_be.3_a1710
 #: model:account.account.template,name:l10n_be.a1710
 msgid ""
 "Unsubordinated debentures with a remaining term of more than one year - "
@@ -5504,6 +6018,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a1711
+#: model:account.account,name:l10n_be.3_a1711
 #: model:account.account.template,name:l10n_be.a1711
 msgid ""
 "Unsubordinated debentures with a remaining term of more than one year - Non "
@@ -5512,6 +6027,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a132
+#: model:account.account,name:l10n_be.3_a132
 #: model:account.account.template,name:l10n_be.a132
 msgid "Untaxed reserves"
 msgstr ""
@@ -5528,72 +6044,84 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4512
+#: model:account.account,name:l10n_be.3_a4512
 #: model:account.account.template,name:l10n_be.a4512
 msgid "VAT due - Current Account"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451
+#: model:account.account,name:l10n_be.3_a451
 #: model:account.account.template,name:l10n_be.a451
 msgid "VAT payable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451055
+#: model:account.account,name:l10n_be.3_a451055
 #: model:account.account.template,name:l10n_be.a451055
 msgid "VAT payable - Intracommunity acquisitions - box 55"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451054
+#: model:account.account,name:l10n_be.3_a451054
 #: model:account.account.template,name:l10n_be.a451054
 msgid "VAT payable - compartment 54"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451063
+#: model:account.account,name:l10n_be.3_a451063
 #: model:account.account.template,name:l10n_be.a451063
 msgid "VAT payable - credit notes - compartment 63"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451056
+#: model:account.account,name:l10n_be.3_a451056
 #: model:account.account.template,name:l10n_be.a451056
 msgid "VAT payable - reverse charge (cocontracting) - compartment 56"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451057
+#: model:account.account,name:l10n_be.3_a451057
 #: model:account.account.template,name:l10n_be.a451057
 msgid "VAT payable - reverse charge (import) - compartment 57"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451830
+#: model:account.account,name:l10n_be.3_a451830
 #: model:account.account.template,name:l10n_be.a451830
 msgid "VAT payable - revisions"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451800
+#: model:account.account,name:l10n_be.3_a451800
 #: model:account.account.template,name:l10n_be.a451800
 msgid "VAT payable - revisions insufficiencies"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a451820
+#: model:account.account,name:l10n_be.3_a451820
 #: model:account.account.template,name:l10n_be.a451820
 msgid "VAT payable - revisions of deductions"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a411
+#: model:account.account,name:l10n_be.3_a411
 #: model:account.account.template,name:l10n_be.a411
 msgid "VAT recoverable"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a4112
+#: model:account.account,name:l10n_be.3_a4112
 #: model:account.account.template,name:l10n_be.a4112
 msgid "VAT recoverable - Current Account"
 msgstr ""
@@ -5612,6 +6140,14 @@ msgstr ""
 #: model:account.group,name:l10n_be.1_be_group_370
 #: model:account.group,name:l10n_be.1_be_group_510
 #: model:account.group,name:l10n_be.1_be_group_520
+#: model:account.group,name:l10n_be.3_be_group_300
+#: model:account.group,name:l10n_be.3_be_group_310
+#: model:account.group,name:l10n_be.3_be_group_320
+#: model:account.group,name:l10n_be.3_be_group_340
+#: model:account.group,name:l10n_be.3_be_group_350
+#: model:account.group,name:l10n_be.3_be_group_370
+#: model:account.group,name:l10n_be.3_be_group_510
+#: model:account.group,name:l10n_be.3_be_group_520
 #: model:account.group.template,name:l10n_be.be_group_300
 #: model:account.group.template,name:l10n_be.be_group_310
 #: model:account.group.template,name:l10n_be.be_group_320
@@ -5625,66 +6161,77 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_54
+#: model:account.group,name:l10n_be.3_be_group_54
 #: model:account.group.template,name:l10n_be.be_group_54
 msgid "Valeurs échues à l'encaissement"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_71
+#: model:account.group,name:l10n_be.3_be_group_71
 #: model:account.group.template,name:l10n_be.be_group_71
 msgid "Variation des stocks et des commandes en cours d'exécution"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_609
+#: model:account.group,name:l10n_be.3_be_group_609
 #: model:account.group.template,name:l10n_be.be_group_609
 msgid "Variations des stocks"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_700
+#: model:account.group,name:l10n_be.3_be_group_700
 #: model:account.group.template,name:l10n_be.be_group_700
 msgid "Ventes et prestations de services"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_58
+#: model:account.group,name:l10n_be.3_be_group_58
 #: model:account.group.template,name:l10n_be.be_group_58
 msgid "Virements internes"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a792
+#: model:account.account,name:l10n_be.3_a792
 #: model:account.account.template,name:l10n_be.a792
 msgid "Withdrawal from allocated funds"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a791
+#: model:account.account,name:l10n_be.3_a791
 #: model:account.account.template,name:l10n_be.a791
 msgid "Withdrawal from the association or foundation funds"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a320
+#: model:account.account,name:l10n_be.3_a320
 #: model:account.account.template,name:l10n_be.a320
 msgid "Work in progress - Acquisition value"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a329
+#: model:account.account,name:l10n_be.3_a329
 #: model:account.account.template,name:l10n_be.a329
 msgid "Work in progress - amounts written down"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a761
+#: model:account.account,name:l10n_be.3_a761
 #: model:account.account.template,name:l10n_be.a761
 msgid "Write-back of amounts written down financial fixed assets"
 msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7600
+#: model:account.account,name:l10n_be.3_a7600
 #: model:account.account.template,name:l10n_be.a7600
 msgid ""
 "Write-back of depreciation and of amounts written off intangible fixed "
@@ -5693,6 +6240,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7601
+#: model:account.account,name:l10n_be.3_a7601
 #: model:account.account.template,name:l10n_be.a7601
 msgid ""
 "Write-back of depreciation and of amounts written off tangible fixed assets"
@@ -5700,6 +6248,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7621
+#: model:account.account,name:l10n_be.3_a7621
 #: model:account.account.template,name:l10n_be.a7621
 msgid ""
 "Write-back of provisions for non-recurring financial liabilities and charges"
@@ -5707,6 +6256,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a7620
+#: model:account.account,name:l10n_be.3_a7620
 #: model:account.account.template,name:l10n_be.a7620
 msgid ""
 "Write-back of provisions for non-recurring operating liabilities and charges"
@@ -5721,6 +6271,7 @@ msgstr ""
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_755
+#: model:account.group,name:l10n_be.3_be_group_755
 #: model:account.group.template,name:l10n_be.be_group_755
 msgid "Écart de conversion des devises"
 msgstr ""

--- a/addons/l10n_be/i18n/nl.po
+++ b/addons/l10n_be/i18n/nl.po
@@ -4,9 +4,9 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Odoo Server 13.0\n"
+"Project-Id-Version: Odoo Server saas~16.1\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2022-04-05 14:50+0000\n"
+"POT-Creation-Date: 2023-02-02 17:05+0000\n"
 "PO-Revision-Date: 2020-01-27 14:01+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,60 +17,25 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00
-msgid "0% Biens d'investissement"
-msgstr "0% Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-G
-msgid "0% Biens divers"
-msgstr "0% Diverse goederen"
-
-#. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-CC
-msgid "0% Cocont."
-msgstr "0% Medecont."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-CC
-msgid "0% Cocont. - Biens d'investissement"
-msgstr "0% Medecont. - Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-CC
-msgid "0% Cocont. M."
-msgstr "0% Medecont. G."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-CC
-msgid "0% Cocont. S."
-msgstr "0% Medecont. D."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-EU
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-EU
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-EU
-msgid "0% EU - Biens d'investissement"
-msgstr "0% EU - Investeringsgoederen"
+msgid "0% Cocont"
+msgstr "0% medecont."
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-EU-G
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-EU-G
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-G
-msgid "0% EU - Biens divers"
-msgstr "0% EU - Diverse goederen"
+msgid "0% EU G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-EU
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-EU
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-EU
+msgid "0% EU IG"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-EU
@@ -79,8 +44,8 @@ msgstr "0% EU - Diverse goederen"
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-L
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-L
-msgid "0% EU M."
-msgstr "0% EU G."
+msgid "0% EU M"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-EU-S
@@ -89,50 +54,78 @@ msgstr "0% EU G."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-S
-msgid "0% EU S."
-msgstr "0% EU D."
+msgid "0% EU S"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-EU-T
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-EU-T
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-EU-T
-msgid "0% EU T."
-msgstr "0% EU. T."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00
-msgid "0% M."
-msgstr "0% G."
+msgid "0% EU T"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-00-ROW
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-ROW
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-ROW
-msgid "0% Non EU"
-msgstr "0% Non EU"
+msgid "0% EX"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-ROW-CC
-msgid "0% Non EU - Biens d'investissement"
-msgstr "0% Niet EU - Investeringsgoederen"
+msgid "0% EX IG"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-ROW-CC
-msgid "0% Non EU M."
-msgstr "0% Non EU G. "
+msgid "0% EX M"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-ROW-CC
-msgid "0% Non EU S."
-msgstr "0% Non EU D."
+msgid "0% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-G
+msgid "0% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00
+msgid "0% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-00-CC
+msgid "0% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00
+msgid "0% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-00-CC
+msgid "0% M.Cocont"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-S
@@ -141,150 +134,174 @@ msgstr "0% Non EU D."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-00-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-00-S
-msgid "0% S."
-msgstr "0% D."
+msgid "0% S"
+msgstr ""
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_00
-msgid "00"
-msgstr "00"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-00-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-00-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-00-CC
+msgid "0% S.Cocont"
+msgstr ""
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_00_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_00
 msgid "00 - Operations subject to a special regulation"
 msgstr "00 - Handelingen onderworpen aan een bijzondere regeling"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_01
-msgid "01"
-msgstr "01"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_01_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_01
 msgid "01 - Operations subject to 6% VAT"
 msgstr "01 - Handelingen onderworpen aan 6% btw"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_02
-msgid "02"
-msgstr "02"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_02_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_02
 msgid "02 - Operations subject to 12% VAT"
 msgstr "02 - Handelingen onderworpen aan 12% btw"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_03
-msgid "03"
-msgstr "03"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_03_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_03
 msgid "03 - Operations subject to 21% VAT"
 msgstr "03 - Handelingen onderworpen aan 21% btw"
 
 #. module: l10n_be
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-L
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-L
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-12-L
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-12-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-12-L
 msgid "12%"
 msgstr "12%"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12
-msgid "12% Biens d'investissement"
-msgstr "12% Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-G
-msgid "12% Biens divers"
-msgstr "12% Diverse goederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-CC
-msgid "12% Cocont. - Biens d'investissement"
-msgstr "12% Medecont. - Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-CC
-msgid "12% Cocont. M."
-msgstr "12% Medecont. G."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-CC
-msgid "12% Cocont. S."
-msgstr "12% Medecont. D."
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-EU-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-G
+msgid "12% EU G"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-EU
-msgid "12% EU - Biens d'investissement"
-msgstr "12% EU - Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-G
-msgid "12% EU - Biens divers"
-msgstr "12% EU - Diverse goederen"
+msgid "12% EU IG"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-EU
-msgid "12% EU M."
-msgstr "12% EU G."
+msgid "12% EU M"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-EU-S
-msgid "12% EU S."
-msgstr "12% EU D."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12
-msgid "12% M."
-msgstr "12% G."
+msgid "12% EU S"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-ROW-CC
-msgid "12% Non EU - Biens d'investissement"
-msgstr "12% Niet EU - Investeringsgoederen"
+msgid "12% EX IG"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-ROW-CC
-msgid "12% Non EU M."
-msgstr "12% Niet EU G."
+msgid "12% EX M"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-ROW-CC
-msgid "12% Non EU S."
-msgstr "12% Niet EU D."
+msgid "12% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-G
+msgid "12% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12
+msgid "12% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-12-CC
+msgid "12% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12
+msgid "12% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-12-CC
+msgid "12% M.Cocont"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-S
@@ -293,106 +310,167 @@ msgstr "12% Niet EU D."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-12-S
-msgid "12% S."
-msgstr "12% D."
+msgid "12% S"
+msgstr ""
 
 #. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-12-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-12-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-12-CC
+msgid "12% S.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,description:l10n_be.1_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-G
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-S
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-EU
+#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-L
+#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-S
+#: model:account.tax,description:l10n_be.2_attn_TVA-21-inclus-dans-prix
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-G
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-S
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-EU
+#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-L
+#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax,name:l10n_be.1_attn_VAT-OUT-21-L
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-21-L
+#: model:account.tax.template,description:l10n_be.attn_TVA-21-inclus-dans-prix
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-G
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-S
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-EU
+#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-ROW-CC
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-L
+#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-21-L
 msgid "21%"
 msgstr "21%"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21
-msgid "21% Biens d'investissement"
-msgstr "21% Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-G
-msgid "21% Biens divers"
-msgstr "21% Diverse goederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-CC
-msgid "21% Cocont .S."
-msgstr "21% Medecont. D."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-CC
-msgid "21% Cocont. - Biens d'investissement"
-msgstr "21% Medecont. - Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-CC
-msgid "21% Cocont. M."
-msgstr "21% Medecont. G."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-EU
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-EU
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-EU
-msgid "21% EU - Biens d'investissement"
-msgstr "21% EU - Investeringsgoederen"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-CAR-EXC
+msgid "21% Car"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-EU-G
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-EU-G
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-EU-G
-msgid "21% EU - Biens divers"
-msgstr "21% EU - Diverse goederen"
+msgid "21% EU G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-EU
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-EU
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-EU
+msgid "21% EU IG"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-EU
-msgid "21% EU M."
-msgstr "21% EU. G."
+msgid "21% EU M"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-EU-S
-msgid "21% EU S."
-msgstr "21% EU D."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21
-msgid "21% M."
-msgstr "21% G."
+msgid "21% EU S"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-ROW-CC
-msgid "21% Non EU - Biens d'investissement"
-msgstr "21% Niet EU - Investeringsgoederen"
+msgid "21% EX IG"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-ROW-CC
-msgid "21% Non EU M."
-msgstr "21% Niet EU G."
+msgid "21% EX M"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-ROW-CC
-msgid "21% Non EU S."
-msgstr "21% Non EU D."
+msgid "21% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-G
+msgid "21% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21
+msgid "21% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-21-CC
+msgid "21% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21
+msgid "21% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-21-CC
+msgid "21% M.Cocont"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-S
@@ -401,37 +479,33 @@ msgstr "21% Non EU D."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-21-S
-msgid "21% S."
-msgstr "21% D."
+msgid "21% S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-21-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-21-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-21-CC
+msgid "21% S.Cocont"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_TVA-21-inclus-dans-prix
 #: model:account.tax,name:l10n_be.2_attn_TVA-21-inclus-dans-prix
 #: model:account.tax.template,name:l10n_be.attn_TVA-21-inclus-dans-prix
-msgid "21% S. TTC"
-msgstr "21% D. (Inclusief BTW)"
+msgid "21% S.TTC"
+msgstr ""
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_44
-msgid "44"
-msgstr "44"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_44_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_44
 msgid "44 - Intra-Community services"
 msgstr "44 - Intracommunautaire diensten"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_45
-msgid "45"
-msgstr "45"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_45_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_45
 msgid "45 - Operations subject to VAT due by the co-contractor"
-msgstr "45 - Handelingen waarvoor de btw verschuldigd is door de medecontractant"
+msgstr ""
+"45 - Handelingen waarvoor de btw verschuldigd is door de medecontractant"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_46
@@ -439,239 +513,168 @@ msgid "46 - Exempted intra-Community deliveries and ABC sales"
 msgstr "46 - Vrijgestelde intracommunautaire leveringen en ABC-verkopen"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_46L
-msgid "46L"
-msgstr "46L"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_46L_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_46L
 msgid "46L - Exempted intra-Community deliveries"
 msgstr "46L - Vrijgestelde intracommunautaire leveringen"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_46T
-msgid "46T"
-msgstr "46T"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_46T_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_46T
 msgid "46T - ABC sales"
 msgstr "46T - ABC-verkopen"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_47
-msgid "47"
-msgstr "47"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_47_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_47
 msgid "47 - Other exempted operations and operations carried out abroad"
-msgstr "47 - Andere vrijgestelde handelingen en andere handelingen verricht in het buitenland"
+msgstr ""
+"47 - Andere vrijgestelde handelingen en andere handelingen verricht in het "
+"buitenland"
 
 #. module: l10n_be
 #: model:account.report.line,name:l10n_be.tax_report_title_operations_sortie_48
 msgid "48 - Credit notes for operations in grids [44] and [46]"
-msgstr "48 - Creditnota's met betrekking tot de handelingen ingeschreven in de roosters [44] en [46]"
+msgstr ""
+"48 - Creditnota's met betrekking tot de handelingen ingeschreven in de "
+"roosters [44] en [46]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s44
-msgid "48s44"
-msgstr "48s44"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s44_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s44
 msgid "48s44 - Credit notes for operations in grid [44]"
-msgstr "48s44 - Creditnota's met betrekking tot de handelingen ingeschreven in rooster [44]"
+msgstr ""
+"48s44 - Creditnota's met betrekking tot de handelingen ingeschreven in "
+"rooster [44]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46L
-msgid "48s46L"
-msgstr "48s46L"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s46L_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s46L
 msgid "48s46L - Credit notes for operations in grid [46L]"
-msgstr "48s46L - Creditnota's met betrekking tot de handelingen ingeschreven in rooster [46L]"
+msgstr ""
+"48s46L - Creditnota's met betrekking tot de handelingen ingeschreven in "
+"rooster [46L]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_48s46T
-msgid "48s46T"
-msgstr "48s46T"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_48s46T_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_48s46T
 msgid "48s46T - Credit notes for operations in grid [46T]"
-msgstr "48s46T - Creditnota's met betrekking tot de handelingen ingeschreven in rooster [46T]"
+msgstr ""
+"48s46T - Creditnota's met betrekking tot de handelingen ingeschreven in "
+"rooster [46T]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_49
-msgid "49"
-msgstr "49"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_49_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_49
 msgid "49 - Credit notes for other operations in part II"
 msgstr "49 - Creditnota's met betrekking tot de andere handelingen van deel II"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-CAR-EXC
-msgid "50% Non Déductible - Frais de voiture (Prix Excl.)"
-msgstr "50% Non Déductible - Frais de voiture (Prix Excl.)"
-
-#. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_54
-msgid "54"
-msgstr "54"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_54_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_54
 msgid "54 - VAT on operations in grids [01], [02] and [03]"
-msgstr "54 - Btw op de handelingen aangegeven in de roosters [01], [02] en [03]"
+msgstr ""
+"54 - Btw op de handelingen aangegeven in de roosters [01], [02] en [03]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_55
-msgid "55"
-msgstr "55"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_55_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_55
 msgid "55 - VAT on operations in grids [86] and [88]"
 msgstr "55 - Btw op de handelingen aangegeven in de roosters [86] en [88]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_56
-msgid "56"
-msgstr "56"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_56_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_56
-msgid "56 - VAT on operations in grid [87], with the exception of imports with reverse charge"
-msgstr "56 - Btw op de handelingen aangegeven in rooster [87], met uitzondering van invoeren met verlegging van heffing"
+msgid ""
+"56 - VAT on operations in grid [87], with the exception of imports with "
+"reverse charge"
+msgstr ""
+"56 - Btw op de handelingen aangegeven in rooster [87], met uitzondering van "
+"invoeren met verlegging van heffing"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_57
-msgid "57"
-msgstr "57"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_57_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_57
 msgid "57 - VAT on import with reverse charge"
 msgstr "57 - Btw op invoeren met verlegging van heffing"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_59
-msgid "59"
-msgstr "59"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_59_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_59
 msgid "59 - Deductible VAT"
 msgstr "59 - Aftrekbare btw"
 
 #. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06
-msgid "6% Biens d'investissement"
-msgstr "6% Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-G
-msgid "6% Biens divers"
-msgstr "6% Diverse goederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-CC
-msgid "6% Cocont. - Biens d'investissement"
-msgstr "6% Medecont. - Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-CC
-msgid "6% Cocont. M."
-msgstr "6% Medecont. G."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-CC
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-CC
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-CC
-msgid "6% Cocont. S."
-msgstr "6% Medecont. D."
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-G
+msgid "6% EU G"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-EU
-msgid "6% EU - Biens d'investissement"
-msgstr "6% EU - Investeringsgoederen"
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-G
-msgid "6% EU - Biens divers"
-msgstr "6% EU - Diverse goederen"
+msgid "6% EU IG"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-EU
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-EU
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-EU
-msgid "6% EU M."
-msgstr "6% EU G."
+msgid "6% EU M"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-EU-S
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-EU-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-EU-S
-msgid "6% EU S."
-msgstr "6% EU D."
-
-#. module: l10n_be
-#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06
-#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06
-#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06
-msgid "6% M."
-msgstr "6% G."
+msgid "6% EU S"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-ROW-CC
-msgid "6% Non EU - Biens d'investissement"
-msgstr "6% Niet EU - Investeringsgoederen"
+msgid "6% EX IG"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-ROW-CC
-msgid "6% Non EU M."
-msgstr "6% Niet EU G."
+msgid "6% EX M"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-ROW-CC
 #: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-ROW-CC
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-ROW-CC
-msgid "6% Non EU S."
-msgstr "6% Niet EU D."
+msgid "6% EX S"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-G
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-G
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-G
+msgid "6% G"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06
+msgid "6% IG"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V83-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V83-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V83-06-CC
+msgid "6% IG.Cocont"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06
+msgid "6% M"
+msgstr ""
+
+#. module: l10n_be
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V81-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V81-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V81-06-CC
+msgid "6% M.Cocont"
+msgstr ""
 
 #. module: l10n_be
 #: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-S
@@ -680,173 +683,85 @@ msgstr "6% Niet EU D."
 #: model:account.tax,name:l10n_be.2_attn_VAT-OUT-06-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-S
 #: model:account.tax.template,name:l10n_be.attn_VAT-OUT-06-S
-msgid "6% S."
-msgstr "6% D."
+msgid "6% S"
+msgstr ""
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_61
-msgid "61"
-msgstr "61"
+#: model:account.tax,name:l10n_be.1_attn_VAT-IN-V82-06-CC
+#: model:account.tax,name:l10n_be.2_attn_VAT-IN-V82-06-CC
+#: model:account.tax.template,name:l10n_be.attn_VAT-IN-V82-06-CC
+msgid "6% S.Cocont"
+msgstr ""
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_61_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_61
 msgid "61 - Various VAT regularizations in favor of the State"
 msgstr "61 - Diverse btw-regularisaties in het voordeel van de Staat"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_62
-msgid "62"
-msgstr "62"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_62_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_62
 msgid "62 - Various VAT regularizations in favor of the declarant"
 msgstr "62 - Diverse btw-regularisaties in het voordeel van de aangever"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_63
-msgid "63"
-msgstr "63"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_63_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_63
 msgid "63 - VAT to be paid back on credit notes received"
 msgstr "63 - Terug te storten btw vermeld op ontvangen creditnota's"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_64
-msgid "64"
-msgstr "64"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_64_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_64
 msgid "64 - VAT to be recovered on credit notes issued"
 msgstr "64 - Te recupereren btw vermeld op uitgereikte creditnota's"
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_71_formula
 #: model:account.report.line,name:l10n_be.tax_report_line_71
 msgid "71 - Taxes due to the State"
 msgstr "71 - Aan de Staat verschuldigde belasting"
 
 #. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_72_formula
 #: model:account.report.line,name:l10n_be.tax_report_line_72
 msgid "72 - Amount owed by the State"
 msgstr "72 - Sommen verschuldigd door de Staat"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_81
-msgid "81"
-msgstr "81"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_81_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_81
 msgid "81 - Trade goods, raw materials and consumables"
 msgstr "81 - Handelsgoederen, grond- en hulpstoffen"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_82
-msgid "82"
-msgstr "82"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_82_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_82
 msgid "82 - Services and miscellaneous goods"
 msgstr "82 - Diensten en diverse goederen"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_83
-msgid "83"
-msgstr "83"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_83_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_83
 msgid "83 - Investment goods"
 msgstr "83 - Bedrijfsmiddelen"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_84
-msgid "84"
-msgstr "84"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_84_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_84
 msgid "84 - Credit notes for operations in grids [86] and [88]"
-msgstr "84 - Creditnota's met betrekking tot de handelingen ingeschreven in de roosters [86] en [88]"
+msgstr ""
+"84 - Creditnota's met betrekking tot de handelingen ingeschreven in de "
+"roosters [86] en [88]"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_85
-msgid "85"
-msgstr "85"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_85_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_85
 msgid "85 - Credit notes received relating to other operations in part III"
-msgstr "85 - Creditnota's met betrekking tot de andere handelingen van deel III"
+msgstr ""
+"85 - Creditnota's met betrekking tot de andere handelingen van deel III"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_86
-msgid "86"
-msgstr "86"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_86_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_86
 msgid "86 - Intra-Community acquisitions and ABC sales"
 msgstr "86 - Intracommunautaire verwervingen en ABC-verkopen"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_87
-msgid "87"
-msgstr "87"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_87_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_87
 msgid "87 - Other operations subject to VAT"
 msgstr "87 - Andere handelingen waarvoor de btw verschuldigd is"
 
 #. module: l10n_be
-#: model:account.report.line,tag_name:l10n_be.tax_report_line_88
-msgid "88"
-msgstr "88"
-
-#. module: l10n_be
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_applied_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_balance
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_balance_unbound
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_carryover
-#: model:account.report.expression,report_line_name:l10n_be.tax_report_line_88_tag
 #: model:account.report.line,name:l10n_be.tax_report_line_88
 msgid "88 - Intra-Community services with reverse charge"
 msgstr "88 -  Intracommunautaire diensten met verlegging van heffing"
@@ -854,7 +769,7 @@ msgstr "88 -  Intracommunautaire diensten met verlegging van heffing"
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_chart_template
 msgid "Account Chart Template"
-msgstr ""
+msgstr "Grootboekschema sjabloon"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a052
@@ -1677,7 +1592,7 @@ msgstr "Saldo"
 #. module: l10n_be
 #: model:account.chart.template,name:l10n_be.l10nbe_chart_template
 msgid "Belgian PCMN"
-msgstr ""
+msgstr "Belgisch MAR"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a6703
@@ -1758,7 +1673,7 @@ msgstr ""
 #: model:ir.model.fields.selection,name:l10n_be.selection__account_journal__invoice_reference_model__be
 #: model:ir.ui.menu,name:l10n_be.account_reports_be_statements_menu
 msgid "Belgium"
-msgstr ""
+msgstr "België"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_07
@@ -2086,7 +2001,7 @@ msgstr "Financiële kosten"
 #: model:account.group,name:l10n_be.2_be_group_65
 #: model:account.group.template,name:l10n_be.be_group_65
 msgid "Charges financières"
-msgstr "Als herstructureringskosten geactiveerde bedrijfskosten (–)"
+msgstr "Financiële kosten"
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_657
@@ -2169,12 +2084,7 @@ msgstr "Committenten en deponenten van goederen en waarden"
 #. module: l10n_be
 #: model:ir.model.fields,field_description:l10n_be.field_account_journal__invoice_reference_model
 msgid "Communication Standard"
-msgstr ""
-
-#. module: l10n_be
-#: model:ir.model,name:l10n_be.model_res_company
-msgid "Companies"
-msgstr ""
+msgstr "Standaard communicatie"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a020
@@ -2291,6 +2201,11 @@ msgstr "Hulpstoffen - Aanschaffingswaarde"
 #: model:account.account.template,name:l10n_be.a319
 msgid "Consumables - amounts written down"
 msgstr "Hulpstoffen - Geboekte waardeverminderingen"
+
+#. module: l10n_be
+#: model:ir.model,name:l10n_be.model_res_partner
+msgid "Contact"
+msgstr "Contact"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a370
@@ -2886,6 +2801,20 @@ msgstr "Tantièmes over het boekjaar"
 #: model:account.account.template,name:l10n_be.a695
 msgid "Directors' or managers' entitlements"
 msgstr "Uitkering aan bestuurders of zaakvoerders"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a657000
+#: model:account.account,name:l10n_be.2_a657000
+#: model:account.account.template,name:l10n_be.a657000
+msgid "Discounts Given"
+msgstr "Gegeven kortingen"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a757000
+#: model:account.account,name:l10n_be.2_a757000
+#: model:account.account.template,name:l10n_be.a757000
+msgid "Discounts Taken"
+msgstr "Gekregen kortingen"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a608
@@ -3866,12 +3795,12 @@ msgstr "Geplaatst kapitaal"
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_journal
 msgid "Journal"
-msgstr ""
+msgstr "Dagboek"
 
 #. module: l10n_be
 #: model:ir.model,name:l10n_be.model_account_move
 msgid "Journal Entry"
-msgstr ""
+msgstr "Boeking"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a220
@@ -3952,7 +3881,7 @@ msgstr "Ontleende terug te geven effecten"
 #: model:account.account,name:l10n_be.2_l10nbe_chart_template_liquidity_transfer
 #: model:account.account.template,name:l10n_be.l10nbe_chart_template_liquidity_transfer
 msgid "Liquidity Transfer"
-msgstr ""
+msgstr "Liquiditeit overschrijving"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a201
@@ -3987,8 +3916,15 @@ msgstr "Gebruiksrechten op lange termijn - Terreinen en gebouwen"
 #: model:account.account,name:l10n_be.1_a690
 #: model:account.account,name:l10n_be.2_a690
 #: model:account.account.template,name:l10n_be.a690
-msgid "Loss brought forward"
-msgstr "Overgedragen verlies van het vorige boekjaar"
+msgid "Loss brought forward from previous year"
+msgstr "Overgedragen verlies van vorig jaar"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a141
+#: model:account.account,name:l10n_be.2_a141
+#: model:account.account.template,name:l10n_be.a141
+msgid "Loss carried forward"
+msgstr "Overgedragen verlies"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a641
@@ -4325,16 +4261,16 @@ msgstr ""
 "Exploitatiesubsidies en vanwege de overheid ontvangen compenserende bedragen"
 
 #. module: l10n_be
+#: model:account.report.line,name:l10n_be.tax_report_title_operations
+msgid "Operations"
+msgstr "Handelingen"
+
+#. module: l10n_be
 #: model:account.account,name:l10n_be.1_a099
 #: model:account.account,name:l10n_be.2_a099
 #: model:account.account.template,name:l10n_be.a099
 msgid "Options (buy or sell) on securities issued."
 msgstr "Opties (kopen of verkopen) op uitgegeven effecten."
-
-#. module: l10n_be
-#: model:account.report.line,name:l10n_be.tax_report_title_operations
-msgid "Operations"
-msgstr "Handelingen"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a668
@@ -5001,8 +4937,15 @@ msgstr "Over te dragen opbrengsten"
 #: model:account.account,name:l10n_be.1_a790
 #: model:account.account,name:l10n_be.2_a790
 #: model:account.account.template,name:l10n_be.a790
-msgid "Profit brought forward"
-msgstr "Overgedragen winst van het vorige boekjaar"
+msgid "Profit brought forward from previous year"
+msgstr "Overgedragen winst van vorig jaar"
+
+#. module: l10n_be
+#: model:account.account,name:l10n_be.1_a140
+#: model:account.account,name:l10n_be.2_a140
+#: model:account.account.template,name:l10n_be.a140
+msgid "Profit carried forward"
+msgstr "Overgedragen winst"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a693
@@ -5998,293 +5941,24 @@ msgid "T.V.A. à récupérer"
 msgstr "Terug te vorderen B.T.W."
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_0
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-S
 msgid "TVA 0%"
 msgstr "BTW 0%"
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-CC
-msgid "TVA 0% Cocont."
-msgstr "BTW 0% Medecont."
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-EU-T
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-EU-T
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-EU-T
-msgid "TVA 0% EU"
-msgstr "BTW 0% EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-00-ROW
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-00-ROW
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-00-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-00-ROW
-msgid "TVA 0% Non EU"
-msgstr "BTW 0% Non EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-12-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-12-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_12
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-12-S
 msgid "TVA 12%"
 msgstr "BTW 12%"
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-CC
-msgid "TVA 12% Cocont."
-msgstr "BTW 12% Medecont."
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-EU
-msgid "TVA 12% EU"
-msgstr "BTW 12% EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-12-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-12-ROW-CC
-msgid "TVA 12% Non EU"
-msgstr "BTW 12% Niet EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-21-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-21-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_21
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-21-S
 msgid "TVA 21%"
 msgstr "BTW 21%"
 
 #. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-CC
-msgid "TVA 21% Cocont."
-msgstr "BTW 21% Medecont."
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-EU
-msgid "TVA 21% EU"
-msgstr "BTW 21% EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-21-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-21-ROW-CC
-msgid "TVA 21% Non EU"
-msgstr "BTW 21% Niet EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_TVA-21-inclus-dans-prix
-#: model:account.tax,description:l10n_be.2_attn_TVA-21-inclus-dans-prix
-#: model:account.tax.template,description:l10n_be.attn_TVA-21-inclus-dans-prix
-msgid "TVA 21% TTC"
-msgstr "VAT 21% (inclusief BTW)"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-CAR-EXC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-CAR-EXC
-msgid "TVA 50% Non Déductible - Frais de voiture (Prix Excl.)"
-msgstr "BTW 50% Niet Aftrekbaar - Auto kosten (Prijs Excl.)"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-06-L
-#: model:account.tax,description:l10n_be.1_attn_VAT-OUT-06-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-06-L
-#: model:account.tax,description:l10n_be.2_attn_VAT-OUT-06-S
 #: model:account.tax.group,name:l10n_be.tax_group_tva_6
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-06-L
-#: model:account.tax.template,description:l10n_be.attn_VAT-OUT-06-S
 msgid "TVA 6%"
 msgstr "BTW 6%"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-CC
-msgid "TVA 6% Cocont."
-msgstr "BTW 6% Medecont."
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-EU
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-EU-S
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-EU
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-EU-G
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-EU-S
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-EU
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-EU-G
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-EU-S
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-EU
-msgid "TVA 6% EU"
-msgstr "BTW 6% EU"
-
-#. module: l10n_be
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax,description:l10n_be.1_attn_VAT-IN-V83-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax,description:l10n_be.2_attn_VAT-IN-V83-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V81-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V82-06-ROW-CC
-#: model:account.tax.template,description:l10n_be.attn_VAT-IN-V83-06-ROW-CC
-msgid "TVA 6% Non EU"
-msgstr "BTW 6% Niet EU"
 
 #. module: l10n_be
 #: model:account.account,name:l10n_be.1_a27
@@ -6851,6 +6525,8 @@ msgid ""
 "You can choose different models for each type of reference. The default one "
 "is the Odoo reference."
 msgstr ""
+"Je kunt verschillende modellen kiezen voor elk type referentie. De standaard "
+"is de Odoo-referentie."
 
 #. module: l10n_be
 #: model:account.group,name:l10n_be.1_be_group_755

--- a/addons/l10n_be_pos_sale/i18n/de.po
+++ b/addons/l10n_be_pos_sale/i18n/de.po
@@ -1,0 +1,35 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_be_pos_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-30 09:20+0000\n"
+"PO-Revision-Date: 2023-10-30 09:20+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: de\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_be_pos_sale
+#. odoo-javascript
+#: code:addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js:0
+#, python-format
+msgid ""
+"If you do not invoice imported orders you will encounter issues in your "
+"accounting. Especially in the EC Sale List report"
+msgstr ""
+"Wenn Sie importierte Aufträge nicht in Rechnung stellen, kommt es zu "
+"Problemen in Ihrer Buchhaltung, vor allem in der EG-Verkaufsliste."
+
+#. module: l10n_be_pos_sale
+#. odoo-javascript
+#: code:addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js:0
+#, python-format
+msgid "This order needs to be invoiced"
+msgstr "Dieser Auftrag muss abgerechnet werden."

--- a/addons/l10n_be_pos_sale/i18n/fr.po
+++ b/addons/l10n_be_pos_sale/i18n/fr.po
@@ -1,0 +1,36 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_be_pos_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-30 09:20+0000\n"
+"PO-Revision-Date: 2023-10-30 09:20+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_be_pos_sale
+#. odoo-javascript
+#: code:addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js:0
+#, python-format
+msgid ""
+"If you do not invoice imported orders you will encounter issues in your "
+"accounting. Especially in the EC Sale List report"
+msgstr ""
+"Si vous ne facturez pas les commandes importées, vous rencontrerez des "
+"problèmes dans votre comptabilité. En particulier dans le relevé "
+"intracommunautaire"
+
+#. module: l10n_be_pos_sale
+#. odoo-javascript
+#: code:addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js:0
+#, python-format
+msgid "This order needs to be invoiced"
+msgstr "Cette commande doit être facturée"

--- a/addons/l10n_be_pos_sale/i18n/nl.po
+++ b/addons/l10n_be_pos_sale/i18n/nl.po
@@ -1,0 +1,35 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_be_pos_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 16.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2023-10-30 09:20+0000\n"
+"PO-Revision-Date: 2023-10-30 09:20+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: nl\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_be_pos_sale
+#. odoo-javascript
+#: code:addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js:0
+#, python-format
+msgid ""
+"If you do not invoice imported orders you will encounter issues in your "
+"accounting. Especially in the EC Sale List report"
+msgstr ""
+"Als je geïmporteerde orders niet factureert, krijg je problemen in je "
+"boekhouding. Vooral in de btw-opgave van de intracommunautaire handelingen"
+
+#. module: l10n_be_pos_sale
+#. odoo-javascript
+#: code:addons/l10n_be_pos_sale/static/src/js/PaymentScreen.js:0
+#, python-format
+msgid "This order needs to be invoiced"
+msgstr "Deze order moet worden gefactureerd"


### PR DESCRIPTION
Sync translations with v16 for l10n_be since it is on Transifex, but the
saas versions are not.

Also add in translations for l10n_be_pos_sale because it was added in
stable and therefore wasn't correctly added to Transifex as well
(separate PR will be done for non-saas versions).

ENT PR: https://github.com/odoo/enterprise/pull/55430

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
