### PR TITLE
[FIX] point_of_sale: keep price with tax-included fiscal position map

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1042,19 +1042,12 @@ export class PosStore extends Reactive {
 
             if (mapped_included_taxes.length > 0) {
                 if (new_included_taxes.length > 0) {
-                    const price_without_taxes = this.compute_all(
-                        mapped_included_taxes,
+                    return this.compute_all(
+                        new_included_taxes,
                         price,
                         1,
                         this.currency.rounding,
                         true
-                    ).total_excluded;
-                    return this.compute_all(
-                        new_included_taxes,
-                        price_without_taxes,
-                        1,
-                        this.currency.rounding,
-                        false
                     ).total_included;
                 } else {
                     return this.compute_all(


### PR DESCRIPTION
Before this commit, when a fiscal position was used to map one tax-included tax to another tax-included tax, the price would change. This was problematic for users who use tax-included pricing to maintain consistent prices. This commit fixes this issue by ensuring the price remains the same in such scenarios.

opw-3701291

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
