### PR TITLE
[IMP] web: progress bar style

### DIFF
--- a/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
+++ b/addons/crm/static/src/views/crm_kanban/crm_column_progress.xml
@@ -5,7 +5,7 @@
             <attribute name="class" remove="w-75" add="w-50" separator=" "/>
         </xpath>
 
-        <xpath expr="//div[hasclass('o_bar_has_records') and hasclass('progress-bar')]" position="attributes">
+        <xpath expr="//div[hasclass('progress-bar')]" position="attributes">
             <attribute name="t-att-data-tooltip">
                 getColumnProgressTooltip(bar)
             </attribute>

--- a/addons/crm/static/tests/forecast_kanban.test.js
+++ b/addons/crm/static/tests/forecast_kanban.test.js
@@ -334,7 +334,7 @@ test("Forecast drag&drop and add column", async () => {
 
     const getProgressBarsColors = () =>
         queryAll(".o_column_progress").map((columnProgressEl) =>
-            queryAll(".progress-bar", { root: columnProgressEl }).map((progressBarEl) =>
+            queryAll(".progress-bar.o_bar_has_records", { root: columnProgressEl }).map((progressBarEl) =>
                 [...progressBarEl.classList].find((htmlClass) => htmlClass.startsWith("bg-"))
             )
         );

--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -48,7 +48,7 @@
                             <a name="%(hr_employee_action_from_department)d" type="action" title="Absent Employee(s), Whose time off requests are either confirmed or validated on today">Absence</a>
                         </div>
                         <div class="col-7">
-                            <field name="absence_of_today" widget="progressbar" options="{'current_value': 'absence_of_today', 'max_value': 'total_employee', 'editable': false}"/>
+                            <field name="absence_of_today" widget="progressbar" options="{'max_value': 'total_employee'}" readonly="1"/>
                         </div>
                     </div>
                 </xpath>

--- a/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.scss
+++ b/addons/hr_skills/static/src/fields/skills_one2many/skills_one2many.scss
@@ -1,10 +1,4 @@
 .o_field_skills_one2many, .o_field_resume_one2many {
-    .o_progress {
-        background: $gray-300;
-        border: 0;
-        height: 5px;
-    }
-
     .o_progressbar_value {
         font-size: $font-size-sm;
         font-weight: bold;

--- a/addons/hr_skills/static/src/scss/hr_employee.scss
+++ b/addons/hr_skills/static/src/scss/hr_employee.scss
@@ -25,9 +25,6 @@
     .o_list_renderer .o_list_table thead .o_list_number_th{
         text-align: start !important;
     }
-    .o_progressbar_value .o_input {
-        width: 0 !important;
-    }
 }
 
 .o_resume_html .note-editable {

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -349,7 +349,7 @@
         <field name="arch" type="xml">
             <list string="Skill Levels" class="o_skill_level_tree" editable="bottom" default_order="level_progress desc">
                 <field name="name"/>
-                <field name="level_progress" widget="progressbar" options="{'editable': true}" width="250"/>
+                <field name="level_progress" widget="progressbar" width="250"/>
                 <field name="default_level" widget="boolean_toggle_load"/>
                 <field name="technical_is_new_default" column_invisible="1"/> <!-- needs to be here to be accessible for the front-end -->
             </list>

--- a/addons/hr_timesheet/static/tests/task_with_hours.test.js
+++ b/addons/hr_timesheet/static/tests/task_with_hours.test.js
@@ -65,7 +65,7 @@ test("project.task (tree): progress bar color", async () => {
             <list>
                 <field name="name"/>
                 <field name="project_id"/>
-                <field name="progress" widget="project_task_progressbar" options="{'overflow_class': 'bg-danger'}"/>
+                <field name="progress" widget="project_task_progressbar" decoration-danger="progress > 1"/>
             </list>
         `,
     });
@@ -76,7 +76,7 @@ test("project.task (tree): progress bar color", async () => {
     expect("div.o_progressbar .bg-warning").toHaveCount(1, {
         message: "Task 2 having progress = 80 >= 80 => orange color",
     });
-    expect("div.o_progressbar .bg-success").toHaveCount(1, {
-        message: "Task 3 having progress = 101 > 100 => red color",
+    expect("div.o_progressbar .bg-danger").toHaveCount(1, {
+        message: "Task 3 having progress = 104 > 100 => red color",
     });
 });

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -18,7 +18,7 @@
                 <field name="subtask_effective_hours" string="Sub-tasks Time Spent" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
                 <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
                 <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
+                <field name="progress" widget="project_task_progressbar" optional="hide" decoration-danger="progress > 1" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/list/field[@name='portal_user_names']" position="after">
                 <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
@@ -26,7 +26,7 @@
                 <field name="subtask_effective_hours" string="Sub-tasks Time Spent" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
                 <field name="total_hours_spent" string="Total Time Spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
                 <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
+                <field name="progress" widget="project_task_progressbar" optional="hide" decoration-danger="progress > 1" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
             </xpath>
             <xpath expr="//div[@name='repeat_intervals']" position="after">
                 <field name="encode_uom_in_days" invisible="1"/>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -12,7 +12,7 @@
                     <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"  column_invisible="context.get('template_project')"/>
                     <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
                     <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
-                    <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user"
+                    <field name="progress" widget="project_task_progressbar" optional="hide" decoration-danger="progress > 1" groups="hr_timesheet.group_hr_timesheet_user"
                     column_invisible="context.get('template_project')"/>
                 </xpath>
                 <xpath expr="//group/field[@name='allocated_hours']" position="replace">
@@ -148,7 +148,7 @@
                     <field name="subtask_effective_hours" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
                     <field name="total_hours_spent" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
                     <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
-                    <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
+                    <field name="progress" widget="project_task_progressbar" optional="hide" decoration-danger="progress > 1" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="context.get('template_project')"/>
                 </xpath>
             </field>
         </record>
@@ -166,7 +166,7 @@
                     <field name="subtask_effective_hours" widget="timesheet_uom" sum="Time Spent on Sub-Tasks" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
                     <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
                     <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining on SO" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" invisible="allocated_hours == 0" groups="hr_timesheet.group_hr_timesheet_user" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
-                    <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
+                    <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" decoration-danger="progress > 1" column_invisible="not context.get('allow_timesheets', True) or context.get('template_project')"/>
                 </field>
             </field>
         </record>

--- a/addons/l10n_ke_edi_tremol/static/src/components/ke_proxy_dialog.xml
+++ b/addons/l10n_ke_edi_tremol/static/src/components/ke_proxy_dialog.xml
@@ -12,7 +12,7 @@
                     <p t-esc="state.message"/>
                     <t t-if="!state.error">
                         <div t-attf-class="o_progressbar align-items-center w-100 d-flex">
-                            <div class="o_progress w-100 flex-fill"
+                            <div class="progress w-100 flex-fill"
                                  aria-valuemin="0"
                                  t-att-aria-valuemax="props.invoices.length"
                                  t-att-aria-valuenow="state.successfullySent">

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -35,7 +35,7 @@
                 <field name="state"/>
                 <field name="allow_milestones" />
                 <field name="has_late_and_unreached_milestone"/>
-                <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200"}'/>
+                <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "300"}'/>
                 <templates>
                 <t t-name="menu" t-if="!selection_mode">
                     <div role="separator" class="dropdown-divider"></div>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -696,7 +696,7 @@
                     <field name="subtask_count"/>
                     <field name="is_template"/>
                     <field name="has_project_template"/>
-                    <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "200" }'/>
+                    <progressbar field="state" colors='{"1_done": "success-done", "1_canceled": "danger", "03_approved": "success", "02_changes_requested": "warning", "04_waiting_normal": "info", "01_in_progress": "300" }'/>
                     <templates>
                         <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
                             <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -38,7 +38,7 @@
                             <field name="project_id" invisible="1"/>
                             <field name="color" invisible="1"/>
                             <field name="status" widget="status_with_color"/>
-                            <field name="progress" widget="progressbar" options="{'editable': true}"/>
+                            <field name="progress" widget="progressbar"/>
                         </group>
                         <group>
                             <field name="user_id" widget="many2one_avatar_user" readonly="1"/>

--- a/addons/sale/static/tests/sales_team_dashboard.test.js
+++ b/addons/sale/static/tests/sales_team_dashboard.test.js
@@ -55,7 +55,7 @@ test("edit progressbar target", async () => {
                 <field name="invoiced_target"/>
                 <templates>
                     <div t-name="card">
-                        <field name="invoiced" widget="sales_team_progressbar" options="{'current_value': 'invoiced', 'max_value': 'invoiced_target', 'editable': true, 'edit_max_value': true}"/>
+                        <field name="invoiced" widget="sales_team_progressbar" options="{'max_value': 'invoiced_target'}"/>
                     </div>
                 </templates>
             </kanban>`,

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.js
@@ -1,12 +1,13 @@
 import { useRef, useState } from "@web/owl2/utils";
 import { _t } from "@web/core/l10n/translation";
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useNumpadDecimal } from "../numpad_decimal_hook";
 import { parseFloat } from "../parsers";
 import { useInputField } from "@web/views/fields/input_field_hook";
 import { standardFieldProps } from "../standard_field_props";
 
-import { Component } from "@odoo/owl";
+import { Component, useEffect } from "@odoo/owl";
 const formatters = registry.category("formatters");
 
 export class ProgressBarField extends Component {
@@ -14,98 +15,111 @@ export class ProgressBarField extends Component {
     static props = {
         ...standardFieldProps,
         maxValueField: { type: [String, Number], optional: true },
-        currentValueField: { type: String, optional: true },
         isEditable: { type: Boolean, optional: true },
-        isCurrentValueEditable: { type: Boolean, optional: true },
-        isMaxValueEditable: { type: Boolean, optional: true },
         title: { type: String, optional: true },
-        overflowClass: { type: String, optional: true },
+        decorations: { type: Object, optional: true },
+    };
+    static defaultProps = {
+        decorations: {},
     };
 
     setup() {
         useNumpadDecimal();
         this.root = useRef("numpadDecimal");
 
-        const { currentValueField, maxValueField, name } = this.props;
-        this.currentValueField = currentValueField ? currentValueField : name;
-        if (maxValueField) {
-            this.maxValueField = maxValueField;
-        }
         this.currentValueRef = useInputField({
             getValue: () => this.formatCurrentValue(),
             parse: (v) => this.parseCurrentValue(v),
             refName: "currentValue",
-            fieldName: this.currentValueField,
-            shouldSave: () => this.props.readonly,
-        });
-        this.maxValueRef = useInputField({
-            getValue: () => this.formatMaxValue(),
-            parse: (v) => this.parseMaxValue(v),
-            refName: "maxValue",
-            fieldName: this.maxValueField,
+            fieldName: this.props.name,
             shouldSave: () => this.props.readonly,
         });
 
         this.state = useState({
             isEditing: false,
         });
+
+        useEffect(
+            () => {
+                this.resizeInput();
+            },
+            () => [this.currentValue, this.state.isEditing]
+        );
+    }
+
+    resizeInput() {
+        const input = this.currentValueRef.el;
+        if (input) {
+            const displayValue = this.state.isEditing ? input.value : this.formatCurrentValue();
+            const charCount = Math.max(3, (displayValue?.toString().length || 0) + 1);
+            input.style.width = `${charCount}ch`;
+        }
     }
 
     get isEditable() {
-        return this.props.isEditable && !this.props.readonly;
+        return this.props.isEditable;
     }
     get isPercentage() {
         return !this.props.maxValueField || !isNaN(this.props.maxValueField);
     }
 
     get currentValue() {
-        return this.props.record.data[this.currentValueField] || 0;
+        return this.props.record.data[this.props.name] || 0;
     }
 
     get maxValue() {
-        return this.props.record.data[this.maxValueField] || 100;
+        return this.props.record.data[this.props.maxValueField] || 100;
     }
 
     get progressBarColorClass() {
-        return this.currentValue > this.maxValue ? this.props.overflowClass : "bg-primary";
+        if (this.props.decorations) {
+            const evalContext = this.props.record.evalContextWithVirtualIds;
+            for (const decorationName in this.props.decorations) {
+                if (evaluateBooleanExpr(this.props.decorations[decorationName], evalContext)) {
+                    return `progress-bar bg-${decorationName}`;
+                }
+            }
+        }
+        return "progress-bar";
     }
 
     formatCurrentValue(humanReadable = !this.state.isEditing) {
-        const formatter = formatters.get(this.props.record.fields[this.currentValueField].type);
+        const formatter = formatters.get(this.props.record.fields[this.props.name].type);
         return formatter(this.currentValue, { humanReadable });
     }
 
     formatMaxValue(humanReadable = !this.state.isEditing) {
-        const formatter = formatters.get(this.props.record.fields[this.maxValueField]?.type ?? "integer");
+        const formatter = formatters.get(this.props.record.fields[this.props.maxValueField]?.type ?? "integer");
         return formatter(this.maxValue, { humanReadable });
     }
 
     parseCurrentValue(value) {
         let parsedValue = parseFloat(value);
-        if (this.props.record.fields[this.currentValueField].type === "integer") {
-            parsedValue = Math.floor(parsedValue);
-        }
-        return parsedValue;
-    }
-
-    parseMaxValue(value) {
-        let parsedValue = parseFloat(value);
-        if (this.props.record.fields[this.maxValueField].type === "integer") {
+        if (this.props.record.fields[this.props.name].type === "integer") {
             parsedValue = Math.floor(parsedValue);
         }
         return parsedValue;
     }
 
     onInputBlur() {
-        if (
-            document.activeElement !== this.maxValueRef.el &&
-            document.activeElement !== this.currentValueRef.el
-        ) {
-            this.state.isEditing = false;
-        }
+        this.state.isEditing = false;
     }
     onInputFocus() {
         this.state.isEditing = true;
+        this.resizeInput();
+    }
+
+    onInputChange() {
+        this.resizeInput();
+    }
+
+    onProgressClick() {
+        if (this.isEditable) {
+            const input = this.root.el?.querySelector(".o_progressbar_value input");
+            if (input) {
+                input.focus();
+            }
+        }
     }
 }
 
@@ -113,25 +127,6 @@ export const progressBarField = {
     component: ProgressBarField,
     displayName: _t("Progress Bar"),
     supportedOptions: [
-        {
-            label: _t("Can edit value"),
-            name: "editable",
-            type: "boolean",
-        },
-        {
-            label: _t("Can edit max value"),
-            name: "edit_max_value",
-            type: "boolean",
-        },
-        {
-            label: _t("Current value field"),
-            name: "current_value",
-            type: "field",
-            availableTypes: ["integer", "float"],
-            help: _t(
-                "Use to override the display value (e.g. if your progress bar is a computed percentage but you want to display the actual field value instead)."
-            ),
-        },
         {
             label: _t("Max value field"),
             name: "max_value",
@@ -141,26 +136,13 @@ export const progressBarField = {
                 "Field that holds the maximum value of the progress bar. If set, will be displayed next to the progress bar (e.g. 10 / 200)."
             ),
         },
-        {
-            label: _t("Overflow style"),
-            name: "overflow_class",
-            type: "string",
-            availableTypes: ["integer", "float"],
-            help: _t(
-                "Bootstrap classname to customize the style of the progress bar when the maximum value is exceeded"
-            ),
-            default: "bg-secondary",
-        },
     ],
     supportedTypes: ["integer", "float"],
-    extractProps: ({ attrs, options }) => ({
-        maxValueField: options.max_value,
-        currentValueField: options.current_value,
-        isEditable: !options.readonly && options.editable,
-        isCurrentValueEditable: options.editable && !options.edit_max_value,
-        isMaxValueEditable: options.editable && options.edit_max_value,
-        title: attrs.title,
-        overflowClass: options.overflow_class || "bg-secondary",
+    extractProps: (fieldInfo, dynamicInfo) => ({
+        maxValueField: fieldInfo.options.max_value,
+        isEditable: !dynamicInfo.readonly,
+        title: fieldInfo.attrs.title,
+        decorations: fieldInfo.decorations,
     }),
 };
 

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.scss
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.scss
@@ -1,26 +1,15 @@
 .o_progressbar {
-    .o_progress {
-        width: 100px;
-        height: 15px;
-        border: 1px solid $o-gray-300;
-        background-color: $o-view-background-color;
-    }
+    --ProgressBarField-width: 150px;
+    --ProgressBarField-min-width: 35px;
+    --ProgressBarField-height: #{map-get($spacers, 2)};
 
-    .o_progressbar_value input {
-        // Prevent the input to grow and deteriorate the visibility
-        width: 45px;
-        min-width: 45px;
-        transition: width .2s;
-    }
-}
+    color: $body-color;
 
-.o_form_view {
-    .o_progressbar_value input {
-        &:focus-within {
-            // To improve the edition of the value, the
-            // input grows to the full available width
-            width: 100%;
-        }
+    .progress {
+        --#{$prefix}progress-height: var(--ProgressBarField-height);
+
+        flex-basis: var(--ProgressBarField-width);
+        min-width: var(--ProgressBarField-min-width);
     }
 }
 
@@ -29,24 +18,12 @@
         text-align: left !important;
     }
 
-    .o_data_cell {
-        .o_progressbar {
-            // Force progress bars to respect table's layout
-            display: table-row;
-            justify-content: start;
-            .o_rtl & {
-                justify-content: flex-end;
-                text-align: right;
-            }
-            .o_progressbar_value {
-                span {
-                    min-width: 1.5rem;
-                    text-align: end;
-                }
-                span:last-child{
-                    text-align: start;
-                }
-            }
+    .o_data_cell .o_progressbar {
+        width: 100%;
+
+        .o_rtl & {
+            justify-content: flex-end;
+            text-align: right;
         }
     }
 }

--- a/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
+++ b/addons/web/static/src/views/fields/progress_bar/progress_bar_field.xml
@@ -2,15 +2,15 @@
 <templates xml:space="preserve">
 
     <t t-name="web.ProgressBarField">
-        <div class="o_progressbar w-100 d-flex align-items-center" t-ref="numpadDecimal">
+        <div class="o_progressbar d-flex align-items-center gap-2" t-ref="numpadDecimal">
             <div t-if="props.title" class="o_progressbar_title text-nowrap pe-1"><t t-esc="props.title"/></div>
-            <div class="o_progress align-middle overflow-hidden" aria-valuemin="0" t-att-aria-valuemax="this.maxValue" t-att-aria-valuenow="this.currentValue">
-                <div t-attf-class="{{ progressBarColorClass }} h-100" t-att-style="'width: min(' + 100 * this.currentValue / this.maxValue + '%, 100%)'"></div>
+            <div class="progress" aria-valuemin="0" t-att-aria-valuemax="this.maxValue" t-att-aria-valuenow="this.currentValue" t-on-click="onProgressClick" t-att-style="isEditable ? 'cursor: pointer' : ''">
+                <div t-attf-class="{{ progressBarColorClass }}" t-att-style="'width: min(' + 100 * this.currentValue / this.maxValue + '%, 100%)'"></div>
             </div>
-            <div class="o_progressbar_value d-flex">
+            <div class="o_progressbar_value d-flex gap-1 flex-shrink-0 text-nowrap">
                 <t t-if="isPercentage">
                     <input
-                        t-if="isEditable and props.isCurrentValueEditable"
+                        t-if="isEditable"
                         t-ref="currentValue"
                         class="o_input h-100 text-center"
                         type="text"
@@ -19,13 +19,14 @@
                         t-att-required="props.required"
                         t-on-focus="onInputFocus"
                         t-on-blur="onInputBlur"
+                        t-on-input="onInputChange"
                     />
-                    <span t-else="" class="mx-1" t-esc="formatCurrentValue(true)"/>
+                    <span t-else="" t-esc="formatCurrentValue(true)"/>
                     <span>%</span>
                 </t>
                 <t t-else="">
                     <input
-                        t-if="isEditable and props.isCurrentValueEditable"
+                        t-if="isEditable"
                         t-ref="currentValue"
                         class="o_input h-100 text-center"
                         type="text"
@@ -33,20 +34,11 @@
                         autocomplete="off"
                         t-on-focus="onInputFocus"
                         t-on-blur="onInputBlur"
+                        t-on-input="onInputChange"
                     />
-                    <span t-else="" class="mx-1" t-esc="formatCurrentValue(true)"/>
+                    <span t-else="" t-esc="formatCurrentValue(true)"/>
                     /
-                    <input
-                        t-if="isEditable and props.isMaxValueEditable"
-                        t-ref="maxValue"
-                        class="o_input h-100 text-center"
-                        type="text"
-                        inputmode="decimal"
-                        autocomplete="off"
-                        t-on-focus="onInputFocus"
-                        t-on-blur="onInputBlur"
-                    />
-                    <span t-else="" class="mx-1" t-esc="formatMaxValue(true)"/>
+                    <span t-esc="formatMaxValue(true)"/>
                 </t>
             </div>
         </div>

--- a/addons/web/static/src/views/kanban/kanban_column_progressbar.scss
+++ b/addons/web/static/src/views/kanban/kanban_column_progressbar.scss
@@ -26,14 +26,6 @@
 
     .o_kanban_counter {
         transition: opacity 0.3s ease 0s;
-
-        > .o_column_progress {
-            height: $font-size-sm;
-
-            .bg-200 {
-                --background-color: RGBA(#{to-rgb($o-gray-300)}, var(--bg-opacity, 1))
-            }
-        }
     }
 
     .o_kanban_group {

--- a/addons/web/static/src/views/kanban/progress_bar_hook.js
+++ b/addons/web/static/src/views/kanban/progress_bar_hook.js
@@ -97,7 +97,7 @@ class ProgressBarState {
                 count: group.count - bars.map((r) => r.count).reduce((a, b) => a + b, 0),
                 value: FALSE,
                 string: _t("Other"),
-                color: "200",
+                color: "300",
             });
 
             // Update activeBars count and aggreagates

--- a/addons/web/static/src/views/view_components/column_progress.xml
+++ b/addons/web/static/src/views/view_components/column_progress.xml
@@ -5,11 +5,13 @@
         <div class="o_column_progress progress bg-300 w-75" t-att-class="offlineService.offline ? 'opacity-50 pe-none': ''">
             <t t-set="maxWidth" t-value="100 - Math.max(0, props.progressBar.bars.filter(x => x.count > 0).length - 1) * 5"/>
             <t t-foreach="props.progressBar.bars" t-as="bar" t-key="bar.value">
-                <t t-set="progressWidth" t-value="Math.max(5, bar.count / (props.group.count or 1) * 100)"/>
-                <div t-if="bar.count > 0"
-                    role="progressbar"
-                    class="progress-bar o_bar_has_records cursor-pointer"
-                    t-att-class="{ 'progress-bar-animated progress-bar-striped': props.progressBar.activeBar === bar.value, 'border border-white': !props.group.isFolded and props.progressBar.activeBar }"
+                <t t-set="progressWidth" t-value="bar.count > 0 ? Math.max(5, bar.count / (props.group.count or 1) * 100) : 0"/>
+                <div role="progressbar"
+                    class="progress-bar"
+                    t-att-class="{
+                        'o_bar_has_records cursor-pointer': bar.count > 0,
+                        'progress-bar-animated progress-bar-striped': props.progressBar.activeBar === bar.value,
+                    }"
                     t-attf-class="bg-{{ bar.color }}"
                     t-attf-style="width: {{ Math.min(progressWidth, maxWidth) }}%;"
                     aria-valuemin="0"
@@ -17,8 +19,8 @@
                     t-att-aria-valuenow="bar.count"
                     aria-label="Progress bar"
                     t-attf-data-tooltip="{{ bar.count }} {{ bar.string }}"
-                    data-tooltip-delay="0"
-                    t-on-click="() => this.onBarClick(bar)"
+                    t-att-data-tooltip-delay="bar.count > 0 ? 0 : undefined"
+                    t-on-click="() => bar.count > 0 and this.onBarClick(bar)"
                 />
             </t>
         </div>

--- a/addons/web/static/tests/_framework/kanban_test_helpers.js
+++ b/addons/web/static/tests/_framework/kanban_test_helpers.js
@@ -74,7 +74,7 @@ export function getKanbanColumnDropdownMenu(columnIndex = 0, ignoreFolded = fals
 export function getKanbanColumnTooltips(columnIndex) {
     queryAllAttributes;
     const root = columnIndex >= 0 && getKanbanColumn(columnIndex);
-    return queryAllAttributes(".o_column_progress .progress-bar", "data-tooltip", { root });
+    return queryAllAttributes(".o_column_progress .progress-bar.o_bar_has_records", "data-tooltip", { root });
 }
 
 export function getKanbanCounters() {
@@ -86,7 +86,7 @@ export function getKanbanCounters() {
  */
 export function getKanbanProgressBars(columnIndex = 0) {
     const column = getKanbanColumn(columnIndex);
-    return queryAll(".o_column_progress .progress-bar", { root: column });
+    return queryAll(".o_column_progress .progress-bar.o_bar_has_records", { root: column });
 }
 
 /**

--- a/addons/web/static/tests/views/fields/numeric_fields.test.js
+++ b/addons/web/static/tests/views/fields/numeric_fields.test.js
@@ -63,7 +63,7 @@ test("Numeric fields: fields with keydown on numpad decimal key", async () => {
                 <field name="monetary"/>
                 <field name="currency_id" invisible="1"/>
                 <field name="percentage" widget="percentage"/>
-                <field name="progressbar" widget="progressbar" options="{'editable': true, 'max_value': 'qux', 'edit_max_value': true}"/>
+                <field name="progressbar" widget="progressbar"/>
             </form>
         `,
         resId: 1,
@@ -113,7 +113,7 @@ test("Numeric fields: fields with keydown on numpad decimal key", async () => {
     await keyDown(".", { code: "NumpadDecimal" });
     await keyDown(",", { code: "NumpadDecimal" });
     await animationFrame();
-    expect(".o_field_progressbar input").toHaveValue("0🇧🇪44🇧🇪🇧🇪");
+    expect(".o_field_progressbar input").toHaveValue("69🇧🇪🇧🇪");
 });
 
 test("Numeric fields: NumpadDecimal key is different from the decimalPoint", async () => {
@@ -128,7 +128,7 @@ test("Numeric fields: NumpadDecimal key is different from the decimalPoint", asy
                 <field name="monetary"/>
                 <field name="currency_id" invisible="1"/>
                 <field name="percentage" widget="percentage"/>
-                <field name="progressbar" widget="progressbar" options="{'editable': true, 'max_value': 'qux', 'edit_max_value': true}"/>
+                <field name="progressbar" widget="progressbar"/>
             </form>
         `,
         resId: 1,
@@ -216,9 +216,9 @@ test("Numeric fields: NumpadDecimal key is different from the decimalPoint", asy
 
     await testInputElementOnNumpadDecimal({
         el: progressbarInput,
-        selectionRange: [1, 3],
-        expectedValue: "0,14",
-        msg: "Progressbar field 2 from 0,44 to 0,14",
+        selectionRange: [1, 2],
+        expectedValue: "6,1",
+        msg: "Progressbar field from 69 to 6,1",
     });
 });
 

--- a/addons/web/static/tests/views/fields/progress_bar_field.test.js
+++ b/addons/web/static/tests/views/fields/progress_bar_field.test.js
@@ -62,17 +62,21 @@ test("ProgressBarField: max_value should update", async () => {
             <form>
                 <field name="name" />
                 <field name="float_field" invisible="1" />
-                <field name="int_field" widget="progressbar" options="{'current_value': 'int_field', 'max_value': 'float_field'}" />
+                <field name="int_field" widget="progressbar" options="{'max_value': 'float_field'}" />
             </form>`,
         resId: 1,
     });
 
-    expect(".o_progressbar").toHaveText("10\n/\n2");
+    expect(queryValue(".o_progressbar_value .o_input") + queryText(".o_progressbar")).toBe(
+        "10/\n2"
+    );
     await click(".o_field_widget[name=name] input");
     await edit("new name", { confirm: "enter" });
     await clickSave();
     await animationFrame();
-    expect(".o_progressbar").toHaveText("999\n/\n5");
+    expect(queryValue(".o_progressbar_value .o_input") + queryText(".o_progressbar")).toBe(
+        "999/\n5"
+    );
 });
 
 test("ProgressBarField: value should update in edit mode when typing in input", async () => {
@@ -86,7 +90,7 @@ test("ProgressBarField: value should update in edit mode when typing in input", 
         resModel: "partner",
         arch: /* xml */ `
             <form>
-                <field name="int_field" widget="progressbar" options="{'editable': true}"/>
+                <field name="int_field" widget="progressbar"/>
             </form>`,
         resId: 1,
     });
@@ -125,7 +129,7 @@ test("ProgressBarField: value should update in edit mode when typing in input wi
         arch: /* xml */ `
             <form>
                 <field name="float_field" invisible="1" />
-                <field name="int_field" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />
+                <field name="int_field" widget="progressbar" options="{'max_value': 'float_field'}" />
             </form>`,
         resId: 1,
     });
@@ -147,47 +151,6 @@ test("ProgressBarField: value should update in edit mode when typing in input wi
     );
 });
 
-test("ProgressBarField: max value should update in edit mode when typing in input with field max value", async () => {
-    expect.assertions(5);
-    Partner._records[0].int_field = 99;
-
-    onRpc("web_save", ({ args }) => {
-        expect(args[1].float_field).toBe(69);
-    });
-    await mountView({
-        type: "form",
-        resModel: "partner",
-        arch: /* xml */ `
-            <form>
-                <field name="float_field" invisible="1" />
-                <field name="int_field" widget="progressbar" options="{'editable': true, 'max_value': 'float_field', 'edit_max_value': true}" />
-            </form>`,
-        resId: 1,
-    });
-
-    expect(queryText(".o_progressbar") + queryValue(".o_progressbar_value .o_input")).toBe(
-        "99\n/0",
-        { message: "Initial value should be correct" }
-    );
-    expect(".o_form_view .o_form_editable").toHaveCount(1, { message: "Form in edit mode" });
-    queryOne(".o_progressbar input").focus();
-    await animationFrame();
-
-    expect(queryText(".o_progressbar") + queryValue(".o_progressbar_value .o_input")).toBe(
-        "99\n/0.44",
-        { message: "Initial value is not formatted when focused" }
-    );
-
-    await click(".o_progressbar_value .o_input");
-    await edit("69", { confirm: "enter" });
-    await clickSave();
-
-    expect(queryText(".o_progressbar") + queryValue(".o_progressbar_value .o_input")).toBe(
-        "99\n/69",
-        { message: "New value should be different than initial after click" }
-    );
-});
-
 test("ProgressBarField: Standard readonly mode is readonly", async () => {
     Partner._records[0].int_field = 99;
 
@@ -198,7 +161,7 @@ test("ProgressBarField: Standard readonly mode is readonly", async () => {
         arch: /* xml */ `
             <form edit="0">
                 <field name="float_field" invisible="1"/>
-                <field name="int_field" widget="progressbar" options="{'editable': true, 'max_value': 'float_field', 'edit_max_value': true}"/>
+                <field name="int_field" widget="progressbar" options="{'max_value': 'float_field'}"/>
             </form>`,
         resId: 1,
     });
@@ -207,13 +170,39 @@ test("ProgressBarField: Standard readonly mode is readonly", async () => {
         message: "Initial value should be correct",
     });
 
-    await click(".o_progress");
+    await click(".progress");
     await animationFrame();
 
     expect(".o_progressbar_value .o_input").toHaveCount(0, {
         message: "no input in readonly mode",
     });
     expect.verifySteps(["get_views", "web_read"]);
+});
+
+test("ProgressBarField: clicking progress bar focuses input when editable", async () => {
+    Partner._records[0].int_field = 50;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="int_field" widget="progressbar"/>
+            </form>`,
+        resId: 1,
+    });
+
+    expect(".o_progressbar_value .o_input").toHaveCount(1, {
+        message: "Input should be present in editable mode",
+    });
+    expect(document.activeElement).not.toBe(queryOne(".o_progressbar_value .o_input"), {
+        message: "Input should not be focused initially",
+    });
+
+    await click(".o_progressbar .progress");
+
+    expect(document.activeElement).toBe(queryOne(".o_progressbar_value .o_input"), {
+        message: "Clicking progress bar should focus the input",
+    });
 });
 
 test("ProgressBarField: field is editable in kanban", async () => {
@@ -230,7 +219,7 @@ test("ProgressBarField: field is editable in kanban", async () => {
                 <kanban>
                     <templates>
                         <t t-name="card">
-                            <field name="int_field" title="ProgressBarTitle" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />
+                            <field name="int_field" title="ProgressBarTitle" widget="progressbar" options="{'max_value': 'float_field'}" />
                         </t>
                     </templates>
                 </kanban>`,
@@ -269,7 +258,7 @@ test("force readonly in kanban", async (assert) => {
         <kanban>
             <templates>
                 <t t-name="card">
-                    <field name="int_field" widget="progressbar" options="{'editable': true, 'max_value': 'float_field', 'readonly': True}" />
+                    <field name="int_field" widget="progressbar" options="{'max_value': 'float_field'}" readonly="1" />
                 </t>
             </templates>
         </kanban>`,
@@ -294,7 +283,7 @@ test("ProgressBarField: readonly and editable attrs/options in kanban", async ()
                     <t t-name="card">
                         <field name="int_field" readonly="1" widget="progressbar" options="{'max_value': 'float_field'}" />
                         <field name="int_field2" widget="progressbar" options="{'max_value': 'float_field'}" />
-                        <field name="int_field3" widget="progressbar" options="{'editable': true, 'max_value': 'float_field'}" />
+                        <field name="int_field3" widget="progressbar" options="{'max_value': 'float_field'}" />
                     </t>
                 </templates>
             </kanban>`,
@@ -302,13 +291,13 @@ test("ProgressBarField: readonly and editable attrs/options in kanban", async ()
     });
 
     expect("[name='int_field'] .o_progressbar_value .o_input").toHaveCount(0, {
-        message: "the field is still in readonly since there is readonly attribute",
+        message: "the field is readonly since readonly='1'",
     });
-    expect("[name='int_field2'] .o_progressbar_value .o_input").toHaveCount(0, {
-        message: "the field is still in readonly since there is readonly attribute",
+    expect("[name='int_field2'] .o_progressbar_value .o_input").toHaveCount(1, {
+        message: "the field is editable by default (no readonly attribute)",
     });
     expect("[name='int_field3'] .o_progressbar_value .o_input").toHaveCount(1, {
-        message: "the field is still in readonly since there is readonly attribute",
+        message: "the field is editable by default (no readonly attribute)",
     });
 
     await click(".o_field_progressbar[name='int_field3'] .o_progressbar_value .o_input");
@@ -337,7 +326,7 @@ test("ProgressBarField: write float instead of int works, in locale", async () =
         resModel: "partner",
         arch: /* xml */ `
             <form>
-                <field name="int_field" widget="progressbar" options="{'editable': true}"/>
+                <field name="int_field" widget="progressbar"/>
             </form>`,
         resId: 1,
     });
@@ -367,7 +356,7 @@ test("ProgressBarField: write gibberish instead of int throws warning", async ()
         resModel: "partner",
         arch: /* xml */ `
             <form>
-                <field name="int_field" widget="progressbar" options="{'editable': true}"/>
+                <field name="int_field" widget="progressbar"/>
             </form>`,
         resId: 1,
     });
@@ -397,7 +386,7 @@ test("ProgressBarField: color is correctly set when value > max value", async ()
         resModel: "partner",
         arch: /* xml */ `
             <form>
-                <field name="float_field" widget="progressbar" options="{'overflow_class': 'bg-warning'}"/>
+                <field name="float_field" widget="progressbar" decoration-warning="float_field > 100"/>
             </form>`,
         resId: 1,
     });
@@ -405,3 +394,107 @@ test("ProgressBarField: color is correctly set when value > max value", async ()
         message: "As the value has excedded the max value, the color should be set to bg-warning",
     });
 });
+
+test("ProgressBarField: decoration-success applies green when condition is true", async () => {
+    Partner._records[0].float_field = 80;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="float_field" widget="progressbar" decoration-success="float_field >= 50"/>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_progressbar .progress-bar.bg-success").toHaveCount(1, {
+        message: "decoration-success should apply bg-success when condition is met",
+    });
+});
+
+test("ProgressBarField: decoration-danger applies red when condition is true", async () => {
+    Partner._records[0].float_field = 25;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="float_field" widget="progressbar" decoration-danger="float_field &lt; 50"/>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_progressbar .progress-bar.bg-danger").toHaveCount(1, {
+        message: "decoration-danger should apply bg-danger when condition is met",
+    });
+});
+
+test("ProgressBarField: decoration-warning applies warning color", async () => {
+    Partner._records[0].float_field = 55;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="float_field" widget="progressbar" decoration-warning="float_field >= 50 and float_field &lt; 80"/>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_progressbar .progress-bar.bg-warning").toHaveCount(1, {
+        message: "decoration-warning should apply bg-warning when condition is met",
+    });
+});
+
+test("ProgressBarField: multiple decorations - first matching wins", async () => {
+    Partner._records[0].float_field = 90;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="float_field" widget="progressbar"
+                       decoration-success="float_field >= 80"
+                       decoration-warning="float_field >= 50"
+                       decoration-danger="float_field &lt; 50"/>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_progressbar .progress-bar.bg-success").toHaveCount(1, {
+        message: "First matching decoration (success) should be applied",
+    });
+});
+
+test("ProgressBarField: no decoration applied when no condition matches", async () => {
+    Partner._records[0].float_field = 60;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="float_field" widget="progressbar"
+                       decoration-success="float_field >= 80"
+                       decoration-danger="float_field &lt; 30"/>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_progressbar .progress-bar:not(.bg-success):not(.bg-danger)").toHaveCount(1, {
+        message: "No decoration should be applied when no condition matches",
+    });
+});
+
+test("ProgressBarField: decoration with field comparison", async () => {
+    Partner._records[0].float_field = 75;
+    Partner._records[0].int_field = 50;
+    await mountView({
+        type: "form",
+        resModel: "partner",
+        arch: /* xml */ `
+            <form>
+                <field name="float_field" widget="progressbar" decoration-success="float_field >= int_field"/>
+                <field name="int_field" invisible="1"/>
+            </form>`,
+        resId: 1,
+    });
+    expect(".o_progressbar .progress-bar.bg-success").toHaveCount(1, {
+        message: "Decoration should support field comparisons in expressions",
+    });
+});
+

--- a/addons/web/static/tests/views/kanban/kanban_column_progressbar.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_column_progressbar.test.js
@@ -320,11 +320,11 @@ test("filter on progressbar in new groups", async () => {
     expect(queryAll(".o_kanban_record", { root: getKanbanColumn(2) })).toHaveCount(1);
     expect(queryAll(".o_kanban_record", { root: getKanbanColumn(3) })).toHaveCount(1);
 
-    expect(".o_kanban_group_show_200").toHaveCount(0);
+    expect(".o_kanban_group_show_300").toHaveCount(0);
 
     await contains(".o_column_progress .progress-bar", { root: getKanbanColumn(2) }).click();
-    expect(".o_kanban_group_show_200").toHaveCount(1);
-    expect(getKanbanColumn(2)).toHaveClass("o_kanban_group_show_200");
+    expect(".o_kanban_group_show_300").toHaveCount(1);
+    expect(getKanbanColumn(2)).toHaveClass("o_kanban_group_show_300");
 });
 
 test('column progressbars: "false" bar is clickable', async () => {
@@ -356,19 +356,19 @@ test('column progressbars: "false" bar is clickable', async () => {
     expect(".o_kanban_group").toHaveCount(2);
     expect(getKanbanCounters()).toEqual(["1", "4"]);
     expect(".o_kanban_group:last-child .o_column_progress .progress-bar").toHaveCount(4);
-    expect(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-200").toHaveCount(1, {
+    expect(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-300").toHaveCount(1, {
         message: "should have false kanban color",
     });
-    expect(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-200:first").toHaveClass(
-        "bg-200"
+    expect(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-300:first").toHaveClass(
+        "bg-300"
     );
 
-    await contains(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-200").click();
+    await contains(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-300").click();
 
-    expect(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-200:first").toHaveClass(
+    expect(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-300:first").toHaveClass(
         "progress-bar-animated"
     );
-    expect(".o_kanban_group:last-child").toHaveClass("o_kanban_group_show_200");
+    expect(".o_kanban_group:last-child").toHaveClass("o_kanban_group_show_300");
     expect(getKanbanCounters()).toEqual(["1", "1"]);
     expect.verifySteps([
         "/web/webclient/translations",
@@ -412,9 +412,9 @@ test('column progressbars: "false" bar with sum_field', async () => {
     expect(".o_kanban_group").toHaveCount(2);
     expect(getKanbanCounters()).toEqual(["-4", "51"]);
 
-    await contains(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-200").click();
+    await contains(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-300").click();
 
-    expect(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-200:first").toHaveClass(
+    expect(".o_kanban_group:last-child .o_column_progress .progress-bar.bg-300:first").toHaveClass(
         "progress-bar-animated"
     );
     expect(getKanbanCounters()).toEqual(["-4", "15"]);
@@ -668,7 +668,7 @@ test("column progressbars on archiving records update counter", async () => {
     await contains(".modal-footer .btn-primary").click();
 
     expect(getKanbanCounters()).toEqual(["-4", "0"]);
-    expect(queryAll(".progress-bar", { root: getKanbanColumn(1) })).toHaveCount(0, {
+    expect(queryAll(".progress-bar.o_bar_has_records", { root: getKanbanColumn(1) })).toHaveCount(0, {
         message: "the counter progressbars should have been correctly updated",
     });
     expect.verifySteps([
@@ -761,7 +761,7 @@ test("kanban with progressbars: slow read_progress_bar", async () => {
     expect(".o_kanban_view").toHaveCount(1);
     expect(".o_kanban_group").toHaveCount(2);
     expect(".o_kanban_group:nth-child(2) .o_column_progress").toHaveCount(1);
-    expect(".o_kanban_group:nth-child(2) .o_column_progress .progress-bar").toHaveCount(3);
+    expect(".o_kanban_group:nth-child(2) .o_column_progress .progress-bar.o_bar_has_records").toHaveCount(3);
     expect(".o_kanban_group:nth-child(2) .o_kanban_header").toHaveText("Yes\n36");
 });
 
@@ -1895,9 +1895,9 @@ test("Color '200' (gray) can be used twice (for false value and another value) i
         groupBy: ["bar"],
     });
 
-    expect(".o_kanban_group:nth-child(1) .progress-bar").toHaveCount(2);
+    expect(".o_kanban_group:nth-child(1) .progress-bar.o_bar_has_records").toHaveCount(2);
     expect(
-        queryAll(".o_kanban_group:nth-child(1) .progress-bar").map((el) => el.dataset.tooltip)
+        queryAll(".o_kanban_group:nth-child(1) .progress-bar.o_bar_has_records").map((el) => el.dataset.tooltip)
     ).toEqual(["1 blip", "1 Other"]);
     expect(".o_kanban_group:nth-child(2) .progress-bar").toHaveCount(4);
     expect(
@@ -1962,7 +1962,7 @@ test("update field on which progress bars are computed", async () => {
     // Initial state: 2 columns, the "Yes" column contains 2 records "abc", 1 "def" and 1 "ghi"
     expect(getKanbanCounters()).toEqual(["1", "4"]);
     expect(queryAll(".o_kanban_record", { root: getKanbanColumn(1) })).toHaveCount(4);
-    expect(queryAll(".o_column_progress .progress-bar", { root: getKanbanColumn(1) })).toHaveCount(
+    expect(queryAll(".o_column_progress .progress-bar.o_bar_has_records", { root: getKanbanColumn(1) })).toHaveCount(
         3
     );
     expect(getKanbanProgressBars(1)[0].style.width).toBe("50%"); // abc: 2
@@ -1974,7 +1974,7 @@ test("update field on which progress bars are computed", async () => {
 
     expect(getKanbanCounters()).toEqual(["1", "2"]);
     expect(queryAll(".o_kanban_record", { root: getKanbanColumn(1) })).toHaveCount(2);
-    expect(queryAll(".o_column_progress .progress-bar", { root: getKanbanColumn(1) })).toHaveCount(
+    expect(queryAll(".o_column_progress .progress-bar.o_bar_has_records", { root: getKanbanColumn(1) })).toHaveCount(
         3
     );
     expect(getKanbanProgressBars(1)[0].style.width).toBe("50%"); // abc: 2
@@ -1990,7 +1990,7 @@ test("update field on which progress bars are computed", async () => {
 
     expect(getKanbanCounters()).toEqual(["1", "1"]);
     expect(queryAll(".o_kanban_record", { root: getKanbanColumn(1) })).toHaveCount(2);
-    expect(queryAll(".o_column_progress .progress-bar", { root: getKanbanColumn(1) })).toHaveCount(
+    expect(queryAll(".o_column_progress .progress-bar.o_bar_has_records", { root: getKanbanColumn(1) })).toHaveCount(
         3
     );
     expect(getKanbanProgressBars(1)[0].style.width).toBe("25%"); // abc: 1

--- a/addons/web/static/tests/views/list/list_view.test.js
+++ b/addons/web/static/tests/views/list/list_view.test.js
@@ -16773,7 +16773,7 @@ test(`classNames given to a field are set on the right field directly`, async ()
         type: "list",
         arch: `
             <list editable="bottom">
-                <field class="d-flex align-items-center" name="int_field" widget="progressbar" options="{'editable': true}"/>
+                <field class="d-flex align-items-center" name="int_field" widget="progressbar"/>
                 <field class="d-none" name="bar"/>
             </list>
         `,


### PR DESCRIPTION
Before this commit, the progressbar widget had custom options that duplicated standard Odoo field attributes and used inconsistent styling conventions.

This commit removes redundant options (`editable` (-> readonly), `current_value`, `edit_max_value`..) in favor of standard attributes. Also the `decoration-*` attributes (standard view decorations) replaces `overflow_class` for conditional styling.

The progressbar styling is updated to use Bootstrap progress bar classes with some dark mode fixes/improvement. Input behavior is improved with dynamic auto-sizing and fixed vertical alignment, while removing the focus-width glitch that caused unwanted resizing.

task-3605453

Enterprise PR: https://github.com/odoo/enterprise/pull/55426

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
