### PR TITLE
[FIX] project: fix alias domain value by setting default value

### DIFF
--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -110,6 +110,8 @@
                                 <group>
                                     <div name="alias_def" colspan="2" class="pb-2">
                                         <!-- Always display the whole alias in edit mode. It depends in read only -->
+                                        <!-- Need to add alias_id in view for getting alias_domain_id by default -->
+                                        <field name="alias_id" invisible="1"/>
                                         <label for="alias_name" class="fw-bold o_form_label" string="Create tasks by sending an email to"/>
                                         <field name="alias_email" class="oe_read_only d-inline" widget="email" readonly="1" invisible="not alias_name" />
                                         <span class="oe_edit_only o_row">
@@ -339,6 +341,8 @@
                     <div name="alias_def" class="mt-2" colspan="2">
                         <label for="alias_name" string="Create tasks by sending an email to"/>
                         <span>
+                            <!-- Need to add alias_id in view for getting alias_domain_id by default -->
+                            <field name="alias_id" invisible="1"/>
                             <field name="alias_name" placeholder="e.g. office-party"/>@
                             <field name="alias_domain_id" class="oe_inline" placeholder="e.g. domain.com"
                                    options="{'no_create': True, 'no_open': True}"/>


### PR DESCRIPTION
Steps:
- Install the project
- Enable use custom enable server from general settings. Set an alias domain
- Create a new project
- Wizard pops up

Issue:
- Default value of alias domain is not set.

Cause:
- alias_domain_id is related to alias_id and it is not present in the view.

Fix:
- Issue is been fixed by adding a field in wizard view as alias domain was getting fetched on that field.
- Additionally the same field is been to added to form view as well.

task-3744319