### PR TITLE
[FIX]snailmail: Cover page duplex fix

### DIFF
--- a/addons/snailmail/models/snailmail_letter.py
+++ b/addons/snailmail/models/snailmail_letter.py
@@ -4,7 +4,7 @@ import re
 import base64
 import io
 
-from PyPDF2 import PdfFileReader, PdfFileMerger, PdfFileWriter
+from PyPDF2 import PdfFileReader, PdfFileWriter
 from reportlab.platypus import Frame, Paragraph, KeepInFrame
 from reportlab.lib.units import mm
 from reportlab.lib.pagesizes import A4
@@ -450,6 +450,7 @@ class SnailmailLetter(models.Model):
         return all(record[key] for key in required_keys)
 
     def _append_cover_page(self, invoice_bin: bytes):
+        out_writer = PdfFileWriter()
         address_split = self.partner_id.with_context(show_address=True, lang='en_US')._get_name().split('\n')
         address_split[0] = self.partner_id.name or self.partner_id.parent_id and self.partner_id.parent_id.name or address_split[0]
         address = '<br/>'.join(address_split)
@@ -472,13 +473,16 @@ class SnailmailLetter(models.Model):
         invoice = PdfFileReader(io.BytesIO(invoice_bin))
         cover_bin = io.BytesIO(cover_buf.getvalue())
         cover_file = PdfFileReader(cover_bin)
-        merger = PdfFileMerger()
+        out_writer.appendPagesFromReader(cover_file)
 
-        merger.append(cover_file, import_bookmarks=False)
-        merger.append(invoice, import_bookmarks=False)
+        # Add a blank buffer page to avoid printing behind the cover page
+        if self.duplex:
+            out_writer.addBlankPage()
+
+        out_writer.appendPagesFromReader(invoice)
 
         out_buff = io.BytesIO()
-        merger.write(out_buff)
+        out_writer.write(out_buff)
         return out_buff.getvalue()
 
     def _overwrite_margins(self, invoice_bin: bytes):


### PR DESCRIPTION
When using a cover page with a duplex letter, it would print the content of the letter behind the cover page due to an extra blank page missing.

Using Unicode characters in the address would result in black boxes. This is fixed by using the Lato font provided by the web module.
