### PR TITLE
[FIX] survey: avoid overlap on multiple lines text box in survey form

### DIFF
--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -845,6 +845,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
     _initTextArea: function () {
         this.$('textarea').each(function () {
             resizeTextArea(this);
+            this.addEventListener('input', () => resizeTextArea(this));
         });
     },
 

--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -101,6 +101,10 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         }
     }
 
+    textarea.o_survey_question_text_box {
+        resize: none;
+    }
+
     div.bg-danger, div.bg-success, div.o_survey_question_skipped {
         .o_survey_question_char_box,
         .o_survey_question_date,


### PR DESCRIPTION
Steps to reproduce:

  - Install `survey` module
  - Create a survey and add 2 questions as `Multiple Lines Text Box`
  - In `Options` tab, set `Pagination` to `One page with all the questions`
  - Open the survey in test mode
  - Fill de first answer with 10 lines
  - Increase the size of the text box to display all lines

Issue:

  The text of the first answer overlap the second answer.

Cause:

  When rendering the textarea the first time, we adjust the height
  of the element AND its parent to the height of the content to
  avoid having the scroll displayed.
  The resize is done only once at first rendering.

Solution:

  Set an event on each textarea to resize it (and it's parent) each time
  we update the content.

opw-3704455