### PR TITLE
[IMP] project: added percentage indication on every stat button relat…

### DIFF
--- a/addons/project/tests/test_project_subtasks.py
+++ b/addons/project/tests/test_project_subtasks.py
@@ -9,6 +9,7 @@ from odoo.tests import Form, tagged
 from odoo.tools import mute_logger
 from odoo.exceptions import ValidationError
 
+
 @tagged('-at_install', 'post_install')
 class TestProjectSubtasks(TestProjectCommon):
 

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -41,8 +41,14 @@
                     </header>
                 <sheet string="Project">
                     <div class="oe_button_box" name="button_box" groups="base.group_user">
-                        <button class="oe_stat_button" type="object" name="action_view_tasks" icon="fa-tasks">
-                            <field string="Tasks" name="open_task_count" widget="statinfo"/>
+                        <button class="oe_stat_button" type="object" name="action_view_tasks" icon="fa-check">
+                            <div class="o_field_widget o_stat_info">
+                                <span class="o_stat_text">Tasks</span>
+                                <span class="o_stat_value">
+                                    <field name="closed_task_count"/> / <field name="task_count"/>
+                                    (<field name="task_completion_percentage" widget="percentage" options="{'digits': [1, 0]}"/>)
+                                </span>
+                            </div>
                         </button>
                         <button class="oe_stat_button" name="project_update_all_action" type="object" groups="project.group_project_user">
                             <field name="last_update_color" invisible="1"/>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -151,12 +151,13 @@
                                 class="oe_stat_button" icon="fa-repeat" context="{'default_user_ids': [(6, 0, [uid])]}">
                             <field name="recurring_count" widget="statinfo" string="Recurring Tasks"/>
                         </button>
-                        <button name="action_project_sharing_open_subtasks" type="object" class="oe_stat_button" icon="fa-tasks"
+                        <button name="action_project_sharing_open_subtasks" type="object" class="oe_stat_button" icon="fa-check"
                             invisible="not id or subtask_count == 0" context="{
                                 'default_user_ids': [(6, 0, [uid])],
                                 'default_project_id': project_id,
                                 'default_display_in_project': False,
-                            }">
+                            }"
+                        >
                             <field name="subtask_count" widget="statinfo" string="Sub-tasks"/>
                             <field name="display_in_project" invisible="True"/>
                         </button>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -346,7 +346,7 @@
                         </button>
                         <!-- Dummy tag used to organize buttons -->
                         <span id="end_rating_buttons" invisible="1"/>
-                        <button name="action_open_parent_task" type="object" class="oe_stat_button" icon="fa-tasks" invisible="not parent_id">
+                        <button name="action_open_parent_task" type="object" class="oe_stat_button" icon="fa-check" invisible="not parent_id">
                             <div class="o_stat_info">
                                 <span class="o_stat_text">Parent Task</span>
                             </div>
@@ -354,30 +354,25 @@
                         <button name="action_recurring_tasks" type="object" invisible="not active or not recurrence_id" class="oe_stat_button" icon="fa-repeat" groups="project.group_project_recurring_tasks">
                             <field name="recurring_count" widget="statinfo" string="Recurring Tasks"/>
                         </button>
-                        <button name="%(project_task_action_sub_task)d" type="action" class="oe_stat_button" icon="fa-tasks"
-                            invisible="not id or subtask_count == 0" context="{
+                        <button name="%(project_task_action_sub_task)d" type="action" class="oe_stat_button" icon="fa-check"
+                            invisible="not id or subtask_count == 0"
+                            context="{
                                 'default_project_id': project_id,
                                 'default_display_in_project': False,
                                 'default_user_ids': user_ids,
                                 'default_milestone_id': milestone_id,
                                 'subtask_action': True,
-                            }">
+                            }"
+                        >
                             <div class="o_field_widget o_stat_info">
-                                <div class="d-flex align-items-baseline gap-1">
-                                    <span class="o_stat_value order-1">
-                                        <field name="subtask_count" widget="statinfo" nolabel="1"/>
-                                    </span>
-                                    <span class="o_stat_text order-2">Sub-tasks</span>
-                                </div>
-                                <div class="d-flex align-items-baseline gap-1">
-                                    <span class="o_stat_value">
-                                        <field name="closed_subtask_count" widget="statinfo" nolabel="1"/>
-                                    </span>
-                                    <span class="o_stat_text order-2">Closed</span>
-                                </div>
+                                <span class="o_stat_text">Sub-tasks</span>
+                                <span class="o_stat_value">
+                                    <field name="closed_subtask_count"/> / <field name="subtask_count"/>
+                                    (<field name="subtask_completion_percentage" widget="percentage" options="{'digits': [1, 0]}"/>)
+                                </span>
                             </div>
                         </button>
-                        <button name="action_dependent_tasks" type="object" invisible="dependent_tasks_count == 0" class="oe_stat_button" icon="fa-tasks" groups="project.group_project_task_dependencies">
+                        <button name="action_dependent_tasks" type="object" invisible="dependent_tasks_count == 0" class="oe_stat_button" icon="fa-check" groups="project.group_project_task_dependencies">
                             <field name="dependent_tasks_count" widget="statinfo" string="Blocking Tasks" />
                         </button>
                         <!-- Dummy tag used to organize buttons -->

--- a/addons/sale_project/views/sale_order_views.xml
+++ b/addons/sale_project/views/sale_order_views.xml
@@ -19,8 +19,14 @@
                 <button class="oe_stat_button" name="action_view_milestone" type="object" icon="fa-check-square-o" invisible="not is_product_milestone or not project_ids or state == 'draft'" groups="project.group_project_milestone">
                     <field name="milestone_count" widget="statinfo" string="Milestones"/>
                 </button>
-                <button type="object" name="action_view_task" class="oe_stat_button" icon="fa-tasks" invisible="not show_task_button" groups="project.group_project_user">
-                    <field name="tasks_count" widget="statinfo" string="Tasks"/>
+                <button type="object" name="action_view_task" class="oe_stat_button" icon="fa-check" invisible="not show_task_button" groups="project.group_project_user">
+                    <div class="o_field_widget o_stat_info">
+                        <span class="o_stat_text">Tasks</span>
+                        <span class="o_stat_value">
+                            <field name="closed_task_count"/> / <field name="tasks_count"/>
+                            (<field name="completed_task_percentage" widget="percentage" options="{'digits': [1, 0]}"/>)
+                        </span>
+                    </div>
                 </button>
             </xpath>
         </field>


### PR DESCRIPTION
…ed of tasks 

- In this commit all the stat icons related to tasks that were change from fa-tasks to  fa-check
- Every stat button is added with a percentage with the reading format of closed task / total tasks(completion percentage)

task-3691772

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
