### PR TITLE
[FIX] website_sale: correct tax with fiscal pos

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -185,7 +185,8 @@ class ProductTemplate(models.Model):
                 'pricelist': pricelist and pricelist.id
             })
 
-            product = (self.env['product.product'].browse(combination_info['product_id']) or self).with_context(context)
+            product_id = combination_info['product_id'] or self.product_variant_id.id
+            product = self.env['product.product'].browse(product_id).with_context(context).sudo()
             partner = self.env.user.partner_id
             company_id = current_website.company_id
 
@@ -193,19 +194,30 @@ class ProductTemplate(models.Model):
             fpos = self.env['account.fiscal.position'].sudo().get_fiscal_position(partner.id)
             product_taxes = product.sudo().taxes_id.filtered(lambda x: x.company_id == company_id)
             taxes = fpos.map_tax(product_taxes)
+            today = fields.Date.context_today(self)
 
             # The list_price is always the price of one.
             quantity_1 = 1
-            combination_info['price'] = self.env['account.tax']._fix_tax_included_price_company(
-                combination_info['price'], product_taxes, taxes, company_id)
+            combination_info['price'] = product._get_tax_included_unit_price(
+                company_id, company_id.currency_id, today, 'sale',
+                product_price_unit=combination_info['price'],
+                fiscal_position=fpos,
+            )
             price = taxes.compute_all(combination_info['price'], pricelist.currency_id, quantity_1, product, partner)[tax_display]
             if pricelist.discount_policy == 'without_discount':
-                combination_info['list_price'] = self.env['account.tax']._fix_tax_included_price_company(
-                    combination_info['list_price'], product_taxes, taxes, company_id)
+                combination_info['list_price'] = product._get_tax_included_unit_price(
+                company_id, company_id.currency_id, today, 'sale',
+                product_price_unit=combination_info['list_price'],
+                fiscal_position=fpos,
+            )
                 list_price = taxes.compute_all(combination_info['list_price'], pricelist.currency_id, quantity_1, product, partner)[tax_display]
             else:
                 list_price = price
-            combination_info['price_extra'] = self.env['account.tax']._fix_tax_included_price_company(combination_info['price_extra'], product_taxes, taxes, company_id)
+            combination_info['price_extra'] = product._get_tax_included_unit_price(
+                company_id, company_id.currency_id, today, 'sale',
+                product_price_unit=combination_info['price_extra'],
+                fiscal_position=fpos,
+            )
             price_extra = taxes.compute_all(combination_info['price_extra'], pricelist.currency_id, quantity_1, product, partner)[tax_display]
             has_discounted_price = pricelist.currency_id.compare_amounts(list_price, price) == 1
 

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -158,6 +158,13 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         self.assertEqual(round(combination_info['list_price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0% for BE)")
         self.assertEqual(combination_info['price_extra'], 173.91, "173.91$ + 0% tax (mapped from fp 15% -> 0% for BE)")
 
+        # Try same flow with tax included for apply tax
+        tax0.write({'name': "Test tax 5", 'amount': 5, 'price_include': True})
+        combination_info = test_product._get_combination_info(combination)
+        self.assertEqual(round(combination_info['price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
+        self.assertEqual(round(combination_info['list_price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
+        self.assertEqual(combination_info['price_extra'], 182.61, "173.91$ + 5% tax (mapped from fp 15% -> 5% for BE)")
+
 @tagged('post_install', '-at_install')
 class TestWebsiteSaleProductPricelist(TestSaleProductAttributeValueCommon, TestWebsiteSaleCommon):
     def test_cart_update_with_fpos(self):


### PR DESCRIPTION
Issue Description:
==================
There is a discrepancy in the displayed prices on the `/shop` and `/shop/[product]` pages when using fiscal positions, despite the `/shop/cart` page reflecting the correct amounts as per the `Sales Order`. This issue arises with inclusive taxes set on the website; it functions correctly until a fiscal position modifies the tax. Specifically, when a fiscal position applies a new tax, the system erroneously calculates tax-inclusive prices twice on the eCommerce platform. Consequently, the prices listed on the eCommerce `/shop` and /`shop/[product]` pages are incorrect. However, once an item is added to the cart, the correct price is displayed. This problem has been identified in versions from 15.0 to the master branch.

The root of this issue lies in the system's failure to check the `price_include` condition for the applied tax within a fiscal position https://github.com/odoo/odoo/blob/9c4194ad3387c55d39ec7bbef1c6414893098c6e/addons/account/models/account_tax.py#L679-L687.

Steps to Reproduce:
===================
1. Create two new taxes with 15% and 5% rates, respectively, ensuring the `Included in Price` option is selected in the` Advanced Options` tab. Navigate to Accounting > Configuration > Taxes to do this.
2. Establish a new fiscal position mapping the 15% tax to the 5% tax, with `Detect Automatically` enabled and a country set, such as France, under Accounting > Configuration > Fiscal Positions. This setup should include specifying `Tax on Product` as the 15% tax and `Tax to Apply` as the 5% tax.
3. Enable the `Tax-Included` setting for the `Website` under the main `Setting`s, specifically within the `Product Prices` section.
4. Create a product priced at $100, applying the 15% tax, and publish it on the website.
5. Access the product page via the `Shop` while logged in as an admin. The price displayed will be $100.
6. Log in as a portal user or create a new user account. Change the user's country to France, then locate the product in the Shop. The price shown will be $86.96, instead of the expected $91.31.

Proposed Solution:
==================
To address this issue, we propose to check for the `price_include` attribute in the tax being applied through the fiscal position. If present, we will adjust the method to calculate the final price based on the base price from the previous tax, setting `handle_price_include=False`. For example, if a product's price is $100 with an included 15% tax (base = $86.96), and a fiscal position changes the tax to 5% with `price_include=True`, the website should display the price as $91.31 ($86.96 + 5%).

opw-3700803
