### PR TITLE
[IMP] project, *: improve project sharing list views

### DIFF
--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -13,20 +13,20 @@
                 <field name="allow_timesheets" column_invisible="1"/>
             </xpath>
             <xpath expr="//field[@name='child_ids']/tree/field[@name='portal_user_names']" position="after">
-                <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="subtask_effective_hours" string="Sub-tasks Time Spent" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
+                <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide"/>
+                <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide"/>
+                <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-tasks Hours Spent" optional="hide"/>
+                <field name="total_hours_spent" string="Total Hours" widget="timesheet_uom" sum="Total Hours" optional="hide"/>
+                <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1"/>
+                <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}"/>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/tree/field[@name='portal_user_names']" position="after">
-                <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="subtask_effective_hours" string="Sub-tasks Time Spent" widget="timesheet_uom" sum="Sub-tasks Time Spent" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="total_hours_spent" string="Total Time Spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
-                <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}" column_invisible="not parent.allow_timesheets" invisible="not allow_timesheets"/>
+                <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" optional="hide"/>
+                <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="hide"/>
+                <field name="subtask_effective_hours" widget="timesheet_uom" sum="Sub-tasks Hours Spent" optional="hide"/>
+                <field name="total_hours_spent" string="Total Hours" widget="timesheet_uom" sum="Total Hours" optional="hide"/>
+                <field name="remaining_hours" widget="timesheet_uom" sum="Remaining Hours" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1"/>
+                <field name="progress" widget="project_task_progressbar" optional="hide" options="{'overflow_class': 'bg-danger'}"/>
             </xpath>
             <xpath expr="//field[@name='partner_id']" position="after">
                 <field name="encode_uom_in_days" invisible="1"/>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -110,6 +110,7 @@
             <tree position="attributes">
                 <attribute name="delete">0</attribute>
                 <attribute name="import">0</attribute>
+                <attribute name="default_group_by">stage_id</attribute>
             </tree>
             <xpath expr="//field[@widget='res_partner_many2one']" position="attributes">
                 <attribute name="widget">many2one</attribute>

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -240,9 +240,9 @@
                                 <tree editable="bottom" decoration-muted="state in ['1_done','1_canceled']">
                                     <field name="project_id" column_invisible="True"/>
                                     <field name="display_in_project" column_invisible="True"/>
-                                    <field name="state" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
-                                    <field name="priority" widget="priority" optional="show" nolabel="1" width="20px"/>
+                                    <field name="id" optional="hide"/>
+                                    <field name="priority" widget="priority" nolabel="1" width="20px"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px"/>
                                     <field name="subtask_count" column_invisible="1"/>
                                     <field name="closed_subtask_count" column_invisible="1"/>
@@ -278,7 +278,8 @@
                                 <tree editable="bottom" decoration-muted="state in ['1_done','1_canceled']">
                                     <field name="project_id" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
-                                    <field name="priority" widget="priority" optional="show" nolabel="1" width="20px" readonly="1"/>
+                                    <field name="id" optional="hide"/>
+                                    <field name="priority" widget="priority" nolabel="1" width="20px" readonly="1"/>
                                     <field name="state" widget="project_task_state_selection" nolabel="1" width="20px" readonly="1"/>
                                     <field name="subtask_count" column_invisible="1"/>
                                     <field name="closed_subtask_count" column_invisible="1"/>

--- a/addons/sale_project/views/project_sharing_views.xml
+++ b/addons/sale_project/views/project_sharing_views.xml
@@ -26,9 +26,11 @@
             </xpath>
             <xpath expr="//field[@name='child_ids']/tree/field[@name='partner_id']" position="after">
                 <field name="allow_billable" column_invisible="1"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1"/>
             </xpath>
             <xpath expr="//field[@name='depend_on_ids']/tree/field[@name='partner_id']" position="after">
                 <field name="allow_billable" column_invisible="1"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1"/>
             </xpath>
             <xpath expr="//field[@name='child_ids']/tree/field[@name='partner_id']" position="attributes">
                 <attribute name="column_invisible">not parent.allow_billable</attribute>

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -248,6 +248,7 @@
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="allow_billable" column_invisible="True"/>
+                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1"/>
             </field>
             <field name="partner_id" position="attributes">
                 <attribute name="column_invisible">context.get('hide_partner')</attribute>
@@ -261,10 +262,12 @@
         <field name="model">project.task</field>
         <field name="inherit_id" ref="project.project_task_view_tree_base"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='partner_id']" position="after">
+            <field name="sale_line_id" position="attributes">
+                <attribute name="groups">!sales_team.group_sale_salesman</attribute>
+            </field>
+            <field name="sale_line_id" position="before">
                 <field name="sale_line_id" optional="hide" groups="sales_team.group_sale_salesman" options="{'no_create': True}"/>
-                <field name="sale_line_id" optional="hide" options="{'no_open': True}" readonly="1" groups="!sales_team.group_sale_salesman"/>
-            </xpath>
+            </field>
         </field>
     </record>
 

--- a/addons/sale_timesheet/views/project_sharing_views.xml
+++ b/addons/sale_timesheet/views/project_sharing_views.xml
@@ -17,14 +17,6 @@
                     context="{'with_remaining_hours': True, 'with_price_unit': True}" options="{'no_create': True, 'no_open': True}"
                     optional="hide"/>
             </xpath>
-            <xpath expr="//field[@name='child_ids']/tree/field[@name='remaining_hours']" position="after">
-                <field name="remaining_hours_available" column_invisible="True"/>
-                <field name="remaining_hours_so" optional="hide" widget="timesheet_uom" column_invisible="not parent.allow_timesheets"/>
-            </xpath>
-            <xpath expr="//field[@name='depend_on_ids']/tree/field[@name='remaining_hours']" position="after">
-                <field name="remaining_hours_available" column_invisible="True"/>
-                <field name="remaining_hours_so" optional="hide" widget="timesheet_uom" column_invisible="not parent.allow_timesheets"/>
-            </xpath>
             <xpath expr="//field[@name='remaining_hours']" position="after">
                 <field name="allow_billable" invisible="1" />
                 <field name="remaining_hours_available" invisible="1"/>


### PR DESCRIPTION
1) [IMP] project: make project sharing list view group_by stage

Before this commit project sharing list view was not
default groupby anything also list view open from sub-
task stat button.

This commit make list view of project sharing default
groupby `stage` field same as in backend to be
consistant and default groupby stage is useful.

2) [IMP] {sale,hr}_timesheet: remove unwanted string and field

This commit:

Remove unwanted string which causing different labels
for `subtask_effective_hours` field in task form and
project sharing task form view.

Remove unwanted field `remaining_hours_on_so` field
from project sharing subtask and blockby page.

Remove invisible conditons from timesheet related field
from subtask and blockby page to display those field
even though allow timesheet is off as it may contain
task from other project which has allow timesheet
enable on them.

Add ID and SOL field in subtask and blockby page in
project sharing task form view also make priority
field default instead of optional.

Add SOL field in project sharing list view.

task-3764779