### PR TITLE
[IMP] im_livechat, mail: allow to easily join/leave live chat channel 

### DIFF
--- a/addons/im_livechat/controllers/webclient.py
+++ b/addons/im_livechat/controllers/webclient.py
@@ -11,3 +11,18 @@ class WebClient(WebclientController):
         return request.render("im_livechat.qunit_embed_suite", {
             "server_url": request.env["ir.config_parameter"].get_base_url(),
         })
+
+    def _process_request_for_internal_user(self, store, **kwargs):
+        super()._process_request_for_internal_user(store, **kwargs)
+        if kwargs.get("livechat_channels"):
+            store.add(
+                {
+                    "LivechatChannel": request.env["im_livechat.channel"].search([]).mapped(
+                        lambda c: {
+                            "id": c.id,
+                            "name": c.name,
+                            "hasSelfAsMember": request.env.user.partner_id in c.user_ids.partner_id,
+                        }
+                    )
+                }
+            )

--- a/addons/im_livechat/models/discuss_channel.py
+++ b/addons/im_livechat/models/discuss_channel.py
@@ -78,6 +78,8 @@ class DiscussChannel(models.Model):
             } if channel.country_id else False
             if channel.livechat_operator_id:
                 channel_infos_dict[channel.id]['operator'] = channel.livechat_operator_id.mail_partner_format(fields={'id': True, 'user_livechat_username': True, 'write_date': True})[channel.livechat_operator_id]
+            if channel.channel_type == "livechat" and channel.livechat_channel_id and self.env.user._is_internal():
+                channel_infos_dict[channel.id]['livechatChannel'] = {"id": channel.livechat_channel_id.id, "name": channel.livechat_channel_id.name}
         return list(channel_infos_dict.values())
 
     @api.autovacuum

--- a/addons/im_livechat/models/im_livechat_channel.py
+++ b/addons/im_livechat/models/im_livechat_channel.py
@@ -102,11 +102,19 @@ class ImLivechatChannel(models.Model):
     # --------------------------
     def action_join(self):
         self.ensure_one()
-        return self.write({'user_ids': [(4, self._uid)]})
+        self.user_ids = [Command.link(self._uid)]
+        self.env["bus.bus"]._sendone(self.env.user.partner_id, "mail.record/insert", {
+            "LivechatChannel": {"id": self.id, "hasSelfAsMember": True}
+        })
+        return True
 
     def action_quit(self):
         self.ensure_one()
-        return self.write({'user_ids': [(3, self._uid)]})
+        self.user_ids = [Command.unlink(self._uid)]
+        self.env["bus.bus"]._sendone(self.env.user.partner_id, "mail.record/insert", {
+            "LivechatChannel": {"id": self.id, "hasSelfAsMember": False}
+        })
+        return True
 
     def action_view_rating(self):
         """ Action to display the rating relative to the channel, so all rating of the

--- a/addons/im_livechat/models/res_users.py
+++ b/addons/im_livechat/models/res_users.py
@@ -47,3 +47,11 @@ class Users(models.Model):
     def _compute_has_access_livechat(self):
         for user in self:
             user.has_access_livechat = user.has_group('im_livechat.im_livechat_group_user')
+
+    def _init_store_data(self, store):
+        super()._init_store_data(store)
+        store.add({
+            "Store": {
+                "hasLivechatAccess": self.env.user.has_access_livechat,
+            },
+        })

--- a/addons/im_livechat/models/res_users_settings.py
+++ b/addons/im_livechat/models/res_users_settings.py
@@ -10,4 +10,3 @@ class ResUsersSettings(models.Model):
     livechat_username = fields.Char("Livechat Username", help="This username will be used as your name in the livechat channels.")
     livechat_lang_ids = fields.Many2many(comodel_name='res.lang', string='Livechat languages',
                             help="These languages, in addition to your main language, will be used to assign you to Live Chat sessions.")
-    is_discuss_sidebar_category_livechat_open = fields.Boolean("Is category livechat open", default=True)

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -1,9 +1,14 @@
 declare module "models" {
     export interface DiscussApp {
-        livechat: DiscussAppCategory,
+        livechatThreads: Thread,
+        defaultLivechatCategory: DiscussAppCategory,
     }
     export interface Thread {
         anonymous_country: Object,
         anonymous_name: String,
+        appAsLivechat: DiscussApp,
+    }
+    export interface DiscussAppCategory {
+        isLivechatCategory: Boolean,
     }
 }

--- a/addons/im_livechat/static/src/core/web/@types/models.d.ts
+++ b/addons/im_livechat/static/src/core/web/@types/models.d.ts
@@ -1,4 +1,7 @@
 declare module "models" {
+    export interface Persona {
+        hasLivechatAccess: boolean;
+    }
     export interface DiscussApp {
         livechatThreads: Thread,
         defaultLivechatCategory: DiscussAppCategory,

--- a/addons/im_livechat/static/src/core/web/command_palette.xml
+++ b/addons/im_livechat/static/src/core/web/command_palette.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="im_livechat.LivechatChannelCommand">
+        <div class="o_command_default d-flex align-items-center justify-content-between px-4 py-2">
+            <i class="me-3" t-att-class="{
+                'fa fa-sign-out text-danger': props.channel.hasSelfAsMember,
+                'fa fa-sign-in text-success': !props.channel.hasSelfAsMember
+            }"/>
+            <span class="flex-grow-1 text-ellipsis"><t t-slot="name" /></span>
+        </div>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/core/web/composer_patch.js
+++ b/addons/im_livechat/static/src/core/web/composer_patch.js
@@ -26,7 +26,7 @@ patch(Composer.prototype, {
         return (
             this.thread?.type === "livechat" &&
             !this.env.inChatWindow &&
-            this.store.discuss.livechat.threads.some(
+            this.store.discuss.livechatThreads.some(
                 (thread) => thread.notEq(this.thread) && thread.isUnread
             )
         );

--- a/addons/im_livechat/static/src/core/web/discuss_app_category_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_app_category_model_patch.js
@@ -2,19 +2,39 @@
 
 import { patch } from "@web/core/utils/patch";
 import { DiscussAppCategory } from "@mail/core/common/discuss_app_category_model";
+import { Record } from "@mail/core/common/record";
 import { compareDatetime } from "@mail/utils/common/misc";
 
 patch(DiscussAppCategory.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.livechatChannel = Record.one("LivechatChannel", { inverse: "appCategory" });
+    },
     /**
      * @param {import("models").Thread} t1
      * @param {import("models").Thread} t2
      */
     sortThreads(t1, t2) {
-        if (this.id === "livechat") {
+        if (this.isLivechatCategory) {
             return (
                 compareDatetime(t2.lastInterestDateTime, t1.lastInterestDateTime) || t2.id - t1.id
             );
         }
         return super.sortThreads(t1, t2);
+    },
+
+    get isLivechatCategory() {
+        return this.livechatChannel || this.eq(this.app?.defaultLivechatCategory);
+    },
+});
+
+patch(DiscussAppCategory, {
+    LIVECHAT_SEQUENCE: 20,
+    insert() {
+        const category = super.insert(...arguments);
+        if (category.isLivechatCategory) {
+            category._store.settings[category.openStateKey] ??= true;
+        }
+        return category;
     },
 });

--- a/addons/im_livechat/static/src/core/web/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_app_model_patch.js
@@ -1,4 +1,4 @@
-/* @odoo-module */
+import { LivechatChannel } from "@im_livechat/core/web/livechat_channel_model";
 
 import { DiscussApp } from "@mail/core/common/discuss_app_model";
 import { Record } from "@mail/core/common/record";
@@ -6,26 +6,20 @@ import { Record } from "@mail/core/common/record";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 
-patch(DiscussApp, {
-    new(data) {
-        const res = super.new(data);
-        res.livechat = {
-            extraClass: "o-mail-DiscussSidebarCategory-livechat",
-            id: "livechat",
-            name: _t("Livechat"),
-            hideWhenEmpty: true,
-            canView: false,
-            canAdd: false,
-            serverStateKey: "is_discuss_sidebar_category_livechat_open",
-            sequence: 20,
-        };
-        return res;
-    },
-});
-
 patch(DiscussApp.prototype, {
     setup(env) {
         super.setup(env);
-        this.livechat = Record.one("DiscussAppCategory");
+        this.livechatThreads = Record.many("Thread", { inverse: "appAsLivechat" });
+        this.defaultLivechatCategory = Record.one("DiscussAppCategory", {
+            compute() {
+                return {
+                    extraClass: "o-mail-DiscussSidebarCategory-livechat",
+                    hideWhenEmpty: true,
+                    id: `im_livechat.category_default`,
+                    name: _t("Livechat"),
+                    sequence: LivechatChannel.LIVECHAT_SEQUENCE,
+                };
+            },
+        });
     },
 });

--- a/addons/im_livechat/static/src/core/web/discuss_app_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_app_model_patch.js
@@ -2,8 +2,8 @@ import { LivechatChannel } from "@im_livechat/core/web/livechat_channel_model";
 
 import { DiscussApp } from "@mail/core/common/discuss_app_model";
 import { Record } from "@mail/core/common/record";
-
 import { _t } from "@web/core/l10n/translation";
+
 import { patch } from "@web/core/utils/patch";
 
 patch(DiscussApp.prototype, {

--- a/addons/im_livechat/static/src/core/web/discuss_client_action_patch.js
+++ b/addons/im_livechat/static/src/core/web/discuss_client_action_patch.js
@@ -1,0 +1,14 @@
+/* @odoo-module */
+
+import { DiscussClientAction } from "@mail/core/web/discuss_client_action";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(DiscussClientAction.prototype, {
+    async restoreDiscussThread() {
+        if (this.store.self.hasLivechatAccess) {
+            await this.store.livechatChannels.fetch();
+        }
+        return super.restoreDiscussThread(...arguments);
+    },
+});

--- a/addons/im_livechat/static/src/core/web/discuss_sidebar_categories_patch.xml
+++ b/addons/im_livechat/static/src/core/web/discuss_sidebar_categories_patch.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="im_livechat.DiscussSidebarCategory" t-inherit="mail.DiscussSidebarCategory" t-inherit-mode="extension">
+        <xpath expr="//*[@name='actions']" position="inside">
+            <i
+                t-if="store.hasLivechatAccess and category.livechatChannel and store.settings[category.openStateKey]"
+                class="ms-1"
+                t-att-class="{
+                    'fa fa-sign-out text-danger': category.livechatChannel.hasSelfAsMember,
+                    'fa fa-sign-in text-success': !category.livechatChannel.hasSelfAsMember
+                }"
+                t-on-click="() => category.livechatChannel.hasSelfAsMember ? category.livechatChannel.leave() : category.livechatChannel.join()"
+                t-attf-title="{{ category.livechatChannel.hasSelfAsMember ? category.leaveTitle : category.joinTitle }}"
+                t-attf-class="{{ hover_class }}" role="img"
+            />
+        </xpath>
+    </t>
+</templates>

--- a/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_command_provider.js
@@ -1,0 +1,49 @@
+/* @odoo-module */
+
+import { Component } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { LivechatChannel } from "@im_livechat/core/web/livechat_channel_model";
+
+class LivechatChannelCommand extends Component {
+    static template = "im_livechat.LivechatChannelCommand";
+    static props = {
+        channel: LivechatChannel,
+        executeCommand: Function,
+        name: String,
+        searchValue: String,
+        slots: Object,
+    };
+}
+
+registry.category("command_provider").add("im_livechat.channel_join_leave", {
+    /**
+     * @param {import("@web/env").OdooEnv} env
+     */
+    async provide(env) {
+        const store = env.services["mail.store"];
+        if (!store?.self.hasLivechatAccess) {
+            return [];
+        }
+        await store.livechatChannels.fetch();
+        const activeChannels = new Set(
+            Object.values(store.LivechatChannel.records)
+                .filter((c) => c.discussChannels.length > 0)
+                .map((c) => c.id)
+        );
+        // Show live chat channels with ongoing conversations first
+        return Object.values(store.LivechatChannel.records)
+            .sort((c) => (activeChannels.has(c.id) ? -1 : 1))
+            .map((c) => ({
+                async action() {
+                    if (c.hasSelfAsMember) {
+                        await c.leave();
+                    } else {
+                        await c.join();
+                    }
+                },
+                Component: LivechatChannelCommand,
+                name: c.name,
+                props: { channel: c },
+            }));
+    },
+});

--- a/addons/im_livechat/static/src/core/web/livechat_channel_model.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_model.js
@@ -1,0 +1,26 @@
+/* @odoo-module */
+
+import { DiscussAppCategory } from "@mail/core/common/discuss_app_category_model";
+import { Record } from "@mail/core/common/record";
+
+export class LivechatChannel extends Record {
+    static id = "id";
+
+    /** @type {number} */
+    id;
+    /** @type {string} */
+    name;
+    discussChannels = Record.many("Thread", { inverse: "livechatChannel" });
+    appCategory = Record.one("DiscussAppCategory", {
+        compute() {
+            return {
+                id: `im_livechat.category_${this.id}`,
+                livechatChannel: this,
+                name: this.name,
+                sequence: DiscussAppCategory.LIVECHAT_SEQUENCE + this.id,
+                extraClass: "o-mail-DiscussSidebarCategory-livechat",
+            };
+        },
+    });
+}
+LivechatChannel.register();

--- a/addons/im_livechat/static/src/core/web/livechat_channel_model.js
+++ b/addons/im_livechat/static/src/core/web/livechat_channel_model.js
@@ -2,6 +2,7 @@
 
 import { DiscussAppCategory } from "@mail/core/common/discuss_app_category_model";
 import { Record } from "@mail/core/common/record";
+import { _t } from "@web/core/l10n/translation";
 
 export class LivechatChannel extends Record {
     static id = "id";
@@ -22,5 +23,17 @@ export class LivechatChannel extends Record {
             };
         },
     });
+
+    async leave() {
+        await this._store.env.services.orm.call("im_livechat.channel", "action_quit", [this.id]);
+        this._store.env.services.notification.add(_t("You left %s.", this.name), { type: "info" });
+    }
+
+    async join() {
+        await this._store.env.services.orm.call("im_livechat.channel", "action_join", [this.id]);
+        this._store.env.services.notification.add(_t("You joined %s.", this.name), {
+            type: "info",
+        });
+    }
 }
 LivechatChannel.register();

--- a/addons/im_livechat/static/src/core/web/persona_model_patch.js
+++ b/addons/im_livechat/static/src/core/web/persona_model_patch.js
@@ -1,0 +1,9 @@
+/* @odoo-module */
+
+import { Persona } from "@mail/core/common/persona_model";
+
+import { patch } from "@web/core/utils/patch";
+
+patch(Persona.prototype, {
+    hasLivechatAcces: false,
+});

--- a/addons/im_livechat/static/src/core/web/store_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/store_service_patch.js
@@ -5,6 +5,19 @@ import { Store } from "@mail/core/common/store_service";
 import { patch } from "@web/core/utils/patch";
 
 patch(Store.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.livechatChannels = this.makeCachedFetchData({ livechat_channels: true });
+    },
+    /**
+     * @override
+     */
+    onStarted() {
+        super.onStarted(...arguments);
+        if (this.discuss.isActive && this.self.hasLivechatAccess) {
+            this.livechatChannels.fetch();
+        }
+    },
     /**
      * @override
      */

--- a/addons/im_livechat/static/src/core/web/thread_service_patch.js
+++ b/addons/im_livechat/static/src/core/web/thread_service_patch.js
@@ -22,7 +22,7 @@ patch(ThreadService.prototype, {
      * @returns {boolean} Whether the livechat thread changed.
      */
     goToOldestUnreadLivechatThread() {
-        const oldestUnreadThread = this.store.discuss.livechat.threads
+        const oldestUnreadThread = this.store.discuss.livechatThreads
             .filter((thread) => thread.isUnread)
             .sort(
                 (t1, t2) =>

--- a/addons/im_livechat/static/src/views/livechat_channel_kanban/livechat_channel_kanban_renderer.js
+++ b/addons/im_livechat/static/src/views/livechat_channel_kanban/livechat_channel_kanban_renderer.js
@@ -2,10 +2,29 @@
 
 import { KanbanRenderer } from "@web/views/kanban/kanban_renderer";
 import { LivechatChannelKanbanRecord } from "./livechat_channel_kanban_record";
+import { onWillUnmount } from "@odoo/owl";
 
 export class LivechatChannelKanbanRenderer extends KanbanRenderer {
     static components = {
         ...KanbanRenderer.components,
         KanbanRecord: LivechatChannelKanbanRecord,
     };
+
+    setup() {
+        super.setup(...arguments);
+        this.onMailRecordInsert = this.onMailRecordInsert.bind(this);
+        this.env.services["bus_service"].subscribe("mail.record/insert", this.onMailRecordInsert);
+        onWillUnmount(() => {
+            this.env.services["bus_service"].unsubscribe(
+                "mail.record/insert",
+                this.onMailRecordInsert
+            );
+        });
+    }
+
+    onMailRecordInsert(payload) {
+        if (payload.LivechatChannel) {
+            this.props.list.model.load();
+        }
+    }
 }

--- a/addons/im_livechat/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/im_livechat/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -27,6 +27,12 @@ patch(MockServer.prototype, {
                         operator.id
                     );
                 }
+                channelInfo.livechatChannel = this.pyEnv["im_livechat.channel"]
+                    .searchRead([["id", "=", channel.livechat_channel_id]])
+                    .map((c) => ({
+                        id: c.id,
+                        name: c.name,
+                    }))[0];
             }
         }
         return channelInfos;

--- a/addons/im_livechat/static/tests/helpers/model_definitions_setup.js
+++ b/addons/im_livechat/static/tests/helpers/model_definitions_setup.js
@@ -1,11 +1,5 @@
 /* @odoo-module */
 
-import {
-    addModelNamesToFetch,
-    insertModelFields,
-} from "@bus/../tests/helpers/model_definitions_helpers";
+import { addModelNamesToFetch } from "@bus/../tests/helpers/model_definitions_helpers";
 
 addModelNamesToFetch(["im_livechat.channel"]);
-insertModelFields("res.users.settings", {
-    is_discuss_sidebar_category_livechat_open: { default: true },
-});

--- a/addons/im_livechat/static/tests/sidebar_patch_tests.js
+++ b/addons/im_livechat/static/tests/sidebar_patch_tests.js
@@ -96,131 +96,6 @@ QUnit.test("Do not show channel when visitor is typing", async () => {
     await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
 });
 
-QUnit.test("Close should update the value on the server", async (assert) => {
-    const pyEnv = await startServer();
-    const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
-    pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
-        channel_member_ids: [
-            [0, 0, { partner_id: pyEnv.currentPartnerId }],
-            Command.create({ guest_id: guestId }),
-        ],
-        channel_type: "livechat",
-        livechat_operator_id: pyEnv.currentPartnerId,
-    });
-    pyEnv["res.users.settings"].create({
-        user_id: pyEnv.currentUserId,
-        is_discuss_sidebar_category_livechat_open: true,
-    });
-    const currentUserId = pyEnv.currentUserId;
-    const { env, openDiscuss } = await start();
-    openDiscuss();
-    const initalSettings = await env.services.orm.call(
-        "res.users.settings",
-        "_find_or_create_for_user",
-        [[currentUserId]]
-    );
-    assert.ok(initalSettings.is_discuss_sidebar_category_livechat_open);
-    await click(".o-mail-DiscussSidebarCategory-livechat .btn");
-    const newSettings = await env.services.orm.call(
-        "res.users.settings",
-        "_find_or_create_for_user",
-        [[currentUserId]]
-    );
-    assert.notOk(newSettings.is_discuss_sidebar_category_livechat_open);
-});
-
-QUnit.test("Open should update the value on the server", async (assert) => {
-    const pyEnv = await startServer();
-    const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
-    pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
-        channel_member_ids: [
-            [0, 0, { partner_id: pyEnv.currentPartnerId }],
-            Command.create({ guest_id: guestId }),
-        ],
-        channel_type: "livechat",
-        livechat_operator_id: pyEnv.currentPartnerId,
-    });
-    pyEnv["res.users.settings"].create({
-        user_id: pyEnv.currentUserId,
-        is_discuss_sidebar_category_livechat_open: false,
-    });
-    const currentUserId = pyEnv.currentUserId;
-    const { env, openDiscuss } = await start();
-    openDiscuss();
-    const initalSettings = await env.services.orm.call(
-        "res.users.settings",
-        "_find_or_create_for_user",
-        [[currentUserId]]
-    );
-    assert.notOk(initalSettings.is_discuss_sidebar_category_livechat_open);
-    await click(".o-mail-DiscussSidebarCategory-livechat .btn");
-    const newSettings = await env.services.orm.call(
-        "res.users.settings",
-        "_find_or_create_for_user",
-        [[currentUserId]]
-    );
-    assert.ok(newSettings.is_discuss_sidebar_category_livechat_open);
-});
-
-QUnit.test("Open from the bus", async () => {
-    const pyEnv = await startServer();
-    const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
-    pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
-        channel_member_ids: [
-            [0, 0, { partner_id: pyEnv.currentPartnerId }],
-            Command.create({ guest_id: guestId }),
-        ],
-        channel_type: "livechat",
-        livechat_operator_id: pyEnv.currentPartnerId,
-    });
-    const settingsId = pyEnv["res.users.settings"].create({
-        user_id: pyEnv.currentUserId,
-        is_discuss_sidebar_category_livechat_open: false,
-    });
-    const { openDiscuss } = await start();
-    openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory-livechat");
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
-        count: 0,
-    });
-    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "res.users.settings", {
-        id: settingsId,
-        is_discuss_sidebar_category_livechat_open: true,
-    });
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
-});
-
-QUnit.test("Close from the bus", async () => {
-    const pyEnv = await startServer();
-    const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
-    pyEnv["discuss.channel"].create({
-        anonymous_name: "Visitor 11",
-        channel_member_ids: [
-            [0, 0, { partner_id: pyEnv.currentPartnerId }],
-            Command.create({ guest_id: guestId }),
-        ],
-        channel_type: "livechat",
-        livechat_operator_id: pyEnv.currentPartnerId,
-    });
-    const settingsId = pyEnv["res.users.settings"].create({
-        user_id: pyEnv.currentUserId,
-        is_discuss_sidebar_category_livechat_open: true,
-    });
-    const { openDiscuss } = await start();
-    openDiscuss();
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel");
-    pyEnv["bus.bus"]._sendone(pyEnv.currentPartner, "res.users.settings", {
-        id: settingsId,
-        is_discuss_sidebar_category_livechat_open: false,
-    });
-    await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
-        count: 0,
-    });
-});
-
 QUnit.test("Smiley face avatar for livechat item linked to a guest", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
@@ -309,7 +184,6 @@ QUnit.test("No counter if category is folded and without unread messages", async
     });
     pyEnv["res.users.settings"].create({
         user_id: pyEnv.currentUserId,
-        is_discuss_sidebar_category_livechat_open: false,
     });
     const { openDiscuss } = await start();
     openDiscuss();
@@ -338,12 +212,9 @@ QUnit.test(
             channel_type: "livechat",
             livechat_operator_id: pyEnv.currentPartnerId,
         });
-        pyEnv["res.users.settings"].create({
-            user_id: pyEnv.currentUserId,
-            is_discuss_sidebar_category_livechat_open: false,
-        });
         const { openDiscuss } = await start();
-        openDiscuss();
+        await openDiscuss();
+        await click(".o-mail-DiscussSidebarCategory-livechat .btn");
         await contains(".o-mail-DiscussSidebarCategory-livechat .o-discuss-badge", { text: "1" });
     }
 );
@@ -362,7 +233,6 @@ QUnit.test("Close manually by clicking the title", async () => {
     });
     pyEnv["res.users.settings"].create({
         user_id: pyEnv.currentUserId,
-        is_discuss_sidebar_category_livechat_open: true,
     });
     const { openDiscuss } = await start();
     openDiscuss();
@@ -386,10 +256,11 @@ QUnit.test("Open manually by clicking the title", async () => {
     });
     pyEnv["res.users.settings"].create({
         user_id: pyEnv.currentUserId,
-        is_discuss_sidebar_category_livechat_open: false,
     });
     const { openDiscuss } = await start();
     openDiscuss();
+    // first, close the live chat category
+    await click(".o-mail-DiscussSidebarCategory-livechat .btn");
     await contains(".o-mail-DiscussSidebarCategory-livechat");
     await contains(".o-mail-DiscussSidebarCategory-livechat + .o-mail-DiscussSidebarChannel", {
         count: 0,
@@ -516,6 +387,5 @@ QUnit.test("unknown livechat can be displayed and interacted with", async () => 
     await click("div[title='Unpin Conversation']", {
         parent: [".o-mail-DiscussSidebarChannel", { text: "Jane" }],
     });
-    await contains(".o-mail-DiscussSidebarCategory-livechat", { count: 0 });
     await contains(".o-mail-DiscussSidebarChannel", { count: 0 });
 });

--- a/addons/mail/static/src/core/common/discuss_app_category_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_category_model.js
@@ -64,6 +64,10 @@ export class DiscussAppCategory extends Record {
         },
         inverse: "discussAppCategory",
     });
+
+    get openStateKey() {
+        return this.serverStateKey ?? this.id;
+    }
 }
 
 DiscussAppCategory.register();

--- a/addons/mail/static/src/core/common/discuss_app_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_model.js
@@ -25,7 +25,7 @@ export class DiscussApp extends Record {
                 name: _t("Direct messages"),
                 canView: false,
                 canAdd: true,
-                sequence: 30,
+                sequence: 100,
                 serverStateKey: "is_discuss_sidebar_category_chat_open",
                 addTitle: _t("Start a conversation"),
                 addHotkey: "d",

--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -695,13 +695,16 @@ export class ThreadService {
     }
 
     getDiscussSidebarCategoryCounter(categoryId) {
-        return this.store.discuss[categoryId].threads.reduce((acc, channel) => {
-            if (categoryId === "channels") {
-                return channel.message_needaction_counter > 0 ? acc + 1 : acc;
-            } else {
-                return channel.message_unread_counter > 0 ? acc + 1 : acc;
-            }
-        }, 0);
+        return this.store.DiscussAppCategory.get({ id: categoryId }).threads.reduce(
+            (acc, channel) => {
+                if (categoryId === "channels") {
+                    return channel.message_needaction_counter > 0 ? acc + 1 : acc;
+                } else {
+                    return channel.message_unread_counter > 0 ? acc + 1 : acc;
+                }
+            },
+            0
+        );
     }
 
     /**

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.js
@@ -143,8 +143,10 @@ export class DiscussSidebarCategories extends Component {
     }
 
     async toggleCategory(category) {
-        this.store.settings[category.serverStateKey] =
-            !this.store.settings[category.serverStateKey];
+        this.store.settings[category.openStateKey] = !this.store.settings[category.openStateKey];
+        if (!category.serverStateKey) {
+            return;
+        }
         await this.orm.call(
             "res.users.settings",
             "set_res_users_settings",

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -14,19 +14,19 @@
         <t t-set="hover_class" t-value="'btn p-0 text-start text-700 opacity-100-hover opacity-75'"/>
         <div class="o-mail-DiscussSidebarCategory d-flex align-items-center my-1" t-att-class="category.extraClass">
             <div t-attf-class="d-flex align-items-baseline mx-1 {{ hover_class }}" t-on-click="() => this.toggleCategory(category)">
-                <i class="o-mail-DiscussSidebarCategory-icon small me-1" t-att-class="store.settings[category.serverStateKey] ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
+                <i class="o-mail-DiscussSidebarCategory-icon small me-1" t-att-class="store.settings[category.openStateKey] ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                 <span class="btn-sm p-0 text-uppercase fw-bolder"><t t-esc="category.name"/></span>
             </div>
             <div class="flex-grow-1"/>
             <div class="d-flex me-3">
                 <i t-if="category.canView" t-attf-class="fa fa-cog {{ hover_class }}" title="View or join channels" t-on-click="() => this.openCategory(category)" role="img"/>
-                <i t-if="category.canAdd and store.settings[category.serverStateKey]" class="o-mail-DiscussSidebarCategory-add" t-attf-class="fa fa-plus {{ hover_class }} ms-1" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" role="img"  t-att-data-hotkey="category.addHotkey"/>
+                <i t-if="category.canAdd and store.settings[category.openStateKey]" class="o-mail-DiscussSidebarCategory-add" t-attf-class="fa fa-plus {{ hover_class }} ms-1" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" role="img"  t-att-data-hotkey="category.addHotkey"/>
             </div>
-            <div t-if="!store.settings[category.serverStateKey] and threadService.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill me-3 o-discuss-badge fw-bold">
+            <div t-if="!store.settings[category.openStateKey] and threadService.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill me-3 o-discuss-badge fw-bold">
                 <t t-esc="threadService.getDiscussSidebarCategoryCounter(category.id)"/>
             </div>
         </div>
-        <t t-if="store.settings[category.serverStateKey]">
+        <t t-if="store.settings[category.openStateKey]">
             <div t-if="state.editing === category.id" class="p-2" t-ref="selector">
                 <ChannelSelector category="category" onValidate.bind="stopEditing" autofocus="true" close.bind="stopEditing" />
             </div>

--- a/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
+++ b/addons/mail/static/src/discuss/core/web/discuss_sidebar_categories.xml
@@ -11,16 +11,16 @@
     </t>
 
     <t t-name="mail.DiscussSidebarCategory">
-        <t t-set="hover_class" t-value="'btn p-0 text-start text-700 opacity-100-hover opacity-75'"/>
+        <t t-set="hover_class" t-value="'btn p-0 text-start opacity-100-hover opacity-75'"/>
         <div class="o-mail-DiscussSidebarCategory d-flex align-items-center my-1" t-att-class="category.extraClass">
-            <div t-attf-class="d-flex align-items-baseline mx-1 {{ hover_class }}" t-on-click="() => this.toggleCategory(category)">
+            <div t-attf-class="d-flex align-items-baseline mx-1 text-700 {{ hover_class }}" t-on-click="() => this.toggleCategory(category)">
                 <i class="o-mail-DiscussSidebarCategory-icon small me-1" t-att-class="store.settings[category.openStateKey] ? 'oi oi-chevron-down' : 'oi oi-chevron-right'"/>
                 <span class="btn-sm p-0 text-uppercase fw-bolder"><t t-esc="category.name"/></span>
             </div>
             <div class="flex-grow-1"/>
-            <div class="d-flex me-3">
-                <i t-if="category.canView" t-attf-class="fa fa-cog {{ hover_class }}" title="View or join channels" t-on-click="() => this.openCategory(category)" role="img"/>
-                <i t-if="category.canAdd and store.settings[category.openStateKey]" class="o-mail-DiscussSidebarCategory-add" t-attf-class="fa fa-plus {{ hover_class }} ms-1" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" role="img"  t-att-data-hotkey="category.addHotkey"/>
+            <div name="actions" class="d-flex me-3">
+                <i t-if="category.canView" t-attf-class="fa fa-cog text-700 {{ hover_class }}" title="View or join channels" t-on-click="() => this.openCategory(category)" role="img"/>
+                <i t-if="category.canAdd and store.settings[category.openStateKey]" class="o-mail-DiscussSidebarCategory-add" t-attf-class="fa fa-plus text-700 {{ hover_class }} ms-1" t-on-click="() => this.addToCategory(category)" t-att-title="category.addTitle" role="img"  t-att-data-hotkey="category.addHotkey"/>
             </div>
             <div t-if="!store.settings[category.openStateKey] and threadService.getDiscussSidebarCategoryCounter(category.id) > 0" class="o-mail-DiscussSidebar-badge badge rounded-pill me-3 o-discuss-badge fw-bold">
                 <t t-esc="threadService.getDiscussSidebarCategoryCounter(category.id)"/>
@@ -58,10 +58,10 @@
             </span>
             <div class="flex-grow-1"/>
             <div class="o-mail-DiscussSidebarChannel-commands d-none ms-1 me-3">
-                <i t-if="thread.channel_type === 'channel'" t-attf-class="fa fa-cog {{ hover_class }}" title="Channel settings" t-on-click.stop="() => this.openSettings(thread)" role="img"/>
-                <div t-if="thread.canLeave" class="fa fa-times ms-1" t-attf-class="{{ hover_class }}"
+                <i t-if="thread.channel_type === 'channel'" t-attf-class="fa fa-cog text-700 {{ hover_class }}" title="Channel settings" t-on-click.stop="() => this.openSettings(thread)" role="img"/>
+                <div t-if="thread.canLeave" class="fa fa-times ms-1 text-700" t-attf-class="{{ hover_class }}"
                     t-on-click.stop="() => this.leaveChannel(thread)" title="Leave this channel" role="img"/>
-                <div t-if="thread.canUnpin" t-attf-class="fa fa-times ms-1 {{ hover_class }}" t-on-click.stop="() => threadService.unpin(thread)" title="Unpin Conversation" role="img"/>
+                <div t-if="thread.canUnpin" t-attf-class="fa fa-times ms-1 text-700 {{ hover_class }}" t-on-click.stop="() => threadService.unpin(thread)" title="Unpin Conversation" role="img"/>
             </div>
             <t t-foreach="channelIndicators" t-as="indicator" t-key="indicator_index" t-component="indicator" t-props="{ thread }"/>
             <div t-if="thread.importantCounter > 0">

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -19,7 +19,8 @@ class TestDiscussFullPerformance(HttpCase):
     #     1: mt_comment_id
     #     6: odoobot format
     #     4: settings
-    _query_count_init_store = 16
+    #     1: hasLivechatAccess
+    _query_count_init_store = 17
     _query_count = 48 + 1  # +1 is necessary to fix nondeterministic issue on runbot
     _query_count_discuss_channels = 69
 
@@ -167,6 +168,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "action_discuss_id": xmlid_to_res_id("mail.action_discuss"),
                 "hasGifPickerFeature": False,
                 "hasLinkPreviewFeature": True,
+                "hasLivechatAccess": False,
                 "hasMessageTranslationFeature": False,
                 "internalUserGroupId": self.env.ref("base.group_user").id,
                 "mt_comment_id": xmlid_to_res_id("mail.mt_comment"),

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -21,7 +21,7 @@ class TestDiscussFullPerformance(HttpCase):
     #     4: settings
     _query_count_init_store = 16
     _query_count = 48 + 1  # +1 is necessary to fix nondeterministic issue on runbot
-    _query_count_discuss_channels = 68
+    _query_count_discuss_channels = 69
 
     def setUp(self):
         super().setUp()
@@ -97,12 +97,12 @@ class TestDiscussFullPerformance(HttpCase):
         # create groups
         self.channel_group_1 = self.env['discuss.channel'].create_group((self.users[0] + self.users[12]).partner_id.ids)
         # create livechats
-        im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
+        self.im_livechat_channel = self.env['im_livechat.channel'].sudo().create({'name': 'support', 'user_ids': [Command.link(self.users[0].id)]})
         self.env['bus.presence'].create({'user_id': self.users[0].id, 'status': 'online'})  # make available for livechat (ignore leave)
         self.authenticate('test1', self.password)
         self.channel_livechat_1 = self.env['discuss.channel'].browse(self.make_jsonrpc_request("/im_livechat/get_session", {
             'anonymous_name': 'anon 1',
-            'channel_id': im_livechat_channel.id,
+            'channel_id': self.im_livechat_channel.id,
             'previous_operator_id': self.users[0].partner_id.id,
         })["Thread"]['id'])
         self.channel_livechat_1.with_user(self.users[1]).message_post(body="test")
@@ -110,7 +110,7 @@ class TestDiscussFullPerformance(HttpCase):
         with patch("odoo.http.GeoIP.country_code", new_callable=PropertyMock(return_value=self.env.ref('base.be').code)):
             self.channel_livechat_2 = self.env['discuss.channel'].browse(self.make_jsonrpc_request("/im_livechat/get_session", {
                 'anonymous_name': 'anon 2',
-                'channel_id': im_livechat_channel.id,
+                'channel_id': self.im_livechat_channel.id,
                 'previous_operator_id': self.users[0].partner_id.id,
             })["Thread"]['id'])
         guest_sudo = self.channel_livechat_2.channel_member_ids.filtered(lambda m: m.guest_id).guest_id.sudo()
@@ -197,7 +197,6 @@ class TestDiscussFullPerformance(HttpCase):
                     "id": self.env["res.users.settings"]._find_or_create_for_user(self.users[0]).id,
                     "is_discuss_sidebar_category_channel_open": True,
                     "is_discuss_sidebar_category_chat_open": True,
-                    "is_discuss_sidebar_category_livechat_open": True,
                     "livechat_lang_ids": [],
                     "livechat_username": False,
                     "push_to_talk_key": False,
@@ -1168,6 +1167,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "is_editable": False,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
+                "livechatChannel": {"id": self.im_livechat_channel.id, "name": self.im_livechat_channel.name},
                 "message_needaction_counter": 0,
                 "name": "test1 Ernest Employee",
                 "custom_notifications": False,
@@ -1249,6 +1249,7 @@ class TestDiscussFullPerformance(HttpCase):
                 "is_editable": False,
                 "is_pinned": True,
                 "last_interest_dt": last_interest_dt,
+                "livechatChannel": {"id": self.im_livechat_channel.id, "name": self.im_livechat_channel.name},
                 "message_needaction_counter": 0,
                 "name": "anon 2 Ernest Employee",
                 "custom_notifications": False,


### PR DESCRIPTION
This PR provides a way for live chat users to efficiently join/leave a
live chat channel. Indeed, this operation is common to control the
number of chats an operator handle thus it should be as convenient as
possible. Currently, the operator must go to the live chat app and
click on the kanban button.

From now on, the operator will be able to either use the discuss
interface or the command palette to do so.

task-3640730

upgrade: https://github.com/odoo/upgrade/pull/5694

![image](https://github.com/odoo/odoo/assets/48757558/e9970485-955e-4a63-86b7-33494c21c7d9)
![image](https://github.com/odoo/odoo/assets/48757558/6ed15e3d-c6a7-422d-8101-a326f9033379)
