### PR TITLE
[IMP] mail, *: schedule push notification

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3648,10 +3648,18 @@ class MailThread(models.AbstractModel):
         if not partner_ids:
             return
 
+        user_ids = self.env['res.users'].search([('partner_id', 'in', partner_ids)])
+        partners_to_notify = set(partner_ids)
+
+        for user in user_ids:
+            if not user.check_push_notification_schedule():
+                partners_to_notify.remove(user.partner_id.id)
+
         partner_devices_sudo = self.env['mail.push.device'].sudo()
         devices = partner_devices_sudo.search([
-            ('partner_id', 'in', partner_ids)
+            ('partner_id', 'in', list(partners_to_notify))
         ])
+
         if not devices:
             return
 

--- a/addons/mail/views/res_users_views.xml
+++ b/addons/mail/views/res_users_views.xml
@@ -11,6 +11,8 @@
                 <data>
                     <field name="email" position="before">
                         <field name="notification_type" widget="radio" readonly="0"/>
+                        <field name="notification_planning" invisible="notification_type == 'email'"/>
+                        <field name="notification_schedule_start" widget="float_time_range" options="{'end_time_field': 'notification_schedule_end'}" invisible="notification_type == 'email' or notification_planning != 'schedule'"/>
                     </field>
                 </data>
             </field>

--- a/addons/web/static/lib/hoot-dom/helpers/dom.js
+++ b/addons/web/static/lib/hoot-dom/helpers/dom.js
@@ -942,7 +942,6 @@ export function getNodeValue(node) {
         case "date":
         case "datetime-local":
         case "month":
-        case "time":
         case "week":
             return node.valueAsDate.toISOString();
     }

--- a/addons/web/static/src/views/fields/float_time_range/float_time_range_field.js
+++ b/addons/web/static/src/views/fields/float_time_range/float_time_range_field.js
@@ -1,0 +1,106 @@
+import { Component } from "@odoo/owl";
+import { parseFloatTime } from "@web/views/fields/parsers";
+import { formatFloatTime } from "@web/views/fields/formatters";
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "../standard_field_props";
+
+const { DateTime } = luxon;
+
+// Converts the time value using the server timezone
+const serializeTime = (value, format) => {
+    const dt = DateTime.fromFormat(value, format);
+    return dt.setZone("utc").toFormat(format);
+};
+
+// Converts the time value coming from the server to the local timezone
+const deserializeTime = (value, format) => {
+    const dt = DateTime.fromFormat(value, format, { zone: "utc" });
+    return dt.toLocal().toFormat(format);
+};
+
+export class TimeRangeField extends Component {
+    static props = {
+        ...standardFieldProps,
+        endDateField: { type: String, optional: true },
+        startDateField: { type: String, optional: true },
+    };
+    static template = "web.TimeRangeField";
+
+    setup() {
+        const relatedField = this.props.startDateField || this.props.endDateField;
+        this.field = this.props.record.fields[this.props.name];
+        this.startDateField = this.props.startDateField || this.props.name;
+        this.endDateField = relatedField ? this.props.endDateField || this.props.name : null;
+    }
+
+    getFormattedValue(valueIndex) {
+        const value = this.getRecordValue()[valueIndex];
+        return deserializeTime(formatFloatTime(value), "HH:mm");
+    }
+
+    getRecordValue() {
+        return [
+            this.props.record.data[this.startDateField],
+            this.props.record.data[this.endDateField],
+        ];
+    }
+
+    onChange(value, fieldName) {
+        const parsedValue = value ? parseFloatTime(serializeTime(value, "HH:mm")) : false;
+        this.props.record.update({ [fieldName]: parsedValue }, { save: this.props.readonly });
+    }
+}
+
+const START_TIME_FIELD_OPTION = "start_time_field";
+const END_TIME_FIELD_OPTION = "end_time_field";
+
+export const timeRangeField = {
+    component: TimeRangeField,
+    displayName: _t("Time Range"),
+    supportedOptions: [
+        {
+            label: _t("Start time field"),
+            name: START_TIME_FIELD_OPTION,
+            type: "field",
+            availableTypes: ["float"],
+        },
+        {
+            label: _t("End time field"),
+            name: END_TIME_FIELD_OPTION,
+            type: "field",
+            availableTypes: ["float"],
+        },
+    ],
+    supportedTypes: ["float"],
+    extractProps: ({ attrs, options }) => ({
+        endDateField: options[END_TIME_FIELD_OPTION],
+        startDateField: options[START_TIME_FIELD_OPTION],
+    }),
+    fieldDependencies: ({ type, attrs, options }) => {
+        const deps = [];
+        if (options[START_TIME_FIELD_OPTION]) {
+            deps.push({
+                name: options[START_TIME_FIELD_OPTION],
+                type,
+                readonly: false,
+                ...attrs,
+            });
+            if (options[END_TIME_FIELD_OPTION]) {
+                console.warn(
+                    `A field cannot have both ${START_TIME_FIELD_OPTION} and ${END_TIME_FIELD_OPTION} options at the same time`
+                );
+            }
+        } else if (options[END_TIME_FIELD_OPTION]) {
+            deps.push({
+                name: options[END_TIME_FIELD_OPTION],
+                type,
+                readonly: false,
+                ...attrs,
+            });
+        }
+        return deps;
+    },
+};
+
+registry.category("fields").add("float_time_range", timeRangeField);

--- a/addons/web/static/src/views/fields/float_time_range/float_time_range_field.xml
+++ b/addons/web/static/src/views/fields/float_time_range/float_time_range_field.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="web.TimeRangeField">
+        <div class="d-flex gap-2 align-items-center" t-ref="root">
+            <t t-if="props.readonly">
+                <span class="text-truncate" t-esc="getFormattedValue(0)" />
+            </t>
+            <t t-else="">
+                <input
+                    t-ref="start-date"
+                    type="time"
+                    t-att-id="props.endDateField and props.id"
+                    class="o_input cursor-pointer"
+                    t-att-placeholder="props.placeholder"
+                    t-att-value="getFormattedValue(0)"
+                    t-on-change="(ev) => this.onChange(ev.target.value, startDateField)"
+                    step="900"
+                />
+            </t>
+            <i class="fa fa-long-arrow-right" aria-label="Arrow icon" title="Arrow" />
+            <t t-if="props.readonly">
+                <span class="text-truncate" t-esc="getFormattedValue(1)" />
+            </t>
+            <t t-else="">
+                <input
+                    t-ref="end-date"
+                    type="time"
+                    t-att-id="props.startDateField and props.id"
+                    class="o_input cursor-pointer"
+                    t-att-placeholder="props.placeholder"
+                    t-att-value="getFormattedValue(1)"
+                    t-on-change="(ev) => this.onChange(ev.target.value, endDateField)"
+                    step="900"
+                />
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/web/static/src/webclient/webclient.scss
+++ b/addons/web/static/src/webclient/webclient.scss
@@ -155,6 +155,7 @@ kbd {
 [type="number"],
 [type="email"],
 [type="tel"],
+[type="time"],
 textarea,
 select {
   width: 100%;

--- a/addons/web/static/tests/views/fields/float_time_range_field.test.js
+++ b/addons/web/static/tests/views/fields/float_time_range_field.test.js
@@ -1,0 +1,37 @@
+import { expect, test } from "@odoo/hoot";
+import { mockTimeZone } from "@odoo/hoot-mock";
+import {
+    clickSave,
+    contains,
+    defineModels,
+    fields,
+    models,
+    mountView,
+    onRpc,
+} from "@web/../tests/web_test_helpers";
+
+class Product extends models.Model {
+    time_start = fields.Float({ string: "Start" });
+    time_end = fields.Float({ string: "End" });
+}
+
+defineModels([Product]);
+
+test("set a time range", async () => {
+    mockTimeZone(0);
+    onRpc("web_save", ({ args }) => {
+        expect(args[1]).toEqual({ time_start: 9.15 });
+    });
+    Product._records = [{ id: 1, time_start: 12.5 }];
+    await mountView({
+        type: "form",
+        resModel: "product",
+        resId: 1,
+        arch: `<form><field name="time_start" widget="float_time_range" options="{'end_time_field': 'time_end'}"/></form>`,
+    });
+    expect(".o_field_float_time_range input[type=time]").toHaveCount(2);
+    expect("input:nth-of-type(1)").toHaveValue("12:30");
+    expect("input:nth-of-type(2)").toHaveValue("00:00");
+    await contains("input:nth-of-type(1)").edit("09:09", { instantly: true });
+    await clickSave();
+});


### PR DESCRIPTION
*: web

This commit introduces a mechanism to avoid users being annoyed by push
notifications and disabling them completely. Now, it is possible to set
a schedule (e.g. during working hours), to only receive those notifications
during that timing. Another option is to only rely on the bus notifications,
when using the 'Only when online' setting.

The settings view contains a new widget, using time inputs, to choose easily
the start and end of the schedule.

Tests have been added too, as the widget must remain usable.

task-3605527