### PR TITLE
[FIX] mrp: give default value if precision rounding is zero

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -299,7 +299,7 @@ class MrpProduction(models.Model):
         # Force to prefetch more than 1000 by 1000
         all_raw_moves._fields['forecast_availability'].compute_value(all_raw_moves)
         for production in productions:
-            if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in production.move_raw_ids):
+            if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in production.move_raw_ids.filtered('product_id')):
                 production.components_availability = _('Not Available')
                 production.components_availability_state = 'late'
             else:


### PR DESCRIPTION
The traceback arises when the user removes the product name from add a line in components and change the ``Schedule Date``.

To reproduce this issue:
1. Install ``MRP``
2. Create a new record for ``Manufacturing Order``
3. Add a product and ``confirm`` it
4. Now add a product from add a line in the component and remove the product name, now change the ``Schedule Date``

Traceback in sentry:-
```
AssertionError: precision_rounding must be positive, got 0.0
  File "odoo/http.py", line 2150, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1722, in _serve_db
    return service_model.retrying(self._serve_ir_http, self.env)
  File "odoo/service/model.py", line 133, in retrying
    result = func()
  File "odoo/http.py", line 1749, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1953, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "addons/website/models/ir_http.py", line 235, in _dispatch
    response = super()._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 722, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 24, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 20, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 466, in call_kw
    result = _call_kw_multi(method, model, args, kwargs)
  File "odoo/api.py", line 453, in _call_kw_multi
    result = method(recs, *args, **kwargs)
  File "addons/web/models/models.py", line 1069, in onchange
    todo = [
  File "addons/web/models/models.py", line 1072, in <listcomp>
    if field_name not in done and snapshot0.has_changed(field_name)
  File "addons/web/models/models.py", line 1185, in has_changed
    return self[field_name] != self.record[field_name]
  File "odoo/models.py", line 6577, in __getitem__
    return self._fields[key].__get__(self, type(self))
  File "odoo/fields.py", line 1206, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1388, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 424, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4858, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 101, in determine
    return needle(*args)
  File "addons/mrp/models/mrp_production.py", line 371, in _compute_components_availability
    if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in production.move_raw_ids):
  File "addons/mrp/models/mrp_production.py", line 371, in <genexpr>
    if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in production.move_raw_ids):
  File "odoo/tools/float_utils.py", line 155, in float_compare
    rounding_factor = _float_check_precision(precision_digits=precision_digits,
  File "odoo/tools/float_utils.py", line 29, in _float_check_precision
    assert precision_rounding is None or precision_rounding > 0,\
```

This commit will filtered the ``production.move_raw_ids`` which does not contain product ID.

https://github.com/odoo/odoo/blob/4419dcc41b2ee3d6d2185b6a4865f8df2e1620d0/addons/mrp/models/mrp_production.py#L302

sentry-4837242424

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
