### PR TITLE
[FIX] hr_homeworking : fix behaviour for multiple employee with the same partner

### DIFF
--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 
 
 class Partner(models.Model):
@@ -10,7 +10,19 @@ class Partner(models.Model):
     employee_ids = fields.One2many(
         'hr.employee', 'work_contact_id', string='Employees', groups="hr.group_hr_user",
         help="Related employees based on their private address")
+    employee_id = fields.Many2one('hr.employee',
+        compute='_compute_company_employee', search='_search_company_employee', string="First employee")
     employees_count = fields.Integer(compute='_compute_employees_count', groups="hr.group_hr_user")
+
+    @api.depends_context('company')
+    @api.depends('employee_ids')
+    def _compute_company_employee(self):
+        for partner in self:
+            employees = partner.sudo().employee_ids.filtered(lambda e: e.company_id == self.env.company)
+            partner.employee_id = employees[0] if employees else False
+
+    def _search_company_employee(self, operator, value):
+        return [('employee_ids', operator, value)]
 
     def _compute_employees_count(self):
         for partner in self:

--- a/addons/hr_homeworking/models/res_partner.py
+++ b/addons/hr_homeworking/models/res_partner.py
@@ -7,19 +7,14 @@ class ResPartner(models.Model):
 
     def _compute_im_status(self):
         super()._compute_im_status()
-        users = self.env["res.users"].search([
-            ('partner_id.id', 'in', self.ids)])
-        for user in users:
-            dayfield = self.env['hr.employee']._get_current_day_location_field()
-            location_type = user[dayfield].location_type
+        dayfield = self.env['hr.employee']._get_current_day_location_field()
+        for partner in self:
+            location_type = self.employee_id[dayfield].location_type
             if not location_type:
                 continue
-            im_status = user.partner_id.im_status
+            im_status = partner.im_status
             if im_status == "online" or im_status == "away" or im_status == "offline":
-                user.partner_id.im_status = location_type + "_" + im_status
+                partner.im_status = location_type + "_" + im_status
 
     def get_worklocation(self, start_date, end_date):
-        employee_id = self.env['hr.employee'].search([
-            ('work_contact_id.id', 'in', self.ids),
-            ('company_id.id', '=', self.env.company.id)])
-        return employee_id._get_worklocation(start_date, end_date)
+        return self.employee_id._get_worklocation(start_date, end_date)


### PR DESCRIPTION

STEP TO REPRODUCE:

	1 - Set work_contact_id in form view to visible
	2 - Set the same work_contact_id to two employees
	3 - Set two differentes work location for the same day
	4 - Go to calendar and select this work_contact_id in filter

You will see two work locations in the calendar.

task : 3741198

Description of the issue/feature this PR addresses:

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
