### PR TITLE
[FIX] project: prevent double insertion of a follower

### DIFF
--- a/addons/project/models/project_task_recurrence.py
+++ b/addons/project/models/project_task_recurrence.py
@@ -82,7 +82,7 @@ class ProjectTaskRecurrence(models.Model):
     def _create_next_occurrence(self, occurrence_from):
         self.ensure_one()
         if occurrence_from.allow_recurring_tasks:
-            self.env['project.task'].sudo().create(
+            self.env['project.task'].sudo().with_context(mail_create_nosubscribe=True).create(
                 self._create_next_occurrence_values(occurrence_from)
             )
 


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create a recurring task;
- change the state to "Done";

Issue:
------
A Validation Error occurs:
```
The operation cannot be completed: Error, a partner cannot follow twice the same object.
```

Cause:
------
We do not respect an sql constraint for the `mail.follower` model:
```sql
unique(res_model,res_id,partner_id)
```

The following piece of code is part of the flow used to create the new task:
```py
threads = super(MailThread, self).create(vals_list)
if not self._context.get('mail_create_nosubscribe') and ...:
    self.env['mail.followers']._insert_followers(...)
```

During creation, `vals_list` contains a value for the `message_partner_ids` field, this will call its inverse method and trigger `_insert_followers`. So we already have a record for the `mail.followers` model. Then, based on the `mail_create_nosubscribe` context key, we try to create a record with the same values (`res_model`, `res_id`, `partner_id`).

Solution:
---------
Use the `mail_create_nosubscribe` context key to prevent the double creation of a record for the `mail.followers` model in reference to the new task.

opw-3755068