### PR TITLE
[IMP] sales: landed Cost to be hidden on other product types

### DIFF
--- a/addons/stock_landed_costs/views/product_views.xml
+++ b/addons/stock_landed_costs/views/product_views.xml
@@ -7,7 +7,7 @@
             <field name="inherit_id" ref="account.product_template_form_view"/>
             <field name="arch" type="xml">
                 <group name="bill" position="inside">
-                    <field name="landed_cost_ok" invisible="type != 'service'"/>
+                    <field name="landed_cost_ok" invisible="detailed_type != 'service'"/>
                     <field name="split_method_landed_cost" invisible="not landed_cost_ok or type != 'service'"/>
                 </group>
             </field>


### PR DESCRIPTION
In this PR fixes the following issue:
- Landed cost boolean is suppose to be visible for a service type product under purchase. But currently it is visible on other type of products specific to other models like booking fees, event tickets, event booths etc. 
- It should be hidden on other types except service.

task-3725202

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
