### PR TITLE
[IMP] web: improve sample data's visibility

### DIFF
--- a/addons/web/static/src/legacy/scss/utils.scss
+++ b/addons/web/static/src/legacy/scss/utils.scss
@@ -392,7 +392,6 @@
 
 // Sample data
 @mixin o-sample-data-disabled {
-    opacity: 0.33;
     pointer-events: none;
     user-select: none;
 }

--- a/addons/web/static/src/views/graph/graph_view.scss
+++ b/addons/web/static/src/views/graph/graph_view.scss
@@ -1,6 +1,7 @@
 // ------- Graph renderer -------
 .o_graph_view {
     --ControlPanel-border-bottom: none;
+    --o-view-nocontent-zindex: 3;
 
     .o_graph_renderer canvas {
         background-color: $o-view-background-color;


### PR DESCRIPTION
By removing the radial gradient and ensuring a smooth box-shadow on the helper, the sample content behind the no-content helper is more visible.

|Before|After|
|-----|-----|
| ![Screenshot 2024-03-01 at 15 53 27](https://github.com/odoo/odoo/assets/19491443/619ac534-30ba-40f6-b3da-47eaa0c8a18c) |  ![Screenshot 2024-03-01 at 16 08 40](https://github.com/odoo/odoo/assets/19491443/efdb54b2-19a0-40cc-a776-8e404e28cc31)  |



task-3751582

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
