### PR TITLE
[IMP] l10n_in: autofill PAN from GST number

### DIFF
--- a/addons/l10n_in/models/res_partner.py
+++ b/addons/l10n_in/models/res_partner.py
@@ -27,6 +27,12 @@ class ResPartner(models.Model):
              "Thus, PAN acts as an identifier for the person with the tax department."
     )
 
+    display_pan_warning = fields.Boolean(string="Display pan warning", compute="_compute_display_pan_warning")
+
+    @api.depends('l10n_in_pan')
+    def _compute_display_pan_warning(self):
+        self.display_pan_warning = self.vat and self.l10n_in_pan and self.l10n_in_pan != self.vat[2:12]
+
     @api.onchange('company_type')
     def onchange_company_type(self):
         res = super().onchange_company_type()
@@ -49,6 +55,8 @@ class ResPartner(models.Model):
             state_id = self.env['res.country.state'].search([('l10n_in_tin', '=', self.vat[:2])], limit=1)
             if state_id:
                 self.state_id = state_id
+            if self.vat[2].isalpha():
+                self.l10n_in_pan = self.vat[2:12]
 
     @api.model
     def _commercial_fields(self):

--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -15,6 +15,13 @@
             <xpath expr="//field[@name='vat']" position="after">
                 <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" />
             </xpath>
+            <xpath expr="//sheet" position="before">
+                <field name="display_pan_warning" invisible="1"/>
+                <div class="alert alert-warning" role="alert"
+                        attrs="{'invisible': [('display_pan_warning', '=', False)]}">
+                        PAN number is not same as the 3rd to 12th characters of the GST number.
+                </div>
+            </xpath>
         </field>
     </record>
 </odoo>


### PR DESCRIPTION
Before this PR, users had to manually input the PAN number after entering
the GST number.

With this PR, when a user enters GST number, the PAN number auto-fills
based on the provided GST number.

**task**-3767627
