### PR TITLE
[FIX] sale: return `sale_order_id` in payment form

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -454,5 +454,6 @@ class PaymentPortal(payment_portal.PaymentPortal):
                 'transaction_route': order_sudo.get_portal_url(suffix='/transaction'),
                 'landing_route': order_sudo.get_portal_url(),
                 'access_token': order_sudo.access_token,
+                'sale_order_id': sale_order_id,
             })
         return form_values


### PR DESCRIPTION
In 7e012dd5441e87ce3c2688f9280381b041b00b0d, `_get_custom_rendering_context_values` was refactored and renamed `_get_extra_payment_form_values`. In this refactoring, `sale_order_id` was inadvertently removed from the values returned to the payment form.

This commit re-introduce `sale_order_id` in the extra payment form values.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
