### PR TITLE
[FIX] base: ir_ui_view: allow to write on view with arbitrary relevan…

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -1564,6 +1564,11 @@ actual arch.
         name_manager.has_field(node, name, {'id': node.get('id'), 'select': node.get('select')})
 
         if validate:
+            class dict_get_bool(dict):
+                def __getitem__(self, *args, **kwargs):
+                    return bool(super().__getitem__(*args, **kwargs))
+                def get(self, *args, **kwargs):
+                    return bool(super().get(*args, **kwargs))
             for attribute in ('invisible', 'readonly', 'required'):
                 val = node.get(attribute)
                 if val:
@@ -1571,7 +1576,8 @@ actual arch.
                         # most (~95%) elements are 1/True/0/False
                         res = str2bool(val)
                     except ValueError:
-                        res = safe_eval.safe_eval(val, {'context': self._context})
+                        context = dict_get_bool(**self._context)
+                        res = safe_eval.safe_eval(val, {'context': context})
                     if res not in (1, 0, True, False, None):
                         msg = _(
                             'Attribute %(attribute)s evaluation expects a boolean, got %(value)s',

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -2292,6 +2292,7 @@ class TestViews(ViewCase):
         for context, expected in [
             ({}, {}),
             ({'foo': True}, {'invisible': True}),
+            ({"foo": "someString"}, {"invisible": True}),
             ({'bar': True}, {'readonly': True}),
             ({'baz': True}, {'required': True}),
             ({'foo': True, 'bar': True}, {'invisible': True, 'readonly': True}),
@@ -2302,6 +2303,16 @@ class TestViews(ViewCase):
             self.assertEqual(modifiers.get('invisible'), expected.get('invisible'))
             self.assertEqual(modifiers.get('readonly'), expected.get('readonly'))
             self.assertEqual(modifiers.get('required'), expected.get('required'))
+
+    def test_modifier_attribute_using_context_write(self):
+        view = self.View.with_context({"default_brol": "echt brol"}).create({
+            "arch": """<tree><field name="function" invisible="context.get('default_brol')"/></tree>""",
+            "type": "tree",
+            "model": "res.partner"
+        })
+        arch = view.get_view(view_id=view.id)["arch"]
+        self.assertEqual(arch, """<tree><field name="function" modifiers="{&quot;column_invisible&quot;: true}"/></tree>""")
+
 
     def test_modifier_attribute_priority(self):
         view = self.assertValid("""


### PR DESCRIPTION
…t context

Have a view on a model that has a field displaying conditionally according to some value in the context (`invisible="context.get('something')")`

When creating or writing a view with that key in the context, the view will go through the validation process, figuring out whether modifiers are correctly written.

When the context's value was a string it crashed because it was not a boolean (obviously) This was asymmetrical to the reading part of those modifiers, were we cast them into boolean at `def _postprocess_context_dependent`

This commit follows [1] which introduces the asymmetry and [2] which made that issue visible.

opw-3719815
opw-3703559
opw-3702620
opw-3702360
opw-3698111
opw-3698108
opw-3702084

[1]: odoo/odoo@df08cacb38624d2a9f756178bacdfed9e3f7bb47
[2]: odoo/enterprise@1fa5832a153097ad6f49662083b93e6e4613f887

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
