### PR TITLE
[FIX] odoo/tools, account_edi_ubl_cii: error processing Factur-X XML 

### DIFF
--- a/addons/account_edi_ubl_cii/models/ir_actions_report.py
+++ b/addons/account_edi_ubl_cii/models/ir_actions_report.py
@@ -71,6 +71,7 @@ class IrActionsReport(models.Model):
                 # If Factur-X hasn't been generated, generate and embed it anyway
                 if invoice.is_sale_document() \
                         and invoice.state == 'posted' \
+                        and edi_doc_codes \
                         and 'facturx_1_0_05' not in edi_doc_codes \
                         and self.env.ref('account_edi_ubl_cii.edi_facturx_1_0_05', raise_if_not_found=False):
                     # Add the attachments to the pdf file

--- a/odoo/tools/xml_utils.py
+++ b/odoo/tools/xml_utils.py
@@ -140,7 +140,8 @@ def cleanup_xml_node(xml_node_or_string, remove_blank_text=True, remove_blank_no
     if isinstance(xml_node, str):
         xml_node = xml_node.encode()  # misnomer: fromstring actually reads bytes
     if isinstance(xml_node, bytes):
-        xml_node = etree.fromstring(remove_control_characters(xml_node))
+        parser = etree.XMLParser(recover=True)
+        xml_node = etree.fromstring(remove_control_characters(xml_node), parser=parser)
 
     # Process leaf nodes iteratively
     # Depth-first, so any inner node may become a leaf too (if children are removed)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses:

1. If we are in a journal that does not support EDI documents, or does not have any available EDI formats (Actually the AR localization does not support these ones at all), when trying to generate the invoice PDF Odoo is processing Factur-X XML format and add it as part of the pdf.
2. If there is a special character in any place of the invoice, for example in the product lines description it will raise a traceback because it found a problem when trying to clean the XML node when preparing to add to the pdf.

## Steps to reproduce

1. Install Loc Arg EDI module
3. Create EDI invoice, add special character \x02 to the description of the product you are using
4. Validate the invoice
5. Try to print it

In our case, our customer copy and paste from an editor the product description and adds it a non visible character **\x02** that generate the problem. Example:

 <ram:Name>Indoor Wireless AP - Tri radio (802.11 b/g/n/ax 2x2 MU[\x02]()MIMO, 802.11 a/n/ac/ax 2x2 MU-MIMO and 1x 802.11 a/b/g/n/ac Wave 2, 1x1 ), internal antennas, 2x 10/100/1000 RJ45 port, BT/BLE, 1x Type A USB, 1x RS-232 RJ45 Serial Port. Ceiling/wall mount kit included.For power order: 802.3at PoE injector GPI-130 or AC adapter SP[\x02]()FAP200-PA. Region Code A</ram:Name>

## Current behavior before PR:
 
We are not able to print the invoice at all, and we don't have any easy hint to know where is the problem. Only can figure it out by doing a deep debug,

```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
  File "/home/odoo/src/odoo/odoo/http.py", line 1633, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "/home/odoo/src/odoo/odoo/service/model.py", line 133, in retrying
    result = func()
  File "/home/odoo/src/odoo/odoo/http.py", line 1660, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "/home/odoo/src/odoo/odoo/http.py", line 1864, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_http.py", line 154, in _dispatch
    result = endpoint(**request.params)
  File "/home/odoo/src/odoo/odoo/http.py", line 697, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/home/odoo/src/odoo/addons/web/controllers/dataset.py", line 42, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "/home/odoo/src/odoo/addons/web/controllers/dataset.py", line 33, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "/home/odoo/src/odoo/odoo/api.py", line 468, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "/home/odoo/src/odoo/odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "/home/odoo/src/odoo/odoo/models.py", line 6573, in onchange
    record._onchange_eval(name, field_onchange[name], result)
  File "/home/odoo/src/odoo/odoo/models.py", line 6284, in _onchange_eval
    method_res = method(self)
  File "/home/odoo/src/odoo/addons/account/wizard/account_invoice_send.py", line 95, in onchange_is_email
    self.composer_id._onchange_template_id_wrapper()
  File "/home/odoo/src/odoo/addons/mail/wizard/mail_compose_message.py", line 176, in _onchange_template_id_wrapper
    values = self._onchange_template_id([self.template_id.id](http://self.template_id.id/), self.composition_mode, self.model, self.res_id)['value']
    values = super()._onchange_template_id(
  File "/home/odoo/src/odoo/addons/mail/wizard/mail_compose_message.py", line 590, in _onchange_template_id
    values = self.generate_email_for_composer(
  File "/home/odoo/src/odoo/addons/mail/wizard/mail_compose_message.py", line 720, in generate_email_for_composer
    template_values = self.env['mail.template'].with_context(tpl_partners_only=True).browse(template_id).generate_email(res_ids, fields)
  File "/home/odoo/src/odoo/addons/account_edi/models/mail_template.py", line 39, in generate_email
    res = super().generate_email(res_ids, fields)
  File "/home/odoo/src/odoo/addons/mail/models/mail_template.py", line 286, in generate_email
    result, report_format = self.env['ir.actions.report']._render_qweb_pdf(report, [res_id])
  File "/home/odoo/src/odoo/addons/account/models/ir_actions_report.py", line 61, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "/home/odoo/src/odoo/odoo/addons/base/models/ir_actions_report.py", line 858, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/home/odoo/src/enterprise/account_followup/models/ir_actions_report.py", line 12, in _render_qweb_pdf_prepare_streams
    res = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids)
  File "/home/odoo/src/odoo/addons/account_edi_ubl_cii/models/ir_actions_report.py", line 89, in _render_qweb_pdf_prepare_streams
    xml_content, _errors = self.env['account.edi.xml.cii']._export_invoice(invoice)
  File "/home/odoo/src/odoo/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py", line 239, in _export_invoice
    return etree.tostring(cleanup_xml_node(xml_content), xml_declaration=True, encoding='UTF-8'), set(errors)
  File "/home/odoo/src/odoo/odoo/tools/xml_utils.py", line 121, in cleanup_xml_node
    xml_node = etree.fromstring(xml_node)
  File "src/lxml/etree.pyx", line 3237, in lxml.etree.fromstring
  File "src/lxml/parser.pxi", line 1896, in lxml.etree._parseMemoryDocument
  File "src/lxml/parser.pxi", line 1784, in lxml.etree._parseDoc
  File "src/lxml/parser.pxi", line 1141, in lxml.etree._BaseParser._parseDoc
  File "src/lxml/parser.pxi", line 615, in lxml.etree._ParserContext._handleParseResultDoc
  File "src/lxml/parser.pxi", line 725, in lxml.etree._handleParseResult
  File "src/lxml/parser.pxi", line 654, in lxml.etree._raiseParseError
  File "<string>", line 142
lxml.etree.XMLSyntaxError: PCDATA invalid Char value 2, line 142, column 89
```

## Desired behavior after PR is merged:

1. The invoice should not generate any edi document or append edi  Factur-X format XML to the PDF because this one is not used/valid for the country.
2. If the invoice elements has not asci characters and need to generate the Factura-X format XML to append to PDF, should not get any error, instead should show a more usefull error or directly work because it will process properly clean up the xml 


OPW 3900030  / LATAM 1199 /  Adhoc task 39312

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
