### PR TITLE
[FIX] web: fix grid view time format for minute

### DIFF
--- a/addons/web/static/src/views/fields/parsers.js
+++ b/addons/web/static/src/views/fields/parsers.js
@@ -101,12 +101,12 @@ export function parseFloatTime(value) {
         value = value.slice(1);
         sign = -1;
     }
-    const values = value.split(":");
-    if (values.length > 2) {
-        throw new InvalidNumberError(`"${value}" is not a correct number`);
-    }
+    const values = value.split(/:|\./);
     if (values.length === 1) {
         return sign * parseFloat(value);
+    }
+    if (values.length > 2 || values[1].length > 2) {
+        throw new InvalidNumberError(`"${value}" is not a correct number`);
     }
     const hours = parseInteger(values[0]);
     const minutes = parseInteger(values[1]);

--- a/addons/web/static/tests/views/fields/float_time_field.test.js
+++ b/addons/web/static/tests/views/fields/float_time_field.test.js
@@ -57,7 +57,7 @@ test("FloatTimeField in form view", async () => {
 test("FloatTimeField value formatted on blur", async () => {
     expect.assertions(4);
     onRpc("partner", "web_save", ({ args }) => {
-        expect(args[1].qux).toBe(9.5, {
+        expect(args[1].qux).toBe(9.083333333333334, {
             message: "the correct float value should be saved",
         });
     });
@@ -76,12 +76,12 @@ test("FloatTimeField value formatted on blur", async () => {
     });
 
     await contains(".o_field_float_time[name=qux] input").edit("9.5");
-    expect(".o_field_float_time[name=qux] input").toHaveValue("09:30", {
+    expect(".o_field_float_time[name=qux] input").toHaveValue("09:05", {
         message: "The new value should be displayed properly in the input.",
     });
 
     await clickSave();
-    expect(".o_field_widget input").toHaveValue("09:30", {
+    expect(".o_field_widget input").toHaveValue("09:05", {
         message: "The new value should be saved and displayed properly.",
     });
 });

--- a/addons/web/static/tests/views/fields/parsers.test.js
+++ b/addons/web/static/tests/views/fields/parsers.test.js
@@ -51,6 +51,7 @@ test("parseFloatTime", () => {
     expect(parseFloatTime("1:")).toBe(1);
     expect(parseFloatTime(":12")).toBe(0.2);
 
+    expect(() => parseFloatTime(":125")).toThrow();
     expect(() => parseFloatTime("a:1")).toThrow();
     expect(() => parseFloatTime("1:a")).toThrow();
     expect(() => parseFloatTime("1:1:")).toThrow();


### PR DESCRIPTION
Versions:
===========
- master

Steps to reproduce:
============
- Go to the timesheet grid view
- Click on grid cell and put time

Issue:
============
Users could input any number of digits for minutes, and  that  was converted into
hours.

Cause: 
==============
Lack of validation for the number of digits in minutes during time parsing.

Solution: 
=============
Added a condition to restrict users from entering more than two digits for
minutes.

task-3429403
