### PR TITLE
[IMP] account, account_payment: minimize likelihood of duplicate payment

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -98,6 +98,7 @@ You could use this simplified accounting in case you work with an (external) acc
             'account/static/src/scss/account_payment_term.scss',
             'account/static/src/components/**/*',
             'account/static/src/services/*.js',
+            'account/static/src/views/*.js',
             'account/static/src/js/tours/account.js',
             'account/static/src/js/search/search_bar/search_bar.js',
             'account/static/src/helpers/*.js',

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -3,6 +3,7 @@ from odoo import models, fields, api, _, Command
 from odoo.exceptions import UserError, ValidationError
 from odoo.tools.misc import format_date, formatLang
 from odoo.tools import create_index
+from odoo.tools import SQL
 
 
 class AccountPayment(models.Model):
@@ -174,6 +175,8 @@ class AccountPayment(models.Model):
         help='Negative value of amount field if payment_type is outbound')
     amount_company_currency_signed = fields.Monetary(
         currency_field='company_currency_id', compute='_compute_amount_company_currency_signed', store=True)
+    # used to get and display duplicate move warning if partner, amount and date match existing payments
+    duplicate_move_ids = fields.Many2many(comodel_name='account.move', compute='_compute_duplicate_move_ids')
 
     _sql_constraints = [
         (
@@ -703,6 +706,126 @@ class AccountPayment(models.Model):
     def _compute_payment_receipt_title(self):
         """ To override in order to change the title displayed on the payment receipt report """
         self.payment_receipt_title = _('Payment Receipt')
+
+    @api.depends('partner_id', 'amount', 'date', 'payment_type')
+    def _compute_duplicate_move_ids(self):
+        """ Retrieve move ids with same partner_id, amount and date as the current payment """
+        payment_to_duplicate_move = self._fetch_duplicate_reference()
+        for payment in self:
+            # Uses payment._origin.id to handle records in edition/existing records and 0 for new records
+            payment.duplicate_move_ids = payment_to_duplicate_move.get(payment._origin.id, self.env['account.move'])
+
+    def _fetch_duplicate_reference(self, matching_states=('draft', 'posted')):
+        """ Retrieve move ids for possible duplicates of payments. Duplicates moves:
+        - Have the same partner_id, amount and date as the payment
+        - Are not reconciled
+        - Represent a credit in the same account receivable or a debit in the same account payable as the payment, or
+        - Represent a credit in outstanding receipts or debit in outstanding payments, so bank statement lines with an
+         outstanding counterpart can be matched, or
+        - Are in the suspense account
+        """
+        def build_query(move_table_and_alias, outstanding_account_ids, payments):
+            suspense_account_id = self.company_id.account_journal_suspense_account_id.id
+
+            return SQL(
+                """
+                SELECT
+                       move_line.payment_id,
+                       array_agg(DISTINCT dup_move_line.move_id) AS duplicate_move_ids
+                  FROM %(move_table_and_alias)s
+                  JOIN account_move_line AS dup_move_line
+                    ON move_line.move_id != dup_move_line.move_id
+                   AND move_line.partner_id = dup_move_line.partner_id
+                   AND move_line.company_id = dup_move_line.company_id
+                   AND move_line.date = dup_move_line.date
+                   AND dup_move_line.parent_state IN %(matching_states)s
+                   AND (
+                       move_line.account_id = dup_move_line.account_id
+                       OR dup_move_line.account_id = %(suspense_account_id)s
+                       OR dup_move_line.account_id IN %(outstanding_account_ids)s
+                   )
+                   AND NOT dup_move_line.reconciled
+                 WHERE move_line.payment_id IN %(payments)s
+                   AND (
+                       -- Case 1: a move is a credit in same account receivable or debit in same acc payable as the payment
+                       (dup_move_line.account_id NOT IN %(outstanding_account_ids)s AND move_line.balance = dup_move_line.balance)
+                       OR
+                       -- Case 2: a move is a credit in outstanding receipts or debit in outstanding payments
+                       (dup_move_line.account_id IN %(outstanding_account_ids)s AND move_line.balance = -1.0 * dup_move_line.balance)
+                   )
+                   AND (
+                       move_line.payment_type = 'inbound' AND dup_move_line.balance < 0.0
+                       OR move_line.payment_type = 'outbound' AND dup_move_line.balance > 0.0
+                   )
+              GROUP BY move_line.payment_id
+            """,
+                move_table_and_alias=move_table_and_alias,
+                matching_states=tuple(matching_states),
+                suspense_account_id=suspense_account_id,
+                outstanding_account_ids=outstanding_account_ids,
+                payments=tuple(payments),
+            )
+
+        # Does not perform unnecessary check if partner_id or amount are not set, nor if payment is posted
+        if not self.filtered(lambda p: p.partner_id and p.amount and p.state != 'posted'):
+            return {}
+        # Separate inbound and outbound payments, as their outstanding accounts differ and need to be checked separately
+        payments_inbound = self.filtered(lambda p: p.payment_type == 'inbound')
+        payments_outbound = self.filtered(lambda p: p.payment_type == 'outbound')
+        if self.journal_id:
+            inbound_outstanding_account_ids = tuple(self.journal_id._get_journal_inbound_outstanding_payment_accounts().ids)
+            outbound_outstanding_account_ids = tuple(self.journal_id._get_journal_outbound_outstanding_payment_accounts().ids)
+        else:
+            inbound_outstanding_account_ids = tuple(self.company_id.account_journal_payment_debit_account_id.ids)
+            outbound_outstanding_account_ids = tuple(self.company_id.account_journal_payment_credit_account_id.ids)
+
+        # Update tables involved in the query
+        self.env['account.move.line'].flush_model(('move_id', 'payment_id', 'balance', 'account_id', 'company_id', 'date', 'partner_id'))
+        self.env['account.payment'].flush_model(('move_id', 'payment_type'))
+
+        if not self[0].id:  # if record is under creation/edition in UI, safely inject values in the query
+            # Necessary since new record aren't searchable in the DB and record in edition aren't up to date yet
+            place_holders = {
+                'move_id': self._origin.move_id.id or 0,
+                'payment_id': self._origin.id or 0,
+                'payment_type': self.payment_type,
+                'balance': self.amount if self.payment_type == 'outbound' else -self.amount,
+                'account_id': self.destination_account_id.id,
+                'company_id': self.company_id.id or None,
+                'date': self.date or None,
+                'partner_id': self.partner_id.id,
+            }
+            # In case of null values, postgres may have issues with the column type, so we cast the columns
+            move_table_and_alias = SQL("""
+                (VALUES (%(move_id)s::int4, %(payment_id)s::int4, %(payment_type)s::varchar, %(balance)s::numeric,%(account_id)s::int4, %(company_id)s::int4, %(date)s::date, %(partner_id)s::int4))
+                AS move_line(move_id, payment_id, payment_type, balance, account_id, company_id, date, partner_id)
+            """, **place_holders)
+            outstanding_account_ids = inbound_outstanding_account_ids if self.payment_type == 'inbound' else outbound_outstanding_account_ids
+            query = build_query(move_table_and_alias, outstanding_account_ids, [0])
+
+        else:
+            move_table_and_alias = SQL("""
+                (SELECT account_move_line.*, account_payment.payment_type
+                   FROM account_move_line
+                   JOIN account_payment
+                     ON account_payment.move_id = account_move_line.move_id) AS move_line
+            """)
+            if payments_inbound and payments_outbound:
+                query_inbound = build_query(move_table_and_alias, inbound_outstanding_account_ids, payments_inbound.ids)
+                query_outbound = build_query(move_table_and_alias, outbound_outstanding_account_ids, payments_outbound.ids)
+                query = SQL(
+                    "%(query_inbound)s UNION %(query_outbound)s",
+                    query_inbound=query_inbound,
+                    query_outbound=query_outbound,
+                )
+            else:
+                outstanding_account_ids = inbound_outstanding_account_ids if payments_inbound else outbound_outstanding_account_ids
+                query = build_query(move_table_and_alias, outstanding_account_ids, self.ids)
+
+        return {
+            payment_id: self.env['account.move'].browse(duplicate_ids)
+            for payment_id, duplicate_ids in self.env.execute_query(query)
+        }
 
     # -------------------------------------------------------------------------
     # ONCHANGE METHODS

--- a/addons/account/static/src/components/x2many_buttons/x2many_buttons.js
+++ b/addons/account/static/src/components/x2many_buttons/x2many_buttons.js
@@ -14,6 +14,7 @@ class X2ManyButtons extends Component {
     };
 
     setup() {
+        this.orm = useService("orm");
         this.action = useService("action");
     }
 
@@ -23,23 +24,22 @@ class X2ManyButtons extends Component {
         this.action.doAction({
             name: this.props.treeLabel,
             type: "ir.actions.act_window",
-            res_model: this.currentField.resModel,
+            res_model: "account.move",
             views: [
                 [false, "list"],
                 [false, "form"],
             ],
             domain: [["id", "in", ids]],
+            context: {
+                form_view_ref: "account.view_duplicated_moves_tree_js",
+            },
         });
     }
 
     async openFormAndDiscard(id) {
+        const action = await this.orm.call(this.currentField.resModel, "action_open_business_doc", [id], {});
         await this.props.record.discard();
-        this.action.doAction({
-            type: "ir.actions.act_window",
-            res_model: this.currentField.resModel,
-            res_id: id,
-            views: [[false, "form"]],
-        });
+        this.action.doAction(action);
     }
 
     get currentField() {

--- a/addons/account/static/src/components/x2many_buttons/x2many_buttons.xml
+++ b/addons/account/static/src/components/x2many_buttons/x2many_buttons.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <templates>
     <t t-name="account.X2ManyButtons">
-        <div class="d-flex align-items-center gap-1">
+        <div class="d-flex align-items-center">
             <t t-foreach="this.currentField.records.slice(0, 3)" t-as="record" t-key="record.id">
                 <button class="btn btn-link p-0"
                         t-on-click="() => this.openFormAndDiscard(record.resId)"
                         t-att-data-hotkey="`shift+${record_index + 1}`"
                         t-out="record.data.display_name"/>
-                <span t-if="!record_last">,</span>
+                <span t-if="!record_last" class="pe-1">,</span>
             </t>
             <t t-if="this.currentField.count gt 3">
                 <button class="btn btn-link p-0" t-on-click="() => this.openTreeAndDiscard()" data-hotkey="shift+4">... (View all)</button>

--- a/addons/account/static/src/css/account.css
+++ b/addons/account/static/src/css/account.css
@@ -28,7 +28,11 @@
     clear: both;
     float: right;
     min-width: 260px;
-    padding-top: 20px;
+    /* The max-width ensures that the widget is not too wide in larger screens,
+     but does not affect the width once the screen size decreases */
+    max-width: 400px;
+    margin-left: auto;
+    background-color: #FAFAFB;
 }
 
 .oe_account_terms {

--- a/addons/account/static/src/views/account_x2many_list_controller.js
+++ b/addons/account/static/src/views/account_x2many_list_controller.js
@@ -1,0 +1,22 @@
+import { ListController } from "@web/views/list/list_controller";
+import { useService } from "@web/core/utils/hooks";
+import {registry} from "@web/core/registry";
+import {listView} from "@web/views/list/list_view";
+
+export class AccountX2ManyListController extends ListController {
+    setup() {
+        super.setup();
+        this.orm = useService("orm");
+        this.action = useService("action");
+    }
+
+    async openRecord(record) {
+        const action = await this.orm.call(record.resModel, 'action_open_business_doc', [record.resId], {});
+        return this.actionService.doAction(action);
+    }
+}
+
+registry.category("views").add("account_x2many_list", {
+    ...listView,
+    Controller: AccountX2ManyListController,
+});

--- a/addons/account/tests/__init__.py
+++ b/addons/account/tests/__init__.py
@@ -13,6 +13,7 @@ from . import test_account_account
 from . import test_account_tax
 from . import test_account_analytic
 from . import test_account_payment
+from . import test_account_payment_duplicate
 from . import test_account_bank_statement
 from . import test_account_invoice_report
 from . import test_account_move_line_tax_details

--- a/addons/account/tests/test_account_payment_duplicate.py
+++ b/addons/account/tests/test_account_payment_duplicate.py
@@ -1,0 +1,229 @@
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install')
+class TestAccountPaymentDuplicateMoves(AccountTestInvoicingCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.company = cls.company_data['company']
+        cls.receivable = cls.company_data['default_account_receivable']
+        cls.payable = cls.company_data['default_account_payable']
+        cls.bank_journal = cls.company_data['default_journal_bank']
+        cls.comp_curr = cls.company_data['currency']
+
+        cls.payment_in = cls.env['account.payment'].create({
+            'amount': 50.0,
+            'payment_type': 'inbound',
+            'partner_id': cls.partner_a.id,
+            'destination_account_id': cls.receivable.id,
+        })
+        cls.payment_out = cls.env['account.payment'].create({
+            'amount': 50.0,
+            'payment_type': 'outbound',
+            'partner_id': cls.partner_a.id,
+            'destination_account_id': cls.payable.id,
+        })
+
+        cls.out_invoice_1 = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'partner_id': cls.partner_a.id,
+            'invoice_line_ids': [(0, 0, {'product_id': cls.product_a.id, 'price_unit': 50.0, 'tax_ids': []})],
+        })
+        cls.in_invoice_1 = cls.env['account.move'].create({
+            'move_type': 'in_invoice',
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'partner_id': cls.partner_a.id,
+            'invoice_line_ids': [(0, 0, {'product_id': cls.product_a.id, 'price_unit': 50.0, 'tax_ids': []})],
+        })
+        cls.out_invoice_2 = cls.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'date': '2017-01-01',
+            'invoice_date': '2017-01-01',
+            'partner_id': cls.partner_a.id,
+            'invoice_line_ids': [(0, 0, {'product_id': cls.product_a.id, 'price_unit': 20.0, 'tax_ids': []})],
+        })
+        (cls.out_invoice_1 + cls.out_invoice_2 + cls.in_invoice_1).action_post()
+
+    def test_duplicate_payments(self):
+        """ Ensure duplicated payments are computed correctly for both inbound and outbound payments.
+        For it to be a duplicate, the partner, the date and the amount must be the same.
+        """
+        payment_in_1 = self.payment_in
+        payment_out_1 = self.payment_out
+
+        # Different type but same partner, amount and date, no duplicate
+        self.assertRecordValues(payment_in_1, [{'duplicate_move_ids': []}])
+
+        # Create duplicate payments
+        payment_in_2 = payment_in_1.copy(default={'date': payment_in_1.date})
+        payment_out_2 = payment_out_1.copy(default={'date': payment_out_1.date})
+        # Inbound payment finds duplicate inbound payment, not the outbound payment with same information
+        self.assertRecordValues(payment_in_2, [{
+            'duplicate_move_ids': [payment_in_1.move_id.id],
+        }])
+        # Outbound payment finds duplicate outbound duplicate, not the inbound payment with same information
+        self.assertRecordValues(payment_out_2, [{
+            'duplicate_move_ids': [payment_out_1.move_id.id],
+        }])
+        # Different date but same amount and same partner, no duplicate
+        payment_out_3 = payment_out_1.copy(default={'date': '2023-12-31'})
+        self.assertRecordValues(payment_out_3, [{'duplicate_move_ids': []}])
+
+        # Different amount but same partner and same date, no duplicate
+        payment_out_4 = self.env['account.payment'].create({
+            'amount': 60.0,
+            'payment_type': 'outbound',
+            'partner_id': self.partner_a.id,
+            'destination_account_id': self.payable.id,
+        })
+        self.assertRecordValues(payment_out_4, [{'duplicate_move_ids': []}])
+
+        # Different partner but same amount and same date, no duplicate
+        payment_out_5 = self.env['account.payment'].create({
+            'amount': 50.0,
+            'payment_type': 'outbound',
+            'partner_id': self.partner_b.id,
+            'destination_account_id': self.payable.id,
+        })
+        self.assertRecordValues(payment_out_5, [{'duplicate_move_ids': []}])
+
+    def test_payment_duplicate_moves(self):
+        """ Ensure payments with matching moves are computed correctly, including journal entries,
+        refunds and statement lines. For it to be a duplicate, the partner, the date, the amount
+        and the account (for bank statements, it can be in the suspense account) must be the same.
+        """
+        payment_in_1 = self.payment_in
+        payment_out_1 = self.payment_out
+
+        # Create statement lines with positive value (inbound payment) and negative value (outbound payment)
+        statement_line_in = self.env['account.bank.statement.line'].create({
+            'date': payment_in_1.date,
+            'journal_id': self.bank_journal.id,
+            'payment_ref': 'line_1_in',
+            'partner_id': self.partner_a.id,
+            'amount': 50.0,
+        })
+        statement_line_out = self.env['account.bank.statement.line'].create({
+            'date': payment_out_1.date,
+            'journal_id': self.bank_journal.id,
+            'payment_ref': 'line_1_out',
+            'partner_id': self.partner_a.id,
+            'amount': -50.0,
+        })
+
+        # Create credit note and refund with same amount, partner and date.
+        credit_note = self.init_invoice('out_refund', amounts=[50.0], invoice_date=payment_in_1.date, partner=self.partner_a)
+        refund = self.init_invoice('in_refund', amounts=[50.0], invoice_date=payment_in_1.date, partner=self.partner_a)
+
+        # create_line_for_reconciliation allows creation of an entry on a specific account. The duplicate moves function
+        # matches credits in a receivable acc or debits in a payable acc, which are the parameters in the helper function
+        # Payment in = credit in a receivable account, hence the negative balance.
+        misc_entry_in = self.create_line_for_reconciliation(-50.0, -50.0, self.comp_curr, payment_in_1.date, self.receivable, self.partner_a)
+        misc_entry_out = self.create_line_for_reconciliation(50.0, 50.0, self.comp_curr, payment_in_1.date, self.payable, self.partner_a)
+
+        # Inbound payment finds statement line, credit note and misc entry crediting receivable account
+        self.assertRecordValues(payment_in_1, [{
+            'duplicate_move_ids': (statement_line_in.move_id + credit_note + misc_entry_in.move_id).ids,
+        }])
+        # Outbound payment finds statement line, refund and misc entry debiting payable account
+        self.assertRecordValues(payment_out_1, [{
+            'duplicate_move_ids': (statement_line_out.move_id + refund + misc_entry_out.move_id).ids,
+        }])
+
+    def test_payment_dup_outstanding_account(self):
+        """ Ensure that moves in other outstanding accounts are also considered as potential duplicates """
+        payment_1 = self.payment_in
+        # In the same journal, a new method line for inbound and a new method for outbound payments will be added
+        journal = payment_1.journal_id
+        outstanding_payment_in = self.company.account_journal_payment_debit_account_id.copy()
+        outstanding_payment_out = self.company.account_journal_payment_credit_account_id.copy()
+        self.env['account.payment.method.line'].create({
+            'name': 'new inbound payment method line',
+            'payment_method_id': journal.available_payment_method_ids[0].id,
+            'payment_type': 'inbound',
+            'journal_id': journal.id,
+            'payment_account_id': outstanding_payment_in.id,
+        })
+        self.env['account.payment.method.line'].create({
+            'name': 'new outbound payment method line',
+            'payment_method_id': journal.available_payment_method_ids[0].id,
+            'payment_type': 'outbound',
+            'journal_id': journal.id,
+            'payment_account_id': outstanding_payment_out.id,
+        })
+        # Create new journal entries using the new outstanding accounts
+        misc_entry_in = self.create_line_for_reconciliation(-50.0, -50.0, self.comp_curr, payment_1.date, outstanding_payment_in, self.partner_a)
+        self.create_line_for_reconciliation(50.0, 50.0, self.comp_curr, payment_1.date, outstanding_payment_out, self.partner_a)
+
+        self.assertRecordValues(payment_1, [{
+            'duplicate_move_ids': [misc_entry_in.move_id.id],  # not misc_entry_out, as the account is for outbound payments
+        }])
+
+    def test_in_payment_multiple_duplicate_inbound_batch(self):
+        """ Ensure duplicated payments are computed correctly when updated in batch,
+        where payments are all of a single payment type
+        """
+        payment_1 = self.payment_in
+        payment_2 = payment_1.copy(default={'date': payment_1.date})
+        payment_3 = payment_1.copy(default={'date': payment_1.date})
+
+        payments = payment_1 + payment_2 + payment_3
+
+        self.assertRecordValues(payments, [
+            {'duplicate_move_ids': (payment_2.move_id + payment_3.move_id).ids},
+            {'duplicate_move_ids': (payment_1.move_id + payment_3.move_id).ids},
+            {'duplicate_move_ids': (payment_1.move_id + payment_2.move_id).ids},
+        ])
+
+    def test_in_payment_multiple_duplicate_mixed_batch(self):
+        """ Ensure duplicated payments are computed correctly when updated in batch,
+        with inbound and outbound payments
+        """
+        payment_in_1 = self.payment_in
+        payment_out_1 = self.payment_out
+        payment_in_2 = payment_in_1.copy(default={'date': payment_in_1.date})
+        payment_out_2 = payment_out_1.copy(default={'date': payment_out_1.date})
+
+        payments = payment_in_1 + payment_out_1 + payment_in_2 + payment_out_2
+
+        self.assertRecordValues(payments, [
+            {'duplicate_move_ids': [payment_in_2.move_id.id]},
+            {'duplicate_move_ids': [payment_out_2.move_id.id]},
+            {'duplicate_move_ids': [payment_in_1.move_id.id]},
+            {'duplicate_move_ids': [payment_out_1.move_id.id]},
+        ])
+
+    def test_register_payment_different_payment_types(self):
+        """ Test that payment wizard correctly calculates duplicate_move_ids """
+        payment_1 = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=self.out_invoice_1.ids).create({})
+        payment_2 = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=self.in_invoice_1.ids).create({})
+        existing_payment_in = self.payment_in
+        existing_payment_out = self.payment_out
+
+        # Payment wizards flag unreconciled existing payments of the same payment type only
+        self.assertRecordValues(payment_1, [{'duplicate_move_ids': [existing_payment_in.move_id.id]}])
+        self.assertRecordValues(payment_2, [{'duplicate_move_ids': [existing_payment_out.move_id.id]}])
+
+    def test_register_payment_single_batch_duplicate_payments(self):
+        """ Test that duplicate_move_ids is correctly calculated for single batches """
+        payment_1 = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=self.out_invoice_1.ids).create({})
+        payment_2 = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=self.out_invoice_2.ids).create({})
+        active_ids = (self.out_invoice_1 + self.out_invoice_2).ids
+        combined_payments = self.env['account.payment.register'].with_context(active_model='account.move', active_ids=active_ids).create({
+            'amount': 50.0,  # amount can be changed manually
+            'group_payment': True,
+            'payment_difference_handling': 'open',
+            'payment_method_line_id': self.inbound_payment_method_line.id,
+        })
+        existing_payment = self.payment_in
+
+        self.assertRecordValues(payment_1, [{'duplicate_move_ids': [existing_payment.move_id.id]}])
+        self.assertRecordValues(payment_2, [{'duplicate_move_ids': []}])  # different amount, not a duplicate
+        # Combined payments does not show payment_1 as duplicate because payment_1 is reconciled
+        self.assertRecordValues(combined_payments, [{'duplicate_move_ids': [existing_payment.move_id.id]}])

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -546,6 +546,27 @@
             </field>
         </record>
 
+        <record id="view_duplicated_moves_tree_js" model="ir.ui.view">
+            <field name="name">account.duplicated.moves.tree.js</field>
+            <field name="model">account.move</field>
+            <field name="mode">primary</field>
+            <field name="inherit_id" ref="account.view_invoice_tree"/>
+            <field name="arch" type="xml">
+                <xpath expr="//tree" position="attributes">
+                    <attribute name="js_class">account_x2many_list</attribute>
+                    <attribute name="create">false</attribute>
+                </xpath>
+                <xpath expr="//field[@name='name']" position="attributes">
+                    <attribute name="column_invisible">True</attribute>
+                </xpath>
+                <xpath expr="//field[@name='name']" position="after">
+                    <!-- For draft moves, name only displays '/'. Since there may be moves of differenty types,
+                         it is better to use display_name indicating what move it refers to when in draft-->
+                    <field name="display_name" decoration-bf="1" string="Number" context="{'name_with_move_type': True}"/>
+                </xpath>
+            </field>
+        </record>
+
         <record id="view_out_invoice_tree" model="ir.ui.view">
             <field name="name">account.out.invoice.tree</field>
             <field name="model">account.move</field>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -698,7 +698,14 @@
                         <!-- Register Payment (only invoices / receipts) -->
                         <button name="action_register_payment" id="account_invoice_payment_btn"
                                 type="object" class="oe_highlight"
-                                invisible="state != 'posted' or payment_state not in ('not_paid', 'partial') or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')"
+                                invisible="state != 'posted' or payment_state not in ('not_paid', 'partial') or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') or invoice_has_outstanding"
+                                context="{'dont_redirect_to_payments': True, 'display_account_trust': True}"
+                                string="Register Payment" data-hotkey="g"
+                                groups="account.group_account_invoice"/>
+                        <!-- Register Payment (only invoices / receipts, with outstanding payments) -->
+                        <button name="action_register_payment" id="account_invoice_payment_secondary_btn"
+                                type="object"
+                                invisible="state != 'posted' or payment_state not in ('not_paid', 'partial') or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') or not invoice_has_outstanding"
                                 context="{'dont_redirect_to_payments': True, 'display_account_trust': True}"
                                 string="Register Payment" data-hotkey="g"
                                 groups="account.group_account_invoice"/>
@@ -750,22 +757,22 @@
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
                          invisible="move_type not in ('out_invoice', 'out_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
-                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> for this customer. You can allocate them to mark this invoice as paid.
+                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> listed below for this customer.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
                          invisible="move_type not in ('in_invoice', 'in_receipt') or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
-                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> for this vendor. You can allocate them to mark this bill as paid.
+                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> listed below for this vendor.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
                          invisible="move_type != 'out_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
-                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> for this customer. You can allocate them to mark this credit note as paid.
+                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding debits</a></bold> listed below for this customer.
                     </div>
                     <div groups="account.group_account_invoice,account.group_account_readonly"
                          class="alert alert-info" role="alert"
                          invisible="move_type != 'in_refund' or not invoice_has_outstanding or payment_state not in ('not_paid', 'partial')">
-                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> for this vendor. You can allocate them to mark this credit note as paid.
+                        You have <bold><a class="alert-link" href="#outstanding" role="button">outstanding credits</a></bold> listed below for this vendor.
                     </div>
                     <div class="alert alert-info" role="alert"
                          invisible="state != 'draft' or auto_post != 'at_date'">
@@ -1203,9 +1210,9 @@
                                             <field name="amount_residual" class="oe_subtotal_footer_separator" invisible="state == 'draft'"/>
                                         </group>
                                         <field name="invoice_outstanding_credits_debits_widget"
-                                            class="oe_invoice_outstanding_credits_debits"
+                                            class="oe_invoice_outstanding_credits_debits py-3"
                                             colspan="2" nolabel="1" widget="payment"
-                                            invisible="state != 'posted'"/>
+                                            invisible="state != 'posted' or not invoice_has_outstanding"/>
                                     </group>
                                 </group>
                             </page>

--- a/addons/account/views/account_payment_view.xml
+++ b/addons/account/views/account_payment_view.xml
@@ -175,6 +175,10 @@
                         The selected payment method requires a bank account but none is set on
                         <button class="oe_link alert-link" type="object" name="action_open_destination_journal" style="padding: 0; vertical-align: baseline;">the destination journal</button>.
                     </div>
+                    <div class="alert alert-warning mb-0" role="alert" invisible="not duplicate_move_ids or state!='draft'">
+                        <span>This payment has the same partner, amount and date as </span>
+                        <field name="duplicate_move_ids" widget="x2many_buttons" string="Duplicated Payments"/>
+                    </div>
                     <sheet>
                         <!-- Invisible fields -->
                         <field name="id" invisible="1"/>

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -42,6 +42,10 @@
                     <div role="alert" class="alert alert-warning" invisible="not missing_account_partners">
                         <span class="fw-bold">Payments related to partners with no bank account specified will be skipped. <button class="oe_link p-0 align-baseline" type="object" name="action_open_missing_account_partners">View Partner(s)</button></span>
                     </div>
+                    <div role="alert" class="alert alert-warning" invisible="not duplicate_move_ids">
+                        <span>This payment has the same partner, amount and date as </span>
+                        <field name="duplicate_move_ids" widget="x2many_buttons" string="Duplicated Payments"/>
+                    </div>
                     <group>
                         <group name="group1">
                             <field name="journal_id" options="{'no_open': True, 'no_create': True}" required="1"/>

--- a/addons/account_payment/views/account_move_views.xml
+++ b/addons/account_payment/views/account_move_views.xml
@@ -10,7 +10,10 @@
             The user must capture/void the authorized transactions before registering a new payment.
             -->
             <xpath expr="//button[@id='account_invoice_payment_btn']" position="attributes">
-                <attribute name="invisible">state != 'posted' or payment_state not in ('partial', 'not_paid') or move_type not in ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt') or authorized_transaction_ids</attribute>
+                <attribute name="invisible" separator="or" add="authorized_transaction_ids"/>
+            </xpath>
+            <xpath expr="//button[@id='account_invoice_payment_secondary_btn']" position="attributes">
+                <attribute name="invisible" separator="or" add="authorized_transaction_ids"/>
             </xpath>
             <xpath expr="//button[@id='account_invoice_payment_btn']" position="after">
                 <field name="authorized_transaction_ids" invisible="1"/>


### PR DESCRIPTION
Users tend to register a new payment for invoices that were reset to draft ot cancelled after being paid, even though a banner is already displayed indicating the existing credit/debt. The duplicate payments created result in a bigger mess later.

The goal is to raise more attention to the existing payments that match the attempted new one, with a simpler message in the move banner and a new warning in payments.

This commit:
- Makes Register Payment button secondary if invoice_has_outstanding is true
- Increases visibility of the outstanding debts/credits session by adding a light background and making it more compact
- Shortens banner message in the move with outstanding debts/credits
- Adds a duplicated_payment_ids and has_duplicated_payment attributes, as well as a computed method
- Displays a banner warning in payments that match an existing draft or posted payment, having same partner, amount and date
- Extends x2many widget to show form view of payment if one existing duplicate, or list view if multiple duplicates
- Adds a test for duplicate payments

task-3754323