### PR TITLE
[IMP] web: cleanup canSelectRecord

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.js
+++ b/addons/web/static/src/views/list/list_renderer.js
@@ -238,6 +238,8 @@ export class ListRenderer extends Component {
             this.lastEditedCell = null;
         });
         this.isRTL = localization.direction === "rtl";
+        this.selectionEnabled =
+            !this.props.list.editedRecord && !this.props.list.model.useSampleModel;
     }
 
     displaySaveNotification() {
@@ -1829,20 +1831,16 @@ export class ListRenderer extends Component {
         group.toggle();
     }
 
-    get canSelectRecord() {
-        return !this.props.list.editedRecord && !this.props.list.model.useSampleModel;
-    }
-
     toggleSelection() {
         const list = this.props.list;
-        if (!this.canSelectRecord) {
+        if (!this.selectionEnabled) {
             return;
         }
         return list.toggleSelection();
     }
 
     toggleRecordSelection(record, ev) {
-        if (!this.canSelectRecord) {
+        if (!this.selectionEnabled) {
             return;
         }
         if (this.shiftKeyMode && this.lastCheckedRecord) {

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -2,7 +2,6 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ListRenderer">
-        <t t-set="_canSelectRecord" t-value="canSelectRecord"/>
         <div
             class="o_list_renderer o_renderer table-responsive"
             tabindex="-1"
@@ -15,7 +14,7 @@
                 <thead>
                     <tr>
                         <th t-if="hasSelectors" class="o_list_record_selector o_list_controller align-middle pe-1 cursor-pointer" tabindex="-1" t-on-keydown="(ev) => this.onCellKeydown(ev)" t-on-click.stop="toggleSelection">
-                            <CheckBox disabled="!_canSelectRecord" value="selectAll" className="'d-flex m-0'" onChange.bind="toggleSelection"/>
+                            <CheckBox disabled="!selectionEnabled" value="selectAll" className="'d-flex m-0'" onChange.bind="toggleSelection"/>
                         </th>
                         <t t-foreach="state.columns" t-as="column" t-key="column.id">
                             <th t-if="column.type === 'field'"
@@ -225,7 +224,7 @@
             t-on-touchmove="() => this.onRowTouchMove(record)"
         >
             <td t-on-keydown="(ev) => this.onCellKeydown(ev, group, record)" t-if="hasSelectors" class="o_list_record_selector user-select-none" t-on-click.stop="() => this.toggleRecordSelection(record)" tabindex="-1">
-                <CheckBox disabled="!_canSelectRecord" value="record.selected" onChange.alike="() => this.toggleRecordSelection(record)" />
+                <CheckBox disabled="!selectionEnabled" value="record.selected" onChange.alike="() => this.toggleRecordSelection(record)" />
             </td>
             <t t-foreach="getColumns(record)" t-as="column" t-key="column.id">
                 <t t-if="column.type === 'field'">


### PR DESCRIPTION
Since `canSelectRecord` getter is cached inside the t-set at the start of the template, it is actually not useful to have it has a getter. This PR move it to the component setup and rename it `selectionEnabled`.