### PR TITLE
[FIX] hr_holidays: selct date range in timeoff calendar

### DIFF
--- a/addons/hr_holidays/static/src/views/calendar/calendar_model.js
+++ b/addons/hr_holidays/static/src/views/calendar/calendar_model.js
@@ -38,7 +38,7 @@ export class TimeOffCalendarModel extends CalendarModel {
         }
         if ("default_date_to" in context) {
             context["default_date_to"] = serializeDateTime(
-                deserializeDateTime(context["default_date_from"]).set({ hours: 19 })
+                deserializeDateTime(context["default_date_to"]).set({ hours: 19 })
             );
         }
         return context;


### PR DESCRIPTION
### Steps to reproduce:
- Open **Timeoff** app.
- Select a date range on the calendar.
- Notice how the **end date** in the popup is the _same_ as the **start date**.

### Investigation:
- the `default_date_to` was set incorrectly inside the `makeContextDefaults()` function

opw-3710320