### PR TITLE
[FIX] pos_restaurant: pos_config_id can be selected even if it's not a bar/restaurant

### DIFF
--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -11,7 +11,7 @@ class RestaurantFloor(models.Model):
     _description = 'Restaurant Floor'
 
     name = fields.Char('Floor Name', required=True, help='An internal identification of the restaurant floor')
-    pos_config_id = fields.Many2one('pos.config', string='Point of Sale')
+    pos_config_id = fields.Many2one('pos.config', string='Point of Sale', domain="[('module_pos_restaurant', '=', True)]")
     background_image = fields.Binary('Background Image', help='A background image used to display a floor layout in the point of sale interface')
     background_color = fields.Char('Background Color', help='The background color of the floor layout, (must be specified in a html-compatible format)', default='rgb(210, 210, 210)')
     table_ids = fields.One2many('restaurant.table', 'floor_id', string='Tables', help='The list of tables in this floor')

--- a/doc/cla/corporate/braintec-group.md
+++ b/doc/cla/corporate/braintec-group.md
@@ -16,4 +16,4 @@ Fréderic Garbely frederic.garbely@braintec-group.com https://github.com/BT-fgar
 Kumar Aberer kumar.aberer@braintec-group.com https://github.com/BT-kaberer
 Pascal Zenklusen pascal.zenklusen@braintec-group.com https://github.com/BT-pzenklusen
 Nadal Francisco Garcia nadal.francisco@braintec-group.com https://github.com/BT-nfrancisco
-
+Cristian Rodriguez Navarro cristian.rodriguez@braintec.com https://github.com/BT-crodriguez


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
You can assign a pos.config to a restaurant.floor that is not a bar/restaurant. 
This causes:
- When loading a session in the said pos.config the FloorScreen is loaded. 
- After proceeding with a payment it redirects you back directly to the ProductScreen instead of the FloorScreen. This means that it skips necessary steps for the creation of a new order so it starts failing within the constructor of the WidgetOrder.

**Current behavior before PR:**
You can assign any pos.config to restaurant.floor/s

**Desired behavior after PR is merged:**
You can only assign pos.config that are bar/restaurants to restaurant.floor/s



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
