### PR TITLE
[FIX] mail: fix client reply to internal message

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -1601,7 +1601,10 @@ class MailThread(models.AbstractModel):
                 limit=1)
         if parent_ids:
             msg_dict['parent_id'] = parent_ids.id
-            msg_dict['is_internal'] = parent_ids.subtype_id and parent_ids.subtype_id.internal or False
+            msg_dict['is_internal'] = False
+            from_partner = self._mail_search_on_user(tools.email_split(msg_dict['from']))
+            if from_partner and from_partner.user_ids._is_internal():
+                msg_dict['is_internal'] = parent_ids.subtype_id and parent_ids.subtype_id.internal or False
 
         msg_dict.update(self._message_parse_extract_payload(message, save_original=save_original))
         msg_dict.update(self._message_parse_extract_bounce(message, msg_dict))


### PR DESCRIPTION
To reproduce
============
- on Helpdesk, create a ticket for portal user (user1)
- (user1) reply to the ticket from mail -> the reply is logged as log note in chatter and not external message event if the user is a portal user

Problem
=======
we check if the message is internal based on the parent message (the one we are replying to), so if the parent message is internal (this case) the reply will be internal too.

Solution
========
if the sender is not an internal user the message is automatically external

opw-3682621
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
