### PR TITLE
[FIX] mail, various: add one-click unsubscribe headers in mailing mode

### DIFF
--- a/addons/digest/controllers/portal.py
+++ b/addons/digest/controllers/portal.py
@@ -5,14 +5,32 @@ from werkzeug.exceptions import Forbidden, NotFound
 from werkzeug.urls import url_encode
 
 from odoo import _
-from odoo.http import Controller, request, route
+from odoo.http import Controller, request, Response, route
 from odoo.tools import consteq
 
 
 class DigestController(Controller):
 
+    # csrf is disabled here because it will be called by the MUA with unpredictable session at that time
+    @route('/digest/<int:digest_id>/unsubscribe_oneclik', type='http', website=True, auth='public',
+           methods=['POST'], csrf=False)
+    def digest_unsubscribe_oneclick(self, digest_id, token=None, user_id=None):
+        """ Propose a one click button to the user to unsubscribe as defined in
+        Only POST method is allowed preventing the risk that anti-spam trigger unwanted
+        unsubscribe (scenario explained in the same rfc). Note: this method
+        must support encoding method 'multipart/form-data' and 'application/x-www-form-urlencoded'.
+        """
+        self.digest_unsubscribe(digest_id, token=token, user_id=user_id)
+        return Response(status=200)
+
     @route('/digest/<int:digest_id>/unsubscribe', type='http', website=True, auth='public')
     def digest_unsubscribe(self, digest_id, token=None, user_id=None):
+        """ Unsubscribe a given user from a given digest
+
+        :param int digest_id: id of digest to unsubscribe from
+        :param str token: token preventing URL forgery
+        :param user_id: id of user to unsubscribe
+        """
         digest_sudo = request.env['digest.digest'].sudo().browse(digest_id).exists()
 
         # new route parameters

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -371,8 +371,8 @@ class Digest(models.Model):
         for digest in self:
             if digest.periodicity == 'daily':  # 3 days ago
                 limit_dt = today - relativedelta(days=3)
-            elif digest.periodicity == 'weekly':  # 2 weeks ago
-                limit_dt = today - relativedelta(days=14)
+            elif digest.periodicity == 'weekly':  # 1 week ago
+                limit_dt = today - relativedelta(days=7)
             elif digest.periodicity == 'monthly':  # 1 month ago
                 limit_dt = today - relativedelta(months=1)
             elif digest.periodicity == 'quarterly':  # 3 month ago

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -7,6 +7,7 @@ import pytz
 from datetime import datetime, date
 from dateutil.relativedelta import relativedelta
 from markupsafe import Markup
+from werkzeug.urls import url_encode, url_join
 
 from odoo import api, fields, models, tools, _
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
@@ -114,6 +115,7 @@ class Digest(models.Model):
 
     def action_send(self):
         to_slowdown = self._check_daily_logs()
+
         for digest in self:
             for user in digest.user_ids:
                 digest.with_context(
@@ -125,6 +127,8 @@ class Digest(models.Model):
             digest.next_run_date = digest._get_next_run_date()
 
     def _action_send_to_user(self, user, tips_count=1, consum_tips=True):
+        unsubscribe_token = self._get_unsubscribe_token(user.id)
+
         rendered_body = self.env['mail.render.mixin'].with_context(preserve_comments=True)._render_template(
             'digest.digest_mail_main',
             'digest.digest',
@@ -136,7 +140,7 @@ class Digest(models.Model):
                 'top_button_url': self.get_base_url(),
                 'company': user.company_id,
                 'user': user,
-                'unsubscribe_token': self._get_unsubscribe_token(user.id),
+                'unsubscribe_token': unsubscribe_token,
                 'tips_count': tips_count,
                 'formatted_date': datetime.today().strftime('%B %d, %Y'),
                 'display_mobile_banner': True,
@@ -155,16 +159,30 @@ class Digest(models.Model):
             },
         )
         # create a mail_mail based on values, without attachments
+        unsub_params = url_encode({
+            "token": unsubscribe_token,
+            "user_id": user.id,
+        })
+        unsub_url = url_join(
+            self.get_base_url(),
+            f'/digest/{self.id}/unsubscribe_oneclik?{unsub_params}'
+        )
         mail_values = {
             'auto_delete': True,
             'author_id': self.env.user.partner_id.id,
+            'body_html': full_mail,
             'email_from': (
                 self.company_id.partner_id.email_formatted
                 or self.env.user.email_formatted
                 or self.env.ref('base.user_root').email_formatted
             ),
             'email_to': user.email_formatted,
-            'body_html': full_mail,
+            # Add headers that allow the MUA to offer a one click button to unsubscribe (requires DKIM to work)
+            'headers': {
+                'List-Unsubscribe': f'<{unsub_url}>',
+                'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
+                'X-Auto-Response-Suppress': 'OOF',  # avoid out-of-office replies from MS Exchange
+            },
             'state': 'outgoing',
             'subject': '%s: %s' % (user.company_id.name, self.name),
         }

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -121,7 +121,7 @@ class Digest(models.Model):
                     lang=user.lang
                 )._action_send_to_user(user, tips_count=1)
             if digest in to_slowdown:
-                digest.write({'periodicity': self._get_next_periodicity()[0]})
+                digest.write({'periodicity': digest._get_next_periodicity()[0]})
             digest.next_run_date = digest._get_next_run_date()
 
     def _action_send_to_user(self, user, tips_count=1, consum_tips=True):

--- a/addons/digest/models/digest.py
+++ b/addons/digest/models/digest.py
@@ -304,11 +304,11 @@ class Digest(models.Model):
         self.ensure_one()
         if self.periodicity == 'daily':
             delta = relativedelta(days=1)
-        if self.periodicity == 'weekly':
+        elif self.periodicity == 'weekly':
             delta = relativedelta(weeks=1)
         elif self.periodicity == 'monthly':
             delta = relativedelta(months=1)
-        elif self.periodicity == 'quarterly':
+        else:
             delta = relativedelta(months=3)
         return date.today() + delta
 
@@ -368,11 +368,11 @@ class Digest(models.Model):
         return to_slowdown
 
     def _get_next_periodicity(self):
+        if self.periodicity == 'daily':
+            return 'weekly', _('weekly')
         if self.periodicity == 'weekly':
             return 'monthly', _('monthly')
-        if self.periodicity == 'monthly':
-            return 'quarterly', _('quarterly')
-        return 'weekly', _('weekly')
+        return 'quarterly', _('quarterly')
 
     def _format_currency_amount(self, amount, currency_id):
         pre = currency_id.position == 'before'

--- a/addons/digest/tests/test_digest.py
+++ b/addons/digest/tests/test_digest.py
@@ -247,8 +247,8 @@ class TestDigest(mail_test.MailCommon):
                 [(self.user_employee, self.reference_datetime - relativedelta(days=4))],  # old logs -> tone down
                 [],  # no logs -> tone down
                 # weekly
-                [(self.user_employee, self.reference_datetime - relativedelta(days=8))],
-                [(self.user_employee, self.reference_datetime - relativedelta(days=15))],  # old logs -> tone down
+                [(self.user_employee, self.reference_datetime - relativedelta(days=6))],
+                [(self.user_employee, self.reference_datetime - relativedelta(days=8))],  # old logs -> tone down
                 [],  # no logs -> tone down
                 # monthly
                 [(self.user_employee, self.reference_datetime - relativedelta(days=25))],

--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -473,6 +473,16 @@ class MailMail(models.Model):
                 # TDE note: could be great to pre-detect missing to/cc and skip sending it
                 # to go directly to failed state update
                 for email in email_list:
+                    # support headers specific to the specific outgoing email
+                    if email.get('headers'):
+                        email_headers = headers.copy()
+                        try:
+                            email_headers.update(email.get('headers'))
+                        except Exception:
+                            pass
+                    else:
+                        email_headers = headers
+
                     msg = IrMailServer.build_email(
                         email_from=email_from,
                         email_to=email.get('email_to'),
@@ -487,7 +497,7 @@ class MailMail(models.Model):
                         object_id=mail.res_id and ('%s-%s' % (mail.res_id, mail.model)),
                         subtype='html',
                         subtype_alternative='plain',
-                        headers=headers)
+                        headers=email_headers)
                     processing_pid = email.pop("partner_id", None)
                     try:
                         res = IrMailServer.send_email(

--- a/addons/mail_group/controllers/portal.py
+++ b/addons/mail_group/controllers/portal.py
@@ -7,8 +7,9 @@ from odoo import http, fields, tools
 from odoo.addons.http_routing.models.ir_http import slug
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.exceptions import AccessError
-from odoo.http import request
+from odoo.http import request, Response
 from odoo.osv import expression
+from odoo.tools import consteq
 
 
 class PortalMailGroup(http.Controller):
@@ -206,6 +207,31 @@ class PortalMailGroup(http.Controller):
     # ------------------------------------------------------------
     # SUBSCRIPTION
     # ------------------------------------------------------------
+
+    # csrf is disabled here because it will be called by the MUA with unpredictable session at that time
+    @http.route('/group/<int:group_id>/unsubscribe_oneclick', website=True, type='http', auth='public',
+           methods=['POST'], csrf=False)
+    def group_unsubscribe_oneclick(self, group_id, token, email):
+        """ Unsubscribe a given user from a given group. One-click unsubscribe
+        allow mail user agent to propose a one click button to the user to
+        unsubscribe as defined in rfc8058. Only POST method is allowed preventing
+        the risk that anti-spam trigger unwanted unsubscribe (scenario explained
+        in the same rfc).
+
+        :param int group_id: group ID from which user wants to unsubscribe;
+        :param str token: optional access token ensuring security;
+        :param email: email to unsubscribe;
+        """
+        group_sudo = request.env['mail.group'].sudo().browse(group_id).exists()
+        # new route parameters
+        if group_sudo and token and email:
+            correct_token = group_sudo._generate_email_access_token(email)
+            if not consteq(correct_token, token):
+                raise werkzeug.exceptions.NotFound()
+            group_sudo._leave_group(email)
+        else:
+            raise werkzeug.exceptions.NotFound()
+        return Response(status=200)
 
     @http.route('/group/subscribe', type='json', auth='public', website=True)
     def group_subscribe(self, group_id=0, email=None, token=None, **kw):

--- a/addons/mail_group/models/mail_group.py
+++ b/addons/mail_group/models/mail_group.py
@@ -412,7 +412,6 @@ class MailGroup(models.Model):
 
         base_url = self.get_base_url()
         body = self.env['mail.render.mixin']._replace_local_links(message.body)
-        access_token = self._generate_group_access_token()
 
         # Email added in a dict to be sure to send only once the email to each address
         member_emails = {
@@ -430,11 +429,14 @@ class MailGroup(models.Model):
 
                 # SMTP headers related to the subscription
                 email_url_encoded = urls.url_quote(email_member)
+                unsubscribe_url = self._get_email_unsubscribe_url(email_member_normalized)
+
                 headers = {
                     ** self._notify_email_header_dict(),
                     'List-Archive': f'<{base_url}/groups/{slug(self)}>',
                     'List-Subscribe': f'<{base_url}/groups?email={email_url_encoded}>',
-                    'List-Unsubscribe': f'<{base_url}/groups?unsubscribe&email={email_url_encoded}>',
+                    'List-Unsubscribe': unsubscribe_url,
+                    'List-Unsubscribe-Post': 'List-Unsubscribe=One-Click',
                     'Precedence': 'list',
                     'X-Auto-Response-Suppress': 'OOF',  # avoid out-of-office replies from MS Exchange
                 }
@@ -453,7 +455,7 @@ class MailGroup(models.Model):
                     'mailto': f'{self.alias_name}@{self.alias_domain}',
                     'group_url': f'{base_url}/groups/{slug(self)}',
                     'unsub_label': f'{base_url}/groups?unsubscribe',
-                    'unsub_url':  f'{base_url}/groups?unsubscribe&group_id={self.id}&token={access_token}&email={email_url_encoded}',
+                    'unsub_url':  unsubscribe_url,
                 }
                 template = self.env.ref('mail_group.mail_group_footer')
                 footer = template._render(template_values, engine='ir.qweb', minimal_qcontext=True)
@@ -666,10 +668,28 @@ class MailGroup(models.Model):
         data = (self.id, email_normalized, action)
         return hmac(self.env(su=True), 'mail_group-email-subscription', data)
 
+    def _generate_email_access_token(self, email):
+        """Generate an action token to be able to unsubscribe from the mailing
+        list, while hashing the target email to avoid spoofind other emails.
+
+        :param str email: email included in hash, should be normalized
+        """
+        return tools.hmac(self.env(su=True), 'mail_group-access-token-portal-email', (self.id, email))
+
     def _generate_group_access_token(self):
         """Generate an action token to be able to subscribe / unsubscribe from the mailing list."""
         self.ensure_one()
         return hmac(self.env(su=True), 'mail_group-access-token-portal', self.id)
+
+    def _get_email_unsubscribe_url(self, email_to):
+        params = urls.url_encode({
+            'email': email_to,
+            'token': self._generate_email_access_token(email_to),
+        })
+        return urls.url_join(
+            self.get_base_url(),
+            f'group/{self.id}/unsubscribe_oneclick?{params}'
+        )
 
     def _find_member(self, email, partner_id=None):
         """Return the <mail.group.member> corresponding to the given email address."""

--- a/addons/mail_group/tests/__init__.py
+++ b/addons/mail_group/tests/__init__.py
@@ -2,5 +2,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_mail_group
+from . import test_mail_group_mailing
 from . import test_mail_group_message
 from . import test_mail_group_moderation

--- a/addons/mail_group/tests/test_mail_group.py
+++ b/addons/mail_group/tests/test_mail_group.py
@@ -4,11 +4,13 @@
 from odoo.addons.mail.tests.common import mail_new_test_user
 from odoo.addons.mail_group.tests.common import TestMailListCommon
 from odoo.exceptions import ValidationError, AccessError
-from odoo.tests.common import users
+from odoo.tests.common import tagged, users
 from odoo.tools import mute_logger, append_content_to_html
 
 
+@tagged("mail_group")
 class TestMailGroup(TestMailListCommon):
+
     def test_clean_email_body(self):
         template = self.env.ref('mail_group.mail_group_footer')
         footer = template._render({'group_url': 'Test remove footer'}, engine='ir.qweb', minimal_qcontext=True)

--- a/addons/mail_group/tests/test_mail_group_mailing.py
+++ b/addons/mail_group/tests/test_mail_group_mailing.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from ast import literal_eval
+
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.addons.mail_group.tests.common import TestMailListCommon
+from odoo.exceptions import ValidationError, AccessError
+from odoo.tests.common import HttpCase, tagged, users
+from odoo.tools import mute_logger, append_content_to_html
+
+
+@tagged("mail_group", "mail_mail", "post_install", "-at_install")
+class TestMailGroupMailing(TestMailListCommon, HttpCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_group.moderation = False
+
+    @users("employee")
+    def test_mail_mail_headers(self):
+        """ Test headers notably unsubscribe headers """
+        test_group = self.test_group.with_env(self.env)
+        # don't contact yourself, banned people receive outgoing emails
+        expected_recipients = self.test_group_member_1 + self.test_group_member_2 + self.test_group_member_3_banned
+
+        with self.mock_mail_gateway(mail_unlink_sent=False):
+            test_group.message_post(
+                body="<p>Test Body</p>",
+            )
+
+        self.assertEqual(len(self._new_mails), len(expected_recipients))
+
+        for member in expected_recipients:
+            mail = self._find_mail_mail_wemail(member.email, "outgoing")
+            unsubscribe_url = literal_eval(mail.headers).get("List-Unsubscribe").strip('<>')
+            response = self.opener.post(unsubscribe_url)
+
+        self.assertEqual(test_group.member_ids, self.test_group_member_4_emp,
+                         "Mail Group: people should have been unsubscribed")

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -5,7 +5,7 @@ import base64
 import werkzeug
 
 from odoo import _, exceptions, http, tools
-from odoo.http import request
+from odoo.http import request, Response
 from odoo.tools import consteq
 from werkzeug.exceptions import BadRequest
 
@@ -27,6 +27,13 @@ class MassMailController(http.Controller):
     def unsubscribe_placeholder_link(self, **post):
         """Dummy route so placeholder is not prefixed by language, MUST have multilang=False"""
         raise werkzeug.exceptions.NotFound()
+
+    # csrf is disabled here because it will be called by the MUA with unpredictable session at that time
+    @http.route(['/mail/mailing/<int:mailing_id>/unsubscribe_oneclick'], type='http', website=True, auth='public',
+                methods=["POST"], csrf=False)
+    def mailing_unsubscribe_oneclick(self, mailing_id, email=None, res_id=None, token="", **post):
+        self.mailing(mailing_id, email=email, res_id=res_id, token=token, **post)
+        return Response(status=200)
 
     @http.route(['/mail/mailing/<int:mailing_id>/unsubscribe'], type='http', website=True, auth='public')
     def mailing(self, mailing_id, email=None, res_id=None, token="", **post):

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -812,6 +812,19 @@ class MassMailing(models.Model):
         done_res_ids = {record['res_id'] for record in already_mailed}
         return [rid for rid in res_ids if rid not in done_res_ids]
 
+    def _get_unsubscribe_oneclick_url(self, email_to, res_id):
+        url = werkzeug.urls.url_join(
+            self.get_base_url(), 'mail/mailing/%(mailing_id)s/unsubscribe_oneclick?%(params)s' % {
+                'mailing_id': self.id,
+                'params': werkzeug.urls.url_encode({
+                    'res_id': res_id,
+                    'email': email_to,
+                    'token': self._unsubscribe_token(res_id, email_to),
+                }),
+            }
+        )
+        return url
+
     def _get_unsubscribe_url(self, email_to, res_id):
         url = werkzeug.urls.url_join(
             self.get_base_url(), 'mail/mailing/%(mailing_id)s/unsubscribe?%(params)s' % {


### PR DESCRIPTION
PURPOSE

One-click unsubscribe headers are becoming required in order to avoid having
marketing emails being qualified as spam. This change adds those headers
in various modules: digest (backport of changes done for v17), mailing
lists (mail_group module) and improve unsubscribe in mass mailing by supporting
one-click unsubscribe (as current portal page is not one-click available).

Modules
* mass mailing
* digest
* mail group

SUMMARY

To ease the way people can unsubscribe from a digest, we have followed the
advice of RFC8058 by adding the following header to the email:
* List-Unsubscribe: unsubscribe route;
* List-Unsubscribe-Post: List-Unsubscribe=One-Click

The unsubscribe route
* must work with the POST method but not the GET. The GET version is disabled
to avoid unintended unsubscrbe that could be triggered by an anti-spam
accessing the URLs in the headers. Email readers are supposed to do
POST requests as described in the RFC;
* must unsubscribe the user without any additional steps (one click)
* should contain an opaque identifier hard-to-forge to identify the list and
the user (our token fulfills that goal). The goal is to avoid that someone
is allowed to unregister someone else easily.
* must fulfill other conditions like no cookie, no redirection, ... hence those
routes return a 200 status.

MISC

Also fix various issues in digest, notably improve tone down computation and
fix issues when computing the new timespan.

Task-3741195 (Digest: Make It Quality Spam)
Task-3717213 (Mail: Ensure Unsubscribe Headers)
Task-3741203 (Digest: Investigate tone down / reminder)