### PR TITLE
[FIX] hr_contract: let smart btn be seen by manager

### DIFF
--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -18,6 +18,7 @@ class Employee(models.Model):
     contracts_count = fields.Integer(compute='_compute_contracts_count', string='Contract Count')
     contract_warning = fields.Boolean(string='Contract Warning', store=True, compute='_compute_contract_warning', groups="hr.group_hr_user")
     first_contract_date = fields.Date(compute='_compute_first_contract_date', groups="hr.group_hr_user", store=True)
+    manager_user_id = fields.Many2one(related='parent_id.user_id', string='Manager UID')
 
     def _get_first_contracts(self):
         self.ensure_one()

--- a/addons/hr_contract/security/ir.model.access.csv
+++ b/addons/hr_contract/security/ir.model.access.csv
@@ -6,3 +6,4 @@ access_hr_contract_manager,hr.contract.manager,model_hr_contract,hr_contract.gro
 access_hr_contract_history_manager,hr.contract.history.manager,model_hr_contract_history,hr_contract.group_hr_contract_manager,1,1,1,1
 access_hr_payroll_structure_type_hr_contract_manager,hr.payroll.structure.type.contract.manager,model_hr_payroll_structure_type,hr_contract.group_hr_contract_manager,1,1,1,1
 access_hr_contract_hr_employee_manager,hr.contract.hr.employee.manager,model_hr_contract,hr_contract.group_hr_contract_employee_manager,1,0,0,0
+access_hr_contract_history_hr_employee_manager,hr.contract.history.hr.employee.manager,model_hr_contract_history,hr_contract.group_hr_contract_employee_manager,1,0,0,0

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -36,9 +36,23 @@
             <field name="domain_force">['|', ('employee_id.parent_id.user_id', '=', user.id), ('employee_id.user_id', '=', user.id)]</field>
         </record>
 
+        <record id="ir_rule_hr_contract_history_employee_manager" model="ir.rule">
+            <field name="name">HR Contract History: Employee Manager</field>
+            <field name="model_id" ref="model_hr_contract_history"/>
+            <field name="groups" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager'))]"/>
+            <field name="domain_force">['|', ('employee_id.parent_id.user_id', '=', user.id), ('employee_id.user_id', '=', user.id)]</field>
+        </record>
+
         <record id="ir_rule_hr_contract_manager" model="ir.rule">
             <field name="name">HR Contract: Contract Manager</field>
             <field name="model_id" ref="model_hr_contract"/>
+            <field name="groups" eval="[(4, ref('hr_contract.group_hr_contract_manager'))]"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+        </record>
+
+        <record id="ir_rule_hr_contract_history_manager" model="ir.rule">
+            <field name="name">HR Contract History: Contract Manager</field>
+            <field name="model_id" ref="model_hr_contract_history"/>
             <field name="groups" eval="[(4, ref('hr_contract.group_hr_contract_manager'))]"/>
             <field name="domain_force">[(1, '=', 1)]</field>
         </record>

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -11,12 +11,49 @@
                     <div name="button_box" position="inside">
                         <field name="contract_warning" invisible="1"/>
                         <field name="employee_type" invisible="1"/>
+                        <field name="manager_user_id" invisible="1"/>
                         <button name="action_open_contract_history"
                             class="oe_stat_button"
                             icon="fa-book"
                             type="object"
                             groups="hr_contract.group_hr_contract_manager"
                             attrs="{'invisible' : [('employee_type', 'not in', ['employee', 'student', 'trainee'])]}">
+                            <div attrs="{'invisible' : [('first_contract_date', '=', False)]}" class="o_stat_info">
+                                <span class="o_stat_text text-success" attrs="{'invisible' : [('contract_warning', '=', True)]}" title="In Contract Since"> In Contract Since</span>
+                                <span class="o_stat_value text-success" attrs="{'invisible' : [('contract_warning', '=', True)]}">
+                                    <field name="first_contract_date" readonly="1"/>
+                                </span>
+                                <span class="o_stat_text text-danger" attrs="{'invisible' : [('contract_warning', '=', False)]}" title="In Contract Since">
+                                    In Contract Since
+                                </span>
+                                <span class="o_stat_value text-danger" attrs="{'invisible' : [('contract_warning', '=', False)]}">
+                                    <field name="first_contract_date" readonly="1"/>
+                                </span>
+                            </div>
+                            <div attrs="{'invisible' : [('first_contract_date', '!=', False)]}" class="o_stat_info">
+                                <span class="o_stat_value text-danger">
+                                   <field name="contracts_count"/>
+                                </span>
+                                <span attrs="{'invisible' : [('contracts_count', '!=', 1)]}" class="o_stat_text text-danger" >
+                                    Contract
+                                </span>
+                                <span attrs="{'invisible' : [('contracts_count', '=', 1)]}" class="o_stat_text text-danger">
+                                    Contracts
+                                </span>
+                            </div>
+                        </button>
+                        <button name="action_open_contract_history"
+                            class="oe_stat_button"
+                            icon="fa-book"
+                            type="object"
+                            groups="hr_contract.group_hr_contract_employee_manager,!hr_contract.group_hr_contract_manager"
+                            attrs="{'invisible' : &quot;[
+                                '|',
+                                ('employee_type', 'not in', ['employee', 'student', 'trainee']),
+                                    '&amp;',
+                                    ('user_id', '!=', uid),
+                                    ('manager_user_id', '!=', uid),
+                            ]&quot;}">
                             <div attrs="{'invisible' : [('first_contract_date', '=', False)]}" class="o_stat_info">
                                 <span class="o_stat_text text-success" attrs="{'invisible' : [('contract_warning', '=', True)]}" title="In Contract Since"> In Contract Since</span>
                                 <span class="o_stat_value text-success" attrs="{'invisible' : [('contract_warning', '=', True)]}">


### PR DESCRIPTION
**Current behavior:**
If an employee with the `Employee Manager` level permission in
the 'Human Resources' section of the User Access Rights menu is
assigned to be a manager of some employee, they are not shown
the contract smart button in the Employees application.

**Expected behavior:**
Users with the `Employee Manager` level access right will have
the smart button to view an employee's contract if they are
their manager.

**Steps to reproduce:**
1. In some users' settings under access right, change the
     `Contracts` right to the `Employee Manager` selection

2. In the Employees Application, assign the user who was given
     the Employee Manager access right to be another employee's
     manager

3. Login to the database as the user from step one, in the
     Employees app navigate to the employee which the current
     user is now the manager of

4. Observe there is no contract smart button (the difference
     can be observed by going back to the employee view while
     logged in with the administrator account)

**Cause of the issue:**
There is currently no read access on the hr.contract.history
model for the group_hr_contract_employee_manager group. This
prevents the manager from accessing the relevant view even if
the button is available to them.

**Fix:**
Add a second button which is visible to those with the employee
manager group instead of the general contract admin group. Grant
this employee manager group read access on the
`hr.contract.history` model, then add an ir rule to limit the
scope of the read access.

Limit the visibility of the new button unless the current user
is either viewing their own record or the record of an employee
that they are the manager of. It may be more desirable to allow
indirect superiors to also view the button, that is left up to
the reviewer to determine.

opw-3714379