### PR TITLE
[IMP] mail: remove redundant fetch of channels

### DIFF
--- a/addons/mail/static/src/discuss/core/web/store_service_patch.js
+++ b/addons/mail/static/src/discuss/core/web/store_service_patch.js
@@ -11,11 +11,5 @@ const StorePatch = {
         this.initChannelsUnreadCounter = 0;
         this.channels = this.makeCachedFetchData({ channels_as_member: true });
     },
-    onStarted() {
-        super.onStarted();
-        if (this.discuss.isActive) {
-            this.channels.fetch();
-        }
-    },
 };
 patch(Store.prototype, StorePatch);


### PR DESCRIPTION
When discuss opens, we want to fetch the channels is it was not already done. Currently, this is done in two places:
- When starting the `DiscussClientAction`
- When starting the store (with a check on whether discuss is active or not)

This PR removes the one in the store service, since the discuss client action is the perfect place to do that.