### PR TITLE
[FIX] hr: correct number of employees

### DIFF
--- a/addons/hr/models/res_partner.py
+++ b/addons/hr/models/res_partner.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models, _
+from odoo import fields, models, _, api
 from odoo.exceptions import AccessError
 
 
@@ -28,17 +28,18 @@ class Partner(models.Model):
 
     def _compute_employees_count(self):
         for partner in self:
-            partner.employees_count = len(partner.employee_ids)
+            partner.employees_count = len([emp_id for emp_id in partner.employee_ids if emp_id.company_id.id in self.env.companies.ids])
 
     def action_open_employees(self):
         self.ensure_one()
-        if len(self.employee_ids) > 1:
+        if self.employees_count > 1:
             return {
                 'name': _('Related Employees'),
                 'type': 'ir.actions.act_window',
                 'res_model': 'hr.employee',
-                'view_mode': 'form',
-                'domain': [('id', 'in', self.employee_ids.ids)],
+                'view_mode': 'kanban',
+                'domain': [('id', 'in', self.employee_ids.ids),
+                           ('company_id', 'in', self.env.companies.ids)],
             }
         return {
             'name': _('Employee'),

--- a/addons/hr/tests/test_hr_employee.py
+++ b/addons/hr/tests/test_hr_employee.py
@@ -21,6 +21,34 @@ class TestHrEmployee(TestHrCommon):
             'image_1920': False
         })
 
+    def test_employee_smart_button_multi_company(self):
+        partner = self.env['res.partner'].create({'name': 'Partner Test'})
+        company_A = self.env['res.company'].create({
+            'name': 'company_A',
+        })
+        company_B = self.env['res.company'].create({
+            'name': 'company_B',
+        })
+        company_A_id = company_A.id
+        company_B_id = company_B.id
+        self.env['hr.employee'].create({
+            'name': 'employee_A',
+            'address_home_id': partner.id,
+            'company_id': company_A_id,
+        })
+        self.env['hr.employee'].create({
+            'name': 'employee_B',
+            'address_home_id': partner.id,
+            'company_id': company_B_id
+        })
+
+        partner.with_context(allowed_company_ids=[company_A_id])._compute_employees_count()
+        self.assertEqual(partner.employees_count, 1)
+        partner.with_context(allowed_company_ids=[company_B_id])._compute_employees_count()
+        self.assertEqual(partner.employees_count, 1)
+        partner.with_context(allowed_company_ids=[company_A_id, company_B_id])._compute_employees_count()
+        self.assertEqual(partner.employees_count, 2)
+
     def test_employee_linked_partner(self):
         user_partner = self.user_without_image.partner_id
         work_contact = self.employee_without_image.work_contact_id


### PR DESCRIPTION
This will fix the number of employees from partner form view and redirect to kanban view of all employees related to this partner.

The smart button on the partner view for the number of employees related to this partner now gives the correct number depending on the companies selected.

If multiple employees are related, the action shows a kanban view of those employees.

Task: 3693173
