### PR TITLE
[FIX] l10n_in: invisible the l10n_in_pan field if company is not indian

### DIFF
--- a/addons/l10n_in/views/res_partner_views.xml
+++ b/addons/l10n_in/views/res_partner_views.xml
@@ -13,7 +13,7 @@
                 <field name="l10n_in_gst_treatment" attrs="{'readonly': [('parent_id', '!=', False)], 'invisible': [('fiscal_country_codes', 'not ilike', 'IN')]}"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="after">
-                <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" />
+                <field name="l10n_in_pan" placeholder="e.g. ABCTY1234D" attrs="{'invisible': [('fiscal_country_codes', 'not ilike', 'IN')]}" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This problem is already solved in this commit (https://github.com/odoo/odoo/pull/147532/commits/f733fc8c338b0d5d4f486caf82c5d8915b3d2404) But this was left to do in (saas-16.2).
