### PR TITLE
[FIX] google_calendar: avoid cache invalidation

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import logging
+import pytz
 import werkzeug
 from werkzeug.urls import url_encode
 
@@ -145,6 +146,9 @@ class AuthSignupHome(Home):
         lang = request.context.get('lang', '')
         if lang in supported_lang_codes:
             values['lang'] = lang
+        tz = request.httprequest.cookies.get('tz')
+        if tz in pytz.all_timezones:
+            values['tz'] = tz
         return values
 
     def do_signup(self, qcontext):

--- a/addons/google_calendar/utils/google_event.py
+++ b/addons/google_calendar/utils/google_event.py
@@ -108,7 +108,7 @@ class GoogleEvent(abc.Set):
                 e._events[e.id]['_odoo_id'] = odoo_id
 
     def _load_odoo_ids_from_db(self, env, model):
-        odoo_events = model.with_context(active_test=False)._from_google_ids(self.ids)
+        odoo_events = model._from_google_ids(self.ids)
         mapping = {e.google_id: e.id for e in odoo_events}  # {google_id: odoo_id}
         existing_google_ids = odoo_events.mapped('google_id')
         for e in self:

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -54,8 +54,11 @@ class Users(models.Model):
     def _inverse_notification_type(self):
         inbox_group = self.env.ref('mail.group_mail_notification_type_inbox')
         inbox_users = self.filtered(lambda user: user.notification_type == 'inbox')
-        inbox_users.write({"groups_id": [Command.link(inbox_group.id)]})
-        (self - inbox_users).write({"groups_id": [Command.unlink(inbox_group.id)]})
+        inbox_users_to_update = inbox_users.filtered(lambda user: inbox_group.id not in user.groups_id.ids)
+        inbox_users_to_update.write({"groups_id": [Command.link(inbox_group.id)]})
+        email_users = (self - inbox_users)
+        email_users_to_update = email_users.filtered(lambda user: inbox_group.id in user.groups_id.ids)
+        email_users_to_update.write({"groups_id": [Command.unlink(inbox_group.id)]})
 
     # ------------------------------------------------------------
     # CRUD


### PR DESCRIPTION
When a google event is updated, the cache is invalidated. This is not necessary as the event google_id didn't change.

Also, slightly simplify the ormcache since there is a single call with active_test=False


