### PR TITLE
[FIX] mail_activity: Filter only active activities in _search_activity_state

### DIFF
--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -178,7 +178,7 @@ class MailActivityMixin(models.AbstractModel):
                     ON res_users.id = mail_activity.user_id
              LEFT JOIN res_partner
                     ON res_partner.id = res_users.partner_id
-                 WHERE mail_activity.res_model = %(res_model_table)s
+                 WHERE mail_activity.res_model = %(res_model_table)s AND mail_activity.active = TRUE
               GROUP BY res_id
             ) AS res_record
           WHERE %(search_states_int)s @> ARRAY[activity_state]


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR fixes the _search_activity_state method in mail_activity_mixin.py to consider only active activities by adding a filter condition.

Current behavior before PR:
Currently, the _search_activity_state method does not filter out inactive activities, potentially leading to inaccurate activity state information. For example in CRM, overdue filter becomes broken because of this

Desired behavior after PR is merged:
After merging this PR, _search_activity_state will correctly consider only active activities, improving the accuracy of activity state reporting.

