### PR TITLE
[FIX] partner_autocomplete: change logger error to warning

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -142,7 +142,7 @@ class ResPartner(models.Model):
             try:
                 vies_result = check_vies(vat)
             except Exception:
-                _logger.exception("Failed VIES VAT check.")
+                _logger.warning("Failed VIES VAT check.", exc_info=True)
             if vies_result:
                 name = vies_result['name']
                 if vies_result['valid'] and name != '---':


### PR DESCRIPTION
``One of the parts of the number are invalid or unknown`` error occurs when the user adds a Tax ID.

This commit changes the logger exception to a warning to avoid an unnecessary error in the log.

sentry-4880057848, 4972280626

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
