### PR TITLE
[REF] spreadsheet: remove style from pivot table

### DIFF
--- a/addons/spreadsheet/static/src/@types/pivot.d.ts
+++ b/addons/spreadsheet/static/src/@types/pivot.d.ts
@@ -106,7 +106,7 @@ declare module "@spreadsheet" {
         isHeader: boolean;
         domain?: string[];
         content?: string;
-        style?: object;
+        type?: "TOP_LEVEL_ROW_HEADER" | "COLUMN_HEADER" | "INDENTED_ROW_HEADER" | "MEASURE" | "TOP_LEFT_CELL";
         measure?: string;
     }
 

--- a/addons/spreadsheet/static/src/pivot/pivot_table.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_table.js
@@ -1,8 +1,6 @@
 /** @odoo-module */
 // @ts-check
 
-import { HEADER_STYLE, TOP_LEVEL_STYLE, MEASURE_STYLE } from "@spreadsheet/helpers/constants";
-
 /**
  * @typedef {import("@spreadsheet").SPTableColumn} SPTableColumn
  * @typedef {import("@spreadsheet").SPTableRow} SPTableRow
@@ -210,17 +208,22 @@ export class SpreadsheetPivotTable {
     _getPivotCell(col, row, includeTotal = true) {
         const colHeadersHeight = this.getNumberOfHeaderRows();
         if (col === 0 && row === colHeadersHeight - 1) {
-            return { content: this._rowTitle, isHeader: true, style: HEADER_STYLE };
+            return { content: this._rowTitle, isHeader: true, type: "TOP_LEFT_CELL" };
         } else if (row <= colHeadersHeight - 1) {
             const domain = this._getColHeaderDomain(col, row);
-            const style = row === colHeadersHeight - 1 ? MEASURE_STYLE : TOP_LEVEL_STYLE;
-            return { domain, isHeader: true, style };
+            const type = row === colHeadersHeight - 1 ? "MEASURE" : "COLUMN_HEADER";
+            return { domain, isHeader: true, type };
         } else if (col === 0) {
             const rowIndex = row - colHeadersHeight;
             const domain = this._getRowDomain(rowIndex);
             const indent = this._rows[rowIndex].indent;
-            const style = indent <= 1 ? TOP_LEVEL_STYLE : indent === 2 ? HEADER_STYLE : undefined;
-            return { domain, isHeader: true, style };
+            const type =
+                indent <= 1
+                    ? "TOP_LEVEL_ROW_HEADER"
+                    : indent === 2
+                    ? "INDENTED_ROW_HEADER"
+                    : undefined;
+            return { domain, isHeader: true, type };
         } else {
             const rowIndex = row - colHeadersHeight;
             if (!includeTotal && this._isTotalRow(rowIndex)) {

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_plugin.js
@@ -16,8 +16,29 @@ import { CommandResult } from "../../o_spreadsheet/cancelled_reason";
 import { _t } from "@web/core/l10n/translation";
 import { deepCopy } from "@web/core/utils/objects";
 import { OdooCorePlugin } from "@spreadsheet/plugins";
+import { HEADER_STYLE, MEASURE_STYLE, TOP_LEVEL_STYLE } from "@spreadsheet/helpers/constants";
 
 const { isDefined } = helpers;
+
+/**
+ * Get the style to apply to a cell according to its type
+ *
+ * @param {SPTableCell["type"]} type
+ * @returns {Object | undefined}
+ */
+function getPivotStyle(type) {
+    switch (type) {
+        case "TOP_LEVEL_ROW_HEADER":
+        case "COLUMN_HEADER":
+            return TOP_LEVEL_STYLE;
+        case "INDENTED_ROW_HEADER":
+        case "TOP_LEFT_CELL":
+            return HEADER_STYLE;
+        case "MEASURE":
+            return MEASURE_STYLE;
+    }
+    return undefined;
+}
 
 export class PivotCorePlugin extends OdooCorePlugin {
     static getters = /** @type {const} */ ([
@@ -354,13 +375,13 @@ export class PivotCorePlugin extends OdooCorePlugin {
         const args = pivotCell.domain
             ? [pivotId, pivotCell.measure, ...pivotCell.domain].filter(isDefined)
             : undefined;
-
+        const style = getPivotStyle(pivotCell.type);
         this.dispatch("UPDATE_CELL", {
             sheetId,
             col,
             row,
             content: pivotCell.content || (args ? makePivotFormula(formula, args) : undefined),
-            style: pivotCell.style,
+            style,
         });
     }
 


### PR DESCRIPTION
This commit removes the style from SpreadsheetPivotTable object as it does not make sense to have it there. The style should be applied to the pivot table when inserting it into the spreadsheet.

This will allow to reuse `getPivotCells` method in the pivot dialog

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
