### PR TITLE
[FIX] base: try/except duration format

### DIFF
--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -639,13 +639,21 @@ class DurationConverter(models.AbstractModel):
             v, r = divmod(r, secs_per_unit)
             if not v:
                 continue
-            section = babel.dates.format_timedelta(
-                v*secs_per_unit,
-                granularity=round_to,
-                add_direction=options.get('add_direction'),
-                format=options.get('format', 'long'),
-                threshold=1,
-                locale=locale)
+
+            fmt_timedelta_args = {
+                'delta': v * secs_per_unit,
+                'granularity': round_to,
+                'add_direction': options.get('add_direction'),
+                'format': options.get('format', 'long'),
+                'threshold': 1,
+                'locale': locale,
+            }
+            try:
+                section = babel.dates.format_timedelta(**fmt_timedelta_args)
+            except KeyError:
+                # Work around babel issues formatting some values for certain locales
+                del fmt_timedelta_args['format']
+                section = babel.dates.format_timedelta(**fmt_timedelta_args)
             if section:
                 sections.append(section)
 

--- a/odoo/addons/base/tests/test_qweb_field.py
+++ b/odoo/addons/base/tests/test_qweb_field.py
@@ -56,3 +56,17 @@ class TestQwebFieldInteger(common.TransactionCase):
             self.value_to_html(125125, {'format_decimalized_number': True, 'precision_digits': 3}),
             "125.125k"
         )
+
+
+class TestQwebFieldDuration(common.TransactionCase):
+    def value_to_html(self, value, options=None, lang=None):
+        options = options or {}
+        language = self.env.lang if not lang else self.env['res.lang']._activate_lang(lang)
+        return self.env['ir.qweb.field.duration'].with_context({'lang': language.code}).value_to_html(value, options)
+
+    def test_duration_value_to_html(self):
+        """
+        Babel version < 2.10.0 format_timedelta() key errors:
+            'pl_PL' locale, duration with 'format': 'short'
+        """
+        self.value_to_html(value=1800, options={'format': 'short'}, lang='pl_PL')


### PR DESCRIPTION
**Current behavior:**
When navigating a website translated into Polish, attempting
to load the web page of certain courses will result in a 500
error.

**Expected behavior:**
The course page should load without error.

**Steps to reproduce:**
1. Install the Polish language pack and set it as an option for
     a website

2. On the website, go to the `Courses` tab and find the course
     "Basics of Furniture Creation'

3. Either before or after clicking on the course, switch the
     site's language to Polish to observe the error

**Cause of the issue:**
In babel we have a method format_timedelta(), there is
currently a bug occurring in this method when you pass the
'format' kwarg to it.

The section of code which is invoked looks for some patterns to
format the time/duration values (e.g., 'many', 'few', 'one') so
it handles things like plurals correctly (1 hour vs 1 hours).

Some locales do not have certain keys for certain values- in
this case a timedelta of 30 minutes for the pl_PL locale did
not have the key 'many'. This resulted in a KeyError exception
which was never handled -> 500 error.

**Fix:**
Add an a try/catch block when calling format_timedelta() and
call it again without any format options if it is failing. This
is one of a few ways to recall the function (e.g., we could call
it again with a different locale which would preserve the
formatting, but IMO this would result in a worse output in the
general case where the first call throws an exception).

opw-3726080