### PR TITLE
[FIX] web: fix image cache in kanban/activity view

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_record.js
+++ b/addons/web/static/src/views/kanban/kanban_record.js
@@ -84,12 +84,15 @@ export function getImageSrcFromRecordInfo(record, model, field, idOrIds, placeho
         return placeholder;
     } else {
         // Else: fetches the image related to the given id.
-        return url("/web/image", {
+        const params = {
             model,
             field,
             id,
-            unique: imageCacheKey(record.data.write_date),
-        });
+        };
+        if (isCurrentRecord) {
+            params.unique = imageCacheKey(record.data.write_date);
+        }
+        return url("/web/image", params);
     }
 }
 

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -10147,12 +10147,12 @@ QUnit.module("Views", (hooks) => {
         });
         assert.containsOnce(
             target,
-            'img[data-src*="/web/image"][data-src$="&id=1&unique="]',
+            'img[data-src*="/web/image"][data-src$="&id=1"]',
             "image url should contain id of set partner_id"
         );
         assert.containsOnce(
             target,
-            'img[data-src*="/web/image"][data-src$="&id=&unique="]',
+            'img[data-src*="/web/image"][data-src$="&id="]',
             "image url should contain an empty id if partner_id is not set"
         );
     });
@@ -13741,7 +13741,7 @@ QUnit.module("Views", (hooks) => {
         assert.containsN(target, ".o_kanban_group", 2);
 
         await createColumn();
-        
+
         // We don't use the editInput helper as it would trigger a change event automatically.
         // We need to wait for the enter key to trigger the event.
         const input = target.querySelector(".o_column_quick_create input");


### PR DESCRIPTION
The way we cache the image is not right when that image is not on the current record. For instance displaying a partner/user image. The unique key used is not related to that record.

Introduced by https://github.com/odoo/odoo/pull/97544

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
