### PR TITLE
[FIX] base: prevent random pylint fail

### DIFF
--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -397,7 +397,7 @@ def get_modules():
             _logger.warning("addons path does not exist: %s", ad)
             continue
         plist.extend(listdir(ad))
-    return list(set(plist))
+    return sorted(set(plist))
 
 def get_modules_with_version():
     modules = get_modules()


### PR DESCRIPTION
pylint sql-injection check may fail because of random checking paths' order this commit fixes the issue by sorting these paths

this fix is also a backport commit from https://github.com/odoo/odoo/pull/142814

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
