### PR TITLE
[FIX] base: Validate URLs on attachments

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -435,6 +435,14 @@ class IrAttachment(models.Model):
                 if not any(has_group(g) for g in attachment.get_serving_groups()):
                     raise ValidationError("Sorry, you are not allowed to write on this document")
 
+    @api.constrains('url')
+    def _check_url_validity(self):
+        for attachment in self:
+            if attachment.type == 'url' and attachment.url:
+                # Make sure that any URL that is inputted is a valid URL if the type is url
+                if not re.match(r"^(ht|f)tp(s?)\:\/\/[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(:(0-9)*)*(\/?)([a-zA-Z0-9\-\.\?\,\'\/\\\+&amp;%\$#_]*)?$", attachment.url):
+                    raise ValidationError(_("Please enter a valid URL \nExample: https://www.odoo.com"))
+
     @api.model
     def check(self, mode, values=None):
         """ Restricts the access to an ir.attachment, according to referred mode """


### PR DESCRIPTION
Added a validation for URLs on ir.attachments to resolve an issue where incomplete links on attachments will redirect to a local URL instead of an external URL. Thus leading to a page that does not exist.

e.g.: youtube.com instead of https://www.youtube.com

This seemed like the proper course of action as there would be no reason to not validate as any URL within the database can still be formatted properly and work the same.

opw-3698591
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
