### PR TITLE
[IMP] base, mail, tests: set no_reset_password=true by default in tests

### DIFF
--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -49,7 +49,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
         })
 
         # test users + fetch admin user for testing (recipient, ...)
-        cls.user_account = cls.env['res.users'].with_context(cls._test_context).create({
+        cls.user_account = cls.env['res.users'].with_context(**cls._test_context).create({
             'company_id': cls.company_main.id,
             'company_ids': [
                 (6, 0, (cls.company_data['company'] + cls.company_data_2['company']).ids)
@@ -67,7 +67,7 @@ class TestAccountComposerPerformance(AccountTestInvoicingCommon, MailCommon):
             'notification_type': 'inbox',
             'signature': '--\nErnest',
         })
-        cls.user_account_other = cls.env['res.users'].with_context(cls._test_context).create({
+        cls.user_account_other = cls.env['res.users'].with_context(**cls._test_context).create({
             'company_id': cls.company_admin.id,
             'company_ids': [(4, cls.company_admin.id)],
             'country_id': cls.env.ref('base.be').id,

--- a/addons/auth_signup/tests/test_reset_password.py
+++ b/addons/auth_signup/tests/test_reset_password.py
@@ -15,7 +15,7 @@ class TestResetPassword(HttpCase):
         cls.test_user = cls.env['res.users'].create({
             'login': 'test',
             'name': 'The King',
-            'email': 'noop@example.com',
+            'email': 'reset-password@example.com',
         })
 
     def test_reset_password(self):

--- a/addons/calendar/tests/test_mail_activity_mixin.py
+++ b/addons/calendar/tests/test_mail_activity_mixin.py
@@ -18,7 +18,7 @@ class TestMailActivityMixin(MailCommon):
     def setUpClass(cls):
         super(TestMailActivityMixin, cls).setUpClass()
         # using res.partner as the model inheriting from mail.activity.mixin
-        cls.test_record = cls.env['res.partner'].with_context(cls._test_context).create({'name': 'Test'})
+        cls.test_record = cls.env['res.partner'].with_context(**cls._test_context).create({'name': 'Test'})
         cls.activity_type_1 = cls.env['mail.activity.type'].create({
             'name': 'Calendar Activity Test Default',
             'summary': 'default activity',

--- a/addons/gamification/tests/test_challenge.py
+++ b/addons/gamification/tests/test_challenge.py
@@ -17,7 +17,7 @@ class TestGamificationCommon(TransactionCaseGamification):
 
         # Push demo user into the challenge before creating a new one
         self.env.ref('gamification.challenge_base_discover')._update_all()
-        self.robot = self.env['res.users'].with_context(no_reset_password=True).create({
+        self.robot = self.env['res.users'].create({
             'name': 'R2D2',
             'login': 'r2d2@openerp.com',
             'email': 'r2d2@openerp.com',

--- a/addons/hr_recruitment/tests/test_recruitment_process.py
+++ b/addons/hr_recruitment/tests/test_recruitment_process.py
@@ -65,7 +65,7 @@ class TestRecruitmentProcess(TestHrCommon):
         new_application_mt = self.env.ref(
             "hr_recruitment.mt_applicant_new"
         )
-        user = self.env["res.users"].with_context(no_reset_password=True).create(
+        user = self.env["res.users"].create(
             {
                 "name": "user_1",
                 "login": "user_1",

--- a/addons/mail/tests/common.py
+++ b/addons/mail/tests/common.py
@@ -27,8 +27,7 @@ from odoo.tools.translate import code_translations
 
 mail_new_test_user = partial(new_test_user, context={'mail_create_nolog': True,
                                                      'mail_create_nosubscribe': True,
-                                                     'mail_notrack': True,
-                                                     'no_reset_password': True})
+                                                     'mail_notrack': True})
 
 
 class MockEmail(common.BaseCase, MockSmtplibCase):
@@ -765,7 +764,6 @@ class MailCase(MockEmail):
         'mail_create_nolog': True,
         'mail_create_nosubscribe': True,
         'mail_notrack': True,
-        'no_reset_password': True,
     }
 
     def setUp(self):

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -20,8 +20,8 @@ class TestChannelInternals(MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.test_channel = cls.env['discuss.channel'].with_context(cls._test_context).channel_create(name='Channel', group_id=None)
-        cls.test_partner = cls.env['res.partner'].with_context(cls._test_context).create({
+        cls.test_channel = cls.env['discuss.channel'].with_context(**cls._test_context).channel_create(name='Channel', group_id=None)
+        cls.test_partner = cls.env['res.partner'].with_context(**cls._test_context).create({
             'name': 'Test Partner',
             'email': 'test_customer@example.com',
         })
@@ -216,15 +216,15 @@ class TestChannelInternals(MailCommon):
             "name": "Jonas",
         })
         test_partner = test_user.partner_id
-        group_restricted_channel = self.env['discuss.channel'].with_context(self._test_context).create({
+        group_restricted_channel = self.env['discuss.channel'].with_context(**self._test_context).create({
             'name': 'Sic Mundus',
             'group_public_id': self.env.ref('base.group_user').id,
             'channel_partner_ids': [Command.link(self.user_employee.partner_id.id), Command.link(test_partner.id)],
         })
-        self.test_channel.with_context(self._test_context).write({
+        self.test_channel.with_context(**self._test_context).write({
             'channel_partner_ids': [Command.link(self.user_employee.partner_id.id), Command.link(test_partner.id)],
         })
-        private_group = self.env['discuss.channel'].with_user(self.user_employee).with_context(self._test_context).create({
+        private_group = self.env['discuss.channel'].with_user(self.user_employee).with_context(**self._test_context).create({
             'name': 'test',
             'channel_type': 'group',
             'channel_partner_ids': [Command.link(self.user_employee.partner_id.id), Command.link(test_partner.id)],

--- a/addons/mail/tests/test_mail_composer.py
+++ b/addons/mail/tests/test_mail_composer.py
@@ -15,7 +15,7 @@ class TestMailComposer(MailCommon):
         super(TestMailComposer, cls).setUpClass()
         cls.env['ir.config_parameter'].set_param('mail.restrict.template.rendering', True)
         cls.user_employee.groups_id -= cls.env.ref('mail.group_mail_template_editor')
-        cls.test_record = cls.env['res.partner'].with_context(cls._test_context).create({
+        cls.test_record = cls.env['res.partner'].with_context(**cls._test_context).create({
             'name': 'Test',
         })
         cls.body_html = """<div>

--- a/addons/mass_mailing/tests/common.py
+++ b/addons/mass_mailing/tests/common.py
@@ -304,7 +304,7 @@ class MassMailCase(MailCase, MockLinkTracker):
     def _create_mailing_list(cls):
         """ Shortcut to create mailing lists. Currently hardcoded, maybe evolve
         in a near future. """
-        cls.mailing_list_1, cls.mailing_list_2, cls.mailing_list_3, cls.mailing_list_4 = cls.env['mailing.list'].with_context(cls._test_context).create([
+        cls.mailing_list_1, cls.mailing_list_2, cls.mailing_list_3, cls.mailing_list_4 = cls.env['mailing.list'].with_context(**cls._test_context).create([
             {
                 'contact_ids': [
                     (0, 0, {'name': 'Déboulonneur', 'email': 'fleurus@example.com'}),
@@ -338,7 +338,7 @@ class MassMailCase(MailCase, MockLinkTracker):
     def _create_mailing_list_of_x_contacts(cls, contacts_nbr):
         """ Shortcut to create a mailing list that contains a defined number
         of contacts. """
-        return cls.env['mailing.list'].with_context(cls._test_context).create({
+        return cls.env['mailing.list'].with_context(**cls._test_context).create({
             'name': 'Test List',
             'contact_ids': [
                 (0, 0, {

--- a/addons/mass_mailing/tests/test_mailing_list.py
+++ b/addons/mass_mailing/tests/test_mailing_list.py
@@ -65,7 +65,7 @@ class TestMailingListMerge(MassMailCommon):
         super(TestMailingListMerge, cls).setUpClass()
         cls._create_mailing_list()
 
-        cls.mailing_list_3 = cls.env['mailing.list'].with_context(cls._test_context).create({
+        cls.mailing_list_3 = cls.env['mailing.list'].with_context(**cls._test_context).create({
             'name': 'ListC',
             'contact_ids': [
                 (0, 0, {'name': 'Norberto', 'email': 'norbert@example.com'}),

--- a/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
+++ b/addons/mrp_landed_costs/tests/test_stock_landed_costs_mrp.py
@@ -72,7 +72,7 @@ class TestStockLandedCostsMrp(ValuationReconciliationTestCommon):
             'name': 'Landed Cost',
             'type': 'service',
         })
-        cls.allow_user = cls.env['res.users'].with_context({'no_reset_password': True}).create({
+        cls.allow_user = cls.env['res.users'].create({
             'name': "Adviser",
             'login': "fm",
             'email': "accountmanager@yourcompany.com",
@@ -142,7 +142,7 @@ class TestStockLandedCostsMrp(ValuationReconciliationTestCommon):
             to a Manufacturing order without the need for MRP access
         """
         # Create a user with only manager access to stock
-        stock_manager = self.env['res.users'].with_context({'no_reset_password': True}).create({
+        stock_manager = self.env['res.users'].create({
             'name': "Stock Manager",
             'login': "test",
             'email': "test@test.com",

--- a/addons/mrp_subcontracting/tests/test_subcontracting_portal_ui.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting_portal_ui.py
@@ -11,7 +11,7 @@ class TestSubcontractingPortalUi(HttpCase):
     def setUpClass(cls):
         super().setUpClass()
         # 1. Create portal user
-        user = cls.env['res.users'].with_context({'mail_create_nolog': True}).create({
+        user = cls.env['res.users'].with_context(mail_create_nolog=True).create({
             'name': 'Georges',
             'login': 'georges1',
             'password': 'georges1',

--- a/addons/mrp_subcontracting/tests/test_subcontracting_portal_ui.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting_portal_ui.py
@@ -11,7 +11,7 @@ class TestSubcontractingPortalUi(HttpCase):
     def setUpClass(cls):
         super().setUpClass()
         # 1. Create portal user
-        user = cls.env['res.users'].with_context({'no_reset_password': True, 'mail_create_nolog': True}).create({
+        user = cls.env['res.users'].with_context({'mail_create_nolog': True}).create({
             'name': 'Georges',
             'login': 'georges1',
             'password': 'georges1',

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -209,7 +209,7 @@ class PortalWizardUser(models.TransientModel):
         """ create a new user for wizard_user.partner_id
             :returns record of res.users
         """
-        return self.env['res.users'].with_context(no_reset_password=True)._create_user_from_template({
+        return self.env['res.users']._create_user_from_template({
             'email': email_normalize(self.email),
             'login': email_normalize(self.email),
             'partner_id': self.partner_id.id,

--- a/addons/project/models/res_partner.py
+++ b/addons/project/models/res_partner.py
@@ -52,7 +52,7 @@ class ResPartner(models.Model):
             return self.env['res.users']
         created_users = self.env['res.users']
         for partner in partners_without_user:
-            created_users += self.env['res.users'].with_context(no_reset_password=True).sudo()._create_user_from_template({
+            created_users += self.env['res.users'].sudo()._create_user_from_template({
                 'email': email_normalize(partner.email),
                 'login': email_normalize(partner.email),
                 'partner_id': partner.id,

--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -236,7 +236,7 @@ class TestProjectPortalCommon(TestProjectCommon):
 
     def setUp(self):
         super(TestProjectPortalCommon, self).setUp()
-        self.user_noone = self.env['res.users'].with_context({'no_reset_password': True, 'mail_create_nosubscribe': True}).create({
+        self.user_noone = self.env['res.users'].with_context({'mail_create_nosubscribe': True}).create({
             'name': 'Noemie NoOne',
             'login': 'noemie',
             'email': 'n.n@example.com',

--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -236,7 +236,7 @@ class TestProjectPortalCommon(TestProjectCommon):
 
     def setUp(self):
         super(TestProjectPortalCommon, self).setUp()
-        self.user_noone = self.env['res.users'].with_context({'mail_create_nosubscribe': True}).create({
+        self.user_noone = self.env['res.users'].with_context(mail_create_nosubscribe=True).create({
             'name': 'Noemie NoOne',
             'login': 'noemie',
             'email': 'n.n@example.com',

--- a/addons/project/tests/test_multicompany.py
+++ b/addons/project/tests/test_multicompany.py
@@ -34,7 +34,7 @@ class TestMultiCompanyCommon(TransactionCase):
 
         # users to use through the various tests
         user_group_employee = cls.env.ref('base.group_user')
-        Users = cls.env['res.users'].with_context({'no_reset_password': True})
+        Users = cls.env['res.users']
 
         cls.user_employee_company_a = Users.create({
             'name': 'Employee Company A',

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -31,7 +31,7 @@ class TestProjectCommon(TransactionCase):
             'email': 'valid.poilboeuf@gmail.com'})
 
         # Test users to use through the various tests
-        Users = cls.env['res.users'].with_context({'no_reset_password': True})
+        Users = cls.env['res.users']
         cls.user_public = Users.create({
             'name': 'Bert Tartignole',
             'login': 'bert',

--- a/addons/project/tests/test_project_sharing_ui.py
+++ b/addons/project/tests/test_project_sharing_ui.py
@@ -10,7 +10,7 @@ class TestProjectSharingUi(HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        user = cls.env['res.users'].with_context({'no_reset_password': True, 'mail_create_nolog': True}).create({
+        user = cls.env['res.users'].with_context({'mail_create_nolog': True}).create({
             'name': 'Georges',
             'login': 'georges1',
             'password': 'georges1',

--- a/addons/project/tests/test_project_sharing_ui.py
+++ b/addons/project/tests/test_project_sharing_ui.py
@@ -10,7 +10,7 @@ class TestProjectSharingUi(HttpCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        user = cls.env['res.users'].with_context({'mail_create_nolog': True}).create({
+        user = cls.env['res.users'].with_context(mail_create_nolog=True).create({
             'name': 'Georges',
             'login': 'georges1',
             'password': 'georges1',

--- a/addons/project/tests/test_project_stage_multicompany.py
+++ b/addons/project/tests/test_project_stage_multicompany.py
@@ -8,9 +8,7 @@ class TestProjectStagesMulticompany(TestMultiCompanyProject):
     @classmethod
     def setUpClass(cls):
         super(TestProjectStagesMulticompany, cls).setUpClass()
-
-        Users = cls.env['res.users'].with_context({'no_reset_password': True})
-        cls.user_manager_companies = Users.create({
+        cls.user_manager_companies = cls.env['res.users'].create({
             'name': 'Manager Companies',
             'login': 'manager-all',
             'email': 'manager@companies.com',

--- a/addons/project/tests/test_project_task_quick_create.py
+++ b/addons/project/tests/test_project_task_quick_create.py
@@ -9,7 +9,7 @@ class TestProjectTaskQuickCreate(TestProjectCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.user1, cls.user2 = cls.env['res.users'].with_context({'no_reset_password': True}).create([{
+        cls.user1, cls.user2 = cls.env['res.users'].create([{
             'name': 'Raouf 1',
             'login': 'raouf1',
             'password': 'raouf1aa',

--- a/addons/purchase/tests/test_access_rights.py
+++ b/addons/purchase/tests/test_access_rights.py
@@ -17,9 +17,7 @@ class TestPurchaseInvoice(AccountTestInvoicingCommon):
         group_employee = cls.env.ref('base.group_user')
         group_partner_manager = cls.env.ref('base.group_partner_manager')
 
-        cls.purchase_user = cls.env['res.users'].with_context(
-            no_reset_password=True
-        ).create({
+        cls.purchase_user = cls.env['res.users'].create({
             'name': 'Purchase user',
             'login': 'purchaseUser',
             'email': 'pu@odoo.com',

--- a/addons/purchase_requisition/tests/common.py
+++ b/addons/purchase_requisition/tests/common.py
@@ -14,7 +14,7 @@ class TestPurchaseRequisitionCommon(common.TransactionCase):
         user_group_purchase_user = cls.env.ref('purchase.group_purchase_user')
 
         # User Data: purchase requisition Manager and User
-        Users = cls.env['res.users'].with_context({'tracking_disable': True})
+        Users = cls.env['res.users'].with_context(tracking_disable=True)
 
         cls.user_purchase_requisition_manager = Users.create({
             'name': 'Purchase requisition Manager',

--- a/addons/sale/tests/common.py
+++ b/addons/sale/tests/common.py
@@ -52,7 +52,7 @@ class TestSaleCommonBase(TransactionCase):
 
     @classmethod
     def setup_sale_configuration_for_company(cls, company):
-        Users = cls.env['res.users'].with_context(no_reset_password=True)
+        Users = cls.env['res.users']
 
         company_data = {
             # Sales Team

--- a/addons/sale_purchase/tests/test_access_rights.py
+++ b/addons/sale_purchase/tests/test_access_rights.py
@@ -16,13 +16,13 @@ class TestAccessRights(TestCommonSalePurchaseNoChart):
         # Create a users
         group_sale_user = cls.env.ref('sales_team.group_sale_salesman')
         group_purchase_user = cls.env.ref('purchase.group_purchase_user')
-        cls.user_salesperson = cls.env['res.users'].with_context(no_reset_password=True).create({
+        cls.user_salesperson = cls.env['res.users'].create({
             'name': 'Le Grand Jojo User',
             'login': 'grand.jojo',
             'email': 'grand.jojo@chansonbelge.com',
             'groups_id': [(6, 0, [group_sale_user.id])]
         })
-        cls.user_purchaseperson = cls.env['res.users'].with_context(no_reset_password=True).create({
+        cls.user_purchaseperson = cls.env['res.users'].create({
             'name': 'Jean-Luc Fonck',
             'login': 'jl.fonck',
             'email': 'jl.fonck@chansonbelge.com',

--- a/addons/sale_purchase_stock/tests/test_access_rights.py
+++ b/addons/sale_purchase_stock/tests/test_access_rights.py
@@ -14,7 +14,7 @@ class TestAccessRights(TestCommonSalePurchaseNoChart):
 
         group_sale_user = cls.env.ref('sales_team.group_sale_salesman')
 
-        cls.user_salesperson = cls.env['res.users'].with_context(no_reset_password=True).create({
+        cls.user_salesperson = cls.env['res.users'].create({
             'name': 'Le Grand Jojo User',
             'login': 'grand.jojo',
             'email': 'grand.jojo@chansonbelge.com',

--- a/addons/sale_purchase_stock/tests/test_lead_time.py
+++ b/addons/sale_purchase_stock/tests/test_lead_time.py
@@ -19,7 +19,7 @@ class TestLeadTime(TestCommonSalePurchaseNoChart):
         cls.mto_route = cls.env.ref('stock.route_warehouse0_mto')
         cls.mto_route.active = True
         cls.vendor = cls.env['res.partner'].create({'name': 'The Emperor'})
-        cls.user_salesperson = cls.env['res.users'].with_context(no_reset_password=True).create({
+        cls.user_salesperson = cls.env['res.users'].create({
             'name': 'Le Grand Horus',
             'login': 'grand.horus',
             'email': 'grand.horus@chansonbelge.dz',

--- a/addons/test_mail/tests/common.py
+++ b/addons/test_mail/tests/common.py
@@ -13,7 +13,6 @@ class TestRecipients(TransactionCase):
             'mail_create_nolog': True,
             'mail_create_nosubscribe': True,
             'mail_notrack': True,
-            'no_reset_password': True,
         })
         cls.partner_1 = Partner.create({
             'name': 'Valid Lelitre',

--- a/addons/test_mail/tests/test_invite.py
+++ b/addons/test_mail/tests/test_invite.py
@@ -11,8 +11,8 @@ class TestInvite(MailCommon):
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_invite_email(self):
-        test_record = self.env['mail.test.simple'].with_context(self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
-        test_partner = self.env['res.partner'].with_context(self._test_context).create({
+        test_record = self.env['mail.test.simple'].with_context(**self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        test_partner = self.env['res.partner'].with_context(**self._test_context).create({
             'name': 'Valid Lelitre',
             'email': 'valid.lelitre@agrolait.com'})
 

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -23,7 +23,7 @@ class TestActivityCommon(MailCommon):
     @classmethod
     def setUpClass(cls):
         super(TestActivityCommon, cls).setUpClass()
-        cls.test_record, cls.test_record_2 = cls.env['mail.test.activity'].with_context(cls._test_context).create([
+        cls.test_record, cls.test_record_2 = cls.env['mail.test.activity'].with_context(**cls._test_context).create([
             {'name': 'Test'}, {'name': 'Test_2'},
         ])
         # reset ctx
@@ -730,7 +730,7 @@ class TestActivityMixin(TestActivityCommon):
             'user_id': self.user_employee.id,
         })
 
-        test_record_1 = self.env['mail.test.activity'].with_context(self._test_context).create({'name': 'Test 1'})
+        test_record_1 = self.env['mail.test.activity'].with_context(**self._test_context).create({'name': 'Test 1'})
         Activity.create({
             'activity_type_id': self.env.ref('test_mail.mail_act_test_todo').id,
             'date_deadline': date_today,

--- a/addons/test_mail/tests/test_mail_composer.py
+++ b/addons/test_mail/tests/test_mail_composer.py
@@ -55,7 +55,7 @@ class TestMailComposer(MailCommon, TestRecipients):
         cls.env.ref('mail.group_mail_template_editor').users -= cls.user_rendering_restricted
 
         with cls.mock_datetime_and_now(cls, cls.reference_now):
-            cls.test_record = cls.env['mail.test.ticket.mc'].with_context(cls._test_context).create({
+            cls.test_record = cls.env['mail.test.ticket.mc'].with_context(**cls._test_context).create({
                 'name': 'TestRecord',
                 'customer_id': cls.partner_1.id,
                 'user_id': cls.user_employee_2.id,

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -535,7 +535,7 @@ class RecipientsNotificationTest(MailCommon):
             'name': 'Common Partner',
             'phone': '+32455998877',
         })
-        cls.user_1, cls.user_2 = cls.env['res.users'].with_context(no_reset_password=True).create([
+        cls.user_1, cls.user_2 = cls.env['res.users'].create([
             {'groups_id': [(4, cls.env.ref('base.group_portal').id)],
              'login': '_login_portal',
              'notification_type': 'email',
@@ -643,7 +643,7 @@ class RecipientsNotificationTest(MailCommon):
             'phone': '+32455998877',
         })
         cids = (company_other + self.company_admin).ids
-        user_2_1, user_2_2, user_2_3 = self.env['res.users'].sudo().with_context(no_reset_password=True).create([
+        user_2_1, user_2_2, user_2_3 = self.env['res.users'].sudo().create([
             {'company_ids': [(6, 0, cids)],
              'company_id': self.company_admin.id,
              'groups_id': [(4, self.env.ref('base.group_portal').id)],

--- a/addons/test_mail/tests/test_mail_followers.py
+++ b/addons/test_mail/tests/test_mail_followers.py
@@ -21,7 +21,7 @@ class BaseFollowersTest(MailCommon):
     @classmethod
     def setUpClass(cls):
         super(BaseFollowersTest, cls).setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
         cls._create_portal_user()
 
         # allow employee to update partners
@@ -387,7 +387,7 @@ class AdvancedFollowersTest(MailCommon):
 
         Inactive partners should not be auto subscribed.
         """
-        container = self.env['mail.test.container'].with_context(self._test_context).create({
+        container = self.env['mail.test.container'].with_context(**self._test_context).create({
             'name': 'Project-Like',
         })
 
@@ -794,7 +794,7 @@ class UnfollowUnreadableRecordTest(MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test'})
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({'name': 'Test'})
         cls.user_portal = cls._create_portal_user()
 
     def _message_unsubscribe_unreadable_record(self, user, override_check='check_access_rule'):
@@ -840,7 +840,7 @@ class UnfollowFromInboxTest(MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test'})
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({'name': 'Test'})
         cls.user_employee.write({'notification_type': 'inbox'})
 
     def _fetch_inbox_message(self, message_id, user=None):
@@ -897,8 +897,8 @@ class UnfollowFromEmailTest(MailCommon, HttpCase):
         super().setUpClass()
         cls.user_portal = cls._create_portal_user()
         cls.partner_portal = cls.user_portal.partner_id
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test'})
-        cls.test_record_unfollow = cls.env['mail.test.simple.unfollow'].with_context(cls._test_context).create(
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({'name': 'Test'})
+        cls.test_record_unfollow = cls.env['mail.test.simple.unfollow'].with_context(**cls._test_context).create(
             {'name': 'unfollow'})
         cls.partner_without_user = cls.env['res.partner'].create({
             'name': 'Dave',

--- a/addons/test_mail/tests/test_mail_gateway.py
+++ b/addons/test_mail/tests/test_mail_gateway.py
@@ -169,12 +169,12 @@ class TestMailgateway(MailCommon):
         cls.mail_test_gateway_company_model = cls.env['ir.model']._get('mail.test.gateway.company')
         cls.email_from = '"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>'
 
-        cls.test_record = cls.env['mail.test.gateway'].with_context(cls._test_context).create({
+        cls.test_record = cls.env['mail.test.gateway'].with_context(**cls._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com',
         }).with_context({})
 
-        cls.partner_1 = cls.env['res.partner'].with_context(cls._test_context).create({
+        cls.partner_1 = cls.env['res.partner'].with_context(**cls._test_context).create({
             'name': 'Valid Lelitre',
             'email': 'valid.lelitre@agrolait.com',
         })

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -27,7 +27,7 @@ class TestMailMail(MailCommon):
     def setUpClass(cls):
         super(TestMailMail, cls).setUpClass()
 
-        cls.test_record = cls.env['mail.test.gateway'].with_context(cls._test_context).create({
+        cls.test_record = cls.env['mail.test.gateway'].with_context(**cls._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com',
         }).with_context({})

--- a/addons/test_mail/tests/test_mail_management.py
+++ b/addons/test_mail/tests/test_mail_management.py
@@ -12,7 +12,7 @@ class TestMailManagement(MailCommon, TestRecipients):
     @classmethod
     def setUpClass(cls):
         super(TestMailManagement, cls).setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test'})
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({'name': 'Test'})
         cls._reset_mail_context(cls.test_record)
         cls.msg = cls.test_record.message_post(body='TEST BODY', author_id=cls.partner_employee.id)
         cls.notif_p1 = cls.env['mail.notification'].create({

--- a/addons/test_mail/tests/test_mail_message.py
+++ b/addons/test_mail/tests/test_mail_message.py
@@ -18,7 +18,7 @@ class TestMessageValues(MailCommon):
     def setUpClass(cls):
         super(TestMessageValues, cls).setUpClass()
 
-        cls.alias_record = cls.env['mail.test.container'].with_context(cls._test_context).create({
+        cls.alias_record = cls.env['mail.test.container'].with_context(**cls._test_context).create({
             'name': 'Pigs',
             'alias_name': 'pigs',
             'alias_contact': 'followers',
@@ -471,7 +471,7 @@ class TestMessageAccess(MailCommon):
     def test_mail_message_access_create_wo_parent_access(self):
         """ Purpose is to test posting a message on a record whose first message / parent
         is not accessible by current user. """
-        test_record = self.env['mail.test.simple'].with_context(self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        test_record = self.env['mail.test.simple'].with_context(**self._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
         partner_1 = self.env['res.partner'].create({
             'name': 'Jitendra Prajapati (jpr-odoo)',
             'email': 'jpr@odoo.com',

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -25,7 +25,7 @@ class TestMailMCCommon(MailCommon, TestRecipients):
         cls.test_model = cls.env['ir.model']._get('mail.test.gateway')
         cls.email_from = '"Sylvie Lelitre" <test.sylvie.lelitre@agrolait.com>'
 
-        cls.test_record = cls.env['mail.test.gateway'].with_context(cls._test_context).create({
+        cls.test_record = cls.env['mail.test.gateway'].with_context(**cls._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com',
         }).with_context({})
@@ -36,7 +36,7 @@ class TestMailMCCommon(MailCommon, TestRecipients):
              'company_id': cls.user_employee_c2.company_id.id},
         ])
 
-        cls.partner_1 = cls.env['res.partner'].with_context(cls._test_context).create({
+        cls.partner_1 = cls.env['res.partner'].with_context(**cls._test_context).create({
             'name': 'Valid Lelitre',
             'email': 'valid.lelitre@agrolait.com',
         })

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -17,7 +17,7 @@ class TestMailTemplateCommon(MailCommon, TestRecipients):
     @classmethod
     def setUpClass(cls):
         super(TestMailTemplateCommon, cls).setUpClass()
-        cls.test_record = cls.env['mail.test.lang'].with_context(cls._test_context).create({
+        cls.test_record = cls.env['mail.test.lang'].with_context(**cls._test_context).create({
             'email_from': 'ignasse@example.com',
             'name': 'Test',
         })

--- a/addons/test_mail/tests/test_mail_thread_internals.py
+++ b/addons/test_mail/tests/test_mail_thread_internals.py
@@ -19,7 +19,7 @@ class TestAPI(MailCommon, TestRecipients):
     @classmethod
     def setUpClass(cls):
         super(TestAPI, cls).setUpClass()
-        cls.ticket_record = cls.env['mail.test.ticket'].with_context(cls._test_context).create({
+        cls.ticket_record = cls.env['mail.test.ticket'].with_context(**cls._test_context).create({
             'email_from': '"Paulette Vachette" <paulette@test.example.com>',
             'name': 'Test',
             'user_id': cls.user_employee.id,
@@ -175,7 +175,7 @@ class TestChatterTweaks(MailCommon, TestRecipients):
     @classmethod
     def setUpClass(cls):
         super(TestChatterTweaks, cls).setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
 
     def test_post_no_subscribe_author(self):
         original = self.test_record.message_follower_ids
@@ -275,7 +275,7 @@ class TestDiscuss(MailCommon, TestRecipients):
     @classmethod
     def setUpClass(cls):
         super(TestDiscuss, cls).setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com'
         })

--- a/addons/test_mail/tests/test_message_management.py
+++ b/addons/test_mail/tests/test_message_management.py
@@ -12,17 +12,17 @@ class TestMailResend(MailCommon):
     @classmethod
     def setUpClass(cls):
         super(TestMailResend, cls).setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
 
         #Two users
         cls.user1 = mail_new_test_user(cls.env, login='e1', groups='base.group_user', name='Employee 1', notification_type='email', email='e1')  # invalid email
         cls.user2 = mail_new_test_user(cls.env, login='e2', groups='base.group_portal', name='Employee 2', notification_type='email', email='e2@example.com')
         #Two partner
-        cls.partner1 = cls.env['res.partner'].with_context(cls._test_context).create({
+        cls.partner1 = cls.env['res.partner'].with_context(**cls._test_context).create({
             'name': 'Partner 1',
             'email': 'p1'  # invalid email
         })
-        cls.partner2 = cls.env['res.partner'].with_context(cls._test_context).create({
+        cls.partner2 = cls.env['res.partner'].with_context(**cls._test_context).create({
             'name': 'Partner 2',
             'email': 'p2@example.com'
         })

--- a/addons/test_mail/tests/test_message_post.py
+++ b/addons/test_mail/tests/test_message_post.py
@@ -45,7 +45,7 @@ class TestMessagePostCommon(MailCommon, TestRecipients):
         )
         cls.partner_employee_2 = cls.user_employee_2.partner_id
 
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com'
         })
@@ -106,7 +106,7 @@ class TestMailNotifyAPI(TestMessagePostCommon):
     @users('employee')
     @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_notify_by_mail_add_signature(self):
-        test_track = self.env['mail.test.track'].with_context(self._test_context).with_user(self.user_employee).create({
+        test_track = self.env['mail.test.track'].with_context(**self._test_context).with_user(self.user_employee).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com'
         })
@@ -1183,7 +1183,7 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
         octet_attachment_data.write({'mimetype': 'application/octet-stream'})
         pdf_attachment_data.write({'mimetype': 'application/pdf'})
 
-        test_record = self.env['mail.test.simple.main.attachment'].with_context(self._test_context).create({
+        test_record = self.env['mail.test.simple.main.attachment'].with_context(**self._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com',
         })
@@ -1248,7 +1248,7 @@ class TestMessagePost(TestMessagePostCommon, CronMixinCase):
         )
         _attachment_records[1].write({'mimetype': 'image/png'})  # to test message_main_attachment heuristic
 
-        test_record = self.env['mail.test.simple.main.attachment'].with_context(self._test_context).create({
+        test_record = self.env['mail.test.simple.main.attachment'].with_context(**self._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com',
         })

--- a/addons/test_mail/tests/test_message_track.py
+++ b/addons/test_mail/tests/test_message_track.py
@@ -19,7 +19,7 @@ class TestTracking(MailCommon):
 
         record = cls.env['mail.test.ticket'].with_user(
             cls.user_employee
-        ).with_context(cls._test_context).create({
+        ).with_context(**cls._test_context).create({
             'name': 'Test',
         })
         cls.record = record.with_context(mail_notrack=False)
@@ -44,7 +44,7 @@ class TestTracking(MailCommon):
         """Check that the default tracking log message defined on the model is used
         and that setting a log message overrides it. See `_track_get_default_log_message`"""
 
-        record = self.env['mail.test.track'].with_context(self._test_context).create({
+        record = self.env['mail.test.track'].with_context(**self._test_context).create({
             'name': 'Test',
             'track_enable_default_log': True,
         }).with_context(mail_notrack=False)
@@ -297,7 +297,7 @@ class TestTracking(MailCommon):
     def test_message_track_template_at_create(self):
         """ Create a record with tracking template on create, template should be sent."""
 
-        Model = self.env['mail.test.ticket'].with_user(self.user_employee).with_context(self._test_context)
+        Model = self.env['mail.test.ticket'].with_user(self.user_employee).with_context(**self._test_context)
         Model = Model.with_context(mail_notrack=False)
         with self.mock_mail_gateway():
             record = Model.create({

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -20,14 +20,14 @@ class BaseMailPerformance(MailCommon, TransactionCaseWithUserDemo):
 
         # creating partners is required notably with template usage
         cls.user_employee.write({'groups_id': [(4, cls.env.ref('base.group_partner_manager').id)]})
-        cls.user_test = cls.user_test_inbox = cls.env['res.users'].with_context(cls._test_context).create({
+        cls.user_test = cls.user_test_inbox = cls.env['res.users'].with_context(**cls._test_context).create({
             'name': 'Paulette Testouille',
             'login': 'paul',
             'email': 'user.test.paulette@example.com',
             'notification_type': 'inbox',
             'groups_id': [(6, 0, [cls.env.ref('base.group_user').id])],
         })
-        cls.user_test_email = cls.env['res.users'].with_context(cls._test_context).create({
+        cls.user_test_email = cls.env['res.users'].with_context(**cls._test_context).create({
             'name': 'Georgette Testouille',
             'login': 'george',
             'email': 'user.test.georgette@example.com',
@@ -35,7 +35,7 @@ class BaseMailPerformance(MailCommon, TransactionCaseWithUserDemo):
             'groups_id': [(6, 0, [cls.env.ref('base.group_user').id])],
         })
 
-        cls.customers = cls.env['res.partner'].with_context(cls._test_context).create([
+        cls.customers = cls.env['res.partner'].with_context(**cls._test_context).create([
             {
                 'country_id': cls.env.ref('base.be').id,
                 'email': 'customer.test@example.com',
@@ -58,7 +58,7 @@ class BaseMailPerformance(MailCommon, TransactionCaseWithUserDemo):
         self.patch(self.env.registry, 'ready', True)
 
     def _create_test_records(self):
-        test_record_full = self.env['mail.test.ticket'].with_context(self._test_context).create({
+        test_record_full = self.env['mail.test.ticket'].with_context(**self._test_context).create({
             'name': 'TestRecord',
             'customer_id': self.customer.id,
             'user_id': self.user_test.id,
@@ -751,7 +751,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
     def setUpClass(cls):
         super().setUpClass()
 
-        cls.user_portal = cls.env['res.users'].with_context(cls._test_context).create({
+        cls.user_portal = cls.env['res.users'].with_context(**cls._test_context).create({
             'name': 'Olivia Portal',
             'login': 'port',
             'email': 'p.p@example.com',
@@ -765,7 +765,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
             'customer_id': cls.customers[0].id,
             'name': 'Test Container',
         })
-        cls.partners = cls.env['res.partner'].with_context(cls._test_context).create([
+        cls.partners = cls.env['res.partner'].with_context(**cls._test_context).create([
             {
                 'name': f'Test {idx}',
                 'email': f'test{idx}@example.com',
@@ -1124,7 +1124,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
                 'name': 'Test Container 2',
             },
         ])
-        cls.partners = cls.env['res.partner'].with_context(cls._test_context).create([
+        cls.partners = cls.env['res.partner'].with_context(**cls._test_context).create([
             {
                 'name': f'Test {idx}',
                 'email': f'test{idx}@example.com',
@@ -1305,21 +1305,21 @@ class TestPerformance(BaseMailPerformance):
             'alias_name': 'test-alias',
         })
         # followers
-        self.user_follower_email = self.env['res.users'].with_context(self._test_context).create({
+        self.user_follower_email = self.env['res.users'].with_context(**self._test_context).create({
             'name': 'user_follower_email',
             'login': 'user_follower_email',
             'email': 'user_follower_email@example.com',
             'notification_type': 'email',
             'groups_id': [(6, 0, [self.env.ref('base.group_user').id])],
         })
-        self.user_follower_inbox = self.env['res.users'].with_context(self._test_context).create({
+        self.user_follower_inbox = self.env['res.users'].with_context(**self._test_context).create({
             'name': 'user_follower_inbox',
             'login': 'user_follower_inbox',
             'email': 'user_follower_inbox@example.com',
             'notification_type': 'inbox',
             'groups_id': [(6, 0, [self.env.ref('base.group_user').id])],
         })
-        self.partner_follower = self.env['res.partner'].with_context(self._test_context).create({
+        self.partner_follower = self.env['res.partner'].with_context(**self._test_context).create({
             'name': 'partner_follower',
             'email': 'partner_follower@example.com',
         })
@@ -1330,21 +1330,21 @@ class TestPerformance(BaseMailPerformance):
         ])
 
         # partner_ids
-        self.user_inbox = self.env['res.users'].with_context(self._test_context).create({
+        self.user_inbox = self.env['res.users'].with_context(**self._test_context).create({
             'name': 'user_inbox',
             'login': 'user_inbox',
             'email': 'user_inbox@example.com',
             'notification_type': 'inbox',
             'groups_id': [(6, 0, [self.env.ref('base.group_user').id])],
         })
-        self.user_email = self.env['res.users'].with_context(self._test_context).create({
+        self.user_email = self.env['res.users'].with_context(**self._test_context).create({
             'name': 'user_email',
             'login': 'user_email',
             'email': 'user_email@example.com',
             'notification_type': 'email',
             'groups_id': [(6, 0, [self.env.ref('base.group_user').id])],
         })
-        self.partner = self.env['res.partner'].with_context(self._test_context).create({
+        self.partner = self.env['res.partner'].with_context(**self._test_context).create({
             'name': 'partner',
             'email': 'partner@example.com',
         })

--- a/addons/test_mail_full/tests/test_odoobot.py
+++ b/addons/test_mail_full/tests/test_odoobot.py
@@ -15,7 +15,7 @@ class TestOdoobot(MailCommon, TestRecipients):
     @classmethod
     def setUpClass(cls):
         super(TestOdoobot, cls).setUpClass()
-        cls.test_record = cls.env['mail.test.simple'].with_context(cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
+        cls.test_record = cls.env['mail.test.simple'].with_context(**cls._test_context).create({'name': 'Test', 'email_from': 'ignasse@example.com'})
 
         cls.odoobot = cls.env.ref("base.partner_root")
         cls.message_post_default_kwargs = {

--- a/addons/test_mail_full/tests/test_web_push.py
+++ b/addons/test_mail_full/tests/test_web_push.py
@@ -23,7 +23,7 @@ class TestWebPushNotification(SMSCommon):
     def setUpClass(cls):
         super().setUpClass()
 
-        channel = cls.env['discuss.channel'].with_context(cls._test_context)
+        channel = cls.env['discuss.channel'].with_context(**cls._test_context)
 
         cls.user_email = cls.user_employee
         cls.user_email.notification_type = 'email'
@@ -33,7 +33,7 @@ class TestWebPushNotification(SMSCommon):
             notification_type='inbox'
         )
 
-        cls.record_simple = cls.env['mail.test.simple'].with_context(cls._test_context).create({
+        cls.record_simple = cls.env['mail.test.simple'].with_context(**cls._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com'
         })
@@ -123,7 +123,7 @@ class TestWebPushNotification(SMSCommon):
         push_to_end_point.reset_mock()
 
         # Test Tracking Message
-        mail_test_ticket = self.env['mail.test.ticket'].with_context(self._test_context)
+        mail_test_ticket = self.env['mail.test.ticket'].with_context(**self._test_context)
         record_full = mail_test_ticket.with_user(self.user_email).create({
             'name': 'Test',
         })
@@ -220,7 +220,7 @@ class TestWebPushNotification(SMSCommon):
 
     @patch.object(odoo.addons.mail.models.mail_thread, 'push_to_end_point')
     def test_push_notifications_mail_replay(self, push_to_end_point):
-        test_record = self.env['mail.test.gateway'].with_context(self._test_context).create({
+        test_record = self.env['mail.test.gateway'].with_context(**self._test_context).create({
             'name': 'Test',
             'email_from': 'ignasse@example.com',
         })

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -14,14 +14,14 @@ class TestSMSPerformance(BaseMailPerformance, sms_common.SMSCase):
     def setUp(self):
         super(TestSMSPerformance, self).setUp()
         self.env.company.country_id = self.env.ref('base.us')
-        self.test_record = self.env['mail.test.sms'].with_context(self._test_context).create({
+        self.test_record = self.env['mail.test.sms'].with_context(**self._test_context).create({
             'name': 'Test',
             'customer_id': self.customer.id,
             'phone_nbr': '0456999999',
         })
 
         # prepare recipients to test for more realistic workload
-        self.partners = self.env['res.partner'].with_context(self._test_context).create([
+        self.partners = self.env['res.partner'].with_context(**self._test_context).create([
             {'name': 'Test %s' % x,
              'email': 'test%s@example.com' % x,
              'mobile': '0456%s%s0000' % (x, x),

--- a/addons/test_mail_sms/tests/test_sms_post.py
+++ b/addons/test_mail_sms/tests/test_sms_post.py
@@ -312,7 +312,6 @@ class TestSMSPostException(SMSCommon, TestSMSRecipients):
             'mail_create_nolog': True,
             'mail_create_nosubscribe': True,
             'mail_notrack': True,
-            'no_reset_password': True,
         }).create({
             'name': 'Ernestine Loubine',
             'email': 'ernestine.loubine@agrolait.com',

--- a/addons/test_website/tests/test_redirect.py
+++ b/addons/test_website/tests/test_redirect.py
@@ -15,7 +15,7 @@ class TestRedirect(HttpCase):
     def setUp(self):
         super(TestRedirect, self).setUp()
 
-        self.user_portal = self.env['res.users'].with_context({'no_reset_password': True}).create({
+        self.user_portal = self.env['res.users'].create({
             'name': 'Test Website Portal User',
             'login': 'portal_user',
             'password': 'portal_user',

--- a/addons/website/tests/test_website_reset_password.py
+++ b/addons/website/tests/test_website_reset_password.py
@@ -30,7 +30,7 @@ class TestWebsiteResetPassword(HttpCase):
             user = self.env['res.users'].create({
                 'login': 'test',
                 'name': 'The King',
-                'email': 'noop@example.com',
+                'email': 'reset-password@example.com',
             })
             websites = self.env['website'].search([])
             website_1 = websites[0]
@@ -92,7 +92,7 @@ class TestWebsiteResetPassword(HttpCase):
             {'name': 'Website 2', 'specific_user_account': True},
         ])
 
-        login = 'user@example.com'  # same login for both users
+        login = 'reset-password@example.com'  # same login for both users
         user_website_1, user_website_2 = self.env['res.users'].create([
             {'website_id': website_1.id, 'login': login, 'email': login, 'name': login},
             {'website_id': website_2.id, 'login': login, 'email': login, 'name': login},

--- a/addons/website/tests/test_website_reset_password.py
+++ b/addons/website/tests/test_website_reset_password.py
@@ -93,7 +93,7 @@ class TestWebsiteResetPassword(HttpCase):
         ])
 
         login = 'user@example.com'  # same login for both users
-        user_website_1, user_website_2 = self.env['res.users'].with_context(no_reset_password=True).create([
+        user_website_1, user_website_2 = self.env['res.users'].create([
             {'website_id': website_1.id, 'login': login, 'email': login, 'name': login},
             {'website_id': website_2.id, 'login': login, 'email': login, 'name': login},
         ])

--- a/addons/website_blog/tests/common.py
+++ b/addons/website_blog/tests/common.py
@@ -14,21 +14,21 @@ class TestWebsiteBlogCommon(common.TransactionCase):
         group_employee_id = self.ref('base.group_user')
         group_public_id = self.ref('base.group_public')
 
-        self.user_employee = Users.with_context({'no_reset_password': True}).create({
+        self.user_employee = Users.create({
             'name': 'Armande Employee',
             'login': 'armande',
             'email': 'armande.employee@example.com',
             'notification_type': 'inbox',
             'groups_id': [(6, 0, [group_employee_id])]
         })
-        self.user_blogmanager = Users.with_context({'no_reset_password': True}).create({
+        self.user_blogmanager = Users.create({
             'name': 'Bastien BlogManager',
             'login': 'bastien',
             'email': 'bastien.blogmanager@example.com',
             'notification_type': 'inbox',
             'groups_id': [(6, 0, [group_blog_manager_id, group_employee_id])]
         })
-        self.user_public = Users.with_context({'no_reset_password': True}).create({
+        self.user_public = Users.create({
             'name': 'Cedric Public',
             'login': 'cedric',
             'email': 'cedric.public@example.com',

--- a/addons/website_blog/tests/test_website_blog_flow.py
+++ b/addons/website_blog/tests/test_website_blog_flow.py
@@ -12,7 +12,7 @@ class TestWebsiteBlogFlow(TestWebsiteBlogCommon):
     def setUp(self):
         super(TestWebsiteBlogFlow, self).setUp()
         group_portal = self.env.ref('base.group_portal')
-        self.user_portal = self.env['res.users'].with_context({'no_reset_password': True}).create({
+        self.user_portal = self.env['res.users'].create({
             'name': 'Dorian Portal',
             'login': 'portal_user',
             'email': 'portal_user@example.com',

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -193,7 +193,7 @@ class TestPartnerLeadPortal(TestCrmCommon):
     def test_lead_access_right(self):
         """ Test another portal user can not write on every leads """
         # portal user having no right
-        poor_portal_user = self.env['res.users'].with_context({'mail_notrack': True}).create({
+        poor_portal_user = self.env['res.users'].with_context(mail_notrack=True).create({
             'name': 'Poor Partner (not integrating one)',
             'email': 'poor.partner@ododo.com',
             'login': 'poorpartner',

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -193,7 +193,7 @@ class TestPartnerLeadPortal(TestCrmCommon):
     def test_lead_access_right(self):
         """ Test another portal user can not write on every leads """
         # portal user having no right
-        poor_portal_user = self.env['res.users'].with_context({'no_reset_password': True, 'mail_notrack': True}).create({
+        poor_portal_user = self.env['res.users'].with_context({'mail_notrack': True}).create({
             'name': 'Poor Partner (not integrating one)',
             'email': 'poor.partner@ododo.com',
             'login': 'poorpartner',

--- a/addons/website_forum/tests/common.py
+++ b/addons/website_forum/tests/common.py
@@ -33,7 +33,7 @@ class TestForumCommon(common.TransactionCase):
         Post = cls.env['forum.post']
 
         # Test users
-        TestUsersEnv = cls.env['res.users'].with_context({'no_reset_password': True})
+        TestUsersEnv = cls.env['res.users']
         group_employee_id = cls.env.ref('base.group_user').id
         group_portal_id = cls.env.ref('base.group_portal').id
         group_public_id = cls.env.ref('base.group_public').id

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -14,7 +14,6 @@ DISABLED_MAIL_CONTEXT = {
     'mail_create_nolog': True,
     'mail_create_nosubscribe': True,
     'mail_notrack': True,
-    'no_reset_password': True,
 }
 
 
@@ -268,7 +267,7 @@ class TransactionCaseWithUserPortal(TransactionCase):
                 'name': 'Joel Willis',
                 'email': 'joel.willis63@example.com',
             })
-            cls.user_portal = cls.env['res.users'].with_context(no_reset_password=True).create({
+            cls.user_portal = cls.env['res.users'].create({
                 'login': 'portal',
                 'password': 'portal',
                 'partner_id': cls.partner_portal.id,
@@ -290,7 +289,7 @@ class HttpCaseWithUserPortal(HttpCase):
                 'name': 'Joel Willis',
                 'email': 'joel.willis63@example.com',
             })
-            cls.user_portal = cls.env['res.users'].with_context(no_reset_password=True).create({
+            cls.user_portal = cls.env['res.users'].create({
                 'login': 'portal',
                 'password': 'portal',
                 'partner_id': cls.partner_portal.id,

--- a/odoo/addons/test_convert/tests/test_convert.py
+++ b/odoo/addons/test_convert/tests/test_convert.py
@@ -7,8 +7,7 @@ import unittest
 from lxml import etree as ET
 from lxml.builder import E
 
-import odoo
-from odoo.tests import common
+from odoo.tests import common, DEFAULT_TESTS_CONTEXT
 from odoo.tools.convert import convert_file, xml_import, _eval_xml
 from odoo.tools.misc import file_path
 
@@ -159,7 +158,7 @@ class TestEvalXML(common.TransactionCase):
             name="model_method",
         )
         rec, args, kwargs = self.eval_xml(xml, obj)
-        self.assertEqual(rec.env.context, {'foo': 2})
+        self.assertEqual(rec.env.context, dict(**DEFAULT_TESTS_CONTEXT, foo=2))
         self.assertEqual(rec.ids, [])
         self.assertEqual(args, (1,))
         self.assertEqual(kwargs, {})
@@ -170,7 +169,7 @@ class TestEvalXML(common.TransactionCase):
             name="method",
         )
         rec, args, kwargs = self.eval_xml(xml, obj)
-        self.assertEqual(rec.env.context, {'foo': 2})
+        self.assertEqual(rec.env.context, dict(**DEFAULT_TESTS_CONTEXT, foo=2))
         self.assertEqual(rec.ids, [1])
         self.assertEqual(args, ())
         self.assertEqual(kwargs, {})
@@ -184,7 +183,7 @@ class TestEvalXML(common.TransactionCase):
             name="method",
         )
         rec, args, kwargs = self.eval_xml(xml, obj)
-        self.assertEqual(rec.env.context, {})
+        self.assertEqual(rec.env.context, DEFAULT_TESTS_CONTEXT)
         self.assertEqual(rec.ids, [])
         self.assertEqual(args, ())
         self.assertEqual(kwargs, {})

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -78,6 +78,10 @@ except ImportError:
 _logger = logging.getLogger(__name__)
 
 
+DEFAULT_TESTS_CONTEXT = {
+    'no_reset_password': True,
+}
+
 # backward compatibility: Form was defined in this file
 def __getattr__(name):
     # pylint: disable=import-outside-toplevel
@@ -764,8 +768,7 @@ class TransactionCase(BaseCase):
 
         cls.cr = cls.registry.cursor()
         cls.addClassCleanup(cls.cr.close)
-
-        cls.env = api.Environment(cls.cr, odoo.SUPERUSER_ID, {})
+        cls.env = api.Environment(cls.cr, odoo.SUPERUSER_ID, DEFAULT_TESTS_CONTEXT)
 
     def setUp(self):
         super().setUp()
@@ -821,7 +824,7 @@ class SingleTransactionCase(BaseCase):
         cls.cr = cls.registry.cursor()
         cls.addClassCleanup(cls.cr.close)
 
-        cls.env = api.Environment(cls.cr, odoo.SUPERUSER_ID, {})
+        cls.env = api.Environment(cls.cr, odoo.SUPERUSER_ID, DEFAULT_TESTS_CONTEXT)
 
     def setUp(self):
         super(SingleTransactionCase, self).setUp()


### PR DESCRIPTION
There is a lot of reset password mails sent in our testing suite which
are not needed and not wanted, ~1000.

The goal is to force the already existing context key
`no_reset_password` to `True` by default when inside the testing suite.

Note that maybe some other context keys could be nice to have by
default, but this one is quite obvious and chosen as the first way to
go.

Also note that the gain time on runbot is probably very tiny if any, but
it's still the way to go: let's avoid entering the email sending code
stack even if the mails are not really sent in test mode, there is still
some processing time when preparing the mail.

Here are some stats, note that the "after" columns is considering the
next few small fix commits.
You can grep in the test logs with `Password reset email sent for user`

**Community**

| build | before | after |
| - | - | - |
| All at_install | 287 | 9 |
| post_install from account to auth_signup | 2 | 0 |
| post_install from auth_totp to microsoft_outlook | 66 | 0 |
| post_install from mrp to resource | 35 | 4 |
| post_install from sale to stock_account | 14 | 0 |
| post_install from stock_delivery to test_mail_sms | 33 | 0 |
| post_install from test_main_flows to web_unsplash | 7 | 0 |
| post_install from website to website | 5 | 4 |
| post_install from website_blog to website_twitter | 27 | 0 |


**Enterprise** (see related branch in enterprise)

| build | before | after |
| - | - | - |
| All at_install | 550 | 9 |
| post_install from account to auth_signup | 6 | 0 |
| post_install from auth_totp to microsoft_outlook | 129 | 4 |
| post_install from mrp to room | 120 | 0 |
| post_install from sale to stock_barcode_mrp | 39 | 0 |
| post_install from stock_barcode_mrp_subcontracting to test_mail_sms | 37 | 0 |
| post_install from test_main_flows to web_unsplash | 8 | 4 |
| post_install from website to website | 5 | 2 |
| post_install from website_appointment to worksheet | 34 | 0 |
