### PR TITLE
[REF] event_*: simplify template_ref

### DIFF
--- a/addons/event/__manifest__.py
+++ b/addons/event/__manifest__.py
@@ -55,6 +55,7 @@ Key Features
             'event/static/src/scss/event.scss',
             'event/static/src/icon_selection_field/icon_selection_field.js',
             'event/static/src/icon_selection_field/icon_selection_field.xml',
+            'event/static/src/template_reference_field/*',
             'event/static/src/js/tours/**/*',
         ],
         'web.assets_frontend': [

--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -12,7 +12,7 @@ from odoo import _, api, Command, fields, models, tools
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import format_date, format_datetime
+from odoo.tools import format_date, format_datetime, frozendict
 from odoo.tools.mail import is_html_empty, html_to_inner_content
 from odoo.tools.misc import formatLang
 from odoo.tools.translate import html_translate
@@ -33,22 +33,19 @@ class EventType(models.Model):
 
     def _default_event_mail_type_ids(self):
         return [(0, 0,
-                 {'notification_type': 'mail',
-                  'interval_nbr': 0,
+                 {'interval_nbr': 0,
                   'interval_unit': 'now',
                   'interval_type': 'after_sub',
                   'template_ref': 'mail.template, %i' % self.env.ref('event.event_subscription').id,
                  }),
                 (0, 0,
-                 {'notification_type': 'mail',
-                  'interval_nbr': 1,
+                 {'interval_nbr': 1,
                   'interval_unit': 'hours',
                   'interval_type': 'before_event',
                   'template_ref': 'mail.template, %i' % self.env.ref('event.event_reminder').id,
                  }),
                 (0, 0,
-                 {'notification_type': 'mail',
-                  'interval_nbr': 3,
+                 {'interval_nbr': 3,
                   'interval_unit': 'days',
                   'interval_type': 'before_event',
                   'template_ref': 'mail.template, %i' % self.env.ref('event.event_reminder').id,
@@ -539,11 +536,11 @@ class EventEvent(models.Model):
 
             # lines to add: those which do not have the exact copy available in lines to keep
             if event.event_type_id.event_type_mail_ids:
-                mails_to_keep_vals = {mail._prepare_event_mail_values() for mail in event.event_mail_ids - mails_to_remove}
+                mails_to_keep_vals = {frozendict(mail._prepare_event_mail_values()) for mail in event.event_mail_ids - mails_to_remove}
                 for mail in event.event_type_id.event_type_mail_ids:
-                    mail_values = mail._prepare_event_mail_values()
+                    mail_values = frozendict(mail._prepare_event_mail_values())
                     if mail_values not in mails_to_keep_vals:
-                        command.append(Command.create(mail_values._asdict()))
+                        command.append(Command.create(mail_values))
             if command:
                 event.event_mail_ids = command
 

--- a/addons/event/static/src/template_reference_field/field_event_mail_template_reference.js
+++ b/addons/event/static/src/template_reference_field/field_event_mail_template_reference.js
@@ -1,0 +1,38 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { ReferenceField, referenceField } from "@web/views/fields/reference/reference_field";
+
+export class EventMailTemplateReferenceField extends ReferenceField {
+    static template = "event.mailTemplateReferenceField";
+
+    setup() {
+        const returnVal = super.setup();
+        // select the first value by default
+        // selection is [['mail', 'Mail Template'], ['sms', 'Sms Template'], ...]
+        const defaultSelect = this.selection?.[0][0];
+        if (defaultSelect) {
+            this.state.currentRelation = defaultSelect;
+        }
+        return returnVal;
+    }
+
+    /**
+     * Make not openable in readonly mode
+     * as we expect m2o fields to just be strings in list view
+     */
+    get m2oProps() {
+        const props = super.m2oProps;
+        if (props.readonly) {
+            props.canOpen = false;
+        }
+        return props;
+    }
+}
+
+export const eventMailTemplateReferenceField = {
+    ...referenceField,
+    component: EventMailTemplateReferenceField,
+    displayName: _t("Event Mail Template Reference"),
+};
+
+registry.category("fields").add("EventMailTemplateReferenceField", eventMailTemplateReferenceField);

--- a/addons/event/static/src/template_reference_field/field_event_mail_template_reference.scss
+++ b/addons/event/static/src/template_reference_field/field_event_mail_template_reference.scss
@@ -1,0 +1,5 @@
+.o_list_renderer .o_field_EventMailTemplateReferenceField div.o_mail_template_reference_field_icon {
+    margin-right: 0.5rem;
+    max-width: 1.5rem !important;
+    width: 1.5rem !important;
+}

--- a/addons/event/static/src/template_reference_field/field_event_mail_template_reference.xml
+++ b/addons/event/static/src/template_reference_field/field_event_mail_template_reference.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<templates xml:space="preserve">
+
+    <t t-name="event.mailTemplateReferenceField" t-inherit="web.ReferenceField" t-inherit-mode="primary">
+        <xpath expr="//t[@t-if='!props.readonly and !hideModelSelector']" position="after">
+            <t t-elif="getValue()">
+                <div class="o_mail_template_reference_field_icon d-flex justify-content-center flex-grow-0 flex-shrink-0">
+                    <span class="event_template_reference_mail fa fa-solid fa-envelope" t-if="relation === 'mail.template'"/>
+                </div>
+            </t>
+        </xpath>
+    </t>
+
+</templates>

--- a/addons/event/tests/test_event_internals.py
+++ b/addons/event/tests/test_event_internals.py
@@ -236,7 +236,6 @@ class TestEventData(TestEventInternalsCommon):
             'event_type_mail_ids': [
                 Command.clear(),
                 Command.create({
-                    'notification_type': 'mail',
                     'interval_nbr': 77,
                     'interval_unit': 'days',
                     'interval_type': 'after_event',
@@ -254,7 +253,6 @@ class TestEventData(TestEventInternalsCommon):
             'event_mail_ids': [
                 Command.clear(),
                 Command.create({
-                    'notification_type': 'mail',
                     'interval_unit': 'now',
                     'interval_type': 'after_sub',
                     'template_ref': 'mail.template,%i' % self.env['ir.model.data']._xmlid_to_res_id('event.event_subscription'),

--- a/addons/event/tests/test_event_mail_schedule.py
+++ b/addons/event/tests/test_event_mail_schedule.py
@@ -52,28 +52,24 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
                     (0, 0, {  # right at subscription
                         'interval_unit': 'now',
                         'interval_type': 'after_sub',
-                        'notification_type': 'mail',
                         'template_ref': f'mail.template,{cls.template_subscription.id}',
                     }),
                     (0, 0, {  # one hour after subscription
                         'interval_nbr': 1,
                         'interval_unit': 'hours',
                         'interval_type': 'after_sub',
-                        'notification_type': 'mail',
                         'template_ref': f'mail.template,{cls.template_subscription.id}',
                     }),
                     (0, 0, {  # 1 days before event
                         'interval_nbr': 1,
                         'interval_unit': 'days',
                         'interval_type': 'before_event',
-                        'notification_type': 'mail',
                         'template_ref': f'mail.template,{cls.template_reminder.id}',
                     }),
                     (0, 0, {  # immediately after event
                         'interval_nbr': 1,
                         'interval_unit': 'hours',
                         'interval_type': 'after_event',
-                        'notification_type': 'mail',
                         'template_ref': f'mail.template,{cls.template_reminder.id}',
                     }),
                 ]
@@ -352,7 +348,6 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             (0, 0, {  # right at subscription
                 'interval_unit': 'now',
                 'interval_type': 'after_sub',
-                'notification_type': 'mail',
                 'template_ref': f'mail.template,{self.template_subscription.id}',
             }),
         ]})
@@ -435,13 +430,11 @@ class TestMailSchedule(EventCase, MockEmail, CronMixinCase):
             'name': "Go Sports",
             'event_type_mail_ids': [
                 Command.create({
-                    'notification_type': 'mail',
                     'interval_nbr': 0,
                     'interval_unit': 'now',
                     'interval_type': 'after_sub',
                     'template_ref': 'mail.template,%i' % self.env['ir.model.data']._xmlid_to_res_id('event.event_subscription')}),
                 Command.create({
-                    'notification_type': 'mail',
                     'interval_nbr': 5,
                     'interval_unit': 'hours',
                     'interval_type': 'before_event',

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -88,7 +88,7 @@
                             <field name="event_mail_ids">
                                 <tree string="Communication" editable="bottom">
                                     <field name="sequence" widget="handle"/>
-                                    <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                                    <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}" widget="EventMailTemplateReferenceField"/>
                                     <field name="interval_nbr" readonly="interval_unit == 'now'"/>
                                     <field name="interval_unit"/>
                                     <field name="interval_type"/>

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -88,9 +88,7 @@
                             <field name="event_mail_ids">
                                 <tree string="Communication" editable="bottom">
                                     <field name="sequence" widget="handle"/>
-                                    <field name="notification_type"/>
-                                    <field name="template_model_id" column_invisible="True"/>
-                                    <field name="template_ref" options="{'hide_model': True, 'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                                    <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
                                     <field name="interval_nbr" readonly="interval_unit == 'now'"/>
                                     <field name="interval_unit"/>
                                     <field name="interval_type"/>

--- a/addons/event/views/event_mail_views.xml
+++ b/addons/event/views/event_mail_views.xml
@@ -11,7 +11,7 @@
                     <group>
                         <group>
                             <field name="event_id"/>
-                            <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                            <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}" widget="EventMailTemplateReferenceField"/>
                             <field name="mail_state"/>
                         </group>
                         <group>
@@ -46,7 +46,7 @@
         <field name="arch" type="xml">
             <tree string="Event Mail Schedulers">
                 <field name="event_id"/>
-                <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}" widget="EventMailTemplateReferenceField"/>
                 <field name="scheduled_date"/>
                 <field name="mail_count_done"/>
                 <field name="mail_state" widget="event_icon_selection" string=" " nolabel="1"

--- a/addons/event/views/event_mail_views.xml
+++ b/addons/event/views/event_mail_views.xml
@@ -11,8 +11,7 @@
                     <group>
                         <group>
                             <field name="event_id"/>
-                            <field name="notification_type"/>
-                            <field name="template_ref" options="{'hide_model': True, 'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                            <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
                             <field name="mail_state"/>
                         </group>
                         <group>
@@ -47,8 +46,7 @@
         <field name="arch" type="xml">
             <tree string="Event Mail Schedulers">
                 <field name="event_id"/>
-                <field name="notification_type"/>
-                <field name="template_ref" options="{'hide_model': True, 'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
                 <field name="scheduled_date"/>
                 <field name="mail_count_done"/>
                 <field name="mail_state" widget="event_icon_selection" string=" " nolabel="1"

--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -42,9 +42,7 @@
                        <page string="Communication" name="event_type_communication">
                            <field name="event_type_mail_ids" class="w-100">
                                <tree string="Communication" editable="bottom">
-                                   <field name="notification_type"/>
-                                   <field name="template_model_id" column_invisible="True"/>
-                                   <field name="template_ref" options="{'model_field': 'template_model_id', 'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                                   <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
                                    <field name="interval_nbr" readonly="interval_unit == 'now'"/>
                                    <field name="interval_unit"/>
                                     <field name="interval_type"/>

--- a/addons/event/views/event_type_views.xml
+++ b/addons/event/views/event_type_views.xml
@@ -42,7 +42,7 @@
                        <page string="Communication" name="event_type_communication">
                            <field name="event_type_mail_ids" class="w-100">
                                <tree string="Communication" editable="bottom">
-                                   <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                                   <field name="template_ref" options="{'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}" widget="EventMailTemplateReferenceField"/>
                                    <field name="interval_nbr" readonly="interval_unit == 'now'"/>
                                    <field name="interval_unit"/>
                                     <field name="interval_type"/>

--- a/addons/event_sms/__manifest__.py
+++ b/addons/event_sms/__manifest__.py
@@ -14,5 +14,10 @@
     ],
     'installable': True,
     'auto_install': True,
+    'assets': {
+        'web.assets_backend': [
+            'event_sms/static/src/template_reference_field/*',
+        ],
+    },
     'license': 'LGPL-3',
 }

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -7,38 +7,25 @@ from odoo import api, fields, models
 class EventTypeMail(models.Model):
     _inherit = 'event.type.mail'
 
-    @api.model
-    def _selection_template_model(self):
-        return super(EventTypeMail, self)._selection_template_model() + [('sms.template', 'SMS')]
+    notification_type = fields.Selection(selection_add=[('sms', 'SMS')])
+    template_ref = fields.Reference(ondelete={'sms.template': 'cascade'}, selection_add=[('sms.template', 'SMS')])
 
-    notification_type = fields.Selection(selection_add=[('sms', 'SMS')], ondelete={'sms': 'set default'})
-
-    @api.depends('notification_type')
-    def _compute_template_model_id(self):
-        sms_model = self.env['ir.model']._get('sms.template')
-        sms_mails = self.filtered(lambda mail: mail.notification_type == 'sms')
-        sms_mails.template_model_id = sms_model
-        super(EventTypeMail, self - sms_mails)._compute_template_model_id()
+    def _compute_notification_type(self):
+        super()._compute_notification_type()
+        sms_schedulers = self.filtered(lambda scheduler: scheduler.template_ref and scheduler.template_ref._name == 'sms.template')
+        sms_schedulers.notification_type = 'sms'
 
 
 class EventMailScheduler(models.Model):
     _inherit = 'event.mail'
 
-    @api.model
-    def _selection_template_model(self):
-        return super(EventMailScheduler, self)._selection_template_model() + [('sms.template', 'SMS')]
+    notification_type = fields.Selection(selection_add=[('sms', 'SMS')])
+    template_ref = fields.Reference(ondelete={'sms.template': 'cascade'}, selection_add=[('sms.template', 'SMS')])
 
-    def _selection_template_model_get_mapping(self):
-        return {**super(EventMailScheduler, self)._selection_template_model_get_mapping(), 'sms': 'sms.template'}
-
-    notification_type = fields.Selection(selection_add=[('sms', 'SMS')], ondelete={'sms': 'set default'})
-
-    @api.depends('notification_type')
-    def _compute_template_model_id(self):
-        sms_model = self.env['ir.model']._get('sms.template')
-        sms_mails = self.filtered(lambda mail: mail.notification_type == 'sms')
-        sms_mails.template_model_id = sms_model
-        super(EventMailScheduler, self - sms_mails)._compute_template_model_id()
+    def _compute_notification_type(self):
+        super()._compute_notification_type()
+        sms_schedulers = self.filtered(lambda scheduler: scheduler.template_ref and scheduler.template_ref._name == 'sms.template')
+        sms_schedulers.notification_type = 'sms'
 
     def execute(self):
         for scheduler in self:
@@ -46,9 +33,6 @@ class EventMailScheduler(models.Model):
             if scheduler.interval_type != 'after_sub' and scheduler.notification_type == 'sms':
                 # before or after event -> one shot email
                 if scheduler.mail_done:
-                    continue
-                # no template -> ill configured, skip and avoid crash
-                if not scheduler.template_ref:
                     continue
                 # Do not send SMS if the communication was scheduled before the event but the event is over
                 if scheduler.scheduled_date <= now and (scheduler.interval_type != 'before_event' or scheduler.event_id.date_end > now):
@@ -62,14 +46,6 @@ class EventMailScheduler(models.Model):
                     })
 
         return super(EventMailScheduler, self).execute()
-
-    @api.onchange('notification_type')
-    def set_template_ref_model(self):
-        super().set_template_ref_model()
-        mail_model = self.env['sms.template']
-        if self.notification_type == 'sms':
-            record = mail_model.search([('model', '=', 'event.registration')], limit=1)
-            self.template_ref = "{},{}".format('sms.template', record.id) if record else False
 
 
 class EventMailRegistration(models.Model):

--- a/addons/event_sms/static/src/template_reference_field/field_event_mail_template_reference.scss
+++ b/addons/event_sms/static/src/template_reference_field/field_event_mail_template_reference.scss
@@ -1,0 +1,8 @@
+.event_template_reference_sms {
+    span[role=icon] {
+        margin-right: 0.1rem;
+    }
+    span[role=text] {
+        font-size: x-small;
+    }
+}

--- a/addons/event_sms/static/src/template_reference_field/field_event_mail_template_reference.xml
+++ b/addons/event_sms/static/src/template_reference_field/field_event_mail_template_reference.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="event.mailTemplateReferenceField" t-inherit-mode="extension">
+        <xpath expr="//span[hasclass('event_template_reference_mail')]" position="after">
+            <div t-if="relation === 'sms.template'" class="event_template_reference_sms">
+                <span class="fa fa-lg fa-solid fa-mobile" role="icon"/>
+                <span role="text">SMS</span>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/event_sms/tests/test_sms_schedule.py
+++ b/addons/event_sms/tests/test_sms_schedule.py
@@ -42,13 +42,11 @@ class TestSMSSchedule(EventCase, SMSCase):
                 (0, 0, {  # right at subscription
                     'interval_unit': 'now',
                     'interval_type': 'after_sub',
-                    'notification_type': 'sms',
                     'template_ref': 'sms.template,%i' % cls.sms_template_sub.id}),
                 (0, 0, {  # 3 days before event
                     'interval_nbr': 3,
                     'interval_unit': 'days',
                     'interval_type': 'before_event',
-                    'notification_type': 'sms',
                     'template_ref': 'sms.template,%i' % cls.sms_template_rem.id}),
             ],
             'name': 'TestEvent',

--- a/addons/test_event_full/__manifest__.py
+++ b/addons/test_event_full/__manifest__.py
@@ -33,7 +33,10 @@ automatic lead generation, full Online support, ...
     ],
     'assets': {
         'web.assets_tests': [
-            'test_event_full/static/**/*',
+            'test_event_full/static/src/js/tours/*',
+        ],
+        'web.assets_unit_tests': [
+            'test_event_full/static/src/js/tests/*',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/test_event_full/data/event_type_data.xml
+++ b/addons/test_event_full/data/event_type_data.xml
@@ -37,21 +37,18 @@
             (5, 0),
             (0, 0, {'interval_unit': 'now',
                     'interval_type': 'after_sub',
-                    'notification_type': 'mail',
                     'template_ref': 'mail.template,%i' % ref('event.event_subscription'),
                    }
             ),
             (0, 0, {'interval_nbr': 1,
                     'interval_unit': 'days',
                     'interval_type': 'before_event',
-                    'notification_type': 'mail',
                     'template_ref': 'mail.template,%i' % ref('event.event_reminder'),
                    }
             ),
             (0, 0, {'interval_nbr': 1,
                     'interval_unit': 'days',
                     'interval_type': 'after_event',
-                    'notification_type': 'sms',
                     'template_ref': 'sms.template,%i' % ref('event_sms.sms_template_data_event_reminder'),
                    }
             )]"/>

--- a/addons/test_event_full/static/src/js/tests/test_template_reference_field_widget.test.js
+++ b/addons/test_event_full/static/src/js/tests/test_template_reference_field_widget.test.js
@@ -1,0 +1,124 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { click, select } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { defineMailModels } from "@mail/../tests/mail_test_helpers";
+import { defineModels, fields, models, mountView, onRpc } from "@web/../tests/web_test_helpers";
+
+class EventMail extends models.Model {
+    _name = "event.mail";
+
+    template_ref = fields.Reference({
+        selection: [
+            ["mail.template", "Mail Template"],
+            ["sms.template", "SMS Template"],
+            ["some.template", "Some Template"],
+        ],
+    });
+
+    _records = [
+        {
+            id: 1,
+            template_ref: "mail.template,1",
+        },
+        {
+            id: 2,
+            template_ref: "sms.template,1",
+        },
+        {
+            id: 3,
+            template_ref: "some.template,1",
+        },
+    ];
+}
+class MailTemplate extends models.Model {
+    _name = "mail.template";
+
+    name = fields.Char();
+
+    _records = [{ id: 1, name: "Mail Template 1" }];
+}
+class SmsTemplate extends models.Model {
+    _name = "sms.template";
+
+    name = fields.Char();
+
+    _records = [{ id: 1, name: "SMS template 1" }];
+}
+class SomeTemplate extends models.Model {
+    _name = "some.template";
+
+    name = fields.Char();
+
+    _records = [{ id: 1, name: "Some Template 1" }];
+}
+defineMailModels();
+defineModels([EventMail, MailTemplate, SmsTemplate, SomeTemplate]);
+
+describe.current.tags("desktop");
+
+test("Reference field displays right icons", async () => {
+    // bypass list controller check
+    onRpc("has_group", () => true);
+
+    await mountView({
+        type: "list",
+        resModel: "event.mail",
+        arch: `
+        <tree editable="top">
+            <field name="template_ref" widget="EventMailTemplateReferenceField"/>
+        </tree>`,
+    });
+
+    // each field cell will be the field of a different record (1 field/line)
+    expect(".o_field_cell").toHaveCount(3);
+    expect(".o_field_cell.o_EventMailTemplateReferenceField_cell").toHaveCount(3);
+    expect(".o_field_cell:eq(0) .fa-envelope").toHaveCount(1);
+    expect(".o_field_cell:eq(1) .fa-mobile").toHaveCount(1);
+    expect(".o_field_cell:eq(2) .fa-envelope").toHaveCount(0);
+    expect(".o_field_cell:eq(2) .fa-mobile").toHaveCount(0);
+
+    // select a sms.template instead of mail.template
+
+    click(".o_field_cell:eq(0)");
+    await animationFrame();
+    click(".o_field_cell:eq(0) select.o_input");
+    select("sms.template");
+    await animationFrame();
+    click(".o_field_cell:eq(0) .o_field_many2one_selection input");
+    await animationFrame();
+    click(".o_field_cell:eq(0) .o-autocomplete--dropdown-item");
+    // click out
+    click(".o_list_renderer");
+    await animationFrame();
+
+    expect(".o_field_cell:eq(0) .fa-mobile").toHaveCount(1);
+    expect(".o_field_cell:eq(0) .fa-envelope").toHaveCount(0);
+
+    // select a some other model to check it has no icon
+
+    click(".o_field_cell:eq(0)");
+    await animationFrame();
+    click(".o_field_cell:eq(0) select.o_input");
+    select("some.template");
+    await animationFrame();
+    click(".o_field_cell:eq(0) .o_field_many2one_selection input");
+    await animationFrame();
+    click(".o_field_cell:eq(0) .o-autocomplete--dropdown-item");
+    click(".o_list_renderer");
+    await animationFrame();
+
+    expect(".o_field_cell:eq(0) .fa-mobile").toHaveCount(0);
+    expect(".o_field_cell:eq(0) .fa-envelope").toHaveCount(0);
+
+    // select no record for the model
+
+    click(".o_field_cell:eq(1)");
+    await animationFrame();
+    click(".o_field_cell:eq(1) select.o_input");
+    select("mail.template");
+    click(".o_list_renderer");
+    await animationFrame();
+
+    expect(".o_field_cell:eq(1) .fa-mobile").toHaveCount(0);
+    expect(".o_field_cell:eq(1) .fa-envelope").toHaveCount(0);
+});

--- a/addons/test_event_full/tests/common.py
+++ b/addons/test_event_full/tests/common.py
@@ -146,21 +146,18 @@ class TestEventFullCommon(EventCrmCase, TestSalesCommon, MockVisitor):
             'event_type_mail_ids': [
                 (0, 0, {'interval_unit': 'now',  # right at subscription
                         'interval_type': 'after_sub',
-                        'notification_type': 'mail',
                         'template_ref': 'mail.template,%i' % subscription_template.id,
                        }
                 ),
                 (0, 0, {'interval_nbr': 1,  # 1 days before event
                         'interval_unit': 'days',
                         'interval_type': 'before_event',
-                        'notification_type': 'mail',
                         'template_ref': 'mail.template,%i' % cls.env['ir.model.data']._xmlid_to_res_id('event.event_reminder'),
                        }
                 ),
                 (0, 0, {'interval_nbr': 1,  # 1 days after event
                         'interval_unit': 'days',
                         'interval_type': 'after_event',
-                        'notification_type': 'sms',
                         'template_ref': 'sms.template,%i' % cls.env['ir.model.data']._xmlid_to_res_id('event_sms.sms_template_data_event_reminder'),
                        }
                 ),

--- a/addons/test_event_full/tests/test_event_mail.py
+++ b/addons/test_event_full/tests/test_event_mail.py
@@ -7,7 +7,6 @@ from freezegun import freeze_time
 from odoo.addons.mail.tests.common import MockEmail
 from odoo.addons.sms.tests.common import MockSMS
 from odoo.addons.test_event_full.tests.common import TestWEventCommon, TestEventFullCommon
-from odoo.exceptions import ValidationError
 from odoo.tests import tagged
 
 
@@ -52,41 +51,6 @@ class TestTemplateRefModel(TestWEventCommon):
         template_sms.unlink()
         self.assertEqual(len(event_type.event_type_mail_ids.exists()), 0)
         self.assertEqual(len(event.event_mail_ids.exists()), 0)
-
-    def test_template_ref_model_constraint(self):
-        test_cases = [
-            ('mail', 'mail.template', True),
-            ('mail', 'sms.template', False),
-            ('sms', 'sms.template', True),
-            ('sms', 'mail.template', False),
-        ]
-
-        for notification_type, template_type, valid in test_cases:
-            with self.subTest(notification_type=notification_type, template_type=template_type):
-                if template_type == 'mail.template':
-                    template = self.env[template_type].create({
-                        'name': 'test template',
-                        'model_id': self.env['ir.model']._get_id('event.registration'),
-                    })
-                else:
-                    template = self.env[template_type].create({
-                        'name': 'test template',
-                        'body': 'Body Test',
-                        'model_id': self.env['ir.model']._get_id('event.registration'),
-                    })
-                if not valid:
-                    with self.assertRaises(ValidationError) as cm:
-                        self.env['event.mail'].create({
-                            'event_id': self.event.id,
-                            'notification_type': notification_type,
-                            'interval_unit': 'now',
-                            'interval_type': 'before_event',
-                            'template_ref': template,
-                        })
-                    if notification_type == 'mail':
-                        self.assertEqual(str(cm.exception), 'The template which is referenced should be coming from mail.template model.')
-                    else:
-                        self.assertEqual(str(cm.exception), 'The template which is referenced should be coming from sms.template model.')
 
 class TestEventSmsMailSchedule(TestWEventCommon, MockEmail, MockSMS):
 


### PR DESCRIPTION
`notification_type` and `model_id` are both used to give a set model to the reference field
`template_ref`. As we don't care about these values when the template is not set these
values are entirely redundant and can be safely removed.

This also makes the template selection in the UI behave better as it doesn't rely on compute methods
to force the model of the reference field in a roundabout way.

We add a custom reference field to maintain the display of the kind of model being used
as the default reference field does not display that information.

task-3256524

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
