### PR TITLE
[FIX] purchase: do not send due date on confirmed RFQs mail

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -394,7 +394,7 @@ class PurchaseOrder(models.Model):
         )
         subtitles = [render_context['record'].name]
         # don't show price on RFQ mail
-        if self.state not in ['draft', 'sent']:
+        if self.state not in ['draft', 'sent', 'purchase']:
             if self.date_order:
                 subtitles.append(_('%(amount)s due\N{NO-BREAK SPACE}%(date)s',
                                    amount=format_amount(self.env, self.amount_total, self.currency_id, lang_code=render_context.get('lang')),


### PR DESCRIPTION
- Create and confirm an RFQ with deadline set
- Send confirmation email to the partner

Bug:
deadline is shwon in subtitles eventhough PO is confirmed and is no longer an RFQ that is due.

Fix:
only display deadline for the applicable states

opw-3664112
