### PR TITLE
[IMP] web: throwing an exception when comparison wrong datatypes

### DIFF
--- a/addons/web/static/src/core/py_js/py_interpreter.js
+++ b/addons/web/static/src/core/py_js/py_interpreter.js
@@ -67,6 +67,15 @@ function pytypeIndex(val) {
 }
 
 /**
+ * @param {any} val
+ * @returns {boolean} boolean type
+ */
+function is_date(val) {
+    const dateRegexp = /^(\d{1,4})[\/-\s](\d{1,2})[\/-\s](\d{1,2})(?:\s(\d{1,2}):(\d{1,2}):(\d{1,2}))?$/;
+    return typeof val === "string" && dateRegexp.test(val) && !isNaN(new Date(val).getTime());
+}
+
+/**
  * @param {Object} obj
  * @returns {boolean}
  */
@@ -82,9 +91,6 @@ function isConstructor(obj) {
  * @returns {boolean}
  */
 function isLess(left, right) {
-    if (typeof left === "number" && typeof right === "number") {
-        return left < right;
-    }
     if (typeof left === "boolean") {
         left = left ? 1 : 0;
     }
@@ -96,7 +102,14 @@ function isLess(left, right) {
     if (leftIndex === rightIndex) {
         return left < right;
     }
-    return leftIndex < rightIndex;
+    if ((left == 0 && rightIndex == 4) || (leftIndex == 4 && right == 0)) {
+        if (is_date(left) || is_date(right)) {
+            return leftIndex < rightIndex;
+        }
+    }
+    throw new TypeError(
+        `Cannot compare values of different types ${typeof left} and ${typeof right}`
+    );
 }
 
 /**

--- a/addons/web/static/tests/core/py_js/py_interpreter.test.js
+++ b/addons/web/static/tests/core/py_js/py_interpreter.test.js
@@ -216,33 +216,40 @@ describe("comparisons", () => {
     });
 
     test("mixed types comparisons", () => {
-        expect(evaluateExpr("None < 42")).toBe(true);
-        expect(evaluateExpr("None > 42")).toBe(false);
-        expect(evaluateExpr("42 > None")).toBe(true);
-        expect(evaluateExpr("None < False")).toBe(true);
-        expect(evaluateExpr("None < True")).toBe(true);
-        expect(evaluateExpr("False > None")).toBe(true);
-        expect(evaluateExpr("True > None")).toBe(true);
-        expect(evaluateExpr("None > False")).toBe(false);
-        expect(evaluateExpr("None > True")).toBe(false);
-        expect(evaluateExpr("0 > True")).toBe(false);
-        expect(evaluateExpr("0 < True")).toBe(true);
-        expect(evaluateExpr("1 <= True")).toBe(true);
-        expect(evaluateExpr('False < ""')).toBe(true);
-        expect(evaluateExpr('"" > False')).toBe(true);
-        expect(evaluateExpr('False > ""')).toBe(false);
-        expect(evaluateExpr('0 < ""')).toBe(true);
-        expect(evaluateExpr('"" > 0')).toBe(true);
-        expect(evaluateExpr('0 > ""')).toBe(false);
-        expect(evaluateExpr("3 < True")).toBe(false);
-        expect(evaluateExpr("3 > True")).toBe(true);
-        expect(evaluateExpr("{} > None")).toBe(true);
-        expect(evaluateExpr("{} < None")).toBe(false);
-        expect(evaluateExpr("{} > False")).toBe(true);
-        expect(evaluateExpr("{} < False")).toBe(false);
-        expect(evaluateExpr("3 < 'foo'")).toBe(true);
-        expect(evaluateExpr("'foo' < 4444")).toBe(false);
-        expect(evaluateExpr("{} < []")).toBe(true);
+        expect(evaluateExpr('False < "2024-02-09"')).toBe(true);
+        expect(evaluateExpr('"2024-02-09" > False')).toBe(true);
+        expect(evaluateExpr('0 > "2024-02-09"')).toBe(false);
+        expect(evaluateExpr('0 < "2024-02-09"')).toBe(true);
+        expect(() => evaluateExpr('0 > ""')).toThrow(
+            /Cannot compare values of different types string and number/
+        );
+        expect(() => evaluateExpr('"" > 0')).toThrow(
+            /Cannot compare values of different types number and string/
+        );
+        expect(() => evaluateExpr('{} < False')).toThrow(
+            /Cannot compare values of different types object and number/
+        );
+        expect(() => evaluateExpr('3 < "foo"')).toThrow(
+            /Cannot compare values of different types number and string/
+        );
+        expect(() => evaluateExpr('"foo" < 3')).toThrow(
+            /Cannot compare values of different types string and number/
+        );
+        expect(() => evaluateExpr('None > 42')).toThrow(
+            /Cannot compare values of different types number and object/
+        );
+        expect(() => evaluateExpr('42 > None')).toThrow(
+            /Cannot compare values of different types object and number/
+        );
+        expect(() => evaluateExpr('"" > None')).toThrow(
+            /Cannot compare values of different types object and string/
+        );
+        expect(() => evaluateExpr('0 > {}')).toThrow(
+            /Cannot compare values of different types object and number/
+        );
+        expect(() => evaluateExpr('{} > 0')).toThrow(
+            /Cannot compare values of different types number and object/
+        );
     });
 });
 


### PR DESCRIPTION
Before this commit

When comparing values of different data types in an XML expression,The expression would return a value instead of throwing an exception.

After this commit

If a developer mistakenly compares values of different data types in an XML expression, An exception will be thrown.

Task - 3600595

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
