### PR TITLE
[IMP] account_tax_python: Fix wrong taken company when evaluating python taxes

### DIFF
--- a/addons/account_test/report/report_account_test.py
+++ b/addons/account_test/report/report_account_test.py
@@ -14,7 +14,7 @@ class ReportAssertAccount(models.AbstractModel):
     _description = 'Account Test Report'
 
     @api.model
-    def execute_code(self, code_exec):
+    def _execute_code(self, code_exec):
         def reconciled_inv():
             """
             returns the list of invoices that are set as reconciled = True
@@ -70,6 +70,6 @@ class ReportAssertAccount(models.AbstractModel):
             'doc_model': report.model,
             'docs': records,
             'data': data,
-            'execute_code': self.execute_code,
+            'execute_code': self._execute_code,
             'datetime': datetime
         }


### PR DESCRIPTION
The company passed to safe_eval was the user's one instead of the tax's one.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
