### PR TITLE
[IMP] website_sale: added support for multiple image uploads

### DIFF
--- a/addons/web_editor/static/src/components/media_dialog/file_selector.xml
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates id="template" xml:space="preserve">
 <t t-name="web_editor.FileSelectorControlPanel">
-    <div class="o_we_file_selector_control_panel sticky-top d-flex flex-wrap gap-2 mb-1 p-3 align-items-end">
+    <div class="o_we_file_selector_control_panel sticky-top d-flex flex-wrap gap-2 mb-1 py-2 align-items-end">
         <SearchMedia searchPlaceholder="props.searchPlaceholder" needle="props.needle" search="props.search"/>
         <div class="d-flex gap-3 justify-content-start align-items-center">
             <div t-if="props.showOptimizedOption" class="flex-shrink-0 form-check form-switch align-items-center" t-on-change="props.changeShowOptimized">

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -116,6 +116,7 @@
             'website_sale/static/src/scss/website_sale_backend.scss',
             'website_sale/static/src/js/tours/website_sale_shop.js',
             'website_sale/static/src/xml/website_sale.xml',
+            'website_sale/static/src/js/components/media_dialog/*',
         ],
         'website.assets_wysiwyg': [
             'website_sale/static/src/scss/website_sale.editor.scss',
@@ -133,8 +134,11 @@
         ],
         'web.assets_tests': [
             'website_sale/static/tests/**/*',
-            'website_sale/static/src/js/tours/product_configurator_tour_utils.js',
+            'website_sale/static/tests/tours/**/*',
         ],
+        'web.qunit_suite_tests': [
+            'website_sale/static/tests/*.js',
+        ]
     },
     'license': 'LGPL-3',
 }

--- a/addons/website_sale/static/src/js/components/media_dialog/kanban_record.scss
+++ b/addons/website_sale/static/src/js/components/media_dialog/kanban_record.scss
@@ -1,0 +1,17 @@
+.o_form_renderer {
+    .o_field_product_media_viewer .o_kanban_renderer {
+        --KanbanRecord-width: 100px;
+
+        article.o_kanban_record {
+            display: flex;
+            justify-content: center;
+            margin-bottom: unset !important;
+
+            & img {
+                height: 128px;
+                width: 168.86px;
+                object-fit: contain;
+            }
+        }
+    }
+}

--- a/addons/website_sale/static/src/js/components/media_dialog/website_sale_image_field.js
+++ b/addons/website_sale/static/src/js/components/media_dialog/website_sale_image_field.js
@@ -1,0 +1,71 @@
+import { registry } from '@web/core/registry';
+import { useService } from '@web/core/utils/hooks';
+import { ImageField, imageField } from '@web/views/fields/image/image_field';
+import { MultiMediaDialog } from './website_sale_media_dialog';
+import { getVideoUrl } from './website_sale_one2many';
+
+export class ProductMultiMediaImageField extends ImageField {
+    static template = "website_sale.ImageField";
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.dialog = useService("dialog");
+    }
+
+    /**
+     * New method and a new edit button is introduced here to overwrite,
+     * standard behavior of opening file input box in order to update a record.
+     */
+
+    onFileEdit(ev) {
+        const isVideo = this.props.record.data.video_url;
+        let mediaEl;
+        if (isVideo) {
+            mediaEl = document.createElement("img");
+            mediaEl.dataset.src = this.props.record.data.video_url;
+        }
+        this.dialog.add(MultiMediaDialog, {
+            onlyImages: true,
+            media: mediaEl,
+            activeTab: isVideo ? "VIDEOS" : "IMAGES",
+            save: (el) => {}, // Simple rebound to fake its execution
+            imageSave: this.onImageSave.bind(this),
+            videoSave: this.onVideoSave.bind(this),
+        });
+    }
+
+    async onImageSave(attachment) {
+        const attachmentRecord = await this.orm.searchRead(
+            "ir.attachment",
+            [["id", "=", attachment[0].id]],
+            ["id", "datas", "name"],
+            {}
+        );
+        await this.props.record.update({
+            [this.props.name]: attachmentRecord[0].datas,
+            name: attachmentRecord[0].name,
+        });
+    }
+
+    async onVideoSave(videoInfo) {
+        const url = getVideoUrl(videoInfo[0].platform, videoInfo[0].videoId, videoInfo[0].params);
+        await this.props.record.update({
+            video_url: url.href,
+            name: videoInfo[0].platform + " - [Video]",
+        });
+    }
+
+    onFileRemove() {
+        const parentRecord = this.props.record?._parentRecord.data;
+        parentRecord?.product_template_image_ids
+            ? parentRecord.product_template_image_ids.delete(this.props.record)
+            : parentRecord.product_variant_image_ids.delete(this.props.record);
+    }
+}
+
+export const productMultiMediaImageField = {
+    ...imageField,
+    component: ProductMultiMediaImageField,
+};
+
+registry.category("fields").add("multi_media_image", productMultiMediaImageField);

--- a/addons/website_sale/static/src/js/components/media_dialog/website_sale_image_field.xml
+++ b/addons/website_sale/static/src/js/components/media_dialog/website_sale_image_field.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates>
+    <t t-name="website_sale.ImageField" t-inherit="web.ImageField" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('position-relative')]//div" position="replace">
+            <div t-attf-class="position-absolute d-flex justify-content-between w-100 bottom-0 opacity-0 opacity-100-hover {{isMobile ? 'o_mobile_controls' : ''}}" aria-atomic="true" t-att-style="sizeStyle">
+                <button
+                    t-if="props.record.data[props.name] and state.isValid"
+                    class="o_select_file_button btn btn-light border-0 rounded-circle m-1 p-1"
+                    data-tooltip="Edit"
+                    aria-label="Edit"
+                    t-on-click.prevent.stop="onFileEdit">
+                    <i class="fa fa-pencil fa-fw"/>
+                </button>
+                <button
+                    t-if="props.record.data[props.name] and state.isValid"
+                    class="o_clear_file_button btn btn-light border-0 rounded-circle m-1 p-1"
+                    data-tooltip="Clear"
+                    aria-label="Clear"
+                    t-on-click.prevent.stop="onFileRemove">
+                    <i class="fa fa-trash-o fa-fw"/>
+                </button>
+            </div>
+        </xpath>
+    </t>
+</templates>

--- a/addons/website_sale/static/src/js/components/media_dialog/website_sale_media_dialog.js
+++ b/addons/website_sale/static/src/js/components/media_dialog/website_sale_media_dialog.js
@@ -1,0 +1,38 @@
+import { MediaDialog, TABS } from '@web_editor/components/media_dialog/media_dialog';
+
+export class MultiMediaDialog extends MediaDialog {
+    setup() {
+        super.setup();
+        this.addTab(TABS.VIDEOS);
+    }
+
+    /**
+     * @override
+     */
+    async save() {
+        if (this.errorMessages[this.state?.activeTab]) {
+            this.notificationService.add(this.errorMessages[this.state.activeTab], {
+                type: "danger",
+            });
+            return;
+        }
+        if (this.state.activeTab == "IMAGES") {
+            const attachments = this.selectedMedia[this.state.activeTab];
+            const preloadedAttachments = attachments.filter((attachment) => attachment.res_model);
+            this.selectedMedia[this.state.activeTab] = attachments.filter(
+                (attachment) => !preloadedAttachments.includes(attachment)
+            );
+            if (this.selectedMedia[this.state.activeTab].length > 0) {
+                await super.save();
+                const newAttachments = this.selectedMedia[this.state.activeTab];
+                this.props.imageSave(newAttachments);
+            }
+            if (preloadedAttachments.length) {
+                this.props.imageSave(preloadedAttachments);
+            }
+        } else {
+            this.props.videoSave(this.selectedMedia[this.state.activeTab]);
+        }
+        this.props.close();
+    }
+}

--- a/addons/website_sale/static/src/js/components/media_dialog/website_sale_one2many.js
+++ b/addons/website_sale/static/src/js/components/media_dialog/website_sale_one2many.js
@@ -1,0 +1,96 @@
+import { registry } from '@web/core/registry';
+import { useService } from '@web/core/utils/hooks';
+import { X2ManyField, x2ManyField } from '@web/views/fields/x2many/x2many_field';
+import { MultiMediaDialog } from './website_sale_media_dialog';
+
+/*
+ * This method is copied from enterprise/knowledge/static/src/js/knowledge_utils.js
+ * We can't import it directly because it adds a dependency on enterprise.
+ */
+export function getVideoUrl(platform, videoId, params) {
+    let url;
+    switch (platform) {
+        case "youtube":
+            url = new URL(`https://www.youtube.com/embed/${videoId}`);
+            break;
+        case "vimeo":
+            url = new URL(`https://player.vimeo.com/video/${videoId}`);
+            break;
+        case "dailymotion":
+            url = new URL(`https://www.dailymotion.com/embed/video/${videoId}`);
+            break;
+        case "instagram":
+            url = new URL(`https://www.instagram.com/p/${videoId}/embed`);
+            break;
+        case "youku":
+            url = new URL(`https://player.youku.com/embed/${videoId}`);
+            break;
+        default:
+            throw new Error();
+    }
+    url.search = new URLSearchParams(params);
+    return url;
+}
+
+export class ProductMediaViewer extends X2ManyField {
+    static template = "website_sale.ProductMediaViewer";
+
+    setup() {
+        super.setup();
+        this.dialogs = useService("dialog");
+        this.orm = useService("orm");
+        this.supportedFields = ["image_1920", "image_1024", "image_512", "image_256", "image_128"];
+    }
+
+    addMedia() {
+        this.dialogs.add(MultiMediaDialog, {
+            save: (el) => {}, // Simple rebound to fake its execution
+            multiImages: true,
+            imageSave: this.onImageSave.bind(this),
+            videoSave: this.onVideoSave.bind(this),
+        });
+    }
+
+    onVideoSave(videoInfo) {
+        const url = getVideoUrl(videoInfo[0].platform, videoInfo[0].videoId, videoInfo[0].params);
+        const videoList = this.props.record.data[this.props.name];
+        videoList.addNewRecord({ position: "bottom" }).then((record) => {
+            record.update({ name: videoInfo[0].platform + " - [Video]", video_url: url.href });
+        });
+    }
+
+    async onImageSave(attachments) {
+        const attachmentIds = attachments.map((attachment) => attachment.id);
+        const attachmentRecords = await this.orm.searchRead(
+            "ir.attachment",
+            [["id", "in", attachmentIds]],
+            ["id", "datas", "name"],
+            {}
+        );
+        attachmentRecords.forEach((attachment) => {
+            const imageList = this.props.record.data[this.props.name];
+            imageList.addNewRecord({ position: "bottom" }).then((record) => {
+                const activeFields = imageList.activeFields;
+                const updateData = {};
+                for (const field in activeFields) {
+                    if (attachment.datas && this.supportedFields.includes(field)) {
+                        updateData[field] = attachment.datas;
+                        updateData["name"] = attachment.name;
+                    }
+                }
+                record.update(updateData);
+            });
+        });
+    }
+
+    async onAdd({ context, editable } = {}) {
+        this.addMedia();
+    }
+}
+
+export const productMediaViewer = {
+    ...x2ManyField,
+    component: ProductMediaViewer,
+};
+
+registry.category("fields").add("product_media_viewer", productMediaViewer);

--- a/addons/website_sale/static/src/js/components/media_dialog/website_sale_one2many.xml
+++ b/addons/website_sale/static/src/js/components/media_dialog/website_sale_one2many.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <t t-name="website_sale.ProductMediaViewer" t-inherit="web.X2ManyField" t-inherit-mode="primary">
+        <xpath expr="//div[hasclass('o_x2m_control_panel')]" position="before">
+           <KanbanRenderer t-if="props.viewMode" t-props="rendererProps"/>
+        </xpath>
+        <xpath expr="//div[hasclass('o_x2m_control_panel')]" position="attributes">
+            <attribute name="class">o_x2m_control_panel d-empty-none mt-1</attribute>
+        </xpath>
+        <xpath expr="//KanbanRenderer[last()]" position="replace"/>
+    </t>
+</templates>

--- a/addons/website_sale/static/tests/website_sale_media_dialog_tests.js
+++ b/addons/website_sale/static/tests/website_sale_media_dialog_tests.js
@@ -1,0 +1,92 @@
+import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+import { click, getFixture, patchWithCleanup } from "@web/../tests/helpers/utils";
+import { MultiMediaDialog } from "@website_sale/js/components/media_dialog/website_sale_media_dialog";
+
+const serverData = {
+    models: {
+        "product.template": {
+            fields: {
+                display_name: { string: "Name", type: "char" },
+                product_template_image_ids: {
+                    string: "Extra Product Media",
+                    type: "one2many",
+                    relation: "product.image",
+                },
+            },
+            records: [
+                {
+                    id: 1,
+                    display_name: "Product 1",
+                    product_template_image_ids: [1, 2],
+                },
+            ],
+        },
+        "product.image": {
+            fields: {
+                name: { string: "Name", type: "char" },
+                image_1920: { string: "Image", type: "binary" },
+                video_url: { string: "Video URL", type: "char" },
+                sequence: { string: "Sequence", type: "integer" },
+            },
+            records: [
+                {
+                    id: 1,
+                    name: "Image 1",
+                    image_1920: "R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==",
+                },
+                {
+                    id: 2,
+                    name: "Image 2",
+                    image_1920: "R0lGODlhAQABAAD/ACwAAAAAAQABAAACAA==",
+                    video_url: "https://www.youtube.com/watch?v=123456",
+                },
+            ],
+        },
+    },
+    views: {
+        "product.image,false,kanban": `
+            <kanban string="Product Images" >
+                <field name="name"/>
+                <field name="image_1920"/>
+                <field name="video_url"/>
+                <field name="sequence" widget="handle"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="o_squared_image">
+                            <field class="card-img-top" name="image_1920"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+        "product.template,false,form": `
+            <form>
+                <group colspan="2" name="product_template_images" string="Extra Product Media">
+                    <field colspan="2" name="product_template_image_ids" mode="kanban" widget="product_media_viewer" add-label="Add Media" nolabel="1"/>
+                </group>
+            </form>`,
+    },
+};
+
+QUnit.module("ProductTemplate > MediaDialog");
+
+QUnit.test("Adding Media button opens a media dialog", async function (assert) {
+    const target = getFixture();
+    setupViewRegistries();
+
+    patchWithCleanup(MultiMediaDialog.prototype, {
+        setup() {
+            this.state = {};
+            assert.step("open media dialog");
+        },
+    });
+
+    await makeView({
+        type: "form",
+        resId: 1,
+        resModel: "product.template",
+        serverData,
+    });
+
+    await click(target, ".o_field_product_media_viewer .o_cp_buttons button");
+    assert.verifySteps(["open media dialog"]);
+});

--- a/addons/website_sale/views/product_image_views.xml
+++ b/addons/website_sale/views/product_image_views.xml
@@ -44,16 +44,17 @@
                 <field name="id"/>
                 <field name="name"/>
                 <field name="image_1920"/>
+                <field name="video_url"/>
                 <field name="sequence" widget="handle"/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div class="card oe_kanban_global_click p-0">
+                        <div class="card p-0">
                             <div class="o_squared_image">
-                                <img class="card-img-top" t-att-src="kanban_image('product.image', 'image_1920', record.id.raw_value)" t-att-alt="record.name.value"/>
+                                <field class="card-img-top" name="image_1920" widget="multi_media_image"/>
                             </div>
                             <div class="card-body p-0">
                                 <h4 class="card-title p-2 m-0 bg-200">
-                                    <small><field name="name"/></small>
+                                    <small t-attf-title="#{record.name.value}"><field name="name" class="text-truncate d-block"/></small>
                                 </h4>
                             </div>
                             <!-- below 100 Kb: good -->
@@ -71,7 +72,7 @@
                                 <t t-set="size_status" t-value="'text-bg-danger'"/>
                                 <t t-set="message">Optimization required! Reduce the image size or increase your compression settings.</t>
                             </t>
-                            <span t-attf-class="badge #{size_status} o_product_image_size" t-esc="record.image_1920.value" t-att-title="message"/>
+                            <span t-attf-class="badge #{size_status} o_product_image_size" t-att-title="message"> </span>
                         </div>
                     </t>
                 </templates>

--- a/addons/website_sale/views/product_views.xml
+++ b/addons/website_sale/views/product_views.xml
@@ -179,8 +179,8 @@
                     <field name="public_categ_ids" widget="many2many_tags" string="Categories"/>
                     <field name="website_ribbon_id" groups="base.group_no_one" options="{'no_quick_create': True}"/>
                 </group>
-                <group name="product_template_images" string="eCommerce Media" invisible="not sale_ok">
-                    <field name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add a Media" nolabel="1"/>
+                <group colspan="2" name="product_template_images" string="eCommerce Media" invisible="not sale_ok">
+                    <field colspan="2" name="product_template_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" widget="product_media_viewer" add-label="Add Media" nolabel="1"/>
                 </group>
             </xpath>
         </field>
@@ -206,8 +206,8 @@
                 <field name="variant_ribbon_id" options="{'no_quick_create': True}"/>
             </group>
             <group name="packaging" position="after">
-                <group name="product_variant_images" string="Extra Variant Media">
-                    <field name="product_variant_image_ids" class="o_website_sale_image_list" context="{'default_name': name}" mode="kanban" add-label="Add a Media" nolabel="1"/>
+                <group colspan="2" name="product_variant_images" string="Extra Variant Media">
+                    <field colspan="2" name="product_variant_image_ids" mode="kanban" widget="product_media_viewer" add-label="Add Media" nolabel="1"/>
                 </group>
             </group>
         </field>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Improving media upload screens and introducing media dialog in backend.

Current behavior before PR:
- Uploading multiple images on a product from backend was tricky as it 
only allowed single file upload.
- Uploaded images has no direct control buttons on them for modifications.

Desired behavior after PR is merged:
- Old form view for uploading images got replaced by MediaDialog, which
supports Multiple image uploads, and has a cleaner view for image and video
upload screens.
- Uploaded images now has two hover buttons on them, which allows modifying or
direct delection of the image.

Task- [3390792](https://www.odoo.com/web#id=3390792&cids=2&menu_id=4722&action=333&active_id=4106&model=project.task&view_type=form)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
