### PR TITLE
[IMP] l10n_in: enhance HSN Code Length Validation for Multi-Company Environments

### DIFF
--- a/addons/l10n_in/__manifest__.py
+++ b/addons/l10n_in/__manifest__.py
@@ -38,6 +38,7 @@ Sheet, now only Vertical format has been permitted Which is Supported By Odoo.
         'data/uom_data.xml',
         'data/account_cash_rounding.xml',
         'views/account_invoice_views.xml',
+        'views/account_move_line_views.xml',
         'views/account_journal_views.xml',
         'views/res_config_settings_views.xml',
         'views/product_template_view.xml',

--- a/addons/l10n_in/models/company.py
+++ b/addons/l10n_in/models/company.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ResCompany(models.Model):
@@ -13,7 +13,18 @@ class ResCompany(models.Model):
             ("8", "8 Digits"),
         ],
         string="HSN Code Digit",
+        compute="_compute_l10n_in_hsn_code_digit",
+        store=True,
+        readonly=False,
     )
+
+    @api.depends('vat')
+    def _compute_l10n_in_hsn_code_digit(self):
+        for record in self:
+            if record.vat:
+                record.l10n_in_hsn_code_digit = "4"
+            else:
+                record.l10n_in_hsn_code_digit = False
 
     def create(self, vals):
         res = super().create(vals)

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -5,6 +5,13 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <div class="alert alert-warning mt-1 mb-1" role="alert" invisible="not l10n_in_hsn_code_warning">
+                    <div>
+                        <field name="l10n_in_hsn_code_warning" widget="actionable_errors"/>
+                    </div>
+                </div>
+            </xpath>
             <xpath expr="//field[@name='ref']" position="after">
                 <field name="country_code" invisible="1"/>
                 <field name="l10n_in_journal_type" invisible="1"/>

--- a/addons/l10n_in/views/account_move_line_views.xml
+++ b/addons/l10n_in/views/account_move_line_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_move_line_tree_hsn_l10n_in" model="ir.ui.view">
+        <field name="name">account.move.line.tree.l10n_in</field>
+        <field name="model">account.move.line</field>
+        <field name="arch" type="xml">
+            <tree string="Products" editable="top" create="0">
+                <field name="product_id" readonly="1"/>
+                <field name="name" widget="section_and_note_text"/>
+                <field name="l10n_in_hsn_code"/>
+            </tree>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_in_edi/tests/test_edi_json.py
+++ b/addons/l10n_in_edi/tests/test_edi_json.py
@@ -35,7 +35,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
         sgst_sale_5 = cls.env["account.chart.template"].ref("sgst_sale_5")
         sgst_purchase_5 = cls.env["account.chart.template"].ref("sgst_purchase_5")
         cls.product_a.write({
-            "l10n_in_hsn_code": "01111",
+            "l10n_in_hsn_code": "111111",
             'taxes_id': sgst_sale_5,
             'supplier_taxes_id': sgst_purchase_5,
         })
@@ -48,7 +48,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
             'property_account_expense_id': cls.company_data['default_account_expense'].id,
             'taxes_id': [Command.set(sgst_sale_5.ids)],
             'supplier_taxes_id': [Command.set(sgst_purchase_5.ids)],
-            "l10n_in_hsn_code": "01111",
+            "l10n_in_hsn_code": "111111",
         })
         cls.product_a_discount = cls.env['product.product'].create({
             'name': 'product_a discount',
@@ -59,7 +59,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
             'property_account_expense_id': cls.company_data['default_account_expense'].id,
             'taxes_id': [Command.set(sgst_sale_5.ids)],
             'supplier_taxes_id': [Command.set(sgst_purchase_5.ids)],
-            "l10n_in_hsn_code": "01111",
+            "l10n_in_hsn_code": "111111",
         })
         gst_with_cess = cls.env.ref("account.%s_sgst_sale_12" % (cls.company_data["company"].id)
             ) + cls.env.ref("account.%s_cess_5_plus_1591_sale" % (cls.company_data["company"].id))
@@ -72,7 +72,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
             "property_account_expense_id": cls.company_data["default_account_expense"].id,
             "taxes_id": [Command.set(gst_with_cess.ids)],
             "supplier_taxes_id": [Command.set(sgst_purchase_5.ids)],
-            "l10n_in_hsn_code": "02222",
+            "l10n_in_hsn_code": "222222",
         })
         rounding = cls.env["account.cash.rounding"].create({
             "name": "half-up",
@@ -162,14 +162,14 @@ class TestEdiJson(AccountTestInvoicingCommon):
                 "GSTIN": "36BBBFF5679L8ZR"},
             "ItemList": [
                 {
-                    "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "01111", "Qty": 1.0,
+                    "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                     "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 100.0, "AssAmt": 900.0,
                     "GstRt": 5.0, "IgstAmt": 0.0, "CgstAmt": 22.5, "SgstAmt": 22.5, "CesRt": 0.0, "CesAmt": 0.0,
                     "CesNonAdvlAmt": 0.0, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
                     "OthChrg": 0.0, "TotItemVal": 945.0
                 },
                 {
-                    "SlNo": "2", "PrdDesc": "product_with_cess", "IsServc": "N", "HsnCd": "02222", "Qty": 1.0,
+                    "SlNo": "2", "PrdDesc": "product_with_cess", "IsServc": "N", "HsnCd": "222222", "Qty": 1.0,
                     "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 100.0, "AssAmt": 900.0,
                     "GstRt": 12.0, "IgstAmt": 0.0, "CgstAmt": 54.0, "SgstAmt": 54.0, "CesRt": 5.0, "CesAmt": 45.0,
                     "CesNonAdvlAmt": 1.59, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
@@ -188,7 +188,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
         expected.update({
             "DocDtls": {"Typ": "INV", "No": "INV/2019/00002", "Dt": "01/01/2019"},
             "ItemList": [{
-                "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "01111", "Qty": 1.0,
+                "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 1000.0, "AssAmt": 0.0,
                 "GstRt": 0.0, "IgstAmt": 0.0, "CgstAmt": 0.0, "SgstAmt": 0.0, "CesRt": 0.0, "CesAmt": 0.0,
                 "CesNonAdvlAmt": 0.0, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
@@ -203,7 +203,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
         expected.update({
             "DocDtls": {"Typ": "INV", "No": "INV/2019/00003", "Dt": "01/01/2019"},
             "ItemList": [{
-                "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "01111", "Qty": 0.0,
+                "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 0.0,
                 "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 0.0, "Discount": 0.0, "AssAmt": 0.0,
                 "GstRt": 0.0, "IgstAmt": 0.0, "CgstAmt": 0.0, "SgstAmt": 0.0, "CesRt": 0.0, "CesAmt": 0.0,
                 "CesNonAdvlAmt": 0.0, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
@@ -217,14 +217,14 @@ class TestEdiJson(AccountTestInvoicingCommon):
             "DocDtls": {"Typ": "INV", "No": "INV/2019/00004", "Dt": "01/01/2019"},
             "ItemList": [
                 {
-                    "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "01111", "Qty": 1.0,
+                    "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                     "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 400.0, "AssAmt": 600.0,
                     "GstRt": 5.0, "IgstAmt": 0.0, "CgstAmt": 15.0, "SgstAmt": 15.0, "CesRt": 0.0, "CesAmt": 0.0,
                     "CesNonAdvlAmt": 0.0, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
                     "OthChrg": 0.0, "TotItemVal": 630.0
                 },
                 {
-                    "SlNo": "3", "PrdDesc": "product_with_cess", "IsServc": "N", "HsnCd": "02222", "Qty": 1.0,
+                    "SlNo": "3", "PrdDesc": "product_with_cess", "IsServc": "N", "HsnCd": "222222", "Qty": 1.0,
                     "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 0.0, "AssAmt": 1000.0,
                     "GstRt": 12.0, "IgstAmt": 0.0, "CgstAmt": 60.0, "SgstAmt": 60.0, "CesRt": 5.0, "CesAmt": 50.0,
                     "CesNonAdvlAmt": 1.59, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
@@ -249,7 +249,7 @@ class TestEdiJson(AccountTestInvoicingCommon):
         expected.update({
             "DocDtls": {"Typ": "INV", "No": "INV/2019/00007", "Dt": "01/01/2019"},
             "ItemList": [{
-                "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "01111", "Qty": 1.0,
+                "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 2000.0, "TotAmt": 2000.0, "Discount": 1400.0, "AssAmt": 600.0,
                 "GstRt": 5.0, "IgstAmt": 0.0, "CgstAmt": 15.0, "SgstAmt": 15.0, "CesRt": 0.0, "CesAmt": 0.0,
                 "CesNonAdvlAmt": 0.0, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
@@ -266,14 +266,14 @@ class TestEdiJson(AccountTestInvoicingCommon):
         expected.update({
             "DocDtls": {"Typ": "INV", "No": "INV/2019/00008", "Dt": "01/01/2019"},
             "ItemList": [{
-                "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "01111", "Qty": 1.0,
+                "SlNo": "1", "PrdDesc": "product_a", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 2000.0, "TotAmt": 2000.0, "Discount": 2000.0, "AssAmt": 0.0,
                 "GstRt": 5.0, "IgstAmt": 0.0, "CgstAmt": 0.0, "SgstAmt": 0.0, "CesRt": 0.0, "CesAmt": 0.0,
                 "CesNonAdvlAmt": 0.0, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,
                 "OthChrg": 0.0, "TotItemVal": 0.0
             },
             {
-                "SlNo": "2", "PrdDesc": "product_a2", "IsServc": "N", "HsnCd": "01111", "Qty": 1.0,
+                "SlNo": "2", "PrdDesc": "product_a2", "IsServc": "N", "HsnCd": "111111", "Qty": 1.0,
                 "Unit": "UNT", "UnitPrice": 1000.0, "TotAmt": 1000.0, "Discount": 100.0, "AssAmt": 900.0,
                 "GstRt": 5.0, "IgstAmt": 0.0, "CgstAmt": 22.5, "SgstAmt": 22.5, "CesRt": 0.0, "CesAmt": 0.0,
                 "CesNonAdvlAmt": 0.0, "StateCesRt": 0.0, "StateCesAmt": 0.0, "StateCesNonAdvlAmt": 0.0,

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -111,16 +111,14 @@ class AccountEdiFormat(models.Model):
             error_message.append(_("%s number should be set and not more than 16 characters",
                 (is_purchase and "Bill Reference" or "Invoice")))
         for line in goods_lines:
-            if line.product_id:
+            if line.display_type == 'product':
                 hsn_code = self._l10n_in_edi_extract_digits(line.l10n_in_hsn_code)
                 if not hsn_code:
-                    error_message.append(_("HSN code is not set in product %s", line.product_id.name))
-                elif not re.match("^[0-9]+$", hsn_code):
+                    error_message.append(_("HSN code is not set in product line %s", line.name))
+                elif not re.match(r'^\d{4}$|^\d{6}$|^\d{8}$', hsn_code):
                     error_message.append(_(
-                        "Invalid HSN Code (%s) in product %s", hsn_code, line.product_id.name
+                        "Invalid HSN Code (%s) in product line %s", hsn_code, line.name
                     ))
-            else:
-                error_message.append(_("product is required to get HSN code"))
         if error_message:
             error_message.insert(0, _("Impossible to send the Ewaybill."))
         return error_message
@@ -507,7 +505,7 @@ class AccountEdiFormat(models.Model):
         extract_digits = self._l10n_in_edi_extract_digits
         tax_details_by_code = self._get_l10n_in_tax_details_by_line_code(line_tax_details.get("tax_details", {}))
         line_details = {
-            "productName": line.product_id.name,
+            "productName": line.product_id.name or line.name,
             "hsnCode": extract_digits(line.l10n_in_hsn_code),
             "productDesc": line.name,
             "quantity": line.quantity,

--- a/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
+++ b/addons/l10n_in_edi_ewaybill/tests/test_edi_ewaybill_json.py
@@ -45,7 +45,7 @@ class TestEdiEwaybillJson(TestEdiJson):
             "itemList": [
             {
               "productName": "product_a",
-              "hsnCode": "01111",
+              "hsnCode": "111111",
               "productDesc": "product_a",
               "quantity": 1.0,
               "qtyUnit": "UNT",
@@ -55,7 +55,7 @@ class TestEdiEwaybillJson(TestEdiJson):
             },
             {
               "productName": "product_with_cess",
-              "hsnCode": "02222",
+              "hsnCode": "222222",
               "productDesc": "product_with_cess",
               "quantity": 1.0,
               "qtyUnit": "UNT",
@@ -81,7 +81,7 @@ class TestEdiEwaybillJson(TestEdiJson):
         expected.update({
             "docNo": "INV/2019/00002",
             "itemList": [{
-                "productName": "product_a", "hsnCode": "01111", "productDesc": "product_a", "quantity": 1.0,
+                "productName": "product_a", "hsnCode": "111111", "productDesc": "product_a", "quantity": 1.0,
                 "qtyUnit": "UNT", "taxableAmount": 0.0, "cgstRate": 0.0, "sgstRate": 0.0
             }],
             "totalValue": 0.0,
@@ -100,7 +100,7 @@ class TestEdiEwaybillJson(TestEdiJson):
         expected.update({
             "docNo": "INV/2019/00003",
             "itemList": [{
-                "productName": "product_a", "hsnCode": "01111", "productDesc": "product_a", "quantity": 0.0,
+                "productName": "product_a", "hsnCode": "111111", "productDesc": "product_a", "quantity": 0.0,
                 "qtyUnit": "UNT", "taxableAmount": 0.0, "cgstRate": 0.0, "sgstRate": 0.0
             }],
             "totalValue": 0.0,


### PR DESCRIPTION

Before this PR:
The HSN code length validation was applied at the product level, causing issues in multi-company environments where the precision of HSN codes varies based on company turnover (e.g., 4-digits, 6-digits).

After this PR:
Moved HSN code length validation from the product to the invoice level. Introduced a non-blocking warning banner on the account.move (invoice) when the HSN code does not meet the company's precision requirements.

Task Id: 3681519
