### PR TITLE
[IMP] l10n_ro_edi, base_vat: Tin numbers

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -69,7 +69,7 @@ _ref_vat = {
     'ph': '123-456-789-123',
     'pl': 'PL1234567883',
     'pt': 'PT123456789',
-    'ro': 'RO1234567897',
+    'ro': 'RO1234567897 or 8001011234567 or 9000123456789',
     'rs': 'RS101134702',
     'ru': 'RU123456789047',
     'se': 'SE123456789701',
@@ -291,6 +291,28 @@ class ResPartner(models.Model):
         if len(number) == 10 and self.__check_vat_al_re.match(number):
             return True
         return False
+
+    __check_tin1_ro_natural_persons = re.compile(r'[1-9]\d{2}(0[1-9]|1[0-2])(0[1-9]|[12]\d|3[01])\d{6}')
+    __check_tin2_ro_natural_persons = re.compile(r'9000\d{9}')
+    def check_vat_ro(self, vat):
+        """
+            Check Romanian VAT number that can be for example 'RO1234567897 or 'xyyzzaabbxxxx' or '9000xxxxxxxx'.
+            - For xyyzzaabbxxxx, 'x' can be any number, 'y' is the two last digit of a year (in the range 00…99),
+              'a' is a month, b is a day of the month, the number 8 and 9 are Country or district code
+              (For those twos digits, we decided to let some flexibility  to avoid complexifying the regex and also
+              for maintainability)
+            - 9000xxxxxxxx, start with 9000 and then is filled by number In the range 0...9
+
+            Also stdum also checks the CUI or CIF (Romanian company identifier). So a number like '123456897' will pass.
+        """
+        tin1 = self.__check_tin1_ro_natural_persons.match(vat)
+        if tin1:
+            return True
+        tin2 = self.__check_tin1_ro_natural_persons.match(vat)
+        if tin2:
+            return True
+        # Check the vat number
+        return stdnum.util.get_cc_module('ro', 'vat').is_valid(vat)
 
     __check_tin_hu_individual_re = re.compile(r'^8\d{9}$')
     __check_tin_hu_companies_re = re.compile(r'^\d{8}-[1-5]-\d{2}$')

--- a/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
+++ b/addons/l10n_ro_edi/models/account_edi_xml_ubl_ciusro.py
@@ -98,11 +98,6 @@ class AccountEdiXmlUBLRO(models.AbstractModel):
                     "At least one of them is required. ",
                     partner.name)
 
-            if partner.vat and not partner.vat.startswith(partner.country_code):
-                constraints[f"ciusro_{partner_type}_country_code_vat_required"] = _(
-                    "The following partner's doesn't have a country code prefix in their VAT: %s.",
-                    partner.name)
-
             if (not partner.vat and partner.company_registry
                     and not partner.company_registry.startswith(partner.country_code)):
                 constraints[f"ciusro_{partner_type}_country_code_company_registry_required"] = _(

--- a/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
+++ b/addons/l10n_ro_edi/tests/test_xml_ubl_ro.py
@@ -115,12 +115,6 @@ class TestUBLRO(TestUBLCommon):
         attachment = self.get_attachment(invoice)
         self._assert_invoice_attachment(attachment, xpaths=None, expected_file_path='from_odoo/ciusro_out_invoice.xml')
 
-    def test_export_vat_without_prefix(self):
-        self.company_data['company'].vat = '1234567897'
-        invoice = self.create_move("out_invoice", send=False)
-        with self.assertRaisesRegex(UserError, "doesn't have a country code prefix in their VAT"):
-            invoice._generate_pdf_and_send_invoice(self.move_template, allow_fallback_pdf=False)
-
     def test_export_constraints(self):
         self.company_data['company'].company_registry = None
         for required_field in ('city', 'street', 'state_id', 'vat'):


### PR DESCRIPTION
There are multiple types of Identification Numbers in Romania and if you invoice
to a natural person, you are also required to send an electronic invoice.

Thus, we will add a check to allow the two TIN numbers that needs to be correct.

Example of valid tax number 'RO1234567897 or 'xyyzzaabbxxxx' or '9000xxxxxxxx'.
-Tin1: For xyyzzaabbxxxx, 'x' can be any number, 'y' is the two last digit of a
year (in the range 00…99), 'a' is a month, b is a day of the month, the number 8
 and 9 are Country or district code
-Tin2: 9000xxxxxxxx, start with 9000 and then is filled by number (range 0 to 9)

Also stdum also checks the CUI or CIF (Romanian company identifier). So a number
like '123456897' will pass.

This commit will remove some test that are not relevant anymore since we can't
apply a vat number that don't follow the legal convention.

task: 3716671

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
