### PR TITLE
[IMP] base: Set memory limits with IEC 80000-13 binary prefixes.

### DIFF
--- a/odoo/addons/base/tests/config/limit_memory.conf
+++ b/odoo/addons/base/tests/config/limit_memory.conf
@@ -1,0 +1,3 @@
+[options]
+limit_memory_hard = 3GiB
+limit_memory_soft = 1536MiB

--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -395,3 +395,35 @@ class TestConfigManager(TransactionCase):
         config._warn_deprecated_options()
         config._parse_config()
         config._warn_deprecated_options()
+
+    @unittest.skipIf(not IS_POSIX, 'this test is POSIX only')
+    def test_06_parse_size(self):
+        config = configmanager(fname=file_path('base/tests/config/limit_memory.conf'))
+        self.assertEqual(config['limit_memory_hard'], 3221225472)
+        self.assertEqual(config['limit_memory_soft'], 1610612736)
+
+        config._parse_config(['--limit-memory-hard', '4GiB', '--limit-memory-soft', '3GiB'])
+        self.assertEqual(config['limit_memory_hard'], 4294967296)
+        self.assertEqual(config['limit_memory_soft'], 3221225472)
+
+        config = configmanager()
+        self.assertEqual(config._parse_size('1024'), 1024)
+        self.assertEqual(config._parse_size('2ki '), 2048)
+        self.assertEqual(config._parse_size(' 4MiB'), 4194304)
+        self.assertEqual(config._parse_size('1 YiB'), 1208925819614629174706176)
+
+        with self.assertRaises(ValueError) as cm:
+            config._parse_size('1.2465')
+        self.assertIn("invalid size", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            config._parse_size('B')
+        self.assertIn("invalid size", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            config._parse_size('10kB')
+        self.assertIn("invalid IEC 80000-13 binary prefix", str(cm.exception))
+
+        with self.assertRaises(ValueError) as cm:
+            config._parse_size('20fiB')
+        self.assertIn("invalid IEC 80000-13 binary prefix", str(cm.exception))

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -6,6 +6,7 @@ import logging
 import optparse
 import glob
 import os
+import re
 import sys
 import tempfile
 import warnings
@@ -331,18 +332,18 @@ class configmanager(object):
             group.add_option("--workers", dest="workers", my_default=0,
                              help="Specify the number of workers, 0 disable prefork mode.",
                              type="int")
-            group.add_option("--limit-memory-soft", dest="limit_memory_soft", my_default=2048 * 1024 * 1024,
+            group.add_option("--limit-memory-soft", dest="limit_memory_soft", my_default="2048MiB",
                              help="Maximum allowed virtual memory per worker (in bytes), when reached the worker be "
                              "reset after the current request (default 2048MiB).",
-                             type="int")
+                             action="callback", callback=self._parse_size_callback, nargs=1, type="string")
             group.add_option("--limit-memory-soft-gevent", dest="limit_memory_soft_gevent", my_default=False,
                              help="Maximum allowed virtual memory per gevent worker (in bytes), when reached the worker will be "
                              "reset after the current request. Defaults to `--limit-memory-soft`.",
                              type="int")
-            group.add_option("--limit-memory-hard", dest="limit_memory_hard", my_default=2560 * 1024 * 1024,
+            group.add_option("--limit-memory-hard", dest="limit_memory_hard", my_default="2560MiB",
                              help="Maximum allowed virtual memory per worker (in bytes), when reached, any memory "
                              "allocation will fail (default 2560MiB).",
-                             type="int")
+                             action="callback", callback=self._parse_size_callback, nargs=1, type="string")
             group.add_option("--limit-memory-hard-gevent", dest="limit_memory_hard_gevent", my_default=False,
                              help="Maximum allowed virtual memory per gevent worker (in bytes), when reached, any memory "
                              "allocation will fail. Defaults to `--limit-memory-hard`.",
@@ -511,8 +512,14 @@ class configmanager(object):
             if getattr(opt, arg) is not None:
                 self.options[arg] = getattr(opt, arg)
             # ... or keep, but cast, the config file value.
-            elif isinstance(self.options[arg], str) and self.casts[arg].type in optparse.Option.TYPE_CHECKER:
-                self.options[arg] = optparse.Option.TYPE_CHECKER[self.casts[arg].type](self.casts[arg], arg, self.options[arg])
+            elif isinstance(self.options[arg], str):
+                opt_str = '--' + arg.replace('_', '-')
+                option = self.parser.get_option(opt_str)
+                if option and option.callback:
+                    option.callback(option, opt, self.options[arg], self.parser)
+                    self.options[arg] = getattr(self.parser.values, arg)
+                elif self.casts[arg].type in optparse.Option.TYPE_CHECKER:
+                    self.options[arg] = optparse.Option.TYPE_CHECKER[self.casts[arg].type](self.casts[arg], arg, self.options[arg])
 
         ismultidb = ',' in (self.options.get('db_name') or '')
         die(ismultidb and (opt.init or opt.update), "Cannot use -i/--init or -u/--update with multiple databases in the -d/--database/db_name")
@@ -566,6 +573,28 @@ class configmanager(object):
             m.strip() for m in self.options['server_wide_modules'].split(',') if m.strip()
         ]
         return opt
+
+    def _parse_size(self, text):
+        # https://en.wikipedia.org/wiki/Binary_prefix
+        pattern = r"""^\s*(?P<size>\d+) # integer
+                       \s*(?P<prefix>\w{2})?B? # IEC 80000-13 binary prefix
+                       \s*$"""
+        match = re.match(pattern, text, re.VERBOSE)
+        if not match:
+            raise ValueError('invalid size: {size}'.format(size=repr(text)))
+        size = int(match['size'])
+        try:
+            exponent = ('', 'ki', 'Mi', 'Gi', 'Ti', 'Pi', 'Ei', 'Zi', 'Yi').index(match['prefix'] or '')
+        except ValueError:
+            raise ValueError('invalid IEC 80000-13 binary prefix: {prefix}'.format(prefix=repr(match['prefix'])))
+        return round(size * (1024 ** exponent))
+
+    def _parse_size_callback(self, option, opt, value, parser):
+        try:
+            size = self._parse_size(value)
+        except Exception as e:
+            raise optparse.OptionValueError("option %s: %s" % (option, str(e)))
+        setattr(parser.values, option.dest, size)
 
     def _warn_deprecated_options(self):
         if self.options.get('longpolling_port', 0):


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

As a human scientist, I prefer to succinctly describe large numbers with IEC 80000-13 binary prefixes, i.e 2048MiB or 5GiB.

See https://en.wikipedia.org/wiki/Metric_prefix

### Current behavior before PR:

Memory limits must be configured as integers, i.e. 1208925819614629174706176.

### Desired behavior after PR is merged:

The limit_memory_hard and limit_memory_hard settings can also be configured as descriptive strings, parsing IEC 80000-13 binary prefixes.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
