### PR TITLE
[FIX] loyalty: fixes multi-product calc for loyalty reward

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -148,7 +148,10 @@ class LoyaltyReward(models.Model):
     @api.depends('reward_product_id', 'reward_product_tag_id', 'reward_type')
     def _compute_multi_product(self):
         for reward in self:
-            products = reward.reward_product_id + reward.reward_product_tag_id.product_ids
+            products = list(set(
+                [reward.reward_product_id.id] if reward.reward_product_id else []
+                + reward.reward_product_tag_id.product_ids.ids
+            ))
             reward.multi_product = reward.reward_type == 'product' and len(products) > 1
             reward.reward_product_ids = reward.reward_type == 'product' and products or self.env['product.product']
 

--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -148,10 +148,7 @@ class LoyaltyReward(models.Model):
     @api.depends('reward_product_id', 'reward_product_tag_id', 'reward_type')
     def _compute_multi_product(self):
         for reward in self:
-            products = list(set(
-                [reward.reward_product_id.id] if reward.reward_product_id else []
-                + reward.reward_product_tag_id.product_ids.ids
-            ))
+            products = reward.reward_product_id | reward.reward_product_tag_id.product_ids
             reward.multi_product = reward.reward_type == 'product' and len(products) > 1
             reward.reward_product_ids = reward.reward_type == 'product' and products or self.env['product.product']
 

--- a/doc/cla/corporate/abilium.md
+++ b/doc/cla/corporate/abilium.md
@@ -13,3 +13,4 @@ Severin Zumbrunn severin.zumbrunn@abilium.com  https://github.com/szumbrunn
 List of contributors:
 
 Severin Zumbrunn sz@tune-x.ch https://github.com/szumbrunn
+Leyla Karahan leyla.karahan@abilium.com https://github.com/LeyKara


### PR DESCRIPTION
duplicated count of product with product tag in multi-product calculation for loyalty reward

product with a product tag is being counted twice in the multi-product calculation for loyalty reward. After this is merged, the system should correctly count each product with a product tag only once during the multi-product calculation for loyalty reward.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
