### PR TITLE
[IMP] core: make updates with less SQL queries

### DIFF
--- a/addons/crm/tests/test_crm_lead_convert_mass.py
+++ b/addons/crm/tests/test_crm_lead_convert_mass.py
@@ -168,7 +168,7 @@ class TestLeadConvertMass(crm_common.TestLeadConvertMassCommon):
 
         # randomness: at least 1 query
         self.env['res.lang']._get_data(code='en_US')  # cache language for validation
-        with self.assertQueryCount(user_sales_manager=1806):  # crm 1503 / com 1790 / ent 1800
+        with self.assertQueryCount(user_sales_manager=1660):  # crm 1335 / com 1648 / ent 1658
             mass_convert = self.env['crm.lead2opportunity.partner.mass'].with_context({
                 'active_model': 'crm.lead',
                 'active_ids': test_leads.ids,

--- a/addons/gamification/tests/test_karma_tracking.py
+++ b/addons/gamification/tests/test_karma_tracking.py
@@ -264,7 +264,7 @@ class TestKarmaTrackingCommon(common.TransactionCase):
         last_tracking_3 = self.test_user_2.karma_tracking_ids[-1]
 
         users = (user | self.test_user | self.test_user_2).with_user(self.test_user)
-        with self.assertQueryCount(12):
+        with self.assertQueryCount(11):
             users.karma = 100
 
         tracking_1 = user.karma_tracking_ids[-1]

--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -293,7 +293,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=1351):  # 770 community
+        with self.assertQueryCount(__system__=756):  # 756 community
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/test_mail_full/tests/test_mail_performance.py
+++ b/addons/test_mail_full/tests/test_mail_performance.py
@@ -239,7 +239,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
     def test_portal_message_format_norating(self):
         messages_all = self.messages_all.with_user(self.env.user)
 
-        with self.assertQueryCount(employee=31):
+        with self.assertQueryCount(employee=11):
             # res = messages_all.portal_message_format(options=None)
             res = messages_all.portal_message_format(options={'rating_include': False})
 
@@ -290,7 +290,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
     def test_portal_message_format_rating(self):
         messages_all = self.messages_all.with_user(self.env.user)
 
-        with self.assertQueryCount(employee=45):
+        with self.assertQueryCount(employee=25):
             res = messages_all.portal_message_format(options={'rating_include': True})
 
         self.assertEqual(len(res), len(messages_all))
@@ -312,7 +312,7 @@ class TestPortalFormatPerformance(FullBaseMailPerformance):
     def test_portal_message_format_monorecord(self):
         message = self.messages_all[0].with_user(self.env.user)
 
-        with self.assertQueryCount(employee=18):
+        with self.assertQueryCount(employee=16):
             res = message.portal_message_format(options={'rating_include': True})
 
         self.assertEqual(len(res), 1)

--- a/addons/test_mail_full/tests/test_rating.py
+++ b/addons/test_mail_full/tests/test_rating.py
@@ -172,25 +172,25 @@ class TestRatingPerformance(TestRatingCommon):
     @users('employee')
     @warmup
     def test_rating_last_value_perfs(self):
-        with self.assertQueryCount(employee=1617):  # tmf 1313 / com 1313
+        with self.assertQueryCount(employee=1612):  # tmf 1612 / com 1612
             self.create_ratings('mail.test.rating.thread')
 
-        with self.assertQueryCount(employee=2101):  # tmf 1901
+        with self.assertQueryCount(employee=2002):  # tmf 2002
             self.apply_ratings(1)
 
-        with self.assertQueryCount(employee=1900):  # tmf 1800
+        with self.assertQueryCount(employee=1801):  # tmf 1801
             self.apply_ratings(5)
 
     @users('employee')
     @warmup
     def test_rating_last_value_perfs_with_rating_mixin(self):
-        with self.assertQueryCount(employee=1724):  # tmf 1419 / com 1419
+        with self.assertQueryCount(employee=1715):  # tmf 1715 / com 1715
             self.create_ratings('mail.test.rating')
 
-        with self.assertQueryCount(employee=2304):  # tmf 2104
+        with self.assertQueryCount(employee=2304):  # tmf 2304
             self.apply_ratings(1)
 
-        with self.assertQueryCount(employee=2203):  # tmf 2103
+        with self.assertQueryCount(employee=2203):  # tmf 2203
             self.apply_ratings(5)
 
         with self.assertQueryCount(employee=1):

--- a/addons/test_mass_mailing/tests/test_performance.py
+++ b/addons/test_mass_mailing/tests/test_performance.py
@@ -47,7 +47,7 @@ class TestMassMailPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +51 compared to local
-        with self.assertQueryCount(__system__=1622, marketing=1623):
+        with self.assertQueryCount(__system__=1525, marketing=1526):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)
@@ -90,7 +90,7 @@ class TestMassMailBlPerformance(TestMassMailPerformanceBase):
         })
 
         # runbot needs +51 compared to local
-        with self.assertQueryCount(__system__=1694, marketing=1695):
+        with self.assertQueryCount(__system__=1585, marketing=1586):
             mailing.action_send_mail()
 
         self.assertEqual(mailing.sent, 50)

--- a/odoo/addons/test_http/tests/test_models.py
+++ b/odoo/addons/test_http/tests/test_models.py
@@ -102,5 +102,5 @@ class TestHttpModels(TestHttpBase):
         self.assertEqual(
             # capture_sql_db.ouput contains the full Stack info, we don't want it
             [rec.msg % rec.args for rec in capture_sql_db.records],
-            [Like('bad query: UPDATE "test_http_galaxy" ... ERROR: cannot execute UPDATE in a read-only transaction')],
+            [Like('bad query:...UPDATE "test_http_galaxy"...ERROR: cannot execute UPDATE in a read-only transaction')],
         )

--- a/odoo/addons/test_new_api/tests/test_properties.py
+++ b/odoo/addons/test_new_api/tests/test_properties.py
@@ -399,7 +399,7 @@ class PropertiesCase(TestPropertiesMixin):
             }])
             self.env.invalidate_all()
 
-        with self.assertQueryCount(8):
+        with self.assertQueryCount(7):
             messages = self.env['test_new_api.message'].create([{
                 'name': 'Test Message',
                 'discussion': self.discussion_1.id,
@@ -1307,7 +1307,14 @@ class PropertiesCase(TestPropertiesMixin):
         with self.assertQueryCount(0, msg='Must read value from cache'):
             self.message_1.attributes
 
-        expected = ['UPDATE "test_new_api_message" SET "attributes" = %s, "write_date" = %s, "write_uid" = %s WHERE id IN %s']
+        expected = ["""
+            UPDATE "test_new_api_message"
+            SET "attributes" = "__tmp"."attributes"::jsonb,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "attributes", "write_date", "write_uid")
+            WHERE "test_new_api_message"."id" = "__tmp"."id"
+        """]
         with self.assertQueryCount(1), self.assertQueries(expected):
             self.message_1.attributes = [
                 {

--- a/odoo/addons/test_new_api/tests/test_search.py
+++ b/odoo/addons/test_new_api/tests/test_search.py
@@ -796,8 +796,11 @@ class TestFlushSearch(TransactionCase):
     def test_flush_fields_in_domain(self):
         with self.assertQueries(['''
             UPDATE "test_new_api_city"
-            SET "name" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "name" = "__tmp"."name"::VARCHAR,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "name", "write_date", "write_uid")
+            WHERE "test_new_api_city"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
@@ -810,8 +813,11 @@ class TestFlushSearch(TransactionCase):
     def test_flush_fields_in_subdomain(self):
         with self.assertQueries(['''
             UPDATE "test_new_api_city"
-            SET "country_id" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "country_id" = "__tmp"."country_id"::int4,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "country_id", "write_date", "write_uid")
+            WHERE "test_new_api_city"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
@@ -827,8 +833,11 @@ class TestFlushSearch(TransactionCase):
 
         with self.assertQueries(['''
             UPDATE "test_new_api_country"
-            SET "name" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "name" = "__tmp"."name"::VARCHAR,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "name", "write_date", "write_uid")
+            WHERE "test_new_api_country"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
@@ -847,8 +856,11 @@ class TestFlushSearch(TransactionCase):
 
         with self.assertQueries(['''
             UPDATE "test_new_api_city"
-            SET "country_id" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "country_id" = "__tmp"."country_id"::int4,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "country_id", "write_date", "write_uid")
+            WHERE "test_new_api_city"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
@@ -866,8 +878,11 @@ class TestFlushSearch(TransactionCase):
 
         with self.assertQueries(['''
             UPDATE "test_new_api_payment"
-            SET "move_id" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "move_id" = "__tmp"."move_id"::int4,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "move_id", "write_date", "write_uid")
+            WHERE "test_new_api_payment"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_payment"."id"
             FROM "test_new_api_payment"
@@ -881,8 +896,11 @@ class TestFlushSearch(TransactionCase):
 
         with self.assertQueries(['''
             UPDATE "test_new_api_move"
-            SET "tag_repeat" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "tag_repeat" = "__tmp"."tag_repeat"::int4,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "tag_repeat", "write_date", "write_uid")
+            WHERE "test_new_api_move"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_payment"."id"
             FROM "test_new_api_payment"
@@ -905,8 +923,11 @@ class TestFlushSearch(TransactionCase):
 
         with self.assertQueries(['''
             UPDATE "test_new_api_city"
-            SET "name" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "name" = "__tmp"."name"::VARCHAR,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "name", "write_date", "write_uid")
+            WHERE "test_new_api_city"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
@@ -919,8 +940,11 @@ class TestFlushSearch(TransactionCase):
     def test_flush_fields_in_order(self):
         with self.assertQueries(['''
             UPDATE "test_new_api_city"
-            SET "name" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "name" = "__tmp"."name"::VARCHAR,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "name", "write_date", "write_uid")
+            WHERE "test_new_api_city"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
@@ -933,8 +957,11 @@ class TestFlushSearch(TransactionCase):
         # test indirect fields, when ordering by many2one field
         with self.assertQueries(['''
             UPDATE "test_new_api_country"
-            SET "name" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "name" = "__tmp"."name"::VARCHAR,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "name", "write_date", "write_uid")
+            WHERE "test_new_api_country"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
@@ -950,8 +977,11 @@ class TestFlushSearch(TransactionCase):
 
         with self.assertQueries(['''
             UPDATE "test_new_api_city"
-            SET "country_id" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "country_id" = "__tmp"."country_id"::int4,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "country_id", "write_date", "write_uid")
+            WHERE "test_new_api_city"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id"
             FROM "test_new_api_city"
@@ -978,8 +1008,11 @@ class TestFlushSearch(TransactionCase):
         # except when the field appears in another clause
         with self.assertQueries(['''
             UPDATE "test_new_api_city"
-            SET "name" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "name" = "__tmp"."name"::VARCHAR,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "name", "write_date", "write_uid")
+            WHERE "test_new_api_city"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id", "test_new_api_city"."name"
             FROM "test_new_api_city"
@@ -991,8 +1024,11 @@ class TestFlushSearch(TransactionCase):
 
         with self.assertQueries(['''
             UPDATE "test_new_api_city"
-            SET "name" = %s, "write_date" = %s, "write_uid" = %s
-            WHERE id IN %s
+            SET "name" = "__tmp"."name"::VARCHAR,
+                "write_date" = "__tmp"."write_date"::timestamp,
+                "write_uid" = "__tmp"."write_uid"::int4
+            FROM (VALUES %s) AS "__tmp"("id", "name", "write_date", "write_uid")
+            WHERE "test_new_api_city"."id" = "__tmp"."id"
         ''', '''
             SELECT "test_new_api_city"."id", "test_new_api_city"."name"
             FROM "test_new_api_city"

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -273,13 +273,13 @@ class TestPerformance(SavepointCaseWithUserDemo):
 
         lines = rec1.line_ids
 
-        # update N lines: O(N) queries
-        with self.assertQueryCount(5):
+        # update N lines: O(1) queries
+        with self.assertQueryCount(4):
             self.env.invalidate_all()
             rec1.write({'line_ids': [Command.update(line.id, {'value': 42}) for line in lines[0]]})
         self.assertEqual(rec1.line_ids, lines)
 
-        with self.assertQueryCount(15):
+        with self.assertQueryCount(4):
             self.env.invalidate_all()
             rec1.write({'line_ids': [Command.update(line.id, {'value': 42 + line.id}) for line in lines[1:]]})
         self.assertEqual(rec1.line_ids, lines)

--- a/odoo/api.py
+++ b/odoo/api.py
@@ -863,7 +863,7 @@ class Environment(Mapping):
         assert isinstance(query, SQL)
         self.flush_query(query)
         self.cr.execute(query)
-        return self.cr.fetchall() if self.cr.rowcount > 0 else []
+        return [] if self.cr.description is None else self.cr.fetchall()
 
 
 class Transaction:

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -4540,7 +4540,8 @@ class One2many(_RelationalMulti):
                             to_create.append(dict(command[2], **{inverse: record.id}))
                         allow_full_delete = False
                     elif command[0] == Command.UPDATE:
-                        comodel.browse(command[1]).write(command[2])
+                        prefetch_ids = recs[self.name]._prefetch_ids
+                        comodel.browse(command[1]).with_prefetch(prefetch_ids).write(command[2])
                     elif command[0] == Command.DELETE:
                         to_delete.append(command[1])
                     elif command[0] == Command.UNLINK:
@@ -4924,7 +4925,8 @@ class Many2many(_RelationalMulti):
                 if command[0] == Command.CREATE:
                     to_create.append((recs._ids, command[2]))
                 elif command[0] == Command.UPDATE:
-                    comodel.browse(command[1]).write(command[2])
+                    prefetch_ids = recs[self.name]._prefetch_ids
+                    comodel.browse(command[1]).with_prefetch(prefetch_ids).write(command[2])
                 elif command[0] == Command.DELETE:
                     to_delete.append(command[1])
                 elif command[0] == Command.UNLINK:


### PR DESCRIPTION
This refactoring changes the strategy for flushing updates: updates are now grouped by the set of updated fields only, and no longer by their values.  So one `UPDATE` can now handle a field update on many records, even when the field value is different on the given records.

The implementation consists in performing updates as follows: all the records to update are given as row values, with their corresponding record id, which is matched for the field updates.  This looks like
```sql
UPDATE <table>
SET foo = "__tmp".foo::int4,
    bar = "__tmp".bar::varchar
FROM (VALUES ...) AS "__tmp"(id, foo, bar)
WHERE "__tmp".id = <table>.id
```
Although this solution is less efficient in the case of many identical updates (same fields with the same values), in practice it performs better, simply because having identical updates is not the most common situation.  We ran some quick stats on the runbot, which show that the average number of SQL updates per record went from 0.62 to 0.49, which means -20% of SQL update queries.

See https://github.com/odoo/enterprise/pull/59330.