### PR TITLE
[FIX] web: use matching model for M2OAutocomplete options

### DIFF
--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -67,7 +67,7 @@ export class Many2OneField extends Component {
         this.computeActiveActions(this.props);
 
         this.openMany2X = useOpenMany2XRecord({
-            resModel: this.relation,
+            resModel: () => this.relation,
             activeActions: this.state.activeActions,
             isToMany: false,
             onRecordSaved: async (record) => {

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -50,11 +50,12 @@ export function useSelectCreate({ resModel, activeActions, onSelected, onCreateE
     const addDialog = useOwnedDialogs();
 
     function selectCreate({ domain, context, filters, title, kanbanViewId }) {
+        const model = resModel.call ? resModel() : resModel;
         addDialog(SelectCreateDialog, {
             title: title || env._t("Select records"),
             noCreate: !activeActions.create,
             multiSelect: "link" in activeActions ? activeActions.link : false, // LPE Fixme
-            resModel,
+            resModel: model,
             context,
             domain,
             onSelected,
@@ -147,10 +148,10 @@ export class Many2XAutocomplete extends Component {
         this.orm = useService("orm");
 
         this.autoCompleteContainer = useForwardRefToParent("autocomplete_container");
-        const { activeActions, resModel, update, isToMany, fieldString } = this.props;
+        const { activeActions, update, isToMany, fieldString } = this.props;
 
         this.openMany2X = useOpenMany2XRecord({
-            resModel,
+            resModel: () => this.props.resModel,
             activeActions,
             isToMany,
             onRecordSaved: (record) => {
@@ -178,7 +179,7 @@ export class Many2XAutocomplete extends Component {
         });
 
         this.selectCreate = useSelectCreate({
-            resModel,
+            resModel: () => this.props.resModel,
             activeActions,
             onSelected: (resId) => {
                 const resIds = Array.isArray(resId) ? resId : [resId];
@@ -390,7 +391,8 @@ export function useOpenMany2XRecord({
         { resId = false, forceModel = null, title, context },
         immediate = false
     ) {
-        const model = forceModel || resModel;
+        const modelGetter = forceModel || resModel;
+        const model = modelGetter.call ? modelGetter() : modelGetter;
         let viewId;
         if (resId !== false) {
             viewId = await orm.call(model, "get_formview_id", [[resId]], {

--- a/addons/web/static/tests/views/fields/reference_field_tests.js
+++ b/addons/web/static/tests/views/fields/reference_field_tests.js
@@ -215,6 +215,38 @@ QUnit.module("Fields", (hooks) => {
                     onchanges: {},
                 },
             },
+            views: {
+                "product,false,form": `
+                    <form>
+                        <header>
+                            <span class="reftest_product_form_header">Product Form</span>
+                        </header>
+                        <field name="name" />
+                    </form>`,
+                "product,false,list": `
+                    <tree>
+                        <field name="name" string="Product Name"/>
+                    </tree>`,
+                "product,false,search": `
+                    <search>
+                        <field name="name" />
+                    </search>`,
+                "partner,false,form": `
+                    <form>
+                        <header>
+                            <span class="reftest_partner_form_header">Partner Form</span>
+                        </header>
+                        <field name="name" />
+                    </form>`,
+                "partner,false,list": `
+                    <tree>
+                        <field name="name" string="Partner Name"/>
+                    </tree>`,
+                "partner,false,search": `
+                    <search>
+                        <field name="name" />
+                    </search>`,
+            },
         };
 
         setupViewRegistries();
@@ -1068,6 +1100,64 @@ QUnit.module("Fields", (hooks) => {
             assert.containsOnce(target, ".o_list_table .reference_field.o_field_invalid");
         }
     );
+
+    QUnit.test("Change model of a ReferenceField and use dialog options.", async function (assert) {
+        serverData.models.turtle.records[0].partner_ids = [1];
+        serverData.models.partner.records[0].reference = "product,41";
+        // add some filler partner models so the "search more" option is available
+        for (let partnerCount = 0; partnerCount < 7; partnerCount++) {
+            serverData.models.partner.records.push({
+                id: 137 + partnerCount,
+                display_name: `partner_${137+ partnerCount}`,
+            })
+        }
+
+        await makeView({
+            type: "form",
+            resModel: "turtle",
+            resId: 1,
+            serverData,
+            arch: `
+                <form>
+                    <field name="partner_ids">
+                        <tree editable="bottom">
+                            <field name="name" />
+                            <field name="reference" class="reference_field" />
+                        </tree>
+                    </field>
+               </form>`,
+        });
+        assert.strictEqual(target.querySelector(".reference_field").textContent, "xpad");
+
+        await click(target, ".reference_field");
+        //Select the "Partner" option, different from original "Product"
+        assert.strictEqual(
+            target.querySelector(".reference_field select.o_input").value,
+            "product",
+        );
+        await editSelect(target, ".reference_field select.o_input", "partner");
+        //Open "Search more..."
+        await click(target, ".o_list_table .reference_field input");
+        await click(target, ".o_m2o_dropdown_option_search_more");
+        assert.equal(
+            target.querySelector(".o_dialog .o_list_renderer thead").textContent,
+            "Partner Name",
+        );
+        await click(target, ".o_dialog .o_form_button_cancel");
+        //Start input and open "Create and edit"
+        await click(target, ".o_list_table .reference_field input");
+        await editInput(target, ".o_list_table .reference_field input", "a brand new value");
+        await click(target, ".o_m2o_dropdown_option_create_edit");
+        assert.containsOnce(target, ".o_dialog .reftest_partner_form_header");
+        assert.equal(
+            target.querySelector(".o_dialog .o_field_char[name='name'] input").value,
+            "a brand new value",
+        );
+        await click(target, ".o_dialog .o_form_button_save");
+
+        await clickSave(target);
+        assert.equal(target.querySelector(".reference_field").textContent, "a brand new value");
+    });
 
     QUnit.test("model selector is displayed only when it should be", async function (assert) {
         //The model selector should be only displayed if


### PR DESCRIPTION
Using a reference field, it's possible to have a m2o field that changes model dynamically.

This is handled well until the user tries opening one of the helper modals to create or search models.

As the dialog openers are "static" functions generated at the startup of the component their `resModel` is never changed.

Although it's possible to force that model for the "create and edit" option it's not practical.

`resModel` can now be a function so that the generated function can dynamically adjust to the underlying component.

task-3256524

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
