### PR TITLE
[REF] odoo.base: _data_get() and format() useless monetary

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -470,7 +470,7 @@ class MonetaryConverter(models.AbstractModel):
 
         lang = self.user_lang()
         formatted_amount = lang.format(fmt, display_currency.round(value),
-                                grouping=True, monetary=True).replace(r' ', '\N{NO-BREAK SPACE}').replace(r'-', '-\N{ZERO WIDTH NO-BREAK SPACE}')
+                                grouping=True).replace(r' ', '\N{NO-BREAK SPACE}').replace(r'-', '-\N{ZERO WIDTH NO-BREAK SPACE}')
 
         pre = post = ''
         if display_currency.position == 'before':

--- a/odoo/addons/base/models/res_lang.py
+++ b/odoo/addons/base/models/res_lang.py
@@ -233,8 +233,8 @@ class Lang(models.Model):
             return 'en_US'
         return code
 
-    @tools.ormcache('self.code', 'monetary')
-    def _data_get(self, monetary=False):
+    @tools.ormcache('self.code')
+    def _data_get(self):
         thousands_sep = self.thousands_sep or ''
         decimal_point = self.decimal_point
         grouping = self.grouping
@@ -330,7 +330,7 @@ class Lang(models.Model):
         self.env.registry.clear_cache()
         return super(Lang, self).unlink()
 
-    def format(self, percent, value, grouping=False, monetary=False):
+    def format(self, percent, value, grouping=False):
         """ Format() will return the language-specific output for float values"""
         self.ensure_one()
         if percent[0] != '%':
@@ -340,7 +340,7 @@ class Lang(models.Model):
 
         # floats and decimal ints need special action!
         if grouping:
-            lang_grouping, thousands_sep, decimal_point = self._data_get(monetary)
+            lang_grouping, thousands_sep, decimal_point = self._data_get()
             eval_lang_grouping = ast.literal_eval(lang_grouping)
 
             if percent[-1] in 'eEfFgG':

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -1245,7 +1245,7 @@ def formatLang(env, value, digits=None, grouping=True, monetary=False, dp=False,
 
     lang_obj = get_lang(env)
 
-    res = lang_obj.format('%.' + str(digits) + 'f', value, grouping=grouping, monetary=monetary)
+    res = lang_obj.format('%.' + str(digits) + 'f', value, grouping=grouping)
 
     if currency_obj and currency_obj.symbol:
         if currency_obj.position == 'after':
@@ -1440,7 +1440,7 @@ def format_amount(env, amount, currency, lang_code=False):
     fmt = "%.{0}f".format(currency.decimal_places)
     lang = get_lang(env, lang_code)
 
-    formatted_amount = lang.format(fmt, currency.round(amount), grouping=True, monetary=True)\
+    formatted_amount = lang.format(fmt, currency.round(amount), grouping=True)\
         .replace(r' ', u'\N{NO-BREAK SPACE}').replace(r'-', u'-\N{ZERO WIDTH NO-BREAK SPACE}')
 
     pre = post = u''


### PR DESCRIPTION
Removes useless parameter `monetary` from `_data_get()` and `format()` function.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
