### PR TITLE
[FIX] analytic: prevent fetching plan from other companies

### DIFF
--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -234,6 +234,8 @@ class AccountAnalyticPlan(models.Model):
             score = 0
             applicability = self.default_applicability
             for applicability_rule in self.applicability_ids:
+                if applicability_rule.company_id != self.env.company:
+                    continue
                 score_rule = applicability_rule._get_score(**kwargs)
                 if score_rule > score:
                     applicability = applicability_rule.applicability


### PR DESCRIPTION
Steps to reproduce:
- have two companies
- in Company A: create a new applicability for optionnal internal plan {domain: invoice, applicability: mandatory, company: Company A } - save
- in Company B, create a new invoice without setting an analytic distribution

Issue:
Error

opw-3764623