### PR TITLE
[FIX] {purchase_,}stock: prevent negative cost

### DIFF
--- a/addons/purchase_stock/i18n/purchase_stock.pot
+++ b/addons/purchase_stock/i18n/purchase_stock.pot
@@ -679,6 +679,12 @@ msgstr ""
 
 #. module: purchase_stock
 #. odoo-python
+#: code:addons/purchase_stock/models/purchase_order_line.py:0
+msgid "The unit price of a storable product should not be negative."
+msgstr ""
+
+#. module: purchase_stock
+#. odoo-python
 #: code:addons/purchase_stock/models/stock_rule.py:0
 msgid ""
 "There is no matching vendor price to generate the purchase order for product"

--- a/addons/purchase_stock/tests/test_purchase_order.py
+++ b/addons/purchase_stock/tests/test_purchase_order.py
@@ -697,3 +697,17 @@ class TestPurchaseOrder(ValuationReconciliationTestCommon):
         self.assertEqual(len(layers), 1)
         self.assertEqual(layers.quantity, 5)
         self.assertEqual(layers.value, 2500)
+
+    def test_positive_unit_price(self):
+        """"
+        Unit price of storable product should be positive
+        """
+        err_msg = "The unit price of a storable product should not be negative."
+        self.product_id_1.type = 'product'
+        with self.assertLogs(level="WARNING") as logger:
+            with Form(self.env['purchase.order']) as po_form:
+                po_form.partner_id = self.partner_a
+                with po_form.order_line.new() as pol:
+                    pol.product_id = self.product_id_1
+                    pol.price_unit = -5
+        self.assertIn(err_msg, logger.output[0])

--- a/addons/stock/i18n/stock.pot
+++ b/addons/stock/i18n/stock.pot
@@ -8275,6 +8275,12 @@ msgstr ""
 
 #. module: stock
 #. odoo-python
+#: code:addons/stock/models/product.py:0
+msgid "The cost of a storable product should not be negative."
+msgstr ""
+
+#. module: stock
+#. odoo-python
 #: code:addons/stock/models/stock_move.py:0
 msgid "The deadline has been automatically updated due to a delay on %s."
 msgstr ""

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -341,3 +341,26 @@ class TestVirtualAvailable(TestStockCommon):
         product_form.detailed_type = 'service'
         product = product_form.save()
         self.assertEqual(product.tracking, 'none')
+
+    def test_positive_cost(self):
+        """"
+        Cost of storable product should be positive
+        """
+        err_msg = "The cost of a storable product should not be negative."
+        variant = self.product_1
+        template = variant.product_tmpl_id
+        template.write({
+            'type': 'product',
+            'standard_price': 1000,
+        })
+
+        with self.assertLogs(level="WARNING") as logger:
+            with Form(template) as template_form:
+                template_form.standard_price = -10
+        self.assertIn(err_msg, logger.output[0])
+
+        template.standard_price = 1000
+        with self.assertLogs(level="WARNING") as logger:
+            with Form(variant) as variant_form:
+                variant_form.standard_price = -10
+        self.assertIn(err_msg, logger.output[0])


### PR DESCRIPTION
The user should not be able to set a negative cost. Else, it will lead to unexpected behaviors and inconsistencies in stock valuations.

The commit adds an onchange because adding a constraint in stable would be too risky.

OPW-3619709