### PR TITLE
[I18n]mail: translate view in mail’s button “view invoice” to Bulgarian.

### DIFF
--- a/addons/mail/i18n/bg.po
+++ b/addons/mail/i18n/bg.po
@@ -5203,13 +5203,13 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:mail.message_user_assigned
 #, python-format
 msgid "View"
-msgstr ""
+msgstr "изглед"
 
 #. module: mail
 #: code:addons/mail/models/mail_thread.py:668
 #, python-format
 msgid "View %s"
-msgstr ""
+msgstr "изглед %s"
 
 #. module: mail
 #. openerp-web


### PR DESCRIPTION
Description of the issue/feature this PR addresses: When sending an invoice to customer and translating the template to Bulgarian(bg_BG), in the button “view invoice” the “view” won’t translate.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
