### PR TITLE
[FIX] mrp: ensure bom line qty rounds to nonzero

### DIFF
--- a/addons/mrp/i18n/mrp.pot
+++ b/addons/mrp/i18n/mrp.pot
@@ -6881,3 +6881,12 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:mrp.mrp_routing_workcenter_form_view
 msgid "work orders"
 msgstr ""
+
+#. module: mrp
+#. odoo-python
+#: code:addons/mrp/models/mrp_production.py:0
+#, python-format
+msgid ""
+"The quantity for the component %(product)s is too low. Consider changing the"
+" UoM for this product from %(uom1)s to %(uom2)s."
+msgstr ""


### PR DESCRIPTION
**Current behavior:**
If you have a product which is stored as some arbitrary unit X, then in a bom you add that product as a component where it is consumed in  quantity measured as some sub-unit of X (e.g., stored as kilograms; used as grams) if you enter a value small enough such that the value in the quantity to use field will be rounded to 0.

**Expected behavior:**
The user should be alerted by the system that they have input a value too small for the given field, and they should consider changing the store UoM for their component product.

**Steps to reproduce:**
1. Create some product that will be manufactured, stored in units

2. Create some component product stored in kilograms

3. In the BoM for the units product, add a line for the kg product and change the bom line UoM to grams

4. Create and confirm a new manufacturing order for the output product, then select 'Product All'

5. The quantity in the bom line is rounded to 0 which raises a ValidationError

**Cause of the issue:**
In the rounding step of the _compute_quantity() method in uom_uom.py, the quantity argument is normalized to the underlying product's UoM. This means if you have a subunit : unit ratio which, when converted, is very small the rounding result will be 0

**Fix:**
Add a guard to the confirmation step of creating manufacturing orders which raises a ValidationError if the value will be rounded to 0.

Modifying the rounding behavior in general is not necessary. A user simply needs to change the UoM of a product to a unit which has greater resolution (i.e., kg -> g).

opw-3721691