### PR TITLE
[IMP] point_of_sale : Config for self-service

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -114,7 +114,7 @@ class PosController(PortalAccount):
             else:
                 date_order = datetime(*[int(i) for i in form_values['date_order'].split('-')])
                 order = request.env['pos.order'].sudo().search([
-                    ('pos_reference', '=like', '%' + form_values['pos_reference'].replace('%', r'\%').replace('_', r'\_')),
+                    ('pos_reference', '=like', '%' + form_values['pos_reference'].strip().replace('%', r'\%').replace('_', r'\_')),
                     ('date_order', '>=', date_order),
                     ('date_order', '<', date_order + timedelta(days=1)),
                     ('ticket_code', '=', form_values['ticket_code']),

--- a/addons/point_of_sale/models/res_company.py
+++ b/addons/point_of_sale/models/res_company.py
@@ -13,11 +13,19 @@ class ResCompany(models.Model):
             ], default='closing', string="Update quantities in stock",
             help="At the session closing: A picking is created for the entire session when it's closed\n In real time: Each order sent to the server create its own picking")
     point_of_sale_use_ticket_qr_code = fields.Boolean(
-        string='Use QR code on ticket',
-        help="Add a QR code on the ticket, which the user can scan to request the invoice linked to its order.")
+        string='Self-service invoicing',
+        help="Print information on the receipt to allow the costumer to easily request the invoice anytime, from Odoo's portal")
     point_of_sale_ticket_unique_code = fields.Boolean(
         string='Generate a code on ticket',
         help="Add a 5-digit code on the receipt to allow the user to request the invoice for an order on the portal.")
+    point_of_sale_ticket_portal_url_display_mode = fields.Selection([
+            ('qr_code', 'QR code'),
+            ('url', 'URL'),
+            ('qr_code_and_url', 'QR code + URL'),
+        ], default='qr_code',
+        string='Print',
+        help="Choose how the URL to the portal will be print on the receipt.",
+        required=True)
     point_of_sale_show_predefined_scenarios = fields.Boolean("Show Predefined Scenarios", default=True)
 
     @api.model
@@ -29,7 +37,7 @@ class ResCompany(models.Model):
         return [
             'id', 'currency_id', 'email', 'website', 'company_registry', 'vat', 'name', 'phone', 'partner_id',
             'country_id', 'state_id', 'tax_calculation_rounding_method', 'nomenclature_id', 'point_of_sale_use_ticket_qr_code',
-            'point_of_sale_ticket_unique_code', 'street', 'city', 'zip',
+            'point_of_sale_ticket_unique_code', 'point_of_sale_ticket_portal_url_display_mode', 'street', 'city', 'zip',
         ]
 
     @api.constrains('period_lock_date', 'fiscalyear_lock_date')

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -111,6 +111,7 @@ class ResConfigSettings(models.TransientModel):
     point_of_sale_ticket_unique_code = fields.Boolean(related='company_id.point_of_sale_ticket_unique_code', readonly=False)
     pos_show_product_images = fields.Boolean(related='pos_config_id.show_product_images', readonly=False)
     pos_show_category_images = fields.Boolean(related='pos_config_id.show_category_images', readonly=False)
+    point_of_sale_ticket_portal_url_display_mode = fields.Selection(related='company_id.point_of_sale_ticket_portal_url_display_mode', readonly=False, required=True)
     pos_note_ids = fields.Many2many(related='pos_config_id.note_ids', readonly=False)
     pos_module_pos_sms = fields.Boolean(related="pos_config_id.module_pos_sms", readonly=False)
 

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -107,9 +107,8 @@ export class PosOrder extends Base {
             pos_qr_code:
                 this.company.point_of_sale_use_ticket_qr_code &&
                 this.finalized &&
-                qrCodeSrc(`${baseUrl}/pos/ticket/validate?access_token=${this.access_token}`),
-            ticket_code:
-                this.company.point_of_sale_ticket_unique_code && this.finalized && this.ticketCode,
+                qrCodeSrc(`${baseUrl}/pos/ticket/`),
+            ticket_code: this.ticket_code,
             base_url: baseUrl,
             footer: this.config.receipt_footer,
             // FIXME: isn't there a better way to handle this date?

--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -77,20 +77,25 @@
             <div class="before-footer" />
 
             <div t-if="props.data.pos_qr_code">
-                <br /><br />
+                <br/>
                 <div class="pos-receipt-order-data mb-2">
-                    Scan me to get an invoice from the Odoo portal.
+                    Need an invoice for your purchase ?
                 </div>
-                <img id="posqrcode" t-att-src="props.data.pos_qr_code" class="pos-receipt-qrcode"/>
             </div>
 
-            <div t-if="props.data.ticket_code">
-                <br /><br />
+            <div t-if="['qr_code', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code" class="mb-2">
+                <img id="posqrcode" t-att-src="props.data.pos_qr_code" class="pos-receipt-logo"/>
+            </div>
+
+            <div t-if="props.data.pos_qr_code">
                 <div class="pos-receipt-order-data">
-                    You can go to <t t-out="props.data.base_url"/>/pos/ticket and use the code below to request an invoice online
+                    Unique Code: <t t-esc="props.data.ticket_code"/>
                 </div>
-                <div class="pos-receipt-order-data">
-                    Unique Code: <t t-out="props.data.ticket_code"/>
+            </div>
+
+            <div t-if="['url', 'qr_code_and_url'].includes(props.data.headerData.company.point_of_sale_ticket_portal_url_display_mode) and props.data.pos_qr_code">
+                <div class="pos-receipt-order-data" t-attf-class="{{ props.data.ticket_portal_url_display_mode === 'qr_code_and_url' ? 'mt-3' : '' }}">
+                    Portal URL: <t t-out="props.data.base_url"/>/pos/ticket
                 </div>
             </div>
 

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -281,12 +281,6 @@
                                     </div>
                                 </div>
                             </setting>
-                            <setting help="Print a QR code on the receipt to allow the user to easily request the invoice for an order." documentation="/applications/sales/point_of_sale/receipts_invoices.html">
-                                <field name="point_of_sale_use_ticket_qr_code"/>
-                            </setting>
-                            <setting help="Add a 5-digit code on the receipt to allow the user to request the invoice for an order on the portal.">
-                                <field name="point_of_sale_ticket_unique_code"/>
-                            </setting>
                             <setting id="order_reference" groups="base.group_no_one" string="Order Reference" help="Generation of your order references">
                                 <field name="pos_sequence_id" readonly="1"/>
                             </setting>
@@ -296,6 +290,17 @@
                                     <div class="content-group mt16" invisible="not pos_module_pos_sms">
                                         <div class="text-warning mb4" id="warning_text_pos_sms" >
                                             Save this page and come back here to set up the feature.
+                                        </div>
+                                    </div>
+                                </div>
+                            </setting>
+                            <setting help="Print information on the receipt to allow the customer to easily request the invoice anytime, from Odoo's portal." documentation="/applications/sales/point_of_sale/receipts_invoices.html">
+                                <field name="point_of_sale_use_ticket_qr_code"/>
+                                <div class="content-group mt16" invisible="not point_of_sale_use_ticket_qr_code">
+                                    <div class="col mt16">
+                                        <div class="content-group row">
+                                            <label for="point_of_sale_ticket_portal_url_display_mode" class="col-lg-2" string="Print"/>
+                                            <field name="point_of_sale_ticket_portal_url_display_mode"/>
                                         </div>
                                     </div>
                                 </div>
@@ -331,7 +336,7 @@
                             </setting>
                             <setting title="The transactions are processed by Mercado Pago on terminal" string="Mercado Pago" help="Accept payments with Mercado Pago on a terminal">
                                 <field name="module_pos_mercado_pago"/>
-                            </setting>                            
+                            </setting>
                         </block>
 
                         <block title="Connected Devices" id="pos_connected_devices_section">


### PR DESCRIPTION
Clarify the self-service invoicing options by grouping them under a single setting in accounting. Offer the choice between a QR code, a link, or both on receipts. Include a checkbox for using a 5-digit code. Adjust the receipt printout based on the selected options.
tasks id : 3709629



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
