### PR TITLE
[FIX] web_editor: insert table as direct child of list with li

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -189,7 +189,15 @@ function insert(editor, data, isText = true) {
         } else {
             currentNode.after(nodeToInsert);
         }
-        if (currentNode.tagName !== 'BR' && isShrunkBlock(currentNode)) {
+        if (
+            currentNode.tagName !== 'BR' &&
+            isShrunkBlock(currentNode) &&
+            !(
+                currentNode.nodeName === 'LI' &&
+                currentNode.nextElementSibling &&
+                currentNode.nextElementSibling.nodeName === 'TABLE'
+            )
+        ) {
             currentNode.remove();
         }
         currentNode = nodeToInsert;

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/deleteBackward.js
@@ -239,7 +239,7 @@ HTMLElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false, 
 };
 
 HTMLLIElement.prototype.oDeleteBackward = function (offset, alreadyMoved = false) {
-    if (offset > 0 || this.previousElementSibling) {
+    if (offset > 0 || this.previousElementSibling && this.previousElementSibling.nodeName !== 'TABLE') {
         // If backspace inside li content or if the li is not the first one,
         // it behaves just like in a normal element.
         HTMLElement.prototype.oDeleteBackward.call(this, offset, alreadyMoved);

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
@@ -109,6 +109,71 @@ describe('List', () => {
                             `),
                         });
                     });
+                    it('should insert a table as direct child of empty list with li', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<ul><li>[]</li></ul>',
+                            stepFunction: async editor => {
+                                await editor.execCommand('insertHTML', unformat(`
+                                <table class="table table-bordered">
+                                    <tbody>
+                                        <tr>
+                                            <td><br></td>
+                                            <td><br></td>
+                                            <td><br></td>
+                                        </tr>
+                                    </tbody>
+                                </table>`
+                            )
+                        )},
+                            contentAfter: unformat(`
+                            <ul>
+                                <li></li>
+                                <table class="table table-bordered">
+                                    <tbody>
+                                        <tr>
+                                            <td><br></td>
+                                            <td><br></td>
+                                            <td><br></td>
+                                         </tr>
+                                    </tbody>
+                                </table>[]
+                                <li></li>
+                            </ul>`),
+                        });
+                    });
+                    it('should insert a table as direct child of list without li, When li has content', async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore: '<ul><li>test[]</li></ul>',
+                            stepFunction: async editor => {
+                                await editor.execCommand('insertHTML', unformat(`
+                                <table class="table table-bordered">
+                                    <tbody>
+                                        <tr>
+                                            <td><br></td>
+                                            <td><br></td>
+                                            <td><br></td>
+                                        </tr>
+                                    </tbody>
+                                </table>`
+                            )
+                        )},
+                            contentAfter: unformat(`
+                            <ul>
+                                <li>test</li>
+                                <table class="table table-bordered">
+                                    <tbody>
+                                        <tr>
+                                            <td><br></td>
+                                            <td><br></td>
+                                            <td><br></td>
+                                        </tr>
+                                    </tbody>
+                                </table>[]
+                                <li></li>
+                            </ul>
+                         `),
+                        });
+                    });
                     it('should create a new unordered list if current node is inside a nav-item list', async () => {
                         await testEditor(BasicEditor, {
                             contentBefore: '<ul><li class="nav-item">a[]b</li></ul>',


### PR DESCRIPTION
**Current behavior before PR:**

When using the /table command within an empty list item (LI), the table is inserted directly under the list as a sibling of the current LI (appearing before it without a list). Additionally, an extra LI is appended after the table.

**Desired behavior after PR is merged:**

When a table is inserted within an LI, it becomes a direct child of the list along with the LI. An additional LI is added after the table. If the user removes this extra LI after the table, it becomes an unremovable p.

task-3550599
