### PR TITLE
[FIX] hr_timesheet: hide timesheets related filters if project is non allow timesheet

### DIFF
--- a/addons/hr_timesheet/models/project_project.py
+++ b/addons/hr_timesheet/models/project_project.py
@@ -205,3 +205,15 @@ class Project(models.Model):
         action = self.env['ir.actions.act_window']._for_xml_id('hr_timesheet.act_hr_timesheet_line_by_project')
         action['display_name'] = _("%(name)s's Timesheets", name=self.name)
         return action
+
+    def action_view_tasks(self):
+        # Using the timesheet filter hide context
+        action = super().action_view_tasks()
+        action['context']['allow_timesheets'] = self.allow_timesheets
+        return action
+
+    def action_project_sharing(self):
+        # Using the timesheet filter hide context
+        action = super().action_project_sharing()
+        action['context']['allow_timesheets'] = self.allow_timesheets
+        return action

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -212,8 +212,10 @@
             <field name="priority">10</field>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='blocking']/following-sibling::separator[1]" position="after">
-                    <filter string="Timesheets 80%" name="timesheet_80" domain="[('remaining_hours_percentage', '&gt;', 0.0), ('remaining_hours_percentage', '&lt;=', 0.2)]"/>
-                    <filter string="Timesheets &gt;100%" name="timesheet_exceeded" domain="[('overtime', '&gt;', 0)]"/>
+                    <filter string="Timesheets 80%" name="timesheet_80" invisible="not context.get('allow_timesheets')"
+                        domain="[('remaining_hours_percentage', '&gt;', 0.0), ('remaining_hours_percentage', '&lt;=', 0.2)]"/>
+                    <filter string="Timesheets &gt;100%" name="timesheet_exceeded" domain="[('overtime', '&gt;', 0)]"
+                        invisible="not context.get('allow_timesheets')"/>
                     <separator/>
                 </xpath>
             </field>


### PR DESCRIPTION
### Steps to reproduce

- Install project.
- Create 2 projects one with timesheets and the second without timesheets.
- Open the project without time sheets.
- Observe that there are timesheet filters even if the timesheets are disabled.

### Issue:
Timesheet filters are available for project tasks even though the project is not using the timesheets.

### Cause:
Filters were missing some conditions to enable only when timesheets are available.

### Solution:
Corrected the timesheet-related filters so they are only available for the project tasks which use the timesheets.

Note: When we refresh the page, filters become visible because the context is lost.

task-3754591