### PR TITLE
[IMP] test_mail: make access tests independent from discuss models

### DIFF
--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -4,6 +4,30 @@
 from odoo import api, fields, models
 
 
+class MailAccessPortal(models.Model):
+    """ Test access on mail models without depending on real models like channel
+    or partner which have their own set of ACLs. """
+    _description = 'Mail Access Portal'
+    _name = 'mail.access.portal'
+    _inherit = ['mail.thread.blacklist']
+    _mail_post_access = 'write'  # default value but ease mock
+    _order = 'id DESC'
+    _primary_email = 'email_from'
+
+    name = fields.Char()
+    email_from = fields.Char()
+    customer_id = fields.Many2one('res.partner', 'Customer')
+    access = fields.Selection(
+        [
+            ('public', 'public'),
+            ('logged', 'Logged'),
+            ('internal', 'Internal'),
+            ('internal_ro', 'Internal readonly'),
+            ('admin', 'Admin'),
+        ],
+        name='Access', default='public')
+
+
 class MailPerformanceThread(models.Model):
     _name = 'mail.performance.thread'
     _description = 'Performance: mail.thread'

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -1,4 +1,7 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mail_access_portal_portal,mail.access.portal.portal,model_mail_access_portal,base.group_portal,1,0,0,0
+access_mail_access_portal_public,mail.access.portal.public,model_mail_access_portal,base.group_public,1,0,0,0
+access_mail_access_portal_user,mail.access.portal.user,model_mail_access_portal,base.group_user,1,1,1,1
 access_mail_performance_thread,access_mail_performance_thread,model_mail_performance_thread,,1,1,1,1
 access_mail_performance_tracking_user,mail.performance.tracking,model_mail_performance_tracking,base.group_user,1,1,1,1
 access_mail_test_simple_portal,mail.test.simple.portal,model_mail_test_simple,base.group_portal,1,0,0,0

--- a/addons/test_mail/security/test_mail_security.xml
+++ b/addons/test_mail/security/test_mail_security.xml
@@ -1,6 +1,45 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo noupdate="1">
 
+        <record id="ir_rule_mail_access_portal_public" model="ir.rule">
+            <field name="name">Public: public only</field>
+            <field name="model_id" ref="test_mail.model_mail_access_portal"/>
+            <field name="domain_force">[('access', '=', 'public')]</field>
+            <field name="groups" eval="[(4, ref('base.group_public'))]"/>
+        </record>
+        <record id="ir_rule_mail_access_portal_portal" model="ir.rule">
+            <field name="name">Portal: public/logged only</field>
+            <field name="model_id" ref="test_mail.model_mail_access_portal"/>
+            <field name="domain_force">[('access', 'in', ('public', 'logged'))]</field>
+            <field name="groups" eval="[(4, ref('base.group_portal'))]"/>
+        </record>
+        <record id="ir_rule_mail_access_portal_internal" model="ir.rule">
+            <field name="name">Internal: read not admin</field>
+            <field name="model_id" ref="test_mail.model_mail_access_portal"/>
+            <field name="domain_force">[('access', '!=', 'admin')]</field>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_read" eval="True"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
+        </record>
+        <record id="ir_rule_mail_access_portal_internal_update" model="ir.rule">
+            <field name="name">Internal: update not admin and not readonly</field>
+            <field name="model_id" ref="test_mail.model_mail_access_portal"/>
+            <field name="domain_force">[('access', 'not in', ('internal_ro', 'admin'))]</field>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_read" eval="False"/>
+            <field name="perm_write" eval="True"/>
+            <field name="perm_create" eval="True"/>
+            <field name="perm_unlink" eval="True"/>
+        </record>
+        <record id="ir_rule_mail_access_portal_admin" model="ir.rule">
+            <field name="name">Admin: all</field>
+            <field name="model_id" ref="test_mail.model_mail_access_portal"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[(4, ref('base.group_system'))]"/>
+        </record>
+
         <record id="mail_test_multi_company_rule" model="ir.rule">
             <field name="name">Mail Test Multi Company</field>
             <field name="model_id" ref="test_mail.model_mail_test_multi_company"/>


### PR DESCRIPTION
Purpose is to make tests independent from channel model which has its own access rules. We now use a test model with simple rules, allowing to simulate models with

  * public access;
  * portal access;
  * internal access;
  * admin access;

Tests are rewritten to be more concise and precise and use this new model.

This is done in stable to keep coherency in tests codebase. It also eases writing bugfixes as tests won't have to be modified during forward port process. Finally it allows to backport improvements or fixes in later versions if it applies to previous versions.

Task-
