### PR TITLE
[FIX] core: consistent context lang in http stack

### DIFF
--- a/addons/http_routing/models/ir_http.py
+++ b/addons/http_routing/models/ir_http.py
@@ -435,10 +435,10 @@ class IrHttp(models.AbstractModel):
             request.registry['ir.http']._auth_method_public()  # it calls update_env
             nearest_url_lang = cls.get_nearest_lang(request.env['res.lang']._lang_get_code(url_lang_str))
             cookie_lang = cls.get_nearest_lang(request.httprequest.cookies.get('frontend_lang'))
-            context_lang = cls.get_nearest_lang(real_env.context.get('lang'))
+            session_lang = cls.get_nearest_lang(request.session.context.get('lang'))
             default_lang = cls._get_default_lang()
             request.lang = request.env['res.lang']._lang_get(
-                nearest_url_lang or cookie_lang or context_lang or default_lang._get_cached('code')
+                nearest_url_lang or cookie_lang or session_lang or default_lang._get_cached('code')
             )
             request_url_code = request.lang._get_cached('url_code')
         finally:

--- a/addons/web/controllers/utils.py
+++ b/addons/web/controllers/utils.py
@@ -102,7 +102,6 @@ def ensure_db(redirect='/web/database/selector', db=None):
     if db != request.session.db:
         request.session = http.root.session_store.new()
         request.session.update(http.get_default_session(), db=db)
-        request.session.context['lang'] = request.default_lang()
         werkzeug.exceptions.abort(request.redirect(request.httprequest.url, 302))
 
 

--- a/addons/website/__init__.py
+++ b/addons/website/__init__.py
@@ -42,5 +42,4 @@ def post_init_hook(env):
     env['ir.module.module'].update_theme_images()
 
     if request:
-        env = env(context=request.default_context())
         request.website_routing = env['website'].get_current_website().id

--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -127,7 +127,7 @@ class Http(models.AbstractModel):
     @classmethod
     def _get_public_users(cls):
         public_users = super()._get_public_users()
-        website = request.env(user=SUPERUSER_ID)['website'].with_context(lang='en_US').get_current_website()  # sudo
+        website = request.env(user=SUPERUSER_ID)['website'].get_current_website()  # sudo
         if website:
             public_users.append(website._get_cached('user_id'))
         return public_users
@@ -138,7 +138,7 @@ class Http(models.AbstractModel):
             public user as request uid.
         """
         if not request.session.uid:
-            website = request.env(user=SUPERUSER_ID)['website'].with_context(lang='en_US').get_current_website()  # sudo
+            website = request.env(user=SUPERUSER_ID)['website'].get_current_website()  # sudo
             if website:
                 request.update_env(user=website._get_cached('user_id'))
 

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -147,8 +147,8 @@ class IrHttp(models.AbstractModel):
     @classmethod
     def _auth_method_public(cls):
         if request.env.uid is None:
-            public_user = request.env.ref('base.public_user')
-            request.update_env(user=public_user.id)
+            public_user_id = cls._get_public_users()[0]
+            request.update_env(user=public_user_id)
 
     @classmethod
     def _authenticate(cls, endpoint):

--- a/odoo/addons/test_http/tests/test_echo_reply.py
+++ b/odoo/addons/test_http/tests/test_echo_reply.py
@@ -186,9 +186,15 @@ class TestHttpEchoReplyJsonWithDB(TestHttpBase):
         })
         res = self.db_url_open("/test_http/echo-json-context", data=payload, headers=CT_JSON)
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(res.text, '{"jsonrpc": "2.0", "id": 0, "result": '
-            f'{{"lang": "en_US", "tz": false, "uid": {self.jackoneill.id}}}'
-            '}')
+        self.assertEqual(res.json(), {
+            "jsonrpc": "2.0",
+            "id": 0,
+            "result": {
+                "lang": "en_US",
+                "tz": False,
+                "uid": self.jackoneill.id
+            }
+        })
 
     def test_echojson3_bad_json(self):
         payload = 'some non json garbage'


### PR DESCRIPTION
The language found inside the session or inside the Accept-Language http header could be deactivated in the database. While the http stack itself has no use of translated fields, the ORM would still prefetch them along with records such as res.lang or website. A recent change now emit an error every time a translated field is read from the database when it would be translated in a deactivated language.

In our original fix, we tracked down usages of the ORM where the lang inside `request.env.context` hadn't yet been verified by `_pre_dispatch` and changed them with `with_context(lang='en_US')`. That fix proved to be partial: we missed some places.

With this fix we now create `request.env.context` with English ("en_US") hardcoded and we set a correct language inside the context at once inside `_pre_dispatch`. This mean that all usages of the ORM inside `_match` and `_authenticate` now use English as expected.

Note about errors: It is possible that a http-404 error occurs during `_match` when the requested page doesn't exist. It is also possible that another http-4xx error occurs during `_authenticate` in case of an authentication failure. In both cases `_handle_error` kicks in and immediately returns an appropriate http error response. It is important to keep in mind that `_handle_error` is called before `_pre_dispatch` hence the context still contains the hardcoded `lang="en_US"`. In case of base/web it is not a problem because the error page was always in English no matter the language inside the context. In case of portal/website, `_frontend_pre_dispatch` is called by `_handle_error` which set an appropriate language in the context before rendering a rich translated page.

Reference-to: https://github.com/odoo/odoo/commit/95169ea ([IMP] core: better lang check)