### PR TITLE
15.0-fix-fleet-negative-distances-odometer-mafl

### DIFF
--- a/addons/fleet/data/fleet_demo.xml
+++ b/addons/fleet/data/fleet_demo.xml
@@ -597,7 +597,7 @@
 
       <record id="log_odometer_15" model="fleet.vehicle.odometer">
           <field name="vehicle_id" ref="vehicle_2" />
-          <field name="date" eval="(DateTime.now() - timedelta(days=233)).strftime('%Y-%m-%d')" />
+          <field name="date" eval="(DateTime.now() - timedelta(days=255)).strftime('%Y-%m-%d')" />
           <field name="value">0</field>
       </record>
 

--- a/addons/fleet/models/fleet_vehicle_odometer.py
+++ b/addons/fleet/models/fleet_vehicle_odometer.py
@@ -1,7 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class FleetVehicleOdometer(models.Model):
@@ -30,3 +31,42 @@ class FleetVehicleOdometer(models.Model):
     def _onchange_vehicle(self):
         if self.vehicle_id:
             self.unit = self.vehicle_id.odometer_unit
+
+    def _check_odometer(self):
+        vehicle_ids = list(set(self.vehicle_id.ids))
+        odometers_to_check = self.search([('vehicle_id', 'in', vehicle_ids)], order='date')
+
+        grouped_odometers = {}
+        for odometer in odometers_to_check:
+            if not grouped_odometers.get(odometer.vehicle_id.id):
+                grouped_odometers[odometer.vehicle_id.id] = odometer
+            else:
+                grouped_odometers[odometer.vehicle_id.id] |= odometer
+
+        for odometer in self:
+            this_vehicle_odometers = grouped_odometers.get(odometer.vehicle_id.id, self.env['fleet.vehicle.odometer'])
+            for odometer_to_check in this_vehicle_odometers:
+                if odometer.date < odometer_to_check.date:
+                    if odometer.value > odometer_to_check.value:
+                        raise UserError(_('You cannot set an odometer value higher than one from the future.'))
+                elif odometer.date == odometer_to_check.date:
+                    if odometer.id > odometer_to_check.id:
+                        if odometer.value < odometer_to_check.value:
+                            raise UserError(_('You cannot set an odometer value lower than one from a previous record.'))
+                    elif odometer.id < odometer_to_check.id:
+                        if odometer.value > odometer_to_check.value:
+                            raise UserError(_('You cannot set an odometer value higher than one from a future record.'))
+                else:
+                    if odometer.value < odometer_to_check.value:
+                        raise UserError(_('You cannot set an odometer value lower than one from the past.'))
+
+    @api.model
+    def create(self, vals):
+        new_odometers = super().create(vals)
+        new_odometers._check_odometer()
+        return new_odometers
+
+    def write(self, vals):
+        res = super().write(vals)
+        self._check_odometer()
+        return res


### PR DESCRIPTION
Steps to reproduce the bug:
- Install the fleet module
- Create a vehicle
- Create an odometer record with any strictly
    positive distance
- Create a second odometer record with a
    smaller distance than the first one
- The second record will be accepted, but the
    distance will be negative which is not
    possible

Expected behavior:
- The second record should not be accepted

fix:
    add a check with other records to ensure
    that the distance is possible on the
    vehicle when creating an odometer record
    or updating a record.

task-3722420

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
