### PR TITLE
[FIX] web: correctly set the user settings

### DIFF
--- a/addons/web/static/src/core/user_service.js
+++ b/addons/web/static/src/core/user_service.js
@@ -57,7 +57,7 @@ export const userService = {
                 return settings;
             },
             async setUserSettings(key, value) {
-                settings = await env.services.orm.call(
+                const changedSettings = await env.services.orm.call(
                     "res.users.settings",
                     "set_res_users_settings",
                     [[this.settings.id]],
@@ -67,6 +67,7 @@ export const userService = {
                         },
                     }
                 );
+                Object.assign(settings, changedSettings);
             },
             name: session.name,
             userName: session.username,

--- a/addons/web/static/tests/core/user_service_tests.js
+++ b/addons/web/static/tests/core/user_service_tests.js
@@ -3,6 +3,8 @@
 import { registry } from "@web/core/registry";
 import { userService } from "@web/core/user_service";
 import { makeTestEnv } from "../helpers/mock_env";
+import { session } from "@web/session";
+import { patchWithCleanup } from "@web/../tests/helpers/utils";
 
 const serviceRegistry = registry.category("services");
 
@@ -24,4 +26,23 @@ QUnit.test("successive calls to hasGroup", async (assert) => {
     assert.strictEqual(hasGroupXAgain, true);
 
     assert.verifySteps(["res.users/has_group/x", "res.users/has_group/y"]);
+});
+
+QUnit.test("set user settings do not override old valid keys", async (assert) => {
+    patchWithCleanup(session, {
+        ...session,
+        user_settings: { a: 1, b: 2 },
+    });
+    serviceRegistry.add("user", userService);
+
+    const mockRPC = (route, args) => {
+        assert.step(JSON.stringify(args.kwargs.new_settings));
+        return { a: 3, c: 4 };
+    };
+    const env = await makeTestEnv({ mockRPC });
+    assert.deepEqual(env.services.user.settings, { a: 1, b: 2 });
+
+    await env.services.user.setUserSettings("a", 3);
+    assert.verifySteps(['{"a":3}']);
+    assert.deepEqual(env.services.user.settings, { a: 3, b: 2, c: 4 });
 });


### PR DESCRIPTION
User settings is used to store user's preferences, in web we use it to store the home menus apps order and in mail for various settings like push to talk key, discuss sidebar preferences, etc.

Before this commit, the `setUserSettings` method from the user service overrided all the previous key that has not been changed because it kept only the changed keys returned by the backend. Leading to preferences being lost during the session when reordering the home menu apps.

With this commit, we keep the previous keys that have not been changed.

Steps to reproduce:

- Go to the home menu
- In the Owl devtool check the settings object from the user service:
```JavaScript
{
    "id": 1,
    "user_id": {
        "id": 2
    },
    "is_discuss_sidebar_category_channel_open": true,
    "is_discuss_sidebar_category_chat_open": true,
    "push_to_talk_key": false,
    "use_push_to_talk": false,
    "voice_active_duration": 0,
    "volume_settings_ids": [
        [
            "ADD",
            []
        ]
    ],
    "homemenu_config": "[\"mail.menu_root_discuss\",\"room.room_menu_root\",\"calendar.mail_menu_calendar\",\"appointment.main_menu_appointments\",\"project_todo.menu_todo_todos\",\"membership.menu_association\",\"knowledge.knowledge_menu_root\",\"contacts.menu_contacts\",\"frontdesk.frontdesk_menu_root\",\"point_of_sale.menu_point_root\",\"crm.crm_menu_root\",\"sale.sale_menu_root\",\"spreadsheet_dashboard.spreadsheet_dashboard_menu_root\",\"sale_subscription.menu_sale_subscription_root\",\"sale_renting.rental_menu_root\",\"pos_preparation_display.menu_point_kitchen_display_root\",\"account_accountant.menu_accounting\",\"documents.menu_root\",\"project.menu_main_pm\",\"hr_timesheet.timesheet_menu_root\",\"industry_fsm.fsm_menu_root\",\"planning.planning_menu_root\",\"helpdesk.menu_helpdesk_root\",\"website.menu_website_configuration\",\"website_slides.website_slides_menu_root\",\"social.menu_social_global\",\"marketing_automation.marketing_automation_menu\",\"mass_mailing.mass_mailing_menu_root\",\"mass_mailing_sms.mass_mailing_sms_menu_root\",\"event.event_main_menu\",\"survey.menu_surveys\",\"purchase.menu_purchase_root\",\"stock.menu_stock_root\",\"mrp.menu_mrp_root\",\"mrp_workorder.menu_mrp_workorder_root\",\"quality_control.menu_quality_root\",\"stock_barcode.stock_barcode_menu\",\"maintenance.menu_maintenance_title\",\"repair.menu_repair_order\",\"mrp_plm.menu_mrp_plm_root\",\"account_consolidation.menu_consolidation\",\"sign.menu_document\",\"hr.menu_hr_root\",\"hr_work_entry_contract_enterprise.menu_hr_payroll_root\",\"hr_appraisal.menu_hr_appraisal_root\",\"hr_attendance.menu_hr_attendance_root\",\"hr_recruitment.menu_hr_recruitment_root\",\"hr_referral.menu_hr_referral_root\",\"fleet.menu_root\",\"hr_holidays.menu_hr_holidays_root\",\"hr_expense.menu_hr_expense_root\",\"lunch.menu_lunch\",\"im_livechat.menu_livechat_root\",\"data_recycle.menu_data_cleaning_root\",\"approvals.approvals_menu_root\",\"whatsapp.whatsapp_menu_main\",\"iot.iot_menu_root\",\"base.menu_management\",\"base.menu_tests\",\"base.menu_administration\"]",
    "voip_username": false,
    "voip_secret": false,
    "should_call_from_another_device": false,
    "external_device_number": false,
    "should_auto_reject_incoming_calls": false,
    "how_to_call_on_mobile": "ask",
    "is_discuss_sidebar_category_whatsapp_open": true,
    "onsip_auth_username": false,
    "livechat_username": false,
    "livechat_lang_ids": [],
    "is_discuss_sidebar_category_livechat_open": true
}
```
- Reorder an app in the home menu and check again the settings object:
```JavaScript
{
    "id": 1,
    "homemenu_config": "[\"mail.menu_root_discuss\",\"room.room_menu_root\",\"project_todo.menu_todo_todos\",\"calendar.mail_menu_calendar\",\"appointment.main_menu_appointments\",\"membership.menu_association\",\"knowledge.knowledge_menu_root\",\"contacts.menu_contacts\",\"frontdesk.frontdesk_menu_root\",\"point_of_sale.menu_point_root\",\"crm.crm_menu_root\",\"sale.sale_menu_root\",\"spreadsheet_dashboard.spreadsheet_dashboard_menu_root\",\"sale_subscription.menu_sale_subscription_root\",\"sale_renting.rental_menu_root\",\"pos_preparation_display.menu_point_kitchen_display_root\",\"account_accountant.menu_accounting\",\"documents.menu_root\",\"project.menu_main_pm\",\"hr_timesheet.timesheet_menu_root\",\"industry_fsm.fsm_menu_root\",\"planning.planning_menu_root\",\"helpdesk.menu_helpdesk_root\",\"website.menu_website_configuration\",\"website_slides.website_slides_menu_root\",\"social.menu_social_global\",\"marketing_automation.marketing_automation_menu\",\"mass_mailing.mass_mailing_menu_root\",\"mass_mailing_sms.mass_mailing_sms_menu_root\",\"event.event_main_menu\",\"survey.menu_surveys\",\"purchase.menu_purchase_root\",\"stock.menu_stock_root\",\"mrp.menu_mrp_root\",\"mrp_workorder.menu_mrp_workorder_root\",\"quality_control.menu_quality_root\",\"stock_barcode.stock_barcode_menu\",\"maintenance.menu_maintenance_title\",\"repair.menu_repair_order\",\"mrp_plm.menu_mrp_plm_root\",\"account_consolidation.menu_consolidation\",\"sign.menu_document\",\"hr.menu_hr_root\",\"hr_work_entry_contract_enterprise.menu_hr_payroll_root\",\"hr_appraisal.menu_hr_appraisal_root\",\"hr_attendance.menu_hr_attendance_root\",\"hr_recruitment.menu_hr_recruitment_root\",\"hr_referral.menu_hr_referral_root\",\"fleet.menu_root\",\"hr_holidays.menu_hr_holidays_root\",\"hr_expense.menu_hr_expense_root\",\"lunch.menu_lunch\",\"im_livechat.menu_livechat_root\",\"data_recycle.menu_data_cleaning_root\",\"approvals.approvals_menu_root\",\"whatsapp.whatsapp_menu_main\",\"iot.iot_menu_root\",\"base.menu_management\",\"base.menu_tests\",\"base.menu_administration\"]"
}
```

- Other keys are lost which is the issue