### PR TITLE
[FIX] hr_expense: resolves account issues in expenses at the source

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -174,7 +174,7 @@
                             <field name="reference" groups="account.group_account_readonly" attrs="{'readonly': [('is_ref_editable', '=', False)], 'invisible': [('product_has_cost', '=', True)]}"/>
                             <field name="date" attrs="{'readonly': [('sheet_is_editable', '=', False)]}"/>
                             <field name="accounting_date" attrs="{'invisible': ['|', ('accounting_date', '=', False), ('state', 'not in', ['approved', 'done'])]}" />
-                            <field name="account_id" options="{'no_create': True}" domain="[('internal_type', '=', 'other'), ('company_id', '=', company_id)]" groups="account.group_account_readonly" attrs="{'readonly': ['|', ('is_editable', '=', False), ('sheet_is_editable', '=', False)]}" context="{'default_company_id': company_id}"/>
+                            <field name="account_id" options="{'no_create': True}" groups="account.group_account_readonly" attrs="{'readonly': ['|', ('is_editable', '=', False), ('sheet_is_editable', '=', False)]}" context="{'default_company_id': company_id}"/>
                             <field name="sheet_id" invisible="1"/>
                             <field name="analytic_account_id" domain="['|', ('company_id', '=', company_id), ('company_id', '=', False)]" groups="analytic.group_analytic_accounting" attrs="{'readonly': [('is_editable', '=', False)]}"/>
                             <field name="analytic_tag_ids" widget="many2many_tags" groups="analytic.group_analytic_tags" attrs="{'readonly': [('is_editable', '=', False)]}"/>


### PR DESCRIPTION
Summary
-----
When creating an expense with an account whose currency is neither the expense currency nor the main currency, an error occurs later, when the expense is approved and the journal entries are posted in the reporting process.

Steps to Reproduce
-----
	1. Create an account (Accounting > Configuration > Accounting > Chart of Accounts) of type expense, and with a linked currency different from the main currency of the company.
	2. Create an expense providing the account created in step 1, a description, who pay the expense, a strictly positive amount, and a currency different from the currency of the account.
	3. Successively click on the "CREATE REPORT", "SUBMIT TO MANAGER", "APPROVE", and "POST JOURNAL ENTRIES" buttons.
	4. A User Error appears: "The account selected on your journal entry forces to provide a secondary currency. You should remove the secondary currency on the account."

Cause
-----
The error is handled too late, affecting the user experience. It should not be allowed to create a such expense.

Fix
-----
Modification of the account_id's domain to prevent the creation of an expense that would cause the error.


opw-3684727
