### PR TITLE
[FIX] hr_holidays: reset time off allocation name

### DIFF
--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -1687,7 +1687,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 f.date_from = '2024-01-01'
                 f.employee_ids.add(self.employee_emp)
                 f.holiday_status_id = self.leave_type
-                f.name = "Employee Allocation"
+                f.private_name = "Employee Allocation"
 
             accrual_allocation = f.record
             accrual_allocation.action_validate()
@@ -1902,7 +1902,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 f.employee_ids.add(self.employee_emp)
                 f.holiday_status_id = leave_type
                 f.date_from = '2024-02-01'
-                f.name = "Accrual allocation for employee"
+                f.private_name = "Accrual allocation for employee"
 
             allocation = f.record
             allocation.action_validate()
@@ -2034,7 +2034,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 f.date_from = '2024-08-07'
                 f.holiday_status_id = self.leave_type
                 f.employee_ids.add(self.employee_emp)
-                f.name = "Employee Allocation"
+                f.private_name = "Employee Allocation"
 
             accrual_allocation = f.record
             allocation_days = accrual_allocation.number_of_days

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -223,11 +223,10 @@ class TestLeaveRequests(TestHrHolidaysCommon):
     def test_allocation_request(self):
         """ Create an allocation request """
         # employee should be set to current user
-        allocation_form = Form(self.env['hr.leave.allocation'].with_user(self.user_employee))
+        allocation_form = Form(self.env['hr.leave.allocation'].with_user(self.user_employee), view='hr_holidays.hr_leave_allocation_view_form')
         allocation_form.holiday_status_id = self.holidays_type_2
-        allocation_form.date_from = date(2019, 5, 6)
-        allocation_form.date_to = date(2019, 5, 6)
-        allocation_form.name = 'New Allocation Request'
+        allocation_form.number_of_days_display = 1
+        allocation_form.notes = ":)"
         allocation_form.save()
 
     def test_allocation_constrain_dates_check(self):

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -162,7 +162,7 @@
             </field>
             <div id="title" position="replace">
                 <div class="oe_title">
-                    <h2><field name="name" placeholder="e.g. Time Off type (From validity start to validity end / no limit)" required="1"/></h2>
+                    <h2><field name="private_name" placeholder="e.g. Time Off type (From validity start to validity end / no limit)" required="1"/></h2>
                 </div>
             </div>
             <field name="employee_id" position="before">

--- a/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
@@ -96,8 +96,7 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
             allocation_form.holiday_status_id = self.leave_type
             allocation_form.holiday_type = 'employee'
             allocation_form.date_from = datetime.date(2024, 3, 20)
-            allocation_form.name = 'Accrual allocation for employee'
+            allocation_form.private_name = 'Accrual allocation for employee'
             self.assertEqual(allocation_form.number_of_hours_display, 8.0)
             allocation_form.date_from = datetime.date(2024, 3, 25)
-            allocation_form.name = 'Accrual allocation for employee'
             self.assertEqual(allocation_form.number_of_hours_display, 8.0)


### PR DESCRIPTION
### NOT FOR MASTER
**17.0 -> Master - 0.1**

Steps to reproduce the bug:

- Go to Time Off -> Allocation -> Create
- put a name
- change the allocation type
-> the name is reset

Expected result:
The name should not be reset to the old value

Reason:
The displayed name is relies on the private_name
field to get its value. And thus every time
an onchange is triggered the name is reset.

Fix:
Put the private_name field in the form view
instead of the name field. Because we rely on
the onchange of name on the dashboard to

task-3713656

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
