### PR TITLE
[FIX] account: account: search translated value of 'id'

### DIFF
--- a/addons/account/models/account_tax.py
+++ b/addons/account/models/account_tax.py
@@ -323,7 +323,7 @@ class AccountTax(models.Model):
                 old_value = ast.literal_eval(old_value)
                 new_value = ast.literal_eval(new_value)
                 diff_keys = [key for key in old_value if old_value[key] != new_value[key]]
-                repartition_line = self.env['account.tax.repartition.line'].search([('id', '=', new_value['id'])])
+                repartition_line = self.env['account.tax.repartition.line'].search([('id', '=', new_value[_('id')])])
                 body = Markup("<b>{type}</b> {rep} {seq}:<ul class='mb-0 ps-4'>{changes}</ul>").format(
                     type=repartition_line.document_type.capitalize(),
                     rep=_('repartition line'),


### PR DESCRIPTION
Problem: When a user tries to update the tax grid on a repartition line for a tax that has been used in account moves and the current language is Dutch,a traceback error will occur.

Solution: The user should be able to modify the tax grid for any taxes regardless of the current language.

Steps to Reproduce on Runbot:
1. Install Sales and Accounting apps
2. Create and confirm a sales order with a tax
3. Create and confirm an invoice
4. Change the user language to Dutch
5. Navigate to the tax used in the sales order
6. Attempt to modify the tax grid and save
7. Traceback error will occur highlighting "KeyError: 'id' "

opw-3742266


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
