### PR TITLE
[FIX] web: adapt property field type selector style and z-index

### DIFF
--- a/addons/web/static/src/core/dropdown/dropdown.scss
+++ b/addons/web/static/src/core/dropdown/dropdown.scss
@@ -71,12 +71,6 @@
     margin-bottom: var(--Dropdown_menu-margin-y, #{map-get($spacers, 1)});
     background-color: $dropdown-bg;
 
-    &.popover {
-        // Sets the z-index to be the same as dialogs, this should ensure dropdowns
-        // appear behind or in front of dialogs based on the order they are opened.
-        z-index: 1055;
-    }
-
     .dropdown-toggle:focus,
     .dropdown-item:focus {
         background-color: transparent;

--- a/addons/web/static/src/core/overlay/overlay_container.scss
+++ b/addons/web/static/src/core/overlay/overlay_container.scss
@@ -1,0 +1,3 @@
+.o-overlay-item {
+    z-index: $zindex-modal;
+}

--- a/addons/web/static/src/core/overlay/overlay_container.xml
+++ b/addons/web/static/src/core/overlay/overlay_container.xml
@@ -5,14 +5,16 @@
         <div class="o-overlay-container">
             <t t-foreach="sortedOverlays" t-as="overlay" t-key="overlay.id">
                 <ErrorHandler onError="(error) => this.handleError(overlay, error)">
-                    <t t-if="overlay.env">
-                        <WithEnv env="overlay.env">
+                    <div class="o-overlay-item position-relative">
+                        <t t-if="overlay.env">
+                            <WithEnv env="overlay.env">
+                                <t t-component="overlay.component" t-props="overlay.props" />
+                            </WithEnv>
+                        </t>
+                        <t t-else="">
                             <t t-component="overlay.component" t-props="overlay.props" />
-                        </WithEnv>
-                    </t>
-                    <t t-else="">
-                        <t t-component="overlay.component" t-props="overlay.props" />
-                    </t>
+                        </t>
+                    </div>
                 </ErrorHandler>
             </t>
         </div>

--- a/addons/web/static/src/views/fields/properties/properties_field.scss
+++ b/addons/web/static/src/views/fields/properties/properties_field.scss
@@ -87,8 +87,6 @@
 }
 
 .o_property_field_popover {
-    // put the popover behind datetime component
-    z-index: $zindex-popover !important;
     font-size: inherit;
     box-sizing: border-box;
 }

--- a/addons/web/static/src/views/fields/properties/property_definition.scss
+++ b/addons/web/static/src/views/fields/properties/property_definition.scss
@@ -7,24 +7,6 @@
         max-width: calc(#{$o-form-view-sheet-max-width} / 2);
     }
 
-    .o_field_property_definition_type {
-        img {
-            width: 20px;
-            height: 20px;
-        }
-
-        .o_input_dropdown {
-            input {
-                background-repeat: no-repeat;
-                background-size: contain;
-                padding-left: 25px;
-                background-position-x: 0px;
-                background-position-y: 3px;
-                background-size: 20px;
-            }
-        }
-    }
-
     .o_field_property_definition_kanban,
     .o_field_property_definition_value {
         .form-check-input {
@@ -60,5 +42,21 @@
                 display: block;
             }
         }
+    }
+}
+
+.o_field_property_definition_type .o_input_dropdown input {
+    background-repeat: no-repeat;
+    background-size: contain;
+    padding-left: 25px;
+    background-position-x: 0px;
+    background-position-y: 3px;
+    background-size: 20px;
+}
+
+.o_field_property_definition_type, .o_field_property_definition_type_menu {
+    img {
+        width: 20px;
+        height: 20px;
     }
 }

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -52,7 +52,7 @@
                                 t-attf-src="/web/static/src/views/fields/properties/icons/{{state.propertyDefinition.type}}.png"/>
                             <span t-out="state.typeLabel"/>
                         </div>
-                        <Dropdown t-else="">
+                        <Dropdown t-else="" menuClass="'o_field_property_definition_type_menu'">
                             <button class="btn btn-link d-flex p-0 w-100" t-att-title="state.typeLabel">
                                 <div class="o_input_dropdown w-100 o_field_property_dropdown">
                                     <img t-attf-src="/web/static/src/views/fields/properties/icons/{{state.propertyDefinition.type}}.png"

--- a/addons/web/static/tests/legacy/core/overlay_service_tests.js
+++ b/addons/web/static/tests/legacy/core/overlay_service_tests.js
@@ -10,6 +10,10 @@ import { getFixture, mount, nextTick } from "../helpers/utils";
 let target = null;
 let overlay = null;
 
+function getOverlay(i) {
+    return target.querySelector(`.o-overlay-container :nth-child(${i}) :nth-child(1)`);
+}
+
 QUnit.module("overlay service", {
     async beforeEach() {
         registry.category("services").add("overlay", overlayService);
@@ -34,11 +38,11 @@ QUnit.test("simple case", async (assert) => {
 
     const remove = overlay.add(MyComp, {});
     await nextTick();
-    assert.containsOnce(target, ".o-overlay-container > .overlayed");
+    assert.containsOnce(target, ".o-overlay-container .overlayed");
 
     remove();
     await nextTick();
-    assert.containsNone(target, ".o-overlay-container > .overlayed");
+    assert.containsNone(target, ".o-overlay-container .overlayed");
 });
 
 QUnit.test("onRemove callback", async (assert) => {
@@ -68,20 +72,20 @@ QUnit.test("multiple overlays", async (assert) => {
     const remove3 = overlay.add(MyComp, { className: "o3" });
     await nextTick();
     assert.containsN(target, ".overlayed", 3);
-    assert.hasClass(target.querySelector(".overlayed:nth-child(1)"), "o1");
-    assert.hasClass(target.querySelector(".overlayed:nth-child(2)"), "o2");
-    assert.hasClass(target.querySelector(".overlayed:nth-child(3)"), "o3");
+    assert.hasClass(getOverlay(1), "o1");
+    assert.hasClass(getOverlay(2), "o2");
+    assert.hasClass(getOverlay(3), "o3");
 
     remove1();
     await nextTick();
     assert.containsN(target, ".overlayed", 2);
-    assert.hasClass(target.querySelector(".overlayed:nth-child(1)"), "o2");
-    assert.hasClass(target.querySelector(".overlayed:nth-child(2)"), "o3");
+    assert.hasClass(getOverlay(1), "o2");
+    assert.hasClass(getOverlay(2), "o3");
 
     remove2();
     await nextTick();
     assert.containsOnce(target, ".overlayed");
-    assert.hasClass(target.querySelector(".overlayed:nth-child(1)"), "o3");
+    assert.hasClass(getOverlay(1), "o3");
 
     remove3();
     await nextTick();
@@ -101,20 +105,20 @@ QUnit.test("sequence", async (assert) => {
     const remove3 = overlay.add(MyComp, { className: "o3" }, { sequence: 40 });
     await nextTick();
     assert.containsN(target, ".overlayed", 3);
-    assert.hasClass(target.querySelector(".overlayed:nth-child(1)"), "o3");
-    assert.hasClass(target.querySelector(".overlayed:nth-child(2)"), "o1");
-    assert.hasClass(target.querySelector(".overlayed:nth-child(3)"), "o2");
+    assert.hasClass(getOverlay(1), "o3");
+    assert.hasClass(getOverlay(2), "o1");
+    assert.hasClass(getOverlay(3), "o2");
 
     remove1();
     await nextTick();
     assert.containsN(target, ".overlayed", 2);
-    assert.hasClass(target.querySelector(".overlayed:nth-child(1)"), "o3");
-    assert.hasClass(target.querySelector(".overlayed:nth-child(2)"), "o2");
+    assert.hasClass(getOverlay(1), "o3");
+    assert.hasClass(getOverlay(2), "o2");
 
     remove2();
     await nextTick();
     assert.containsOnce(target, ".overlayed");
-    assert.hasClass(target.querySelector(".overlayed:nth-child(1)"), "o3");
+    assert.hasClass(getOverlay(1), "o3");
 
     remove3();
     await nextTick();

--- a/addons/web/static/tests/legacy/views/pivot_view_tests.js
+++ b/addons/web/static/tests/legacy/views/pivot_view_tests.js
@@ -2859,7 +2859,7 @@ QUnit.module("Views", (hooks) => {
         await mouseEnter(target.querySelector(".o-dropdown--menu .dropdown-toggle"));
         await click(
             target.querySelectorAll(
-                ".o-overlay-container .o-dropdown--menu:nth-child(2) .dropdown-item"
+                ".o-overlay-item:nth-child(2) .o-dropdown--menu .dropdown-item"
             )[3]
         );
 

--- a/addons/web/static/tests/legacy/views/view_dialogs/export_data_dialog_tests.js
+++ b/addons/web/static/tests/legacy/views/view_dialogs/export_data_dialog_tests.js
@@ -420,7 +420,7 @@ QUnit.module("ViewDialogs", (hooks) => {
             "a confirmation dialog has appeared on top"
         );
 
-        await click(document.body, ".o_dialog:nth-child(2) .btn-primary");
+        await click(document.body, ".o-overlay-item:nth-child(2) .btn-primary");
         assert.strictEqual(
             target.querySelector(".o_exported_lists_select").selectedOptions[0].textContent,
             "",


### PR DESCRIPTION
The dropdown inside the property field popover style was broken due to a dropdown refacor, some styles where not applied correctly and the field type dropdown was displayed behind the popover. (https://github.com/odoo/odoo/pull/137691).

This PR fixes the issue in 2 commits:
The first one adds a supplementary div around each overlay in the overlay container, this isolates each overlay so their z-index do not interfere, their order in the overlay-container is now sufficient to ensure a proper z-index, whatever the amount of popovers, modals, dropdowns, etc...

The second adapts the property field style and removes now unnecessary custom z-index values.

Enterprise: https://github.com/odoo/enterprise/pull/56598

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
