### PR TITLE
[IMP] mail: track property fields at parent change

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -105,7 +105,7 @@ class HrEmployee(models.Model):
     newly_hired = fields.Boolean('Newly Hired', compute='_compute_newly_hired', search='_search_newly_hired')
 
     active = fields.Boolean('Active', related='resource_id.active', default=True, store=True, readonly=False)
-    company_id = fields.Many2one('res.company', required=True)
+    company_id = fields.Many2one('res.company', required=True, tracking=True)
     company_country_id = fields.Many2one('res.country', 'Company Country', related='company_id.country_id', readonly=True, groups="base.group_system,hr.group_hr_user")
     company_country_code = fields.Char(related='company_country_id.code', depends=['company_country_id'], readonly=True, groups="base.group_system,hr.group_hr_user", string='Company Country Code')
     work_phone = fields.Char('Work Phone', compute="_compute_phones", store=True, readonly=False, tracking=True)

--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -113,21 +113,70 @@ class MailTrackingValue(models.Model):
                 'new_value_char': new_value and dict(col_info['selection'])[new_value] or ''
             })
         elif col_info['type'] == 'many2one':
+            # Can be:
+            # - False value
+            # - recordset, in case of standard field
+            # - (id, display name), in case of properties (read format)
+            if not initial_value:
+                initial_value = (0, '')
+            elif isinstance(initial_value, models.BaseModel):
+                initial_value = (initial_value.id, initial_value.display_name)
+
+            if not new_value:
+                new_value = (0, '')
+            elif isinstance(new_value, models.BaseModel):
+                new_value = (new_value.id, new_value.display_name)
+
             values.update({
-                'old_value_integer': initial_value.id if initial_value else 0,
-                'new_value_integer': new_value.id if new_value else 0,
-                'old_value_char': initial_value.display_name if initial_value else '',
-                'new_value_char': new_value.display_name if new_value else ''
+                'old_value_integer': initial_value[0],
+                'new_value_integer': new_value[0],
+                'old_value_char': initial_value[1],
+                'new_value_char': new_value[1]
             })
-        elif col_info['type'] in {'one2many', 'many2many'}:
+        elif col_info['type'] in {'one2many', 'many2many', 'tags'}:
+            # Can be:
+            # - False value
+            # - recordset, in case of standard field
+            # - [(id, display name), ...], in case of properties (read format)
+            if not initial_value:
+                old_value_char = ''
+            elif isinstance(initial_value, models.BaseModel):
+                old_value_char = ', '.join(initial_value.mapped('display_name'))
+            else:
+                old_value_char = ', '.join(value[1] for value in initial_value)
+            if not new_value:
+                new_value_char = ''
+            elif isinstance(new_value, models.BaseModel):
+                new_value_char = ', '.join(new_value.mapped('display_name'))
+            else:
+                new_value_char = ', '.join(value[1] for value in new_value)
+
             values.update({
-                'old_value_char': ', '.join(initial_value.mapped('display_name')) if initial_value else '',
-                'new_value_char': ', '.join(new_value.mapped('display_name')) if new_value else '',
+                'old_value_char': old_value_char,
+                'new_value_char': new_value_char,
             })
         else:
             raise NotImplementedError(f'Unsupported tracking on field {field.name} (type {col_info["type"]}')
 
         return values
+
+    @api.model
+    def _create_tracking_values_property(self, initial_value, col_name, col_info, record):
+        """Generate the values for the <mail.tracking.values> corresponding to a property."""
+        col_info = col_info | {'type': initial_value['type'], 'selection': initial_value.get('selection')}
+
+        field_info = {
+            'desc': f"{col_info['string']}: {initial_value['string']}",
+            'name': col_name,
+            'type': initial_value['type'],
+        }
+        value = initial_value.get('value', False)
+        if value and initial_value['type'] == 'tags':
+            value = [t for t in initial_value.get('tags', []) if t[0] in value]
+
+        tracking_values = self.env['mail.tracking.value']._create_tracking_values(
+            value, False, col_name, col_info, record)
+        return {**tracking_values, 'field_info': field_info}
 
     def _tracking_value_format(self):
         """ Return structure and formatted data structure to be used by chatter
@@ -178,7 +227,9 @@ class MailTrackingValue(models.Model):
         )
         # generate dict of field information, if available
         fields_col_info = (
-            tracked_fields.get(tracking.field_id.name) or {
+            tracking.field_id.ttype != 'properties'
+            and tracked_fields.get(tracking.field_id.name)
+            or {
                 'string': tracking.field_info['desc'] if tracking.field_info else self.env._('Unknown'),
                 'type': tracking.field_info['type'] if tracking.field_info else 'char',
             } for tracking in self
@@ -187,7 +238,11 @@ class MailTrackingValue(models.Model):
         def sort_tracking_info(tracking_info_tuple):
             tracking = tracking_info_tuple[0]
             field_name = tracking.field_id.name or (tracking.field_info['name'] if tracking.field_info else 'unknown')
-            return (fields_sequence_map.get(field_name, 100), field_name)
+            return (
+                fields_sequence_map.get(field_name, 100),
+                tracking.field_id.ttype == 'properties',
+                field_name,
+            )
 
         formatted = [
             {
@@ -197,6 +252,7 @@ class MailTrackingValue(models.Model):
                     'currencyId': tracking.currency_id.id,
                     'floatPrecision': col_info.get('digits'),
                     'fieldType': col_info['type'],
+                    'isPropertyField': tracking.field_id.ttype == 'properties',
                 },
                 'newValue': tracking._format_display_value(col_info['type'], new=True)[0],
                 'oldValue': tracking._format_display_value(col_info['type'], new=False)[0],

--- a/addons/mail/static/src/core/web/message_patch.xml
+++ b/addons/mail/static/src/core/web/message_patch.xml
@@ -14,8 +14,10 @@
                             <t name="trackingValues" t-foreach="message.trackingValues" t-as="trackingValue" t-key="trackingValue.id">
                                 <li class="o-mail-Message-tracking mb-1" role="group">
                                     <span class="o-mail-Message-trackingOld text-muted fw-bold" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.oldValue)"/>
-                                    <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-2 text-600"/>
-                                    <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.newValue)"/>
+                                    <t t-if="!trackingValue.fieldInfo.isPropertyField">
+                                        <i class="o-mail-Message-trackingSeparator fa fa-long-arrow-right mx-2 text-600"/>
+                                        <span class="o-mail-Message-trackingNew me-1 fw-bold text-info" t-esc="formatTrackingOrNone(trackingValue.fieldInfo, trackingValue.newValue)"/>
+                                    </t>
                                     <span class="o-mail-Message-trackingField ms-1 fst-italic text-muted">(<t t-esc="trackingValue.fieldInfo.changedField"/>)</span>
                                 </li>
                             </t>

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -44,7 +44,7 @@ class StockLot(models.Model):
         'product.product', 'Product', index=True,
         domain=("[('tracking', '!=', 'none'), ('is_storable', '=', True)] +"
             " ([('product_tmpl_id', '=', context['default_product_tmpl_id'])] if context.get('default_product_tmpl_id') else [])"),
-        required=True, check_company=True)
+        required=True, check_company=True, tracking=True)
     product_uom_id = fields.Many2one(
         'uom.uom', 'Unit',
         related='product_id.uom_id')

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -625,7 +625,7 @@ class StockPicking(models.Model):
     picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type',
         required=True, index=True,
-        default=_default_picking_type_id)
+        default=_default_picking_type_id, tracking=True)
     warehouse_address_id = fields.Many2one('res.partner', related='picking_type_id.warehouse_id.partner_id')
     picking_type_code = fields.Selection(
         related='picking_type_id.code',

--- a/addons/test_mail/models/test_mail_corner_case_models.py
+++ b/addons/test_mail/models/test_mail_corner_case_models.py
@@ -116,6 +116,13 @@ class MailTestTrackAllO2m(models.Model):
     mail_track_all_id = fields.Many2one('mail.test.track.all')
 
 
+class MailTestTrackAllPropertiesParent(models.Model):
+    _description = 'Properties Parent'
+    _name = "mail.test.track.all.properties.parent"
+
+    definition_properties = fields.PropertiesDefinition()
+
+
 class MailTestTrackAll(models.Model):
     _description = 'Test tracking on all field types'
     _name = "mail.test.track.all"
@@ -140,6 +147,8 @@ class MailTestTrackAll(models.Model):
         'mail.test.track.all.o2m', 'mail_track_all_id',
         string='One2Many',
         tracking=11)
+    properties_parent_id = fields.Many2one('mail.test.track.all.properties.parent', tracking=True)
+    properties = fields.Properties('Properties', definition='properties_parent_id.definition_properties')
     selection_field = fields.Selection(
         string='Selection',
         selection=[('first', 'FIRST'), ('second', 'SECOND')],

--- a/addons/test_mail/security/ir.model.access.csv
+++ b/addons/test_mail/security/ir.model.access.csv
@@ -64,6 +64,7 @@ access_mail_test_nothread_portal,mail.test.nothread.portal,model_mail_test_nothr
 access_mail_test_recipients_user,mail.test.recipients.user,model_mail_test_recipients,base.group_user,1,1,1,1
 access_mail_test_thread_customer_user,mail.test.thread.customer.user,model_mail_test_thread_customer,base.group_user,1,1,1,1
 access_mail_test_track_all,mail.test.track.all,model_mail_test_track_all,base.group_user,1,1,1,1
+access_mail_test_track_all_properties_parent,access_mail_test_track_all_properties_parent,model_mail_test_track_all_properties_parent,base.group_user,1,0,0,0
 access_mail_test_track_all_m2m,mail.test.track.all.m2m,model_mail_test_track_all_m2m,base.group_user,1,1,1,1
 access_mail_test_track_all_o2m,mail.test.track.all.o2m,model_mail_test_track_all_o2m,base.group_user,1,1,1,1
 access_mail_test_track_compute,mail.test.track.compute,model_mail_test_track_compute,base.group_user,1,1,1,1


### PR DESCRIPTION
Purpose
=======

Track property fields values. However we don't want to log all
property changes; we only want to log a note when the parent
changes, which removes all properties.

Technical
=========

Because we want to track the change only if the parent changed,
the definition record field needs to be tracked.

Task-3644407