### PR TITLE
[FIX] l10n_din5008_sale: added translation comment

### DIFF
--- a/addons/l10n_din5008_sale/i18n/de.po
+++ b/addons/l10n_din5008_sale/i18n/de.po
@@ -17,26 +17,31 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Customer Reference"
 msgstr "Kundenreferenz"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Expiration"
 msgstr "Ablauf"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Incoterm"
 msgstr "Lieferbedingung"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Invoicing Address:"
 msgstr "Rechnungsadresse:"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Invoicing and Shipping Address:"
 msgstr "Rechnungs- und Lieferadresse:"
@@ -57,47 +62,56 @@ msgid "L10N Din5008 Template Data"
 msgstr "L10N Din5008 Template Daten"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Order Date"
 msgstr "Bestelldatum"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Order No."
 msgstr "Auftragsnummer"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Pro Forma Invoice"
 msgstr "Proformarechnung"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation"
 msgstr "Angebot"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation Date"
 msgstr "Angebotsdatum"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation No."
 msgstr "Angebotsnummer"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 #: model:ir.model,name:l10n_din5008_sale.model_sale_order
 msgid "Sales Order"
 msgstr "Auftragsbestätigung"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Salesperson"
 msgstr "Verkäufer"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Shipping Address:"
 msgstr "Lieferadresse:"

--- a/addons/l10n_din5008_sale/i18n/fr.po
+++ b/addons/l10n_din5008_sale/i18n/fr.po
@@ -17,26 +17,31 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Customer Reference"
 msgstr "Référence client"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Expiration"
 msgstr "Expiration"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Incoterm"
 msgstr "Incoterms"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Invoicing Address:"
 msgstr "Adresse de facturation:"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Invoicing and Shipping Address:"
 msgstr "Adresse de facturation et d'expédition:"
@@ -57,47 +62,56 @@ msgid "L10N Din5008 Template Data"
 msgstr "Données de modèle L10N Din5008"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Order Date"
 msgstr "Date de commande"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Order No."
 msgstr "N ° de commande."
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Pro Forma Invoice"
 msgstr "Facture pro forma"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation"
 msgstr "Devis"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation Date"
 msgstr "Date du devis"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation No."
 msgstr "Devis N."
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 #: model:ir.model,name:l10n_din5008_sale.model_sale_order
 msgid "Sales Order"
 msgstr "Bon de commande"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Salesperson"
 msgstr "Vendeur"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Shipping Address:"
 msgstr "Adresse de livraison:"

--- a/addons/l10n_din5008_sale/i18n/l10n_din5008_sale.pot
+++ b/addons/l10n_din5008_sale/i18n/l10n_din5008_sale.pot
@@ -16,26 +16,31 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Customer Reference"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Expiration"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Incoterm"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Invoicing Address:"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Invoicing and Shipping Address:"
 msgstr ""
@@ -56,47 +61,56 @@ msgid "L10N Din5008 Template Data"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Order Date"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Order No."
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Pro Forma Invoice"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation Date"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Quotation No."
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 #: model:ir.model,name:l10n_din5008_sale.model_sale_order
 msgid "Sales Order"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Salesperson"
 msgstr ""
 
 #. module: l10n_din5008_sale
+#. odoo-python
 #: code:addons/l10n_din5008_sale/models/sale.py:0
 msgid "Shipping Address:"
 msgstr ""


### PR DESCRIPTION
**Current behavior:**
Terms which have translations defined in .po files do not get translated if they are from the din5008_sale module.

**Expected behavior:**
Terms which have mapped translations will be translated.

**Steps to reproduce:**
1. Install the din5008_sale module, set the din5008 template to be used in for quotations

2. Change a company's language to German

3. Generate a Quotation PDF and observe that some terms are not translated

**Cause of the issue:**
The .pot file for this module and some of the .po files are missing the '#. odoo-python' comment which the filter function defined in the _load_python_translations() method expects -> function returns false instead of the translated value.

**Fix:**
Add the comment where it need be added.

opw-3740412