### PR TITLE
[IMP] rating: batchsize function

### DIFF
--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -324,5 +324,5 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
             'res_id': record_rating.id,
         } for x in range(10)])
 
-        with self.assertQueryCount(default=19):
+        with self.assertQueryCount(default=10):
             mail_record.portal_message_format({'allow_composer': 1, 'rating_include': True})

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -316,3 +316,13 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
             res = message.portal_message_format(options={'rating_include': True})
 
         self.assertEqual(len(res), 1)
+
+    def test_portal_message_format_single_rating(self):
+        record_rating = self.record_ratings[0]
+        mail_record = self.env['mail.message'].create([{
+            'model': record_rating._name,
+            'res_id': record_rating.id,
+        } for x in range(10)])
+
+        with self.assertQueryCount(default=19):
+            mail_record.portal_message_format({'allow_composer': 1, 'rating_include': True})


### PR DESCRIPTION
The performance test is added to measure number of queries
run when computation is needed on batch of records


This commit enables `rating_get_stats` function
to support batch operations.

The performance test is updated, because function
previously didn't support batching. After the change
fewer queries are run, therefore query count parameter is updated.



Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
