### PR TITLE
[FIX] delivery: do not archive shipping method for neutralisation

### DIFF
--- a/addons/delivery/data/neutralize.sql
+++ b/addons/delivery/data/neutralize.sql
@@ -1,4 +1,3 @@
 -- disable delivery carriers
 UPDATE delivery_carrier
-   SET prod_environment = false,
-       active = false;
+   SET prod_environment = false;


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
The neutralisation process already puts the shipping method in test mode, on top of that, every shipping provider uses dummy values for credentials, as a result the shipping methods are not usable when neutered.

With this commit we no longer archive the shipping method. Archiving of shipping methods cause some confusion for the users, particularly in context of testing e-commerce flows in upgrade test databases. As mentioned earlier, it is not even necessary to do that anyway.

**Current behavior before PR:**
Neutralisation archives the existing shipping method.

**Desired behavior after PR is merged:**
Neutralisation does not archive the existing shipping method.

opw-3754005


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
