### PR TITLE
[FIX] sale,payment : get suitable payment methods on subscription order

### DIFF
--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -229,7 +229,7 @@ class PaymentMethod(models.Model):
             ])
 
         # Handle tokenization support requirements.
-        if force_tokenization:
+        if force_tokenization or self._is_tokenization_required():
             domain = expression.AND([domain, [('support_tokenization', '=', True)]])
 
         # Handle express checkout.
@@ -239,6 +239,18 @@ class PaymentMethod(models.Model):
         # Search the payment methods matching the compatibility criteria.
         compatible_payment_methods = self.env['payment.method'].search(domain)
         return compatible_payment_methods
+
+    @api.model
+    def _is_tokenization_required(self):
+        """ Return whether tokenizing the transaction is required given its context.
+
+        For a module to make the tokenization required based on the payment context, it must
+        override this method and return whether it is required.
+
+        :return: Whether tokenizing the transaction is required.
+        :rtype: bool
+        """
+        return False
 
     def _get_from_code(self, code, mapping=None):
         """ Get the payment method corresponding to the given provider-specific code.

--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -215,7 +215,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
             sale_order_id=order_sudo.id,
             **kwargs,
         )  # In sudo mode to read the fields of providers and partner (if logged out).
-        payment_methods_sudo = request.env['payment.method'].sudo()._get_compatible_payment_methods(
+        payment_methods_sudo = request.env['payment.method'].sudo().with_context(sale_order_id=order_sudo.id)._get_compatible_payment_methods(
             providers_sudo.ids,
             partner_sudo.id,
             currency_id=currency.id,


### PR DESCRIPTION
**Steps to reproduce:**
	1- Install Sale, Subscription, Website and eCommerce modules
	2- Activate a payment provider that has PayPal as one of its methods (e.g. Stripe)
	3- Go to shop and add a subscription item to the cart
	4- Navigate to checkout

**Current behavior before PR:**
when you have a payment method that don't support tokenization activated it will appear in checkout even if the order is a subscription order. This is happening because we don't check if the order is a subscription one or not like we do when getting payment providers

**Desired behavior after PR is merged:**
It doesn't appear anymore as we added a condition to check if the order is subscription or not and if it is we have to remove it from compatible payment methods.

opw-3747656