### PR TITLE
[FIX] pos_self_order: Prevent order duplication in kiosk mode

### DIFF
--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -164,7 +164,7 @@ class PosOrder(models.Model):
     def export_for_ui_shared_order(self, config_id):
         orders = super().export_for_ui_shared_order(config_id)
         self_orders = self.get_standalone_self_order().export_for_ui()
-        return orders + self_orders
+        return list({order['id']: order for order in orders + self_orders}.values())
 
     @api.model
     def export_for_ui_table_draft(self, table_ids):


### PR DESCRIPTION
Before this commit, when using the kiosk with a normal point of sale, the kiosk orders were displayed twice within the PoS interface.

Steps to reproduce the issue:
 1. Enable kiosk mode on a normal point of sale.
 2. Open the kiosk and add an order.
 3. Open the point of sale and view the orders. => Notice that there are two instances of the kiosk order in the list.

opw-3750155

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
