### PR TITLE
[FIX] account:show correct rounding invoice widget

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -1212,6 +1212,10 @@ class AccountMove(models.Model):
                 move.tax_totals = self.env['account.tax']._prepare_tax_totals(**kwargs)
                 if move.invoice_cash_rounding_id:
                     rounding_amount = move.invoice_cash_rounding_id.compute_difference(move.currency_id, move.tax_totals['amount_total'])
+                    if not rounding_amount:
+                        rounding_line = move.line_ids.filtered(lambda line: line.account_id == move.invoice_cash_rounding_id.loss_account_id or line.account_id == move.invoice_cash_rounding_id.profit_account_id)
+                        rounding_amount = rounding_line.credit - rounding_line.debit
+
                     totals = move.tax_totals
                     totals['display_rounding'] = True
                     if rounding_amount:


### PR DESCRIPTION
Current behavior:
In PoS when a rounding is done on the amount due
after a first payment. The rounding is not
displayed in the invoice form view.

Steps to reproduce:
- Setup a 0.05 rounding for PoS
- Create a sale order with a product of 17.5
- Go to payment screen
- Pay 17.09 by card (no rounding)
- Pay 0.41 by cash (rounding), this will be rounded to 0.40 when you pay it
- Invoice the order and go in the backend on the invoice form view
- The rounding is not displayed

opw-3669566
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
