### PR TITLE
[IMP] 16.0 l10n_es_edi_tbai support out invoices with taxes of type "retención"

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_invoice.xml
+++ b/addons/l10n_es_edi_tbai/data/template_invoice.xml
@@ -118,7 +118,7 @@
                     </IDDetalleFactura>
                 </DetallesFactura>
                 <ImporteTotalFactura t-out="format_float(amount_total)"/>
-                <!-- <RetencionSoportada/> NOTE (potentially has to be computed/decided manually) -->
+                <RetencionSoportada t-if="amount_retention != 0.0" t-out="format_float(amount_retention)"/>
                 <!-- <BaseImponibleACoste/> NOTE (only applicable with ClaveRegimenIvaOpTrascendencia 06, not supported yet) -->
                 <Claves>
                     <IDClave t-foreach="regime_key" t-as="key">

--- a/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
+++ b/addons/l10n_es_edi_tbai/tests/test_edi_xml.py
@@ -118,6 +118,20 @@ class TestEdiTbaiXmls(TestEsEdiTbaiCommon):
             xml_expected = self.with_applied_xpath(xml_expected_base, xpath)
             self.assertXmlTreeEqual(xml_doc, xml_expected)
 
+    def test_xml_tree_post_retention(self):
+        self.out_invoice.invoice_line_ids.tax_ids = [(4, self._get_tax_by_xml_id('s_irpf15').id)]
+        with freeze_time(self.frozen_today):
+            xml_doc = self.edi_format._get_l10n_es_tbai_invoice_xml(self.out_invoice, cancel=False)[self.out_invoice]['xml_file']
+            xml_doc.remove(xml_doc.find("Signature", namespaces=NS_MAP))
+            xml_expected_base = etree.fromstring(super().L10N_ES_TBAI_SAMPLE_XML_POST)
+            xpath = """
+                <xpath expr="//ImporteTotalFactura" position="after">
+                    <RetencionSoportada>600.00</RetencionSoportada>
+                </xpath>
+            """
+            xml_expected = self.with_applied_xpath(xml_expected_base, xpath)
+            self.assertXmlTreeEqual(xml_doc, xml_expected)
+
     def test_xml_tree_in_post(self):
         """Test XML of vendor bill for LROE Batuz"""
         with freeze_time(self.frozen_today):

--- a/doc/cla/individual/uolaizola.md
+++ b/doc/cla/individual/uolaizola.md
@@ -1,0 +1,11 @@
+Spain, 2024-02-01
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Ugaitz Olaizola Arbelaitz uolaizola@binovo.es https://github.com/uolaizola


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Support out invoices with taxes of type "retención":

- Do not take into account "retención" type taxes in the sum of the total price of the invoice lines, these taxes are of retention types and are declared in RetencionSoportada XML node.
- Add amount_retention in invoice values and change template_invoice_factura to activate RetencionSoportada xml node.

Current behavior before PR:

Invoices with "retención" type taxes are not declared correctly, validation errors in the response of the tax agency.

Desired behavior after PR is merged:

Invoices with "retención" type taxes are declared correctly and accepted with no validation errors in the response of the tax agency.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
