### PR TITLE
[FIX] mail: lock mail.mail record before sending email

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -579,6 +579,7 @@ class MailMail(models.Model):
                     'state': 'exception',
                     'failure_reason': _('Error without exception. Probably due to sending an email without computed recipients.'),
                 })
+                mail.flush_recordset()
                 # Update notification in a transient exception state to avoid concurrent
                 # update in case an email bounces while sending all emails related to current
                 # mail record.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

In this line:

https://github.com/odoo/odoo/blob/c58a34294112b9d156fd563c207aaaacb1a90eb5/addons/mail/models/mail_mail.py#L730

The changes applied in `mail.mail ` sending the email are applied, if there is another process at the same time updating the same record, that is going to raise a concurrence error. The problem with this is the email went out already, but in Odoo, it keeps as `outgoing`, causing multiple emails to go out for the same record.

This commit adds a `flush_recordset` before sending the email, if there is another process trying to update the same record, it will be blocked and it must wait until the sending email process finishes.
The mail record will be updated as `sent`.

Video how it is reproduced in a clean installation using the master branch (no custom changes)

[![Video master](https://img.youtube.com/vi/GR2vJu0_RAw/0.jpg)](https://www.youtube.com/watch?v=GR2vJu0_RAw)

Video how it is reproduced in a clean installation using version 14.0 (no custom changes)

https://www.youtube.com/watch?v=f5ZrOo7b6qQ

Current behavior before PR:

If there is a concurrence error in this:

https://github.com/odoo/odoo/blob/c58a34294112b9d156fd563c207aaaacb1a90eb5/addons/mail/models/mail_mail.py#L730

the email goes out but it's not saved as `sent` in Odoo.

Desired behavior after PR is merged:

If there is a concurrence error in this line:

https://github.com/odoo/odoo/blob/c58a34294112b9d156fd563c207aaaacb1a90eb5/addons/mail/models/mail_mail.py#L730

the email goes out and it's saved as `sent` in Odoo because it's locked by the flush.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
