### PR TITLE
[FIX][16.0] mrp_landed_costs: account move for qty of child MO

### DIFF
--- a/addons/mrp_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_landed_costs/models/stock_landed_cost.py
@@ -22,3 +22,15 @@ class StockLandedCost(models.Model):
 
     def _get_targeted_move_ids(self):
         return super()._get_targeted_move_ids() | self.mrp_production_ids.move_finished_ids
+
+
+class AdjustmentLines(models.Model):
+    _inherit = 'stock.valuation.adjustment.lines'
+
+    def _create_account_move_line(self, move, credit_account_id, debit_account_id, qty_out, already_out_account_id):
+        """
+            The accounting journal entries for recording costs related to inventory issued for sale and issued for production are different.
+        """
+        if qty_out > 0 and self.move_id.production_id and self.move_id.location_id.usage == 'production':
+            already_out_account_id = self.move_id.location_id.valuation_out_account_id.id or already_out_account_id
+        return super(AdjustmentLines, self)._create_account_move_line(move, credit_account_id, debit_account_id, qty_out, already_out_account_id)


### PR DESCRIPTION
- Create MO2 with child MO1
- Validate Landed cost: manufacturer overhead for child MO1

- Check journal entry of landed cost

Current:
	journal entry of qty out with account: Costs of goods sold

Expectation:
	journal entry of qty out with account: Work in progress

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
