### PR TITLE
[16.0] [FIX] mail: include inactive users/partners in _subscribe_users_automatically_get_members

### DIFF
--- a/addons/mail/models/mail_channel.py
+++ b/addons/mail/models/mail_channel.py
@@ -294,7 +294,7 @@ class Channel(models.Model):
         """ Return new members per channel ID """
         return dict(
             (channel.id, (channel.group_ids.users.partner_id - channel.channel_partner_ids).ids)
-            for channel in self
+            for channel in self.with_context(active_test=False)
         )
 
     def action_unfollow(self):


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Automatic mail  channel subscription. 

**Current behavior before PR:**
Before this fix, the _subscribe_users_automatically function tried to re-subscribe partners to mail channels. Triggering the unicity constraint on mail.channel.member.

**Desired behavior after PR is merged:**
Deactivated partners are correctly handled.




------------
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
