### PR TITLE
[FIX] mail: vacuum all old notifications

### DIFF
--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -87,6 +87,11 @@ class MailNotification(models.Model):
         ]
         return self.search(domain).unlink()
 
+    @api.autovacuum
+    def _gc_notifications_all(self, max_age_days=365):
+        domain = [('mail_message_id.create_date', '<', fields.Datetime.now() - relativedelta(days=max_age_days))]
+        self.sudo().search(domain).unlink()
+
     # ------------------------------------------------------------
     # TOOLS
     # ------------------------------------------------------------


### PR DESCRIPTION
WIP

rationale is that if a user didn't read the notification in one year, he will never do it. This would solve the issue of this table forever growing for large databases, which leads to slower queries on a frequently read table for no good reason.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
