### PR TITLE
[IMP] core: log ormcache invalidation

### DIFF
--- a/odoo/modules/registry.py
+++ b/odoo/modules/registry.py
@@ -746,11 +746,9 @@ class Registry(Mapping):
             self.cache_invalidated.add(cache_name)
 
         # log information about invalidation_cause
-        if _logger.isEnabledFor(logging.DEBUG):
-            # could be interresting to log in info but this will need to minimize invalidation first,
-            # mainly in some setupclass and crons
+        if self.ready and not config['test_enable']:
             caller_info = format_frame(inspect.currentframe().f_back)
-            _logger.debug('Invalidating %s model caches from %s', ','.join(cache_names), caller_info)
+            _logger.info('Invalidating %s model caches from %s', ','.join(cache_names), caller_info)
 
     def clear_all_caches(self):
         """ Clear the caches associated to methods decorated with
@@ -761,9 +759,9 @@ class Registry(Mapping):
                 self.__caches[cache].clear()
             self.cache_invalidated.add(cache_name)
 
-        caller_info = format_frame(inspect.currentframe().f_back)
-        log = _logger.info if self.loaded else _logger.debug
-        log('Invalidating all model caches from %s', caller_info)
+        if self.ready and not config['test_enable']:
+            caller_info = format_frame(inspect.currentframe().f_back)
+            _logger.info('Invalidating all model caches from %s', caller_info)
 
     def is_an_ordinary_table(self, model):
         """ Return whether the given model has an ordinary table. """


### PR DESCRIPTION
before this commit, ormcache invalidation was only logged in the debug mode. This commit allows ormcache invalidation to be logged when the registry is ready in production, which helps developers to trace/optimize ormcache invalidation.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
