### PR TITLE
[FIX] project: fix state selection in kanban and list view

### DIFF
--- a/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
+++ b/addons/project/static/src/components/project_task_state_selection/project_task_state_selection.xml
@@ -4,14 +4,6 @@
         <xpath expr="//t[@t-if='isReadonly']/button/span[1]" position="attributes">
             <attribute name="t-attf-class">{{ stateIcon(currentValue) }} {{ statusColor(currentValue) }}</attribute>
         </xpath>
-        <!-- Waiting state button -->
-        <xpath expr="//t[@t-if='isReadonly']" position="after">
-            <t t-elif="currentValue == '04_waiting_normal' and isView(['kanban', 'list'])">
-                <button class="d-flex align-items-center btn fw-normal p-0 justify-content-center " title="This task is blocked by another unfinished task" t-att-class="{'o_task_state_list_view': isView(['list'])}">
-                    <i class="fa fa-lg fa-hourglass-o"></i>
-                </button>
-            </t>
-        </xpath>
         <!-- The toggle mark as done button -->
         <xpath expr="//t[@t-if='isReadonly']" position="after">
             <t t-elif="isToggleMode and currentValue == '01_in_progress'">


### PR DESCRIPTION
Versions:
---------
- saas-16.2

Steps to Reproduce:
---------
- open projects
- go to settings select task dependencies
- open list view of tasks of the project
- click on the waiting task icon

Issue:
---------

It does not display closed state in tree and kanban view when try to edit them.

Cause:
---------
Editing of waiting task was not allowed in kanban and list view.

Fix:
---------
We remove the restrictions of edit of waiting task in  kanban and list view.

task-3690533
