### PR TITLE
[FIX] project_timesheet_holidays: changing public holidays deletes auto-cancelled linked timesheets

### DIFF
--- a/addons/project_timesheet_holidays/models/hr_holidays.py
+++ b/addons/project_timesheet_holidays/models/hr_holidays.py
@@ -139,3 +139,10 @@ class Holidays(models.Model):
         timesheets.unlink()
         self._check_missing_global_leave_timesheets()
         return res
+
+    def _force_cancel(self, *args, **kwargs):
+        super()._force_cancel(*args, **kwargs)
+        # override this method to reevaluate timesheets after the leaves are updated via force cancel
+        timesheets = self.sudo().timesheet_ids
+        timesheets.holiday_id = False
+        timesheets.unlink()

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -204,3 +204,48 @@ class TestTimesheetHolidays(TestCommonTimesheet):
 
         self.assertEqual(len(timesheets.filtered('holiday_id')), 4, "4 timesheet should be linked to employee's timeoff")
         self.assertEqual(len(timesheets.filtered('global_leave_id')), 1, '1 timesheet should be linked to global leave')
+
+    def test_delete_timesheet_after_new_holiday_covers_whole_timeoff(self):
+        """ User should be able to delete a timesheet created after a new public holiday is added,
+            covering the *whole* period of a existing time off.
+            Test Case:
+            =========
+            1) Create a Time off, approve and validate it.
+            2) Create a new Public Holiday, covering the whole time off created in step 1.
+            3) Delete the new timesheet associated with the public holiday.
+        """
+
+        leave_start_datetime = datetime(2022, 1, 31, 7, 0, 0, 0)    # Monday
+        leave_end_datetime = datetime(2022, 1, 31, 18, 0, 0, 0)
+
+        # (1) Create a timeoff and validate it
+        time_off = self.Requests.with_user(self.user_employee).create({
+            'name': 'Test Time off please',
+            'employee_id': self.empl_employee.id,
+            'holiday_status_id': self.hr_leave_type_with_ts.id,
+            'date_from': leave_start_datetime,
+            'date_to': leave_end_datetime,
+        })
+        time_off.with_user(SUPERUSER_ID).action_validate()
+
+        # (2) Create a public holiday
+        self.env['resource.calendar.leaves'].create({
+            'name': 'New Public Holiday',
+            'calendar_id': self.employee_working_calendar.id,
+            'date_from': datetime(2022, 1, 31, 5, 0, 0, 0),     # Covers the whole time off
+            'date_to': datetime(2022, 1, 31, 23, 0, 0, 0),
+        })
+
+        # The timeoff should have been force_cancelled and its associated timesheet unlinked.
+        self.assertFalse(time_off.timesheet_ids, '0 timesheet should remain for this time off.')
+
+        # (3) Delete the timesheet
+        timesheets = self.env['account.analytic.line'].search([
+            ('date', '>=', leave_start_datetime),
+            ('date', '<=', leave_end_datetime),
+            ('employee_id', '=', self.empl_employee.id),
+        ])
+
+        # timesheet should be unlinked to the timeoff, and be able to delete it
+        timesheets.with_user(SUPERUSER_ID).unlink()
+        self.assertFalse(timesheets.exists(), 'Timesheet should be deleted')


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
-------------------

Auto-cancelling Time Offs when editing public holidays was added in Jun 2022 ([see PR](https://github.com/odoo/odoo/pull/81225)) , but the cancellation of Time Offs wasn't updated to also remove the link to timesheets. If the user attempts to manually delete a timesheet linked to a Time Off (`holiday_id`​ in `hr.leave`​), they will be asked to cancel the Time Off which by this point had already been auto-cancelled, and as long as the link exists (regardless of cancellation) the timesheet cannot be deleted from the user frontend.

This PR adds an override call to unlink the timesheets before the leave (the inital validated timeoff) is force canceled.

Current behavior before PR:
-------------------
Steps to reproduce:
1. Create and validate an arbitrary Time Off, checking that it also creates a timesheet entry.
2. Create a new public holiday spanning the entire duration of the Time Off created in (1)
3. Attempt to delete the timesheet entry created in (1), if it is not already deleted.

Although you will be asked to cancel the timeoff first, that is not possible because the timeoff will be auto-cancelled by this point, making the deletion of the timesheet impossible.

Desired behavior after PR is merged:
-------------------

At step 3, user should be able to delete the timesheet associated to the timeoff.

Task-3697074

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
