### PR TITLE
[FIX] core: evaluate representation of field as a string

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -345,8 +345,8 @@ class Field(MetaField('DummyField', (object,), {})):
 
     def __repr__(self):
         if self.name is None:
-            return "<%s.%s>" % (__name__, type(self).__name__)
-        return "%s.%s" % (self.model_name, self.name)
+            return f"{'<%s.%s>'!r}" % (__name__, type(self).__name__)
+        return f"{'%s.%s'!r}" % (self.model_name, self.name)
 
     ############################################################################
     #


### PR DESCRIPTION
In some scenarios, it is necessary to evaluate the representation of fields as a string (which triggers issues if this is not the case).