### PR TITLE
[IMP] project: improve task and project sharing search view

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -9,7 +9,6 @@
                 <search string="Tasks">
                     <field name="name" string="Tasks" filter_domain="['|', ('name', 'ilike', self), ('id', 'ilike', self)]"/>
                     <field name="tag_ids"/>
-                    <field name="user_ids" filter_domain="[('user_ids.name', 'ilike', self), ('user_ids.active', 'in', [True, False])]"/>
                     <field name="stage_id"/>
                     <field name="milestone_id" groups="project.group_project_milestone"/>
                     <field name="partner_id" operator="child_of"/>
@@ -34,7 +33,6 @@
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group expand="0" string="Group By">
-                        <filter string="Assignees" name="user" context="{'group_by': 'user_ids'}"/>
                         <filter string="Stage" name="stage" context="{'group_by': 'stage_id'}"/>
                         <filter string="Milestone" name="milestone" context="{'group_by': 'milestone_id'}" groups="project.group_project_milestone"/>
                         <filter string="Tags" name="tags" context="{'group_by': 'tag_ids'}"/>
@@ -56,15 +54,21 @@
             <field name="mode">primary</field>
             <field name="priority">999</field>
             <field name="arch" type="xml">
+                 <field name="stage_id" position="before">
+                    <field name="user_ids" filter_domain="[('user_ids.name', 'ilike', self), ('user_ids.active', 'in', [True, False])]"/>
+                </field>
                 <field name="stage_id" position="after">
-                    <field name="project_id" string="Project"/>
+                    <field name="project_id" string="Project" invisible="context.get('default_project_id')"/>
                 </field>
                 <field name="partner_id" position="after">
                     <field name="company_id" groups="base.group_multi_company"/>
                     <filter string="My Tasks" name="my_tasks" domain="[('user_ids', 'in', uid)]"/>
                 </field>
+                <filter name="stage" position="before">
+                    <filter string="Assignees" name="user" context="{'group_by': 'user_ids'}"/>
+                </filter>
                 <filter name="stage" position="after">
-                    <filter string="Project" name="project" context="{'group_by': 'project_id'}"/>
+                    <filter string="Project" name="project" context="{'group_by': 'project_id'}" invisible="context.get('default_project_id')"/>
                 </filter>
             </field>
         </record>


### PR DESCRIPTION
- project sharing, group by assignees showing none for all tasks
- removing some groupby/filters if they are not useful in project sharing search view
- Group by a project is not useful in project sharing search view, if the task search view open from the specific project

 task-3690541

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
