### PR TITLE
[IMP] sms: fetch phone/mobile number

### DIFF
--- a/addons/sms/models/mail_thread.py
+++ b/addons/sms/models/mail_thread.py
@@ -120,7 +120,7 @@ class MailThread(models.AbstractModel):
                     'sanitized': False,
                     'number': value,
                     'partner_store': False,
-                    'field_store': fname
+                    'field_store': fname,
                 }
         return result
 

--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -120,7 +120,7 @@ class SendSMS(models.TransientModel):
                 composer.recipient_single_number_itf = ''
                 continue
             records.ensure_one()
-            res = records._sms_get_recipients_info(force_field=composer.number_field_name, partner_fallback=False)
+            res = records._sms_get_recipients_info(force_field=composer.number_field_name, partner_fallback=True)
             if not composer.recipient_single_number_itf:
                 composer.recipient_single_number_itf = res[records.id]['number'] or ''
             if not composer.number_field_name:

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -10,9 +10,9 @@
                     invisible="not res_model_description or not comment_single_recipient or recipient_single_valid">
                     <p class="my-0">
                         <strong>Invalid number:</strong>
-                        <span> make sure to set a country on the </span>
+                        <span> make sure to set a country or country code on </span>
                         <span><field name="res_model_description"/></span>
-                        <span> or to specify the country code.</span>
+                        <span> or on the related Contact</span>
                     </p>
                 </div>
 

--- a/addons/test_mail_sms/models/__init__.py
+++ b/addons/test_mail_sms/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_mail_sms_models
+from . import test_sms_models

--- a/addons/test_mail_sms/models/test_sms_models.py
+++ b/addons/test_mail_sms/models/test_sms_models.py
@@ -1,0 +1,9 @@
+
+from odoo import fields, models
+
+
+class SMSPartner(models.Model):
+    _description = 'SMS: Test model that allows testing SMS features'
+    _name = 'sms.test.partner'
+    _inherit = 'mail.thread'
+    partner_id = fields.Many2one('res.partner')

--- a/addons/test_mail_sms/security/ir.model.access.csv
+++ b/addons/test_mail_sms/security/ir.model.access.csv
@@ -11,3 +11,4 @@ access_mail_test_sms_partner_all,mail.test.sms.partner.all,model_mail_test_sms_p
 access_mail_test_sms_partner_user,mail.test.sms.partner.user,model_mail_test_sms_partner,base.group_user,1,1,1,1
 access_mail_test_sms_partner_2many_all,mail.test.sms.partner.2many.all,model_mail_test_sms_partner_2many,,0,0,0,0
 access_mail_test_sms_partner_2many_user,mail.test.sms.partner.2many.user,model_mail_test_sms_partner_2many,base.group_user,1,1,1,1
+access_sms_test_partner,sms.test.partner,model_sms_test_partner,base.group_user,1,0,0,0


### PR DESCRIPTION
When SMS composer is opened customer mobile/phone numbers should be
fetched automatically.

task-3743525

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
