### PR TITLE
[ADD] pos_order_recovery: Recover from backend captured pos orders

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -924,6 +924,7 @@ class PosOrder(models.Model):
                 existing_draft_order = self.env['pos.order'].search(['&', ('pos_reference', '=', order_name), ('state', '=', 'draft')], limit=1)
 
             try:
+                # 0/0
                 if existing_draft_order:
                     order_ids.append(self._process_order(order, draft, existing_draft_order))
                 else:

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -22,6 +22,9 @@ from odoo.tools.misc import str2bool
 
 _logger = logging.getLogger(__name__)
 
+POS_CAPTURE_PREFIX = 'pos_order_save_'
+POS_CAPTURE_SUFFIX = '.json'
+POS_CAPTURE_SEPARATOR = '_'
 
 class PosSession(models.Model):
     _name = 'pos.session'
@@ -2139,10 +2142,10 @@ class PosSession(models.Model):
         )
         self._capture_order_data(order, exception, current_pos_order_data_hash)
 
-    def _shorten_pos_order_data_hash(self, pos_order_data_hash: int):
+    def _shorten_pos_order_data_hash(self, pos_order_data_hash: int, precision: int = 6):
         # The bigger the value, the less likely a hash collision will occur
         # but a bigger value also means a longer name in the attachment
-        return str(pos_order_data_hash)[:6]
+        return str(pos_order_data_hash)[:precision]
 
     def _get_unprocessed_pos_order_scheduled_activity(self, order_ref: str, pos_order_data_hash: int, assigned_user_id: Optional[int] = None, create: bool = True):
         if create:
@@ -2172,7 +2175,7 @@ class PosSession(models.Model):
         return scheduled_activity
 
     def _capture_order_data_attachment_name(self, order_ref: str, pos_order_data_hash: int):
-        return f"pos_order_save_{order_ref}_{self._shorten_pos_order_data_hash(pos_order_data_hash)}.json"
+        return POS_CAPTURE_PREFIX + order_ref + POS_CAPTURE_SEPARATOR + self._shorten_pos_order_data_hash(pos_order_data_hash) + POS_CAPTURE_SUFFIX
 
     def _get_captured_order_attachment(self, pos_order_ref: str, pos_order_data_hash: int):
         return self.env['ir.attachment'].search([

--- a/addons/pos_order_recovery/__init__.py
+++ b/addons/pos_order_recovery/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+
+from . import models
+
+
+from odoo import api, SUPERUSER_ID
+
+
+def _generate_capture_record_from_existing_capture_attachments(cr, registry):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    env['pos.order.capture']._generate_capture_record_from_existing_capture_attachments()

--- a/addons/pos_order_recovery/__manifest__.py
+++ b/addons/pos_order_recovery/__manifest__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+{
+    'name': "PoS Order Recovery",
+    'summary': "Allows to create PoS orders on received PoS orders that failed to syncronize",
+    'description': """
+        When a PoS order is validated, it is sent to the server which will attempt to create a PoS order in the backend.
+        If the creation process failed for any reason, the PoS wil create by default an attachment file with the received content.
+        This module allows to recover the failed PoS orders and create them in the backend from the PoS session.
+    """,
+    'category': 'Sales/Point of Sale',
+    'version': '1.0',
+    'depends': ['point_of_sale'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/views.xml',
+        'views/pos_session_smart_button.xml',
+    ],
+    'license': 'LGPL-3',
+    'post_init_hook': '_generate_capture_record_from_existing_capture_attachments',
+}

--- a/addons/pos_order_recovery/models/__init__.py
+++ b/addons/pos_order_recovery/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+from . import pos_order_capture
+from . import pos_order_capture_comparer_wizard
+from . import pos_session

--- a/addons/pos_order_recovery/models/pos_order_capture.py
+++ b/addons/pos_order_recovery/models/pos_order_capture.py
@@ -1,0 +1,90 @@
+
+import logging
+import json
+
+from odoo import _, api, fields, models
+from odoo.addons.point_of_sale.models.pos_session import POS_CAPTURE_PREFIX, POS_CAPTURE_SUFFIX, POS_CAPTURE_SEPARATOR
+from odoo.exceptions import UserError
+
+_logger = logging.getLogger(__name__)
+
+
+class PosOrderCapture(models.Model):
+    _name = 'pos.order.capture'
+    _description = 'Point of Sale capture order'
+
+    name = fields.Char(compute='_compute_name', store=True, readonly=True)
+    json_content_id = fields.Many2one('ir.attachment', required=True, readonly=True, ondelete='cascade')
+    order_name = fields.Char(required=True, readonly=True, index=True)
+    order_hash = fields.Integer(required=True, readonly=True, index=True)
+    session_id = fields.Many2one('pos.session', string='Session', required=True, readonly=True, index=True)
+
+    json_content_text = fields.Text(compute='_compute_json_content')
+    traceback_text = fields.Text(compute='_compute_json_content')
+    conflicting_capture_count = fields.Integer(compute='_compute_conflicting_capture_count')
+
+    @api.model
+    def _generate_capture_record_from_existing_capture_attachments(self):
+        # Get the existing data from the other model
+        existing_captured_orders = self.env['ir.attachment'].search([
+            ['name', '=like', f"{POS_CAPTURE_PREFIX}%{POS_CAPTURE_SUFFIX}"]
+        ])
+
+        # Create the new records based on the existing data
+        for existing_captured_order in existing_captured_orders:
+            order_name, order_hash = existing_captured_order.name[len(POS_CAPTURE_PREFIX): -len(POS_CAPTURE_SUFFIX)].split(POS_CAPTURE_SEPARATOR, 1)
+            self.create({
+                'json_content_id': existing_captured_order.id,
+                'order_name': order_name,
+                'order_hash': order_hash,
+                'session_id': existing_captured_order.res_id,
+            })
+
+    def action_compare_conflicting_capture(self):
+        self.ensure_one()
+        return {
+            "type": "ir.actions.act_window",
+            "name": "Compare Conflicting Capture",
+            "res_model": "pos.order.capture.comparer.wizard",
+            "view_mode": "form",
+            "target": "new",
+            "view_id": self.env.ref('pos_order_recovery.compare_conflicting_capture_wizard_view').id,
+        }
+
+    @api.depends('order_name', 'order_hash')
+    def _compute_name(self):
+        for capture in self:
+            capture.name = f"Unsynced {capture.order_name} (#{capture.order_hash})"
+
+    def _compute_json_content(self):
+        for capture in self:
+            capture.json_content_text = capture.with_context(bin_size=False).json_content_id.raw
+
+            json_data = capture.get_json_dict_content()
+            capture.traceback_text = ''.join(json_data.get('traceback', []))
+
+    def get_json_dict_content(self):
+        self.ensure_one()
+        return json.loads(self.json_content_text)
+
+    def _compute_conflicting_capture_count(self):
+        for capture in self:
+            capture.conflicting_capture_count = self.search_count(
+                [('order_name', '=', capture.order_name)]
+                ) - 1  # Don't count ourself
+
+    def _sync(self):
+        conflicting_orders = self.filtered_domain([["conflicting_capture_count", "!=", 0]])
+        if conflicting_orders:
+            raise UserError(_(
+                "Operation cancelled.\n" \
+                "At least one of the selected unsynced order have conflict for the same order reference: %s.\n" \
+                "You can choose the file to keep using the smart button on the form view", 
+                conflicting_orders
+                )
+            )
+        
+        pos_order_model = self.env['pos.order']
+        for capture_order in self:
+            _logger.info('Manual PoS order sync using %s', capture_order)
+            pos_order_model.create_from_ui([capture_order.get_json_dict_content()], draft=False)

--- a/addons/pos_order_recovery/security/ir.model.access.csv
+++ b/addons/pos_order_recovery/security/ir.model.access.csv
@@ -1,0 +1,3 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+pos_order_recovery.access_pos_order_capture,access_pos_order_capture,pos_order_recovery.model_pos_order_capture,point_of_sale.group_pos_user,1,1,1,1
+pos_order_recovery.access_pos_order_capture_comparer_wizard,access_pos_order_capture_comparer_wizard,pos_order_recovery.model_pos_order_capture_comparer_wizard,base.group_user,1,1,1,1

--- a/addons/pos_order_recovery/views/pos_session_smart_button.xml
+++ b/addons/pos_order_recovery/views/pos_session_smart_button.xml
@@ -1,0 +1,16 @@
+<odoo>
+  <data>
+    <record id="pos_session_unsynced_orders_stat_button" model="ir.ui.view">
+      <field name="name">pos.session.form.unsynced.orders.stat.buttons</field>
+      <field name="model">pos.session</field>
+      <field name="inherit_id" ref="point_of_sale.view_pos_session_form" />
+      <field name="arch" type="xml">
+          <div name="button_box" position="inside">
+              <button class="oe_stat_button" type="object" name="action_view_unsynced_orders" icon="fa-medkit" attrs="{'invisible':[('unsynced_orders_count', '=', 0)]}">
+                  <field string="Unsync Orders" name="unsynced_orders_count" widget="statinfo"/>
+              </button>
+          </div>
+      </field>
+    </record>
+  </data>
+</odoo>

--- a/addons/pos_order_recovery/views/views.xml
+++ b/addons/pos_order_recovery/views/views.xml
@@ -1,0 +1,92 @@
+<odoo>
+  <data>
+    <record model="ir.ui.view" id="pos_order_recovery.list">
+      <field name="name">pos_order_recovery list</field>
+      <field name="model">pos.order.capture</field>
+      <field name="arch" type="xml">
+        <tree create="false" delete="false" edit="false">
+          <field name="session_id"/>
+          <field name="order_name"/>
+          <field name="order_hash"/>
+        </tree>
+      </field>
+    </record>
+
+    <record model="ir.ui.view" id="pos_order_recovery.form">
+      <field name="name">pos_order_recovery form</field>
+      <field name="model">pos.order.capture</field>
+      <field name="arch" type="xml">
+        <form create="false" delete="false" edit="false">
+        <sheet>
+          <div class="oe_button_box" name="button_box">
+          <button class="oe_stat_button" type="object" name="action_compare_conflicting_capture" icon="fa-exclamation-circle" attrs="{'invisible':[('conflicting_capture_count', '=', 0)]}">
+            <field name="conflicting_capture_count" widget="statinfo"/>
+          </button>
+          </div>
+          <h1 class="oe_title">
+            <field name="display_name"/>
+          </h1>
+          <group>
+            <field name="order_name"/>
+            <field name="session_id"/>
+            <field name="json_content_id"/>
+            <field name="order_hash"/>
+          </group>
+
+          <notebook>
+            <page string="Traceback">
+              <field name="traceback_text" widget="ace" options="{'mode': 'python'}"/>
+            </page>
+            <page string="JSON Content">
+              <field name="json_content_text" widget="ace" options="{'mode': 'python'}"/>
+            </page>
+          </notebook>
+
+          </sheet>
+        </form>
+      </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="pos_order_recovery.action_window">
+      <field name="name">Unsynced Orders</field>
+      <field name="res_model">pos.order.capture</field>
+      <field name="view_mode">tree,form</field>
+    </record>
+
+    <record model="ir.actions.server" id="pos_order_recovery.sync_unsynced_order_action" >
+      <field name="name">Synchronise</field>
+      <field name="model_id" ref="model_pos_order_capture"/>
+      <field name="binding_model_id" ref="model_pos_order_capture"/>
+      <field name="state">code</field>
+      <field name="code">
+records._sync()
+      </field>
+    </record>
+
+    <!-- Wizard related views -->
+    <record id="compare_conflicting_capture_wizard_view" model="ir.ui.view">
+      <field name="name">compare_conflicting_capture_wizard_view</field>
+      <field name="model">pos.order.capture.comparer.wizard</field>
+      <field name="arch" type="xml">
+        <form string="Reset View Architecture">
+          <group>
+            <group>
+              <field name="capture_id" invisible="1"/>
+              <field name="allowed_capture_ids" invisible="1"/>
+              <field name="capture_compare_id"/>
+            </group>
+          </group>
+          <field name="capture_diff"/>
+          <footer>
+            <button string="Keep current (remove other)" name="action_keep_current" type="object" class="btn-primary"/>
+            <button string="Keep other (remove current)" name="action_keep_other" type="object" class="btn-secondary"/>
+            <button string="Cancel" class="btn-secondary" special="cancel"/>
+          </footer>
+        </form>
+    </field>
+    </record> 
+
+    <menuitem name="Unsynced Orders" id="pos_order_recovery.menu_unsynced_orders" parent="point_of_sale.menu_point_of_sale"
+              action="pos_order_recovery.action_window" sequence="200"/>
+  </data>
+</odoo>


### PR DESCRIPTION
Since: https://github.com/odoo/odoo/pull/147130
PoS orders that are received by the server but can't be processed are stored as an attachment.

This new optional module would allow to compare the attachments and synchronise from the backend the orders (without the need to open PoS).
It also add a smartbutton on the PoS sessions which redirect to the unsynced orders

opw-3650239