### PR TITLE
[FIX] point_of_sale: traceback when search in empty category

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.js
@@ -353,6 +353,9 @@ export class ProductScreen extends Component {
                       this.pos.selectedCategoryId
                   )
                 : this.pos.models["product.product"].getAll();
+            if (!product) {
+                return list;
+            }
             list = fuzzyLookup(
                 this.searchWord,
                 product,


### PR DESCRIPTION
Steps to reproduce:
- create an empty category
- open pos and select empty category
- search a product
- pos crash

This commit fixes the issue by returning an empty
list before performing the fuzzylookup.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
