### PR TITLE
[FIX] partner_autocomplete: display autocomplete createEdit

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_many2one.js
@@ -19,7 +19,7 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
 
     get sources() {
         const sources = super.sources;
-        if (!this.props.quickCreate)
+        if (!this.props.canCreate)
         {
             return sources;
         }
@@ -67,7 +67,14 @@ export class PartnerMany2XAutocomplete extends Many2XAutocomplete {
 
 }
 
-export class PartnerAutoCompleteMany2one extends Many2OneField {}
+export class PartnerAutoCompleteMany2one extends Many2OneField {
+    get Many2XAutocompleteProps() {
+        return {
+            ...super.Many2XAutocompleteProps,
+            canCreate: this.props.canCreate,
+        };
+    }
+}
 
 PartnerAutoCompleteMany2one.components = {
     ...Many2OneField.components,

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -378,4 +378,26 @@ QUnit.module('partner_autocomplete', {
             "There should be no option when partner field has no_create attribute"
         );
     });
+
+    QUnit.test("Display auto complete suggestion for canCreate", async function (assert) {
+        assert.expect(1);
+        const partnerMakeViewParams = {
+            ...makeViewParams,
+            arch:
+                `<form>
+                    <field name="company_type"/>
+                    <field name="parent_id" widget="res_partner_many2one" options="{'no_create': False}"/>
+                </form>`
+        }
+        await makeView(partnerMakeViewParams);
+        const input = target.querySelector("[name='parent_id'] input");
+        await editInputNoChangeEvent(input, "blabla");
+        const autocompleteContainer = input.parentElement;
+        assert.containsN(
+            autocompleteContainer,
+            ".o-autocomplete--dropdown-item",
+            8,
+            "Clearbit and Odoo autocomplete options should be shown"
+        );
+    });
 });


### PR DESCRIPTION
Steps to reproduce:
[account, iap credit]
- create a new invoice
- start to write "test" for the partner

Issue:
The partner autocomplete is not displayed

Cause:
in https://github.com/odoo/odoo/pull/150106 we add a condition for the quickCreate bypassing the possibility of having createEdit set to true

opw-3698400
