### PR TITLE
[FIX] stock: Create a reusable package for internal transfers

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1463,7 +1463,10 @@ class Picking(models.Model):
             return {}
 
     def _put_in_pack(self, move_line_ids):
-        package = self.env['stock.quant.package'].create({})
+        package_data = {}
+        if self.location_dest_id.usage == 'internal':
+            package_data['package_use'] = 'reusable'
+        package = self.env['stock.quant.package'].create(package_data)
         package_type = move_line_ids.move_id.product_packaging_id.package_type_id
         if len(package_type) == 1:
             package.package_type_id = package_type


### PR DESCRIPTION
**Steps to reproduce the issue:**
- Enable "Packages" in inventory settings.
- Create a storable product "P1".
- Set the delivery to 3 steps.
- Create a Sales Order with 5 units of P1:
    - Confirm the SO.
    - Go to the first picking ("Pick")
    - Click on the "Put in Pack" button


**Problem:**
A package with the usage type "Disposable" is created and set as the result package. Consequently, it is propagated to the next move as both source and destination:
https://github.com/odoo/odoo/blob/13cb47d4f2825e8c8e821d2e472f8c3c4f85582f/addons/stock/models/stock_picking.py#L1019-L1021

opw-3764822
