### PR TITLE
[FIX] event: make template field clickable if empty

### DIFF
--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -98,7 +98,7 @@
                                     <field name="sequence" widget="handle"/>
                                     <field name="notification_type"/>
                                     <field name="template_model_id" column_invisible="True"/>
-                                    <field name="template_ref" options="{'hide_model': True, 'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
+                                    <field name="template_ref" options="{'model_field': 'template_model_id', 'hide_model': True, 'no_quick_create': True}" context="{'filter_template_on_event': True, 'default_model': 'event.registration'}"/>
                                     <field name="interval_nbr" readonly="interval_unit == 'now'"/>
                                     <field name="interval_unit"/>
                                     <field name="interval_type"/>


### PR DESCRIPTION
Steps to reproduce:
- Install events
- Go in events
- Select any events
- Go to communication tab
- Remove template field in a line

Issues:
The field is now unclickable for that line.

opw-3727038