### PR TITLE
[PERF] survey: improve page switching performance

### DIFF
--- a/addons/survey/tests/test_certification_flow.py
+++ b/addons/survey/tests/test_certification_flow.py
@@ -109,7 +109,9 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
 
         with self.mock_mail_gateway():
             self._answer_question(q01, q01.suggested_answer_ids.ids[3], answer_token, csrf_token)
-            self._answer_question(q02, q02.suggested_answer_ids.ids[1], answer_token, csrf_token)
+            self._answer_question(q02, q02.suggested_answer_ids.ids[0], answer_token, csrf_token)  # incorrect => no points
+            self._answer_question(q03, "", answer_token, csrf_token, button_submit='previous')
+            self._answer_question(q02, q02.suggested_answer_ids.ids[1], answer_token, csrf_token)  # correct answer
             self._answer_question(q03, "I think they're great!", answer_token, csrf_token)
             self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token, button_submit='previous')
             self._answer_question(q03, "Just kidding, I don't like it...", answer_token, csrf_token)
@@ -117,7 +119,7 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
                                   submit_query_count=42, access_page_query_count=24)
             q05_answers = q05.suggested_answer_ids.ids[0:2] + [q05.suggested_answer_ids.ids[3]]
             self._answer_question(q05, q05_answers, answer_token, csrf_token,
-                                  submit_query_count=33, access_page_query_count=24)
+                                  submit_query_count=28, access_page_query_count=24)
             self._answer_question(q06, q06.suggested_answer_ids.ids[0], answer_token, csrf_token,
                                   submit_query_count=104, access_page_query_count=24)
 

--- a/addons/survey/tests/test_certification_flow.py
+++ b/addons/survey/tests/test_certification_flow.py
@@ -79,6 +79,11 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
                     {'value': 'a_future_and_yet_unknown_model', 'is_correct': True, 'answer_score': 1.0},
                     {'value': 'none', 'answer_score': -1.0}
                 ])
+            q06 = self._add_question(
+                None, 'Are you sure of all your answers (not rated)', 'simple_choice',
+                sequence=6,
+                constr_mandatory=False, survey_id=certification.id,
+                labels=[{'value': 'Yes'}, {'value': 'No'}])
 
         # Step: employee takes the certification
         # --------------------------------------------------
@@ -108,8 +113,13 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
             self._answer_question(q03, "I think they're great!", answer_token, csrf_token)
             self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token, button_submit='previous')
             self._answer_question(q03, "Just kidding, I don't like it...", answer_token, csrf_token)
-            self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token)
-            self._answer_question(q05, [q05.suggested_answer_ids.ids[0], q05.suggested_answer_ids.ids[1], q05.suggested_answer_ids.ids[3]], answer_token, csrf_token)
+            self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token,
+                                  submit_query_count=49, access_page_query_count=31)
+            q05_answers = q05.suggested_answer_ids.ids[0:2] + [q05.suggested_answer_ids.ids[3]]
+            self._answer_question(q05, q05_answers, answer_token, csrf_token,
+                                  submit_query_count=40, access_page_query_count=31)
+            self._answer_question(q06, q06.suggested_answer_ids.ids[0], answer_token, csrf_token,
+                                  submit_query_count=111, access_page_query_count=31)
 
         user_inputs.invalidate_recordset()
         # Check that certification is successfully passed

--- a/addons/survey/tests/test_certification_flow.py
+++ b/addons/survey/tests/test_certification_flow.py
@@ -114,12 +114,12 @@ class TestCertificationFlow(common.TestSurveyCommon, MockEmail, HttpCase):
             self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token, button_submit='previous')
             self._answer_question(q03, "Just kidding, I don't like it...", answer_token, csrf_token)
             self._answer_question(q04, q04.suggested_answer_ids.ids[0], answer_token, csrf_token,
-                                  submit_query_count=49, access_page_query_count=31)
+                                  submit_query_count=42, access_page_query_count=24)
             q05_answers = q05.suggested_answer_ids.ids[0:2] + [q05.suggested_answer_ids.ids[3]]
             self._answer_question(q05, q05_answers, answer_token, csrf_token,
-                                  submit_query_count=40, access_page_query_count=31)
+                                  submit_query_count=33, access_page_query_count=24)
             self._answer_question(q06, q06.suggested_answer_ids.ids[0], answer_token, csrf_token,
-                                  submit_query_count=111, access_page_query_count=31)
+                                  submit_query_count=104, access_page_query_count=24)
 
         user_inputs.invalidate_recordset()
         # Check that certification is successfully passed

--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -843,6 +843,8 @@ class TestSurveyInternals(common.TestSurveyCommon, MailCase):
             'time_limit': 60,
             'title': 'Where is india?',
         }])
+        test_survey.session_question_id = q_01
+
         answer_correct, answer_incorrect = q_01.suggested_answer_ids
         user_input = self.env['survey.user_input'].create({'survey_id': test_survey.id, 'is_session_answer': True})
         for (seconds_since_start, answer), expected_score in zip(

--- a/addons/survey/tests/test_survey_flow.py
+++ b/addons/survey/tests/test_survey_flow.py
@@ -95,7 +95,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             page0_q1.id: {'value': ['44.0']},
         }
         post_data = self._format_submission_data(page_0, answer_data, {'csrf_token': csrf_token, 'token': answer_token, 'button_submit': 'next'})
-        r = self._access_submit(survey, answer_token, post_data, query_count=45)
+        r = self._access_submit(survey, answer_token, post_data, query_count=38)
         self.assertResponse(r, 200)
         answers.invalidate_recordset()  # TDE note: necessary as lots of sudo in controllers messing with cache
 
@@ -113,7 +113,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             page1_q0.id: {'value': [page1_q0.suggested_answer_ids.ids[0], page1_q0.suggested_answer_ids.ids[1]]},
         }
         post_data = self._format_submission_data(page_1, answer_data, {'csrf_token': csrf_token, 'token': answer_token, 'button_submit': 'next'})
-        r = self._access_submit(survey, answer_token, post_data, query_count=48)
+        r = self._access_submit(survey, answer_token, post_data, query_count=41)
         self.assertResponse(r, 200)
         answers.invalidate_recordset()  # TDE note: necessary as lots of sudo in controllers messing with cache
 

--- a/addons/survey/tests/test_survey_flow.py
+++ b/addons/survey/tests/test_survey_flow.py
@@ -113,7 +113,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             page1_q0.id: {'value': [page1_q0.suggested_answer_ids.ids[0], page1_q0.suggested_answer_ids.ids[1]]},
         }
         post_data = self._format_submission_data(page_1, answer_data, {'csrf_token': csrf_token, 'token': answer_token, 'button_submit': 'next'})
-        r = self._access_submit(survey, answer_token, post_data, query_count=41)
+        r = self._access_submit(survey, answer_token, post_data, query_count=40)
         self.assertResponse(r, 200)
         answers.invalidate_recordset()  # TDE note: necessary as lots of sudo in controllers messing with cache
 

--- a/addons/survey/tests/test_survey_flow.py
+++ b/addons/survey/tests/test_survey_flow.py
@@ -95,7 +95,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             page0_q1.id: {'value': ['44.0']},
         }
         post_data = self._format_submission_data(page_0, answer_data, {'csrf_token': csrf_token, 'token': answer_token, 'button_submit': 'next'})
-        r = self._access_submit(survey, answer_token, post_data)
+        r = self._access_submit(survey, answer_token, post_data, query_count=45)
         self.assertResponse(r, 200)
         answers.invalidate_recordset()  # TDE note: necessary as lots of sudo in controllers messing with cache
 
@@ -113,7 +113,7 @@ class TestSurveyFlow(common.TestSurveyCommon, HttpCase):
             page1_q0.id: {'value': [page1_q0.suggested_answer_ids.ids[0], page1_q0.suggested_answer_ids.ids[1]]},
         }
         post_data = self._format_submission_data(page_1, answer_data, {'csrf_token': csrf_token, 'token': answer_token, 'button_submit': 'next'})
-        r = self._access_submit(survey, answer_token, post_data)
+        r = self._access_submit(survey, answer_token, post_data, query_count=48)
         self.assertResponse(r, 200)
         answers.invalidate_recordset()  # TDE note: necessary as lots of sudo in controllers messing with cache
 


### PR DESCRIPTION
Validating answers when completing a survey is sometimes slow.

This PR reduces the number of queries required to validate answers 
and see the next question by 6.5% to 30% depending on the endpoint, 
question type and number of answers selected in multiple choice 
questions.

Task-3742599