### PR TITLE
[FIX] web: calendar, adjust "Today" color accross the views

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -497,8 +497,10 @@
                     }
 
                     &:hover > .fc-day-number {
-                        --o-cw-color: #{$o-white};
-                        --o-cw-bg: #{mix($o-white, $o-action, 50%)};
+                        $-bg: mix($o-view-background-color, $o-action, 75%);
+
+                        --o-cw-color: #{color-contrast($-bg)};
+                        --o-cw-bg: #{$-bg};
 
                         &:before {
                             display: block;

--- a/addons/web/static/src/views/calendar/calendar_renderer.scss
+++ b/addons/web/static/src/views/calendar/calendar_renderer.scss
@@ -233,10 +233,12 @@
                 }
 
                 &.fc-today {
-                    color: $primary;
+                    --o-cw-color: #{color-contrast($o-cw-color-today-accent)};
+                    --o-cw-bg: #{$o-cw-color-today-accent};
+
                     .o_cw_day_number {
                         position:relative;
-                        color: $o-view-background-color;
+                        color: var(--o-cw-color);
 
                         &:before {
                             content: '';
@@ -245,7 +247,7 @@
                             z-index: -1;
                             width: 100%;
                             border-radius: $border-radius-pill;
-                            background: $primary;
+                            background: var(--o-cw-bg);
                             aspect-ratio: 1;
                             color: $o-view-background-color;
                         }
@@ -428,7 +430,7 @@
                     }
 
                     &.fc-today {
-                        --o-cw-color: #{$white};
+                        --o-cw-color: #{color-contrast($o-cw-color-today-accent)};
                         --o-cw-bg: #{$o-cw-color-today-accent};
                         padding-top: map-get($spacers, 1)/2;
 


### PR DESCRIPTION
Prior to this PR, colors of "Today" were inconsistent depending on the view in calendar, sometimes red, sometimes purple. There was also a contrast issue when switching to dark mode.

This PR adjusts the color of "Today" to maintain color consistency and to provide contrast in bright mode and dark mode.

task-3754159
Part of task-3575827

| Before | After |
|--------|--------|
| ![image](https://github.com/odoo/odoo/assets/80679690/62476368-c3cd-4652-a8a4-19afc09631a1) | ![Capture d’écran 2024-02-21 à 11 40 56](https://github.com/odoo/odoo/assets/80679690/62b8cd53-4f4e-4f41-9b93-803b83e49d7d) |
| ![image](https://github.com/odoo/odoo/assets/80679690/274fb188-5779-4259-9681-ae7eb402b842) | ![Capture d’écran 2024-02-21 à 11 41 46](https://github.com/odoo/odoo/assets/80679690/35148fb7-1eea-49f1-b5b0-7aff46593a99) |
| ![Capture d’écran 2024-02-21 à 11 42 51](https://github.com/odoo/odoo/assets/80679690/536f6b4e-bff2-4ecb-963d-72c9acc78a59) |  ![Capture d’écran 2024-02-21 à 11 43 24](https://github.com/odoo/odoo/assets/80679690/3d2c3b20-b49b-4cb0-98e6-4c655778bd3d) |
| ![Capture d’écran 2024-02-22 à 08 39 12](https://github.com/odoo/odoo/assets/80679690/f91f0375-4768-4929-a89a-60152ead96a6) | ![Capture d’écran 2024-02-22 à 08 38 17](https://github.com/odoo/odoo/assets/80679690/daf670c1-86b6-4e2a-bfb6-dfceb4de6de5) |


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
