### PR TITLE
[FIX] account_edi: generate payment edi on full reconcile only

### DIFF
--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -134,14 +134,6 @@ class AccountEdiDocument(models.Model):
                         'error': False,
                         'blocking_level': False,
                     })
-                    if doc_type == 'invoice':
-                        reconciled_lines = move.line_ids.filtered(lambda line: line.account_id.user_type_id.type in ('receivable', 'payable'))
-                        reconciled_amls = reconciled_lines.mapped('matched_debit_ids.debit_move_id') \
-                                          | reconciled_lines.mapped('matched_credit_ids.credit_move_id')
-                        reconciled_amls\
-                            .filtered(lambda x: x.move_id.payment_id or x.move_id.statement_line_id)\
-                            .move_id\
-                            ._update_payments_edi_documents()
                 else:
                     document.write({
                         'error': move_result.get('error', False),

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -456,9 +456,9 @@ class AccountMove(models.Model):
         invoices is changing.
         '''
         edi_document_vals_list = []
-        to_remove = self.env['account.edi.document']
         for payment in self:
-            edi_formats = payment._get_reconciled_invoices().journal_id.edi_format_ids | payment.edi_document_ids.edi_format_id
+            edi_formats = payment._get_reconciled_invoices().journal_id.edi_format_ids + payment.edi_document_ids.edi_format_id
+            edi_formats = self.env['account.edi.format'].browse(edi_formats.ids) # Avoid duplicates
             for edi_format in edi_formats:
                 existing_edi_document = payment.edi_document_ids.filtered(lambda x: x.edi_format_id == edi_format)
 
@@ -476,9 +476,12 @@ class AccountMove(models.Model):
                             'state': 'to_send',
                         })
                 elif existing_edi_document:
-                    to_remove |= existing_edi_document
+                    existing_edi_document.write({
+                        'state': False,
+                        'error': False,
+                        'blocking_level': False,
+                    })
 
-        to_remove.unlink()
         self.env['account.edi.document'].create(edi_document_vals_list)
         self.edi_document_ids._process_documents_no_web_services()
 
@@ -679,15 +682,39 @@ class AccountMoveLine(models.Model):
         # documents during the reconciliation.
         all_lines = self + self.matched_debit_ids.debit_move_id + self.matched_credit_ids.credit_move_id
         payments = all_lines.move_id.filtered(lambda move: move.payment_id or move.statement_line_id)
-        res = super().reconcile()
-        changed_payments = self.env['account.move']
 
-        for payment in payments:
-            amls = payment.line_ids.filtered(lambda x: x.account_id.user_type_id.type == 'receivable')
-            if all(amls.mapped('reconciled')):
-                matched_invoices = payment._get_reconciled_invoices()
-                if all(inv.edi_state == 'sent' for inv in matched_invoices):
-                    changed_payments |= payment
+        invoices_per_payment_before = {pay: pay._get_reconciled_invoices() for pay in payments}
+        res = super().reconcile()
+        invoices_per_payment_after = {pay: pay._get_reconciled_invoices() for pay in payments}
+
+        changed_payments = self.env['account.move']
+        for payment, invoices_after in invoices_per_payment_after.items():
+            invoices_before = invoices_per_payment_before[payment]
+
+            if set(invoices_after.ids) != set(invoices_before.ids):
+                changed_payments |= payment
+        changed_payments._update_payments_edi_documents()
+
+        return res
+
+    def remove_move_reconcile(self):
+        # OVERRIDE
+        # When a payment has been sent to the government, it usually contains some information about reconciled
+        # invoices. If the user breaks a reconciliation, the related payments must be cancelled properly and then, a new
+        # electronic document must be generated.
+        all_lines = self + self.matched_debit_ids.debit_move_id + self.matched_credit_ids.credit_move_id
+        payments = all_lines.move_id.filtered(lambda move: move.payment_id or move.statement_line_id)
+
+        invoices_per_payment_before = {pay: pay._get_reconciled_invoices() for pay in payments}
+        res = super().remove_move_reconcile()
+        invoices_per_payment_after = {pay: pay._get_reconciled_invoices() for pay in payments}
+
+        changed_payments = self.env['account.move']
+        for payment, invoices_after in invoices_per_payment_after.items():
+            invoices_before = invoices_per_payment_before[payment]
+
+            if set(invoices_after.ids) != set(invoices_before.ids):
+                changed_payments |= payment
         changed_payments._update_payments_edi_documents()
 
         return res


### PR DESCRIPTION
It ended up in sending the payment multiple times when the payment was not fully reconciled

opw-3528265

This reverts commit c0d82bc352354155ce7c9fd1345d34d71fa1482d.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
