### PR TITLE
[FIX] hr_expense: Fix price_unit rounding

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -406,7 +406,7 @@ class HrExpense(models.Model):
                     company=expense.company_id,
                 )[product_id.id]
             else:
-                expense.price_unit = expense.company_currency_id.round(expense.total_amount / expense.quantity) if expense.quantity else 0.
+                expense.price_unit = (expense.total_amount / expense.quantity) if expense.quantity else 0.
 
     @api.depends('product_id', 'company_id')
     def _compute_account_id(self):


### PR DESCRIPTION
During the forward-port of c940d3f fix about
the price_unit display, the changes introduced by the refactoring in 68fbdc9 weren't taken into consideration.

task-3749434

This completes the fix by removing the price_unit rounding entirely in the compute method

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
