### PR TITLE
[IMP] web: set default time and prevent shifting in the daterange picker

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -421,8 +421,10 @@ export class DateTimePicker extends Component {
             throw new Error(`DateTimePicker error: given "maxDate" comes before "minDate".`);
         }
 
-        const timeValues = this.values.map((val) => [
-            (val || DateTime.local()).hour,
+        const timeValues = this.values.map((val, index) => [
+            index === 1 && !this.values[1]
+                ? (val || DateTime.local()).hour + 1
+                : (val || DateTime.local()).hour,
             val?.minute || 0,
             val?.second || 0,
         ]);
@@ -480,11 +482,7 @@ export class DateTimePicker extends Component {
      * @param {number} focusedDateIndex
      */
     adjustFocus(values, focusedDateIndex) {
-        if (
-            !this.shouldAdjustFocusDate &&
-            this.state.focusDate &&
-            focusedDateIndex === this.props.focusedDateIndex
-        ) {
+        if (!this.shouldAdjustFocusDate && this.state.focusDate) {
             return;
         }
 

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -142,7 +142,9 @@ export class DateTimeField extends Component {
      */
     async addDate(valueIndex) {
         const values = this.values;
-        values[valueIndex] = values[valueIndex ? 0 : 1];
+        values[valueIndex] = valueIndex
+            ? values[0].plus({ hours: 1 })
+            : values[1].minus({ hours: 1 });
 
         this.state.focusedDateIndex = valueIndex;
         this.state.value = values;

--- a/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
+++ b/addons/web/static/tests/core/components/datetime/datetime_picker.test.js
@@ -705,7 +705,7 @@ test.tags("desktop")("additional month, empty range value", async () => {
         ],
         time: [
             [13, 0],
-            [13, 0],
+            [14, 0],
         ],
     });
 
@@ -866,7 +866,7 @@ test.tags("desktop")("range value, previous month", async () => {
         ],
         time: [
             [13, 0],
-            [13, 0],
+            [14, 0],
         ],
     });
 
@@ -901,7 +901,7 @@ test.tags("desktop")("range value, previous month", async () => {
         ],
         time: [
             [13, 0],
-            [13, 0],
+            [14, 0],
         ],
     });
 });


### PR DESCRIPTION
PURPOSE-

- Prevent flickering on clicking apply in daterange picker.
- The time selector in the daterange,  time default to the current hour(rounded down to the hour) and the 'to' time default to the next hour .
 - Stop automatic shifting of month when we select a range in the month on the
 right panel.

SPECIFICATIONS-

- Check the current default hours and increase the hours by +1 if index==1.
- prevent automatic shifting of month in daterange.

Task:3471424

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
