### PR TITLE
[FIX] point_of_sale: make catg. btn dynamic width

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
@@ -2,6 +2,10 @@
     width: 60%;
 }
 
+.category-button {
+    width: auto !important;
+}
+
 .product-list {
     grid-template-columns: repeat(auto-fill, minmax(122px, 1fr));
 }


### PR DESCRIPTION
**Current behavior:**
If there are too many product categories displayed in the POS application, the buttons will overlap.

**Expected behavior:**
The buttons should be able to dynamically adjust their width based on their label length.

**Steps to reproduce:**
1. In the PoS Product Categories menu, add ~10 or so categories

2. Start a new session

3. The category buttons atop the page are overlapping

**Cause of the issue:**
The category buttons have a fixed width set in the XML file.

**Fix:**
Override the width in the associated .scss file. The XML could also be modified but the fix would have to be manually applied to those affected.

opw-3747159