### PR TITLE
[IMP] website_sale: add a new location selector for pickup point

### DIFF
--- a/addons/delivery/controllers/__init__.py
+++ b/addons/delivery/controllers/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import location_selector

--- a/addons/delivery/controllers/location_selector.py
+++ b/addons/delivery/controllers/location_selector.py
@@ -1,0 +1,37 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.http import Controller, request, route
+
+
+class LocationSelectorController(Controller):
+
+    @route('/delivery/set_pickup_location', type='json', auth='user')
+    def delivery_set_pickup_location(self, order_id, pickup_location_data):
+        """ Fetch the order and set the pickup location on the current order.
+
+        :param int order_id: The sales order, as a `sale.order` id.
+        :param str pickup_location_data: The JSON-formatted pickup location address.
+        :return: None
+        """
+        order = request.env['sale.order'].browse(order_id)
+        order._set_pickup_location(pickup_location_data)
+
+    @route('/delivery/get_pickup_locations', type='json', auth='user')
+    def delivery_get_pickup_locations(self, order_id, zip_code=None):
+        """ Fetch the order and return the pickup locations close to a given zip code.
+
+        Determine the country based on GeoIP or fallback on the order's delivery address' country.
+
+        :param int order_id: The sales order, as a `sale.order` id.
+        :param int zip_code: The zip code to look up to.
+        :return: The close pickup locations data.
+        :rtype: dict
+        """
+        order = request.env['sale.order'].browse(order_id)
+        if request.geoip.country_code:
+            country = self.env['res.country'].search(
+                [('code', '=', request.geoip.country_code)], limit=1,
+            )
+        else:
+            country = order.partner_shipping_id.country_id
+        return order._get_pickup_locations(zip_code, country)

--- a/addons/delivery/static/src/js/location_selector/location/location.js
+++ b/addons/delivery/static/src/js/location_selector/location/location.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+
+import {
+    LocationSchedule
+} from '@delivery/js/location_selector/location_schedule/location_schedule';
+import { Component } from '@odoo/owl';
+
+export class Location extends Component {
+    static components = { LocationSchedule };
+    static template = 'delivery.locationSelector.location';
+    static props = {
+        id: String,
+        number: Number,
+        name: String,
+        street: String,
+        city: String,
+        zipCode: String,
+        openingHours: {
+            type: Object,
+            values: {
+                type: Array,
+                element: String,
+                optional: true,
+            },
+        },
+        isSelected: Boolean,
+        setSelectedLocation: Function,
+    };
+
+    /**
+     * Get the city and the zip code.
+     *
+     * @return {Object} The city and the zip code.
+     */
+    getCityAndZipCode() {
+        return `${this.props.zipCode} ${this.props.city}`;
+    }
+}

--- a/addons/delivery/static/src/js/location_selector/location/location.xml
+++ b/addons/delivery/static/src/js/location_selector/location/location.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="delivery.locationSelector.location">
+        <button
+            t-attf-id="location-{{this.props.id}}"
+            class="list-group-item list-group-item-action collapsed d-flex gap-2 gap-lg-3"
+            t-att-class="{'text-bg-light': props.isSelected}"
+            t-on-click="() => props.setSelectedLocation(props.id)"
+            type="button"
+            t-attf-data-bs-target="#collapseHours_{{props.id}}"
+            aria-expanded="false"
+            t-attf-aria-controls="collapseHours_{{props.id}}"
+            data-bs-toggle="collapse"
+        >
+            <span
+                class="position-absolute top-0 start-0 h-100 ps-1 bg-primary transition-base"
+                t-attf-class="#{props.isSelected ? 'ms-0' : 'ms-n1' }"
+            />
+            <strong t-out="props.number" class="o_location_selector_number fw-bold text-center"/>
+            <span class="d-flex flex-column gap-1 gap-md-0 w-100">
+                <span class="d-flex flex-column">
+                    <strong t-out="props.name" class="fw-bold"/>
+                    <small class="opacity-75" t-out="props.street"/>
+                    <small class="opacity-75" t-out="this.getCityAndZipCode()"/>
+                </span>
+                <small class="d-flex d-md-none align-items-center gap-1 fw-bold">
+                    <i class="fa fa-clock-o" role="img"/>
+                    Opening hours
+                    <i class="o_location_selector_hours_caret fa fa-caret-up ms-auto transition-base"/>
+                </small>
+
+                <!-- Schedule -->
+                <span
+                    class="collapse d-md-none"
+                    t-attf-id="collapseHours_{{props.id}}"
+                    data-bs-parent="#o_location_selector_list_view"
+                  >
+                    <LocationSchedule openingHours="props.openingHours"/>
+                </span>
+            </span>
+        </button>
+    </t>
+</templates>

--- a/addons/delivery/static/src/js/location_selector/location_list/location_list.js
+++ b/addons/delivery/static/src/js/location_selector/location_list/location_list.js
@@ -1,0 +1,59 @@
+/** @odoo-module **/
+
+import { Location } from '@delivery/js/location_selector/location/location';
+import { Component, onMounted, useEffect } from '@odoo/owl';
+
+export class LocationList extends Component {
+    static components = { Location };
+    static template = 'delivery.locationSelector.locationList';
+    static props = {
+        locations: {
+            type: Array,
+            element: {
+                type: Object,
+                values: {
+                    id: String,
+                    name: String,
+                    openingHours: {
+                        type: Object,
+                        values: {
+                            type: Array,
+                            element: String,
+                            optional: true,
+                        },
+                    },
+                    street: String,
+                    city: String,
+                    zip_code: String,
+                    state: { type: String, optional: true},
+                    country_code: String,
+                    additional_data: { type: Object, optional: true},
+                    latitude: String,
+                    longitude: String,
+                }
+            },
+        },
+        selectedLocationId: [String, {value: false}],
+        setSelectedLocation: Function,
+        validateSelection: Function,
+    };
+
+    setup() {
+        onMounted(() => {
+            document.getElementById(`location-${this.props.selectedLocationId}`).focus();
+        });
+
+        // Focus on the location on the list when clicking on the map marker.
+        useEffect(
+            (locations, selectedLocationId) => {
+                const selectedLocation = locations.find(
+                    l => String(l.id) === selectedLocationId
+                );
+                if (selectedLocation) {
+                    document.getElementById(`location-${selectedLocation.id}`).focus();
+                }
+            },
+            () => [this.props.locations, this.props.selectedLocationId]
+        );
+    }
+}

--- a/addons/delivery/static/src/js/location_selector/location_list/location_list.xml
+++ b/addons/delivery/static/src/js/location_selector/location_list/location_list.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="delivery.locationSelector.locationList">
+        <div class="d-flex flex-grow-1 h-100 h-md-auto overflow-x-auto">
+            <div id="o_location_selector_list_view" class="list-group list-group-flush flex-grow-1">
+                <t
+                    t-foreach="this.props.locations"
+                    t-as="location"
+                    t-key="location.id"
+                >
+                    <Location
+                        id="location.id.toString()"
+                        number="location_index + 1"
+                        name="location.name"
+                        street="location.street"
+                        city="location.city"
+                        zipCode="location.zip_code"
+                        openingHours="location.opening_hours"
+                        isSelected="this.props.selectedLocationId === location.id.toString()"
+                        setSelectedLocation="this.props.setSelectedLocation"
+                    />
+                </t>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.js
+++ b/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.js
@@ -1,0 +1,28 @@
+/** @odoo-module **/
+
+import { Component } from '@odoo/owl';
+
+export class LocationSchedule extends Component {
+    static template = 'delivery.locationSelector.schedule';
+    static props = {
+        openingHours: {
+            type: Object,
+            values: {
+                type: Array,
+                element: String,
+                optional: true,
+            },
+        },
+        wrapClass: { type: String, optional: true },
+    };
+
+    /**
+     * Return the localized day's name given his index in the week.
+     *
+     * @param {Number} weekday - The number of the day of the week. 0 for Monday, 6 for Sunday.
+     * @return {Object} the localized name of the day (long version).
+     */
+    getWeekDay(weekday) {
+        return luxon.Info.weekdays()[weekday]
+    }
+}

--- a/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.xml
+++ b/addons/delivery/static/src/js/location_selector/location_schedule/location_schedule.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="delivery.locationSelector.schedule">
+        <span t-attf-class="o_location_selector_schedule d-grid gap-1 #{props.wrapClass}">
+            <t t-foreach="this.props.openingHours" t-as="openingHour" t-key="openingHour_index">
+                <t t-call="delivery.locationSelector.dailySchedule">
+                    <t t-set="weekday" t-value="openingHour_index"/>
+                    <t t-set="openingPeriods" t-value="openingHour_value"/>
+                </t>
+            </t>
+        </span>
+    </t>
+
+    <t t-name="delivery.locationSelector.dailySchedule">
+        <span class="d-contents">
+            <small class="me-4 text-muted" t-out="getWeekDay(weekday)"/>
+            <span class="o_location_selector_schedule_hours d-flex flex-wrap">
+                <t t-if="openingPeriods.length">
+                    <t t-foreach="openingPeriods" t-as="openingPeriod" t-key="openingPeriod_index">
+                        <small t-out="openingPeriod" class="text-nowrap"/>
+                    </t>
+                </t>
+                <t t-else="">
+                    <small class="text-danger">Closed</small>
+                </t>
+            </span>
+        </span>
+    </t>
+</templates>

--- a/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
+++ b/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
@@ -1,0 +1,157 @@
+/** @odoo-module **/
+
+import { LocationList } from '@delivery/js/location_selector/location_list/location_list';
+import { MapContainer } from '@delivery/js/location_selector/map_container/map_container';
+import { Component, onMounted, onWillUnmount, useEffect, useState } from '@odoo/owl';
+import { browser } from '@web/core/browser/browser';
+import { Dialog } from '@web/core/dialog/dialog';
+import { _t } from '@web/core/l10n/translation';
+import { rpc } from '@web/core/network/rpc';
+import { useDebounced } from '@web/core/utils/timing';
+
+export class LocationSelectorDialog extends Component {
+    static components = { Dialog, LocationList, MapContainer };
+    static template = 'delivery.locationSelector.dialog';
+    static props = {
+        orderId: Number,
+        zipCode: String,
+        selectedLocationId: { type: String, optional: true},
+        save: Function,
+        close: Function, // This is the close from the env of the Dialog Component
+    };
+    static defaultProps = {
+        selectedLocationId: false,
+    };
+
+    setup() {
+        this.title = _t("Choose a pick-up point");
+        this.state = useState({
+            locations: [],
+            error: false,
+            viewMode: 'list',
+            zipCode: this.props.zipCode,
+            // Some APIs like FedEx use strings to identify locations.
+            selectedLocationId: String(this.props.selectedLocationId),
+            isSmall: this.env.isSmall,
+        });
+
+        this.getLocationUrl = '/delivery/get_pickup_locations';
+
+        this.debouncedOnResize = useDebounced(this.updateSize, 300);
+        this.debouncedSearchButton = useDebounced((zipCode) => {
+            this.state.locations = [];
+            this._updateLocations(zipCode);
+        }, 300);
+
+        onMounted(() => {
+            browser.addEventListener('resize', this.debouncedOnResize);
+            this.updateSize();
+        });
+        onWillUnmount(() => browser.removeEventListener('resize', this.debouncedOnResize));
+
+        // Fetch new locations when the zip code is updated.
+        useEffect(
+            (zipCode) => {
+                this._updateLocations(zipCode)
+                return () => {
+                    this.state.locations = []
+                };
+            },
+            () => [this.state.zipCode]
+        );
+    }
+
+    //--------------------------------------------------------------------------
+    // Data Exchanges
+    //--------------------------------------------------------------------------
+
+    /**
+     * Fetch the closest pickup locations based on the zip code.
+     *
+     * @private
+     * @param {String} zip - The zip code used to look for close locations.
+     * @return {Object} The result values.
+     */
+    async _getLocations(zip) {
+        return rpc(this.getLocationUrl, {order_id: this.props.orderId, zip_code: zip});
+    }
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Get the locations based on the zip code.
+     *
+     * Select the first location available if no location is currently selected or if the currently
+     * selected location is not on the list anymore.
+     *
+     * @private
+     * @param {String} zip - The zip code used to look for close locations.
+     * @return {void}
+     */
+    async _updateLocations(zip) {
+        this.state.error = false;
+        const { pickup_locations, error } = await this._getLocations(zip);
+        if (error) {
+            this.state.error = error;
+            console.error(error);
+        } else {
+            this.state.locations = pickup_locations;
+            if (!this.state.locations.find(l => String(l.id) === this.state.selectedLocationId)) {
+                this.state.selectedLocationId = this.state.locations[0]
+                                                ? String(this.state.locations[0].id)
+                                                : false;
+            }
+        }
+    }
+
+    /**
+     * Set the selectedLocationId in the state.
+     *
+     * @param {String} locationId
+     * @return {void}
+     */
+    setSelectedLocation(locationId) {
+        this.state.selectedLocationId = String(locationId);
+    }
+
+    /**
+     * Confirm the current selected location.
+     *
+     * @return {void}
+     */
+    async validateSelection() {
+        if (!this.state.selectedLocationId) return;
+        const selectedLocation = this.state.locations.find(
+            l => String(l.id) === this.state.selectedLocationId
+        );
+        await this.props.save(selectedLocation);
+        this.props.close();
+    }
+
+    //--------------------------------------------------------------------------
+    // User Interface
+    //--------------------------------------------------------------------------
+
+    /**
+     * Determines the component to show in mobile view based on the current state.
+     *
+     * Returns the MapContainer component if `viewMode` is strictly equal to `map`, else return the
+     * List component.
+     *
+     * @return {Component} The component to show in mobile view.
+     */
+    get mobileComponent() {
+        if (this.state.viewMode === 'map') return MapContainer;
+        return LocationList;
+    }
+
+    /**
+     *
+     * @return {void}
+     */
+    updateSize() {
+        this.state.isSmall = this.env.isSmall;
+    }
+}

--- a/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.scss
+++ b/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.scss
@@ -1,0 +1,45 @@
+.o_location_selector {
+    .o_location_selector_view {
+        // Force tab-pane to be displayed on desktop.
+        @include media-breakpoint-up(md) {
+            opacity: 1;
+        }
+
+        // Remove border-start class for mobile
+        @include media-breakpoint-down(md) {
+            border-left: 0 !important;
+        }
+    }
+
+    .o_location_selector_number {
+        width: 3ch;
+        font-variant-numeric: tabular-nums;
+    }
+
+    .o_location_selector_details {
+        transform: translateY(-100%);
+    }
+
+    .collapsed i.o_location_selector_hours_caret {
+        transform: rotate(180deg) !important;
+    }
+
+    .o_location_selector_mobile_tab.active {
+        font-weight: $font-weight-bold;
+        --border-color: #{$primary};
+    }
+
+    .modal-footer,
+    .modal.o_modal_full &.modal-content .modal-footer {
+        padding: 0;
+        box-shadow: none;
+    }
+
+    .o_location_selector_schedule {
+        grid-template-columns: auto 1fr;
+    }
+
+    .o_location_selector_schedule_hours {
+        gap: 0 map-get($spacers, 3);
+    }
+}

--- a/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
+++ b/addons/delivery/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="delivery.locationSelector.dialog">
+        <Dialog
+            title="title"
+            bodyClass="'d-flex flex-column border-top p-0 px-md-3'"
+            contentClass="'o_location_selector h-100 overflow-hidden'"
+        >
+            <!-- Mobile view -->
+            <t t-if="this.state.isSmall">
+                <!-- Search bar -->
+                <t t-call="delivery.locationSelector.searchbar"/>
+
+                <!-- "List view / Map view" navigation -->
+                <div class="nav nav-tabs">
+                    <button
+                        class="o_location_selector_mobile_tab btn flex-grow-1 border-0 border-bottom rounded-0 py-3 bg-transparent"
+                        t-att-class="{'active': this.state.viewMode === 'list'}"
+                        t-on-click="() => this.state.viewMode = 'list'"
+                    >
+                        List view
+                    </button>
+                    <button
+                        class="o_location_selector_mobile_tab btn flex-grow-1 border-0 border-bottom rounded-0 py-3 bg-transparent"
+                        t-att-class="{'active' : this.state.viewMode === 'map'}"
+                        t-on-click="() => this.state.viewMode = 'map'"
+                    >
+                        Map view
+                    </button>
+                </div>
+
+                <!-- Component -->
+                <div class="flex-grow-1 overflow-x-auto">
+                    <t
+                        t-if="this.state.locations.length"
+                        t-component="mobileComponent"
+                        locations="this.state.locations"
+                        selectedLocationId="this.state.selectedLocationId.toString()"
+                        setSelectedLocation.bind="setSelectedLocation"
+                        validateSelection.bind="validateSelection"
+                    />
+                    <t t-else="">
+                        <p t-if="this.state.error" class="p-3 fw-bold">No result</p>
+                        <div t-else="" class="position-absolute start-50 top-50 translate-middle">
+                            <div class="spinner-border" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                            </div>
+                        </div>
+                    </t>
+                </div>
+            </t>
+
+            <!-- Desktop view -->
+            <div t-else="" class="d-flex h-100 mx-0 mx-md-n3 overflow-hidden">
+
+                <!-- List view -->
+                <section class="o_location_selector_view col-md-4 d-flex flex-grow-1 flex-column">
+
+                    <!-- Search bar -->
+                    <t t-call="delivery.locationSelector.searchbar">
+                        <t t-set="wrapClass" t-value="'d-flex'"/>
+                    </t>
+
+                    <!-- List group -->
+                    <LocationList
+                        t-if="this.state.locations.length"
+                        locations="this.state.locations"
+                        selectedLocationId="this.state.selectedLocationId.toString()"
+                        setSelectedLocation.bind="setSelectedLocation"
+                        validateSelection.bind="validateSelection"
+                    />
+                    <t t-else="">
+                        <p t-if="this.state.error" class="p-3 fw-bold">No result</p>
+                        <div t-else="" class="position-absolute start-50 top-50 translate-middle">
+                            <div class="spinner-border" role="status">
+                                <span class="visually-hidden">Loading...</span>
+                            </div>
+                        </div>
+                    </t>
+                </section>
+
+                <!-- Map view -->
+                <section class="o_location_selector_view col-md-8 d-flex flex-grow-1 border-start pe-2">
+                    <MapContainer
+                        locations="this.state.locations"
+                        selectedLocationId="this.state.selectedLocationId.toString()"
+                        setSelectedLocation.bind="setSelectedLocation"
+                        validateSelection.bind="validateSelection"
+                    />
+                </section>
+            </div>
+
+            <!-- Validation button in mobile view -->
+            <t t-if="this.state.isSmall" t-set-slot="footer">
+                <div class="w-100 m-0 border-top p-3">
+                    <button
+                        type="button"
+                        class="btn btn-primary w-100"
+                        t-att-disabled="!this.state.selectedLocationId"
+                        t-on-click="validateSelection"
+                    >
+                        Choose this location
+                    </button>
+                </div>
+            </t>
+        </Dialog>
+    </t>
+
+    <t t-name="delivery.locationSelector.searchbar">
+        <div role="search" class="input-group p-3 border-bottom" t-att-class="wrapClass">
+            <input
+                class="search-query form-control oe_search_box border-0 text-bg-light"
+                t-model.lazy="this.state.zipCode"
+            />
+            <button
+                t-on-click="() => this.debouncedSearchButton(this.state.zipCode)"
+                aria-label="Search"
+                title="Search"
+                class="btn btn-light"
+            >
+                <i class="oi oi-search"/>
+            </button>
+        </div>
+    </t>
+</templates>

--- a/addons/delivery/static/src/js/location_selector/map/map.js
+++ b/addons/delivery/static/src/js/location_selector/map/map.js
@@ -1,0 +1,154 @@
+/** @odoo-module **/
+/*global L*/
+
+import { Component, useEffect, useRef } from '@odoo/owl';
+import { renderToString } from '@web/core/utils/render';
+
+export class Map extends Component {
+    static template = 'delivery.locationSelector.map';
+    static props = {
+        locations: {
+            type: Array,
+            element: {
+                type: Object,
+                values: {
+                    id: String,
+                    name: String,
+                    openingHours: {
+                        type: Object,
+                        values: {
+                            type: Array,
+                            element: String,
+                            optional: true,
+                        },
+                    },
+                    street: String,
+                    city: String,
+                    zip_code: String,
+                    state: { type: String, optional: true},
+                    country_code: String,
+                    additional_data: { type: Object, optional: true},
+                    latitude: String,
+                    longitude: String,
+                }
+            },
+        },
+        selectedLocationId: [String, {value: false}],
+        setSelectedLocation: Function,
+    };
+
+    setup() {
+        this.leafletMap = null;
+        this.markers = [];
+        this.mapRef = useRef('map');
+
+        // Create the map.
+        useEffect(
+            () => {
+                this.leafletMap = L.map(this.mapRef.el, {
+                    zoom: 13,
+                });
+                L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png', {
+                    maxZoom: 19,
+                    attribution: "&copy; <a href='http://www.openstreetmap.org/copyright'>OpenStreetMap</a>"
+                }).addTo(this.leafletMap);
+                return () => {
+                    this.leafletMap.remove();
+                }
+            },
+            () => []
+        );
+
+        // Update the size of the map.
+        useEffect(
+            (locations) => {
+                this.leafletMap.invalidateSize();
+            },
+            () => [this.props.locations]
+        );
+
+        // Update the markers and center the map on the selected location.
+        useEffect(
+            (locations, selectedLocationId) => {
+                this.addMarkers(locations);
+                const selectedLocation = locations.find(
+                    l => String(l.id) === selectedLocationId
+                );
+                if (selectedLocation) {
+                    // Center the Map.
+                    this.leafletMap.panTo(
+                        [selectedLocation.latitude, selectedLocation.longitude],
+                        { animate: true }
+                    );
+                }
+                return () => {
+                    this.removeMarkers();
+                };
+            },
+            () => [this.props.locations, this.props.selectedLocationId]
+        );
+    }
+
+    /**
+     * Add the markers of the closest locations on the map.
+     * Binds events to the created markers.
+     *
+     * @param {Array} locations - The list of locations to display on the map.
+     * @return {void}
+     */
+    addMarkers(locations) {
+        for (const loc of locations) {
+            const isSelected = String(loc.id) === this.props.selectedLocationId
+            // Icon creation
+            const iconInfo = {
+                className: isSelected ? 'o_location_selector_marker_icon_selected'
+                                      : 'o_location_selector_marker_icon',
+                html: renderToString(
+                    'delivery.locationSelector.map.marker',
+                    { number: locations.indexOf(loc) + 1 },
+                ),
+            };
+
+            const marker = L.marker(
+                [ loc.latitude, loc.longitude ],
+                {
+                    icon: L.divIcon(iconInfo),
+                    title: locations.indexOf(loc) + 1,
+                },
+            );
+
+            // By default, the marker's zIndex is based on its latitude. This ensures the selected
+            // marker is always displayed on top of all others.
+            if (isSelected) marker.setZIndexOffset(100);
+
+            marker.addTo(this.leafletMap);
+            marker.addEventListener('click', () => {
+                this.props.setSelectedLocation(loc.id);
+            });
+
+            this.markers.push(marker);
+        }
+    }
+
+    /**
+     * Remove the markers from the map and empty the markers array.
+     *
+     * @return {void}
+     */
+    removeMarkers() {
+        for (const marker of this.markers) {
+            marker.removeEventListener();
+            this.leafletMap.removeLayer(marker);
+        }
+        this.markers = [];
+    }
+
+    /**
+     * Find the selected location based on its id.
+     *
+     * @return {Object} The selected location.
+     */
+    get selectedLocation() {
+        return this.props.locations.find(l => String(l.id) === this.props.selectedLocationId)
+    }
+}

--- a/addons/delivery/static/src/js/location_selector/map/map.scss
+++ b/addons/delivery/static/src/js/location_selector/map/map.scss
@@ -1,0 +1,15 @@
+.o_location_selector_marker_icon {
+    --LocationSelectorMarker-border-color: #{mix($body-bg, $body-color)};
+    --LocationSelectorMarker-background: #{$body-bg};
+    --LocationSelectorMarker-color: #{$body-color};
+}
+
+.o_location_selector_marker_icon_selected {
+    --LocationSelectorMarker-border-color: #{mix(map-get($theme-colors, 'primary'), color-contrast(map-get($theme-colors, 'primary')))};
+    --LocationSelectorMarker-background: #{map-get($theme-colors, 'primary')};
+    --LocationSelectorMarker-color: #{color-contrast(map-get($theme-colors, 'primary'))};
+}
+
+.o_location_selector_map {
+    min-height: 25vh;
+}

--- a/addons/delivery/static/src/js/location_selector/map/map.xml
+++ b/addons/delivery/static/src/js/location_selector/map/map.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="delivery.locationSelector.map">
+        <div class="o_location_selector_map w-100 flex-grow-1" t-ref="map"/>
+    </t>
+
+    <t t-name="delivery.locationSelector.map.marker">
+        <svg width="30" height="40" viewBox="0 0 30 40" xmlns="http://www.w3.org/2000/svg">
+            <ellipse cx="15" cy="38" rx="12" ry="2" fill="#000" fill-opacity="0.25"/>
+            <path
+                d="M15 39.2507C14.9216 39.1623 14.8316 39.0606 14.731 38.9461C14.323 38.482 13.7395 37.8091 13.0391 36.9752C11.6379 35.3068 9.77066 32.9967 7.90454 30.4276C6.03711 27.8567 4.17807 25.0364 2.78794 22.3465C1.38981 19.6411 0.5 17.1309 0.5 15.1621C0.5 7.06077 6.9955 0.5 14.9995 0.5C23.0004 0.5 29.5 7.06089 29.5 15.1621C29.5 17.1309 28.6102 19.6411 27.2121 22.3465C25.8219 25.0364 23.9629 27.8567 22.0955 30.4276C20.2293 32.9967 18.3621 35.3068 16.9609 36.9752C16.2605 37.8091 15.677 38.482 15.269 38.9461C15.1684 39.0606 15.0784 39.1623 15 39.2507Z"
+                fill="var(--LocationSelectorMarker-background)"
+                stroke="var(--LocationSelectorMarker-border-color)"
+            />
+            <text
+                x="50%"
+                y="50%"
+                text-anchor="middle"
+                t-out="number"
+                fill="var(--LocationSelectorMarker-color)"
+            />
+        </svg>
+    </t>
+</templates>

--- a/addons/delivery/static/src/js/location_selector/map_container/map_container.js
+++ b/addons/delivery/static/src/js/location_selector/map_container/map_container.js
@@ -1,0 +1,90 @@
+/** @odoo-module **/
+
+import {
+    LocationSchedule
+} from '@delivery/js/location_selector/location_schedule/location_schedule';
+import { Map } from '@delivery/js/location_selector/map/map';
+import { Component, onWillStart, useState } from '@odoo/owl';
+import { AssetsLoadingError, loadCSS, loadJS } from '@web/core/assets';
+
+export class MapContainer extends Component {
+    static components = { LocationSchedule, Map };
+    static template = 'delivery.locationSelector.mapContainer';
+    static props = {
+        locations: {
+            type: Array,
+            element: {
+                type: Object,
+                values: {
+                    id: String,
+                    name: String,
+                    openingHours: {
+                        type: Object,
+                        values: {
+                            type: Array,
+                            element: String,
+                            optional: true,
+                        },
+                    },
+                    street: String,
+                    city: String,
+                    zip_code: String,
+                    state: { type: String, optional: true},
+                    country_code: String,
+                    additional_data: { type: Object, optional: true},
+                    latitude: String,
+                    longitude: String,
+                }
+            },
+        },
+        selectedLocationId: [String, {value: false}],
+        setSelectedLocation: Function,
+        validateSelection: Function,
+    };
+
+    setup() {
+        this.state = useState({
+            shouldLoadMap: false,
+        });
+
+        onWillStart(async () => {
+            /**
+             * We load the script for the map before rendering the owl component to avoid a
+             * UserError if the script can't be loaded (e.g. if the customer loses the connection
+             * between the rendering of the page and when he opens the location selector, or if the
+             * CDN’s doesn't host the library anymore).
+             */
+            try {
+                await Promise.all([
+                    loadJS('https://unpkg.com/leaflet@1.9.4/dist/leaflet.js'),
+                    loadCSS('https://unpkg.com/leaflet@1.9.4/dist/leaflet.css'),
+                ])
+                this.state.shouldLoadMap = true;
+            } catch (error) {
+                if (!(error instanceof AssetsLoadingError)) {
+                    throw error;
+                }
+            }
+        });
+    }
+
+    /**
+     * Get the city and the zip code.
+     *
+     * @param {Number} selectedLocation - The location form which the city and the zip code
+     *                                    should be taken.
+     * @return {Object} The city and the zip code.
+     */
+    getCityAndZipCode(selectedLocation) {
+        return `${selectedLocation.zip_code} ${selectedLocation.city}`;
+    }
+
+    /**
+     * Find the selected location based on its id.
+     *
+     * @return {Object} The selected location.
+     */
+    get selectedLocation() {
+        return this.props.locations.find(l => String(l.id) === this.props.selectedLocationId);
+    }
+}

--- a/addons/delivery/static/src/js/location_selector/map_container/map_container.xml
+++ b/addons/delivery/static/src/js/location_selector/map_container/map_container.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<templates xml:space="preserve">
+    <t t-name="delivery.locationSelector.mapContainer">
+        <div class="d-flex flex-column h-100 w-100">
+            <Map
+                t-if="this.state.shouldLoadMap"
+                locations="this.props.locations"
+                selectedLocationId="this.props.selectedLocationId"
+                setSelectedLocation="this.props.setSelectedLocation"
+            />
+            <div
+                t-else=""
+                class="d-flex justify-content-center align-items-center flex-grow-1 w-100 bg-200"
+            >
+                <span>There was an error loading the map</span>
+            </div>
+
+            <!-- Desktop infos -->
+            <div t-if="selectedLocation" class="d-none d-md-flex justify-content-between flex-column flex-lg-row gap-3 gap-lg-0 p-4">
+                <div class="col-lg-5 d-flex flex-column justify-content-between">
+                    <div class="d-flex gap-2">
+                        <strong
+                            class="o_location_selector_number flex-shrink-0 h5 fw-bold text-center"
+                            t-out="this.props.locations.indexOf(selectedLocation) + 1"
+                        />
+                        <div class="d-flex flex-column flex-grow-1">
+                            <strong class="h5 fw-bold" t-out="selectedLocation.name"/>
+                            <small t-out="selectedLocation.street"/>
+                            <small t-out="this.getCityAndZipCode(selectedLocation)"/>
+                        </div>
+                    </div>
+                    <!-- large screen and + -->
+                    <button
+                        type="button"
+                        class="btn btn-primary d-none d-lg-block mt-3"
+                        t-att-disabled="!this.props.selectedLocationId"
+                        t-on-click="this.props.validateSelection">
+                            Choose this location
+                    </button>
+                </div>
+
+                <!-- Schedule -->
+                <LocationSchedule
+                    openingHours="selectedLocation.opening_hours"
+                    wrapClass="'col-lg-7 flex-grow-1 flex-lg-grow-0 ps-lg-4'"
+                />
+
+                <!-- medium size screen like Tablets, etc. -->
+                <button
+                    type="button"
+                    class="btn btn-primary d-block d-lg-none align-self-stretch ms-lg-4"
+                    t-att-disabled="!this.props.selectedLocationId"
+                    t-on-click="this.props.validateSelection">
+                        Choose this location
+                </button>
+            </div>
+
+            <!-- Mobile infos -->
+            <button
+                t-if="selectedLocation"
+                class="btn collapsed d-flex d-md-none gap-2 gap-lg-3 w-100 border-0 p-3 bg-transparent text-start"
+                type="button"
+                data-bs-target="#map_collapseHours"
+                aria-expanded="false"
+                aria-controls="map_collapseHours"
+                data-bs-toggle="collapse"
+            >
+                <strong
+                    t-out="this.props.locations.indexOf(selectedLocation) + 1"
+                    class="o_location_selector_number fw-bold text-center"
+                />
+                <span class="d-flex flex-column gap-1 w-100">
+                    <span class="d-flex flex-column">
+                        <strong class="fw-bold" t-out="selectedLocation.name"/>
+                        <small class="text-muted">
+                            <span t-out="selectedLocation.street"/>
+                            <span class="d-block" t-out="this.getCityAndZipCode(selectedLocation)"/>
+                        </small>
+                    </span>
+                    <span class="d-flex align-items-center gap-1 small fw-bold">
+                        <i class="fa fa-clock-o" role="img"/>
+                        Opening hours
+                        <i class="o_location_selector_hours_caret fa fa-caret-up ms-auto transition-base"/>
+                    </span>
+
+                    <!-- Schedule -->
+                    <span class="collapse" id="map_collapseHours">
+                        <LocationSchedule openingHours="selectedLocation.opening_hours"/>
+                    </span>
+                </span>
+            </button>
+        </div>
+    </t>
+</templates>

--- a/addons/web/static/src/core/assets.js
+++ b/addons/web/static/src/core/assets.js
@@ -54,7 +54,7 @@ const cacheMap = new Map();
 
 whenReady(computeCacheMap);
 
-class AssetsLoadingError extends Error {}
+export class AssetsLoadingError extends Error {}
 
 /**
  * Loads the given url inside a script tag.

--- a/addons/website_sale/__manifest__.py
+++ b/addons/website_sale/__manifest__.py
@@ -106,6 +106,11 @@
             'website_sale/static/src/js/product_configurator_dialog/*',
             'website_sale/static/src/js/product_list/*',
             'website_sale/static/src/js/product_template_attribute_line/*',
+
+            # Location selector components are defined in `delivery` to share the codebase with the
+            # backend.
+            'delivery/static/src/js/location_selector/**/*',
+            'website_sale/static/src/js/location_selector/**/*',
         ],
         'web._assets_primary_variables': [
             'website_sale/static/src/scss/primary_variables.scss',

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
 import logging
 from datetime import datetime
 
@@ -983,6 +984,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return {
             'order': order,
             'website_sale_order': order,
+            'json_pickup_location_data': json.dumps(order.pickup_location_data or {}),
             'shippings': ship_partners,
             'billings': bill_partners,
             'only_services': order and order.only_services or False

--- a/addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
+++ b/addons/website_sale/static/src/js/location_selector/location_selector_dialog/location_selector_dialog.js
@@ -1,0 +1,24 @@
+/** @odoo-module **/
+
+import {
+    LocationSelectorDialog
+} from '@delivery/js/location_selector/location_selector_dialog/location_selector_dialog';
+import { patch } from '@web/core/utils/patch';
+
+patch(LocationSelectorDialog, {
+    props: {
+        ...LocationSelectorDialog.props,
+        orderId: { type: Number, optional: true },
+        isFrontend: { type: Boolean, optional: true },
+    },
+});
+
+patch(LocationSelectorDialog.prototype, {
+    setup() {
+        super.setup(...arguments);
+
+        if (this.props.isFrontend) {
+            this.getLocationUrl = '/website_sale/get_pickup_locations';
+        }
+    },
+});

--- a/addons/website_sale/views/delivery_form_templates.xml
+++ b/addons/website_sale/views/delivery_form_templates.xml
@@ -64,27 +64,49 @@
             </div>
         </div>
         <!-- === Pick up location === -->
-        <div class="position-relative d-flex flex-column gap-2 mt-2">
-            <div class="o_pickup_location d-none ms-2">
+        <div
+            t-if="is_pickup_needed"
+            name="o_pickup_location"
+            t-attf-class="position-relative d-flex gap-2 mt-2 {{'' if is_selected else 'd-none'}}"
+        >
+            <t t-set="pickup_location_data" t-value="order.pickup_location_data or {}"/>
+            <div
+                name="o_pickup_location_details"
+                t-attf-class="ms-4 {{'' if is_selected and pickup_location_data else 'd-none'}}"
+            >
                 <span>
-                    <b name="o_pickup_location_name"/>
+                    <b name="o_pickup_location_name" t-out="pickup_location_data.get('name', '')"/>
                     <br/>
-                    <i name="o_pickup_location_address"/>
+                    <i
+                        name="o_pickup_location_address"
+                        t-out="pickup_location_data.get('street', '') + ' ' + pickup_location_data.get('zip_code', '') + ' ' + pickup_location_data.get('city', '')"
+                    />
                 </span>
                 <span
-                    name="o_remove_pickup_location"
-                    class="fa fa-times ms-2"
-                    title="Remove this location"
-                    aria-label="Remove this location"
+                    name="o_pickup_location_selector"
+                    class="btn btn-primary fa fa-pencil ms-2 p-1"
+                    title="Change location"
+                    aria-label="Change location"
+                    t-att-data-location-id="pickup_location_data.get('id')"
+                    t-att-data-zip-code="pickup_location_data.get('zip_code')"
+                    t-att-data-pickup-location-data="json_pickup_location_data"
                 />
             </div>
-            <t t-if="is_pickup_needed">
-                <div name="o_list_pickup_locations"/>
-            </t>
+            <button
+                t-if="not (is_selected and pickup_location_data)"
+                name="o_pickup_location_selector"
+                type="button"
+                class="btn btn-primary ms-4"
+                t-att-data-zip-code="order.partner_shipping_id.zip"
+            >
+                Select a location
+            </button>
         </div>
-        <t t-if="dm.website_description">
-            <div t-field="dm.website_description" class="text-muted mt-1"/>
-        </t>
+        <div
+            t-if="dm.website_description"
+            t-field="dm.website_description"
+            class="text-muted mt-1"
+        />
     </template>
 
 </odoo>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2125,14 +2125,14 @@
                 <a class="float-end no-decoration" href="/shop/checkout"><i class="fa fa-pencil me-1"/>Edit</a>
                 <t
                     t-set="separate_billing_address"
-                    t-value="order.partner_invoice_id != order.partner_shipping_id or order.access_point_address"
+                    t-value="order.partner_invoice_id != order.partner_shipping_id or order.pickup_location_data"
                 />
                 <div>
                     <b>Billing<t t-if="not separate_billing_address and not only_services"> &amp; Delivery</t>: </b>
                     <span t-esc="order.partner_invoice_id" t-options="dict(widget='contact', fields=['address'], no_marker=True, separator=', ')" class="address-inline"/>
                 </div>
                 <div t-if="separate_billing_address and order._has_deliverable_products()" groups="account.group_delivery_invoice_address">
-                    <t t-if="not order.access_point_address">
+                    <t t-if="not order.pickup_location_data">
                         <b>Delivery: </b>
                         <span
                             t-out="order.partner_shipping_id"
@@ -2142,7 +2142,7 @@
                     </t>
                     <t t-else="">
                         <b>Deliver to pickup point: </b>
-                        <t t-out="order.access_point_address.get('pick_up_point_name', '') + ', '+ order.access_point_address.get('address', '')"/>
+                        <t t-out="order.pickup_location_data.get('pick_up_point_name', '') + ', '+ order.pickup_location_data.get('address', '')"/>
                     </t>
                 </div>
             </div>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2132,17 +2132,17 @@
                     <span t-esc="order.partner_invoice_id" t-options="dict(widget='contact', fields=['address'], no_marker=True, separator=', ')" class="address-inline"/>
                 </div>
                 <div t-if="separate_billing_address and order._has_deliverable_products()" groups="account.group_delivery_invoice_address">
-                    <t t-if="not order.pickup_location_data">
+                    <t t-if="order.pickup_location_data">
+                        <b>Deliver to pickup point: </b>
+                        <t t-out="order.pickup_location_data.get('name', '') + ', ' + order.pickup_location_data.get('street', '') + ' ' + order.pickup_location_data.get('zip_code', '') + ' ' + order.pickup_location_data.get('city','')"/>
+                    </t>
+                    <t t-else="">
                         <b>Delivery: </b>
                         <span
                             t-out="order.partner_shipping_id"
                             t-options="dict(widget='contact', fields=['address'], no_marker=True, separator=', ')"
                             class="address-inline"
                         />
-                    </t>
-                    <t t-else="">
-                        <b>Deliver to pickup point: </b>
-                        <t t-out="order.pickup_location_data.get('pick_up_point_name', '') + ', '+ order.pickup_location_data.get('address', '')"/>
                     </t>
                 </div>
             </div>


### PR DESCRIPTION
Currently, the location selector doesn't offer a great UX: the buttons
are tiny, customers have to click on a "pin" button to open the map view
in another tab, locations are displayed in a list inside the inline form
of the delivery method... Furthermore, the location selector is bound to
the list of delivery methods and cannot be displayed elsewhere on the
website.

This commit introduces a new modal allowing customers to select the
location of a delivery pick-up point in a more friendly way. It features
a list of available pick-up points displayed both on a list and a map.
Customers can click on either the list element or map pin to select the
pick-up point of their choice, and they can give a postal code to look
for pick-up points in a specific area.

See also:
- https://github.com/odoo/enterprise/pull/58198
- https://github.com/odoo/upgrade/pull/6194

task-3747001