### PR TITLE
[FIX] base: Missing constraint for groups check in views

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -477,7 +477,7 @@ actual arch.
 
         return True
 
-    @api.constrains('type', 'groups_id', 'inherit_id')
+    @api.constrains('groups_id', 'inherit_id', 'mode')
     def _check_groups(self):
         for view in self:
             if (view.groups_id and

--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -3425,6 +3425,29 @@ class TestViewTranslations(common.TransactionCase):
         self.assertIn("<i>", view_fr.arch_db)
         self.assertIn("<i>", view_fr.arch)
 
+    def test_no_groups_for_inherited(self):
+        parent = self.env["ir.ui.view"].create({
+            "name": "test_no_groups_for_inherited_parent",
+            "model": "ir.ui.view",
+            "arch": "<form></form>",
+        })
+
+        view = self.env["ir.ui.view"].create({
+            "name": "test_no_groups_for_inherited_child",
+            "model": "ir.ui.view",
+            "arch": "<data></data>",
+            "inherit_id": parent.id,
+            "mode": "extension",
+        })
+
+        with self.assertRaises(ValidationError):
+            view.write({'groups_id': [1]})
+
+        view.write({'mode': 'primary'})
+        view.write({'groups_id': [1]})
+
+        with self.assertRaises(ValidationError):
+            view.write({'mode': 'extension'})
 
 class ViewModeField(ViewCase):
     """


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
It's possible to setup an inherited view with groups if we update the mode

Steps:
- Open an inherited view form
- Change its mode to "Base"
- Add a group
- Rollback the mode to "Inherited"
- Save, no problem
- Try to upgrade a module linked to this view

Current behavior before PR:
- Traceback as inherited view cannot have groups

Desired behavior after PR is merged:
- Save is not possible

opw-3263438
opw-3774300


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
