### PR TITLE
[FIX] mail: fix missing space between the task name and calendar icon 

### DIFF
--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -307,6 +307,10 @@ export class Message extends Component {
         return Boolean(this.env.inChatWindow && this.props.message.isSelfAuthored);
     }
 
+    get isPersistentMessageFromAnotherThread() {
+        return !this.isOriginThread && !this.message.is_transient;
+    }
+
     get isOriginThread() {
         if (!this.props.thread) {
             return false;

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -45,7 +45,7 @@
                                 className="'ms-1'"
                                 message="props.message"
                                 thread="props.thread"/>
-                            <small t-if="!isOriginThread and !message.is_transient" t-on-click.prevent="openRecord" class="ms-1 text-500">
+                            <small t-if="isPersistentMessageFromAnotherThread" t-on-click.prevent="openRecord" class="ms-1 text-500">
                                 <t t-if="message.model !== 'discuss.channel'">
                                     on <a t-att-href="message.resUrl"><t t-esc="message.originThread?.displayName"/></a>
                                 </t>
@@ -53,7 +53,7 @@
                                     (from <a t-att-href="message.resUrl"><t t-esc="message.originThread?.prefix"/><t t-esc="message.originThread?.displayName"/></a>)
                                 </t>
                             </small>
-                            <div t-if="props.message.scheduledDate" t-att-class="{ 'ms-2': props.isInChatWindow and isAlignedRight }" t-att-title="messageService.scheduledDateSimple(props.message)">
+                            <div t-if="props.message.scheduledDate" t-att-class="{ 'ms-2': (props.isInChatWindow and isAlignedRight) or (isPersistentMessageFromAnotherThread) }" t-att-title="messageService.scheduledDateSimple(props.message)">
                                 <span class="text-600 cursor-pointer">
                                     <i class="fa fa-calendar-o"/>
                                 </span>


### PR DESCRIPTION
Steps to reproduce:
-----------------------------------------------------------------------------------------------------------
1. Install the Project.
2. Go to settings and select customer ratings.
3. Then go to any project edit the stage and select the template for the rating
 email template.
4. Then change the stage of any task. check the email and give a rating to your
 task.
5. Check the Discus app then you will see a notification and no space between the
 name of the task and the calendar icon. 

Issue:
-----------------------------------------------------------------------------------------------------------
- A missing space between the name of the task and the calendar icon. 

Cause:
-----------------------------------------------------------------------------------------------------------
- The task's name and the calendar icon are not separated.

Fix:
-----------------------------------------------------------------------------------------------------------
- After this commit there is a space between the name of the task and the
 calendar icon 

task-3681318