### PR TITLE
[FIX] website_slides: allow typing in tag / upload select2s

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_tag_add.js
+++ b/addons/website_slides/static/src/js/slides_course_tag_add.js
@@ -47,6 +47,19 @@ var TagCourseDialog = Dialog.extend({
         });
     },
 
+    /**
+     * Dirty hack to de-activate the "focustrap" from Bootstrap.
+     * Indeed, it prevents typing into our "select2" elements.
+     *
+     * Note that this is removed in saas-17.1 as dialog is owlified.
+     */
+    on_attach_callback: function () {
+        const bootstrapModal = Modal.getInstance(this.$modal[0]);
+        if (bootstrapModal) {
+            bootstrapModal._focustrap.deactivate();
+        }
+    },
+
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------

--- a/addons/website_slides/static/src/js/slides_upload.js
+++ b/addons/website_slides/static/src/js/slides_upload.js
@@ -66,6 +66,19 @@ var SlideUploadDialog = Dialog.extend({
         });
     },
 
+    /**
+     * Dirty hack to de-activate the "focustrap" from Bootstrap.
+     * Indeed, it prevents typing into our "select2" elements.
+     *
+     * Note that this is removed in saas-17.2 as dialog is owlified.
+     */
+    on_attach_callback: function () {
+        const bootstrapModal = Modal.getInstance(this.$modal[0]);
+        if (bootstrapModal) {
+            bootstrapModal._focustrap.deactivate();
+        }
+    },
+
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------


### PR DESCRIPTION
Typing in select2 being in modals does not work from v16 as select2 and bootstrap modals are in conflict when it comes to the focus of elements.

HACK
====

Disable bootstrap modal's focustrap in order to
let the user type in the select2 on the modal's
attachment.

(Solution taken from odoo/enterprise#35733)

Task-3527175

