### PR TITLE
[FIX] website_sale_loyalty: apply reward if multi_product

### DIFF
--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -90,7 +90,7 @@ class WebsiteSale(main.WebsiteSale):
             if reward_id in rewards:
                 coupon_id = coupon
         redirect = post.get('r', '/shop/cart')
-        if not coupon_id or not reward_id.exists() or reward_id.multi_product:
+        if not coupon_id or not reward_id.exists():
             return request.redirect(redirect)
         self._apply_reward(order, reward_id, coupon_id)
         return request.redirect(redirect)

--- a/addons/website_sale_loyalty/tests/test_free_product_reward.py
+++ b/addons/website_sale_loyalty/tests/test_free_product_reward.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import http
+from odoo import Command
 from odoo.tests.common import HttpCase
 from odoo.tests import tagged
 from odoo.addons.website.tools import MockRequest
@@ -28,27 +29,7 @@ class TestFreeProductReward(HttpCase):
         })
 
         # Disable any other program
-        self.program = self.env['loyalty.program'].search([]).write({'active': False})
-
-        self.program = self.env['loyalty.program'].create({
-            'name': 'Get a product for free',
-            'program_type': 'promotion',
-            'applies_on': 'current',
-            'trigger': 'auto',
-            'rule_ids': [(0, 0, {
-                'minimum_qty': 1,
-                'minimum_amount': 0.00,
-                'reward_point_amount': 1,
-                'reward_point_mode': 'order',
-                'product_ids': self.sofa,
-            })],
-            'reward_ids': [(0, 0, {
-                'reward_type': 'product',
-                'reward_product_id': self.carpet.id,
-                'reward_product_qty': 1,
-                'required_points': 1,
-            })],
-        })
+        self.env['loyalty.program'].search([]).write({'active': False})
 
         self.steve = self.env['res.partner'].create({
             'name': 'Steve Bucknor',
@@ -68,10 +49,29 @@ class TestFreeProductReward(HttpCase):
     def test_add_product_to_cart_when_it_exist_as_free_product(self):
         # This test the flow when we claim a reward in the cart page and then we
         # want to add the product again
+        program = self.env['loyalty.program'].create({
+            'name': 'Get a product for free',
+            'program_type': 'promotion',
+            'applies_on': 'current',
+            'trigger': 'auto',
+            'rule_ids': [Command.create({
+                'minimum_qty': 1,
+                'minimum_amount': 0.00,
+                'reward_point_amount': 1,
+                'reward_point_mode': 'order',
+                'product_ids': self.sofa,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'product',
+                'reward_product_id': self.carpet.id,
+                'reward_product_qty': 1,
+                'required_points': 1,
+            })],
+        })
         order = self.empty_order
         with MockRequest(self.env, website=self.website, sale_order_id=order.id, website_sale_current_pl=1):
             self.WebsiteSaleController.cart_update_json(self.sofa.id, set_qty=1)
-            self.WebsiteSaleController.claim_reward(self.program.reward_ids[0].id)
+            self.WebsiteSaleController.claim_reward(program.reward_ids[0].id)
             self.WebsiteSaleController.cart_update_json(self.carpet.id, set_qty=1)
             sofa_line = order.order_line.filtered(lambda line: line.product_id.id == self.sofa.id)
             carpet_reward_line = order.order_line.filtered(lambda line: line.product_id.id == self.carpet.id and line.is_reward_line)
@@ -79,3 +79,40 @@ class TestFreeProductReward(HttpCase):
             self.assertEqual(sofa_line.product_uom_qty, 1, "Should have only 1 qty of Sofa")
             self.assertEqual(carpet_reward_line.product_uom_qty, 1, "Should have only 1 qty for the carpet as reward")
             self.assertEqual(carpet_line.product_uom_qty, 1, "Should have only 1 qty for carpet as non reward")
+
+    def test_free_product_reward_multi_product(self):
+        """ Test that multi product reward is applied when it is claimed on the cart page """
+        reward_tag_id = self.env['product.tag'].create({
+            'name': 'reward_product_tag',
+            'product_product_ids': (self.sofa | self.carpet).ids,
+        }).id
+        free_multi_product = self.env['loyalty.program'].create({
+            'name': '3 items of products with tag get 1 for free',
+            'program_type': 'promotion',
+            'trigger': 'auto',
+            'applies_on': 'current',
+            'rule_ids': [Command.create({
+                'product_tag_id': reward_tag_id,
+                'reward_point_mode': 'unit',
+                'minimum_qty': 0,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'product',
+                'reward_product_tag_id': reward_tag_id,
+                'reward_product_qty': 1,
+                'required_points': 3,
+            })],
+        })
+        order = self.empty_order
+        with MockRequest(
+            self.env, website=self.website, sale_order_id=order.id, website_sale_current_pl=1
+        ):
+            self.WebsiteSaleController.cart_update_json(self.sofa.id, set_qty=3)
+            self.WebsiteSaleController.claim_reward(free_multi_product.reward_ids[0].id)
+            reward_line_product = order.order_line.filtered(lambda line: line.is_reward_line)
+            msg = "Should have only 1 qty of free product."
+            self.assertEqual(reward_line_product.product_uom_qty, 1, msg)
+            msg = "Free product should have the reward tag."
+            self.assertIn(
+                reward_tag_id, reward_line_product.product_id.additional_product_tag_ids.ids, msg
+            )


### PR DESCRIPTION
Steps to reproduce:
1) Create 2 products with a product tag (ex. '3+1')
2) Create Buy X Get Y reward.
	In the conditional rules choose:
		- in the 'among' section the product tag '3+1',
		- in the 'grant' 1 point per unit paid
	In the rewards choose:
		- reward type as 'Free product'
		- in exchage of 3 points
		- in the 'among' section the product tag '3+1'
3) Go to /shop page and add 3 products with the tag '3+1'
4) Try to click on the button 'Free product'
5) The reward is not applied

Reason:
In the claim_reward function a reward is not applied if it is a
multi_product one.

After this commit the reward will be applied.

opw-3587020
