### PR TITLE
[FIX] l10n_in: prevent error when user save empty customer invoice sequence

### DIFF
--- a/addons/l10n_in/models/account_invoice.py
+++ b/addons/l10n_in/models/account_invoice.py
@@ -64,7 +64,7 @@ class AccountMove(models.Model):
 
     @api.onchange('name')
     def _onchange_name_warning(self):
-        if self.country_code == 'IN' and self.journal_id.type == 'sale' and (len(self.name) > 16 or not re.match(r'^[a-zA-Z0-9-\/]+$', self.name)):
+        if self.country_code == 'IN' and self.journal_id.type == 'sale' and self.name and (len(self.name) > 16 or not re.match(r'^[a-zA-Z0-9-\/]+$', self.name)):
             return {'warning': {
                 'title' : _("Invalid sequence as per GST rule 46(b)"),
                 'message': _(


### PR DESCRIPTION
The error is arises when user change the  invoice sequence into  empty and try to save the invoice.

Steps to reproduce:

- Install `l10n_in` module
- Change company from 'Your company' to 'IN company'
- Open invoicing app and open any existing invoice
- Click 'Reset to Draft' Button
- Provide empty value to 'Customer Invoice' field and save
- Error will be generated

Stack Trace:
```
TypeError: object of type 'bool' has no len()
  File "odoo/http.py", line 2207, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1778, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1799, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1776, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1784, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2009, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 30, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/account/models/account_move.py", line 2771, in onchange
    return super().onchange(values, field_names, fields_spec)
  File "addons/web/models/models.py", line 1066, in onchange
    record._apply_onchange_methods(field_name, result)
  File "odoo/models.py", line 6962, in _apply_onchange_methods
    res = method(self)
  File "addons/l10n_in/models/account_invoice.py", line 66, in _onchange_name_warning
    if self.country_code == 'IN' and self.journal_id.type == 'sale' and (len(self.name) > 16 or not re.match(r'^[a-zA-Z0-9-\/]+$', self.name)):
```

When we provide empty value to 'Customer Invoice' field than 'name' field get by default False value  and when the code[1] try to execute 'len((self.name)' function Error will be generated.

[1]https://github.com/odoo/odoo/blob/045cbce4375c7adeca309064915a6ce832c6e32e/addons/l10n_in/models/account_invoice.py#L67

This commit fix the above issue by check length of the invoice name if it
 is available.

sentry-4952642897




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
