### PR TITLE
[FIX] hr,mail: make avatar card popover visible properly for mobile view 

### DIFF
--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.xml
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.xml
@@ -7,7 +7,7 @@
     </t>
 
     <t t-name="hr.avatarCardUserInfos">
-        <small class="text-muted" t-if="user.job_title" t-esc="user.job_title"/>
-        <span class="text-muted" t-if="user.department_id" data-tooltip="Department" t-esc="user.department_id[1]"/>
+        <small class="text-muted text-truncate" t-if="user.job_title" t-att-title="user.job_title" t-esc="user.job_title"/>
+        <span class="text-muted text-truncate" t-if="user.department_id" data-tooltip="Department" t-att-title="user.department_id[1]" t-esc="user.department_id[1]"/>
     </t>
 </templates>

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -34,5 +34,6 @@ export class AvatarCardPopover extends Component {
 
     onSendClick() {
         this.openChat(this.user.id);
+        this.props.close();
     }
 }

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.scss
@@ -15,5 +15,8 @@
 }
 
 .o_avatar_card {
-    width: 380px;
+    max-width: 380px;
+    @media screen  and (max-width: 480px) {
+        max-width: 90vw;
+    }
 }

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -17,13 +17,13 @@
                             <i t-elif="!user.im_status" class="fa fa-fw fa-question-circle" title="No IM status available"/>
                         </span>
                     </span>
-                    <div class="d-flex flex-column o_card_user_infos">
+                    <div class="d-flex flex-column o_card_user_infos overflow-hidden">
                         <span class="fw-bold" t-esc="user.name"/>
                         <t t-if="userInfoTemplate" t-call="{{userInfoTemplate}}"/>
-                        <a t-if="email" t-att-href="'mailto:'+email">
+                        <a t-if="email" t-att-href="'mailto:'+email" t-att-title="email" class="text-truncate">
                             <i class="fa fa-fw fa-envelope me-1"/><t t-esc="email"/>
                         </a>
-                        <a t-if="phone" t-att-href="'tel:'+phone">
+                        <a t-if="phone" t-att-href="'tel:'+phone" t-att-title="phone" class="text-truncate">
                             <i class="fa fa-fw fa-phone me-1"/><t t-esc="phone"/>
                         </a>
                     </div>

--- a/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2many_avatar_user_field/many2many_avatar_user_field.js
@@ -33,7 +33,7 @@ const WithUserChatter = (T) =>
             return {
                 ...super.getTagProps(...arguments),
                 onImageClicked: (ev) => {
-                    if (this.env.isSmall || this.relation !== "res.users") {
+                    if (this.relation !== "res.users") {
                         return;
                     }
                     const target = ev.currentTarget;

--- a/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
+++ b/addons/mail/static/src/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field.js
@@ -26,7 +26,7 @@ const WithUserChatter = (T) =>
         onClickAvatar(ev) {
             const id = this.props.record.data[this.props.name][0] ?? false;
             if (id !== false) {
-                if (this.env.isSmall || this.relation !== "res.users") {
+                if (this.relation !== "res.users") {
                     return;
                 }
                 const target = ev.currentTarget;


### PR DESCRIPTION
PURPOSE
The card is simply too wide for the display in mobile view.

SPECIFICATIONS
- made the avatar card responsive
- enabled the avatar card popover for m2x avatar user widget
- close avatar card when clicking on 'send message'

Task-3713375

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
