### PR TITLE
[IMP] stock: available quantity import feature without XML IDs

### DIFF
--- a/addons/stock/__manifest__.py
+++ b/addons/stock/__manifest__.py
@@ -6,7 +6,7 @@
     'version': '1.1',
     'summary': 'Manage your stock and logistics activities',
     'website': 'https://www.odoo.com/app/inventory',
-    'depends': ['product', 'barcodes_gs1_nomenclature', 'digest'],
+    'depends': ['base_import', 'product', 'barcodes_gs1_nomenclature', 'digest'],
     'category': 'Inventory/Inventory',
     'sequence': 25,
     'demo': [

--- a/addons/stock/models/__init__.py
+++ b/addons/stock/models/__init__.py
@@ -23,3 +23,4 @@ from . import product
 from . import stock_package_level
 from . import stock_package_type
 from . import stock_storage_category
+from . import productTemplate_import_csv

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -715,6 +715,7 @@ class ProductTemplate(models.Model):
         string="Category Routes", related='categ_id.total_route_ids', related_sudo=False)
     show_on_hand_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
     show_forecasted_qty_status_button = fields.Boolean(compute='_compute_show_qty_status_button')
+    create_onhand_qty_from_import = fields.Float('Create Available Quantity', digits='Quantity', store=True)
 
     @api.depends('type')
     def compute_is_storable(self):

--- a/addons/stock/models/productTemplate_import_csv.py
+++ b/addons/stock/models/productTemplate_import_csv.py
@@ -1,0 +1,21 @@
+from odoo import models
+
+
+class ProductTemplateImportCSV(models.TransientModel):
+
+    _inherit = 'base_import.import'
+
+    def execute_import(self, fields, columns, options, dryrun=False):
+        res = super().execute_import(fields, columns, options, dryrun=dryrun)
+        if options.get('product_import'):
+            location = self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1).lot_stock_id.id
+            templates = self.env['product.template'].browse(res.get('ids'))
+            for template in templates:
+                if template.product_variant_id.exists():
+                    vals = {
+                        'product_id': template.product_variant_id.id,
+                        'location_id': location,
+                        'inventory_quantity': template.create_onhand_qty_from_import,
+                    }
+                self.env['stock.quant'].with_context(inventory_mode=True).create(vals).action_apply_inventory()
+        return res

--- a/addons/stock/static/src/import_base/product_csv_import_model.js
+++ b/addons/stock/static/src/import_base/product_csv_import_model.js
@@ -1,0 +1,15 @@
+/** @odoo-module **/
+
+import { BaseImportModel } from "@base_import/import_model";
+import { patch } from "@web/core/utils/patch";
+
+patch(BaseImportModel.prototype, {
+    async init() {
+        await super.init(...arguments);
+        if (this.resModel === "product.template") {
+            this.importOptionsValues.product_import = {
+                value: true,
+            };
+        }
+    }
+});


### PR DESCRIPTION
Before this commit
================
Currently, if you want to import your stock, you need to import your products first, followed by their quantities using XML IDs. This process can be complex and is a very common scenario when starting with Odoo.

After this commit
===============

With this update, importing now includes quantities, so users no longer have to import quantities separately using XML IDs. You can now import available quantities directly along with the product.

TaskId: 3476677

