### PR TITLE
[PERF] stock: refactor _get_rule & _search_rule

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -589,7 +589,7 @@ class Product(models.Model):
         warehouse = location.warehouse_id
         if not warehouse and seen_rules:
             warehouse = seen_rules[-1].propagate_warehouse_id
-        rule = self.env['procurement.group'].with_context(active_test=True)._get_rule(self, location, {
+        rule = self.env['stock.rule'].with_context(active_test=True)._get_rule(self, location, {
             'route_ids': route_ids,
             'warehouse_id': warehouse,
         })

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2871,7 +2871,7 @@ class TestRoutes(TestStockCommon):
         })
 
         # We alter one rule and we set it to 'mts_else_mto'
-        rule = self.env['procurement.group']._get_rule(product_A, final_location, {'warehouse_id': warehouse})
+        rule = self.env['stock.rule']._get_rule(product_A, final_location, {'warehouse_id': warehouse})
         rule.procure_method = 'mts_else_mto'
 
         self.env['stock.quant']._update_available_quantity(product_A, warehouse.lot_stock_id, 5.0)
@@ -2924,7 +2924,7 @@ class TestRoutes(TestStockCommon):
         })
 
         # We alter one rule and we set it to 'mts_else_mto'
-        rule = self.env['procurement.group']._get_rule(product_A, final_location, {'warehouse_id': warehouse})
+        rule = self.env['stock.rule']._get_rule(product_A, final_location, {'warehouse_id': warehouse})
         rule.procure_method = 'mts_else_mto'
 
         self.env['stock.quant']._update_available_quantity(product_A, warehouse.lot_stock_id, 5.0)
@@ -2987,7 +2987,7 @@ class TestRoutes(TestStockCommon):
         })
 
         # We alter one rule and we set it to 'mts_else_mto'
-        rule = self.env['procurement.group']._get_rule(product_A, final_location, {'warehouse_id': warehouse})
+        rule = self.env['stock.rule']._get_rule(product_A, final_location, {'warehouse_id': warehouse})
         rule.procure_method = 'mts_else_mto'
 
         self.env['stock.quant']._update_available_quantity(product_A, warehouse.lot_stock_id, 4.0)

--- a/addons/stock/tests/test_old_rules.py
+++ b/addons/stock/tests/test_old_rules.py
@@ -140,7 +140,7 @@ class TestOldRules(TestStockCommon):
 
         # We alter one rule and we set it to 'mts_else_mto'
         values = {'warehouse_id': self.warehouse_3_steps}
-        rule = self.env['procurement.group']._get_rule(self.productA, final_location, values)
+        rule = self.env['stock.rule']._get_rule(self.productA, final_location, values)
         rule.procure_method = 'mts_else_mto'
 
         pg = self.env['procurement.group'].create({'name': 'Test-pg-mtso-mto'})
@@ -188,7 +188,7 @@ class TestOldRules(TestStockCommon):
 
         # We alter one rule and we set it to 'mts_else_mto'
         values = {'warehouse_id': self.warehouse_3_steps}
-        rule = self.env['procurement.group']._get_rule(self.productA, final_location, values)
+        rule = self.env['stock.rule']._get_rule(self.productA, final_location, values)
         rule.procure_method = 'mts_else_mto'
 
         pg = self.env['procurement.group'].create({'name': 'Test-pg-mtso-mts'})
@@ -233,7 +233,7 @@ class TestOldRules(TestStockCommon):
 
         # We alter one rule and we set it to 'mts_else_mto'
         values = {'warehouse_id': warehouse}
-        rule = self.env['procurement.group']._get_rule(product_a, final_location, values)
+        rule = self.env['stock.rule']._get_rule(product_a, final_location, values)
         rule.procure_method = 'mts_else_mto'
 
         pg1 = self.env['procurement.group'].create({'name': 'Test-pg-mtso-mts-1'})

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -118,7 +118,7 @@ class StockReplenishmentOption(models.TransientModel):
     @api.depends('replenishment_info_id')
     def _compute_lead_time(self):
         for record in self:
-            rule = self.env['procurement.group']._get_rule(record.product_id, record.location_id, {
+            rule = self.env['stock.rule']._get_rule(record.product_id, record.location_id, {
                 'route_ids': record.route_id,
                 'warehouse_id': record.warehouse_id,
             })

--- a/addons/stock_dropshipping/models/stock.py
+++ b/addons/stock_dropshipping/models/stock.py
@@ -15,16 +15,13 @@ class StockRule(models.Model):
         """
         return procurement.values.get('sale_line_id'), super(StockRule, self)._get_procurements_to_merge_groupby(procurement)
 
-
-class ProcurementGroup(models.Model):
-    _inherit = "procurement.group"
-
     @api.model
-    def _get_rule_domain(self, location, values):
-        domain = super()._get_rule_domain(location, values)
+    def _get_rule_domain(self, operator, location, values):
+        domain = super()._get_rule_domain(operator, location, values)
         if 'sale_line_id' in values and values.get('company_id'):
             domain = expression.AND([domain, [('company_id', '=', values['company_id'].id)]])
         return domain
+
 
 class StockPicking(models.Model):
     _inherit = 'stock.picking'
@@ -39,6 +36,7 @@ class StockPicking(models.Model):
     def _is_to_external_location(self):
         self.ensure_one()
         return super()._is_to_external_location() or self.is_dropship
+
 
 class StockPickingType(models.Model):
     _inherit = 'stock.picking.type'


### PR DESCRIPTION
This refactor consists of:
- create a new _search_rules function that searches for all applicable rules from an aggregated dataset
- move _search_rule, _get_rule & _get_rule_domain to the stock.rule model
- make them filter the 'self' rules when called on a recordset prepared by _search_rules

This a an impact on:
- 'procurement.group' run()
- 'stock.move' _push_apply() & _adjust_procure_method()

The gain of confirming a purchase order (10-1000 lines) is 5-15%
The gain of confirming a sale order (10-1000 lines) is 5-30% (procurement's gain 40-90%)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
