### PR TITLE
[FIX] portal: allow vertical resize portal chatter

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -387,6 +387,7 @@ img, .media_iframe_video, .o_image {
     .o_portal_chatter_composer_body  {
         textarea {
             border: 0;
+            resize: vertical !important;
         }
         > div {
             border: 1px solid var(--o-border-color);


### PR DESCRIPTION
**Current behavior:**
The textarea where a portal user can leave some comments is not vertically resizable.

**Expected behavior:**
A portal user can resize this textarea vertically.

**Steps to reproduce:**
1. Share a project with a portal user

2. Login as the portal user, on your account page navigate to /my/tasks and click on one

3. Observe that the box to leave a comment cannot be vertically resized

**Cause of the issue:**
In the XML defining this webpage, the textarea corresponding to this input has style="resize:none".

**Fix:**
Override this style definition in the .scss file for this page to allow for vertical resizing. In master it could be better to fix it by modifying the XML file to not have conflicting a style definition.

opw-3757555