### PR TITLE
[FIX] point_of_sale: pricelist-change-combo

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -2006,6 +2006,9 @@ export class Order extends PosModel {
         if (options.tax_ids) {
             orderline.compute_related_tax(options.tax_ids);
         }
+        if (options.combo_line_id) {
+            orderline.combo_line_id = options.combo_line_id;
+        }
     }
     get_selected_orderline() {
         return this.selected_orderline;


### PR DESCRIPTION
Steps to reproduce:
-add a combo product to the orderlines
-change the customer
-a traceback will be shown

The problem is that the onderlines doesn't contain the combo_line_id related to it. The combo_line_id is needed to recompute the prices with the pricelist of the new customer.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
