### PR TITLE
[IMP] tools, web: improve precision of rounding utils

### DIFF
--- a/addons/account/tests/test_invoice_tax_totals.py
+++ b/addons/account/tests/test_invoice_tax_totals.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.fields import Command
 from odoo.tests import tagged
@@ -662,10 +660,10 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             (-500, self.tax_10),
         ]
         run_case('round_per_line', lines, [15.45])
-        # 5.445 + 60 - 50 = 15.444999999999993 ~= 15.44
+        # 5.445 + 60 - 50 = 15.444999999999993 ~= 15.45
         # 5.445 - 50 + 60 = 15.445 ~= 15.45
         # 5.445 + 10 = 15.445 ~= 15.45
-        run_case('round_globally', lines, [15.44])
+        run_case('round_globally', lines, [15.45])
 
         lines = [
             (94.7, self.tax_23_1),
@@ -784,7 +782,7 @@ class TestTaxTotals(AccountTestInvoicingCommon):
             ],
         })
         self.assert_document_tax_totals(invoice, {
-            'amount_total': 43.050000000000004,
+            'amount_total': 43.05,
             'amount_untaxed': 33.58,
             'display_tax_base': True,
             'groups_by_subtotal': {

--- a/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
+++ b/addons/l10n_account_edi_ubl_cii_tests/tests/test_xml_ubl_be.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import base64
 from lxml import etree
 
@@ -825,7 +824,7 @@ class TestUBLBE(TestUBLCommon, TestAccountMoveSendCommon):
                     'price_unit': 99,
                     'quantity': 2,
                     'discount': 10,
-                    'price_subtotal': 178.20000000000002,
+                    'price_subtotal': 178.2,
                     'tax_ids': (tax_21 + self.recupel).ids,
                 }]
             },

--- a/addons/mrp_account/tests/test_analytic_account.py
+++ b/addons/mrp_account/tests/test_analytic_account.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests.common import TransactionCase
@@ -356,7 +355,7 @@ class TestAnalyticAccount(TestMrpAnalyticAccount):
         self.assertEqual(mo.state, 'progress')
         aals = mo.move_raw_ids.analytic_account_line_ids
         self.assertEqual(len(aals), 3)
-        self.assertEqual(sum(aals.mapped('amount')), -49.99)
+        self.assertEqual(sum(aals.mapped('amount')), -50.00)
 
         # increase qty_producing to 10.0
         mo_form = Form(mo)

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 import heapq
 import logging
@@ -1199,7 +1198,7 @@ class StockQuant(models.Model):
         self.ensure_one()
         if self.env.context.get('inventory_name'):
             name = self.env.context.get('inventory_name')
-        elif fields.Float.is_zero(qty, 0, precision_rounding=self.product_uom_id.rounding):
+        elif fields.Float.is_zero(qty, precision_rounding=self.product_uom_id.rounding):
             name = _('Product Quantity Confirmed')
         else:
             name = _('Product Quantity Updated')

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -1,10 +1,8 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 import odoo.tests
 from odoo.tests import Form
 from odoo.tests.common import TransactionCase
-from odoo.tools import float_round
 from odoo.exceptions import UserError
 from odoo import Command
 
@@ -333,14 +331,10 @@ class TestPacking(TestPackingCommon):
 
     def test_move_picking_with_package(self):
         """
-        355.4 rounded with 0.01 precision is 355.40000000000003.
+        355.4 rounded with 0.01 precision is 355.4.
         check that nonetheless, moving a picking is accepted
         """
         self.assertEqual(self.productA.uom_id.rounding, 0.01)
-        self.assertEqual(
-            float_round(355.4, precision_rounding=self.productA.uom_id.rounding),
-            355.40000000000003,
-        )
         location_dict = {
             'location_id': self.stock_location.id,
         }

--- a/addons/web/static/tests/core/utils/numbers.test.js
+++ b/addons/web/static/tests/core/utils/numbers.test.js
@@ -46,8 +46,8 @@ describe("roundPrecision", () => {
         expect(roundPrecision(1.0, 0.00000001)).toBe(1);
         expect(roundPrecision(0.5, 1)).toBe(1);
         expect(roundPrecision(-0.5, 1)).toBe(-1);
-        expect(roundPrecision(2.6745, 0.001)).toBe(2.6750000000000003);
-        expect(roundPrecision(-2.6745, 0.001)).toBe(-2.6750000000000003);
+        expect(roundPrecision(2.6745, 0.001)).toBe(2.675);
+        expect(roundPrecision(-2.6745, 0.001)).toBe(-2.675);
         expect(roundPrecision(2.6744, 0.001)).toBe(2.674);
         expect(roundPrecision(-2.6744, 0.001)).toBe(-2.674);
         expect(roundPrecision(0.0004, 0.001)).toBe(0);
@@ -56,7 +56,7 @@ describe("roundPrecision", () => {
         expect(roundPrecision(-357.4555, 0.001)).toBe(-357.456);
         expect(roundPrecision(457.4554, 0.001)).toBe(457.455);
         expect(roundPrecision(-457.4554, 0.001)).toBe(-457.455);
-        expect(roundPrecision(-457.4554, 0.05)).toBe(-457.45000000000005);
+        expect(roundPrecision(-457.4554, 0.05)).toBe(-457.45);
         expect(roundPrecision(457.444, 0.5)).toBe(457.5);
         expect(roundPrecision(457.3, 5)).toBe(455);
         expect(roundPrecision(457.5, 5)).toBe(460);
@@ -64,8 +64,8 @@ describe("roundPrecision", () => {
 
         expect(roundPrecision(2.6735, 0.001)).toBe(2.674);
         expect(roundPrecision(-2.6735, 0.001)).toBe(-2.674);
-        expect(roundPrecision(2.6745, 0.001)).toBe(2.6750000000000003);
-        expect(roundPrecision(-2.6745, 0.001)).toBe(-2.6750000000000003);
+        expect(roundPrecision(2.6745, 0.001)).toBe(2.675);
+        expect(roundPrecision(-2.6745, 0.001)).toBe(-2.675);
         expect(roundPrecision(2.6744, 0.001)).toBe(2.674);
         expect(roundPrecision(-2.6744, 0.001)).toBe(-2.674);
         expect(roundPrecision(0.0004, 0.001)).toBe(0);
@@ -80,9 +80,9 @@ describe("roundPrecision", () => {
         // We use 2.425 because when normalizing 2.425 with precision=0.001 it gives
         // us 2424.9999999999995 as value, and if not handle correctly the rounding DOWN
         // value will be incorrect (should be 2.425 and not 2.424)
-        expect(roundPrecision(2.425, 0.001, "DOWN")).toBe(2.4250000000000003);
+        expect(roundPrecision(2.425, 0.001, "DOWN")).toBe(2.425);
         expect(roundPrecision(2.4249, 0.001, "DOWN")).toBe(2.424);
-        expect(roundPrecision(-2.425, 0.001, "DOWN")).toBe(-2.4250000000000003);
+        expect(roundPrecision(-2.425, 0.001, "DOWN")).toBe(-2.425);
         expect(roundPrecision(-2.4249, 0.001, "DOWN")).toBe(-2.424);
         expect(roundPrecision(-2.5, 0.001, "DOWN")).toBe(-2.5);
         expect(roundPrecision(1.8, 1, "DOWN")).toBe(1);
@@ -107,8 +107,8 @@ describe("roundPrecision", () => {
     test("HALF-UP", () => {
         expect(roundPrecision(2.6735, 0.001, "HALF-UP")).toBe(2.674);
         expect(roundPrecision(-2.6735, 0.001, "HALF-UP")).toBe(-2.674);
-        expect(roundPrecision(2.6745, 0.001, "HALF-UP")).toBe(2.6750000000000003);
-        expect(roundPrecision(-2.6745, 0.001, "HALF-UP")).toBe(-2.6750000000000003);
+        expect(roundPrecision(2.6745, 0.001, "HALF-UP")).toBe(2.675);
+        expect(roundPrecision(-2.6745, 0.001, "HALF-UP")).toBe(-2.675);
         expect(roundPrecision(2.6744, 0.001, "HALF-UP")).toBe(2.674);
         expect(roundPrecision(-2.6744, 0.001, "HALF-UP")).toBe(-2.674);
         expect(roundPrecision(0.0004, 0.001, "HALF-UP")).toBe(0);
@@ -120,6 +120,10 @@ describe("roundPrecision", () => {
     });
 
     test("HALF-EVEN", () => {
+        expect(roundPrecision(5.015, 0.01, "HALF-EVEN")).toBe(5.02);
+        expect(roundPrecision(-5.015, 0.01, "HALF-EVEN")).toBe(-5.02);
+        expect(roundPrecision(5.025, 0.01, "HALF-EVEN")).toBe(5.02);
+        expect(roundPrecision(-5.025, 0.01, "HALF-EVEN")).toBe(-5.02);
         expect(roundPrecision(2.6735, 0.001, "HALF-EVEN")).toBe(2.674);
         expect(roundPrecision(-2.6735, 0.001, "HALF-EVEN")).toBe(-2.674);
         expect(roundPrecision(2.6745, 0.001, "HALF-EVEN")).toBe(2.674);
@@ -128,8 +132,8 @@ describe("roundPrecision", () => {
         expect(roundPrecision(-2.6744, 0.001, "HALF-EVEN")).toBe(-2.674);
         expect(roundPrecision(0.0004, 0.001, "HALF-EVEN")).toBe(0);
         expect(roundPrecision(-0.0004, 0.001, "HALF-EVEN")).toBe(-0);
-        expect(roundPrecision(357.4555, 0.001, "HALF-EVEN")).toBe(357.455);
-        expect(roundPrecision(-357.4555, 0.001, "HALF-EVEN")).toBe(-357.455);
+        expect(roundPrecision(357.4555, 0.001, "HALF-EVEN")).toBe(357.456);
+        expect(roundPrecision(-357.4555, 0.001, "HALF-EVEN")).toBe(-357.456);
         expect(roundPrecision(457.4554, 0.001, "HALF-EVEN")).toBe(457.455);
         expect(roundPrecision(-457.4554, 0.001, "HALF-EVEN")).toBe(-457.455);
     });
@@ -160,8 +164,8 @@ test("roundDecimals", () => {
     expect(roundDecimals(1.0, 8)).toBe(1);
     expect(roundDecimals(0.5, 0)).toBe(1);
     expect(roundDecimals(-0.5, 0)).toBe(-1);
-    expect(roundDecimals(2.6745, 3)).toBe(2.6750000000000003);
-    expect(roundDecimals(-2.6745, 3)).toBe(-2.6750000000000003);
+    expect(roundDecimals(2.6745, 3)).toBe(2.675);
+    expect(roundDecimals(-2.6745, 3)).toBe(-2.675);
     expect(roundDecimals(2.6744, 3)).toBe(2.674);
     expect(roundDecimals(-2.6744, 3)).toBe(-2.674);
     expect(roundDecimals(0.0004, 3)).toBe(0);


### PR DESCRIPTION
Steps
-----
```python
from odoo.tools import float_round
assert float_round(99.99, 2) == 99.99
assert float_round(357.4555, 3, rounding_method='HALF-EVEN') == 357.456
```

Issue
-----
`AssertionError`
`float_round(99.99, 2)` returns 99.99000000000001
`float_round(357.4555, 3, rounding_method='HALF-EVEN')` returns 357.455

Cause
-----
`float_round` loses precision denormalizing a value by multiplying it with a rounding factor close to 0.

Solution
--------
Invert rounding factors < 1, then normalize using multiplication instead of division and denormalize using division instead of multiplication.

Do the same for `round_precision` in web utils to have frontend calculations match backend calculations.

Other
-----
- Increase the epsilon value to make rounding more tolerant of errors which may accumulate after multiple floating point operations.
- Prevent `precision_rounding` values being passed accidentally as `precision_digits` parameters.
- Passing both `precision_rounding` & `precision_digits` was allowed if the latter was `0`.
- Short return `float_compare` when values are strictly equal, and `float_is_zero` when value is strictly equal to zero, to reduce the amount of calls to `float_round`.
- Factor out calls to `abs` & `math.floor`/`math.ceil`, replace them with `math.trunc` where possible to reduce #ops & simplify logic.
- Don't rely on `builtins.round` to accurately round floats half-evenly, instead use the epsilon value to check for tie-breaking condition.

Enterprise branch: https://github.com/odoo/enterprise/pull/60903