### PR TITLE
[IMP] project, _*: display the sum of hours spent when grouping tasks in portal

### DIFF
--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -274,3 +274,11 @@ class ProjectTask(models.Model):
         uom_hour = self.env.ref('uom.product_uom_hour')
         uom_day = self.env.ref('uom.product_uom_day')
         return round(uom_hour._compute_quantity(time, uom_day, raise_if_failure=False), 2)
+
+    def _get_portal_total_hours_dict(self):
+        if not (timesheetable_tasks := self.filtered('allow_timesheets')):
+            return {}
+        return {
+            'allocated_hours': sum(timesheetable_tasks.mapped('allocated_hours')),
+            'effective_hours': sum(timesheetable_tasks.mapped('effective_hours')),
+        }

--- a/addons/hr_timesheet/views/project_task_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_task_portal_templates.xml
@@ -45,15 +45,34 @@
             <t t-set="timesheet_ids" t-value="task.sudo().timesheet_ids"/>
             <t t-set="is_uom_day" t-value="timesheet_ids._is_timesheet_encode_uom_day()"/>
         </xpath>
-        <xpath expr="//thead/tr/t[@t-set='number_of_header']" position="after">
-            <t t-if="allow_timesheets">
-                 <t t-set="number_of_header" t-value="number_of_header + 1"/>
-            </t>
-        </xpath>
         <xpath expr="//thead/tr/th[@name='project_portal_milestones']" position="after">
             <t t-if="not project or project.allow_timesheets">
                 <th class="text-end">Time Spent</th>
             </t>
+        </xpath>
+        <xpath expr="//th[@name='state_col']" position="before">
+            <th t-if="not project or project.allow_timesheets" class="text-end text-muted fw-normal">
+                <t t-set="total_hours_dict" t-value="tasks._get_portal_total_hours_dict()"/>
+                <t t-if="total_hours_dict">
+                    <t t-set="total_allocated_hours" t-value="tasks.project_id.allocated_hours if groupby == 'project_id' else total_hours_dict['allocated_hours']"/>
+                    <t t-set="total_effective_hours" t-value="total_hours_dict['effective_hours']"/>
+                    <span>
+                        Total:
+                        <t t-if="is_uom_day">
+                            <t t-out="tasks._convert_hours_to_days(total_effective_hours)" t-options='{"widget": "timesheet_uom"}'/>
+                            <t t-if="total_allocated_hours"> /
+                                <t t-out="tasks._convert_hours_to_days(total_allocated_hours)" t-options='{"widget": "timesheet_uom"}'/>
+                            </t>
+                        </t>
+                        <t t-else="">
+                            <t t-out="total_effective_hours" t-options='{"widget": "float_time"}'/>
+                            <t t-if="total_allocated_hours"> /
+                                <t t-out="total_allocated_hours" t-options='{"widget": "float_time"}'/>
+                            </t>
+                        </t>
+                    </span>
+                </t>
+            </th>
         </xpath>
         <xpath expr="//tbody/t/tr/td[@name='project_portal_milestones']" position="after">
             <td t-if="not project or project.allow_timesheets" class="text-end">

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -17,11 +17,12 @@
                 <thead>
                     <tr>
                         <!-- Allows overrides in modules -->
-                        <t t-set="group_by_in_header_list" t-value="['priority', 'state', 'project_id', 'stage_id', 'milestone_id']"></t>
-                        <t t-set="number_of_header" t-value="8"></t>
+                        <t t-set="group_by_in_header_list" t-value="['priority', 'milestone_id']"></t>
+                        <t t-if="multiple_projects" t-set="group_by_in_header_list" t-value="group_by_in_header_list + ['project_id']"/>
                         <!-- Computes the right colspan once and use it everywhere -->
-                        <t t-set="grouped_tasks_colspan" t-value="number_of_header - 1 if groupby in group_by_in_header_list else number_of_header"></t>
-                        <t t-set="grouped_tasks_colspan" t-value="grouped_tasks_colspan if allow_milestone else grouped_tasks_colspan - 1"></t>
+                        <t t-set="grouped_tasks_colspan" t-value="5 if groupby in group_by_in_header_list else 6"></t>
+                        <t t-set="grouped_tasks_colspan" t-if="not allow_milestone" t-value="grouped_tasks_colspan - 1"></t>
+                        <t t-set="grouped_tasks_colspan" t-if="not multiple_projects" t-value="grouped_tasks_colspan - 1"/>
                         <th t-attf-colspan="{{2 if groupby != 'priority' else 1}}"/>
                         <th>Name</th>
                         <th>Assignees</th>
@@ -33,36 +34,42 @@
                 </thead>
                 <t t-foreach="grouped_tasks" t-as="tasks">
                     <tbody t-if="tasks">
-                        <tr t-if="not groupby == 'none'" class="table-light">
-                            <th t-if="groupby == 'project_id' and multiple_projects" t-attf-colspan="{{grouped_tasks_colspan}}">
-                                <!-- This div is necessary for documents_project_sale -->
-                                <div name="project_name" class="d-flex w-100 align-items-center">
-                                    <span t-if="tasks[0].sudo().project_id" t-field="tasks[0].sudo().project_id.name"/>
-                                    <span t-else="">No Project</span>
-                                </div>
+                        <tr name="grouped_tasks_groupby_columns" t-if="groupby != 'none'" class="table-light">
+                            <th name="groupby_name_col" t-att-colspan="grouped_tasks_colspan">
+                                <t t-if="groupby == 'project_id' and multiple_projects">
+                                    <!-- This div is necessary for documents_project_sale -->
+                                    <div name="project_name" class="d-flex w-100 align-items-center">
+                                        <span t-if="tasks[0].sudo().project_id" t-field="tasks[0].sudo().project_id.name"/>
+                                        <span t-else="">No Project</span>
+                                    </div>
+                                </t>
+                                <t t-elif="groupby == 'milestone_id'">
+                                    <span t-if="tasks[0].sudo().milestone_id and tasks[0].sudo().allow_milestones"
+                                        class="text-truncate"
+                                        t-field="tasks[0].sudo().milestone_id.name"/>
+                                    <span t-else="">No Milestone</span>
+                                </t>
+                                <t t-if="groupby == 'stage_id'">
+                                    <!-- This div is necessary for documents_project_sale -->
+                                    <div name="stage_name" class="d-flex w-100 align-items-center">
+                                        <span class="text-truncate" t-field="tasks[0].sudo().stage_id.name"/>
+                                    </div>
+                                </t>
+                                <t t-if="groupby == 'priority'">
+                                    <span class="text-truncate" t-field="tasks[0].sudo().priority"/>
+                                </t>
+                                <t t-if="groupby == 'state'">
+                                    <span class="text-truncate" t-field="tasks[0].sudo().state"/>
+                                </t>
+                                <t t-if="groupby == 'partner_id'">
+                                    <span t-if="tasks[0].sudo().partner_id"
+                                        class="text-truncate"
+                                        t-field="tasks[0].sudo().partner_id.name"/>
+                                    <span t-else="">No Customer</span>
+                                </t>
                             </th>
-                            <th t-if="groupby == 'milestone_id'" t-attf-colspan="{{grouped_tasks_colspan}}">
-                                <span t-if="tasks[0].sudo().milestone_id and tasks[0].sudo().allow_milestones"
-                                      class="text-truncate"
-                                      t-field="tasks[0].sudo().milestone_id.name"/>
-                                <span t-else="">No Milestone</span>
-                            </th>
-                            <th t-if="groupby == 'stage_id'" t-attf-colspan="{{grouped_tasks_colspan}}">
-                                <!-- This div is necessary for documents_project_sale -->
-                                <div name="stage_name" class="d-flex w-100 align-items-center">
-                                    <span class="text-truncate" t-field="tasks[0].sudo().stage_id.name"/>
-                                </div>
-                            </th>
-                            <th t-if="groupby == 'priority'" t-attf-colspan="{{grouped_tasks_colspan}}">
-                                <span class="text-truncate" t-field="tasks[0].sudo().priority"/></th>
-                            <th t-if="groupby == 'state'" t-attf-colspan="{{grouped_tasks_colspan}}">
-                                <span class="text-truncate" t-field="tasks[0].sudo().state"/></th>
-                            <th t-if="groupby == 'partner_id'" t-attf-colspan="{{grouped_tasks_colspan}}">
-                                <span t-if="tasks[0].sudo().partner_id"
-                                      class="text-truncate"
-                                      t-field="tasks[0].sudo().partner_id.name"/>
-                                <span t-else="">No Customer</span>
-                            </th>
+                            <th name="state_col" t-if="groupby != 'state'"/>
+                            <th name="stage_id_col" t-if="groupby != 'stage_id'"/>
                         </tr>
                     </tbody>
                     <tbody t-if="tasks">

--- a/addons/sale_project/views/sale_project_portal_templates.xml
+++ b/addons/sale_project/views/sale_project_portal_templates.xml
@@ -2,15 +2,11 @@
 <odoo>
 
     <template id="portal_tasks_list_inherit" inherit_id="project.portal_tasks_list">
-        <xpath expr="//t[@t-foreach='grouped_tasks']/tbody/tr[hasclass('table-light')]" position="inside">
-            <th t-if="groupby == 'sale_order_id'" t-attf-colspan="{{grouped_tasks_colspan}}">
-                <span t-if="tasks[0].sudo().sale_order_id" class="text-truncate" t-field="tasks[0].sudo().sale_order_id"/>
-                <span t-else="">Not Billed</span>
-            </th>
-            <th t-if="groupby == 'sale_line_id'" t-attf-colspan="{{grouped_tasks_colspan}}">
+        <xpath expr="//th[@name='groupby_name_col']" position="inside">
+            <t t-if="groupby == 'sale_line_id'">
                 <span t-if="tasks[0].sudo().sale_line_id" class="text-truncate" t-field="tasks[0].sudo().sale_line_id"/>
                 <span t-else="">Not Billed</span>
-            </th>
+            </t>
         </xpath>
     </template>
 


### PR DESCRIPTION
_*= hr_timesheet, sale_project

- In this commit we have enhanced the functionality of displaying effective
  hours divided by allocated hours of grouped tasks in the portal list view.

task-3609050