### PR TITLE
[IMP] account: Send & Print - allow force regenerate pdf

### DIFF
--- a/addons/account/wizard/account_move_send_views.xml
+++ b/addons/account/wizard/account_move_send_views.xml
@@ -16,6 +16,7 @@
                 <field name="send_mail_readonly" invisible="1"/>
                 <field name="send_mail_warning_message" invisible="1"/>
                 <field name="display_mail_composer" invisible="1"/>
+                <field name="display_force_regenerate_pdf" invisible="1"/>
                 <field name="mail_lang" invisible="1"/>
 
                 <div class="m-0" name="warnings">
@@ -42,7 +43,14 @@
                                 invisible="not send_mail_readonly"/>
                         </div>
                     </div>
-                    <div name="advanced_options" class="col-3"/>
+                    <div name="advanced_options" class="col-3">
+                        <div name="option_force_regenerate_pdf"
+                            invisible="not display_force_regenerate_pdf">
+                            <field name="force_regenerate_pdf"/>
+                            <b invisible="mode == 'invoice_single'"><label for="force_regenerate_pdf" string="Regenerate invoices"/></b>
+                            <b invisible="mode == 'invoice_multi'"><label for="force_regenerate_pdf" string="Regenerate invoice"/></b>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Mail -->


### PR DESCRIPTION
Allow to re-run the Send & Print as if there was no previously generated pdf. The invoice's PDF will therefore be re-generated and synchronized with most recent data.

Reminder: we don't do this by default because when the invoice become public it is in most cases not supposed to change, even prohibited to change in some cases.

task-3742236
