### PR TITLE
[FIX] point_of_sale: incorrect pos.order.line export data to UI

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -1048,7 +1048,7 @@ class PosOrderLine(models.Model):
             'pack_lot_ids': [[0, 0, lot] for lot in orderline.pack_lot_ids.export_for_ui()],
             'customer_note': orderline.customer_note,
             'refunded_qty': orderline.refunded_qty,
-            'refunded_orderline_id': orderline.refunded_orderline_id,
+            'refunded_orderline_id': orderline.refunded_orderline_id.id,
             'full_product_name': orderline.full_product_name,
         }
 

--- a/doc/cla/corporate/braintec.md
+++ b/doc/cla/corporate/braintec.md
@@ -16,4 +16,5 @@ List of contributors:
 Raul Martin raul.martin@braintec.com https://github.com/BT-rmartin
 Frédéric Garbely frederic.garbely@braintec.com https://github.com/BT-fgarbely
 Carlos Serra Toro carlos.serra@braintec.com https://github.com/BT-cserra
+Ernesto Tejeda ernesto.tejeda@braintec.com https://github.com/BT-etejeda
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Point of Sale UI receives 'refunded order lines' as an object instead of an integer. This error is affecting custom development, but it could perfectly cause a problem in Odoo standard if it is not solved.

Note: In v17 it is already solved https://github.com/odoo/odoo/blob/ca6fcfb65c44bcd2017303dd90d5e72786d5b447/addons/point_of_sale/models/pos_order.py#L1388

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
