### PR TITLE
[FIX] stock, tools: floating-point precision error

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -434,7 +434,7 @@ class StockQuant(models.Model):
                 with self._cr.savepoint(flush=False):  # Avoid flush compute store of package
                     self._cr.execute("SELECT 1 FROM stock_quant WHERE id = %s FOR UPDATE NOWAIT", [quant.id], log_exceptions=False)
                     quant.write({
-                        'quantity': quant.quantity + quantity,
+                        'quantity': float_round(quant.quantity + quantity, precision_rounding=quant.product_uom_id.rounding),
                         'in_date': in_date,
                     })
                     break

--- a/odoo/tools/float_utils.py
+++ b/odoo/tools/float_utils.py
@@ -96,7 +96,9 @@ def float_round(value, precision_digits=None, precision_rounding=None, rounding_
         normalized_value += math.copysign(epsilon, normalized_value)
         rounded_value = round(normalized_value)     # round to integer
 
-    result = rounded_value * rounding_factor # de-normalize
+    denormarlized_value = rounded_value * rounding_factor # de-normalize
+    precision_digits = precision_digits or abs(builtins.round(math.log(rounding_factor, 10)))
+    result = builtins.round(denormarlized_value, precision_digits)
     return result
 
 def float_is_zero(value, precision_digits=None, precision_rounding=None):


### PR DESCRIPTION
The issue stems from Python's handling of floating-point numbers, which cannot accurately represent certain decimals. Consequently, operations involving these numbers can introduce small errors in the results.

## [[FIX] stock: floating-point precision error](https://github.com/odoo/odoo/commit/d33745dedd57dbe3d742e2c9ebbb30621fda0f87)

This commit fixes a floating-point rounding error observed during the arithmetic operation of updating stock quantities in Odoo. A specific example illustrating this issue is when 7718.27 + (-7000.0) yields 718.2700000000004 instead of the precise 718.27. Such inaccuracies in floating-point calculations can lead to slight discrepancies in stock records, which are critical to maintain accurately for inventory management purposes.

**Proposed Solution**
We propose to use Odoo's float_round function to round the result of arithmetic operations on stock quantities. This ensures that the outcome is rounded accurately to the precision specified for stock quantities, effectively preventing rounding errors from impacting inventory accuracy.

Attached is an image of the debug of the _update_available_quantity() function:

![image](https://github.com/odoo/odoo/assets/121382390/68fb4bfa-1d15-4050-8e48-8ab86b237061)
![image](https://github.com/odoo/odoo/assets/121382390/9fd6227e-85fb-42d1-a606-a0ccbda27e52)

But we also saw that float_round inside its code has the same floating-point error, so it cannot really solve the problem if we don't solve the issue within float_round first.

## [[FIX] tools: floating-point precision error](https://github.com/odoo/odoo/commit/11864703774157d7f9ec37b5c8b5aac17797b403)

This commit proposes a critical enhancement to the float_round function within Odoo, addressing an inherent floating-point precision error observed during multiplication operations. A notable example of this issue is in line "result = rounded_value * rounding_factor" when multiplying 1714692.0 by 0.01, which unexpectedly results in 17146.920000000002 instead of the accurate 17146.92. Such discrepancies can significantly impact financial calculations, inventory management, and any functionality relying on precise numerical operations within Odoo.

**Proposed Solution**
To address this, we have introduced a modification in the float_round calculation, ensuring the result adheres to the desired precision by leveraging Python's built-in round function. This approach mitigates the floating-point error by rounding the final result to the correct number of decimal places, determined by the rounding factor or explicitly specified precision digits.

Attached is an image of the debug of the float_round() function:

![photo_2024-02-21_15-00-53](https://github.com/odoo/odoo/assets/121382390/1bd82c34-8fbf-4761-896b-77d3d855bf66)
![image](https://github.com/odoo/odoo/assets/121382390/ee638114-569e-49d0-88b7-ec97dc89cfc6)

This error is present in later versions (15, 16, and 17)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
