### PR TITLE
[IMP] project: tasks dependencies copy when generating next occurrence of recurring task

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -749,13 +749,14 @@ class Task(models.Model):
         milestone_mapping = self.env.context.get('milestone_mapping', {})
         for task, vals in zip(self, vals_list):
 
-            vals['stage_id'] = task.stage_id.id
+            if not default.get('stage_id'):
+                vals['stage_id'] = task.stage_id.id
             vals['name'] = task.name if self.env.context.get('copy_project') else _("%s (copy)", task.name)
-            if task.recurrence_id:
+            if task.recurrence_id and not default.get('recurrence_id'):
                 vals['recurrence_id'] = task.recurrence_id.copy().id
             if task.allow_milestones:
                 vals['milestone_id'] = milestone_mapping.get(vals['milestone_id'], vals['milestone_id'])
-            if task.child_ids:
+            if task.child_ids and not default.get('child_ids'):
                 default = {
                     'depend_on_ids': False,
                     'dependent_ids': False,


### PR DESCRIPTION
Before this commit, when a recurring task with sub-tasks and dependencies was re-generated due to the next occurrence of the recurrence, the dependencies were lost in the newly created task.

After this commit, the dependency structure is kept the same in the newly created task as in the original one.
Moreover, the next occurrence generation has been simplified and is now using the copy() method.

task-3716523

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
