### PR TITLE
[FIX] google_calendar: fix the sync issue after resuming

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -323,6 +323,16 @@ class GoogleSync(models.AbstractModel):
         # they will be synchronized eventually with the cron running few times a day
         return self.with_context(active_test=False).search(domain, limit=200)
 
+    def _check_any_records_to_sync(self):
+        """ Returns True if there are pending records to be synchronized from Odoo to Google, False otherwise. """
+        is_active_clause = (self._active_name, '=', True) if self._active_name else expression.TRUE_LEAF
+        domain = expression.AND([self._get_sync_domain(), [
+            '|',
+                '&', ('google_id', '=', False), is_active_clause,
+                ('need_sync', '=', True),
+        ]])
+        return self.search_count(domain, limit=1) > 0
+
     def _write_from_google(self, gevent, vals):
         self.write(vals)
 


### PR DESCRIPTION
**Version:**

- 17.0

**Step to reproduce:**
- open the Calendar and navigate to Configuration > Settings
- add Google credentials and sync it
- create an event and then pause the sync.
- again create an event and unpause the sync with Google Calendar
- event fails to update on Google Calendar

**Issue:**

Currently, when an event is created during the sync_pause period, the `_google_insert` function will not be called. After unpausing the sync, the event will return an empty GoogleEvent ID.

**Solution:**

This PR enables the synchronization to restart automatically when unpausing the Google Calendar.

task-3731607

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr