### PR TITLE
[FIX] website_slides: do not fetch metadata in tests

### DIFF
--- a/addons/website_slides/tests/test_slide_slide.py
+++ b/addons/website_slides/tests/test_slide_slide.py
@@ -8,7 +8,7 @@ class TestSlideInternals(slides_common.SlidesCase):
 
     def test_change_content_type(self):
         """ To prevent constraint violation when changing type from video to webpage and vice-versa """
-        slide = self.env['slide.slide'].create({
+        slide = self.env['slide.slide'].with_context(website_slides_skip_fetch_metadata=True).create({
             'channel_id': self.channel.id,
             'slide_type': 'video',
             'is_published': True,


### PR DESCRIPTION
BUg
===
Because a context key is missing, the test will try to fetch the metadata over the internet, and therefore trigger a warning on the runbot.