### PR TITLE
[FIX] web: form oe_inline class width modification

### DIFF
--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -70,7 +70,7 @@
         opacity: 0.5;
     }
     .oe_inline, .o_field_widget.oe_inline > * {
-        width: auto!important;
+        width: 100% !important;
     }
     @for $i from 2 through 13 {
         .o_field_widget.o_input_#{$i}ch input{


### PR DESCRIPTION
**Current behavior:**
Form fields and/or selections using the oe_inline class and have very long selection options will result in views with many stylistically broken page elements; specifically vertical text and text breaking out of its container.

**Expected behavior:**
Form views will look uniform.

**Steps to reproduce:**
1. Install sale_management and web_studio, then install the Dutch (BE) language pack and activate it

2. From the home screen, go to `Verkoop` (Sales), then toggle studio

3. Go to the `Automatiseringen` (automations) menu -> `Niuew`

4. Observe the broken style

**Cause of the issue:**
The oe_inline class is allowing auto width, which is problematic for the `trigger` field in this specific instance because there are very long selections available for this selection element.

**Fix:**
Change width: auto to width: 100%.

opw-3756540