### PR TITLE
[IMP] mail: copy message link

### DIFF
--- a/addons/im_livechat/static/tests/embed/message_actions.test.js
+++ b/addons/im_livechat/static/tests/embed/message_actions.test.js
@@ -40,7 +40,8 @@ test("Only two quick actions are shown", async () => {
     await contains("[title='Reply']");
     await contains("[title='Expand']");
     await click("[title='Expand']");
-    await contains(".o-mail-Message-actions i, .o-mail-Message-moreMenu i", { count: 6 });
+    await contains(".o-mail-Message-actions i, .o-mail-Message-moreMenu i", { count: 7 });
+    await contains("[title='Copy Message Link']");
     await contains("[title='Edit']");
     await contains("[title='Delete']");
     await contains("[title='View Reactions']");

--- a/addons/mail/controllers/mail.py
+++ b/addons/mail/controllers/mail.py
@@ -3,11 +3,15 @@
 import logging
 
 from werkzeug.urls import url_encode
+from werkzeug.exceptions import NotFound, Unauthorized
 
 from odoo import _, http
 from odoo.exceptions import AccessError
 from odoo.http import request
 from odoo.tools import consteq
+from odoo.addons.mail.controllers.discuss.public_page import PublicPageController
+from odoo.addons.mail.models.discuss.mail_guest import add_guest_to_context
+from odoo.addons.mail.tools.discuss import Store
 
 _logger = logging.getLogger(__name__)
 
@@ -83,7 +87,7 @@ class MailController(http.Controller):
                     #   _get_redirect_suggested_company
                     #   - If no company, then redirect to the messaging
                     #   - Merge the suggested company with the companies on the cookie
-                    # - Make a new access test if it succeeds, redirect to the record. Otherwise, 
+                    # - Make a new access test if it succeeds, redirect to the record. Otherwise,
                     #   redirect to the messaging.
                     if not suggested_company:
                         raise AccessError('')
@@ -197,3 +201,41 @@ class MailController(http.Controller):
             'model_name': request.env['ir.model'].sudo()._get(model).display_name,
             'access_url': record._notify_get_action_link('view', model=model, res_id=res_id) if display_link else False,
         })
+
+    @http.route('/mail/message/<int:message_id>', type='http', auth='public')
+    @add_guest_to_context
+    def mail_thread_message_redirect(self, message_id, **kwargs):
+        message = request.env['mail.message'].search([('id', '=', message_id)])
+        if not message:
+            if request.env.user._is_public():
+                return request.redirect(f'/web/login?redirect=/mail/message/{message_id}')
+            raise Unauthorized()
+
+        # sudo: public user can access some relational fields of mail.message
+        if message.sudo()._filter_empty():
+            raise NotFound()
+        if not request.env.user._is_internal():
+            thread = request.env[message.model].search([('id', '=', message.res_id)])
+            if message.model == 'discuss.channel':
+                store = Store({'isChannelTokenSecret': True})
+                store.add(thread, {'highlightMessage': Store.one(message, only_id=True)})
+                return PublicPageController()._response_discuss_channel_invitation(store, thread)
+            elif hasattr(thread, '_get_share_url'):
+                return request.redirect(thread._get_share_url(share_token=False))
+            else:
+                raise Unauthorized()
+
+        url_params = {
+            'highlight_message_id': message_id,
+        }
+        if message.model == 'discuss.channel':
+            url_params['active_id'] = message.res_id
+            url_params['action'] = 'mail.action_discuss'
+        else:
+            url_params.update({
+                'model': message.model,
+                'id': message.res_id,
+                'view_type': 'form',
+            })
+        url = '/web#%s' % url_encode(url_params)
+        return request.redirect(url)

--- a/addons/mail/static/src/chatter/web/chatter_patch.js
+++ b/addons/mail/static/src/chatter/web/chatter_patch.js
@@ -43,6 +43,7 @@ Chatter.props.push(
     "hasParentReloadOnAttachmentsChanged?",
     "hasParentReloadOnFollowersUpdate?",
     "hasParentReloadOnMessagePosted?",
+    "highlightMessageId?",
     "isAttachmentBoxVisibleInitially?",
     "isChatterAside?",
     "isInFormSheetBg?",
@@ -303,6 +304,13 @@ patch(Chatter.prototype, {
         document.body.click(); // hack to close dropdown
         this.reloadParentView();
         this.load(thread, ["followers", "suggestedRecipients"]);
+    },
+
+    _onMounted() {
+        super._onMounted();
+        if (this.state.thread && this.props.highlightMessageId) {
+            this.state.thread.highlightMessage = this.props.highlightMessageId;
+        }
     },
 
     onPostCallback() {

--- a/addons/mail/static/src/chatter/web/form_compiler.js
+++ b/addons/mail/static/src/chatter/web/form_compiler.js
@@ -20,6 +20,7 @@ function compileChatter(node, params) {
         threadModel: "__comp__.props.record.resModel",
         webRecord: "__comp__.props.record",
         saveRecord: "() => __comp__.save and __comp__.save()",
+        highlightMessageId: "__comp__.highlightMessageId",
     });
     const chatterContainerHookXml = createElement("div");
     chatterContainerHookXml.classList.add("o-mail-ChatterContainer", "o-mail-Form-chatter");

--- a/addons/mail/static/src/chatter/web/form_renderer.js
+++ b/addons/mail/static/src/chatter/web/form_renderer.js
@@ -4,6 +4,7 @@ import { Chatter } from "@mail/chatter/web_portal/chatter";
 import { onMounted, onWillUnmount, useState } from "@odoo/owl";
 
 import { browser } from "@web/core/browser/browser";
+import { router } from "@web/core/browser/router";
 import { SIZES } from "@web/core/ui/ui_service";
 import { useService } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
@@ -17,6 +18,7 @@ patch(FormRenderer.prototype, {
             AttachmentView,
             Chatter,
         };
+        this.highlightMessageId = router.current.highlight_message_id;
         this.messagingState = useState({
             /** @type {import("models").Thread} */
             thread: undefined,

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -35,15 +35,7 @@ export class Chatter extends Component {
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
         useChildSubEnv(this.childSubEnv);
 
-        onMounted(() => {
-            this.changeThread(this.props.threadModel, this.props.threadId);
-            if (!this.env.chatter || this.env.chatter?.fetchData) {
-                if (this.env.chatter) {
-                    this.env.chatter.fetchData = false;
-                }
-                this.load(this.state.thread, this.requestList);
-            }
-        });
+        onMounted(this._onMounted);
         onWillUpdateProps((nextProps) => {
             if (
                 this.props.threadId !== nextProps.threadId ||
@@ -100,6 +92,16 @@ export class Chatter extends Component {
             return;
         }
         thread.fetchData(requestList);
+    }
+
+    _onMounted() {
+        this.changeThread(this.props.threadModel, this.props.threadId);
+        if (!this.env.chatter || this.env.chatter?.fetchData) {
+            if (this.env.chatter) {
+                this.env.chatter.fetchData = false;
+            }
+            this.load(this.state.thread, this.requestList);
+        }
     }
 
     onPostCallback() {

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -97,6 +97,15 @@ messageActionsRegistry
         title: (component) => (component.state.showTranslation ? _t("Revert") : _t("Translate")),
         onClick: (component) => component.onClickToggleTranslation(),
         sequence: 100,
+    })
+    .add("copy-link", {
+        condition: (component) =>
+            component.message.message_type &&
+            component.message.message_type !== "user_notification",
+        icon: "fa-link",
+        title: _t("Copy Message Link"),
+        onClick: (component) => component.message.copyLink(),
+        sequence: 110,
     });
 
 function transformAction(component, id, action) {

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -7,6 +7,7 @@ import {
 } from "@mail/utils/common/format";
 import { rpc } from "@web/core/network/rpc";
 
+import { browser } from "@web/core/browser/browser";
 import { deserializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
 import { user } from "@web/core/user";
@@ -336,6 +337,18 @@ export class Message extends Record {
         return this.scheduledDatetime.toLocaleString(DateTime.TIME_24_SIMPLE, {
             locale: user.lang?.replace("_", "-"),
         });
+    }
+
+    async copyLink() {
+        let notification = _t("Message Link Copied!");
+        let type = "info";
+        try {
+            await browser.navigator.clipboard.writeText(url(`/mail/message/${this.id}`));
+        } catch {
+            notification = _t("Message Link Copy Failed (Permission denied?)!");
+            type = "danger";
+        }
+        this.store.env.services.notification.add(notification, { type });
     }
 
     async edit(body, attachments = [], { mentionedChannels = [], mentionedPartners = [] } = {}) {

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -137,6 +137,18 @@ export class Thread extends Component {
         );
         useEffect(
             () => {
+                if (this.props.thread.highlightMessage && this.state.mountedAndLoaded) {
+                    this.messageHighlight?.highlightMessage(
+                        this.props.thread.highlightMessage,
+                        this.props.thread
+                    );
+                    this.props.thread.highlightMessage = null;
+                }
+            },
+            () => [this.props.thread.highlightMessage, this.state.mountedAndLoaded]
+        );
+        useEffect(
+            () => {
                 if (!this.state.mountedAndLoaded) {
                     return;
                 }

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -307,6 +307,12 @@ export class Thread extends Record {
     });
     /** @type {"not_fetched"|"pending"|"fetched"} */
     fetchMembersState = "not_fetched";
+    /** @type {integer|null} */
+    highlightMessage = Record.one("Message", {
+        onAdd(msg) {
+            msg.thread = this;
+        },
+    });
 
     get accessRestrictedToGroupText() {
         if (!this.authorizedGroupFullName) {

--- a/addons/mail/static/src/core/public_web/discuss_client_action.js
+++ b/addons/mail/static/src/core/public_web/discuss_client_action.js
@@ -63,6 +63,10 @@ export class DiscussClientAction extends Component {
         const [model, id] = this.parseActiveId(rawActiveId);
         const activeThread = await this.store.Thread.getOrFetch({ model, id });
         if (activeThread && activeThread.notEq(this.store.discuss.thread)) {
+            if (props.action?.params?.highlight_message_id) {
+                activeThread.highlightMessage = props.action.params.highlight_message_id;
+                delete props.action.params.highlight_message_id;
+            }
             activeThread.setAsDiscussThread(false);
         }
         this.store.discuss.hasRestoredThread = true;


### PR DESCRIPTION
**PURPOSE:**

Easily share the content of a message that is in another thread via a link.

**SPECIFICATIONS:**

- Add a 'copy message link' action under the More menu on message hover.
- When user clicks on this action display a toast notification stating message copied to your clipboard.
- User should be able to paste this link wherever he wants
- Clicking on this link should redirect the user to the message in a new tab and highlight it.

**task**-[2365623](https://www.odoo.com/web#id=2365623&menu_id=6478&action=4043&model=project.task&view_type=form&cids=2)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
