### PR TITLE
[FIX] purchase: override onchange to NOT update all date_planned on POL

### DIFF
--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -43,8 +43,13 @@ class TestPurchase(AccountTestInvoicingCommon):
 
         # Set an even earlier date planned on the other PO line and check that the PO expected date matches it.
         new_date_planned = orig_date_planned - timedelta(hours=72)
-        po.order_line[1].date_planned = new_date_planned
+        po_form = Form(po)
+        with po_form.order_line.edit(1) as line_form:
+            line_form.date_planned = new_date_planned
+        po = po_form.save()
         self.assertAlmostEqual(po.order_line[1].date_planned, po.date_planned, delta=timedelta(seconds=10))
+        # Updating a PO line's date planned to the earliest one, should not affect the planned dates of other lines
+        self.assertNotEqual(po.order_line[0].date_planned, po.order_line[1].date_planned)
 
     def test_purchase_order_sequence(self):
         PurchaseOrder = self.env['purchase.order'].with_context(tracking_disable=True)

--- a/addons/purchase_product_matrix/models/purchase.py
+++ b/addons/purchase_product_matrix/models/purchase.py
@@ -30,8 +30,8 @@ class PurchaseOrder(models.Model):
             self.grid_update = False
             self.grid = json.dumps(self._get_matrix(self.grid_product_tmpl_id))
 
-    def _must_delete_date_planned(self, field_name):
-        return super()._must_delete_date_planned(field_name) or field_name == "grid"
+    def _must_delete_date_planned(self, field_names):
+        return super()._must_delete_date_planned(field_names) or "grid" in field_names
 
     @api.onchange('grid')
     def _apply_grid(self):


### PR DESCRIPTION
**Steps to reproduce:**
- Create a purchase order:
    - Add two products with planned dates, e.g: “21/02/2024”
    - Save
    - Update the “date_planned” of one “purchase.order.line”

**Problem:**
The compute of the “purchase.order” will be triggered because it depends on the `orderline.date_planned`:
 https://github.com/odoo/odoo/blob/ccfc54113da51e2d137b994649417cec0d80c1fa/addons/purchase/models/purchase.py#L166-L174

And when we save, the onchange of the PO will be called, because its planned_date has been changed:
https://github.com/odoo/odoo/blob/ccfc54113da51e2d137b994649417cec0d80c1fa/addons/purchase/models/purchase.py#L188-L191

opw-3741209
