### PR TITLE
[IMP] project: change behavior of task created directly in waiting stage.

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -935,6 +935,10 @@ class Task(models.Model):
     def default_get(self, default_fields):
         vals = super(Task, self).default_get(default_fields)
 
+        # prevent creating new task in the waiting state
+        if 'state' in default_fields and vals.get('state') == '04_waiting_normal':
+            vals['state'] = '01_in_progress'
+
         if 'repeat_until' in default_fields:
             vals['repeat_until'] = fields.Date.today() + timedelta(days=7)
 

--- a/addons/project/tests/test_task_state.py
+++ b/addons/project/tests/test_task_state.py
@@ -155,3 +155,17 @@ class TestTaskState(TestProjectCommon):
 
         self.assertEqual(self.task_1.state, '04_waiting_normal')
         self.assertEqual(task_1_copy.state, '04_waiting_normal')
+
+    def test_task_created_in_waiting_stage_gets_in_progress_state(self):
+        """
+            Test that when a new task is created in the "Waiting" state (by grouping by state in Kanban view), it gets the state "In Progress" by default.
+        """
+        project_pigs = self.env['project.project'].search([('name', '=', 'Pigs')])
+        task = self.env['project.task'].with_context({
+            'default_state': '04_waiting_normal',
+        }).create({
+            'name': 'Task initially waiting state',
+            'project_id': project_pigs.id,
+        })
+
+        self.assertEqual(task.state, '01_in_progress', "The task should be in progress")


### PR DESCRIPTION

Prior to this commit:
---------------------
1. Whenever a task is directly created in the waiting stage, the state of the task was set to `waiting` although the task dependencies were not set.

Steps to reproduce:
-------------------
Task created directly in waiting stage
    1. Group tasks by state
    2. Create task in the waiting stage.
    3. task is in 'waiting' state.

After this commit:
------------------
The task created directly in the waiting stage will be in the 'in progress' stage by default. Hoewever, the task will remain in the 'waiting' stage until the page is refreshed.

Task-3690545

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
