### PR TITLE
[FIX] base_address_extended: sync city_id with children contacts

### DIFF
--- a/addons/base_address_extended/models/res_partner.py
+++ b/addons/base_address_extended/models/res_partner.py
@@ -16,6 +16,10 @@ class Partner(models.Model):
     city_id = fields.Many2one(comodel_name='res.city', string='City ID')
     country_enforce_cities = fields.Boolean(related='country_id.enforce_cities')
 
+    @api.model
+    def _address_fields(self):
+        return super()._address_fields() + ['city_id']
+
     def _inverse_street_data(self):
         """ update self.street based on street_name, street_number and street_number2 """
         for partner in self:


### PR DESCRIPTION
Steps to reproduce:
- Install contacts and base_address_extended
- Install a module adding "res.city" records (e.g. l10n_co_edi)
- Go to Contacts and create a new one:
  * Name: [any]
  * Country: Colombia
  * City (city_id): [any]
- Create a "child" contact of "Contact" type
- Save the contact

Issue:
"city_id" field of the child contact is False.
It is not possible to set the address of a contact-type contact manually. Some address fields ('street', 'street2', 'zip', 'city', 'state_id', 'country_id') are synchronized with the parent contact.
"city_id" is not and is not settable at all for contact-type contact. It could be an issue for Colombian or Mexican localizations if a child contact is used for an invoice as some data has to be retrieved from "city_id" field to generate the electronic invoice.

Solution:
Add "city_id" in the list of address fields to sync.

opw-3747296



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
