### PR TITLE
[FIX] product_matrix: allow horizontal scroll in order grid entry

### DIFF
--- a/addons/product_matrix/static/src/scss/product_matrix.scss
+++ b/addons/product_matrix/static/src/scss/product_matrix.scss
@@ -1,4 +1,6 @@
 .o_matrix_input_table {
+    overflow-x: auto;
+
     .o_matrix_ps {
         padding-left: $modal-inner-padding;
     }


### PR DESCRIPTION
### Steps to reproduce issue:

1. Add multiple long variants to a product, choose Order Grid Entry in Sales Variant Selection right below
2. Create a quotation
3. Try to add the product with variants
4. Some variants can not be accessed in the pop up because you can not scroll horizontally

### Explanation:

Before 16.4, the overflow was set to `auto` thanks to the bootstrap classes. Since then, the classes changed and the new one does not have any overflow management.

### Suggested fix:

The automatic overflow added to `.o_matrix_input_table` makes the scrollbar only appear when the list is longer than its container. In the use case, only horizontal scrolling is needed. No vertical overflow management is added to avoid unintended behaviour.

opw-3749931