### PR TITLE
[IMP] *: avoid calling CRUD methods to empty records

### DIFF
--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -327,7 +327,8 @@ class AccountBankStatement(models.Model):
         yield
 
         for stmt, attachments in zip(container['records'], attachments_to_fix_list):
-            attachments.write({'res_id': stmt.id, 'res_model': stmt._name})
+            if attachments:
+                attachments.write({'res_id': stmt.id, 'res_model': stmt._name})
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -30,11 +30,12 @@ class AccountPaymentMethod(models.Model):
 
                 journals = self.env['account.journal'].search(method_domain)
 
-                self.env['account.payment.method.line'].create([{
-                    'name': method.name,
-                    'payment_method_id': method.id,
-                    'journal_id': journal.id
-                } for journal in journals])
+                if journals:
+                    self.env['account.payment.method.line'].create([{
+                        'name': method.name,
+                        'payment_method_id': method.id,
+                        'journal_id': journal.id
+                    } for journal in journals])
         return payment_methods
 
     @api.model

--- a/addons/account/models/account_payment_term.py
+++ b/addons/account/models/account_payment_term.py
@@ -226,10 +226,12 @@ class AccountPaymentTerm(models.Model):
             raise UserError(_('You can not delete payment terms as other records still reference it. However, you can archive it.'))
 
     def unlink(self):
-        for terms in self:
-            self.env['ir.property'].sudo().search(
-                [('value_reference', 'in', ['account.payment.term,%s'%payment_term.id for payment_term in terms])]
-            ).unlink()
+        if self:
+            to_unlink = self.env['ir.property'].sudo().search(
+                [('value_reference', 'in', ['account.payment.term,%s' % payment_term.id for payment_term in self])]
+            )
+            if to_unlink:
+                to_unlink.unlink()
         return super(AccountPaymentTerm, self).unlink()
 
     def _get_last_discount_date(self, date_ref):

--- a/addons/account/wizard/account_move_reversal.py
+++ b/addons/account/wizard/account_move_reversal.py
@@ -126,6 +126,8 @@ class AccountMoveReversal(models.TransientModel):
         # Handle reverse method.
         moves_to_redirect = self.env['account.move']
         for moves, default_values_list, is_cancel_needed in batches:
+            if not moves:
+                continue
             new_moves = moves._reverse_moves(default_values_list, cancel=is_cancel_needed)
             moves._message_log_batch(
                 bodies={move.id: _('This entry has been %s', reverse._get_html_link(title=_("reversed"))) for move, reverse in zip(moves, new_moves)}

--- a/addons/account_edi/models/account_move.py
+++ b/addons/account_edi/models/account_move.py
@@ -261,8 +261,8 @@ class AccountMove(models.Model):
                             'move_id': move.id,
                             'state': 'to_send',
                         })
-
-        self.env['account.edi.document'].create(edi_document_vals_list)
+        if edi_document_vals_list:
+            self.env['account.edi.document'].create(edi_document_vals_list)
         posted.edi_document_ids._process_documents_no_web_services()
         self.env.ref('account_edi.ir_cron_edi_network')._trigger()
         return posted

--- a/addons/account_fleet/models/account_move.py
+++ b/addons/account_fleet/models/account_move.py
@@ -21,9 +21,10 @@ class AccountMove(models.Model):
             log = _('Service Vendor Bill: %s', line.move_id._get_html_link())
             val_list.append(val)
             log_list.append(log)
-        log_service_ids = self.env['fleet.vehicle.log.services'].create(val_list)
-        for log_service_id, log in zip(log_service_ids, log_list):
-            log_service_id.message_post(body=log)
+        if val_list:
+            log_service_ids = self.env['fleet.vehicle.log.services'].create(val_list)
+            for log_service_id, log in zip(log_service_ids, log_list):
+                log_service_id.message_post(body=log)
         return posted
 
 

--- a/addons/account_payment/__init__.py
+++ b/addons/account_payment/__init__.py
@@ -16,7 +16,9 @@ def post_init_hook(env):
 def uninstall_hook(env):
     """ Delete `account.payment.method` records created for the installed payment providers. """
     installed_providers = env['payment.provider'].search([('module_id.state', '=', 'installed')])
-    env['account.payment.method'].search([
+    to_unlink = env['account.payment.method'].search([
         ('code', 'in', installed_providers.mapped('code')),
         ('payment_type', '=', 'inbound'),
-    ]).unlink()
+    ])
+    if to_unlink:
+        to_unlink.unlink()

--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -140,7 +140,8 @@ class AccountPayment(models.Model):
         payments_tx_not_done = payments_need_tx.filtered(
             lambda p: p.payment_transaction_id.state != 'done'
         )
-        payments_tx_not_done.action_cancel()
+        if payments_tx_not_done:
+            payments_tx_not_done.action_cancel()
 
         return res
 

--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -100,7 +100,8 @@ class PaymentTransaction(models.Model):
         """
         processed_txs = super()._set_canceled(state_message, **kwargs)
         # Cancel the existing payments
-        processed_txs.payment_id.action_cancel()
+        if processed_txs.payment_id:
+            processed_txs.payment_id.action_cancel()
         return processed_txs
 
     #=== BUSINESS METHODS - POST-PROCESSING ===#

--- a/addons/bus/models/bus.py
+++ b/addons/bus/models/bus.py
@@ -54,7 +54,10 @@ class ImBus(models.Model):
     def _gc_messages(self):
         timeout_ago = fields.Datetime.now() - datetime.timedelta(seconds=TIMEOUT*2)
         domain = [('create_date', '<', timeout_ago)]
-        return self.sudo().search(domain).unlink()
+        to_unlink = self.sudo().search(domain)
+        if to_unlink:
+            return to_unlink.unlink()
+        return True
 
     @api.model
     def _sendmany(self, notifications):
@@ -70,7 +73,8 @@ class ImBus(models.Model):
                     'payload': message,
                 })
             })
-        self.sudo().create(values)
+        if values:
+            self.sudo().create(values)
         if channels:
             # We have to wait until the notifications are commited in database.
             # When calling `NOTIFY imbus`, notifications will be fetched in the

--- a/addons/bus/models/bus_presence.py
+++ b/addons/bus/models/bus_presence.py
@@ -69,4 +69,6 @@ class BusPresence(models.Model):
 
     @api.autovacuum
     def _gc_bus_presence(self):
-        self.search([('user_id.active', '=', False)]).unlink()
+        to_unlink = self.search([('user_id.active', '=', False)])
+        if to_unlink:
+            to_unlink.unlink()

--- a/addons/calendar/models/calendar_recurrence.py
+++ b/addons/calendar/models/calendar_recurrence.py
@@ -277,7 +277,8 @@ class RecurrenceRule(models.Model):
             **clean_context(self.env.context),
             **{'no_mail_to_attendees': True, 'mail_create_nolog': True},
         }
-        self.env['calendar.event'].with_context(context).create(event_vals)
+        if event_vals:
+            self.env['calendar.event'].with_context(context).create(event_vals)
         return detached_events
 
     def _setup_alarms(self, recurrence_update=False):

--- a/addons/event_crm/models/event_lead_rule.py
+++ b/addons/event_crm/models/event_lead_rule.py
@@ -183,8 +183,9 @@ class EventLeadRule(models.Model):
                             })
                     elif group_registrations:
                         lead_vals_list.append(group_registrations._get_lead_values(rule))
-
-        return self.env['crm.lead'].create(lead_vals_list)
+        if lead_vals_list:
+            return self.env['crm.lead'].create(lead_vals_list)
+        return self.env['crm.lead'].browse()
 
     def _filter_registrations(self, registrations):
         """ Keep registrations matching rule conditions. Those are

--- a/addons/event_crm/models/event_registration.py
+++ b/addons/event_crm/models/event_registration.py
@@ -32,13 +32,19 @@ class EventRegistration(models.Model):
         # as registrations can be automatically confirmed, or even created directly
         # with a state given in values
         if not self.env.context.get('event_lead_rule_skip'):
-            self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'create')]).sudo()._run_on_registrations(registrations)
+            rules = self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'create')]).sudo()
+            if rules:
+                rules._run_on_registrations(registrations)
             open_registrations = registrations.filtered(lambda reg: reg.state == 'open')
             if open_registrations:
-                self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'confirm')]).sudo()._run_on_registrations(open_registrations)
+                rules = self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'confirm')]).sudo()
+                if rules:
+                    rules._run_on_registrations(open_registrations)
             done_registrations = registrations.filtered(lambda reg: reg.state == 'done')
             if done_registrations:
-                self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'done')]).sudo()._run_on_registrations(done_registrations)
+                rules = self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'done')]).sudo()
+                if rules:
+                    rules._run_on_registrations(done_registrations)
 
         return registrations
 
@@ -70,9 +76,13 @@ class EventRegistration(models.Model):
         # handle triggers based on state
         if not event_lead_rule_skip:
             if vals.get('state') == 'open':
-                self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'confirm')]).sudo()._run_on_registrations(self)
+                rules = self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'confirm')]).sudo()
+                if rules:
+                    rules._run_on_registrations(self)
             elif vals.get('state') == 'done':
-                self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'done')]).sudo()._run_on_registrations(self)
+                rules = self.env['event.lead.rule'].search([('lead_creation_trigger', '=', 'done')]).sudo()
+                if rules:
+                    rules._run_on_registrations(self)
 
         return res
 

--- a/addons/event_sms/models/event_mail.py
+++ b/addons/event_sms/models/event_mail.py
@@ -88,6 +88,7 @@ class EventMailRegistration(models.Model):
                 template=reg_mail.scheduler_id.template_ref,
                 mass_keep_log=True
             )
-        todo.write({'mail_sent': True})
+        if todo:
+            todo.write({'mail_sent': True})
 
         return super(EventMailRegistration, self).execute()

--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -143,13 +143,16 @@ class FleetVehicleLogContract(models.Model):
                 user_id=contract.user_id.id)
 
         expired_contracts = self.search([('state', 'not in', ['expired', 'closed']), ('expiration_date', '<',fields.Date.today() )])
-        expired_contracts.write({'state': 'expired'})
+        if expired_contracts:
+            expired_contracts.write({'state': 'expired'})
 
         futur_contracts = self.search([('state', 'not in', ['futur', 'closed']), ('start_date', '>', fields.Date.today())])
-        futur_contracts.write({'state': 'futur'})
+        if futur_contracts:
+            futur_contracts.write({'state': 'futur'})
 
         now_running_contracts = self.search([('state', '=', 'futur'), ('start_date', '<=', fields.Date.today())])
-        now_running_contracts.write({'state': 'open'})
+        if now_running_contracts:
+            now_running_contracts.write({'state': 'open'})
 
     def run_scheduler(self):
         self.scheduler_manage_contract_expiration()

--- a/addons/hr/models/hr_department.py
+++ b/addons/hr/models/hr_department.py
@@ -106,12 +106,14 @@ class Department(models.Model):
     def _update_employee_manager(self, manager_id):
         employees = self.env['hr.employee']
         for department in self:
-            employees = employees | self.env['hr.employee'].search([
-                ('id', '!=', manager_id),
-                ('department_id', '=', department.id),
-                ('parent_id', '=', department.manager_id.id)
-            ])
-        employees.write({'parent_id': manager_id})
+            if department.manager_id.id != manager_id:
+                employees = employees | self.env['hr.employee'].search([
+                    ('id', '!=', manager_id),
+                    ('department_id', '=', department.id),
+                    ('parent_id', '=', department.manager_id.id)
+                ])
+        if employees:
+            employees.write({'parent_id': manager_id})
 
     def get_formview_action(self, access_uid=None):
         res = super().get_formview_action(access_uid=access_uid)

--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -304,7 +304,8 @@ class HrEmployeePrivate(models.Model):
                         employee=employee.name,
                         date=formated_date),
                     user_id=responsible_user_id)
-        employees_scheduled.write({'work_permit_scheduled_activity': True})
+        if employees_scheduled:
+            employees_scheduled.write({'work_permit_scheduled_activity': True})
 
     @api.model
     def get_view(self, view_id=None, view_type='form', **options):

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -380,13 +380,16 @@ class HrAttendance(models.Model):
                         affected_employees |= overtime.employee_id
                 elif overtime:
                     overtime_to_unlink |= overtime
-        created_overtimes = self.env['hr.attendance.overtime'].sudo().create(overtime_vals_list)
-        employees_worked_hours_to_compute = (affected_employees.ids +
-                                             created_overtimes.employee_id.ids +
-                                             overtime_to_unlink.employee_id.ids)
-        overtime_to_unlink.sudo().unlink()
-        self.env.add_to_compute(self._fields['overtime_hours'],
-                                self.search([('employee_id', 'in', employees_worked_hours_to_compute)]))
+        if overtime_vals_list:
+            created_overtimes = self.env['hr.attendance.overtime'].sudo().create(overtime_vals_list)
+            employees_worked_hours_to_compute = (affected_employees.ids +
+                                                 created_overtimes.employee_id.ids +
+                                                 overtime_to_unlink.employee_id.ids)
+        if overtime_to_unlink:
+            overtime_to_unlink.sudo().unlink()
+        if overtime_vals_list:
+            self.env.add_to_compute(self._fields['overtime_hours'],
+                                    self.search([('employee_id', 'in', employees_worked_hours_to_compute)]))
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -261,7 +261,8 @@ class Contract(models.Model):
 
     def _assign_open_contract(self):
         for contract in self:
-            contract.employee_id.sudo().write({'contract_id': contract.id})
+            if contract.employee_id:
+                contract.employee_id.sudo().write({'contract_id': contract.id})
 
     @api.depends('wage')
     def _compute_contract_wage(self):

--- a/addons/hr_contract/models/resource.py
+++ b/addons/hr_contract/models/resource.py
@@ -24,9 +24,11 @@ class ResourceCalendar(models.Model):
         ]
         domain = AND([domain, [('resource_id', 'in', resources.ids)]]) if resources else domain
 
-        self.env['resource.calendar.leaves'].search(domain).write({
-            'calendar_id': other_calendar.id,
-        })
+        to_write = self.env['resource.calendar.leaves'].search(domain)
+        if to_write:
+            to_write.write({
+                'calendar_id': other_calendar.id,
+            })
 
     def _compute_contracts_count(self):
         count_data = self.env['hr.contract']._read_group(

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -229,10 +229,12 @@ class HrEmployeeBase(models.AbstractModel):
         # 'no_leave_resource_calendar_update'
         if 'resource_calendar_id' in values and not self.env.context.get('no_leave_resource_calendar_update'):
             try:
-                self.env['hr.leave'].search([
+                to_write = self.env['hr.leave'].search([
                     ('employee_id', 'in', self.ids),
                     ('resource_calendar_id', '!=', int(values['resource_calendar_id'])),
-                    ('date_from', '>', fields.Datetime.now())]).write({'resource_calendar_id': values['resource_calendar_id']})
+                    ('date_from', '>', fields.Datetime.now())])
+                if to_write:
+                    to_write.write({'resource_calendar_id': values['resource_calendar_id']})
             except ValidationError:
                 raise ValidationError(_("Changing this working schedule results in the affected employee(s) not having enough "
                                         "leaves allocated to accomodate for their leaves already taken in the future. Please "

--- a/addons/hr_work_entry/models/hr_work_entry.py
+++ b/addons/hr_work_entry/models/hr_work_entry.py
@@ -193,7 +193,9 @@ class HrWorkEntry(models.Model):
             return super().unlink()
 
     def _reset_conflicting_state(self):
-        self.filtered(lambda w: w.state == 'conflict').write({'state': 'draft'})
+        to_reset = self.filtered(lambda w: w.state == 'conflict')
+        if to_reset:
+            to_reset.write({'state': 'draft'})
 
     @contextmanager
     def _error_checking(self, start=None, stop=None, skip=False, employee_ids=False):

--- a/addons/hr_work_entry_contract/models/hr_work_entry.py
+++ b/addons/hr_work_entry_contract/models/hr_work_entry.py
@@ -169,7 +169,8 @@ class HrWorkEntry(models.Model):
             entries_intervals = entries._to_intervals()
             overlapping_entries = self._from_intervals(entries_intervals & calendar_intervals)
             outside_entries |= entries - overlapping_entries
-        outside_entries.write({'state': 'conflict'})
+        if outside_entries:
+            outside_entries.write({'state': 'conflict'})
         return bool(outside_entries)
 
     def _to_intervals(self):

--- a/addons/hr_work_entry_holidays/models/hr_work_entry.py
+++ b/addons/hr_work_entry_holidays/models/hr_work_entry.py
@@ -21,7 +21,8 @@ class HrWorkEntry(models.Model):
     def _reset_conflicting_state(self):
         super()._reset_conflicting_state()
         attendances = self.filtered(lambda w: w.work_entry_type_id and not w.work_entry_type_id.is_leave)
-        attendances.write({'leave_id': False})
+        if attendances:
+            attendances.write({'leave_id': False})
 
     def _check_if_error(self):
         res = super()._check_if_error()

--- a/addons/im_livechat/models/discuss_channel_member.py
+++ b/addons/im_livechat/models/discuss_channel_member.py
@@ -18,7 +18,8 @@ class ChannelMember(models.Model):
             ('channel_id.channel_type', '=', 'livechat'),
         ])
         sessions_to_be_unpinned = members.filtered(lambda m: m.message_unread_counter == 0)
-        sessions_to_be_unpinned.write({'is_pinned': False})
+        if sessions_to_be_unpinned:
+            sessions_to_be_unpinned.write({'is_pinned': False})
         self.env['bus.bus']._sendmany([(member.partner_id, 'discuss.channel/unpin', {'id': member.channel_id.id}) for member in sessions_to_be_unpinned])
 
     def _get_partner_data(self, fields=None):

--- a/addons/lunch/models/lunch_supplier.py
+++ b/addons/lunch/models/lunch_supplier.py
@@ -197,7 +197,9 @@ class LunchSupplier(models.Model):
             if topping_values:
                 topping_values.update({'topping_category': 3})
         if values.get('company_id'):
-            self.env['lunch.order'].search([('supplier_id', 'in', self.ids)]).write({'company_id': values['company_id']})
+            to_add_company = self.env['lunch.order'].search([('supplier_id', 'in', self.ids)])
+            if to_add_company:
+                to_add_company.write({'company_id': values['company_id']})
         res = super().write(values)
         if not CRON_DEPENDS.isdisjoint(values):
             # flush automatic_email_time field to call _sql_constraints

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -326,8 +326,9 @@ class Channel(models.Model):
                 for channel_id in new_members
                 for partner_id in new_members[channel_id]
             ]
-            # sudo: discuss.channel.member - adding member of other users based on channel auto-subscribe
-            self.env['discuss.channel.member'].sudo().create(to_create)
+            if to_create:
+                # sudo: discuss.channel.member - adding member of other users based on channel auto-subscribe
+                self.env['discuss.channel.member'].sudo().create(to_create)
         notifications = []
         for channel in self:
             for group in channel.group_ids:

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -171,7 +171,8 @@ class ChannelMember(models.Model):
     def _unmute(self):
         # Unmute notifications for the all the channel members whose mute date is passed.
         members = self.search([("mute_until_dt", "<=", fields.Datetime.now())])
-        members.write({"mute_until_dt": False})
+        if members:
+            members.write({"mute_until_dt": False})
         notifications = []
         for member in members:
             channel_data = {

--- a/addons/mail/models/discuss/discuss_channel_rtc_session.py
+++ b/addons/mail/models/discuss/discuss_channel_rtc_session.py
@@ -85,7 +85,9 @@ class MailRtcSession(models.Model):
             this can happen when the server or the user's browser crash
             or when the user's odoo session ends.
         """
-        self.search(self._inactive_rtc_session_domain()).unlink()
+        to_unlink = self.search(self._inactive_rtc_session_domain())
+        if to_unlink:
+            to_unlink.unlink()
 
     def action_disconnect(self):
         session_ids_by_channel_by_url = defaultdict(lambda: defaultdict(list))

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -826,4 +826,5 @@ class MailActivity(models.Model):
             return
         deadline_threshold_dt = datetime.now() - relativedelta(years=year_threshold)
         old_overdue_activities = self.env['mail.activity'].search([('date_deadline', '<', deadline_threshold_dt)], limit=10_000)
-        old_overdue_activities.unlink()
+        if old_overdue_activities:
+            old_overdue_activities.unlink()

--- a/addons/mail/models/mail_alias_mixin_optional.py
+++ b/addons/mail/models/mail_alias_mixin_optional.py
@@ -139,7 +139,8 @@ class AliasMixinOptional(models.AbstractModel):
         """ Delete the given records, and cascade-delete their corresponding alias. """
         aliases = self.mapped('alias_id')
         res = super().unlink()
-        aliases.sudo().unlink()
+        if aliases:
+            aliases.sudo().unlink()
         return res
 
     def copy_data(self, default=None):

--- a/addons/mail/models/mail_message_translation.py
+++ b/addons/mail/models/mail_message_translation.py
@@ -28,5 +28,7 @@ class MessageTranslation(models.Model):
 
     @api.autovacuum
     def _gc_translations(self):
-        treshold = fields.Datetime().now() - relativedelta(weeks=2)
-        self.search([("create_date", "<", treshold)]).unlink()
+        threshold = fields.Datetime().now() - relativedelta(weeks=2)
+        to_unlink = self.search([("create_date", "<", threshold)])
+        if to_unlink:
+            to_unlink.unlink()

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -99,7 +99,10 @@ class MailNotification(models.Model):
             ('res_partner_id.partner_share', '=', False),
             ('notification_status', 'in', ('sent', 'canceled'))
         ]
-        return self.search(domain).unlink()
+        to_unlink = self.search(domain)
+        if to_unlink:
+            return to_unlink.unlink()
+        return True
 
     # ------------------------------------------------------------
     # TOOLS

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -149,7 +149,8 @@ class MailTemplate(models.Model):
 
     def _fix_attachment_ownership(self):
         for record in self:
-            record.attachment_ids.write({'res_model': record._name, 'res_id': record.id})
+            if record.attachment_ids:
+                record.attachment_ids.write({'res_model': record._name, 'res_id': record.id})
         return self
 
     def _check_abstract_models(self, vals_list):

--- a/addons/mail/models/res_users.py
+++ b/addons/mail/models/res_users.py
@@ -54,8 +54,11 @@ class Users(models.Model):
     def _inverse_notification_type(self):
         inbox_group = self.env.ref('mail.group_mail_notification_type_inbox')
         inbox_users = self.filtered(lambda user: user.notification_type == 'inbox')
-        inbox_users.write({"groups_id": [Command.link(inbox_group.id)]})
-        (self - inbox_users).write({"groups_id": [Command.unlink(inbox_group.id)]})
+        if inbox_users:
+            inbox_users.write({"groups_id": [Command.link(inbox_group.id)]})
+        other_users = self - inbox_users
+        if other_users:
+            other_users.write({"groups_id": [Command.unlink(inbox_group.id)]})
 
     # ------------------------------------------------------------
     # CRUD

--- a/addons/mail_plugin/models/res_partner.py
+++ b/addons/mail_plugin/models/res_partner.py
@@ -37,7 +37,8 @@ class ResPartner(models.Model):
             'iap_enrich_info': vals.get('iap_enrich_info'),
             'iap_search_domain': vals.get('iap_search_domain'),
         } for partner, vals in zip(partners, vals_list) if vals.get('iap_enrich_info') or vals.get('iap_search_domain')]
-        self.env['res.partner.iap'].sudo().create(partner_iap_vals_list)
+        if partner_iap_vals_list:
+            self.env['res.partner.iap'].sudo().create(partner_iap_vals_list)
         return partners
 
     def write(self, vals):

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -103,8 +103,9 @@ class MailMail(models.Model):
         return email_list
 
     def _postprocess_sent_message(self, success_pids, failure_reason=False, failure_type=None):
-        if failure_type:  # we consider that a recipient error is a failure with mass mailing and show them as failed
-            self.filtered('mailing_id').mailing_trace_ids.set_failed(failure_type=failure_type)
-        else:
-            self.filtered('mailing_id').mailing_trace_ids.set_sent()
+        traces = self.filtered('mailing_id').mailing_trace_ids
+        if failure_type and traces:  # we consider that a recipient error is a failure with mass mailing and show them as failed
+            traces.set_failed(failure_type=failure_type)
+        elif traces:
+            traces.set_sent()
         return super()._postprocess_sent_message(success_pids, failure_reason=failure_reason, failure_type=failure_type)

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -555,11 +555,14 @@ class MassMailing(models.Model):
             mailing._get_default_ab_testing_campaign_values()
             for mailing in self.filtered(lambda mailing: mailing.ab_testing_enabled and not mailing.campaign_id)
         ]
-        return self.env['utm.campaign'].create(campaign_vals)
+        if campaign_vals:
+            return self.env['utm.campaign'].create(campaign_vals)
+        return self.env['utm.campaign'].browse()
 
     def _fix_attachment_ownership(self):
         for record in self:
-            record.attachment_ids.write({'res_model': record._name, 'res_id': record.id})
+            if record.attachment_ids:
+                record.attachment_ids.write({'res_model': record._name, 'res_id': record.id})
         return self
 
     def copy_data(self, default=None):

--- a/addons/mass_mailing/models/mailing_trace.py
+++ b/addons/mass_mailing/models/mailing_trace.py
@@ -146,7 +146,8 @@ class MailingTrace(models.Model):
 
     def set_sent(self, domain=None):
         traces = self + (self.search(domain) if domain else self.env['mailing.trace'])
-        traces.write({'trace_status': 'sent', 'sent_datetime': fields.Datetime.now(), 'failure_type': False})
+        if traces:
+            traces.write({'trace_status': 'sent', 'sent_datetime': fields.Datetime.now(), 'failure_type': False})
         return traces
 
     def set_opened(self, domain=None):
@@ -154,7 +155,9 @@ class MailingTrace(models.Model):
         open, click implies open. Let us avoid status override by skipping traces
         that are not already opened or replied. """
         traces = self + (self.search(domain) if domain else self.env['mailing.trace'])
-        traces.filtered(lambda t: t.trace_status not in ('open', 'reply')).write({'trace_status': 'open', 'open_datetime': fields.Datetime.now()})
+        to_open = traces.filtered(lambda t: t.trace_status not in ('open', 'reply'))
+        if to_open:
+            to_open.write({'trace_status': 'open', 'open_datetime': fields.Datetime.now()})
         return traces
 
     def set_clicked(self, domain=None):

--- a/addons/membership/models/account_move.py
+++ b/addons/membership/models/account_move.py
@@ -33,9 +33,11 @@ class AccountMove(models.Model):
         # OVERRIDE to write the partner on the membership lines.
         res = super(AccountMove, self).write(vals)
         if 'partner_id' in vals:
-            self.env['membership.membership_line'].search([
+            to_write = self.env['membership.membership_line'].search([
                 ('account_invoice_line', 'in', self.mapped('invoice_line_ids').ids)
-            ]).write({'partner': vals['partner_id']})
+            ])
+            if to_write:
+                to_write.write({'partner': vals['partner_id']})
         return res
 
 

--- a/addons/mrp/__init__.py
+++ b/addons/mrp/__init__.py
@@ -27,7 +27,8 @@ def _create_warehouse_data(env):
     installed after some warehouses were already created.
     """
     warehouse_ids = env['stock.warehouse'].search([('manufacture_pull_id', '=', False)])
-    warehouse_ids.write({'manufacture_to_resupply': True})
+    if warehouse_ids:
+        warehouse_ids.write({'manufacture_to_resupply': True})
 
 def uninstall_hook(env):
     warehouses = env["stock.warehouse"].search([])

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2000,10 +2000,12 @@ class MrpProduction(models.Model):
         # Moves without quantity done are not posted => set them as done instead of canceling. In
         # case the user edits the MO later on and sets some consumed quantity on those, we do not
         # want the move lines to be canceled.
-        (productions_not_to_backorder.move_raw_ids | productions_not_to_backorder.move_finished_ids).filtered(lambda x: x.state not in ('done', 'cancel')).write({
-            'state': 'done',
-            'product_uom_qty': 0.0,
-        })
+        to_write = (productions_not_to_backorder.move_raw_ids | productions_not_to_backorder.move_finished_ids).filtered(lambda x: x.state not in ('done', 'cancel'))
+        if to_write:
+            to_write.write({
+                'state': 'done',
+                'product_uom_qty': 0.0,
+            })
         for production in self:
             production.write({
                 'date_finished': fields.Datetime.now(),

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -143,9 +143,11 @@ class ProductProduct(models.Model):
 
     def write(self, values):
         if 'active' in values:
-            self.filtered(lambda p: p.active != values['active']).with_context(active_test=False).variant_bom_ids.write({
-                'active': values['active']
-            })
+            to_activate = self.filtered(lambda p: p.active != values['active']).with_context(active_test=False).variant_bom_ids
+            if to_activate:
+                to_activate.write({
+                    'active': values['active']
+                })
         return super().write(values)
 
     def get_components(self):

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -396,8 +396,9 @@ class StockMove(models.Model):
             moves_ids_to_return |= phantom_moves.action_explode().ids
         move_to_unlink = self.env['stock.move'].browse(moves_ids_to_unlink).sudo()
         move_to_unlink.quantity = 0
-        move_to_unlink._action_cancel()
-        move_to_unlink.unlink()
+        if move_to_unlink:
+            move_to_unlink._action_cancel()
+            move_to_unlink.unlink()
         return self.env['stock.move'].browse(moves_ids_to_return)
 
     def action_show_details(self):

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -144,9 +144,11 @@ class StockWarehouseOrderpoint(models.Model):
         """ Confirm the productions only after all the orderpoints have run their
         procurement to avoid the new procurement created from the production conflict
         with them. """
-        self.env['mrp.production'].sudo().search([
+        to_confirm = self.env['mrp.production'].sudo().search([
             ('orderpoint_id', 'in', self.ids),
             ('move_raw_ids', '!=', False),
             ('state', '=', 'draft'),
-        ]).action_confirm()
+        ])
+        if to_confirm:
+            to_confirm.action_confirm()
         return super()._post_process_scheduler()

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -295,8 +295,10 @@ class StockWarehouse(models.Model):
         return routes
 
     def _update_location_manufacture(self, new_manufacture_step):
-        self.mapped('pbm_loc_id').write({'active': new_manufacture_step != 'mrp_one_step'})
-        self.mapped('sam_loc_id').write({'active': new_manufacture_step == 'pbm_sam'})
+        if self.pbm_loc_id:
+            self.pbm_loc_id.write({'active': new_manufacture_step != 'mrp_one_step'})
+        if self.sam_loc_id:
+            self.sam_loc_id.write({'active': new_manufacture_step == 'pbm_sam'})
 
     def _update_name_and_code(self, name=False, code=False):
         res = super(StockWarehouse, self)._update_name_and_code(name, code)

--- a/addons/mrp_subcontracting/models/stock_location.py
+++ b/addons/mrp_subcontracting/models/stock_location.py
@@ -91,7 +91,8 @@ class StockLocation(models.Model):
                             existing_rule = existing_rules[(rule.route_id, rule.picking_type_id, rule.action, location)]
                             if not existing_rule.active:
                                 rules_to_unarchive += existing_rule
-        self.env['stock.rule'].create(new_rules_vals)
+        if new_rules_vals:
+            self.env['stock.rule'].create(new_rules_vals)
         rules_to_unarchive.action_unarchive()
 
     def _archive_subcontracting_location_rules(self):

--- a/addons/onboarding/models/onboarding_onboarding.py
+++ b/addons/onboarding/models/onboarding_onboarding.py
@@ -97,8 +97,10 @@ class Onboarding(models.Model):
         onboardings_to_refresh_progress = self.filtered(
             lambda o: o.is_per_company and o.progress_ids and not o.progress_ids.company_id
         )
-        onboardings_to_refresh_progress.progress_ids.unlink()
-        onboardings_to_refresh_progress._create_progress()
+        if onboardings_to_refresh_progress.progress_ids:
+            onboardings_to_refresh_progress.progress_ids.unlink()
+        if onboardings_to_refresh_progress:
+            onboardings_to_refresh_progress._create_progress()
 
     def action_toggle_visibility(self):
         self.current_progress_id.action_toggle_visibility()
@@ -106,7 +108,8 @@ class Onboarding(models.Model):
     def _search_or_create_progress(self):
         """Create Progress record(s) as necessary for the context."""
         onboardings_without_progress = self.filtered(lambda onboarding: not onboarding.current_progress_id)
-        onboardings_without_progress._create_progress()
+        if onboardings_without_progress:
+            onboardings_without_progress._create_progress()
         return self.current_progress_id
 
     def _create_progress(self):

--- a/addons/point_of_sale/models/chart_template.py
+++ b/addons/point_of_sale/models/chart_template.py
@@ -14,11 +14,15 @@ class AccountChartTemplate(models.AbstractModel):
         """
         reload_template = template_code == company.chart_template
         if not reload_template:
-            self.env['pos.payment.method'].with_context(active_test=False).search(self.env['pos.payment.method']._check_company_domain(company)).unlink()
-            self.env["pos.config"].with_context(active_test=False).search(self.env['pos.config']._check_company_domain(company)).write({
-                'journal_id': False,
-                'invoice_journal_id': False,
-            })
+            to_unlink = self.env['pos.payment.method'].with_context(active_test=False).search(self.env['pos.payment.method']._check_company_domain(company))
+            if to_unlink:
+                to_unlink.unlink()
+            to_write = self.env["pos.config"].with_context(active_test=False).search(self.env['pos.config']._check_company_domain(company))
+            if to_write:
+                to_write.write({
+                    'journal_id': False,
+                    'invoice_journal_id': False,
+                })
         result = super()._load(template_code, company, install_demo)
         self.env['pos.config'].post_install_pos_localisation(companies=company)
         return result

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -186,7 +186,8 @@ class PosOrder(models.Model):
 
     def _clean_payment_lines(self):
         self.ensure_one()
-        self.payment_ids.unlink()
+        if self.payment_ids:
+            self.payment_ids.unlink()
 
     def _process_payment_lines(self, pos_order, order, pos_session, draft):
         """Create account.bank.statement.lines from the dictionary given to the parent function.
@@ -1003,7 +1004,8 @@ class PosOrder(models.Model):
                     destination_id = picking_type.default_location_dest_id.id
 
                 pickings = self.env['stock.picking']._create_picking_from_pos_order_lines(destination_id, self.lines, picking_type, self.partner_id)
-                pickings.write({'pos_session_id': self.session_id.id, 'pos_order_id': self.id, 'origin': self.name})
+                if pickings:
+                    pickings.write({'pos_session_id': self.session_id.id, 'pos_order_id': self.id, 'origin': self.name})
 
     def add_payment(self, data):
         """Create a new payment for the order"""
@@ -1491,7 +1493,8 @@ class PosOrderLine(models.Model):
                 for product_id, lines in lines_by_tracked_product:
                     lines = self.env['pos.order.line'].concat(*lines)
                     moves = pickings_to_confirm.move_ids.filtered(lambda m: m.product_id.id == product_id)
-                    moves.move_line_ids.unlink()
+                    if moves.move_line_ids:
+                        moves.move_line_ids.unlink()
                     moves._add_mls_related_to_order(lines, are_qties_done=False)
                     moves._recompute_state()
         return True

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -230,7 +230,8 @@ class StockMove(models.Model):
                 missing_lot_values = []
                 for lot_product_id, lot_name in filter(lambda l: l[0] in moves_product_ids, lots_data):
                     missing_lot_values.append({'company_id': self.company_id.id, 'product_id': lot_product_id, 'name': lot_name})
-                valid_lots |= self.env['stock.lot'].create(missing_lot_values)
+                if missing_lot_values:
+                    valid_lots |= self.env['stock.lot'].create(missing_lot_values)
         return valid_lots
 
     def _add_mls_related_to_order(self, related_order_lines, are_qties_done=True):
@@ -269,7 +270,8 @@ class StockMove(models.Model):
                         move_lines_to_create.append(ml_vals)
                         mls_qties.append(qty)
                         sum_of_lots += qty
-            self.env['stock.move.line'].create(move_lines_to_create)
+            if move_lines_to_create:
+                self.env['stock.move.line'].create(move_lines_to_create)
         else:
             for move in moves_remaining:
                 for line in lines_data[move.product_id.id]['order_lines']:

--- a/addons/point_of_sale/tests/common.py
+++ b/addons/point_of_sale/tests/common.py
@@ -14,7 +14,9 @@ def archive_products(env):
     # Archive all existing product to avoid noise during the tours
     all_pos_product = env['product.product'].search([('available_in_pos', '=', True)])
     tip = env.ref('point_of_sale.product_product_tip')
-    (all_pos_product - tip)._write({'active': False})
+    to_activate = all_pos_product - tip
+    if to_activate:
+        to_activate._write({'active': False})
 
 class TestPointOfSaleCommon(ValuationReconciliationTestCommon):
 

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -44,7 +44,9 @@ class TestPointOfSaleHttpCommon(AccountTestInvoicingHttpCommon):
         env.company.account_default_pos_receivable_account_id = account_receivable
         env['ir.property']._set_default('property_account_receivable_id', 'res.partner', account_receivable, main_company)
         # Pricelists are set below, do not take demo data into account
-        env['ir.property'].sudo().search([('name', '=', 'property_product_pricelist')]).unlink()
+        to_unlink = env['ir.property'].sudo().search([('name', '=', 'property_product_pricelist')])
+        if to_unlink:
+            to_unlink.unlink()
 
         # Create user.
         cls.pos_user = cls.env['res.users'].create({

--- a/addons/point_of_sale/tests/test_point_of_sale.py
+++ b/addons/point_of_sale/tests/test_point_of_sale.py
@@ -9,7 +9,9 @@ class TestPointOfSale(TransactionCase):
         super(TestPointOfSale, self).setUp()
 
         # ignore pre-existing pricelists for the purpose of this test
-        self.env["product.pricelist"].search([]).write({"active": False})
+        to_archive = self.env["product.pricelist"].search([])
+        if to_archive:
+            to_archive.write({"active": False})
 
         self.currency = self.env.ref("base.USD")
         self.company1 = self.env["res.company"].create({

--- a/addons/pos_online_payment/models/pos_order.py
+++ b/addons/pos_online_payment/models/pos_order.py
@@ -22,7 +22,8 @@ class PosOrder(models.Model):
     def _clean_payment_lines(self):
         self.ensure_one()
         order_payments = self.env['pos.payment'].search(['&', ('pos_order_id', '=', self.id), ('online_account_payment_id', '=', False)])
-        order_payments.unlink()
+        if order_payments:
+            order_payments.unlink()
 
     def get_and_set_online_payments_data(self, next_online_payment_amount=False):
         """ Allows to update the amount to pay for the next online payment and

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -420,9 +420,12 @@ class ProductProduct(models.Model):
             self = self.sudo()
             to_unlink = self._filter_to_unlink()
             to_archive = self - to_unlink
-            to_archive.write({'active': False})
+            if to_archive:
+                to_archive.write({'active': False})
             self = to_unlink
 
+        if not self:
+            return
         try:
             with self.env.cr.savepoint(), tools.mute_logger('odoo.sql_db'):
                 self.unlink()

--- a/addons/product/models/product_template_attribute_line.py
+++ b/addons/product/models/product_template_attribute_line.py
@@ -242,11 +242,14 @@ class ProductTemplateAttributeLine(models.Model):
                     })
             # Handle active at each step in case a following line might want to
             # re-use a value that was archived at a previous step.
-            ptav_to_activate.write({'ptav_active': True})
-            ptav_to_unlink.write({'ptav_active': False})
+            if ptav_to_activate:
+                ptav_to_activate.write({'ptav_active': True})
+            if ptav_to_unlink:
+                ptav_to_unlink.write({'ptav_active': False})
         if ptav_to_unlink:
             ptav_to_unlink.unlink()
-        ProductTemplateAttributeValue.create(ptav_to_create)
+        if ptav_to_create:
+            ProductTemplateAttributeValue.create(ptav_to_create)
         self.product_tmpl_id._create_variant_ids()
 
     def _without_no_variant_attributes(self):

--- a/addons/product/models/product_template_attribute_value.py
+++ b/addons/product/models/product_template_attribute_value.py
@@ -145,7 +145,8 @@ class ProductTemplateAttributeValue(models.Model):
                 # We catch all kind of exceptions to be sure that the operation
                 # doesn't fail.
                 ptav_to_archive += ptav
-        ptav_to_archive.write({'ptav_active': False})
+        if ptav_to_archive:
+            ptav_to_archive.write({'ptav_active': False})
         return True
 
     @api.depends('attribute_id')

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -392,9 +392,10 @@ class Project(models.Model):
             lambda task: not task.display_in_project
         )
         project.write({'tasks': [Command.set(new_tasks.ids)]})
-        subtasks_not_displayed.write({
-            'display_in_project': False
-        })
+        if subtasks_not_displayed:
+            subtasks_not_displayed.write({
+                'display_in_project': False
+            })
         return True
 
     def copy_data(self, default=None):
@@ -409,7 +410,7 @@ class Project(models.Model):
         for old_project, new_project in zip(self, new_projects):
             for follower in old_project.message_follower_ids:
                 new_project.message_subscribe(partner_ids=follower.partner_id.ids, subtype_ids=follower.subtype_ids.ids)
-            if old_project.allow_milestones:
+            if old_project.allow_milestones and self.milestone_ids:
                 new_project.milestone_ids = self.milestone_ids.copy().ids
             if 'tasks' not in default:
                 old_project.map_tasks(new_project.id)

--- a/addons/project_timesheet_holidays/models/hr_employee.py
+++ b/addons/project_timesheet_holidays/models/hr_employee.py
@@ -68,4 +68,6 @@ class Employee(models.Model):
                             work_hours_count
                         )
                     )
-        return self.env['account.analytic.line'].sudo().create(lines_vals)
+        if lines_vals:
+            return self.env['account.analytic.line'].sudo().create(lines_vals)
+        return self.env['account.analytic.line'].sudo()

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -476,7 +476,9 @@ class PurchaseOrder(models.Model):
     def button_approve(self, force=False):
         self = self.filtered(lambda order: order._approval_allowed())
         self.write({'state': 'purchase', 'date_approve': fields.Datetime.now()})
-        self.filtered(lambda p: p.company_id.po_lock == 'lock').write({'state': 'done'})
+        to_approve = self.filtered(lambda p: p.company_id.po_lock == 'lock')
+        if to_approve:
+            to_approve.write({'state': 'done'})
         return {}
 
     def button_draft(self):

--- a/addons/purchase_stock/__init__.py
+++ b/addons/purchase_stock/__init__.py
@@ -13,4 +13,5 @@ def _create_buy_rules(env):
     were already created.
     """
     warehouse_ids = env['stock.warehouse'].search([('buy_pull_id', '=', False)])
-    warehouse_ids.write({'buy_to_resupply': True})
+    if warehouse_ids:
+        warehouse_ids.write({'buy_to_resupply': True})

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -114,7 +114,9 @@ class AccountMove(models.Model):
 
     def _post(self, soft=True):
         if not self._context.get('move_reverse_cancel'):
-            self.env['account.move.line'].create(self._stock_account_prepare_anglo_saxon_in_lines_vals())
+            to_create = self._stock_account_prepare_anglo_saxon_in_lines_vals()
+            if to_create:
+                self.env['account.move.line'].create(to_create)
 
         # Create correction layer and impact accounts if invoice price is different
         stock_valuation_layers = self.env['stock.valuation.layer'].sudo()

--- a/addons/rating/models/mail_thread.py
+++ b/addons/rating/models/mail_thread.py
@@ -20,7 +20,9 @@ class MailThread(models.AbstractModel):
         """ When removing a record, its rating should be deleted too. """
         record_ids = self.ids
         result = super().unlink()
-        self.env['rating.rating'].sudo().search([('res_model', '=', self._name), ('res_id', 'in', record_ids)]).unlink()
+        to_unlink = self.env['rating.rating'].sudo().search([('res_model', '=', self._name), ('res_id', 'in', record_ids)])
+        if to_unlink:
+            to_unlink.unlink()
         return result
 
     def _message_create(self, values_list):

--- a/addons/repair/models/stock_move.py
+++ b/addons/repair/models/stock_move.py
@@ -126,8 +126,8 @@ class StockMove(models.Model):
                 so_line_vals[-1]['price_unit'] = 0.0
             elif move.price_unit:
                 so_line_vals[-1]['price_unit'] = move.price_unit
-
-        self.env['sale.order.line'].create(so_line_vals)
+        if so_line_vals:
+            self.env['sale.order.line'].create(so_line_vals)
 
     def _clean_repair_sale_order_line(self):
         self.filtered(

--- a/addons/resource/models/res_company.py
+++ b/addons/resource/models/res_company.py
@@ -14,7 +14,9 @@ class ResCompany(models.Model):
 
     @api.model
     def _init_data_resource_calendar(self):
-        self.search([('resource_calendar_id', '=', False)])._create_resource_calendar()
+        to_create = self.search([('resource_calendar_id', '=', False)])
+        if to_create:
+            to_create._create_resource_calendar()
 
     def _create_resource_calendar(self):
         vals_list = [

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -120,9 +120,11 @@ class ResConfigSettings(models.TransientModel):
             self.env['ir.config_parameter'].set_param(key='sale.automatic_invoice', value=False)
 
         if not self.group_discount_per_so_line:
-            self.env['product.pricelist'].search([
+            add_discount_policy = self.env['product.pricelist'].search([
                 ('discount_policy', '=', 'without_discount')
-            ]).write({'discount_policy': 'with_discount'})
+            ])
+            if add_discount_policy:
+                add_discount_policy.write({'discount_policy': 'with_discount'})
 
         send_invoice_cron = self.env.ref('sale.send_invoice_cron', raise_if_not_found=False)
         if send_invoice_cron and send_invoice_cron.active != self.automatic_invoice:

--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -164,8 +164,10 @@ class SaleAdvancePaymentInv(models.TransientModel):
                     self._prepare_down_payment_section_values(order)
                 )
 
-            values, accounts = self._prepare_down_payment_lines_values(order)
-            down_payment_lines = SaleOrderline.create(values)
+            vals_list, accounts = self._prepare_down_payment_lines_values(order)
+            if not vals_list:
+                return self.env['account.move'].sudo()
+            down_payment_lines = SaleOrderline.create(vals_list)
 
             invoice = self.env['account.move'].sudo().create(
                 self._prepare_invoice_values(order, down_payment_lines, accounts)

--- a/addons/sale_loyalty/models/sale_order_line.py
+++ b/addons/sale_loyalty/models/sale_order_line.py
@@ -58,6 +58,8 @@ class SaleOrderLine(models.Model):
 
         Returns self
         """
+        if not self:
+            return self
         vals = {
             'points_cost': 0,
             'price_unit': 0,

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -200,15 +200,16 @@ class SaleOrderLine(models.Model):
             values['name'] = "%s - %s" % (values['name'], self.product_id.project_template_id.name)
             # The no_create_folder context key is used in documents_project
             project = self.product_id.project_template_id.with_context(no_create_folder=True).copy(values)
-            project.tasks.write({
-                'sale_line_id': self.id,
-                'partner_id': self.order_id.partner_id.id,
-            })
-            # duplicating a project doesn't set the SO on sub-tasks
-            project.tasks.filtered('parent_id').write({
-                'sale_line_id': self.id,
-                'sale_order_id': self.order_id.id,
-            })
+            if project.tasks:
+                project.tasks.write({
+                    'sale_line_id': self.id,
+                    'partner_id': self.order_id.partner_id.id,
+                })
+                # duplicating a project doesn't set the SO on sub-tasks
+                project.tasks.filtered('parent_id').write({
+                    'sale_line_id': self.id,
+                    'sale_order_id': self.order_id.id,
+                })
         else:
             project_only_sol_count = self.env['sale.order.line'].search_count([
                 ('order_id', '=', self.order_id.id),

--- a/addons/sale_timesheet/models/account_move.py
+++ b/addons/sale_timesheet/models/account_move.py
@@ -127,5 +127,6 @@ class AccountMoveLine(models.Model):
             if so_line.id in sale_line_ids_per_move[timesheet_invoice.id].ids:
                 timesheet_ids += ids
 
-        self.sudo().env['account.analytic.line'].browse(timesheet_ids).write({'timesheet_invoice_id': False})
+        if timesheet_ids:
+            self.sudo().env['account.analytic.line'].browse(timesheet_ids).write({'timesheet_invoice_id': False})
         return super().unlink()

--- a/addons/sms/models/sms_template.py
+++ b/addons/sms/models/sms_template.py
@@ -46,7 +46,9 @@ class SMSTemplate(models.Model):
         return [dict(vals, name=_("%s (copy)", template.name)) for template, vals in zip(self, vals_list)]
 
     def unlink(self):
-        self.sudo().mapped('sidebar_action_id').unlink()
+        to_unlink = self.sudo().mapped('sidebar_action_id')
+        if to_unlink:
+            to_unlink.unlink()
         return super(SMSTemplate, self).unlink()
 
     def action_create_sidebar_action(self):

--- a/addons/snailmail/models/res_partner.py
+++ b/addons/snailmail/models/res_partner.py
@@ -21,7 +21,8 @@ class ResPartner(models.Model):
                 ('state', 'not in', ['sent', 'canceled']),
                 ('partner_id', 'in', self.ids),
             ])
-            letters.write(letter_address_vals)
+            if letters:
+                letters.write(letter_address_vals)
 
         return super(ResPartner, self).write(vals)
 

--- a/addons/stock/__init__.py
+++ b/addons/stock/__init__.py
@@ -10,10 +10,12 @@ from . import populate
 
 # TODO: Apply proper fix & remove in master
 def pre_init_hook(env):
-    env['ir.model.data'].search([
+    to_unlink = env['ir.model.data'].search([
         ('model', 'like', 'stock'),
         ('module', '=', 'stock')
-    ]).unlink()
+    ])
+    if to_unlink:
+        to_unlink.unlink()
 
 def _assign_default_mail_template_picking_id(env):
     company_ids_without_default_mail_template_id = env['res.company'].search([
@@ -27,4 +29,5 @@ def _assign_default_mail_template_picking_id(env):
 
 def uninstall_hook(env):
     picking_type_ids = env["stock.picking.type"].with_context({"active_test": False}).search([])
-    picking_type_ids.sequence_id.unlink()
+    if picking_type_ids.sequence_id:
+        picking_type_ids.sequence_id.unlink()

--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -568,9 +568,11 @@ class Product(models.Model):
 
     def write(self, values):
         if 'active' in values:
-            self.filtered(lambda p: p.active != values['active']).with_context(active_test=False).orderpoint_ids.write({
-                'active': values['active']
-            })
+            orderpoints_to_activate = self.filtered(lambda p: p.active != values['active']).with_context(active_test=False).orderpoint_ids
+            if orderpoints_to_activate:
+                orderpoints_to_activate.write({
+                    'active': values['active']
+                })
         return super().write(values)
 
     def _get_quantity_in_progress(self, location_ids=False, warehouse_ids=False):

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -232,7 +232,7 @@ class Location(models.Model):
                     raise UserError(_(
                         "You can't disable locations %s because they still contain products.",
                         ', '.join(children_quants.mapped('location_id.display_name'))))
-                else:
+                elif children_location - self:
                     super(Location, children_location - self).with_context(do_not_check_quant=True).write({
                         'active': values['active'],
                     })

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -476,7 +476,8 @@ class StockWarehouseOrderpoint(models.Model):
             expression.AND([domain, [('ids', 'in', self.ids)]])
         orderpoints_to_remove = self.env['stock.warehouse.orderpoint'].with_context(active_test=False).search(domain)
         # Remove previous automatically created orderpoint that has been refilled.
-        orderpoints_to_remove.unlink()
+        if orderpoints_to_remove:
+            orderpoints_to_remove.unlink()
         return orderpoints_to_remove
 
     def _prepare_procurement_values(self, date=False, group=False):

--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -53,9 +53,11 @@ class StockPackageLevel(models.Model):
             if package_level.is_done:
                 if not package_level.is_fresh_package:
                     ml_update_dict = defaultdict(float)
-                    package_level.picking_id.move_line_ids.filtered(
+                    to_unlink = package_level.picking_id.move_line_ids.filtered(
                         lambda ml: not ml.package_level_id and ml.package_id == package_level.package_id
-                    ).unlink()
+                    )
+                    if to_unlink:
+                        to_unlink.unlink()
                     for quant in package_level.package_id.quant_ids:
                         corresponding_mls = package_level.move_line_ids.filtered(lambda ml: ml.product_id == quant.product_id and ml.lot_id == quant.lot_id)
                         to_dispatch = quant.quantity
@@ -87,7 +89,9 @@ class StockPackageLevel(models.Model):
                         rec.quantity = quant
                         rec.picked = True
             else:
-                package_level.move_line_ids.unlink()
+                to_unlink = package_level.move_line_ids
+                if to_unlink:
+                    to_unlink.unlink()
 
     @api.depends('move_line_ids', 'move_line_ids.package_id', 'move_line_ids.result_package_id')
     def _compute_fresh_pack(self):

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -1115,7 +1115,8 @@ class StockQuant(models.Model):
         params = (precision_digits, precision_digits, precision_digits)
         self.env.cr.execute(query, params)
         quant_ids = self.env['stock.quant'].browse([quant['id'] for quant in self.env.cr.dictfetchall()])
-        quant_ids.sudo().unlink()
+        if quant_ids:
+            quant_ids.sudo().unlink()
 
     @api.model
     def _merge_quants(self):

--- a/addons/stock_account/models/account_move.py
+++ b/addons/stock_account/models/account_move.py
@@ -43,7 +43,9 @@ class AccountMove(models.Model):
             return super()._post(soft)
 
         # Create additional COGS lines for customer invoices.
-        self.env['account.move.line'].create(self._stock_account_prepare_anglo_saxon_out_lines_vals())
+        vals_list = self._stock_account_prepare_anglo_saxon_out_lines_vals()
+        if vals_list:
+            self.env['account.move.line'].create(vals_list)
 
         # Post entries.
         posted = super()._post(soft)
@@ -57,7 +59,9 @@ class AccountMove(models.Model):
         res = super(AccountMove, self).button_draft()
 
         # Unlink the COGS lines generated during the 'post' method.
-        self.mapped('line_ids').filtered(lambda line: line.display_type == 'cogs').unlink()
+        to_unlink = self.mapped('line_ids').filtered(lambda line: line.display_type == 'cogs')
+        if to_unlink:
+            to_unlink.unlink()
         return res
 
     def button_cancel(self):
@@ -67,7 +71,9 @@ class AccountMove(models.Model):
         # Unlink the COGS lines generated during the 'post' method.
         # In most cases it shouldn't be necessary since they should be unlinked with 'button_draft'.
         # However, since it can be called in RPC, better be safe.
-        self.mapped('line_ids').filtered(lambda line: line.display_type == 'cogs').unlink()
+        to_unlink = self.mapped('line_ids').filtered(lambda line: line.display_type == 'cogs')
+        if to_unlink:
+            to_unlink.unlink()
         return res
 
     # -------------------------------------------------------------------------

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -34,7 +34,8 @@ class StockMove(models.Model):
         return action_data
 
     def _action_cancel(self):
-        self.analytic_account_line_ids.unlink()
+        if self.analytic_account_line_ids:
+            self.analytic_account_line_ids.unlink()
         return super()._action_cancel()
 
     def _should_force_price_unit(self):

--- a/addons/utm/models/utm_source.py
+++ b/addons/utm/models/utm_source.py
@@ -54,16 +54,17 @@ class UtmSourceMixin(models.AbstractModel):
     def create(self, vals_list):
         """Create the UTM sources if necessary, generate the name based on the content in batch."""
         # Create all required <utm.source>
-        utm_sources = self.env['utm.source'].create([
-            {'name': values.get('name') or self.env['utm.source']._generate_name(self, values.get(self._rec_name))}
-            for values in vals_list
-            if not values.get('source_id')
-        ])
-
-        # Update "vals_list" to add the ID of the newly created source
         vals_list_missing_source = [values for values in vals_list if not values.get('source_id')]
-        for values, source in zip(vals_list_missing_source, utm_sources):
-            values['source_id'] = source.id
+        if vals_list_missing_source:
+            utm_sources = self.env['utm.source'].create([
+                {'name': values.get('name') or self.env['utm.source']._generate_name(self, values.get(self._rec_name))}
+                for values in vals_list
+                if not values.get('source_id')
+            ])
+
+            # Update "vals_list" to add the ID of the newly created source
+            for values, source in zip(vals_list_missing_source, utm_sources):
+                values['source_id'] = source.id
 
         for values in vals_list:
             if 'name' in values:

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -89,12 +89,14 @@ class Menu(models.Model):
                 menus |= super().create(vals)
                 continue
             else:
+                new_menu = self.browse()
                 # create for every site
                 w_vals = [dict(vals, **{
                     'website_id': website.id,
                     'parent_id': website.menu_id.id,
                 }) for website in self.env['website'].search([])]
-                new_menu = super().create(w_vals)[-1:]  # take the last one
+                if w_vals:
+                    new_menu = super().create(w_vals)[-1:]  # take the last one
                 # if creating a default menu, we should also save it as such
                 default_menu = self.env.ref('website.main_menu', raise_if_not_found=False)
                 if default_menu and vals.get('parent_id') == default_menu.id:

--- a/addons/website_event/models/website_event_menu.py
+++ b/addons/website_event/models/website_event_menu.py
@@ -20,5 +20,6 @@ class EventMenu(models.Model):
         ], string="Menu Type", required=True)
 
     def unlink(self):
-        self.view_id.sudo().unlink()
+        if self.view_id:
+            self.view_id.sudo().unlink()
         return super(EventMenu, self).unlink()

--- a/addons/website_event/models/website_menu.py
+++ b/addons/website_event/models/website_menu.py
@@ -19,7 +19,8 @@ class WebsiteMenu(models.Model):
 
         # manually remove website_event_menus to call their ``unlink`` method. Otherwise
         # super unlinks at db level and skip model-specific behavior.
-        website_event_menus.unlink()
+        if website_event_menus:
+            website_event_menus.unlink()
         res = super(WebsiteMenu, self).unlink()
 
         # update events

--- a/addons/website_forum/models/forum_forum.py
+++ b/addons/website_forum/models/forum_forum.py
@@ -268,7 +268,8 @@ class Forum(models.Model):
         if 'privacy' in vals:
             if not vals['privacy']:
                 # The forum is neither public, neither private, remove menu to avoid conflict
-                self.menu_id.unlink()
+                if self.menu_id:
+                    self.menu_id.unlink()
             elif vals['privacy'] == 'public':
                 # The forum is public, the menu must be also public
                 vals['authorized_group_id'] = False

--- a/addons/website_sale_wishlist/models/product_wishlist.py
+++ b/addons/website_sale_wishlist/models/product_wishlist.py
@@ -68,10 +68,12 @@ class ProductWishlist(models.Model):
     @api.autovacuum
     def _gc_sessions(self, *args, **kwargs):
         """Remove wishlists for unexisting sessions."""
-        self.with_context(active_test=False).search([
+        to_unlink = self.with_context(active_test=False).search([
             ("create_date", "<", fields.Datetime.to_string(datetime.now() - timedelta(weeks=kwargs.get('wishlist_week', 5)))),
             ("partner_id", "=", False),
-        ]).unlink()
+        ])
+        if to_unlink:
+            to_unlink.unlink()
 
 
 class ResPartner(models.Model):

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -936,8 +936,9 @@ class Channel(models.Model):
                 to_update_as_joined += channel_partners.filtered(lambda cp: cp.member_status == 'invited')
             for partner in target_partners - channel_partners.partner_id:
                 to_create_channel_partners_values.append(dict(channel_id=channel.id, partner_id=partner.id, member_status=member_status))
-
-        new_slide_channel_partners = SlideChannelPartnerSudo.create(to_create_channel_partners_values)
+        new_slide_channel_partners = SlideChannelPartnerSudo
+        if to_create_channel_partners_values:
+            new_slide_channel_partners = SlideChannelPartnerSudo.create(to_create_channel_partners_values)
         to_update_as_joined.member_status = 'joined'
         to_update_as_joined._recompute_completion()
 

--- a/addons/website_slides_forum/models/slide_channel.py
+++ b/addons/website_slides_forum/models/slide_channel.py
@@ -37,7 +37,7 @@ class Channel(models.Model):
         res = super(Channel, self).write(vals)
         if 'forum_id' in vals:
             self.forum_id.privacy = False
-            if old_forum != self.forum_id:
+            if old_forum and old_forum != self.forum_id:
                 old_forum.write({
                     'privacy': 'private',
                     'authorized_group_id': self.env.ref('website_slides.group_website_slides_officer').id,

--- a/addons/website_slides_survey/models/slide_slide.py
+++ b/addons/website_slides_survey/models/slide_slide.py
@@ -24,9 +24,11 @@ class SlidePartnerRelation(models.Model):
     def _compute_field_value(self, field):
         super()._compute_field_value(field)
         if field.name == 'survey_scoring_success':
-            self.filtered('survey_scoring_success').write({
-                'completed': True
-            })
+            to_complete = self.filtered('survey_scoring_success')
+            if to_complete:
+                to_complete.write({
+                    'completed': True
+                })
 
     def _recompute_completion(self):
         super(SlidePartnerRelation, self)._recompute_completion()
@@ -123,10 +125,12 @@ class Slide(models.Model):
         If the survey is unlinked from the slide, the challenge category must be reset to 'certification'"""
         if old_surveys:
             old_certification_challenges = old_surveys.mapped('certification_badge_id').challenge_ids
-            old_certification_challenges.write({'challenge_category': 'certification'})
+            if old_certification_challenges:
+                old_certification_challenges.write({'challenge_category': 'certification'})
         if not unlink:
             certification_challenges = self.survey_id.certification_badge_id.challenge_ids
-            certification_challenges.write({'challenge_category': 'slides'})
+            if certification_challenges:
+                certification_challenges.write({'challenge_category': 'slides'})
 
     def _generate_certification_url(self):
         """ get a map of certification url for certification slide from `self`. The url will come from the survey user input:

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -89,7 +89,8 @@ class IrActions(models.Model):
         """unlink ir.action.todo which are related to actions which will be deleted.
            NOTE: ondelete cascade will not work on ir.actions.actions so we will need to do it manually."""
         todos = self.env['ir.actions.todo'].search([('action_id', 'in', self.ids)])
-        todos.unlink()
+        if todos:
+            todos.unlink()
         res = super(IrActions, self).unlink()
         # self.get_bindings() depends on action records
         self.env.registry.clear_cache()

--- a/odoo/addons/base/models/ir_cron.py
+++ b/odoo/addons/base/models/ir_cron.py
@@ -534,4 +534,6 @@ class ir_cron_trigger(models.Model):
 
     @api.autovacuum
     def _gc_cron_triggers(self):
-        self.search([('call_at', '<', datetime.now() + relativedelta(weeks=-1))]).unlink()
+        to_unlink = self.search([('call_at', '<', datetime.now() + relativedelta(weeks=-1))])
+        if to_unlink:
+            to_unlink.unlink()

--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -177,7 +177,10 @@ class IrDefault(models.Model):
         domain = [('field_id.ttype', '=', 'many2one'),
                   ('field_id.relation', '=', records._name),
                   ('json_value', 'in', json_vals)]
-        return self.search(domain).unlink()
+        to_discard = self.search(domain)
+        if to_discard:
+            return to_discard.unlink()
+        return True
 
     @api.model
     def discard_values(self, model_name, field_name, values):

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -1705,7 +1705,9 @@ class IrModelSelection(models.Model):
             elif ondelete.startswith('set '):
                 safe_write(selection._get_records(), field.name, ondelete[4:])
             elif ondelete == 'cascade':
-                selection._get_records().unlink()
+                to_unlink = selection._get_records()
+                if to_unlink:
+                    to_unlink.unlink()
             else:
                 # this shouldn't happen... simply a sanity check
                 raise ValueError(_(

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -498,7 +498,8 @@ class Module(models.Model):
         """
         domain = expression.OR([[('key', '=like', m.name + '.%')] for m in self])
         orphans = self.env['ir.ui.view'].with_context(**{'active_test': False, MODULE_UNINSTALL_FLAG: True}).search(domain)
-        orphans.unlink()
+        if orphans:
+            orphans.unlink()
 
     @api.returns('self')
     def downstream_dependencies(self, known_deps=None,

--- a/odoo/addons/base/models/ir_profile.py
+++ b/odoo/addons/base/models/ir_profile.py
@@ -46,7 +46,10 @@ class IrProfile(models.Model):
     def _gc_profile(self):
         # remove profiles older than 30 days
         domain = [('create_date', '<', fields.Datetime.now() - datetime.timedelta(days=30))]
-        return self.sudo().search(domain).unlink()
+        to_unlink = self.sudo().search(domain)
+        if to_unlink:
+            return to_unlink.unlink()
+        return True
 
     def _compute_speedscope(self):
         for execution in self:

--- a/odoo/addons/base/models/ir_property.py
+++ b/odoo/addons/base/models/ir_property.py
@@ -378,7 +378,8 @@ class Property(models.Model):
                     'value': value,
                     'type': self.env[model]._fields[name].type,
                 })
-        self.sudo().create(vals_list)
+        if vals_list:
+            self.sudo().create(vals_list)
 
     @api.model
     def search_multi(self, name, model, operator, value):

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -309,7 +309,9 @@ class Company(models.Model):
             })
 
         # Make sure that the selected currencies are enabled
-        companies.currency_id.sudo().filtered(lambda c: not c.active).active = True
+        to_active = companies.currency_id.sudo().filtered(lambda c: not c.active)
+        if to_active:
+            to_active.active = True
 
         return companies
 

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -604,9 +604,11 @@ class Partner(models.Model):
         sync_children = self.child_ids.filtered(lambda c: not c.is_company)
         for child in sync_children:
             child._commercial_sync_to_children()
-        res = sync_children.write(sync_vals)
-        sync_children._compute_commercial_partner()
-        return res
+        if sync_children:
+            res = sync_children.write(sync_vals)
+            sync_children._compute_commercial_partner()
+            return res
+        return True
 
     def _fields_sync(self, values):
         """ Sync commercial fields and address fields from company and to children after create/update,

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -1349,7 +1349,8 @@ class GroupsImplied(models.Model):
         :param implied_group: the implied group to add
         """
         groups = self.filtered(lambda g: implied_group not in g.implied_ids)
-        groups.write({'implied_ids': [Command.link(implied_group.id)]})
+        if groups:
+            groups.write({'implied_ids': [Command.link(implied_group.id)]})
 
     def _remove_group(self, implied_group):
         """ Remove the given group from the implied groups of the current group

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2477,7 +2477,7 @@ class Binary(Field):
 
     def create(self, record_values):
         assert self.attachment
-        if not record_values:
+        if not [x for (x,y) in record_values if y]:
             return
         # create the attachments that store the values
         env = record_values[0][0].env
@@ -2526,7 +2526,8 @@ class Binary(Field):
                 ])
             if value:
                 # update the existing attachments
-                atts.write({'datas': value})
+                if atts:
+                    atts.write({'datas': value})
                 atts_records = records.browse(atts.mapped('res_id'))
                 # create the missing attachments
                 missing = (real_records - atts_records)
@@ -2541,7 +2542,7 @@ class Binary(Field):
                         }
                         for record in missing
                     ])
-            else:
+            elif atts:
                 atts.unlink()
 
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5628,6 +5628,8 @@ class BaseModel(metaclass=MetaModel):
 
         """
         vals_list = self.with_context(active_test=False).copy_data(default)
+        if not vals_list:
+            return self.browse()
         new_records = self.create(vals_list)
         for old_record, new_record in zip(self, new_records):
             old_record.copy_translations(new_record, excluded=default or ())
@@ -7168,7 +7170,9 @@ class TransientModel(Model):
             SQL("(now() AT TIME ZONE 'UTC') - interval %s", f"{seconds} seconds"),
         ))
         ids = [x[0] for x in self._cr.fetchall()]
-        self.sudo().browse(ids).unlink()
+        to_unlink = self.sudo().browse(ids)
+        if to_unlink:
+            to_unlink.unlink()
 
 
 def itemgetter_tuple(items):


### PR DESCRIPTION
The CRUD methods are inherited in many models through many modules. When they are called, they form a chain of super() calls through module dependencies until the core is reached (where the CRUD methods are defined). If the CRUD methods are called on empty records/value_lists, forming this chain is inefficient.

Thus, this commit aims to avoid calling this chain of super() in several cases. The aim is not to be exhaustive, just only correcting the most relevant (found) cases.

Moreover, besides obtaining slightly better performance, less spiky flamegraphs and less error-prone code, it will help with manual debugging and cron interruptions.

**Current behavior before PR:**
![Selection_2727](https://github.com/odoo/odoo/assets/25005517/94d7821f-d5b8-47e4-8f40-dde4421b8f57)
![Selection_2730](https://github.com/odoo/odoo/assets/25005517/ac55c44c-5ae1-4962-b1ec-ab787906c794)



**Desired behavior after PR is merged:**
![Selection_2732](https://github.com/odoo/odoo/assets/25005517/02ea4d8d-e74c-4d15-bf03-950101e44958)
![Selection_2733](https://github.com/odoo/odoo/assets/25005517/fa13a6be-e1ea-475c-b866-9c256ac9f45d)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr