### PR TITLE
[IMP] crm: Context difference after a page reload

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -932,7 +932,7 @@ class Lead(models.Model):
         # - ('id', 'in', stages.ids): add columns that should be present
         # - OR ('fold', '=', False): add default columns that are not folded
         # - OR ('team_ids', '=', team_id), ('fold', '=', False) if team_id: add team columns that are not folded
-        team_id = self._context.get('default_team_id')
+        team_id = self._context.get('default_team_id') or self.env.user.sale_team_id.id
         if team_id:
             search_domain = ['|', ('id', 'in', stages.ids), '|', ('team_id', '=', False), ('team_id', '=', team_id)]
         else:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Accessing your CRM pipeline with menu and then triggering a reload will hide some stage

- Set user.sale_team_id to X
- Update crm.stage.team_id
	- 2 with X
	- 2 with False 
- Open CRM/Sales/My Pipeline
	- All stages are displayed
- Reload the page
	- All stages are displayed
	
- Move all lead from a stage with X as team to another stage
- Move all lead from a stage without team to another stage

- Reopen CRM/Sales/My Pipeline
OR
- Reload the page

Current behavior before PR:
- 1 stage is missing, the one with team and without lead
- default_team_id is not defined in context
- context based on the url

Desired behavior after PR is merged:
- All stages are displayed
- Stages displayed via menu are the same after a page reload

opw-3754053

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
