### PR TITLE
[FIX] l10n_ch: include tax code 230 in total taxable amount

### DIFF
--- a/addons/l10n_ch/data/account_tax_report_data.xml
+++ b/addons/l10n_ch/data/account_tax_report_data.xml
@@ -20,7 +20,7 @@
                     <record id="account_tax_report_line_chtax_200" model="account.report.line">
                         <field name="name">200 - Total amount of agreed or collected consideration incl. from supplies opted for taxation, transfer of supplies acc. to the notification procedure and supplies provided abroad (worldwide turnover)</field>
                         <field name="code">tax_ch_200</field>
-                        <field name="aggregation_formula">tax_ch_302a.balance + tax_ch_303a.balance + tax_ch_312a.balance + tax_ch_313a.balance + tax_ch_342a.balance + tax_ch_343a.balance + tax_ch_382a.balance + tax_ch_383a.balance</field>
+                        <field name="aggregation_formula">tax_ch_230.balance + tax_ch_302a.balance + tax_ch_303a.balance + tax_ch_312a.balance + tax_ch_313a.balance + tax_ch_342a.balance + tax_ch_343a.balance + tax_ch_382a.balance + tax_ch_383a.balance</field>
                         <field name="sequence" eval="1"/>
                     </record>
                     <record id="account_tax_report_line_chtax_205" model="account.report.line">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Update formula of tax 200 to include balance of tax 230.

Current behavior before PR:

When invoicing services with tax code "0% Excluded" (`l10n_ch.vat_O_exclude`) the taxable turnover is negative.

Desired behavior after PR is merged:

It seems the balance of 230 is missing in the formula of the total taxable amount. The taxable turnover 299 in this example is supposed to be 0.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
