### PR TITLE
[IMP] project: add button to hide closed sub-tasks

### DIFF
--- a/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.js
+++ b/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import { useState } from "@odoo/owl";
+
+import { _t } from "@web/core/l10n/translation";
+
+import { TaskListRenderer } from "../task_list_renderer";
+
+export class NotebookTaskListRenderer extends TaskListRenderer {
+    static rowsTemplate = "project.NotebookTaskListRenderer.Rows";
+    setup() {
+        super.setup();
+        this.hideState = useState({
+            hide: localStorage.getItem(this._getStorageKey) === 'true',
+        });
+    }
+
+    /**
+     * @private
+     * @returns {string}
+     */
+    get _getStorageKey() {
+        return `hide_closed_${this.constructor.name}`;
+    }
+
+    get hideClosed() {
+        return this.hideState.hide;
+    }
+
+    get closedX2MCount() {
+        return this.props.list.context.closed_X2M_count;
+    }
+
+    get openLabel() {
+        return typeof this.closedX2MCount === "undefined" ? _t("Show closed tasks") : _t("%s closed tasks", this.closedX2MCount);
+    }
+
+    get closeLabel() {
+        return _t("Hide closed tasks");
+    }
+
+    get toggleListHideLabel() {
+        return this.hideClosed ? this.openLabel : this.closeLabel;
+    }
+
+    get ShowX2MRecords() {
+        // If there isn't a closed_X2M_count defined in the context of the x2m task in the view we are always displaying the Toggle button
+        // In case there is no computed field to calculate the number of closed X2M tasks in the backend
+        return this.closedX2MCount > 0 || typeof this.closedX2MCount === "undefined";
+    }
+
+    toggleHideClosed() {
+        this.hideState.hide = !this.hideState.hide;
+        localStorage.setItem(this._getStorageKey, this.hideState.hide);
+        document.activeElement.blur();
+    }
+}

--- a/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.xml
+++ b/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_list_renderer.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="project.NotebookTaskListRenderer.Rows" t-inherit="web.ListRenderer.Rows" t-inherit-mode="primary">
+        <xpath expr="//t[@t-foreach='list.records']" position="replace">
+            <t t-foreach="list.records" t-as="record" t-key="record.id">
+                <t t-if="!['1_done','1_canceled'].includes(record.data.state) or !hideState.hide">
+                    <t t-call="{{ constructor.recordRowTemplate }}"/>
+                </t>
+            </t>
+        </xpath>
+
+        <xpath expr="//t[@t-foreach='creates']" position="after">
+            <a t-if="ShowX2MRecords" role="button" class="ml16 o_toggle_closed_task_button" href="#" t-on-click="() => this.toggleHideClosed()">
+                <t t-esc="toggleListHideLabel"/>
+            </a>
+        </xpath>
+    </t>
+</templates>

--- a/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_one2many_field.js
+++ b/addons/project/static/src/components/notebook_task_one2many_field/notebook_task_one2many_field.js
@@ -1,0 +1,20 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+import { X2ManyField, x2ManyField } from '@web/views/fields/x2many/x2many_field';
+
+import { NotebookTaskListRenderer } from './notebook_task_list_renderer';
+
+export class NotebookTaskOne2ManyField extends X2ManyField {
+    static components = {
+        ...X2ManyField.components,
+        ListRenderer: NotebookTaskListRenderer,
+    };
+}
+
+export const notebookTaskOne2ManyField = {
+    ...x2ManyField,
+    component: NotebookTaskOne2ManyField,
+}
+
+registry.category("fields").add("notebook_task_one2many", notebookTaskOne2ManyField);

--- a/addons/project/static/src/components/subtask_one2many_field/subtask_list_renderer.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_list_renderer.js
@@ -2,9 +2,9 @@
 
 import { _t } from "@web/core/l10n/translation";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { TaskListRenderer } from "../task_list_renderer";
+import { NotebookTaskListRenderer } from '../notebook_task_one2many_field/notebook_task_list_renderer';
 
-export class SubtaskListRenderer extends TaskListRenderer {
+export class SubtaskListRenderer extends NotebookTaskListRenderer {
     async onDeleteRecord(record) {
         this.dialog.add(ConfirmationDialog, {
             body: _t("Are you sure you want to delete this record?"),

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -48,6 +48,8 @@ export class ProjectTask extends models.Model {
     });
     planned_date_begin = fields.Datetime({ string: "Start Date" });
     date_deadline = fields.Datetime({ string: "Stop Date" });
+    depend_on_ids = fields.Many2many({ relation: "project.task" });
+    closed_depend_on_count = fields.Integer();
 
     _records = [
         {

--- a/addons/project/static/tests/project_notebook_task_list.test.js
+++ b/addons/project/static/tests/project_notebook_task_list.test.js
@@ -1,0 +1,154 @@
+import { beforeEach, expect, describe, test } from "@odoo/hoot";
+import { click } from "@odoo/hoot-dom";
+import { animationFrame } from "@odoo/hoot-mock";
+import { mountView } from "@web/../tests/web_test_helpers";
+
+import { defineProjectModels, ProjectProject, ProjectTask } from "./project_models";
+
+defineProjectModels();
+
+describe.current.tags("desktop");
+
+beforeEach(() => {
+    ProjectProject._records = [
+        {
+            id:5,
+            name: "Project One"
+        },
+    ];
+
+    ProjectTask._records = [
+        {
+            id: 1,
+            name: 'task one',
+            project_id: 5,
+            closed_subtask_count: 1,
+            closed_depend_on_count: 1,
+            subtask_count: 4,
+            child_ids: [2, 3, 4, 7],
+            depend_on_ids: [5,6],
+            state: '04_waiting_normal',
+        },
+        {
+            name: 'task two',
+            parent_id: 1,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: '03_approved'
+        },
+        {
+            name: 'task three',
+            parent_id: 1,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: '02_changes_requested'
+        },
+        {
+            name: 'task four',
+            parent_id: 1,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: '1_done'
+        },
+        {
+            name: 'task five',
+            closed_subtask_count: 0,
+            subtask_count: 1,
+            child_ids: [6],
+            depend_on_ids: [],
+            state: '03_approved'
+        },
+        {
+            name: 'task six',
+            parent_id: 5,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: '1_canceled'
+        },
+        {
+            name: 'task seven',
+            parent_id: 1,
+            closed_subtask_count: 0,
+            subtask_count: 0,
+            child_ids: [],
+            depend_on_ids: [],
+            state: '01_in_progress',
+        },
+    ];
+
+    ProjectTask._views = {
+        form: `
+            <form>
+                <field name="closed_depend_on_count" invisible="1"/>
+                <field name="child_ids" widget="subtasks_one2many">
+                    <list editable="bottom">
+                        <field name="display_in_project" force_save="1"/>
+                        <field name="project_id" widget="project"/>
+                        <field name="name"/>
+                        <field name="state"/>
+                    </list>
+                </field>
+                <field name="depend_on_ids" widget="notebook_task_one2many" context="{ 'closed_X2M_count': closed_depend_on_count }">
+                    <list editable="bottom">
+                        <field name="display_in_project" force_save="1"/>
+                        <field name="project_id" widget="project"/>
+                        <field name="name"/>
+                        <field name="state"/>
+                    </list>
+                </field>
+            </form>
+        `,
+    };
+});
+
+test("test Project Task Calendar Popover with task_stage_with_state_selection widget", async () => {
+    await mountView({
+        resModel: "project.task",
+        type: "form",
+        resId: 1,
+    });
+
+    expect('div[name="child_ids"] .o_data_row').toHaveCount(4, {
+        message: "The subtasks list should display all subtasks by default, thus we are looking for 4 in total"
+    });
+    expect('div[name="depend_on_ids"] .o_data_row').toHaveCount(2, {
+        message: "The depend on tasks list should display all blocking tasks by default, thus we are looking for 2 in total"
+    });
+
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+
+    click("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button");
+    await animationFrame();
+
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Show closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Hide closed tasks");
+
+    expect('div[name="child_ids"] .o_data_row').toHaveCount(3, {
+        message: "The subtasks list should only display the open subtasks of the task, in this case 3"
+    });
+    expect('div[name="depend_on_ids"] .o_data_row').toHaveCount(2, {
+        message: "The depend on tasks list should still display all blocking tasks, in this case 2"
+    });
+
+    click("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button");
+    await animationFrame();
+
+    expect("div[name='child_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("Show closed tasks");
+    expect("div[name='depend_on_ids'] .o_field_x2many_list_row_add a.o_toggle_closed_task_button").toHaveText("1 closed tasks");
+
+    expect('div[name="child_ids"] .o_data_row').toHaveCount(3, {
+        message: "The subtasks list should only display the open subtasks of the task, in this case 3"
+    });
+    expect('div[name="depend_on_ids"] .o_data_row').toHaveCount(1, {
+        message: "The depend on tasks list should only display open tasks, in this case 1"
+    });
+});

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -329,6 +329,8 @@
                     <field name="company_id" invisible="1"/>
                     <field name="project_id" invisible="1"/>
                     <field name="is_closed" invisible="1"/>
+                    <field name="depend_on_count" invisible="1"/>
+                    <field name="closed_depend_on_count" invisible="1"/>
                     <field name="html_field_history_metadata" invisible="1"/>
                     <field name="show_display_in_project" invisible="1"/>
                     <header>
@@ -476,6 +478,7 @@
                                         'default_partner_id': partner_id,
                                         'default_milestone_id': allow_milestones and milestone_id,
                                         'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
+                                        'closed_X2M_count': closed_subtask_count,
                                    }"
                                    widget="subtasks_one2many">
                                 <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
@@ -501,7 +504,7 @@
                                     <field name="company_id" column_invisible="True"/>
                                     <field name="date_deadline" invisible="state in ['1_done', '1_canceled']" optional="hide" decoration-danger="date_deadline &lt; current_date"/>
                                     <field name="activity_ids" string="Next Activity" widget="list_activity" optional="hide"/>
-                                     <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" options="{'allow_order': '1'}" optional="hide"/>
+                                    <field name="my_activity_date_deadline" string="My Deadline" widget="remaining_days" options="{'allow_order': '1'}" optional="hide"/>
                                     <field name="rating_last_text" string="Rating" decoration-danger="rating_last_text == 'ko'"
                                         decoration-warning="rating_last_text == 'ok'" decoration-success="rating_last_text == 'top'"
                                         class="fw-bold" widget="badge" optional="hide" invisible="rating_last_text == 'none'" column_invisible="True" groups="project.group_project_rating"/>
@@ -521,7 +524,9 @@
                                         'list_view_ref': 'project.open_view_all_tasks_list_view',
                                         'search_default_open_tasks': 1,
                                         'kanban_view_ref': 'project.project_sub_task_view_kanban_mobile',
-                                   }">
+                                        'closed_X2M_count': closed_depend_on_count,
+                                   }"
+                                   widget="notebook_task_one2many">
                                 <list editable="bottom" decoration-muted="state in ['1_done','1_canceled']" open_form_view="True">
                                     <field name="allow_milestones" column_invisible="True"/>
                                     <field name="parent_id" column_invisible="True" />


### PR DESCRIPTION
project.task form view > sub-tasks notebook > add a 'hide closed tasks' button (in the same style as 'add a line')

Small remark for the JS tests =>
The behavior of this widget is related to the currentStorage (simply remembers the previous configuration)
i do not reset them in the tests so if you run the same Qunit test again in your browser, it'll fails.
It seems to work on the runbot but it will be better with localStorage reset before the test.
I tried those with a few ways but couldn't succeed to reset the localStorage consistently.

Task-3703563

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
