### PR TITLE
[IMP][wip] sale_project, sale_timesheet: set company to False for some test data

### DIFF
--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -54,6 +54,10 @@ class SaleOrderLine(models.Model):
                     sale_order = self.env['sale.order'].create(so_create_values)
                     sale_order.action_confirm()
                 default_values['order_id'] = sale_order.id
+                # When a user create a sol from a task/ticket without company, the default value in the context will be empty. We set a correct default company instead.
+                if not self.env.context.get('company_id'):
+                    default_values['company_id'] = sale_order.company_id.id
+
             if product_name := self.env.context.get('sol_product_name') or self.env.context.get('default_name'):
                 product = self.env['product.product'].search([
                     ('name', 'ilike', product_name),

--- a/addons/sale_project/tests/common.py
+++ b/addons/sale_project/tests/common.py
@@ -21,7 +21,7 @@ class TestSaleProjectCommon(TestSaleCommon):
             'name': 'Project for selling timesheet - AA',
             'code': 'AA-2030',
             'plan_id': cls.analytic_plan.id,
-            'company_id': cls.company_data['company'].id,
+            'company_id': False,
         })
         Project = cls.env['project.project'].with_context(tracking_disable=True)
         cls.project_global = Project.create({

--- a/addons/sale_timesheet/tests/common.py
+++ b/addons/sale_timesheet/tests/common.py
@@ -80,6 +80,7 @@ class TestCommonSaleTimesheet(TestSaleProjectCommon):
             'allow_billable': True,
             'partner_id': cls.partner_b.id,
             'analytic_account_id': cls.analytic_account_sale.id,
+            'company_id': False,
         })
 
         cls.project_subtask = Project.create({


### PR DESCRIPTION
This commit's purpose is to adjust some of the testing data to ease the test creation and to correct existing ones according to the changes made in the enterprise part of this pr.

enterprise pr: https://github.com/odoo/enterprise/pull/56691
task - 3456861

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
