### PR TITLE
[FIX] web: Record: ask changes before discarding

### DIFF
--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -185,7 +185,10 @@ export class Record extends DataPoint {
         if (this.model._closeUrgentSaveNotification) {
             this.model._closeUrgentSaveNotification();
         }
-        return this.model.mutex.exec(() => this._discard());
+        return this.model.mutex.exec(() => {
+            this.model._discardLocalChanges();
+            this._discard();
+        });
     }
 
     duplicate() {

--- a/addons/web/static/src/model/relational_model/record.js
+++ b/addons/web/static/src/model/relational_model/record.js
@@ -1,7 +1,6 @@
 /* @odoo-module */
 
 import { markRaw, markup, toRaw } from "@odoo/owl";
-import { AlertDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { Domain } from "@web/core/domain";
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { _t } from "@web/core/l10n/translation";
@@ -181,10 +180,11 @@ export class Record extends DataPoint {
         });
     }
 
-    discard() {
+    async discard() {
         if (this.model._closeUrgentSaveNotification) {
             this.model._closeUrgentSaveNotification();
         }
+        await this.model._askChanges();
         return this.model.mutex.exec(() => this._discard());
     }
 
@@ -231,9 +231,9 @@ export class Record extends DataPoint {
         return this.model.mutex.exec(() => this._save(options));
     }
 
-    async setInvalidField(fieldName) {
+    async setInvalidField() {
         this.dirty = true;
-        return this._setInvalidField(fieldName);
+        return this._setInvalidField(...arguments);
     }
 
     switchMode(mode) {
@@ -1110,19 +1110,10 @@ export class Record extends DataPoint {
         }
     }
 
-    async _setInvalidField(fieldName) {
-        const canProceed = this.model.hooks.onWillSetInvalidField(this, fieldName);
+    async _setInvalidField(fieldName, undoChange) {
+        const canProceed = this.model.hooks.onWillSetInvalidField(this, undoChange);
         if (canProceed === false) {
             return;
-        }
-        if (this.selected && this.model.multiEdit && !this._invalidFields.has(fieldName)) {
-            await this.model.dialog.add(AlertDialog, {
-                body: _t("No valid record to save"),
-                confirm: async () => {
-                    await this.discard();
-                    this.switchMode("readonly");
-                },
-            });
         }
         this._invalidFields.add(fieldName);
     }

--- a/addons/web/static/src/model/relational_model/relational_model.js
+++ b/addons/web/static/src/model/relational_model/relational_model.js
@@ -220,6 +220,10 @@ export class RelationalModel extends Model {
         return Promise.all([...proms, this.mutex.getUnlockedDef()]);
     }
 
+    _discardLocalChanges() {
+        this.bus.trigger("DISCARD_LOCAL_CHANGES");
+    }
+
     /**
      *
      * @param {Config} config

--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -62,7 +62,11 @@ export function useInputField(params) {
                 try {
                     val = params.parse(val);
                 } catch {
-                    component.props.record.setInvalidField(component.props.name);
+                    const resetLastSetValue = () => {
+                        isInvalid = false;
+                        ev.target.value = lastSetValue;
+                    };
+                    component.props.record.setInvalidField(component.props.name, resetLastSetValue);
                     isInvalid = true;
                 }
             }

--- a/addons/web/static/src/views/fields/input_field_hook.js
+++ b/addons/web/static/src/views/fields/input_field_hook.js
@@ -62,11 +62,7 @@ export function useInputField(params) {
                 try {
                     val = params.parse(val);
                 } catch {
-                    const resetLastSetValue = () => {
-                        isInvalid = false;
-                        ev.target.value = lastSetValue;
-                    };
-                    component.props.record.setInvalidField(component.props.name, resetLastSetValue);
+                    component.props.record.setInvalidField(component.props.name);
                     isInvalid = true;
                 }
             }

--- a/addons/web/static/src/views/fields/many2many_checkboxes/many2many_checkboxes_field.js
+++ b/addons/web/static/src/views/fields/many2many_checkboxes/many2many_checkboxes_field.js
@@ -29,6 +29,9 @@ export class Many2ManyCheckboxesField extends Component {
         this.idsToRemove = new Set();
         this.debouncedCommitChanges = debounce(this.commitChanges.bind(this), 500);
         useBus(this.props.record.model.bus, "NEED_LOCAL_CHANGES", this.commitChanges.bind(this));
+        useBus(this.props.record.model.bus, "DISCARD_LOCAL_CHANGES", () => {
+            this.debouncedCommitChanges.cancel();
+        });
         onWillUnmount(this.commitChanges.bind(this));
     }
 

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -4,6 +4,7 @@ import { _t } from "@web/core/l10n/translation";
 import {
     deleteConfirmationMessage,
     ConfirmationDialog,
+    AlertDialog,
 } from "@web/core/confirmation_dialog/confirmation_dialog";
 import { download } from "@web/core/network/download";
 import { evaluateExpr, evaluateBooleanExpr } from "@web/core/py_js/py";
@@ -62,8 +63,10 @@ export class ListController extends Component {
         // "Discard". So we set a flag on mousedown (which triggers the update) to block the multi
         // save or invalid notification.
         // However, if the mouseup (and click) is done outside "Discard", we finally want to do it.
-        // We use `nextActionAfterMouseup` for this purpose: it registers a callback to execute if
-        // the mouseup following a mousedown on "Discard" isn't done on "Discard".
+        // We use `nextActionAfterMouseup` for this purpose: it registers callbacks to execute if
+        // the mouseup following a mousedown on "Discard":
+        //   - is done on "Discard" (confirmDiscard)
+        //   - isn't done on "Discard" (cancelDiscard)
         this.hasMousedownDiscard = false;
         this.nextActionAfterMouseup = null;
 
@@ -280,10 +283,12 @@ export class ListController extends Component {
             "mouseup",
             (mouseUpEvent) => {
                 this.hasMousedownDiscard = false;
+                const cancel = this.nextActionAfterMouseup?.cancelDiscard || (() => {});
+                const confirm = this.nextActionAfterMouseup?.confirmDiscard || (() => {});
                 if (mouseUpEvent.target !== mouseDownEvent.target) {
-                    if (this.nextActionAfterMouseup) {
-                        this.nextActionAfterMouseup();
-                    }
+                    cancel();
+                } else {
+                    confirm();
                 }
                 this.nextActionAfterMouseup = null;
             },
@@ -565,7 +570,9 @@ export class ListController extends Component {
 
     onWillSaveMulti(editedRecord, changes, validSelectedRecords) {
         if (this.hasMousedownDiscard) {
-            this.nextActionAfterMouseup = () => this.model.root.multiSave(editedRecord);
+            this.nextActionAfterMouseup = {
+                cancelDiscard: () => this.model.root.multiSave(editedRecord),
+            };
             return false;
         }
         if (validSelectedRecords.length > 1) {
@@ -614,10 +621,23 @@ export class ListController extends Component {
         return true;
     }
 
-    onWillSetInvalidField(record, fieldName) {
+    onWillSetInvalidField(record, fieldName, undoChange) {
         if (this.hasMousedownDiscard) {
-            this.nextActionAfterMouseup = () => record.setInvalidField(fieldName);
+            this.nextActionAfterMouseup = {
+                cancelDiscard: () => record.setInvalidField(fieldName),
+                confirmDiscard: undoChange,
+            };
             return false;
+        }
+        if (record.selected && this.model.multiEdit && !record.isFieldInvalid(fieldName)) {
+            console.log("open dialog");
+            this.dialogService.add(AlertDialog, {
+                body: _t("No valid record to save"),
+                confirm: async () => {
+                    await record.discard();
+                    record.switchMode("readonly");
+                },
+            });
         }
         return true;
     }

--- a/addons/web/static/tests/views/fields/domain_field_tests.js
+++ b/addons/web/static/tests/views/fields/domain_field_tests.js
@@ -7,7 +7,6 @@ import {
     clickSave,
     editInput,
     getFixture,
-    getNodesTextContent,
     makeDeferred,
     nextTick,
     patchDate,
@@ -518,79 +517,6 @@ QUnit.module("Fields", (hooks) => {
             "1 record(s)"
         );
         assert.verifySteps(['[["id","<",40]]']);
-    });
-
-    QUnit.test("domain field: edit domain in textarea, discard and leave", async function (assert) {
-        patchWithCleanup(odoo, { debug: true });
-
-        serverData.models.partner.records[0].foo = false;
-        serverData.models.partner.fields.bar.type = "char";
-        serverData.models.partner.records[0].bar = "product";
-
-        serverData.views = {
-            "partner,false,form": `
-                <form>
-                    <field name="bar"/>
-                    <field name="foo" widget="domain" options="{'model': 'bar'}"/>
-                </form>`,
-            "partner,false,search": `<search />`,
-            "partner,false,list": `<tree><field name="foo"/></tree>`,
-        };
-
-        serverData.actions = {
-            1: {
-                id: 1,
-                name: "test",
-                res_id: 1,
-                res_model: "partner",
-                type: "ir.actions.act_window",
-                views: [
-                    [false, "list"],
-                    [false, "form"],
-                ],
-            },
-        };
-
-        const webClient = await createWebClient({
-            serverData,
-            mockRPC(route) {
-                if (route === "/web/domain/validate") {
-                    return true;
-                }
-            },
-        });
-
-        await doAction(webClient, 1);
-        assert.containsOnce(target, ".o_list_view");
-        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), [
-            "",
-            "blip",
-            "gnap",
-            "abc",
-            "blop",
-        ]);
-
-        await click(target.querySelector(".o_data_row .o_data_cell"));
-        assert.containsOnce(target, ".o_form_view");
-
-        await editInput(target, dsHelpers.SELECTORS.debugArea, "[['id', '<', 40]]");
-        assert.strictEqual(
-            target.querySelector(dsHelpers.SELECTORS.debugArea).value,
-            "[['id', '<', 40]]"
-        );
-
-        await clickDiscard(target);
-        assert.strictEqual(target.querySelector(dsHelpers.SELECTORS.debugArea).value, "[]");
-
-        await click(target.querySelector(".o_breadcrumb .o_back_button"));
-        assert.containsOnce(target, ".o_list_view");
-        assert.deepEqual(getNodesTextContent(target.querySelectorAll(".o_data_cell")), [
-            "",
-            "blip",
-            "gnap",
-            "abc",
-            "blop",
-        ]);
     });
 
     QUnit.test(

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -12168,6 +12168,7 @@ QUnit.module("Views", (hooks) => {
             await click(rows[1], ".o_list_record_selector input");
             await click(rows[0].querySelector(".o_data_cell"));
             target.querySelector(".o_data_row .o_data_cell input").value = "oof";
+            await triggerEvents(target, ".o_data_row .o_data_cell input", ["input"]);
 
             const discardButton = $(".o_list_button_discard:visible").get(0);
             // Simulates an actual click (event chain is: mousedown > change > blur > focus > mouseup > click)
@@ -12212,6 +12213,7 @@ QUnit.module("Views", (hooks) => {
             await click(rows[1], ".o_list_record_selector input");
             await click(rows[0].querySelector(".o_data_cell"));
             target.querySelector(".o_data_row .o_data_cell input").value = "oof";
+            await triggerEvents(target, ".o_data_row .o_data_cell input", ["input"]);
 
             await triggerEvents($(".o_list_button_discard:visible").get(0), null, ["mousedown"]);
             await triggerEvents(target, ".o_data_row .o_data_cell input", [
@@ -12314,6 +12316,7 @@ QUnit.module("Views", (hooks) => {
             await click(rows[1], ".o_list_record_selector input");
             await click(rows[0].querySelector(".o_data_cell"));
             target.querySelector(".o_data_row .o_data_cell input").value = "oof";
+            await triggerEvents(target, ".o_data_row .o_data_cell input", ["input"]);
 
             const discardButton = $(".o_list_button_discard:visible").get(0);
             // Simulates an actual click (event chain is: mousedown > change > blur > focus > mouseup > click)


### PR DESCRIPTION
Before this commit, the model didn't ask fields to commit their changes before discarding. This isn't problematic for a lot of fields, but it is for instance for the domain field, which doesn't commit its changes directly. So the following steps:
 - from a list view, open a record
 - in the form view, edit the domain field with the textarea
 - click on discard
 - click on the breadcrumb to go back led to the record being saved, even though the change had been discarded. Indeed, we only asked for changes when the user clicked on the breadcrumb, so after discarding.

With this commit, we ask for changes before discarding.

Issue spotted with task 3586303

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
