### PR TITLE
[FIX] web_editor: prevent triggering powerbox for non-editable drop zone

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -441,7 +441,7 @@ export class Wysiwyg extends Component {
             getPowerboxElement: () => {
                 const selection = (this.options.document || document).getSelection();
                 if (selection.isCollapsed && selection.rangeCount) {
-                    const baseNode = closestElement(selection.anchorNode, 'P:not([t-field]), DIV:not([t-field])');
+                    const baseNode = closestElement(selection.anchorNode, "P:not([t-field]), DIV:not([t-field]):not(.o_not_editable):not([contenteditable='false'])");
                     const fieldContainer = closestElement(selection.anchorNode, '[data-oe-field]');
                     if (!baseNode ||
                         (


### PR DESCRIPTION
Step to Reproduce:

1. Enter the edit mode of Homepage
2. click on drop zone area having "Drag building blocks here" message.
-> sometime the "drag and drop a building block here" unexpectedly moves
up. which should stay as it is.

Before this commit, all `<p>` and `<div>` elements were considered as
potential PowerBox elements, making them editable using the `/` command.
This occurred even when the elements had the `o_not_editable` class or
`contenteditable="false"` attribute.

For example, in the case of the `#wrap` element, it has the `o_editable`
class along with `contenteditable="false"`. This caused PowerBox element
or placeholders to be added unnecessarily, even though no text editing
was allowed.

In this commit, we adapted the solution merged[1] in master and specify
the selector to make sure that no command hint shown on div while having
`o_not_editable` class or `contenteditable=false` attribute.

[1] https://github.com/odoo/odoo/commit/302250cdde936a47048b8f3403e024e2e617ace7

Before this PR :

![image](https://github.com/odoo/odoo/assets/103405229/4039d00b-43c3-4865-aa3f-83f3edab22f1)


Desired behavior after PR is merged:

No hint/placeholder is added to contenteditable false block, resulting in data editor message to stay on its place.

task-3443430
