### PR TITLE
[FIX] purchase_stock: apply exchange rate at bill date for SVL

### DIFF
--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -47,40 +47,27 @@ class StockMove(models.Model):
         if line.product_id.purchase_method == 'purchase' and float_compare(line.qty_invoiced, received_qty, precision_rounding=line.product_uom.rounding) > 0:
             move_layer = line.move_ids.sudo().stock_valuation_layer_ids
             invoiced_layer = line.sudo().invoice_lines.stock_valuation_layer_ids
-            # value on valuation layer is in company's currency, while value on invoice line is in order's currency
-            receipt_value = 0
-            if move_layer:
-                receipt_value += sum(move_layer.mapped(lambda l: l.currency_id._convert(
-                    l.value, order.currency_id, order.company_id, l.create_date, round=False)))
-            if invoiced_layer:
-                receipt_value += sum(invoiced_layer.mapped(lambda l: l.currency_id._convert(
-                    l.value, order.currency_id, order.company_id, l.create_date, round=False)))
+            receipt_value = sum((move_layer + invoiced_layer).mapped('value'))
             invoiced_value = 0
             invoiced_qty = 0
             for invoice_line in line.sudo().invoice_lines:
                 if invoice_line.move_id.state != 'posted':
                     continue
                 if invoice_line.tax_ids:
-                    invoiced_value += invoice_line.tax_ids.with_context(round=False).compute_all(
+                    invoice_value = invoice_line.tax_ids.with_context(round=False).compute_all(
                         invoice_line.price_unit, currency=invoice_line.currency_id, quantity=invoice_line.quantity)['total_void']
                 else:
-                    invoiced_value += invoice_line.price_unit * invoice_line.quantity
+                    invoice_value = invoice_line.price_unit * invoice_line.quantity
+                invoiced_value += order.currency_id._convert(
+                        invoice_value, order.company_id.currency_id, order.company_id, invoice_line.move_id.invoice_date, round=False)
                 invoiced_qty += invoice_line.product_uom_id._compute_quantity(invoice_line.quantity, line.product_id.uom_id)
             # TODO currency check
             remaining_value = invoiced_value - receipt_value
             # TODO qty_received in product uom
             remaining_qty = invoiced_qty - line.product_uom._compute_quantity(received_qty, line.product_id.uom_id)
-            price_unit = float_round(remaining_value / remaining_qty, precision_digits=price_unit_prec) if remaining_value and remaining_qty else line._get_gross_price_unit()
-        else:
-            price_unit = line._get_gross_price_unit()
-        if order.currency_id != order.company_id.currency_id:
-            # The date must be today, and not the date of the move since the move move is still
-            # in assigned state. However, the move date is the scheduled date until move is
-            # done, then date of actual move processing. See:
-            # https://github.com/odoo/odoo/blob/2f789b6863407e63f90b3a2d4cc3be09815f7002/addons/stock/models/stock_move.py#L36
-            price_unit = order.currency_id._convert(
-                price_unit, order.company_id.currency_id, order.company_id, fields.Date.context_today(self), round=False)
-        return price_unit
+            if remaining_value and remaining_qty:
+                return float_round(remaining_value / remaining_qty, precision_digits=price_unit_prec)
+        return order.currency_id._convert(line._get_gross_price_unit(), order.company_id.currency_id, order.company_id, fields.Date.context_today(self), round=False)
 
     def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description):
         """ Overridden from stock_account to support amount_currency on valuation lines generated from po

--- a/addons/purchase_stock/tests/test_stockvaluation.py
+++ b/addons/purchase_stock/tests/test_stockvaluation.py
@@ -670,6 +670,75 @@ class TestStockValuationWithCOA(AccountTestInvoicingCommon):
         # has gone to the stock account, and must be reflected in inventory valuation
         self.assertEqual(self.product1.value_svl, 150)
 
+    def test_billed_valuation_multicurrency(self):
+        """
+            Product with an invoice policy on ordered quantity should keep the valuation
+            of the bill with the exchange rate at the bill date
+        """
+        company = self.env.user.company_id
+        company.anglo_saxon_accounting = True
+        company.currency_id = self.usd_currency
+
+        date_po = '1993-07-18'
+
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
+        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+        self.product1.purchase_method = 'purchase'
+
+        self.env['res.currency.rate'].create([{
+            'name': date_po,
+            'rate': 1/1.5,
+            'currency_id': self.eur_currency.id,
+            'company_id': company.id,
+        }, {
+            'name': '1993-08-30', # exchange rate updated
+            'rate': 1/1.7,
+            'currency_id': self.eur_currency.id,
+            'company_id': company.id,
+        }])
+
+        # Create PO
+        po = self.env['purchase.order'].create({
+            'currency_id': self.eur_currency.id,
+            'partner_id': self.partner_id.id,
+            'order_line': [
+                (0, 0, {
+                    'name': self.product1.name,
+                    'product_id': self.product1.id,
+                    'product_qty': 1.0,
+                    'product_uom': self.product1.uom_po_id.id,
+                    'price_unit': 100.0, # 100€ = 150$ (at that time)
+                    'date_planned': date_po,
+                }),
+            ],
+        })
+        po.button_confirm()
+
+        # Create and post the vendor bill before recieving the product
+        self.env['account.move'].with_context(default_move_type='in_invoice').create({
+            'move_type': 'in_invoice',
+            'invoice_date': date_po,
+            'date': date_po,
+            'currency_id': self.eur_currency.id,
+            'partner_id': self.partner_id.id,
+            'invoice_line_ids': [(0, 0, {
+                'name': 'Test',
+                'price_unit': 100.0,
+                'product_id': self.product1.id,
+                'purchase_line_id': po.order_line.id,
+                'quantity': 1.0,
+                'account_id': self.stock_input_account.id,
+            })]
+        }).action_post()
+
+        receipt = po.picking_ids
+        receipt.move_line_ids.qty_done = 1
+
+        with freeze_time("4000-01-01"):
+            receipt.button_validate()
+
+        self.assertEqual(receipt.move_ids.stock_valuation_layer_ids.value, 150)
+
     def test_standard_valuation_multicurrency(self):
         company = self.env.user.company_id
         company.anglo_saxon_accounting = True


### PR DESCRIPTION
Steps to reproduce:
- Anglo-Saxon accounting, Category average cost, bill control policy: ordered quantities.
- Add two different exchange rates for euro one last week and one 2 months ago
- Purchase order (EUR) -> create bill (previous month) -> confirm -> receive goods

Bug:
Unit price is computed in the PO currency and then is convert back to the company currency at the end when we recieve the product

Fix:
replace each invoice value with the equivalent amount that matches the exchange rate at that time

opw-3572832

