### PR TITLE
[FIX] website_event: remove obsolete fold_register_details toggle

### DIFF
--- a/addons/website_event/views/snippets/snippets.xml
+++ b/addons/website_event/views/snippets/snippets.xml
@@ -70,12 +70,6 @@
                          data-reload="/"/>
         </div>
         <!-- Event page  -->
-        <div data-selector="main:has(.o_wevent_event_title)" data-page-options="true" groups="website.group_website_designer" data-no-check="true" string="Event Page">
-            <we-checkbox string="Fold Tickets Details"
-                         data-customize-website-views="website_event.fold_register_details"
-                         data-no-preview="true"
-                         data-reload="/"/>
-        </div>
         <div data-js="WebsiteEvent" data-selector="main:has(.o_wevent_event)" data-page-options="true" groups="website.group_website_designer" data-no-check="true" string="Event Page">
             <we-checkbox string="Sub-menu (Specific)"
                          data-display-submenu="true"


### PR DESCRIPTION
__Current behavior before commit:__
In [`4a890e1`][1] the view `website_event.fold_register_details` has been removed and the tickets details are now display only through a modal.

However the toggle in the website editor had not been removed so it doesn't do anything when clicking on it.

__Description of the fix:__
Remove the toggle from the website editor.

__Steps to reproduce the issue on runbot:__
1. Go to an event registration page such as `/event/openwood-collection-online-reveal-8/register`
2. Edit > CUSTOMIZE > Fold Tickets Details
3. Nothing is modified

opw-3721926

[1]: https://github.com/odoo/odoo/commit/4a890e1f92a665dd53f17ee57b4e7792c33da7db
