### PR TITLE
[FIX] web, project: fix the name is misaligned 

### DIFF
--- a/addons/project/static/tests/legacy/project_task_groupby_tests.js
+++ b/addons/project/static/tests/legacy/project_task_groupby_tests.js
@@ -60,7 +60,7 @@ QUnit.module("Project", (hooks) => {
             context: { group_by: ["project_id"] },
         });
 
-        assert.strictEqual(target.querySelector(".o_group_name").innerText, "🔒 Private (1)");
+        assert.strictEqual(target.querySelector(".o_group_name").innerText, "🔒 Private\n(1)");
     });
     QUnit.test("Test group label for empty assignees in tree", async function (assert) {
         assert.expect(1);
@@ -77,7 +77,7 @@ QUnit.module("Project", (hooks) => {
             context: { group_by: ["user_ids"] },
         });
 
-        assert.strictEqual(target.querySelector(".o_group_name").innerText, "👤 Unassigned (1)");
+        assert.strictEqual(target.querySelector(".o_group_name").innerText, "👤 Unassigned\n(1)");
     });
 
     QUnit.test("Test group label for empty deadline in tree", async function (assert) {
@@ -95,7 +95,7 @@ QUnit.module("Project", (hooks) => {
             context: { group_by: ["date_deadline"] },
         });
 
-        assert.strictEqual(target.querySelector(".o_group_name").innerText, "None (1)");
+        assert.strictEqual(target.querySelector(".o_group_name").innerText, "None\n(1)");
     });
 
     QUnit.test("Test group label for empty project in kanban", async function (assert) {

--- a/addons/project/static/tests/project_task_groupby.test.js
+++ b/addons/project/static/tests/project_task_groupby.test.js
@@ -23,7 +23,7 @@ test("project.task (tree): check group label for no project", async () => {
         arch: `<tree js_class="project_task_list"/>`,
         groupBy: ["project_id"],
     });
-    expect(".o_group_name").toHaveText("🔒 Private (1)");
+    expect(".o_group_name").toHaveText("🔒 Private\n(1)");
 });
 
 test("project.task (tree): check group label for no assignees", async () => {
@@ -33,7 +33,7 @@ test("project.task (tree): check group label for no assignees", async () => {
         arch: `<tree js_class="project_task_list"/>`,
         groupBy: ["user_ids"],
     });
-    expect(".o_group_name").toHaveText("👤 Unassigned (1)");
+    expect(".o_group_name").toHaveText("👤 Unassigned\n(1)");
 });
 
 test("project.task (tree): check group label for no deadline", async () => {
@@ -43,7 +43,7 @@ test("project.task (tree): check group label for no deadline", async () => {
         arch: `<tree js_class="project_task_list"/>`,
         groupBy: ["date_deadline"],
     });
-    expect(".o_group_name").toHaveText("None (1)");
+    expect(".o_group_name").toHaveText("None\n(1)");
 });
 
 test("project.task (kanban): check group label for no project", async () => {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -176,9 +176,9 @@
                 t-attf-class="o_group_name fs-6 fw-bold {{!group.isFolded ? 'text-900' : 'text-700'}}"
                 t-att-colspan="getGroupNameCellColSpan(group)">
                 <div class="d-flex align-items-center">
-                    <span t-attf-class="o_group_caret fa fa-fw {{group.isFolded ? 'fa-caret-right' : 'fa-caret-down' }} me-1"
+                    <span t-attf-class="o_group_caret fa {{group.isFolded ? 'fa-caret-right' : 'fa-caret-down' }}"
                         t-attf-style="--o-list-group-level: {{getGroupLevel(group)}}"/>
-                    <t t-esc="getGroupDisplayName(group)"/> (<t t-esc="group.count"/>)
+                    <div class="text-truncate ms-2 me-1" t-esc="getGroupDisplayName(group)"/> (<t t-esc="group.count"/>)
                     <div t-if="(groupByButtons[group.groupByField.name] and !group.isFolded and group.record.resId)" class="o_group_buttons">
                         <t t-foreach="groupByButtons[group.groupByField.name]" t-as="button" t-key="button.id">
                             <t t-if="!evalInvisible(button.invisible, group.record)">

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -1769,7 +1769,7 @@ test(`group a list view with the aggregable field 'value'`, async () => {
         groupBy: ["bar"],
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["No (1)\n 1", "Yes (3)\n 3"]);
+    expect(queryAllTexts(`.o_group_header`)).toEqual(["No\n(1)\n 1", "Yes\n(3)\n 3"]);
 });
 
 test(`basic grouped list rendering with groupby m2m field`, async () => {
@@ -1786,7 +1786,7 @@ test(`basic grouped list rendering with groupby m2m field`, async () => {
     });
     expect(`.o_group_header`).toHaveCount(4, { message: "should contain 4 open groups" });
     expect(`.o_group_open`).toHaveCount(0, { message: "no group is open" });
-    expect(queryAllTexts(`.o_group_header .o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_header .o_group_name`).map(text => text.replace("\n", " "))).toEqual([
         "Value 1 (3)",
         "Value 2 (2)",
         "Value 3 (1)",
@@ -1800,16 +1800,16 @@ test(`basic grouped list rendering with groupby m2m field`, async () => {
     await contains(`.o_group_name:eq(3)`).click();
     expect(`.o_group_open`).toHaveCount(4, { message: "all groups are open" });
     expect(queryAllTexts(`.o_list_view tbody > tr`)).toEqual([
-        "Value 1 (3)",
+        "Value 1\n(3)",
         "yop \nValue 1\nValue 2",
         "blip \nValue 1\nValue 2\nValue 3",
         "blip \nValue 1",
-        "Value 2 (2)",
+        "Value 2\n(2)",
         "yop \nValue 1\nValue 2",
         "blip \nValue 1\nValue 2\nValue 3",
-        "Value 3 (1)",
+        "Value 3\n(1)",
         "blip \nValue 1\nValue 2\nValue 3",
-        "None (1)",
+        "None\n(1)",
         "gnap",
     ]);
 });
@@ -1827,10 +1827,10 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
         `,
         groupBy: ["m2o", "m2m"],
     });
-    expect(queryAllTexts(`tbody > tr`)).toEqual(["Value 1 (3)", "Value 2 (1)"]);
+    expect(queryAllTexts(`tbody > tr`)).toEqual(["Value 1\n(3)", "Value 2\n(1)"]);
 
     await contains(`th.o_group_name`).click();
-    expect(queryAllTexts(`tbody > tr`)).toEqual([
+    expect(queryAllTexts(`tbody > tr`).map(text => text.replace("\n", " "))).toEqual([
         "Value 1 (3)",
         "Value 1 (2)",
         "Value 2 (1)",
@@ -1839,7 +1839,7 @@ test(`grouped list rendering with groupby m2o and m2m field`, async () => {
     ]);
 
     await contains(`tbody th.o_group_name:eq(4)`).click();
-    expect(queryAllTexts(`.o_list_view tbody > tr`)).toEqual([
+    expect(queryAllTexts(`.o_list_view tbody > tr`).map(text => text.replace("\n", " "))).toEqual([
         "Value 1 (3)",
         "Value 1 (2)",
         "Value 2 (1)",
@@ -1861,7 +1861,7 @@ test(`list view with multiple groupbys`, async () => {
     });
     expect(`.o_view_nocontent`).toHaveCount(0);
     expect(`.o_group_has_content`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_has_content`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`.o_group_has_content`)).toEqual(["No\n(1)", "Yes\n(3)"]);
 });
 
 test(`enabling archive in list when groupby m2m field`, async () => {
@@ -2037,7 +2037,7 @@ test(`add record in list grouped by m2m`, async () => {
     });
 
     expect(`.o_group_header`).toHaveCount(4);
-    expect(queryAllTexts(`.o_group_header`)).toEqual([
+    expect(queryAllTexts('.o_group_header').map(text => text.replace("\n", " "))).toEqual([
         "Value 1 (3)",
         "Value 2 (2)",
         "Value 3 (1)",
@@ -3235,13 +3235,13 @@ test(`selection is kept on render without reload`, async () => {
     expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(0);
 
     // open blip grouping and check all lines
-    await contains(`.o_group_header:contains(blip (2))`).click();
+    await contains(`.o_group_header:contains(blip\n(2))`).click();
     await contains(`.o_data_row input`).click();
     expect(`div.o_control_panel .o_cp_action_menus`).toHaveCount(1);
     expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
 
     // open yop grouping and verify blip are still checked
-    await contains(`.o_group_header:contains(yop (1))`).click();
+    await contains(`.o_group_header:contains(yop\n(1))`).click();
     expect(`.o_data_row input:checked`).toHaveCount(1, {
         message: "opening a grouping does not uncheck others",
     });
@@ -3249,8 +3249,8 @@ test(`selection is kept on render without reload`, async () => {
     expect(`.o_control_panel_actions .o_list_selection_box`).toHaveCount(1);
 
     // close and open blip grouping and verify blip are unchecked
-    await contains(`.o_group_header:contains(blip (2))`).click();
-    await contains(`.o_group_header:contains(blip (2))`).click();
+    await contains(`.o_group_header:contains(blip\n(2))`).click();
+    await contains(`.o_group_header:contains(blip\n(2))`).click();
     expect(`.o_data_row input:checked`).toHaveCount(0, {
         message: "opening and closing a grouping uncheck its elements",
     });
@@ -3404,7 +3404,7 @@ test(`date field aggregates in grouped lists`, async () => {
         `,
     });
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_header`)).toEqual([`Value 1 (3)`, `Value 2 (1)`]);
+    expect(queryAllTexts(`.o_group_header`)).toEqual([`Value 1\n(3)`, `Value 2\n(1)`]);
 });
 
 test(`hide aggregated value in grouped lists when no data provided by RPC call`, async () => {
@@ -3688,8 +3688,8 @@ test(`groups can be sorted on the first field of the groupBy`, async () => {
         arch: `<tree default_order="bar desc"><field name="foo"/><field name="bar"/></tree>`,
         groupBy: ["bar"],
     });
-    expect(`.o_group_header:eq(0)`).toHaveText("Yes (3)");
-    expect(`.o_group_header:eq(-1)`).toHaveText("No (1)");
+    expect(`.o_group_header:eq(0)`).toHaveText("Yes\n(3)");
+    expect(`.o_group_header:eq(-1)`).toHaveText("No\n(1)");
     expect.verifySteps(["web_read_group"]);
 });
 
@@ -4586,9 +4586,9 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
         groupBy: ["foo", "bar"],
         actionMenus: {},
     });
-    expect(`.o_group_header:eq(0)`).toHaveText("blip (6)");
-    expect(`.o_group_header:eq(1)`).toHaveText("No (2)");
-    expect(`.o_group_header:eq(2)`).toHaveText("Yes (4)");
+    expect(`.o_group_header:eq(0)`).toHaveText("blip\n(6)");
+    expect(`.o_group_header:eq(1)`).toHaveText("No\n(2)");
+    expect(`.o_group_header:eq(2)`).toHaveText("Yes\n(4)");
 
     await contains(`.o_group_header:eq(2)`).click();
     expect(`.o_data_row`).toHaveCount(4);
@@ -4597,8 +4597,8 @@ test(`grouped, update the count of the group (and ancestors) when a record is de
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await toggleMenuItem("Delete");
     await contains(`.modal .btn-primary`).click();
-    expect(`.o_group_header:eq(0)`).toHaveText("blip (5)");
-    expect(`.o_group_header:eq(2)`).toHaveText("Yes (3)");
+    expect(`.o_group_header:eq(0)`).toHaveText("blip\n(5)");
+    expect(`.o_group_header:eq(2)`).toHaveText("Yes\n(3)");
 });
 
 test(`grouped list, reload aggregates when a record is deleted`, async () => {
@@ -6932,7 +6932,7 @@ test(`list view with nested groups`, async () => {
 
     // basic rendering tests
     expect(`.o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1 (4)", "Value 2 (2)"]);
+    expect(queryAllTexts(`.o_group_name`)).toEqual(["Value 1\n(4)", "Value 2\n(2)"]);
     expect(`.o_group_name .fa-caret-right`).toHaveCount(2);
     expect(`.o_group_header:eq(0) span`).toHaveStyle({ "--o-list-group-level": "0" });
     expect(queryAllTexts(`.o_group_header .o_list_number`)).toEqual(["13", "16", "8", "14"]);
@@ -6940,7 +6940,7 @@ test(`list view with nested groups`, async () => {
     // open the first group
     await contains(`.o_group_header:eq(0)`).click();
     expect.verifySteps(["web_read_group"]);
-    expect(queryAllTexts(`.o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_name`).map(text => text.replace("\n", " "))).toEqual([
         "Value 1 (4)",
         "blip (2)",
         "gnap (1)",
@@ -7025,7 +7025,7 @@ test(`grouped list on selection field at level 2`, async () => {
     expect(`.o_group_header`).toHaveCount(5, {
         message: "should contain 2 groups at first level and 3 groups at second level",
     });
-    expect(queryAllTexts(`.o_group_header .o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_header .o_group_name`).map(text => text.replace("\n", " "))).toEqual([
         "Value 1 (5)",
         "Low (3)",
         "Medium (1)",
@@ -10268,7 +10268,7 @@ test(`list grouped by date:month`, async () => {
         arch: `<tree><field name="date"/></tree>`,
         groupBy: ["date:month"],
     });
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["January 2017 (1)", "None (3)"], {
+    expect(queryAllTexts(`.o_group_header`)).toEqual(["January 2017\n(1)", "None\n(3)"], {
         message: "the group names should be correct",
     });
 });
@@ -10482,10 +10482,10 @@ test(`grouped list view move to previous page of group when all records from las
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`th:contains(Value 1 (3))`).toHaveCount(1, {
+    expect(`th:contains(Value 1\n(3))`).toHaveCount(1, {
         message: "Value 1 should contain 3 records",
     });
-    expect(`th:contains(Value 2 (1))`).toHaveCount(1, {
+    expect(`th:contains(Value 2\n(1))`).toHaveCount(1, {
         message: "Value 2 should contain 1 record",
     });
 
@@ -10525,8 +10525,8 @@ test(`grouped list view move to next page when all records from the current page
         actionMenus: {},
         groupBy: ["m2o"],
     });
-    expect(`tr.o_group_header:eq(0) th:eq(0)`).toHaveText("Value 1 (6)");
-    expect(`tr.o_group_header:eq(1) th:eq(0)`).toHaveText("Value 2 (1)");
+    expect(`tr.o_group_header:eq(0) th:eq(0)`).toHaveText("Value 1\n(6)");
+    expect(`tr.o_group_header:eq(1) th:eq(0)`).toHaveText("Value 2\n(1)");
 
     const firstGroup = queryFirst(`tr.o_group_header:eq(0)`);
     await contains(firstGroup).click();
@@ -10538,7 +10538,7 @@ test(`grouped list view move to next page when all records from the current page
     await contains(`.o_cp_action_menus .dropdown-toggle`).click();
     await contains(`.dropdown-item:contains(Delete)`).click();
     await contains(`.modal .btn-primary`).click();
-    expect(`.o_group_header:eq(0) .o_group_name`).toHaveText(`Value 1 (4)\n1-2 / 4`);
+    expect(`.o_group_header:eq(0) .o_group_name`).toHaveText(`Value 1\n(4)\n1-2 / 4`);
     expect(queryAllTexts(`.o_data_row`)).toEqual(["yop3", "yop4"]);
 });
 
@@ -10815,12 +10815,12 @@ test(`multi level grouped list with groups_limit attribute`, async () => {
         message: "pager should be correct",
     });
     expect(`.o_pager_limit`).toHaveText("4");
-    expect(queryAllTexts(`.o_group_header`)).toEqual(["blip (2)", "foo (5)", "gnap (1)"]);
+    expect(queryAllTexts(`.o_group_header`)).toEqual(["blip\n(2)", "foo\n(5)", "gnap\n(1)"]);
 
     // open foo group
     await contains(`.o_group_header:eq(1)`).click();
     expect(`.o_group_header`).toHaveCount(6);
-    expect(queryAllTexts(`.o_group_header`)).toEqual([
+    expect(queryAllTexts(`.o_group_header`).map(text => text.replace("\n", " "))).toEqual([
         "blip (2)",
         "foo (5)\n1-3 / 5",
         "50 (1)",
@@ -10920,7 +10920,7 @@ test(`grouped lists with expand attribute and a lot of groups`, async () => {
     expect(`.o_group_header`).toHaveCount(10); // page 1
     expect(`.o_data_row`).toHaveCount(10); // two groups contains two records
     expect(`.o_pager`).toHaveCount(1); // has a pager
-    expect(queryAllTexts(`.o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_name`).map(text => text.replace("\n", " "))).toEqual([
         "-4 (1)",
         "0 (1)",
         "1 (1)",
@@ -10936,7 +10936,7 @@ test(`grouped lists with expand attribute and a lot of groups`, async () => {
     await pagerNext(); // switch to page 2
     expect(`.o_group_header`).toHaveCount(7); // page 2
     expect(`.o_data_row`).toHaveCount(9); // two groups contains two records
-    expect(queryAllTexts(`.o_group_name`)).toEqual([
+    expect(queryAllTexts(`.o_group_name`).map(text => text.replace("\n", " "))).toEqual([
         "9 (2)",
         "10 (2)",
         "11 (1)",
@@ -11897,7 +11897,7 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     expect(`.o_selected_row`).toHaveCount(0);
 
     // Click on last data row of first group
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(1)\n -4");
     await contains(`.o_data_row:eq(0) [name=foo]`).click();
     expect(`.o_data_row:eq(0) [name=foo] input`).toBeFocused();
 
@@ -11905,13 +11905,13 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(2)\n -4");
 
     // Enter should discard the edited row as it is pristine + get to next data row
     press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(1)\n -4");
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // Shift+Tab should focus back the last field of first row
@@ -11923,12 +11923,12 @@ test(`keyboard navigation from last cell in editable grouped list`, async () => 
     press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(2)\n -4");
 
     // Edit the row and press enter: should add a new row
     await contains(`.o_data_row:eq(1) [name=foo] input`).edit("zzapp", { confirm: "enter" });
     expect(`.o_data_row`).toHaveCount(7);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (3)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(3)\n -4");
     expect(`.o_data_row:eq(2) [name=foo] input`).toBeFocused();
 });
 
@@ -11998,7 +11998,7 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
     expect(`.o_selected_row`).toHaveCount(0);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(1)\n -4");
 
     // Click on last data row of first group
     await contains(`.o_data_row:eq(0) [name=foo]`).click();
@@ -12008,13 +12008,13 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(2)\n -4");
 
     // Enter should discard the edited row as it is pristine + get to next data row
     press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(1)\n -4");
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // Shift+Tab should focus back the last field of first row
@@ -12026,13 +12026,13 @@ test(`keyboard navigation from last cell in multi-edit list`, async () => {
     press("Enter");
     await animationFrame();
     expect(`.o_data_row`).toHaveCount(6);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(2)\n -4");
 
     // Edit the row and press enter: should add a new row
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
     await contains(`.o_data_row:eq(1) [name=foo] input`).edit("zzapp", { confirm: "enter" });
     expect(`.o_data_row`).toHaveCount(7);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (3)\n -4");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(3)\n -4");
     expect(`.o_data_row:eq(2) [name=foo] input`).toBeFocused();
 });
 
@@ -12141,22 +12141,22 @@ test(`editable grouped list: adding a second record pass the first in readonly`,
     await contains(`.o_group_header:eq(0)`).click();
     await contains(`.o_group_header:eq(1)`).click();
     expect(`.o_data_row`).toHaveCount(4);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)");
-    expect(`.o_group_header:eq(1)`).toHaveText("Yes (3)");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(1)");
+    expect(`.o_group_header:eq(1)`).toHaveText("Yes\n(3)");
 
     // add a row in first group
     await contains(`.o_group_field_row_add:eq(0) a`).click();
     expect(`.o_selected_row`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(0)`).toHaveText("No (2)");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(2)");
     expect(`.o_data_row:eq(1) [name=foo] input`).toBeFocused();
 
     // add a row in second group
     await contains(`.o_group_field_row_add:eq(1) a`).click();
     expect(`.o_selected_row`).toHaveCount(1);
     expect(`.o_data_row`).toHaveCount(5);
-    expect(`.o_group_header:eq(1)`).toHaveText("Yes (4)");
-    expect(`.o_group_header:eq(0)`).toHaveText("No (1)");
+    expect(`.o_group_header:eq(1)`).toHaveText("Yes\n(4)");
+    expect(`.o_group_header:eq(0)`).toHaveText("No\n(1)");
     expect(`.o_data_row:eq(4) [name=foo] input`).toBeFocused();
 });
 
@@ -12468,7 +12468,7 @@ test(`add a new row in grouped editable="top" list`, async () => {
     expect(`.o_data_row`).toHaveCount(4);
 
     await contains(`.o_group_field_row_add a:eq(1)`).click(); // create row in second group "Yes"
-    expect(`.o_group_name:eq(1)`).toHaveText("Yes (4)", {
+    expect(`.o_group_name:eq(1)`).toHaveText("Yes\n(4)", {
         message: "group should have correct name and count",
     });
     expect(`.o_data_row`).toHaveCount(5);
@@ -13792,7 +13792,7 @@ test(`go to the next page after leaving and coming back to a grouped list view`,
     });
     expect(`.o_list_view`).toHaveCount(1);
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("No (1)");
+    expect(`.o_group_header`).toHaveText("No\n(1)");
 
     // unfold the second group
     await contains(`.o_group_header`).click();
@@ -13805,11 +13805,11 @@ test(`go to the next page after leaving and coming back to a grouped list view`,
 
     await contains(`.breadcrumb-item a`).click();
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("No (1)");
+    expect(`.o_group_header`).toHaveText("No\n(1)");
 
     await pagerNext();
     expect(`.o_group_header`).toHaveCount(1);
-    expect(`.o_group_header`).toHaveText("Yes (3)");
+    expect(`.o_group_header`).toHaveText("Yes\n(3)");
 });
 
 test(`keep order after grouping`, async () => {
@@ -13832,7 +13832,7 @@ test(`keep order after grouping`, async () => {
 
     await toggleSearchBarMenu();
     await toggleMenuItem("Foo");
-    expect(queryAllTexts`.o_group_name`).toEqual(["yop (1)", "gnap (1)", "blip (2)"]);
+    expect(queryAllTexts`.o_group_name`).toEqual(["yop\n(1)", "gnap\n(1)", "blip\n(2)"]);
 
     await toggleMenuItem("Foo");
     expect(queryAllTexts`.o_data_row td[name=foo]`).toEqual(["yop", "gnap", "blip", "blip"]);
@@ -14218,7 +14218,7 @@ test(`have some records, then go to next page in pager then group by some field:
     await toggleSearchBarMenu();
     await toggleMenuItem("Bar");
     expect(`tbody .o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`tbody .o_group_header`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`tbody .o_group_header`)).toEqual(["No\n(1)", "Yes\n(3)"]);
 
     await removeFacet("Bar");
     expect(`tbody .o_data_row`).toHaveCount(2);
@@ -14231,7 +14231,7 @@ test(`have some records, then go to next page in pager then group by some field:
     await toggleSearchBarMenu();
     await toggleMenuItem("Bar");
     expect(`tbody .o_group_header`).toHaveCount(2);
-    expect(queryAllTexts(`tbody .o_group_header`)).toEqual(["No (1)", "Yes (3)"]);
+    expect(queryAllTexts(`tbody .o_group_header`)).toEqual(["No\n(1)", "Yes\n(3)"]);
 });
 
 test(`optional field selection do not unselect current row`, async () => {


### PR DESCRIPTION
Steps to reproduce:
--------------------------
- Install project.
- Go to the project.
- Create or edit the project name too long.
- Then go to Configuration and select Task stages.
- The project name is slightly misaligned in list view.

Issue:
------------------------------
- Before this commit, in the project's task stages, if the project's name
 was long, it would misalign in list view.

Cause:
----------------------------------
- When the name is too long it will be laid out in a row.

Fix:
------------------------------------
- After this commit the name is now aligned and If the text exceeds the
 element's content area, it is truncated and displays the count with an ellipsis
 at the end.

task-3681318