### PR TITLE
[IMP] stock: made customer lead time company specific

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -663,7 +663,7 @@ class ProductTemplate(models.Model):
         company_dependent=True, check_company=True, domain="[('usage', '=', 'inventory'), '|', ('company_id', '=', False), ('company_id', '=', allowed_company_ids[0])]",
         help="This stock location will be used, instead of the default one, as the source location for stock moves generated when you do an inventory.")
     sale_delay = fields.Integer(
-        'Customer Lead Time', default=0,
+        'Customer Lead Time', default=0, company_dependent=True,
         help="Delivery lead time, in days. It's the number of days, promised to the customer, between the confirmation of the sales order and the delivery.")
     tracking = fields.Selection([
         ('serial', 'By Unique Serial Number'),


### PR DESCRIPTION
In this commit:
==================
Adjusted customer lead times to suit each company's location and supply chain. This means that even for the same product, lead times can vary depending on the company.

task-3734658
