### PR TITLE
[FIX] purchase: do not send due date on confirmed RFQs mail

### DIFF
--- a/addons/purchase/data/mail_template_data.xml
+++ b/addons/purchase/data/mail_template_data.xml
@@ -51,7 +51,7 @@
         amounting in <strong t-out="format_amount(object.amount_total, object.currency_id) or ''">$ 10.00</strong>
         from <t t-out="object.company_id.name or ''">YourCompany</t>. 
         <br/><br/>
-        <t t-if="object.date_planned">
+        <t t-if="object.date_planned and not object.state in ['purchase', 'done', 'cancel']">
             The receipt is expected for <strong t-out="format_date(object.get_localized_date_planned()) or ''">05/05/2021</strong>.
             <br/><br/>
             Could you please acknowledge the receipt of this order?


### PR DESCRIPTION
Steps to reproduce:
- Create and confirm an RFQ with deadline set
- Send confirmation email to the partner

Bug:
deadline is shwon eventhough PO is confirmed and is no longer an RFQ that is due.

Fix:
only display deadline for the applicable states

opw-3664112