### PR TITLE
[IMP] mrp_landed_costs: do not apply landed costs to byproducts without cost_share

### DIFF
--- a/addons/mrp_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_landed_costs/models/stock_landed_cost.py
@@ -21,4 +21,8 @@ class StockLandedCost(models.Model):
             self.mrp_production_ids = False
 
     def _get_targeted_move_ids(self):
-        return super()._get_targeted_move_ids() | self.mrp_production_ids.move_finished_ids
+        return (
+            super()._get_targeted_move_ids()
+            | self.mrp_production_ids.move_finished_ids
+            - self.mrp_production_ids.move_byproduct_ids.filtered(lambda move: not move.cost_share)
+        )


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
Apply landed costs to byproducts without cost_share

Desired behavior after PR is merged:
Do not apply landed costs to byproducts without cost_share



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
