### PR TITLE
[FIX] payment: enable using different journals on duplicate acquirers

### DIFF
--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -127,20 +127,7 @@ class AccountPaymentMethodLine(models.Model):
 
     @api.constrains('name')
     def _ensure_unique_name_for_journal(self):
-        self.flush(['name'])
-        self._cr.execute('''
-            SELECT apml.name, apm.payment_type
-            FROM account_payment_method_line apml
-            JOIN account_payment_method apm ON apml.payment_method_id = apm.id
-            WHERE apml.journal_id IS NOT NULL
-            GROUP BY apml.name, journal_id, apm.payment_type
-            HAVING count(apml.id) > 1
-        ''')
-        res = self._cr.fetchall()
-        if res:
-            (name, payment_type) = res[0]
-            raise UserError(_("You can't have two payment method lines of the same payment type (%s) "
-                              "and with the same name (%s) on a single journal.", payment_type, name))
+        self.journal_id._check_payment_method_line_ids_multiplicity()
 
     def unlink(self):
         """

--- a/addons/payment/models/account_journal.py
+++ b/addons/payment/models/account_journal.py
@@ -13,36 +13,6 @@ class AccountJournal(models.Model):
 
         return lines.filtered(lambda l: l.payment_acquirer_state != 'disabled')
 
-    @api.depends('outbound_payment_method_line_ids', 'inbound_payment_method_line_ids')
-    def _compute_available_payment_method_ids(self):
-        super()._compute_available_payment_method_ids()
-
-        installed_acquirers = self.env['payment.acquirer'].sudo().search([])
-        method_information = self.env['account.payment.method']._get_payment_method_information()
-        pay_methods = self.env['account.payment.method'].search([('code', 'in', list(method_information.keys()))])
-        pay_method_by_code = {x.code + x.payment_type: x for x in pay_methods}
-
-        # On top of the basic filtering, filter to hide unavailable acquirers.
-        # This avoid allowing payment method lines linked to an acquirer that has no record.
-        for code, vals in method_information.items():
-            payment_method = pay_method_by_code.get(code + 'inbound')
-
-            if not payment_method:
-                continue
-
-            for journal in self:
-                to_remove = []
-
-                available_providers = installed_acquirers.filtered(
-                    lambda a: a.company_id == journal.company_id
-                ).mapped('provider')
-                available = payment_method.code in available_providers
-
-                if vals['mode'] == 'unique' and not available:
-                    to_remove.append(payment_method.id)
-
-                journal.available_payment_method_ids = [Command.unlink(payment_method) for payment_method in to_remove]
-
     @api.ondelete(at_uninstall=False)
     def _unlink_except_linked_to_payment_acquirer(self):
         linked_acquirers = self.env['payment.acquirer'].sudo().search([]).filtered(

--- a/addons/payment/views/account_journal_views.xml
+++ b/addons/payment/views/account_journal_views.xml
@@ -7,8 +7,9 @@
         <field name="inherit_id" ref="account.view_account_journal_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='inbound_payment_method_line_ids']//field[@name='payment_account_id']" position="after">
-                <field name="payment_acquirer_id" invisible="1"/>
+                <field name="payment_acquirer_id" options="{'no_open': True, 'no_create': True}" optional="hide"/>
                 <field name="payment_acquirer_state" invisible="1"/>
+                <field name="code" invisible="1"/>
                 <button name="action_open_acquirer_form"
                         type="object"
                         string="SETUP"

--- a/addons/payment_alipay/models/account_payment_method.py
+++ b/addons/payment_alipay/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['alipay'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['alipay'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_authorize/models/account_payment_method.py
+++ b/addons/payment_authorize/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['authorize'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['authorize'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_buckaroo/models/account_payment_method.py
+++ b/addons/payment_buckaroo/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['buckaroo'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['buckaroo'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_mollie/models/account_payment_method.py
+++ b/addons/payment_mollie/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['mollie'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['mollie'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_ogone/models/account_payment_method.py
+++ b/addons/payment_ogone/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['ogone'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['ogone'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_paypal/models/account_payment_method.py
+++ b/addons/payment_paypal/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['paypal'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['paypal'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_payulatam/models/account_payment_method.py
+++ b/addons/payment_payulatam/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['payulatam'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['payulatam'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_payumoney/models/account_payment_method.py
+++ b/addons/payment_payumoney/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['payumoney'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['payumoney'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_sips/models/account_payment_method.py
+++ b/addons/payment_sips/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['sips'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['sips'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_stripe/models/account_payment_method.py
+++ b/addons/payment_stripe/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['stripe'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['stripe'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res

--- a/addons/payment_test/models/account_payment_method.py
+++ b/addons/payment_test/models/account_payment_method.py
@@ -10,5 +10,5 @@ class AccountPaymentMethod(models.Model):
     @api.model
     def _get_payment_method_information(self):
         res = super()._get_payment_method_information()
-        res['test'] = {'mode': 'unique', 'domain': [('type', '=', 'bank')]}
+        res['test'] = {'mode': 'electronic', 'domain': [('type', '=', 'bank')]}
         return res


### PR DESCRIPTION
Issue:
- unable to set up different journals on duplicated payment providers.
- As a result, customers cannot set up different currencies for the same payment provider in one company database. A very common case with Authorize.Net -> for each currency, a different account needs to be created: USD and CAD.The customers are unable to set up different journals on a payment provider.

Steps To Reproduce:
- Under one company duplicate a payment acquirer.
- Try to set a different journal per each duplicate.
- Notice changing journal on one acquirer changes it on the duplicate.

Solution:
- WIP

Ticket [link](https://www.odoo.com/web#model=project.task&id=3704407)
opw-3704407