### PR TITLE
[FIX] mail: do not fetch channel infos when leaving a channel

### DIFF
--- a/addons/bus/static/tests/bus_tests.js
+++ b/addons/bus/static/tests/bus_tests.js
@@ -131,6 +131,7 @@ QUnit.test("two tabs adding a different channel", async () => {
 });
 
 QUnit.test("channel management from multiple tabs", async (assert) => {
+    await startServer();
     addBusServicesToRegistry();
     patchWebsocketWorkerWithCleanup({
         _sendToServer({ event_name, data }) {
@@ -159,6 +160,7 @@ QUnit.test("channel management from multiple tabs", async (assert) => {
 });
 
 QUnit.test("channels subscription after disconnection", async (assert) => {
+    await startServer();
     addBusServicesToRegistry();
     const worker = patchWebsocketWorkerWithCleanup();
     const env = await makeTestEnv({ activateMockServer: true });

--- a/addons/bus/static/tests/helpers/mock_server.js
+++ b/addons/bus/static/tests/helpers/mock_server.js
@@ -17,13 +17,13 @@ patch(MockServer.prototype, {
         super.init(...arguments);
         Object.assign(this, TEST_USER_IDS);
         const self = this;
+        this.notificationQueue = [];
         this.websocketWorker = patchWebsocketWorkerWithCleanup({
             _sendToServer(message) {
                 self._performWebsocketRequest(message);
                 super._sendToServer(message);
             },
         });
-        this.notificationsToBeResolved = [];
         this.lastBusNotificationId = 0;
         this.channelsByUser = {};
         for (const modelName in this.models) {
@@ -71,7 +71,8 @@ patch(MockServer.prototype, {
             this._mockIrWebsocket__updatePresence(inactivity_period, im_status_ids_by_model);
         } else if (event_name === "subscribe") {
             const { channels } = data;
-            this.channelsByUser[this.pyEnv?.currentUser] = channels;
+            this.channelsByUser[this.pyEnv.currentUser] =
+                this._mockIrWebsocket__buildBusChannelList(channels);
         }
         const callbackFn = registry
             .category("mock_server_websocket_callbacks")
@@ -109,9 +110,8 @@ patch(MockServer.prototype, {
                   context: { active_test: false },
               })[0]
             : null;
-        const channels = this._mockIrWebsocket__buildBusChannelList().concat(
-            this.channelsByUser[authenticatedUser]
-        );
+        const channels =
+            this.channelsByUser[authenticatedUser] ?? this._mockIrWebsocket__buildBusChannelList();
         notifications = notifications.filter(([target]) =>
             channels.some((channel) => {
                 if (typeof target === "string") {
@@ -126,11 +126,30 @@ patch(MockServer.prototype, {
         for (const notification of notifications) {
             const [type, payload] = notification.slice(1, notification.length);
             values.push({ id: ++this.lastBusNotificationId, message: { payload, type } });
-            if (this.debug) {
-                console.log("%c[bus]", "color: #c6e; font-weight: bold;", type, payload);
-            }
         }
-        this.websocketWorker.broadcast("notification", values);
+        this.notificationQueue.push(...values);
+        if (this.notificationQueue.length === values.length) {
+            this._planNotificationSending();
+        }
+    },
+
+    /**
+     * Helper to send the pending notifications to the client. This method is
+     * push to the micro task queue to simulate server-side batching of
+     * notifications.
+     */
+    _planNotificationSending() {
+        queueMicrotask(() => {
+            if (this.debug) {
+                console.group("%c[BUS]", "color: #c6e; font-weight: bold;");
+                for (const { message } of this.notificationQueue) {
+                    console.log(message.type, message.payload);
+                }
+                console.groupEnd();
+            }
+            this.websocketWorker.broadcast("notification", this.notificationQueue);
+            this.notificationQueue = [];
+        });
     },
     /**
      * Simulate the lost of the connection by simulating a closeEvent on

--- a/addons/bus/static/tests/helpers/mock_server/models/ir_websocket.js
+++ b/addons/bus/static/tests/helpers/mock_server/models/ir_websocket.js
@@ -41,8 +41,9 @@ patch(MockServer.prototype, {
     /**
      * Simulates `_build_bus_channel_list` on `ir.websocket`.
      */
-    _mockIrWebsocket__buildBusChannelList() {
-        const channels = ["broadcast"];
+    _mockIrWebsocket__buildBusChannelList(channels = []) {
+        channels = [...channels];
+        channels.push("broadcast");
         const authenticatedUserId = this.pyEnv.cookie.get("authenticated_user_sid");
         const authenticatedPartner = authenticatedUserId
             ? this.pyEnv["res.partner"].searchRead([["user_ids", "in", [authenticatedUserId]]], {

--- a/addons/bus/static/tests/simple_notification_tests.js
+++ b/addons/bus/static/tests/simple_notification_tests.js
@@ -2,7 +2,7 @@
 
 import { simpleNotificationService } from "@bus/simple_notification_service";
 import { addBusServicesToRegistry } from "@bus/../tests/helpers/test_utils";
-import { getPyEnv } from "@bus/../tests/helpers/mock_python_environment";
+import { getPyEnv, startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { registry } from "@web/core/registry";
 import { browser } from "@web/core/browser/browser";
@@ -13,6 +13,7 @@ import { createWebClient } from "@web/../tests/webclient/helpers";
 QUnit.module("simple_notification");
 
 QUnit.test("receive and display simple notification with message", async () => {
+    await startServer();
     addBusServicesToRegistry();
     registry.category("services").add("simple_notification", simpleNotificationService);
     await createWebClient({});
@@ -24,6 +25,7 @@ QUnit.test("receive and display simple notification with message", async () => {
 });
 
 QUnit.test("receive and display simple notification with title", async () => {
+    await startServer();
     addBusServicesToRegistry();
     registry.category("services").add("simple_notification", simpleNotificationService);
     await createWebClient({});
@@ -36,6 +38,7 @@ QUnit.test("receive and display simple notification with title", async () => {
 });
 
 QUnit.test("receive and display simple notification with specific type", async () => {
+    await startServer();
     addBusServicesToRegistry();
     registry.category("services").add("simple_notification", simpleNotificationService);
     await createWebClient({});
@@ -48,6 +51,7 @@ QUnit.test("receive and display simple notification with specific type", async (
 });
 
 QUnit.test("receive and display simple notification as sticky", async () => {
+    await startServer();
     addBusServicesToRegistry();
     registry.category("services").add("simple_notification", simpleNotificationService);
     await createWebClient({});

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -18,7 +18,7 @@ const threadPatch = {
         this.fetchChannelInfoState = Record.attr("not_fetched", {
             /** @this {import("models").Thread} */
             onUpdate() {
-                if (this.fetchChannelInfoState === "fetched") {
+                if (["fetched", "left"].includes(this.fetchChannelInfoState)) {
                     this._store.updateBusSubscription();
                 }
             },
@@ -89,11 +89,14 @@ const threadPatch = {
         }
         return super.avatarUrl;
     },
+    _computeDisplayToSelf() {
+        return this.fetchChannelInfoState !== "left" && super._computeDisplayToSelf();
+    },
     async fetchChannelInfo() {
-        if (this.fetchChannelInfoState === "fetched") {
+        if (["fetched", "left"].includes(this.fetchChannelInfoState)) {
             return this.fetchChannelInfoDeferred ?? Promise.resolve(this);
         }
-        if (this.fetchChannelInfoStateState === "fetching") {
+        if (this.fetchChannelInfoState === "fetching") {
             return this.fetchChannelInfoDeferred;
         }
         this.fetchChannelInfoState = "fetching";

--- a/addons/mail/static/tests/core/out_of_focus_tests.js
+++ b/addons/mail/static/tests/core/out_of_focus_tests.js
@@ -1,6 +1,7 @@
 /* @odoo-module */
 
 import { makeFakePresenceService } from "@bus/../tests/helpers/mock_services";
+import { waitUntilSubscribe } from "@bus/../tests/helpers/websocket_event_deferred";
 
 import { start } from "@mail/../tests/helpers/test_utils";
 
@@ -17,6 +18,7 @@ QUnit.test("Spaces in notifications are not encoded", async () => {
     const channelId = pyEnv["discuss.channel"].create({ channel_type: "chat" });
     const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
     await openDiscuss();
+    await waitUntilSubscribe();
     pyEnv["bus.bus"]._sendone(channel, "discuss.channel/new_message", {
         id: channelId,
         message: {

--- a/addons/mail/static/tests/discuss/core/discuss_tests.js
+++ b/addons/mail/static/tests/discuss/core/discuss_tests.js
@@ -6,7 +6,7 @@ import { start } from "@mail/../tests/helpers/test_utils";
 
 import { assertSteps, click, contains, insertText, step } from "@web/../tests/utils";
 import { patchWebsocketWorkerWithCleanup } from "@bus/../tests/helpers/mock_websocket";
-import { patchDate } from "@web/../tests/helpers/utils";
+import { nextTick, patchDate } from "@web/../tests/helpers/utils";
 
 QUnit.module("discuss");
 
@@ -27,6 +27,7 @@ QUnit.test("bus subscription is refreshed when channel is joined", async () => {
     pyEnv["discuss.channel"].create([{ name: "General" }, { name: "Sales" }]);
     patchWebsocketWorkerWithCleanup({
         _sendToServer({ event_name, data }) {
+            super._sendToServer(...arguments);
             if (event_name === "subscribe") {
                 step(`subscribe - ${JSON.stringify(data.channels)}`);
             }
@@ -37,6 +38,7 @@ QUnit.test("bus subscription is refreshed when channel is joined", async () => {
     const { openDiscuss } = await start();
     await assertSteps(["subscribe - []"]);
     await openDiscuss();
+    await nextTick(); // Wait for the initial fetch to occur.
     await assertSteps([]);
     await click(".o-mail-DiscussSidebar i[title='Add or join a channel']");
     await insertText(".o-discuss-ChannelSelector input", "new channel");
@@ -49,6 +51,7 @@ QUnit.test("bus subscription is refreshed when channel is left", async () => {
     pyEnv["discuss.channel"].create({ name: "General" });
     patchWebsocketWorkerWithCleanup({
         _sendToServer({ event_name, data }) {
+            super._sendToServer(...arguments);
             if (event_name === "subscribe") {
                 step(`subscribe - ${JSON.stringify(data.channels)}`);
             }
@@ -59,6 +62,7 @@ QUnit.test("bus subscription is refreshed when channel is left", async () => {
     const { openDiscuss } = await start();
     await assertSteps(["subscribe - []"]);
     await openDiscuss();
+    await nextTick(); // Wait for the initial fetch to occur.
     await assertSteps([]);
     await click("[title='Leave this channel']");
     await assertSteps(["subscribe - []"]);

--- a/addons/mail/static/tests/discuss/core/web/crosstab_tests.js
+++ b/addons/mail/static/tests/discuss/core/web/crosstab_tests.js
@@ -1,10 +1,10 @@
 /* @odoo-module */
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { waitForWorkerEvent } from "@bus/../tests/helpers/websocket_event_deferred";
 
 import { start } from "@mail/../tests/helpers/test_utils";
 
-import { patchWithCleanup } from "@web/../tests/helpers/utils";
 import { click, contains, insertText } from "@web/../tests/utils";
 
 QUnit.module("crosstab");
@@ -12,17 +12,11 @@ QUnit.module("crosstab");
 QUnit.test("Channel subscription is renewed when channel is manually added", async (assert) => {
     const pyEnv = await startServer();
     pyEnv["discuss.channel"].create({ name: "General", channel_member_ids: [] });
-    const { env, openDiscuss } = await start();
-    patchWithCleanup(env.services["bus_service"], {
-        forceUpdateChannels() {
-            assert.step("update-channels");
-        },
-    });
+    const { openDiscuss } = await start();
     openDiscuss();
     await click("[title='Add or join a channel']");
     await insertText(".o-discuss-ChannelSelector input", "General");
     await click(":nth-child(1 of .o-discuss-ChannelSelector-suggestion)");
     await contains(".o-mail-DiscussSidebarChannel", { count: 1 });
-    await new Promise((resolve) => setTimeout(resolve)); // update of channels is debounced
-    assert.verifySteps(["update-channels"]);
+    await waitForWorkerEvent("force_update_channels");
 });

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -244,11 +244,10 @@ patch(MockServer.prototype, {
         this.pyEnv["discuss.channel"].write([channel.id], {
             channel_member_ids: [[2, channelMember.id]],
         });
-        this.pyEnv["bus.bus"]._sendone(
-            this.pyEnv.currentPartner,
-            "discuss.channel/leave",
-            this._mockDiscussChannelChannelInfo([channel.id])[0]
-        );
+        this.pyEnv["bus.bus"]._sendone(this.pyEnv.currentPartner, "discuss.channel/leave", {
+            ...this._mockDiscussChannelChannelInfo([channel.id])[0],
+            is_pinned: false,
+        });
         this.pyEnv["bus.bus"]._sendone(channel, "mail.record/insert", {
             Thread: {
                 id: channel.id,
@@ -259,19 +258,11 @@ patch(MockServer.prototype, {
                 model: "discuss.channel",
             },
         });
-
-        /**
-         * Leave message not posted here because it would send the new message
-         * notification on a separate bus notification list from the unsubscribe
-         * itself which would lead to the channel being pinned again (handler
-         * for unsubscribe is weak and is relying on both of them to be sent
-         * together on the bus).
-         */
-        // this._mockDiscussChannelMessagePost(channel.id, {
-        //     author_id: this.pyEnv.currentPartnerId,
-        //     body: '<div class="o_mail_notification">left the channel</div>',
-        //     subtype_xmlid: "mail.mt_comment",
-        // });
+        this._mockDiscussChannelMessagePost(channel.id, {
+            author_id: this.pyEnv.currentPartnerId,
+            body: '<div class="o_mail_notification">left the channel</div>',
+            subtype_xmlid: "mail.mt_comment",
+        });
         return true;
     },
     /**

--- a/addons/mail/static/tests/helpers/mock_server/models/ir_websocket.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/ir_websocket.js
@@ -32,8 +32,8 @@ patch(MockServer.prototype, {
     /**
      * Simulates `_build_bus_channel_list` on `ir.websocket`.
      */
-    _mockIrWebsocket__buildBusChannelList() {
-        const channels = super._mockIrWebsocket__buildBusChannelList();
+    _mockIrWebsocket__buildBusChannelList(channels) {
+        channels = [...super._mockIrWebsocket__buildBusChannelList(channels)];
         const guest = this._mockMailGuest__getGuestFromContext();
         const authenticatedUserId = this.pyEnv.cookie.get("authenticated_user_sid");
         const authenticatedPartner = authenticatedUserId

--- a/addons/mail/static/tests/helpers/mock_server/models/res_partner.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/res_partner.js
@@ -297,6 +297,11 @@ patch(MockServer.prototype, {
         if (search_term) {
             search_term = search_term.toLowerCase(); // simulates ILIKE
         }
+        const channelPartnerIds = new Set(
+            this.getRecords("discuss.channel.member", [["channel_id", "=", channel_id]]).map(
+                (member) => member.partner_id
+            )
+        );
         // simulates domain with relational parts (not supported by mock server)
         const matchingPartners = [
             ...this._mockResPartnerMailPartnerFormat(
@@ -305,12 +310,12 @@ patch(MockServer.prototype, {
                         const partner = this.getRecords("res.partner", [
                             ["id", "=", user.partner_id],
                         ])[0];
-                        // user must have a partner
-                        if (!partner) {
+                        // partner is not already member
+                        if (channelPartnerIds.has(partner.id)) {
                             return false;
                         }
-                        // not current partner
-                        if (partner.id === this.pyEnv.currentPartnerId) {
+                        // user must have a partner
+                        if (!partner) {
                             return false;
                         }
                         // no name is considered as return all

--- a/addons/mail/static/tests/qunit_suite_tests/widgets/emojis_char_field_tests.js
+++ b/addons/mail/static/tests/qunit_suite_tests/widgets/emojis_char_field_tests.js
@@ -29,7 +29,6 @@ QUnit.module("widgets", {}, (hooks) => {
     QUnit.module("emojis_char_field_tests.js");
 
     QUnit.test("emojis_char_field_tests widget: insert emoji at end of word", async function (assert) {
-        assert.expect(2);
         const {openFormView} =  await start({serverData});
         await openFormView("mailing.mailing");
 
@@ -44,7 +43,6 @@ QUnit.module("widgets", {}, (hooks) => {
     });
 
     QUnit.test("emojis_char_field_tests widget: insert emoji as new word", async function (assert) {
-        assert.expect(2);
         const {openFormView} =  await start({serverData});
         await openFormView("mailing.mailing");
 

--- a/addons/mail/static/tests/thread/thread_tests.js
+++ b/addons/mail/static/tests/thread/thread_tests.js
@@ -3,6 +3,7 @@
 import { rpc } from "@web/core/network/rpc";
 
 import { startServer } from "@bus/../tests/helpers/mock_python_environment";
+import { waitUntilSubscribe } from "@bus/../tests/helpers/websocket_event_deferred";
 
 import { Command } from "@mail/../tests/helpers/command";
 import { start } from "@mail/../tests/helpers/test_utils";
@@ -10,6 +11,7 @@ import { start } from "@mail/../tests/helpers/test_utils";
 import { config as transitionConfig } from "@web/core/transition";
 import { makeDeferred, nextTick, patchWithCleanup } from "@web/../tests/helpers/utils";
 import {
+    assertSteps,
     click,
     contains,
     createFile,
@@ -17,6 +19,7 @@ import {
     focus,
     insertText,
     scroll,
+    step,
     triggerEvents,
 } from "@web/../tests/utils";
 
@@ -307,11 +310,12 @@ QUnit.test(
                     );
                 } else if (route === "/discuss/channel/set_last_seen_message") {
                     assert.strictEqual(args.channel_id, channelId);
-                    assert.step("rpc:set_last_seen_message");
+                    step("rpc:set_last_seen_message");
                 }
             },
         });
-        openDiscuss(channelId);
+        await openDiscuss(channelId);
+        await waitUntilSubscribe();
         await focus(".o-mail-Composer-input");
         // simulate receiving a message
         await pyEnv.withUser(userId, () =>
@@ -322,7 +326,7 @@ QUnit.test(
             })
         );
         await contains(".o-mail-Message");
-        assert.verifySteps(["rpc:set_last_seen_message"]);
+        await assertSteps(["rpc:set_last_seen_message"]);
     }
 );
 


### PR DESCRIPTION
When a channel is left, a `discuss.channel/new_message` and a
`discuss.channel/leave` notifications are received from the bus in the
same batch. Before [1], we checked if a `discuss.channel/leave`
notification was received as part of the same batch and we ignore the
`discuss.channel/new_message` one if it was the case.

After [1], the check is not done anymore which results in fetching the
channel infos of the channel that was just left.

This PR adapts the code to only remove the channel member of the
current user instead of deleting the whole channel. This prevents the
channel info request since it is already known.

Steps to reproduce the issue:
- Go to the discuss app
- Join a channel
- Leave the channel
- Notice that à call to `/discuss/channel/info` was done for the channel
that was left.

[1]: https://github.com/odoo/odoo/pull/147747