### PR TITLE
[FIX] *: UPDATE sql queries mismanaging cache & dependents

### DIFF
--- a/addons/auth_ldap/models/res_users.py
+++ b/addons/auth_ldap/models/res_users.py
@@ -61,9 +61,8 @@ class Users(models.Model):
         return super(Users, self).change_password(old_passwd, new_passwd)
 
     def _set_empty_password(self):
-        self.flush_recordset(['password'])
-        self.env.cr.execute(
-            'UPDATE res_users SET password=NULL WHERE id=%s',
-            (self.id,)
-        )
-        self.invalidate_recordset(['password'])
+        with self.modifying_recordset(outputs=['password']):
+            self.env.cr.execute(
+                'UPDATE res_users SET password=NULL WHERE id=%s',
+                [self.id],
+            )

--- a/addons/auth_passkey/models/auth_passkey_key.py
+++ b/addons/auth_passkey/models/auth_passkey_key.py
@@ -170,11 +170,12 @@ class PassKeyCreate(models.TransientModel):
             'credential_identifier': bytes_to_base64url(verification['credential_id']),
         })]})
         passkey = self.env.user.auth_passkey_key_ids[0]
-        self.env.cr.execute(SQL(
-            "UPDATE auth_passkey_key SET public_key = %s WHERE id = %s",
-            base64.urlsafe_b64encode(verification['credential_public_key']).decode(),
-            passkey.id,
-        ))
+        with passkey.modifying_recordset(outputs=['public_key']):
+            self.env.cr.execute(SQL(
+                "UPDATE auth_passkey_key SET public_key = %s WHERE id = %s",
+                base64.urlsafe_b64encode(verification['credential_public_key']).decode(),
+                passkey.id,
+            ))
         ip = request.httprequest.environ['REMOTE_ADDR'] if request else 'n/a'
         _logger.info(
             "Passkey (#%d) created by %s (#%d) from %s",


### PR DESCRIPTION
SQL-level UPDATE queries should invalidate the cache, and notify the ORM in case there are computed fields depending on the field(s) they updated.
