### PR TITLE
[FIX] im_livechat: only return active chats from init messaging

### DIFF
--- a/addons/im_livechat/tests/test_get_discuss_channel.py
+++ b/addons/im_livechat/tests/test_get_discuss_channel.py
@@ -7,7 +7,7 @@ from unittest.mock import patch, PropertyMock
 from odoo import fields
 from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
 from odoo.addons.mail.tests.common import MailCommon
-from odoo.tests.common import tagged
+from odoo.tests.common import tagged, new_test_user
 
 
 @tagged("post_install", "-at_install")
@@ -243,3 +243,40 @@ class TestGetDiscussChannel(TestImLivechatCommon, MailCommon):
             ],
         ):
             channel.execute_command_help()
+
+    def test_only_active_livechats_returned_by_init_messaging(self):
+        self.authenticate(None, None)
+        operator = new_test_user(self.env, login="John")
+        self.env["bus.presence"].create({"user_id": operator.id, "status": "online"})
+        livechat_channel = self.env["im_livechat.channel"].create(
+            {"name": "Customer Support", "user_ids": [operator.id]}
+        )
+        inactive_livechat = self.env["discuss.channel"].browse(
+            self.make_jsonrpc_request(
+                "/im_livechat/get_session",
+                {
+                    "anonymous_name": "Visitor",
+                    "channel_id": livechat_channel.id,
+                    "persisted": True,
+                },
+            )["Thread"]["id"]
+        )
+        self.make_jsonrpc_request(
+            "/im_livechat/visitor_leave_session", {"uuid": inactive_livechat.uuid}
+        )
+        active_livechat = self.env["discuss.channel"].browse(
+            self.make_jsonrpc_request(
+                "/im_livechat/get_session",
+                {
+                    "anonymous_name": "Visitor",
+                    "channel_id": livechat_channel.id,
+                    "persisted": True,
+                },
+            )["Thread"]["id"]
+        )
+        init_messaging_result = self.make_jsonrpc_request(
+            "/mail/action",
+            {"init_messaging": True, "context": {"is_for_livechat": True}},
+        )
+        self.assertEqual(len(init_messaging_result["Thread"]), 1)
+        self.assertEqual(init_messaging_result["Thread"][0]["id"], active_livechat.id)

--- a/addons/mail/controllers/webclient.py
+++ b/addons/mail/controllers/webclient.py
@@ -34,7 +34,7 @@ class WebclientController(http.Controller):
                 user = request.env.user.sudo(False)
                 self._add_to_res(res, user._init_messaging())
             else:
-                guest = request.env["mail.guest"]._get_guest_from_context()
+                guest = request.env["mail.guest"]._get_guest_from_context().with_context(**request.context)
                 if guest:
                     self._add_to_res(res, guest._init_messaging())
                 else:


### PR DESCRIPTION
Since [1], only active live chat channels are returned by the
`init_messaging` rpc since the inactive ones are not required.

This is done by passing the `is_for_livechat` key in the context.
Since [2], the context is not propagated anymore thus inactive
channels are returned as well.

This PR ensures the context is correctly propagated to keep the
previous behavior.

[1]: https://github.com/odoo/odoo/pull/146098
[2]: https://github.com/odoo/odoo/pull/150367