### PR TITLE
[IMP] auth_signup: removing reset pasword/signup token from db

### DIFF
--- a/addons/auth_signup/controllers/main.py
+++ b/addons/auth_signup/controllers/main.py
@@ -135,7 +135,7 @@ class AuthSignupHome(Home):
         if qcontext.get('token'):
             try:
                 # retrieve the user info (name, login or email) corresponding to a signup token
-                token_infos = request.env['res.partner'].sudo().signup_retrieve_info(qcontext.get('token'))
+                token_infos = request.env['res.partner'].sudo()._signup_retrieve_info(qcontext.get('token'))
                 for k, v in token_infos.items():
                     qcontext.setdefault(k, v)
             except:

--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -40,11 +40,12 @@
                         Dear <t t-out="object.name or ''">Marc Demo</t>,<br /><br />
                         You have been invited by <t t-out="object.create_uid.name or ''">OdooBot</t> of <t t-out="object.company_id.name or ''">YourCompany</t> to connect on Odoo.
                         <div style="margin: 16px 0px 16px 0px;">
-                            <a t-att-href="object.signup_url"
+                            <a t-att-href="object.partner_id._get_signup_url()"
                                 t-attf-style="background-color: {{object.company_id.email_secondary_color or '#875A7B'}}; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
                                 Accept invitation
                             </a>
                         </div>
+                        <b>  This link will remain valid during <t t-out="int(int(object.env['ir.config_parameter'].sudo().get_param('auth_signup.signup.validity.hours',144))/24)"></t> days </b> <br/>
                         <t t-set="website_url" t-value="object.get_base_url()"></t>
                         Your Odoo domain is: <b><a t-att-href='website_url' t-out="website_url or ''">http://yourcompany.odoo.com</a></b><br />
                         Your sign in email is: <b><a t-attf-href="/web/login?login={{ object.email }}" target="_blank" t-out="object.email or ''">mark.brown23@example.com</a></b><br /><br />

--- a/addons/auth_signup/models/res_partner.py
+++ b/addons/auth_signup/models/res_partner.py
@@ -7,8 +7,8 @@ import werkzeug.urls
 from collections import defaultdict
 from datetime import datetime, timedelta
 
-from odoo import api, exceptions, fields, models, _
-from odoo.tools import sql
+from odoo import api, exceptions, fields, models, tools, _
+
 class SignupError(Exception):
     pass
 
@@ -24,42 +24,16 @@ def now(**kwargs):
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    signup_token = fields.Char(copy=False, groups="base.group_erp_manager", compute='_compute_token', inverse='_inverse_token')
     signup_type = fields.Char(string='Signup Token Type', copy=False, groups="base.group_erp_manager")
-    signup_expiration = fields.Datetime(copy=False, groups="base.group_erp_manager")
-    signup_valid = fields.Boolean(compute='_compute_signup_valid', string='Signup Token is Valid')
-    signup_url = fields.Char(compute='_compute_signup_url', string='Signup URL')
 
-    def init(self):
-        super().init()
-        if not sql.column_exists(self.env.cr, self._table, "signup_token"):
-            self.env.cr.execute("ALTER TABLE res_partner ADD COLUMN signup_token varchar")
-
-    @api.depends('signup_token', 'signup_expiration')
-    def _compute_signup_valid(self):
-        dt = now()
-        for partner, partner_sudo in zip(self, self.sudo()):
-            partner.signup_valid = bool(partner_sudo.signup_token) and \
-            (not partner_sudo.signup_expiration or dt <= partner_sudo.signup_expiration)
-
-    def _compute_signup_url(self):
-        """ proxy for function field towards actual implementation """
+    def _get_signup_url(self):
+        self.ensure_one()
         result = self.sudo()._get_signup_url_for_action()
-        for partner in self:
-            if any(u._is_internal() for u in partner.user_ids if u != self.env.user):
-                self.env['res.users'].check_access_rights('write')
-            if any(u._is_portal() for u in partner.user_ids if u != self.env.user):
-                self.env['res.partner'].check_access_rights('write')
-            partner.signup_url = result.get(partner.id, False)
-
-    def _compute_token(self):
-        for partner in self:
-            self.env.cr.execute('SELECT signup_token FROM res_partner WHERE id=%s', (partner._origin.id,))
-            partner.signup_token = self.env.cr.fetchone()[0]
-
-    def _inverse_token(self):
-        for partner in self:
-            self.env.cr.execute('UPDATE res_partner SET signup_token = %s WHERE id=%s', (partner.signup_token or None, partner.id))
+        if any(u._is_internal() for u in self.user_ids if u != self.env.user):
+            self.env['res.users'].check_access_rights('write')
+        if any(u._is_portal() for u in self.user_ids if u != self.env.user):
+            self.env['res.partner'].check_access_rights('write')
+        return result.get(self.id, False)
 
     def _get_signup_url_for_action(self, url=None, action=None, view_type=None, menu_id=None, res_id=None, model=None):
         """ generate a signup url for the given partner ids and action, possibly overriding
@@ -82,12 +56,7 @@ class ResPartner(models.Model):
             if signup_type:
                 route = 'reset_password' if signup_type == 'reset' else signup_type
 
-            if partner.sudo().signup_token and signup_type:
-                query['token'] = partner.sudo().signup_token
-            elif partner.user_ids:
-                query['login'] = partner.user_ids[0].login
-            else:
-                continue        # no signup token, no user, thus no signup url!
+            query['token'] = partner.sudo()._generate_signup_token()
 
             if url:
                 query['redirect'] = url
@@ -114,7 +83,6 @@ class ResPartner(models.Model):
             if not self.env.context.get('relative_url'):
                 signup_url = werkzeug.urls.url_join(base_url, signup_url)
             res[partner.id] = signup_url
-
         return res
 
     def action_signup_prepare(self):
@@ -134,24 +102,19 @@ class ResPartner(models.Model):
             partner = partner.sudo()
             if allow_signup and not partner.user_ids:
                 partner.signup_prepare()
-                res[partner.id]['auth_signup_token'] = partner.signup_token
+                res[partner.id]['auth_signup_token'] = partner._generate_signup_token()
             elif partner.user_ids:
                 res[partner.id]['auth_login'] = partner.user_ids[0].login
         return res
 
     def signup_cancel(self):
-        return self.write({'signup_token': False, 'signup_type': False, 'signup_expiration': False})
+        return self.write({'signup_type': None})
 
-    def signup_prepare(self, signup_type="signup", expiration=False):
+    def signup_prepare(self, signup_type="signup"):
         """ generate a new token for the partners with the given validity, if necessary
             :param expiration: the expiration datetime of the token (string, optional)
         """
-        for partner in self:
-            if expiration or not partner.signup_valid:
-                token = random_token()
-                while self._signup_retrieve_partner(token):
-                    token = random_token()
-                partner.write({'signup_token': token, 'signup_type': signup_type, 'signup_expiration': expiration})
+        self.write({'signup_type': signup_type})
         return True
 
     @api.model
@@ -162,36 +125,64 @@ class ResPartner(models.Model):
             :param raise_exception: if True, raise exception instead of returning False
             :return: partner (browse record) or False (if raise_exception is False)
         """
-        self.env.cr.execute("SELECT id FROM res_partner WHERE signup_token = %s AND active", (token,))
-        partner_id = self.env.cr.fetchone()
-        partner = self.browse(partner_id[0]) if partner_id else None
+        partner = self._get_partner_from_token(token)
         if not partner:
-            if raise_exception:
-                raise exceptions.UserError(_("Signup token '%s' is not valid", token))
-            return False
-        if check_validity and not partner.signup_valid:
-            if raise_exception:
-                raise exceptions.UserError(_("Signup token '%s' is no longer valid", token))
-            return False
+            raise exceptions.UserError(_("Signup token '%s' is not valid or expired", token))
         return partner
 
     @api.model
-    def signup_retrieve_info(self, token):
+    def _signup_retrieve_info(self, token):
         """ retrieve the user info about the token
-            :return: a dictionary with the user information:
+            :return: a dictionary with the user information if the token is valid, None otherwise:
                 - 'db': the name of the database
                 - 'token': the token, if token is valid
                 - 'name': the name of the partner, if token is valid
                 - 'login': the user login, if the user already exists
                 - 'email': the partner email, if the user does not exist
         """
-        partner = self._signup_retrieve_partner(token, raise_exception=True)
+        partner = self._get_partner_from_token(token)
+        if not partner:
+            return None
         res = {'db': self.env.cr.dbname}
-        if partner.signup_valid:
-            res['token'] = token
-            res['name'] = partner.name
+        res['token'] = token
+        res['name'] = partner.name
         if partner.user_ids:
             res['login'] = partner.user_ids[0].login
         else:
             res['email'] = res['login'] = partner.email or ''
         return res
+
+    def _get_login_date(self):
+        self.ensure_one()
+        users_login_dates = self.user_ids.mapped('login_date')
+        users_login_dates = list(filter(None, users_login_dates))  # remove falsy values
+        if any(users_login_dates):
+            return int(max(map(datetime.timestamp, users_login_dates)))
+        return None
+
+    def _generate_signup_token(self, expiration=None):
+        """ This function generate the signup token for the partner in self.
+            pre-condition: self.signup_type must be either 'signup' or 'reset'
+            :return: the signed payload/token that can be used to reset the password/signup.
+                - 'expiration': the time in hours before the expiration of the token
+        Since the last_login_date is part of the payload, this token is invalidated as soon as the user logs in
+        """
+        self.ensure_one()
+        if not expiration:
+            if self.signup_type == 'reset':
+                expiration = int(self.env['ir.config_parameter'].get_param("auth_signup.reset_password.validity.hours", 4))
+            else:
+                expiration = int(self.env['ir.config_parameter'].get_param("auth_signup.signup.validity.hours", 144))
+        plist = [self.id, self._get_login_date(), self.signup_type]
+        payload = tools.hash_sign(self.sudo().env, 'signup', plist, expiration_hours=expiration)
+        return payload
+
+    @api.model
+    def _get_partner_from_token(self, token):
+        if payload := tools.verify_hash_signed(self.sudo().env, 'signup', token):
+            partner_id, login_date, signup_type = payload
+            # login_date can be either an int or "None" as a string for signup
+            partner = self.browse(partner_id)
+            if login_date == partner._get_login_date() and signup_type == partner.browse(partner_id).signup_type:
+                return partner
+        return None

--- a/addons/auth_signup/tests/test_auth_signup.py
+++ b/addons/auth_signup/tests/test_auth_signup.py
@@ -63,4 +63,4 @@ class TestAuthSignupFlow(HttpCaseWithUserPortal, HttpCaseWithUserDemo):
         partner.signup_prepare()
 
         with self.assertRaises(AccessError):
-            partner.with_user(user.id).signup_url
+            partner.with_user(user.id)._get_signup_url()

--- a/addons/auth_signup/tests/test_reset_password.py
+++ b/addons/auth_signup/tests/test_reset_password.py
@@ -25,13 +25,13 @@ class TestResetPassword(HttpCase):
             'signup_email' is used in the web controller (web_auth_reset_password) to detect this behaviour
         """
 
-        self.assertEqual(self.test_user.email, url_parse(self.test_user.with_context(create_user=True).signup_url).decode_query()["signup_email"], "query must contain 'signup_email'")
+        self.assertEqual(self.test_user.email, url_parse(self.test_user.with_context(create_user=True).partner_id._get_signup_url()).decode_query()["signup_email"], "query must contain 'signup_email'")
 
         # Invalidate signup_url to skip signup process
         self.env.invalidate_all()
         self.test_user.action_reset_password()
 
-        self.assertNotIn("signup_email", url_parse(self.test_user.signup_url).decode_query(), "query should not contain 'signup_email'")
+        self.assertNotIn("signup_email", url_parse(self.test_user.partner_id._get_signup_url()).decode_query(), "query should not contain 'signup_email'")
 
     @patch('odoo.addons.mail.models.mail_mail.MailMail.send')
     def test_reset_password_mail_server_error(self, mock_send):

--- a/addons/auth_signup/views/auth_signup_templates_email.xml
+++ b/addons/auth_signup/views/auth_signup_templates_email.xml
@@ -30,9 +30,9 @@
                             <div>
                                 Dear <t t-out="object.name or ''">Marc Demo</t>,<br/><br/>
                                 A password reset was requested for the Odoo account linked to this email.
-                                You may change your password by following this link which will remain valid during 24 hours:<br/>
+                                You may change your password by following this link which will remain valid during <t t-out="user.env['ir.config_parameter'].sudo().get_param('auth_signup.reset_password.validity.hours',4)"></t> hours:<br/>
                                 <div style="margin: 16px 0px 16px 0px;">
-                                    <a t-att-href="object.signup_url"
+                                    <a t-att-href="object.partner_id._get_signup_url()"
                                         style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
                                         Change password
                                     </a>

--- a/addons/auth_signup/views/res_users_views.xml
+++ b/addons/auth_signup/views/res_users_views.xml
@@ -16,20 +16,6 @@
                                 invisible="state != 'new'"/>
                     <field name="state" widget="statusbar"/>
                 </xpath>
-
-                <xpath expr="//sheet" position="before">
-                    <div class="alert alert-success text-center o_form_header alert-dismissible" invisible="not signup_valid" role="status">
-                        <button class="btn-close" data-bs-dismiss="alert" aria-label="Close"/>
-                        <div invisible="state != 'active'">
-                            <strong>A password reset has been requested for this user. An email containing the following link has been sent:</strong>
-                        </div>
-                        <div invisible="state != 'new'">
-                            <strong>An invitation email containing the following subscription link has been sent:</strong>
-                        </div>
-                        <div><field name="signup_url" widget="url"/></div>
-                         <field name="signup_valid" invisible="1"/>
-                     </div>
-                 </xpath>
             </field>
         </record>
 

--- a/addons/portal/data/mail_template_data.xml
+++ b/addons/portal/data/mail_template_data.xml
@@ -39,7 +39,7 @@
                         An account has been created for you with the following login: <t t-out="object.user_id.login">demo</t><br/><br/>
                         Click on the button below to pick a password and activate your account.
                         <div style="margin: 16px 0px 16px 0px; text-align: center;">
-                            <a t-att-href="object.user_id.signup_url" style="display: inline-block; padding: 10px; text-decoration: none; font-size: 12px; background-color: #875A7B; color: #fff; border-radius: 5px;">
+                            <a t-att-href="object.user_id.partner_id._get_signup_url()" style="display: inline-block; padding: 10px; text-decoration: none; font-size: 12px; background-color: #875A7B; color: #fff; border-radius: 5px;">
                                 <strong>Activate Account</strong>
                             </a>
                         </div>

--- a/addons/portal/wizard/portal_wizard.py
+++ b/addons/portal/wizard/portal_wizard.py
@@ -177,7 +177,7 @@ class PortalWizardUser(models.TransientModel):
         self._update_partner_email()
 
         # Remove the sign up token, so it can not be used
-        self.partner_id.sudo().signup_token = False
+        self.partner_id.sudo().signup_type = None
 
         user_sudo = self.user_id.sudo()
 

--- a/addons/website/tests/test_website_reset_password.py
+++ b/addons/website/tests/test_website_reset_password.py
@@ -50,20 +50,20 @@ class TestWebsiteResetPassword(HttpCase):
             self.env.invalidate_all()  # invalidate get_base_url
 
             user.action_reset_password()
-            self.assertIn(website_2.domain, user.signup_url)
+            self.assertIn(website_2.domain, user.partner_id._get_signup_url())
 
             self.env.invalidate_all()
 
             user.partner_id.website_id = website_1.id
-            user.action_reset_password()
-            self.assertIn(website_1.domain, user.signup_url)
+            user.partner_id.signup_prepare(signup_type="reset")
+            self.assertIn(website_1.domain, user.partner_id._get_signup_url())
 
             (website_1 + website_2).domain = False
 
-            user.action_reset_password()
+            user.partner_id.signup_prepare(signup_type="reset")
             self.env.invalidate_all()
 
-            self.start_tour(user.signup_url, 'website_reset_password', login=None)
+            self.start_tour(user.partner_id._get_signup_url(), 'website_reset_password', login=None)
 
     def test_02_multi_user_login(self):
         # In case Specific User Account is activated on a website, the same login can be used for
@@ -110,10 +110,10 @@ class TestWebsiteResetPassword(HttpCase):
             {'website_id': website_2.id, 'login': login, 'email': login, 'name': login, "groups_id": [Command.link(portal_group.id), Command.unlink(internal_group.id)]},
         ])
 
-        self.assertFalse(user_website_1.signup_valid)
-        self.assertFalse(user_website_2.signup_valid)
+        self.assertFalse(user_website_1.signup_type)
+        self.assertFalse(user_website_2.signup_type)
 
         self.env['res.users'].with_context(website_id=website_1.id).reset_password(login)
 
-        self.assertTrue(user_website_1.signup_valid)
-        self.assertFalse(user_website_2.signup_valid)
+        self.assertTrue(user_website_1.signup_type)
+        self.assertFalse(user_website_2.signup_type)

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2419,7 +2419,7 @@
             </t>
             <t t-if="request.env['res.users']._get_signup_invitation_scope() == 'b2c' and request.website.is_public_user()">
                 <p class="alert alert-info mt-3" role="status">
-                    <a role="button" t-att-href="order.partner_id.signup_prepare() and order.partner_id.with_context(relative_url=True).signup_url" class="btn btn-primary">Sign Up</a>
+                    <a role="button" t-att-href="order.partner_id.signup_prepare() and order.partner_id.with_context(relative_url=True)._get_signup_url()" class="btn btn-primary">Sign Up</a>
                     to follow your order.
                 </p>
             </t>

--- a/addons/website_slides/tests/test_attendee.py
+++ b/addons/website_slides/tests/test_attendee.py
@@ -305,7 +305,6 @@ class TestAttendeeCase(HttpCaseWithUserPortal):
         decoded_url = url_decode(res.url)
         self.assertEqual(res.status_code, 200)
         self.assertTrue('/signup' in res.url, "Should redirect to signup page if not logged in and without user.")
-        self.assertEqual(self.partner_no_user.signup_token, decoded_url['token'], "Signup should correspond to the invited partner.")
         self.assertEqual(f'/slides/{self.channel.id}', decoded_url['redirect'], "Signup should redirect to the course.")
 
         # Logged user is an attendee of the course

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -78,6 +78,8 @@ __all__ = [
     'get_lang',
     'groupby',
     'hmac',
+    'hash_sign',
+    'verify_hash_signed',
     'html_escape',
     'human_size',
     'is_list_of',


### PR DESCRIPTION
This commit aims at not storing the tokens anymore.

The resonning behind this is that it is more secure to not store them
at all than to restrict the access to such tokens.

The token can now be stateless, it is a signed payload for which the
authenticity and integrity can be verified when used by the end-user.

This commits remove most field of res.users in auth_signup, and also
remove the warning on the user form view, saying that the link was
send with the link.

Also, add a toast warning when clicking the big button
"Send and Invitation Email" and "Send Password Reset Instruction"