### PR TITLE
[IMP] resource_mail: improve M2MAvatarResource widget 

### DIFF
--- a/addons/resource_mail/models/resource_resource.py
+++ b/addons/resource_mail/models/resource_resource.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from random import randint
 
 from odoo import fields, models
 
@@ -7,4 +8,8 @@ from odoo import fields, models
 class ResourceResource(models.Model):
     _inherit = 'resource.resource'
 
+    def _default_color(self):
+        return randint(1, 11)
+
+    color = fields.Integer(default=_default_color)
     im_status = fields.Char(related='user_id.im_status')

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -1,13 +1,19 @@
 import { registry } from "@web/core/registry";
 import { usePopover } from "@web/core/popover/popover_hook";
+import { _t } from "@web/core/l10n/translation";
 import {
+    KanbanMany2ManyTagsAvatarUserField,
+    ListMany2ManyTagsAvatarUserField,
     Many2ManyTagsAvatarUserField,
-    many2ManyTagsAvatarUserField,
     Many2ManyAvatarUserTagsList,
+    kanbanMany2ManyTagsAvatarUserField,
+    listMany2ManyTagsAvatarUserField,
+    many2ManyTagsAvatarUserField,
 } from "@mail/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field";
 import { AvatarMany2XAutocomplete } from "@web/views/fields/relational_utils";
 import { AvatarCardResourcePopover } from "@resource_mail/components/avatar_card_resource/avatar_card_resource_popover";
 import { Domain } from "@web/core/domain";
+import { KanbanMany2ManyTagsAvatarFieldTagsList } from "@web/views/fields/many2many_tags_avatar/many2many_tags_avatar_field";
 
 
 export class AvatarResourceMany2XAutocomplete extends AvatarMany2XAutocomplete {
@@ -50,6 +56,7 @@ export class AvatarResourceMany2XAutocomplete extends AvatarMany2XAutocomplete {
             resModel: this.props.resModel,
             value: result.id,
             resourceType: result.resource_type,
+            colorIndex: result.color,
             label: result.display_name,
             color: result.color,
         };
@@ -60,7 +67,7 @@ class Many2ManyAvatarResourceTagsList extends Many2ManyAvatarUserTagsList {
     static template = "resource_mail.Many2ManyAvatarResourceTagsList";
 }
 
-export class Many2ManyAvatarResourceField extends Many2ManyTagsAvatarUserField {
+const WithResourceFieldMixin = (T) => class ResourceFieldMixin extends T {
     setup() {
         super.setup(...arguments);
         if (this.relation == "resource.resource") {
@@ -82,26 +89,66 @@ export class Many2ManyAvatarResourceField extends Many2ManyTagsAvatarUserField {
         return {
             ...super.getTagProps(...arguments),
             icon: record.data.resource_type === "user" ? null : "fa-wrench",
+            colorIndex: record.data.color,
             img: record.data.resource_type === "user"
                 ? `/web/image/${this.relation}/${record.resId}/avatar_128`
                 : null,
         };
     }
-}
+};
 
-export const many2ManyAvatarResourceField = {
-    ...many2ManyTagsAvatarUserField,
-    component: Many2ManyAvatarResourceField,
-    additionalClasses: ["o_field_many2many_tags_avatar"],
+const resourceFieldMixin = {
     relatedFields: (fieldInfo) => {
         return [
             ...many2ManyTagsAvatarUserField.relatedFields(fieldInfo),
             {
                 name: "resource_type",
                 type: "selection",
+                selection: [
+                    ["user", _t("Human")],
+                    ["material", _t("Material")],
+                ],
+            },
+            {
+                name: "color",
+                type: "integer",
             },
         ];
     },
 };
 
+export class Many2ManyAvatarResourceField extends WithResourceFieldMixin(Many2ManyTagsAvatarUserField) {}
+export const many2ManyAvatarResourceField = {
+    ...many2ManyTagsAvatarUserField,
+    ...resourceFieldMixin,
+    component: Many2ManyAvatarResourceField,
+};
 registry.category("fields").add("many2many_avatar_resource", many2ManyAvatarResourceField);
+
+export class ListMany2ManyAvatarResourceField extends WithResourceFieldMixin(ListMany2ManyTagsAvatarUserField) {}
+export const listMany2ManyAvatarResourceField = {
+    ...listMany2ManyTagsAvatarUserField,
+    ...resourceFieldMixin,
+    component: ListMany2ManyAvatarResourceField,
+};
+registry.category("fields").add("list.many2many_avatar_resource", listMany2ManyAvatarResourceField);
+
+export class KanbanMany2ManyAvatarResourceTagsList extends Many2ManyAvatarResourceTagsList {
+    static props = KanbanMany2ManyTagsAvatarFieldTagsList.props;
+}
+export class KanbanMany2ManyAvatarResourceField extends WithResourceFieldMixin(KanbanMany2ManyTagsAvatarUserField) {
+    static components = {
+        ...super.components,
+        TagsList: KanbanMany2ManyAvatarResourceTagsList,
+    };
+
+    get tags() {
+        return super.tags.reverse();
+    }
+}
+export const kanbanMany2ManyAvatarResourceField = {
+    ...kanbanMany2ManyTagsAvatarUserField,
+    ...resourceFieldMixin,
+    component: KanbanMany2ManyAvatarResourceField,
+};
+registry.category("fields").add("kanban.many2many_avatar_resource", kanbanMany2ManyAvatarResourceField);

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
@@ -11,8 +11,23 @@
     </t>
 
     <t t-name="resource_mail.Many2ManyAvatarResourceTagsList" t-inherit="mail.Many2ManyAvatarUserTagsList">
-        <xpath expr="//span[hasclass('o_tag')]/i" position="attributes">
+        <i position="attributes">
             <attribute name="t-on-click.stop.prevent">tag.onImageClicked</attribute>
+            <attribute name="class">o_avatar o_m2m_avatar position-relative rounded</attribute>
+            <attribute name="t-attf-class" separator=" " add="o_colorlist_item_color_{{ tag.colorIndex }}"/>
+        </i>
+        <xpath expr="//span[hasclass('o_tag')]" position="attributes">
+            <attribute name="t-attf-class"/>
+            <attribute name="t-att-class"/>
+            <attribute name="class" separator=" " add="o_avatar opacity-trigger-hover"/>
         </xpath>
+        <xpath expr="//div[hasclass('o_tag_badge_text')]" position="attributes">
+            <attribute name="t-attf-class"/>
+            <attribute name="class" separator=" " add="position-relative ms-1"/>
+        </xpath>
+        <a position="attributes">
+            <attribute name="t-attf-class"/>
+            <attribute name="class" separator=" " add="btn btn-link position-relative py-0 px-1 text-danger opacity-0"/>
+        </a>
     </t>
 </templates>

--- a/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
+++ b/addons/resource_mail/static/tests/many2many_avatar_resource.test.js
@@ -3,11 +3,12 @@ import {
     contains,
     openFormView,
     openListView,
+    openKanbanView,
     start,
     startServer,
 } from "@mail/../tests/mail_test_helpers";
 import { beforeEach, describe, expect, test } from "@odoo/hoot";
-import { queryAll } from "@odoo/hoot-dom";
+import { queryAll, queryFirst } from "@odoo/hoot-dom";
 import { defineResourceMailModels } from "./resource_mail_test_helpers";
 
 describe.current.tags("desktop");
@@ -62,11 +63,16 @@ beforeEach(async () => {
         },
     ]);
 
-    // Task linked to those resources
-    data.task1Id = pyEnv["resource.task"].create({
+    // Tasks linked to those resources
+    [ data.task1Id, data.task2Id ] = pyEnv["resource.task"].create([{
         display_name: "Task with three resources",
         resource_ids: [data.resourceComputerId, data.resourceMarieId, data.resourcePierreId],
-    });
+    }, {
+        display_name: "Task with one resources",
+        resource_ids: [
+            data.resourcePierreId,
+        ],
+    }]);
 });
 test("many2many_avatar_resource widget in form view", async () => {
     await start();
@@ -128,30 +134,44 @@ test("many2many_avatar_resource widget in list view", async () => {
     await openListView("resource.task", {
         arch: '<list><field name="display_name"/><field name="resource_ids" widget="many2many_avatar_resource"/></list>',
     });
+
+    const [ row1, row2 ] = queryAll(".o_data_row");
     await contains(
-        ".o_m2m_avatar",
-        { count: 2 },
-        "Two human resources with avatar should be displayed"
+        "img.o_m2m_avatar",
+        { count: 2, target: row1 },
+        "Two human resources with avatar should be displayed",
     );
     await contains(
-        "i.fa-wrench",
-        { count: 1 },
-        "Two material resources with fa-wrench icon should be displayed"
+        "i.fa-wrench.o_m2m_avatar",
+        { count: 1, target: row1 },
+        "One material resource with fa-wrench icon should be displayed",
     );
+    await contains(
+        "div.o_tag_badge_text",
+        { count: 0, target: row1 },
+        "No text should be displayed on any avatar",
+    );
+
+    await contains(
+        "img.o_m2m_avatar",
+        { count: 1, target: row2 },
+        "One human resource with avatar should be displayed",
+    );
+    await contains(
+        "div.o_tag_badge_text",
+        { count: 1, target: row2 },
+        "The text should be displayed on the avatar",
+    );
+
     // Second and third records in widget should display employee avatars
-    expect(".many2many_tags_avatar_field_container .o_tag img:eq(0)").toHaveAttribute(
-        "data-src",
-        `/web/image/resource.resource/${data.resourceMarieId}/avatar_128`
-    );
-    expect(".many2many_tags_avatar_field_container .o_tag img:eq(1)").toHaveAttribute(
-        "data-src",
-        `/web/image/resource.resource/${data.resourcePierreId}/avatar_128`
-    );
+    const [ tagMarie, tagPierre ] = document.querySelectorAll(".many2many_tags_avatar_field_container .o_tag img");
+    expect(tagMarie).toHaveAttribute("data-src", `/web/image/resource.resource/${data.resourceMarieId}/avatar_128`);
+    expect(tagPierre).toHaveAttribute("data-src", `/web/image/resource.resource/${data.resourcePierreId}/avatar_128`);
     // 1. Clicking on material resource's icon
     await click(".many2many_tags_avatar_field_container .o_tag i.fa-wrench");
     await contains(".o_avatar_card", { count: 0 });
     // 2. Clicking on human resource's avatar with no user associated
-    await click(".many2many_tags_avatar_field_container .o_tag img:first");
+    await click(tagMarie);
     await contains(".o_card_user_infos span", { text: "Marie" });
     await contains(
         ".o_avatar_card",
@@ -164,7 +184,96 @@ test("many2many_avatar_resource widget in list view", async () => {
         'No "Send Message" button should be displayed for this employee as it is linked to no user'
     );
     // 3. Clicking on human resource's avatar with one user associated
-    await click(queryAll(".many2many_tags_avatar_field_container .o_tag img")[1]);
+    await click(tagPierre);
+    await contains(".o_card_user_infos span", { text: "Pierre" });
+    await contains(
+        ".o_avatar_card",
+        { count: 1 },
+        "Only one popover resource card should be opened at a time"
+    );
+    await contains(".o_card_user_infos > a", { text: "Pierre@odoo.test" });
+    await contains(".o_card_user_infos > a", { text: "+32487898933" });
+    expect(queryFirst(".o_avatar_card_buttons button").textContent).toBe("Send message");
+    await click(".o_avatar_card_buttons button");
+    await contains(".o-mail-ChatWindow");
+    expect(
+        queryFirst(
+            ".o-mail-ChatWindow-header button.o-dropdown.o-mail-ChatWindow-command > .text-truncate"
+        ).textContent
+    ).toBe("Pierre");
+});
+
+
+test("many2many_avatar_resource widget in kanban view", async () => {
+    await start();
+    await openKanbanView("resource.task", {
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="card">
+                        <div class="oe_kanban_global_click container">
+                            <div class="oe_kanban_content">
+                                <field name="display_name"/>
+                                <div class="o_kanban_record_bottom">
+                                    <field name="resource_ids" widget="many2many_avatar_resource"/>
+                                </div>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    const [ card1, card2 ] = queryAll(".oe_kanban_content");
+    await contains(
+        "img.o_m2m_avatar",
+        { count: 2, target: card1 },
+        "Two human resources with avatar should be displayed",
+    );
+    await contains(
+        "i.fa-wrench.o_m2m_avatar",
+        { count: 1, target: card1 },
+        "One material resource with fa-wrench icon should be displayed",
+    );
+    await contains(
+        "div.o_tag_badge_text",
+        { count: 0, target: card1 },
+        "No text should be displayed on any avatar",
+    );
+
+    await contains(
+        "img.o_m2m_avatar",
+        { count: 1, target: card2 },
+        "One human resource with avatar should be displayed",
+    );
+    await contains(
+        "div.o_tag_badge_text",
+        { count: 0, target: card2 },
+        "No text should be displayed on the avatar",
+    );
+
+    // Second and third records in widget should display employee avatars
+    const [ tagMarie, tagPierre ] = document.querySelectorAll(".many2many_tags_avatar_field_container .o_tag img");
+    expect(tagMarie).toHaveAttribute("data-src", `/web/image/resource.resource/${data.resourceMarieId}/avatar_128`);
+    expect(tagPierre).toHaveAttribute("data-src", `/web/image/resource.resource/${data.resourcePierreId}/avatar_128`);
+    // 1. Clicking on material resource's icon
+    await click(".many2many_tags_avatar_field_container .o_tag i.fa-wrench");
+    await contains(".o_avatar_card", { count: 0 });
+    // 2. Clicking on human resource's avatar with no user associated
+    await click(tagMarie);
+    await contains(".o_card_user_infos span", { text: "Marie" });
+    await contains(
+        ".o_avatar_card",
+        { count: 1 },
+        "Only one popover resource card should be opened at a time"
+    );
+    await contains(
+        ".o_avatar_card_buttons button",
+        { text: "Send message", count: 0 },
+        'No "Send Message" button should be displayed for this employee as it is linked to no user'
+    );
+    // 3. Clicking on human resource's avatar with one user associated
+    await click(tagPierre);
     await contains(".o_card_user_infos span", { text: "Pierre" });
     await contains(
         ".o_avatar_card",


### PR DESCRIPTION
In tree view:
- Display the material resources using squared and colored icons (with fa-wrench) followed by the name of the resources.
- Hide the name of all resources if there is more than one, except in edit mode.
- Display a tooltip with the name of the resource when its avatar/icon is hovered.

In kanban view:
- Replace the tags by avatar/icon (with color code).
- Hide the name of the resources when not in edit mode.
- Display a tooltip with the name of the resource when its avatar/icon is hovered.

task-3516745




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
