### PR TITLE
[FIX] portal: fix postmerge redesign issues

### DIFF
--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -114,8 +114,8 @@
                     <t t-set="classes" t-value="'col-lg-3 col-xl-4 d-print-none me-lg-auto'"/>
                     <t t-set="title">
                         <h2>
-                            <span t-if="invoice.amount_residual > 0" t-field="invoice.amount_residual"/>
-                            <span t-else="1" t-field="invoice.amount_total"/>
+                            <span t-if="invoice.amount_residual > 0" t-field="invoice.amount_residual" class="text-break"/>
+                            <span t-else="1" t-field="invoice.amount_total" class="text-break"/>
                         </h2>
                         <div class="small" t-if="invoice.payment_state not in ('paid', 'in_payment') and invoice.move_type == 'out_invoice'"><i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="invoice.invoice_date_due"/></div>
                     </t>

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -113,11 +113,13 @@
                 <t t-call="portal.portal_record_sidebar">
                     <t t-set="classes" t-value="'col-lg-3 col-xl-4 d-print-none me-lg-auto'"/>
                     <t t-set="title">
-                        <h2>
-                            <span t-if="invoice.amount_residual > 0" t-field="invoice.amount_residual" class="text-break"/>
-                            <span t-else="1" t-field="invoice.amount_total" class="text-break"/>
-                        </h2>
-                        <div class="small" t-if="invoice.payment_state not in ('paid', 'in_payment') and invoice.move_type == 'out_invoice'"><i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="invoice.invoice_date_due"/></div>
+                    <t t-if="invoice.amount_residual > 0">
+                        <h2 t-field="invoice.amount_residual" class="text-break"/>
+                    </t>
+                    <t t-else="1">
+                        <h2 t-field="invoice.amount_total" class="text-break"/>
+                    </t>
+                    <div class="small" t-if="invoice.payment_state not in ('paid', 'in_payment') and invoice.move_type == 'out_invoice'"><i class="fa fa-clock-o"/><span class="o_portal_sidebar_timeago ml4" t-att-datetime="invoice.invoice_date_due"/></div>
                     </t>
 
                     <t t-set="entries">

--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -384,15 +384,6 @@ img, .media_iframe_video, .o_image {
         margin-bottom: 15px;
     }
 
-    .o_portal_chatter_composer_body  {
-        textarea {
-            border: 0;
-        }
-        > div {
-            border: 1px solid var(--o-border-color);
-        }
-    }
-
     .o_portal_chatter_messages {
         margin-bottom: 15px;
         overflow-wrap: break-word;

--- a/addons/portal/static/src/xml/portal_chatter.xml
+++ b/addons/portal/static/src/xml/portal_chatter.xml
@@ -36,10 +36,10 @@
                          t-if="!widget.options['is_user_public'] or !widget.options['token']"/>
                     <div class="flex-grow-1">
                         <div class="o_portal_chatter_composer_input">
-                            <div class="o_portal_chatter_composer_body d-flex flex-nowrap align-items-start flex-grow-1 mb-4">
+                            <div class="o_portal_chatter_composer_body d-flex flex-nowrap align-items-start flex-grow-1 mb-4 border rounded-3">
                                 <div class="d-flex flex-column flex-grow-1 rounded-3">
                                     <div class="position-relative flex-grow-1">
-                                        <textarea rows="4" name="message" class="form-control rounded-3 shadow-none" placeholder="Write a message..." style="resize:none;"/>
+                                        <textarea rows="4" name="message" class="form-control border-0" placeholder="Write a message..." style="resize:none;"/>
                                     </div>
                                     <div class="d-flex flex-row align-self-end p-2">
                                         <div class="d-flex px-1">

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -163,7 +163,7 @@
                 </div>
             </div>
             <div id="wrap" class='o_portal_wrap'>
-                <div class="container pt-3">
+                <div class="container pt-3 pb-5">
                     <t t-if="my_details">
                         <div class="wrapper col-12 d-flex flex-wrap justify-content-between align-items-center">
                             <h3 class="my-3">My account</h3>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -140,7 +140,7 @@
                   <t t-set="classes" t-value="'col-lg-3 col-xl-4 d-print-none'"/>
 
                   <t t-set="title">
-                      <h2 t-field="order.amount_total" data-id="total_amount"/>
+                      <h2 t-field="order.amount_total" data-id="total_amount" class="text-break"/>
                   </t>
                   <t t-set="entries">
                       <div class="d-flex flex-column gap-4">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -139,7 +139,7 @@
                     <t t-set="classes" t-value="'d-print-none col-lg-3 col-xl-4'"/>
 
                     <t t-set="title">
-                        <h2 t-field="sale_order.amount_total" data-id="total_amount"/>
+                        <h2 t-field="sale_order.amount_total" data-id="total_amount" class="text-break"/>
                     </t>
                     <t t-set="entries">
                         <div class="d-flex flex-column gap-4">

--- a/addons/sale/views/sale_portal_templates.xml
+++ b/addons/sale/views/sale_portal_templates.xml
@@ -359,12 +359,18 @@
 
                     <div t-if="sale_order.state == 'cancel'" class="alert alert-danger alert-dismissible d-print-none" role="alert">
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="close"></button>
-                        <strong>This quotation has been canceled.</strong> <a role="button" href="#discussion"><i class="fa fa-comment"/> Contact us to get a new quotation.</a>
+                        <div class="text-center">
+                            <span>This quotation has been canceled.</span>
+                            <a role="button" href="#discussion" class="alert-link"><i class="fa fa-comment"/> Contact us to get a new quotation.</a>
+                        </div>
                     </div>
 
                     <div t-if="sale_order.is_expired" class="alert alert-warning alert-dismissible d-print-none" role="alert">
                         <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="close"></button>
-                        <strong>This offer expired!</strong> <a role="button" href="#discussion"><i class="fa fa-comment"/> Contact us to get a new quotation.</a>
+                        <div class="text-center">
+                            <span>This offer expired!</span>
+                            <a role="button" href="#discussion" class="alert-link"><i class="fa fa-comment"/> Contact us to get a new quotation.</a>
+                        </div>
                     </div>
 
                     <!-- main content -->

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -89,15 +89,11 @@
 
     <template id="portal_invoice_page_inherit" inherit_id="account.portal_invoice_page">
         <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="inside">
-            <div t-if="invoice.timesheet_count > 0" class="flex-grow-1 border-0">
-                <div class="btn-toolbar flex-sm-nowrap justify-content-center">
-                    <div class="btn-group mb-1">
-                        <t t-set="search_value" t-value="invoice.name"/>
-                        <t t-if="invoice.state == 'draft'" t-set="search_value" t-value="invoice.id"/>
-                        <a t-if="invoice.move_type == 'out_invoice' and invoice.state in ('draft', 'posted') and invoice.timesheet_count > 0"
-                           target="_blank" t-att-href="'/my/timesheets?search_in=invoice&amp;search=%s' % search_value">View Timesheets</a>
-                    </div>
-                </div>
+            <div t-if="invoice.timesheet_count > 0" class="flex-grow-1">
+                <t t-set="search_value" t-value="invoice.name"/>
+                <t t-if="invoice.state == 'draft'" t-set="search_value" t-value="invoice.id"/>
+                <a t-if="invoice.move_type == 'out_invoice' and invoice.state in ('draft', 'posted') and invoice.timesheet_count > 0"
+                    target="_blank" t-att-href="'/my/timesheets?search_in=invoice&amp;search=%s' % search_value" class="btn btn-secondary d-block w-100">View Timesheets</a>
             </div>
         </xpath>
     </template>

--- a/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
+++ b/addons/sale_timesheet/views/sale_timesheet_portal_templates.xml
@@ -88,8 +88,8 @@
     </template>
 
     <template id="portal_invoice_page_inherit" inherit_id="account.portal_invoice_page">
-        <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="inside">
-            <div t-if="invoice.timesheet_count > 0" class="flex-grow-1">
+        <xpath expr="//t[@t-set='entries']/div/div/div[hasclass('o_download_pdf')]" position="after">
+            <div t-if="invoice.timesheet_count > 0" class="flex-grow-1 mt-2">
                 <t t-set="search_value" t-value="invoice.name"/>
                 <t t-if="invoice.state == 'draft'" t-set="search_value" t-value="invoice.id"/>
                 <a t-if="invoice.move_type == 'out_invoice' and invoice.state in ('draft', 'posted') and invoice.timesheet_count > 0"


### PR DESCRIPTION
This PR aims to fix issues introduced after the portal redesign.

task-3714408
part of task-3703251

- Requires https://github.com/odoo/enterprise/pull/55519

-----------

## Overflowing sidebar

With the portal redesign, we now use a two columns layout with a `d-inline-block` on the left one (sidebar), which allows the sidebar column to grow depending on its content.

While this brought more fluidity to the layout, it also introduced an issue, having a very long amount would make the sidebar overflow on the right column.

## Missing padding-bottom on container

Commit[1] removed a `padding-bottom` class from the container in order to reduce the vertical whitespace, but this introduced an issue in some cases, depending on the footer in use. By removing the `padding-bottom` utility class, the content of the customer portal would sometimes stick to the footer of the page.

## View timesheet button display

Depending on the sidebar layout, the View timesheet button will be display next to two other buttons, and with a `btn-link` class. We adapt the styling and position of the button to make it consistent with other views in which it is also displayed. 


## Alerts

While fixing the sidebar issue, this PR also fix some inconsistencies in the alerts used within Portal. Mainly about text alignment, and alerts with a link that were missing an `alert-link` class.