### PR TITLE
[FIX]: update picking reference type when user change on stock draft status

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -866,6 +866,12 @@ class MrpProduction(models.Model):
                 if command == Command.CREATE and not field_values.get('warehouse_id', False):
                     field_values['warehouse_id'] = warehouse_id
 
+        if vals.get('picking_type_id'):
+            picking_type = self.env['stock.picking.type'].browse(vals.get('picking_type_id'))
+            for production in self:
+                if production.state == 'draft' and picking_type != production.picking_type_id:
+                    production.name = picking_type.sequence_id.next_by_id()
+
         res = super(MrpProduction, self).write(vals)
 
         for production in self:

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -3372,6 +3372,34 @@ class TestMrpOrder(TestMrpCommon):
         ], ['company_id'], load=False, limit=1)
         self.assertEqual(mo_2.picking_type_id.id, picking_type_company[0]['id'])
 
+    def test_onchange_picking_type_id_and_name(self):
+        """
+        Test that when changing the operation type, the name of the MO should be changed too
+        """
+        picking_type_1 = self.env['stock.picking.type'].create({
+            'name': 'new_picking_type_1',
+            'code': 'mrp_operation',
+            'sequence_code': 'PT1',
+            'default_location_src_id': self.stock_location_components.id,
+            'default_location_dest_id': self.env.ref('stock.stock_location_stock').id,
+            'warehouse_id': self.warehouse_1.id,
+        })
+        picking_type_2 = picking_type_1.copy({
+            'name': 'new_picking_type_2',
+            'sequence_code': 'PT2'
+        })
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.product_1
+        mo_form.picking_type_id = picking_type_1
+        mo = mo_form.save()
+        self.assertEqual(mo.name, "BWH/PT1/00001")
+        mo.picking_type_id = picking_type_2
+        self.assertEqual(mo.name, "BWH/PT2/00001")
+        mo.picking_type_id = picking_type_1
+        self.assertEqual(mo.name, "BWH/PT1/00002")
+        mo.picking_type_id = picking_type_1
+        self.assertEqual(mo.name, "BWH/PT1/00002")
+
     def test_onchange_bom_ids_and_picking_type(self):
         warehouse01 = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
         warehouse02, warehouse03 = self.env['stock.warehouse'].create([

--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -299,6 +299,11 @@ class Repair(models.Model):
         return super().create(vals_list)
 
     def write(self, vals):
+        if vals.get('picking_type_id'):
+            picking_type = self.env['stock.picking.type'].browse(vals.get('picking_type_id'))
+            for repair in self:
+                if picking_type != repair.picking_type_id:
+                    repair.name = picking_type.sequence_id.next_by_id()
         res = super().write(vals)
         if 'product_id' in vals and self.tracking == 'serial':
             self.write({'product_qty': 1.0})

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -653,3 +653,30 @@ class TestRepair(common.TransactionCase):
             {'product_id': product_a.id, 'product_qty': 1.0},
             {'product_id': product_a.id, 'product_qty': 1.0},
         ])
+
+    def test_onchange_picking_type_id_and_name(self):
+        """
+        Test that when changing the picking_type_id, the name of the repair order should be changed too
+        """
+        repair_order = self.env['repair.order'].create({
+            'product_id': self.product_product_3.id,
+            'picking_type_id': self.stock_warehouse.repair_type_id.id,
+        })
+        picking_type_1 = self.env['stock.picking.type'].create({
+            'name': 'new_picking_type_1',
+            'code': 'repair_operation',
+            'sequence_code': 'PT1/',
+        })
+        picking_type_2 = self.env['stock.picking.type'].create({
+            'name': 'new_picking_type_2',
+            'code': 'repair_operation',
+            'sequence_code': 'PT2/',
+        })
+        repair_order.picking_type_id = picking_type_1
+        self.assertEqual(repair_order.name, "PT1/00001")
+        repair_order.picking_type_id = picking_type_2
+        self.assertEqual(repair_order.name, "PT2/00001")
+        repair_order.picking_type_id = picking_type_1
+        self.assertEqual(repair_order.name, "PT1/00002")
+        repair_order.picking_type_id = picking_type_1
+        self.assertEqual(repair_order.name, "PT1/00002")

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -860,6 +860,11 @@ class Picking(models.Model):
                     if picking.partner_id:
                         picking.message_unsubscribe(picking.partner_id.ids)
                     picking.message_subscribe([vals.get('partner_id')])
+        if vals.get('picking_type_id'):
+            picking_type = self.env['stock.picking.type'].browse(vals.get('picking_type_id'))
+            for picking in self:
+                if picking.picking_type_id != picking_type:
+                    picking.name = picking_type.sequence_id.next_by_id()
         res = super(Picking, self).write(vals)
         if vals.get('signature'):
             for picking in self:

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -2617,3 +2617,30 @@ class TestStockFlowPostInstall(TestStockCommon):
         backorder = picking.backorder_ids
         self.assertEqual(backorder.move_ids.product_uom_qty, 2)
         self.assertEqual(backorder.move_ids.description_picking, 'Ipsum')
+
+    def test_onchange_picking_type_id_and_name(self):
+        """
+        when changing picking_type_id of a stock.picking, should change the name too
+        """
+        picking_type_1 = self.env['stock.picking.type'].create({
+            'name': 'new_picking_type_1',
+            'code': 'internal',
+            'sequence_code': 'PT1/',
+        })
+        picking_type_2 = self.env['stock.picking.type'].create({
+            'name': 'new_picking_type_2',
+            'code': 'internal',
+            'sequence_code': 'PT2/',
+        })
+        picking = self.env['stock.picking'].create({
+            'picking_type_id': picking_type_1.id,
+            'location_id': self.supplier_location,
+            'location_dest_id': self.stock_location,
+        })
+        self.assertEqual(picking.name, "PT1/00001")
+        picking.picking_type_id = picking_type_2
+        self.assertEqual(picking.name, "PT2/00001")
+        picking.picking_type_id = picking_type_1
+        self.assertEqual(picking.name, "PT1/00002")
+        picking.picking_type_id = picking_type_1
+        self.assertEqual(picking.name, "PT1/00002")


### PR DESCRIPTION
Task ID: 3703643

To reproduce issue:

- create a new picking of any operation type

- save the picking (so that a name is formed)

- edit the picking and change the operation type to another type

- save manually

Expected result:

- new name with matching prefix to the new operation type

Actual result:

- previous name with prefix from previous operation type is still there

This is an issue because then the name doesn't match and this can be confusing to users



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
