### PR TITLE
[IMP] web_tour: add debug mode in start_tour

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -45,7 +45,6 @@ import { callWithUnloadCheck } from "./tour_utils";
  * @property {number} [width]
  * @property {number} [timeout]
  * @property {boolean} [consumeVisibleOnly]
- * @property {boolean} [noPrepend]
  * @property {string} [consumeEvent]
  * @property {boolean} [mobile]
  * @property {string} [title]
@@ -316,6 +315,8 @@ export const tourService = {
                 startUrl: "",
                 showPointerDuration: 0,
                 redirect: true,
+                debug: false,
+                hasError: false,
             };
             options = Object.assign(defaultOptions, options);
             const tour = tours[tourName];
@@ -325,9 +326,15 @@ export const tourService = {
             tourState.set(tourName, "currentIndex", 0);
             tourState.set(tourName, "stepDelay", options.stepDelay);
             tourState.set(tourName, "keepWatchBrowser", options.keepWatchBrowser);
+            tourState.set(tourName, "debug", options.debug);
             tourState.set(tourName, "showPointerDuration", options.showPointerDuration);
             tourState.set(tourName, "mode", options.mode);
             tourState.set(tourName, "sequence", tour.sequence);
+            if (tourState.get(tourName, "debug") !== false) {
+                // Starts the tour with a debugger to allow you to choose devtools configuration.
+                // eslint-disable-next-line no-debugger
+                debugger;
+            }
             const pointer = createPointer(tourName, {
                 bounce: !(options.mode === "auto" && options.keepWatchBrowser),
             });

--- a/addons/web_tour/static/src/tour_service/tour_state.js
+++ b/addons/web_tour/static/src/tour_service/tour_state.js
@@ -35,6 +35,15 @@ const ALLOWED_KEYS = {
 
     // Used to order the tours.
     sequence: INTEGER,
+
+    // Open DevTools at tour initialization.
+    debug: BOOLEAN,
+
+    // To check if triggers of the current step have been found.
+    triggersFound: BOOLEAN,
+
+    // To check if triggers of the current step have been found.
+    hasError: BOOLEAN,
 };
 
 function getPrefixedName(tourName, key) {


### PR DESCRIPTION
In this commit, we add the possibility of starting a tour in debug=True
mode. In this mode, the browser opens in a large window with a devtools
and a breakpoint is triggered at the start of the test.
This allows the devtools to be configured before the tour runs.

We also added features for steps :
step.break => the tour stops at the start of the step by a debugger.
	This makes it easier to debug a specific step.
step.pause => the round stops at the end of the step. This allows you
	to manipulate the dom and check the next step before it processes.

We have also improved the error messages in order to target where
it is located in the step.