### PR TITLE
[IMP] web, *: allow to filter setting form view to focus on one setting

### DIFF
--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -26,7 +26,7 @@
                                 <div class="content-group" invisible="not hr_expense_use_mailgateway or alias_domain_id">
                                     <div class="mt16">
                                         <button type="action" name="base_setup.action_general_configuration"
-                                                icon="oi-arrow-right" string="Setup your alias domain" class="btn-link"/>
+                                                icon="oi-arrow-right" string="Setup your alias domain" class="btn-link" context="{'setting_default_alias_domain_id': 1}"/>
                                     </div>
                                 </div>
                             </setting>

--- a/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
+++ b/addons/web/static/src/webclient/settings_form_view/settings_form_controller.js
@@ -17,14 +17,25 @@ export class SettingsFormController extends formView.Controller {
     setup() {
         super.setup();
         useAutofocus();
-        this.state = useState({ displayNoContent: false });
         // Deprecated warning: a new way to point to sections or items will be
         // developed so that putting a default search value won't be necessary
-        if ("default_search_setting" in this.props.context){
-            this.searchState = useState({value: this.props.context.default_search_setting});
+        let searchStateValue = "";
+        if ("default_search_setting" in this.props.context) {
+            searchStateValue = this.props.context.default_search_setting;
         } else {
-            this.searchState = useState({value: ""});
+            for (const [key, value] of Object.entries(this.props.context || {})) {
+                if (key.startsWith("setting_default_") && value) {
+                    const fieldName = key.replace("setting_default_", "");
+                    delete this.props.context[key];
+                    if (fieldName in this.props.fields) {
+                        searchStateValue = this.props.fields[fieldName].string;
+                        break;
+                    }
+                }
+            }
         }
+        this.state = useState({ displayNoContent: false });
+        this.searchState = useState({ value: searchStateValue });
         this.rootRef = useRef("root");
         this.canCreate = false;
         useSubEnv({ searchState: this.searchState });

--- a/addons/web/static/tests/legacy/webclient/settings_form_view/settings_form_view_tests.js
+++ b/addons/web/static/tests/legacy/webclient/settings_form_view/settings_form_view_tests.js
@@ -1982,4 +1982,70 @@ QUnit.module("SettingsFormView", (hooks) => {
         await click(target.querySelector("button[name='2']"));
         assert.verifySteps(["/web/action/run"]);
     });
+
+    QUnit.test("apply default setting to filter by default the settings view", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "res.config.settings",
+            serverData,
+            arch: `
+                <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
+                    <app string="CRM" name="crm">
+                        <block title="Title of group Bar">
+                            <setting help="this is bar" documentation="/applications/technical/web/settings/this_is_a_test.html">
+                                <field name="bar"/>
+                            </setting>
+                            <setting>
+                                <label string="Big BAZ" for="baz"/>
+                                <div class="text-muted">this is a baz</div>
+                                <field name="baz"/>
+                                <label>label with content</label>
+                            </setting>
+                        </block>
+                    </app>
+                </form>`,
+            context: { setting_default_bar: true },
+        });
+        assert.strictEqual(
+            target.querySelector(".o_searchview input").value,
+            "Bar",
+            "input value should get the label of the Bar field"
+        );
+        assert.strictEqual(
+            target.querySelector(".highlighter").textContent,
+            "Bar",
+            "The label of the field found should be highlighted"
+        );
+    });
+
+    QUnit.test("don't apply default search value if no field is found with default setting set in the context", async (assert) => {
+        await makeView({
+            type: "form",
+            resModel: "res.config.settings",
+            serverData,
+            arch: `
+                <form string="Settings" class="oe_form_configuration o_base_settings" js_class="base_settings">
+                    <app string="CRM" name="crm">
+                        <block title="Title of group Bar">
+                            <setting help="this is bar" documentation="/applications/technical/web/settings/this_is_a_test.html">
+                                <field name="bar"/>
+                            </setting>
+                            <setting>
+                                <label string="Big BAZ" for="baz"/>
+                                <div class="text-muted">this is a baz</div>
+                                <field name="baz"/>
+                                <label>label with content</label>
+                            </setting>
+                        </block>
+                    </app>
+                </form>`,
+            context: { setting_default_test: true },
+        });
+        assert.strictEqual(
+            target.querySelector(".o_searchview input").value,
+            "",
+            "input value should get the label of the Bar field"
+        );
+        assert.containsNone(target, ".app_settings_block:not(.d-none) .app_settings_header");
+    });
 });


### PR DESCRIPTION
Before this commit, when the alias domain has to be set to set another setting, a button redirects the user to the General Settings but it could have many settings in the view and so the user cannot directly know which setting he has to set.

This commit allows to redirect the user to one specific setting by using a context defined in the button. That is, the setting form view will check in the context if there is a key starting with `setting_default_`, if yes, then the right part of `setting_default_` should be the field name. If a field name is found in the model of the view then the label of that field is added in the search bar to highlight the right setting and filter the setting form view to only get that setting by default.

task-3614449
