### PR TITLE
[FIX] survey: done answer from start

### DIFF
--- a/addons/survey/controllers/main.py
+++ b/addons/survey/controllers/main.py
@@ -235,7 +235,9 @@ class Survey(http.Controller):
             return self._redirect_with_error(access_data, access_data['validity_code'])
 
         survey_sudo, answer_sudo = access_data['survey_sudo'], access_data['answer_sudo']
-        if not answer_sudo:
+        # From this controller we want to start the survey and only retake it if it's in progress. If by chance the
+        # browser cookie of our last completed survey wasn't deleted, we won't be able to start a new survey anymore
+        if not answer_sudo or answer_sudo.state == "done":
             try:
                 answer_sudo = survey_sudo._create_answer(user=request.env.user, email=email)
             except UserError:


### PR DESCRIPTION
Normally when a user finsished a survey the browser cookie that match the answer gets deleted.

If by chance this doesn't happen, when we try to start over the survey from the /survey/start controller, we will be redirected again to the end of the survey and we won't be able to start a brand new survey.

I'm trying to find out the steps that lead to the cookie not being deleted, but what when it happens, this is the effect.

@Tecnativa TT47653


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
