### PR TITLE
[FIX] web: set command palette on top of the popover

### DIFF
--- a/addons/web/static/src/core/commands/command_palette.scss
+++ b/addons/web/static/src/core/commands/command_palette.scss
@@ -1,3 +1,7 @@
+.o_command_palette_modal {
+    z-index: $zindex-popover + 1 !important;
+}
+
 .o_command_palette {
     $-app-icon-size: 1.8rem;
 

--- a/addons/web/static/src/core/commands/command_palette.xml
+++ b/addons/web/static/src/core/commands/command_palette.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
   <t t-name="web.CommandPalette" owl="1">
-    <Dialog header="false" footer="false" size="'md'" contentClass="'o_command_palette mt-5'">
+    <Dialog header="false" footer="false" size="'md'" contentClass="'o_command_palette mt-5'" headerClass="'o_command_palette_modal'">
       <div t-ref="root">
         <div class="o_command_palette_search input-group mb-2 px-4 py-3 border-bottom">
           <span t-if="state.namespace !== 'default'" class="o_namespace d-flex align-items-center me-1" t-out="state.namespace"/>

--- a/addons/web/static/src/core/dialog/dialog.js
+++ b/addons/web/static/src/core/dialog/dialog.js
@@ -79,6 +79,7 @@ export class Dialog extends Component {
 Dialog.template = "web.Dialog";
 Dialog.props = {
     contentClass: { type: String, optional: true },
+    headerClass: { type: String, optional: true },
     bodyClass: { type: String, optional: true },
     fullscreen: { type: Boolean, optional: true },
     footer: { type: Boolean, optional: true },
@@ -98,6 +99,7 @@ Dialog.props = {
     withBodyPadding: { type: Boolean, optional: true },
 };
 Dialog.defaultProps = {
+    headerClass: "",
     contentClass: "",
     bodyClass: "",
     fullscreen: false,

--- a/addons/web/static/src/core/dialog/dialog.xml
+++ b/addons/web/static/src/core/dialog/dialog.xml
@@ -7,6 +7,7 @@
                 tabindex="-1"
                 t-att-class="{ o_technical_modal: props.technical, o_modal_full: isFullscreen }"
                 t-ref="modalRef"
+                t-attf-class="{{props.headerClass}}"
                 >
                 <div class="modal-dialog modal-dialog-centered" t-attf-class="modal-{{props.size}}">
                     <div class="modal-content" t-att-class="props.contentClass" t-att-style="contentStyle">


### PR DESCRIPTION
Current behaviour
- currently when there is popover is open and after that when we open the command palette, the popover appears on top of the command palette.

Expected behaviour
- Upon opening the command palette,other popovers should be positioned behind it

To address this issue, i have added a class and set their z index higher than the popover's z-index, the popover's z-index is higher than the modal class in the command palette, causing the popover to be displayed on top. By adding the z-index higher than popover's z-index, the popover should now appear behind the command palette.

Task-3581747

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
