### PR TITLE
[IMP] calendar(_sms): make notify responsible field general

### DIFF
--- a/addons/calendar/models/calendar_alarm.py
+++ b/addons/calendar/models/calendar_alarm.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 
 
 class CalendarAlarm(models.Model):
@@ -25,6 +25,7 @@ class CalendarAlarm(models.Model):
         compute='_compute_mail_template_id', readonly=False, store=True,
         help="Template used to render mail reminder content.")
     body = fields.Text("Additional Message", help="Additional message that would be sent with the notification for the reminder")
+    notify_responsible = fields.Boolean("Notify Responsible", default=False)
 
     @api.depends('interval', 'duration')
     def _compute_duration_minutes(self):
@@ -54,10 +55,14 @@ class CalendarAlarm(models.Model):
             '&', ('interval', '=', 'days'), ('duration', operator, value / 60 / 24),
         ]
 
-    @api.onchange('duration', 'interval', 'alarm_type')
+    @api.onchange('duration', 'interval', 'alarm_type', 'notify_responsible')
     def _onchange_duration_interval(self):
+        if self.notify_responsible and self.alarm_type in ('email', 'notification'):
+            self.notify_responsible = False
         display_interval = self._interval_selection.get(self.interval, '')
         display_alarm_type = {
             key: value for key, value in self._fields['alarm_type']._description_selection(self.env)
         }[self.alarm_type]
         self.name = "%s - %s %s" % (display_alarm_type, self.duration, display_interval)
+        if self.notify_responsible:
+            self.name += " - " + _("Notify Responsible")

--- a/addons/calendar/models/calendar_alarm_manager.py
+++ b/addons/calendar/models/calendar_alarm_manager.py
@@ -190,13 +190,7 @@ class CalendarAlarm_Manager(models.AbstractModel):
                 notify_author=True,
             )
 
-        for event in events:
-            if event.recurrence_id:
-                next_date = event.get_next_alarm_date(events_by_alarm)
-                # In cron, setup alarm only when there is a next date on the target. Otherwise the 'now()'
-                # check in the call below can generate undeterministic behavior and setup random alarms.
-                if next_date:
-                    event.recurrence_id.with_context(date=next_date)._setup_alarms()
+        events._setup_event_recurrent_alarms(events_by_alarm)
 
     @api.model
     def get_next_notif(self):

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -53,6 +53,7 @@
                                 <field name="duration"/>
                                 <field name="interval"/>
                             </div>
+                            <field name="notify_responsible" invisible="alarm_type in ('email', 'notification')"/>
                         </group>
                     </group>
                 </sheet>

--- a/addons/calendar_sms/models/calendar_alarm.py
+++ b/addons/calendar_sms/models/calendar_alarm.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, api, fields, models
+from odoo import api, fields, models
 
 
 class CalendarAlarm(models.Model):
@@ -15,7 +15,6 @@ class CalendarAlarm(models.Model):
         domain=[('model', 'in', ['calendar.event'])],
         compute='_compute_sms_template_id', readonly=False, store=True,
         help="Template used to render SMS reminder content.")
-    sms_notify_responsible = fields.Boolean("Notify Responsible")
 
     @api.depends('alarm_type', 'sms_template_id')
     def _compute_sms_template_id(self):
@@ -24,11 +23,3 @@ class CalendarAlarm(models.Model):
                 alarm.sms_template_id = self.env['ir.model.data']._xmlid_to_res_id('calendar_sms.sms_template_data_calendar_reminder')
             elif alarm.alarm_type != 'sms' or not alarm.sms_template_id:
                 alarm.sms_template_id = False
-
-    @api.onchange('duration', 'interval', 'alarm_type', 'sms_notify_responsible')
-    def _onchange_duration_interval(self):
-        super()._onchange_duration_interval()
-        if self.alarm_type != 'sms':
-            self.sms_notify_responsible = False
-        elif self.sms_notify_responsible:
-            self.name += " - " + _("Notify Responsible")

--- a/addons/calendar_sms/models/calendar_alarm_manager.py
+++ b/addons/calendar_sms/models/calendar_alarm_manager.py
@@ -22,6 +22,4 @@ class CalendarAlarm_Manager(models.AbstractModel):
         for event in events:
             alarm = event.alarm_ids.filtered(lambda alarm: alarm.id in alarms.ids)
             event._do_sms_reminder(alarm)
-            if event.recurrence_id:
-                next_date = event.get_next_alarm_date(events_by_alarm)
-                event.recurrence_id.with_context(date=next_date)._setup_alarms()
+            event._setup_event_recurrent_alarms(events_by_alarm)

--- a/addons/calendar_sms/models/calendar_event.py
+++ b/addons/calendar_sms/models/calendar_event.py
@@ -16,7 +16,7 @@ class CalendarEvent(models.Model):
                 partners = event._mail_get_partners()[event.id].filtered(
                     lambda partner: partner.phone_sanitized and partner not in declined_partners
                 )
-                if event.user_id and not alarm.sms_notify_responsible:
+                if event.user_id and not alarm.notify_responsible:
                     partners -= event.user_id.partner_id
                 event._message_sms_with_template(
                     template=alarm.sms_template_id,

--- a/addons/calendar_sms/views/calendar_views.xml
+++ b/addons/calendar_sms/views/calendar_views.xml
@@ -10,9 +10,6 @@
                 <field name="sms_template_id" invisible="alarm_type != 'sms'" required="alarm_type == 'sms'"
                     context="{'default_model': 'calendar.event'}"/>
             </xpath>
-            <xpath expr="//group[@name='right_details']" position="inside">
-                <field name="sms_notify_responsible" invisible="alarm_type != 'sms'"/>
-            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
Before this commit:

`sms_notify_responsible` is a field in the calendar_sms module that decides whether to send an SMS to the Organizer of the event or not. We need the same functionality in WhatsApp as well.

After this commit:

The `sms_notify_responsible` field will be moved to the calendar module as `notify_responsible`. Now, `notify_responsible` can be used in both modules `calendar_sms` and `whatsapp_calendar`.

Related Upgrade PR: https://github.com/odoo/upgrade/pull/5709

Task-3506616