### PR TITLE
[FIX] mail: fix mail chatter overriding optional dropdown

### DIFF
--- a/addons/mail/static/src/web/chatter.xml
+++ b/addons/mail/static/src/web/chatter.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.Chatter" owl="1">
-    <div class="o-mail-Chatter w-100 h-100 flex-grow-1 d-flex flex-column" t-att-class="{ 'overflow-auto': props.hasMessageListScrollAdjust, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
+    <div class="o-mail-Chatter z-index-0 w-100 h-100 flex-grow-1 d-flex flex-column" t-att-class="{ 'overflow-auto': props.hasMessageListScrollAdjust, 'o-chatter-disabled': props.threadId === false }" t-on-scroll="onScrollDebounced" t-ref="root">
         <div class="o-mail-Chatter-top position-sticky top-0" t-att-class="{ 'shadow-sm': state.isTopStickyPinned }" t-ref="top">
             <div class="o-mail-Chatter-topbar d-flex flex-shrink-0 flex-grow-0 px-3 overflow-x-auto">
                 <button t-if="props.hasMessageList" class="o-mail-Chatter-sendMessage btn text-nowrap me-1" t-att-class="{


### PR DESCRIPTION
Steps to reproduce:
-------------------------------

- Install the project module..
- Open any project and open any task .
- Go to the subtask page.
- Click on the optional dropdown located on the right side.
- Scroll down the page.
- Notice how the mail chatter overrides the content of the optional dropdown.

Issue:
-------------
When scrolling down after opening a optional dropdown, the mail chatter panel covers the dropdown choices, making them inaccessible or difficult to see.

Cause:
--------
The mail chatter window doesn't have the right layering, so it covers optional dropdown menus while scrolling.

Solution:
---------------
Add a 'z-index-0' class to the mail chatter window element in the XML file to keep it behind other elements, avoiding overlap.

task-3743360

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
