### PR TITLE
[FIX] project: allow customer edition in portal subtasks subview

### DIFF
--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -197,7 +197,7 @@
                                         attrs="{'invisible': [('allow_milestones', '=', False)], 'column_invisible': [('parent.allow_milestones', '=', False)]}"
                                     />
                                     <field name="company_id" invisible="1"/>
-                                    <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" optional="hide" attrs="{'invisible': [('project_id', '=', False)]}"/>
+                                    <field name="partner_id" options="{'no_open': True, 'no_create': True, 'no_edit': True}" optional="hide"/>
                                     <field name="user_ids" invisible="1" />
                                     <field name="portal_user_names" string="Assignees" optional="show"/>
                                     <field name="date_deadline" attrs="{'invisible': [('state', 'in', ['1_done','1_canceled'])]}" optional="show"/>


### PR DESCRIPTION
Steps:
- Login as portal, and to to a task form, page sub-tasks.
- Make Customer column visible.
- Add a line and try to edit that field.

Issue:
You can't. But after saving, you can.

Cause:
The new record doesn't have a project (it will be given to it on save). Yet this PR https://github.com/odoo/odoo/pull/111335 added the condition that it should be invisible if no project.
The reason why it caused no issue in 16.3 (where it was merged) was that there was a default project in `child_ids`'s context.

Solution:
In this case, the condition is not needed. Subtasks always have a project : private tasks can't have subtasks and deleting project field on a non-private task's subtask will actually give it its parent project. So the solution is simple: remove the condition.

task-3713729
