### PR TITLE
[FIX] account_edi_ubl_cii: filter the control characters

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_cii_facturx.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 from odoo import models, _
 from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, float_repr, is_html_empty, html2plaintext, cleanup_xml_node
-from lxml import etree
 
 from datetime import datetime
 
@@ -182,6 +181,7 @@ class AccountEdiXmlCII(models.AbstractModel):
                 and invoice.purchase_order_reference else invoice.ref or invoice.name,
             'contract_reference': invoice.contract_reference if 'contract_reference' in invoice._fields
                 and invoice.contract_reference else '',
+            'main_template': 'account_edi_ubl_cii.account_invoice_facturx_export_22',
         }
 
         # data used for IncludedSupplyChainTradeLineItem / SpecifiedLineTradeSettlement
@@ -234,12 +234,6 @@ class AccountEdiXmlCII(models.AbstractModel):
         template_values['tax_total_amount'] = balance_sign * tax_details['tax_amount_currency']
 
         return template_values
-
-    def _export_invoice(self, invoice):
-        vals = self._export_invoice_vals(invoice)
-        errors = [constraint for constraint in self._export_invoice_constraints(invoice, vals).values() if constraint]
-        xml_content = self.env['ir.qweb']._render('account_edi_ubl_cii.account_invoice_facturx_export_22', vals)
-        return etree.tostring(cleanup_xml_node(xml_content), xml_declaration=True, encoding='UTF-8'), set(errors)
 
     # -------------------------------------------------------------------------
     # IMPORT

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -1,9 +1,6 @@
 # -*- coding: utf-8 -*-
-
-from lxml import etree
-
 from odoo import models, _
-from odoo.tools import html2plaintext, cleanup_xml_node
+from odoo.tools import html2plaintext
 
 
 class AccountEdiXmlUBL20(models.AbstractModel):
@@ -477,12 +474,6 @@ class AccountEdiXmlUBL20(models.AbstractModel):
             'ubl20_invoice_date_required': self._check_required_fields(invoice, 'invoice_date'),
         })
         return constraints
-
-    def _export_invoice(self, invoice):
-        vals = self._export_invoice_vals(invoice)
-        errors = [constraint for constraint in self._export_invoice_constraints(invoice, vals).values() if constraint]
-        xml_content = self.env['ir.qweb']._render(vals['main_template'], vals)
-        return etree.tostring(cleanup_xml_node(xml_content), xml_declaration=True, encoding='UTF-8'), set(errors)
 
     # -------------------------------------------------------------------------
     # IMPORT


### PR DESCRIPTION
Using `etree.fromstring()` will raise an XMLSyntaxError for special characters such as `b'\x02'`. To avoid this, we can use the XMLParser with parameter "recover".

opw-3203218
opw-3757455
