### PR TITLE
[IMP] mail_group: automatically accept moderators emails

### DIFF
--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -341,6 +341,9 @@ class MailGroup(models.Model):
         elif moderation_rule and moderation_rule.status == 'ban':
             group_message.action_moderate_reject()
 
+        elif email_normalized in map(email_normalize, self.moderator_ids.mapped('email')):
+            group_message.action_moderate_accept()
+
         elif self.moderation_notify:
             self.env['mail.mail'].sudo().create({
                 'author_id': self.env.user.partner_id.id,


### PR DESCRIPTION
Purpose
=======
When a moderator sends an email to his mail group, he needs to accept his own message if no moderation rules exist for him.

Instead, we want to automatically accept the message.

Task-3724917
