### PR TITLE
[FIX] web: patch fullcalendar to create short event

### DIFF
--- a/addons/web/static/lib/fullcalendar/interaction/main.js
+++ b/addons/web/static/lib/fullcalendar/interaction/main.js
@@ -1134,7 +1134,10 @@ Docs & License: https://fullcalendar.io/
                 var pointer = _this.dragging.pointer;
                 if (!pointer.wasTouchScroll) {
                     var _b = _this.hitDragging, initialHit = _b.initialHit, finalHit = _b.finalHit;
-                    if (initialHit && finalHit && isHitsEqual(initialHit, finalHit)) {
+                    var origY = pointer.origPageY, prevY = pointer.prevPageY;
+                    if (initialHit && finalHit && isHitsEqual(initialHit, finalHit)
+                        // patch to not trigger a `DateClicking` if `DateSelecting` (to be able to create 15' min event)
+                        && origY === prevY) {
                         calendar.triggerDateClick(initialHit.dateSpan, initialHit.dayEl, view, ev.origEvent);
                     }
                 }


### PR DESCRIPTION
Issue:
------
On the calendar application, it is not possible to create a 15-minute event directly from a selection using the mouse.

An event with a default duration of one hour is created.

Cause:
------
The fullcalendar library detects two events:
- a date selection
- a click

The date selection is correct, but the size of the "rectange" is the same (15 minutes is the smallest unit in terms of size). As a result, a click using a default time is detected.

Solution:
---------
Thanks to the pointer, it is possible to know the original coordinates. We can use them with the following strong hypothesis: "If the origin coordinates along the Y axis are equal, a click is made."

Note:
-----
It is necessary to patch upstream when events are triggered. After that, we have to believe the information we receive and apply it.

opw-3743945