### PR TITLE
[FIX] project_sale_expense: fix project update profitability rounding currency issue

### DIFF
--- a/addons/project_sale_expense/models/project_project.py
+++ b/addons/project_sale_expense/models/project_project.py
@@ -30,7 +30,7 @@ class Project(models.Model):
 
         amount_billed = amount_to_bill = 0.0
         for currency, untaxed_amount_currency_sum in dict_amount_per_currency.items():
-            amount_to_bill += currency._convert(untaxed_amount_currency_sum, self.currency_id, self.company_id)
+            amount_to_bill += currency._convert(untaxed_amount_currency_sum, self.currency_id, self.company_id, round=False)
 
         sol_read_group = self.env['sale.order.line'].sudo()._read_group(
             [


### PR DESCRIPTION
Steps to reproduce:
-------------
- Install project_sale_expenses and timesheet_grid

- Create a new product
  - Can be Expensed.
  - Re-Invoice Expenses set to Sales price
  - Set sales price and cost to 957
- Create a project(service type)
- Create a sale order with the service type product
  and confirm

- Go to the expense App
- Create a expense:
    - Choose a category (the product with Expensed).
    - Customer to Reinvoice: Select the above sale order.
- Expense posted and approved

- Go to project and open project update
- Check the margin percentage to bill.

Issue:
-------------
Sometimes, the margin percentage of the 'to bill' item becomes unexpectedly
incorrect.

Cause:
-------------
In the _get_expenses_profitability_items function of project_sale_expense,
rounding during currency conversion may lead to minor variations
(e.g., 832.17 to 832.1700000000001)for some values, not all. These differences
accumulate when subtracting untaxed amounts from amount_to_bill, resulting
in a residual value (e.g., 1.1368683772161603e-13) instead of zero, causing
unexpected margin percentages.

Solution :
----------------
  The _convert method will not round the value since we passed the round=False in the _convert method.

task-3706741