### PR TITLE
[FIX] web_editor: ColorPalette wrong placement

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg.scss
@@ -168,6 +168,9 @@ $o-we-zindex: $o-we-overlay-zindex + 1 !default;
         align-items: center;
         justify-content: center;
     }
+    .dropdown-menu {
+        transform: unset !important;
+    }
 
     .colorpicker-menu {
         height: auto!important;


### PR DESCRIPTION
Issue:
======
Color palette appears in bottom end in editor toolbar

Steps to reproduce the issue:
=============================
- Install email marketing
- Create a new mailings
- Choose any template
- Select a text and try to chnage font color Sometimes id doesn't work from first try for some reason , refresh the page and try again

Origin of the issue:
====================
The popper library add `transform` style to the dropdown which is not calculated correctly.

Solution:
=========
remove the transform style from the dropdown

task-3614965