### PR TITLE
[FIX] hr_work_entry_contract: stop making extra work entries for overtime

### DIFF
--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -368,17 +368,14 @@ class HrContract(models.Model):
             # For each contract, we found each interval we must generate
             # In some cases we do not want to set the generated dates beforehand, since attendance based work entries
             #  is more dynamic, we want to update the dates within the _get_work_entries_values function
-            is_static_work_entries = contract.has_static_work_entries()
             last_generated_from = min(contract.date_generated_from, contract_stop)
             if last_generated_from > date_start_work_entries:
-                if is_static_work_entries:
-                    contract.date_generated_from = date_start_work_entries
+                contract.date_generated_from = date_start_work_entries
                 intervals_to_generate[(date_start_work_entries, last_generated_from)] |= contract
 
             last_generated_to = max(contract.date_generated_to, contract_start)
             if last_generated_to < date_stop_work_entries:
-                if is_static_work_entries:
-                    contract.date_generated_to = date_stop_work_entries
+                contract.date_generated_to = date_stop_work_entries
                 intervals_to_generate[(last_generated_to, date_stop_work_entries)] |= contract
 
         for interval, contracts in intervals_to_generate.items():


### PR DESCRIPTION
Steps to reproduce:
1) Install hr_work_entry_contract_planning_attendance
2) Create planning-based contracts for employee
3) create a shift for the employee for 8 hours (Based on the working schedule) 4) create attendance more than shift hours
5) Open work entries and you get Extra Overtime work entry

Cause:
For the work entries, we defined date_generated_from and date_generated_to in contracts
Based on these dates we are going to decide whether we need to create work entries for the specific period working schedule as work entry source

Fix:
these dates are set for both types of contracts

task-3646385