### PR TITLE
[FIX] web, partner_autocomplete: font-weight

### DIFF
--- a/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
+++ b/addons/partner_autocomplete/static/src/scss/partner_autocomplete.scss
@@ -12,9 +12,6 @@
                     > * {
                         @include o-text-overflow(block);
                     }
-                    > strong {
-                        font-weight: $font-weight-bolder;
-                    }
                 }
             }
         }

--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -114,9 +114,10 @@ $caret-width: 4px !default;
 //
 // Font, line-height, and color for body text, headings, and more.
 
-$font-weight-normal: 400 !default;
-$font-weight-bold: 500 !default;
-$font-weight-bolder: 700 !default;
+// Desired weights, not necessarily matching the final result on screen.
+// Check primary_variables.scss for more info.
+$font-weight-normal: $o-font-weight-normal !default;
+$font-weight-bold: $o-font-weight-medium !default;
 
 $font-family-sans-serif: $o-font-family-sans-serif !default;
 

--- a/addons/web/static/src/scss/primary_variables.scss
+++ b/addons/web/static/src/scss/primary_variables.scss
@@ -22,6 +22,21 @@ $o-line-height-base: 1.5 !default; // This is BS default
 // automatically added.
 $o-system-fonts: (-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Ubuntu, "Liberation Sans", Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji") !default;
 
+
+// Font weights
+// Caution: These values represent the desired font weights, but they may vary
+// depending on the user's operating system.
+// Because we rely on system fonts, the browser will interpret these values
+// based on the available fonts on the user's device.
+// If the exact font weight is unavailable, the browser will attempt to assign
+// a suitable weight using the fallowing fallback scheme.
+// https://developer.mozilla.org/en-US/docs/Web/CSS/font-weight#fallback_weights
+
+$o-font-weight-normal: 400 !default;
+$o-font-weight-medium: 500 !default;
+$o-font-weight-bold: 700 !default;
+$o-font-weight-extrabold: 800 !default;
+
 // Colors
 // This is BS default
 $o-white: #FFFFFF !default;

--- a/addons/web/static/src/views/kanban/kanban_controller.scss
+++ b/addons/web/static/src/views/kanban/kanban_controller.scss
@@ -107,7 +107,7 @@
             }
         }
 
-        .o_kanban_record_title {
+        .o_kanban_record_title, .o_kanban_record_title strong {
             @include o-kanban-record-title($font-size: 13px);
             overflow-wrap: break-word;
             word-wrap: break-word;

--- a/addons/web/static/src/views/widgets/ribbon/ribbon.scss
+++ b/addons/web/static/src/views/widgets/ribbon/ribbon.scss
@@ -22,7 +22,8 @@
         padding: 0 44px;
         box-shadow: 0 5px 10px rgba(0, 0, 0, .1);
         color: #fff;
-        font: 700 18px/1 'Lato', sans-serif;
+        font-weight: $o-font-weight-bold;
+        font-family: 'Lato', sans-serif;
         text-shadow: 0 1px 1px rgba(0, 0, 0, .2);
         text-transform: uppercase;
         text-align: center;

--- a/addons/web/static/src/webclient/icons.scss
+++ b/addons/web/static/src/webclient/icons.scss
@@ -26,6 +26,12 @@ $oi-sizes: (
     ),
 );
 
+// Force font-weight to normal
+// ----------------------------------------------------------------------------
+.oi, .fa {
+    font-weight: $font-weight-normal;
+}
+
 // Define base-classes' properties using CSS variables.
 // Allows to dinamically update rules according to the context and eventual
 // utility classes.

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -315,14 +315,6 @@ select {
 // Misc.
 //------------------------------------------------------------------------------
 
-// By default, <b> and <strong> are set to `$font-weight-bolder`.
-// Override with `$font-weight-bold` in order to ensure consistency with default
-// bold text, while keeping `$font-weight-bolder` variable untouched for specific
-// uses (eg. '.fw-bolder' class).
-b, strong {
-  font-weight: $font-weight-bold;
-}
-
 //== Titles
 @include media-breakpoint-down(md) {
   h1 {


### PR DESCRIPTION
This is a backport of https://github.com/odoo/odoo/commit/74fce06cad4000a3894757d4fef9074b64153b7b that was originally merged on saas-16.3

The `o_kanban_record_title` moved in original commit from their parent div to the strong are replaced with a CSS rule to avoid breaking potential xpath. Note: we target all strong inside  `o_kanban_record_title` because some modules (eg lunch) wrap their title in additional containers. 

Original commit description:
Establish a set of target font-weight values (may not directly match the final result on screen).
Enable the system to naturally utilize the "bolder" font-weight.
Remove previous customizations designed for "Roboto" that clashed with certain system-fonts.
Enforce the "normal" font-weight for icons, regardless by their parent design.
Adapts some kanban titles.

task-3733669

Enterprise PR: https://github.com/odoo/enterprise/pull/56131

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
