### PR TITLE
[IMP] base: Allow overriding wkhtmltopdf path for experimentation

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -45,7 +45,8 @@ except Exception:
 
 
 def _get_wkhtmltopdf_bin():
-    return find_in_path('wkhtmltopdf')
+    return os.environ.get('WKHTMLTOPDF_PATH') or \
+        find_in_path('wkhtmltopdf')
 
 
 # Check the presence of Wkhtmltopdf and return its version at Odoo start-up


### PR DESCRIPTION
This PR introduces an environment variable, WKHTMLTOPDF_PATH, to specify the wkhtmltopdf binary location. The choice of an environment variable instead of mangling with the PATH or configs was made for simplicity, explicit control, and the ability to easily target different wkhtmltopdf versions.

Usage examples:
```
WKHTMLPDF_PATH=/some/path/wkhtmltopdf-with-profiler ./odoo-bin
WKHTMLPDF_PATH=/some/path/wkhtmltopdf-0.12.6-with-profiler ./odoo-bin
```

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
