### PR TITLE
[IMP] models: avoid querying the database for sorted(key=None)

### DIFF
--- a/addons/account/tests/test_account_move_out_invoice.py
+++ b/addons/account/tests/test_account_move_out_invoice.py
@@ -2694,7 +2694,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         })
         invoice.action_post()
 
-        self.assertRecordValues(invoice.line_ids.sorted('tax_line_id'), [
+        self.assertRecordValues(invoice.line_ids.sorted(lambda l: bool(l.tax_line_id)), [
             # Product line
             {'tax_line_id': False,          'tax_ids': taxes.ids,       'tax_tag_ids': (tags[0] + tags[4]).ids},
             # Receivable line
@@ -2706,7 +2706,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
 
         refund = invoice._reverse_moves(cancel=True)
 
-        self.assertRecordValues(refund.line_ids.sorted('tax_line_id'), [
+        self.assertRecordValues(refund.line_ids.sorted(lambda l: bool(l.tax_line_id)), [
             # Product line
             {'tax_line_id': False,          'tax_ids': taxes.ids,       'tax_tag_ids': (tags[2] + tags[6]).ids},
             # Receivable line
@@ -4671,7 +4671,7 @@ class TestAccountMoveOutInvoiceOnchanges(AccountTestInvoicingCommon):
         })
         invoice.action_post()
 
-        self.assertRecordValues(invoice.line_ids.sorted('tax_line_id'), [
+        self.assertRecordValues(invoice.line_ids.sorted(lambda l: bool(l.tax_line_id)), [
             # Product line
             {'tax_line_id': False, 'tax_tag_ids': (tags_a[0] + tags_b[0]).ids},
             # Receivable line

--- a/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
+++ b/addons/mrp/tests/test_warehouse_multistep_manufacturing.py
@@ -817,10 +817,10 @@ class TestMultistepManufacturingWarehouse(TestMrpCommon):
         for picking in mo.picking_ids:
             if demo in [m.product_id for m in picking.move_ids_without_package]:
                 self.assertEqual(len(picking.move_ids_without_package), 3, "Should have 3 moves for: Demo, Bprod1 and Bprod2")
-                self.assertEqual([move.product_id for move in picking.move_ids_without_package.sorted('product_id')], [demo, bprod1, bprod2])
+                self.assertEqual([move.product_id for move in picking.move_ids_without_package.sorted(lambda m: bool(m.product_id))], [demo, bprod1, bprod2])
             else:
                 self.assertEqual(len(picking.move_ids_without_package), 2, "Should have 2 moves for: Comp1 and Comp2")
-                self.assertEqual([move.product_id for move in picking.move_ids_without_package.sorted('product_id')], [comp1, comp2])
+                self.assertEqual([move.product_id for move in picking.move_ids_without_package.sorted(lambda m: bool(m.product_id))], [comp1, comp2])
 
     def test_pick_components_uses_shipping_policy_from_picking_type(self):
         self.warehouse.manufacture_steps = "pbm"

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -320,10 +320,10 @@ class StockLocation(models.Model):
                                                        (not rule.category_id or rule.category_id in categs) and
                                                        (not rule.package_type_ids or package_type in rule.package_type_ids))
 
-        putaway_rules = putaway_rules.sorted(lambda rule: (rule.package_type_ids,
-                                                           rule.product_id,
-                                                           rule.category_id == categs[:1],  # same categ, not a parent
-                                                           rule.category_id),
+        putaway_rules = putaway_rules.sorted(lambda rule: (bool(rule.package_type_ids),
+                                                           bool(rule.product_id),
+                                                           bool(rule.category_id == categs[:1]),  # same categ, not a parent
+                                                           bool(rule.category_id)),
                                              reverse=True)
 
         putaway_location = None

--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -106,7 +106,7 @@ class IrUiView(models.Model):
         # Website-specific views need to be updated first because they might
         # be relocated to new ids by the cow if they are involved in the
         # inheritance tree.
-        for view in self.with_context(active_test=False).sorted(key='website_id', reverse=True):
+        for view in self.with_context(active_test=False).sorted('website_id.id'):
             # Make sure views which are written in a website context receive
             # a value for their 'key' field
             if not view.key and not vals.get('key'):

--- a/odoo/addons/base/tests/test_api.py
+++ b/odoo/addons/base/tests/test_api.py
@@ -651,38 +651,6 @@ class TestAPI(SavepointCaseWithUserDemo):
         by_name_ids = [p.id for p in sorted(ps, key=lambda p: p.name, reverse=True)]
         self.assertEqual(ps.sorted('name', reverse=True).ids, by_name_ids)
 
-        # sorted doesn't filter out new records but don't sort them either (limitation)
-        new_p = self.env['res.partner'].new({
-            'child_ids': [
-                Command.create({'name': 'z'}),
-                Command.create({'name': 'a'}),
-            ],
-        })
-        self.assertEqual(len(new_p.child_ids.sorted()), 2)
-
-        # sorted keeps the _prefetch_ids
-        partners_with_children = self.env['res.partner'].create([
-            {
-                'name': 'required',
-                'child_ids': [
-                    Command.create({'name': 'z'}),
-                    Command.create({'name': 'a'}),
-                ],
-            },
-            {
-                'name': 'required',
-                'child_ids': [
-                    Command.create({'name': 'z'}),
-                    Command.create({'name': 'a'}),
-                ],
-            },
-        ])
-        partners_with_children.invalidate_model(['name'])
-        # Only one query to fetch name of children of each partner
-        with self.assertQueryCount(1):
-            for partner in partners_with_children:
-                partner.child_ids.sorted('id').mapped('name')
-
     def test_group_on(self):
         p0, p1, p2 = self.env['res.partner'].create([
             {'name': "bob", 'function': "guest"},

--- a/odoo/addons/base/tests/test_expression.py
+++ b/odoo/addons/base/tests/test_expression.py
@@ -541,7 +541,7 @@ class TestExpression(SavepointCaseWithUserDemo, TransactionExpressionCase):
         assert parents and leaves, "did we test something?"
 
         # check `in` condition containing False or/and an id
-        leaves_with_parent = leaves.sorted('parent_id', reverse=True) # Prioritize leaves with parents
+        leaves_with_parent = leaves.sorted('parent_id.id')  # Prioritize leaves with parents
         leaves_or_parent = self._search(categories, [('child_ids', 'in', [leaves_with_parent[0].id, False])])
         self.assertEqual(leaves_or_parent, leaves | leaves_with_parent[0].parent_id)
 

--- a/odoo/addons/test_orm/tests/__init__.py
+++ b/odoo/addons/test_orm/tests/__init__.py
@@ -15,6 +15,7 @@ from . import (
     test_related_translation,
     test_schema,
     test_search,
+    test_sort,
     test_timeit,
     test_ui,
     test_unity_read,

--- a/odoo/addons/test_orm/tests/test_sort.py
+++ b/odoo/addons/test_orm/tests/test_sort.py
@@ -1,0 +1,205 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.api import NewId
+from odoo.fields import Command
+from odoo.tests import TransactionCase
+
+
+class TestSort(TransactionCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.countries = cls.env['test_orm.country'].create([
+            {'name': 'B'},
+            {'name': 'A'},
+            {'name': 'C'},
+        ])
+        b, a, c = cls.countries
+        cls.cities = cls.env['test_orm.city'].create([
+            {'name': 'c2', 'country_id': c.id},
+            {'name': 'b1', 'country_id': b.id},
+            {'name': 'b2', 'country_id': b.id},
+            {'name': 'c1', 'country_id': c.id},
+            {'name': 'a1', 'country_id': a.id},
+            {'name': 'a2', 'country_id': a.id},
+        ])
+
+    def test_basic(self):
+        db_result = self.env['test_orm.country'].search([])
+        with self.assertQueryCount(1):
+            # 1 query to fetch the fields, in practice it is already prefetched
+            self.assertEqual(db_result.ids, self.countries.sorted().ids)
+        with self.assertQueryCount(0):
+            self.assertEqual(db_result[::-1].ids, self.countries.sorted(reverse=True).ids)
+        self.assertEqual(
+            self.countries.sorted().mapped('name'),
+            ['A', 'B', 'C']
+        )
+
+    def test_stable(self):
+        self.assertEqual(
+            self.cities.sorted('name', reverse=True).sorted('country_id.id'),
+            self.cities.sorted(lambda c: (-c.country_id.id, c.name), reverse=True),
+        )
+
+    def test_basic_m2o(self):
+        db_result = self.env['test_orm.city'].search([])
+        with self.assertQueryCount(2):
+            # 1 query to fetch the fields of both models,
+            # in practice at least one is already prefetched or needs to be and the other is likely to be needed too
+            self.assertEqual(db_result.ids, self.cities.sorted().ids)
+        with self.assertQueryCount(0):
+            self.assertEqual(db_result[::-1].ids, self.cities.sorted(reverse=True).ids)
+        self.assertEqual(
+            self.cities.sorted().mapped('name'),
+            ['a1', 'a2', 'b1', 'b2', 'c1', 'c2']
+        )
+
+    def test_basic_boolean(self):
+        records = self.env['test_orm.model_active_field'].create([{'name': v} for v in 'abc'])
+        records[1].active = False
+        t_records = records.filtered('active')
+        f_records = records - t_records
+        with self.assertQueryCount(0):
+            records.sorted('active, name')
+        self.assertEqual(f_records + t_records, records.sorted('active, name'))
+        self.assertEqual(t_records + f_records, records.sorted('active DESC, name'))
+
+    def test_custom_m2o(self):
+        order = 'country_id DESC, id ASC'
+        db_result = self.env['test_orm.city'].search([], order=order)
+        with self.assertQueryCount(2):
+            # 1 query to fetch the fields of both models,
+            # in practice at least one is already prefetched or needs to be and the other is likely to be needed too
+            self.assertEqual(db_result.ids, self.cities.sorted(order).ids)
+        with self.assertQueryCount(0):
+            self.assertEqual(db_result[::-1].ids, self.cities.sorted(order, reverse=True).ids)
+        self.assertEqual(
+            self.cities.sorted(order).mapped('name'),
+            ['c2', 'c1', 'b1', 'b2', 'a1', 'a2'],
+        )
+
+    def test_nulls(self):
+        cities = self.env['test_orm.city'].create([
+            {'name': 'not null 2', 'country_id': self.countries[2].id},
+            {'name': 'not null 0', 'country_id': self.countries[0].id},
+            {'name': False, 'country_id': self.countries[1].id},
+            {'name': "", 'country_id': False},
+            {'name': False, 'country_id': False},
+            {'name': 'not null 1', 'country_id': self.countries[1].id},
+        ])
+
+        for order in [
+            'country_id ASC, id',
+            'country_id DESC, id',
+            'country_id ASC NULLS FIRST, id',
+            'country_id DESC NULLS FIRST, id',
+            'country_id ASC NULLS LAST, id',
+            'country_id DESC NULLS LAST, id',
+            'name ASC, id',
+            'name DESC, id',
+            'name ASC NULLS FIRST, id',
+            'name DESC NULLS FIRST, id',
+            'name ASC NULLS LAST, id',
+            'name DESC NULLS LAST, id',
+        ]:
+            with self.subTest(order=order):
+                self.assertEqual(
+                    self.env['test_orm.city'].search([('id', 'in', cities.ids)], order=order).mapped('name'),
+                    cities.sorted(order).mapped('name')
+                )
+
+    def test_collation(self):
+        countries = self.env['test_orm.country'].create([
+            {'name': 'é'},
+            {'name': 'e'},
+            {'name': 'É'},
+            {'name': '1.0'},
+            {'name': '1,0'},
+            {'name': '01'},
+            {'name': '10'},
+            {'name': '9'},
+            {'name': 'Ab'},
+            {'name': '👍'},
+            {'name': 'AB'},
+            {'name': 'Aa'},
+            {'name': 'AA'},
+        ])
+
+        for order in [
+            "name DESC",
+            "name ASC",
+        ]:
+            with self.subTest(order=order):
+                self.assertEqual(
+                    countries.search([('id', 'in', countries.ids)], order=order).mapped('name'),
+                    countries.sorted(order).mapped('name')
+                )
+
+    def test_sorted_recursion(self):
+        categories = self.env['test_orm.category'].search([])
+        for order in [
+            'parent ASC, id ASC',
+            'parent ASC, id DESC',
+            'parent DESC, id ASC',
+            'parent DESC, id DESC',
+        ]:
+            with self.subTest(order=order):
+                self.assertEqual(
+                    categories.search([('id', 'in', categories.ids)], order=order).mapped('name'),
+                    categories.sorted(order).mapped('name')
+                )
+
+    def test_compare_new_id(self):
+        self.assertLess(5, NewId())
+        self.assertLess(3, NewId(4))
+        self.assertGreater(5, NewId(4))
+        self.assertGreaterEqual(5, NewId(4))
+        self.assertLess(4, NewId(4))
+        self.assertGreater(NewId(5), NewId(4))
+
+    def test_sorted_new_id(self):
+        new_countries = self.env['test_orm.country'].concat(*[
+            self.env['test_orm.country'].new(vals)
+            for vals in [
+                {'name': 'B'},
+                {'name': 'A'},
+                {'name': 'C'},
+            ]
+        ])
+
+        order = 'id'  # new id after existing ones
+        self.assertEqual(
+            (self.countries + new_countries).sorted(order),
+            self.countries.sorted(order) + new_countries.sorted(order),
+        )
+
+        order = 'id DESC'  # new id before existing ones
+        self.assertEqual(
+            (self.countries + new_countries).sorted(order),
+            new_countries.sorted(order) + self.countries.sorted(order),
+        )
+
+    def test_prefetch(self):
+        # sorted keeps the _prefetch_ids
+        partners_with_children = self.env['res.partner'].create([
+            {
+                'name': 'required',
+                'child_ids': [
+                    Command.create({'name': 'z'}),
+                    Command.create({'name': 'a'}),
+                ],
+            },
+            {
+                'name': 'required',
+                'child_ids': [
+                    Command.create({'name': 'z'}),
+                    Command.create({'name': 'a'}),
+                ],
+            },
+        ])
+        partners_with_children.invalidate_model(['name'])
+        # Only one query to fetch name of children of each partner
+        with self.assertQueryCount(1):
+            for partner in partners_with_children:
+                partner.child_ids.sorted('id').mapped('name')

--- a/odoo/orm/identifiers.py
+++ b/odoo/orm/identifiers.py
@@ -1,6 +1,8 @@
+import functools
 import typing
 
 
+@functools.total_ordering
 class NewId:
     """ Pseudo-ids for new records, encapsulating an optional origin id (actual
         record id) and an optional reference (any value).
@@ -23,6 +25,15 @@ class NewId:
 
     def __hash__(self):
         return self.__hash
+
+    def __lt__(self, other):
+        if isinstance(other, NewId):
+            other = other.origin
+            if other is None:
+                return other > self.origin if self.origin else False
+        if isinstance(other, int):
+            return bool(self.origin) and self.origin < other
+        return NotImplemented
 
     def __repr__(self):
         return (


### PR DESCRIPTION
The sorting without a key was always doing a database query to avoid parsing the default `_order`.
That extra query could be a performance issue when sorting records in a loop.

Instead, we now support the same syntax as for the `order` attribute for `search` or `fetch`, including the `NULLS` management, as well as the implicit sorting according to the related many2one field.

Multiple bugs are fixed:
* the previous implementation was unexpected when using `sorted('many2one_id')` because `__lt__` was implemented to do only set comparison and not ordering. Some pieces of code had to be adapted because they were using that bug as a feature. 
Note that the behavior was working before only because it used `__lt__` and not `__le__` for instance, leading to the operator being equivalent to using `bool`
* Using `.sorted()` on a new record would just discard silently the record.
* Using `.sorted(lambda r: r.id)` would be an issue in compute methods because `NewId` is not sortable (even if coming from an origin)
* Avoid flushing if not needed yet, allowing to use `sorted` as expected in more contexts

odoo/enterprise#88105
