### PR TITLE
[WIP] base_automation: add support to create new records from remote webhook

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -9,7 +9,7 @@ from uuid import uuid4
 
 from dateutil.relativedelta import relativedelta
 
-from odoo import _, api, exceptions, fields, models
+from odoo import _, api, exceptions, fields, models, SUPERUSER_ID
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
 from odoo.tools import safe_eval
 from odoo.http import request
@@ -498,7 +498,7 @@ class BaseAutomation(models.Model):
                 raise e
 
         if not self.record_getter:
-            new_record = record.create(payload)
+            new_record = record.with_user(SUPERUSER_ID).create(payload)
             return new_record
 
         if not record.exists():

--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -497,6 +497,10 @@ class BaseAutomation(models.Model):
                     ir_logging_sudo.create(self._prepare_loggin_values(message=msg % msg_args, level="ERROR"))
                 raise e
 
+        if not self.record_getter:
+            new_record = record.create(payload)
+            return new_record
+
         if not record.exists():
             msg = "Webhook #%s could not be triggered because no record to run it on was found."
             msg_args = (self.id,)


### PR DESCRIPTION
Description of the issue/feature this PR addresses: allow direct record creation through remote webhooks

Current behavior before PR: It is not possible to trigger the creation of a new record through an Odoo webhook.

Desired behavior after PR is merged: If no "Target record" is set we take the payload from the remote webhook call and automatically push these values as a `.create()` call to the model configured on the webhook



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
