### PR TITLE
[IMP] pos_restaurant: Send order by category

### DIFF
--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.js
@@ -9,6 +9,8 @@ import { useService } from "@web/core/utils/hooks";
 import { useAsyncLockedMethod } from "@point_of_sale/app/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { BillScreen } from "@pos_restaurant/app/bill_screen/bill_screen";
+import { SelectionPopup } from "@point_of_sale/app/utils/input_popups/selection_popup";
+import { makeAwaitable } from "@point_of_sale/app/store/make_awaitable_dialog";
 
 patch(ControlButtons.prototype, {
     setup() {
@@ -43,6 +45,39 @@ patch(ControlButtons.prototype, {
         this.pos.orderToTransfer = this.pos.selectedOrder;
         this.pos.get_order().setBooked(true);
         this.pos.showScreen("FloorScreen");
+    },
+    async sendOrderInPreparatonByCateg() {
+        const lineOldSkipState = {};
+        const selectable = this.pos.models["pos.category"].map((c) => {
+            return {
+                id: c.id,
+                label: c.name,
+                isSelected: false,
+                item: c,
+            };
+        });
+        const category = await makeAwaitable(this.dialog, SelectionPopup, {
+            title: _t("Select a category to send in preparation"),
+            list: selectable,
+        });
+
+        if (!category) {
+            return;
+        }
+
+        for (const line of this.currentOrder.orderlines) {
+            const lineCategids = line.product.pos_categ_ids.map((c) => c.id);
+            lineOldSkipState[line.id] = line.skipChange;
+
+            if (!lineCategids.includes(category.id)) {
+                line.skipChange = true;
+            }
+        }
+        this.pos.db.save_unpaid_order(this.currentOrder);
+        await this.pos.sendOrderInPreparationUpdateLastChange(this.currentOrder);
+        for (const line of this.currentOrder.orderlines) {
+            line.skipChange = lineOldSkipState[line.id];
+        }
     },
 });
 patch(ControlButtons, {

--- a/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
+++ b/addons/pos_restaurant/static/src/app/control_buttons/control_buttons.xml
@@ -25,6 +25,10 @@
                 <button class="btn btn-light rounded-0 fw-bolder" t-on-click="clickTransferOrder">
                     <i class="oi oi-arrow-right me-1" />Transfer / Merge
                 </button>
+                <button class="btn btn-light rounded-0 fw-bolder" t-on-click="sendOrderInPreparatonByCateg">
+                    <i class="fa fa-fire me-1" role="img" aria-label="Preparation Batch" title="Preparation Batch" />
+                    <t>Send</t>
+                </button>
                 <SelectPartnerButton partner="partner" t-if="pos.config.module_pos_restaurant" />
             </t>
         </xpath>


### PR DESCRIPTION
**Before the change:**
The control buttons in the POS restaurant module did not have an option to send orders in preparation by category. Users were only able to send all orderline to preparation without categorization.

**After the change:**
After the modification, a new button labeled "Send" with a fire icon was added to the control buttons. This button allows users to select a category and send all products within that category to preparation.

This enhancement provides a more efficient way to organize and prepare orders in the point of sale system, improving workflow and order management.
https://github.com/odoo/enterprise/pull/57054
