### PR TITLE
[FIX] point_of_sale: total show Nan in coins pop-up

### DIFF
--- a/addons/point_of_sale/data/point_of_sale_data.xml
+++ b/addons/point_of_sale/data/point_of_sale_data.xml
@@ -40,16 +40,6 @@
             <field name="is_pos_groupable">True</field>
         </record>
 
-        <record model="pos.bill" id="0_01" forcecreate="0">
-            <field name="name">0.01</field>
-            <field name="value">0.01</field>
-        </record>
-
-        <record model="pos.bill" id="0_02" forcecreate="0">
-            <field name="name">0.02</field>
-            <field name="value">0.02</field>
-        </record>
-
         <record model="pos.bill" id="0_05" forcecreate="0">
             <field name="name">0.05</field>
             <field name="value">0.05</field>

--- a/addons/point_of_sale/static/src/app/generic_components/inputs/t_model_input.js
+++ b/addons/point_of_sale/static/src/app/generic_components/inputs/t_model_input.js
@@ -19,6 +19,6 @@ export class TModelInput extends Component {
     }
     setValue(newValue, tModel = this.props.tModel) {
         const [obj, key] = tModel;
-        obj[key] = newValue;
+        obj[key] = isNaN(newValue) ? 0 : newValue;
     }
 }

--- a/addons/point_of_sale/static/src/app/utils/money_details_popup/money_details_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/money_details_popup/money_details_popup.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.MoneyDetailsPopup">
-        <Dialog title="'Coins/Bills'" size="'md'" >
+        <Dialog title="'Coins/Notes'" size="'md'" >
             <t t-set="bills" t-value="Object.keys(state.moneyDetails).sort((a, b) => b - a)"/>
             <div t-attf-style="display: grid; grid-template-rows: repeat(calc({{bills.length}}/2) ,auto); grid-auto-flow: column;">
                 <div t-foreach="bills" t-as="moneyValue" t-key="moneyValue" class="d-flex align-items-center justify-content-center my-1 ">


### PR DESCRIPTION
Before this commit:
================
 In coins/bills pop pup, if user adds some coin and removes quantity from any of the fields (blank space) then it's showing 
 `NAN` and not calculating the other inputted value which is completely annoying.

After this commit:
==================
- If user removes quantity from any of the fields (blank space) then the input will count `0` in the backend and calculate accordingly. 
- `Coins/Bills` title change to `Coins/`Notes`.
- Removed two coins `0.01` and `0.02` because globally any country don't have coins below`0.05`.

task - 3728728

