### PR TITLE
[FIX] hr_timesheet: fix double appearance of table header

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -3,7 +3,7 @@
         <div class="row" style="margin-top:10px;">
             <div class="col-lg-12">
                 <table class="table table-sm">
-                    <thead>
+                    <thead style="display: table-row-group">
                         <tr>
                             <th class="align-middle"><span>Date</span></th>
                             <th class="align-middle"><span>Responsible</span></th>


### PR DESCRIPTION
Steps:
- Install Project
- Inside project task list view, select all task
- Print timesheets

Issues:
- Header of some tables appears double

Cause:
- Missing grouping container css inside table header

Fix:
- Proper css was added to group container inside table header

task-3744319