### PR TITLE
[FIX] web: weird behavior with daterange widget

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -480,15 +480,6 @@ export class DateTimePicker extends Component {
      */
     applyValueAtIndex(value, valueIndex) {
         const result = [...this.values];
-        if (this.isRange) {
-            if (result[0] && value.endOf("day") < result[0].startOf("day")) {
-                valueIndex = 0;
-            } else if (result[1] && result[1].endOf("day") < value.startOf("day")) {
-                valueIndex = 1;
-            }
-        } else {
-            valueIndex = 0;
-        }
         result[valueIndex] = value;
         return [result, valueIndex];
     }

--- a/addons/web/static/src/core/datetime/datetime_picker.scss
+++ b/addons/web/static/src/core/datetime/datetime_picker.scss
@@ -85,7 +85,8 @@
     }
 
     .o_out_of_range {
-        color: var(--gray-400);
+        visibility: hidden;
+        pointer-events: none;
     }
 
     .o_time_picker_select {

--- a/addons/web/static/tests/core/datetime/datetime_picker_tests.js
+++ b/addons/web/static/tests/core/datetime/datetime_picker_tests.js
@@ -1022,7 +1022,7 @@ QUnit.module("Components", ({ beforeEach }) => {
 
         await click(getPickerCell("19").at(0));
 
-        assert.verifySteps(["2023-04-19T08:43:00,2023-04-23T17:16:00"]);
+        assert.verifySteps(["2023-04-20T08:43:00,2023-04-19T17:16:00"]);
     });
 
     QUnit.test("range value, select date for first value after second value", async (assert) => {
@@ -1037,7 +1037,7 @@ QUnit.module("Components", ({ beforeEach }) => {
 
         await click(getPickerCell("27").at(1));
 
-        assert.verifySteps(["2023-04-20T08:43:00,2023-04-27T17:16:00"]);
+        assert.verifySteps(["2023-04-27T08:43:00,2023-04-23T17:16:00"]);
     });
 
     QUnit.test("focus proper month when changing props out of current month", async (assert) => {

--- a/addons/web/static/tests/core/datetime/datetime_picker_tests.js
+++ b/addons/web/static/tests/core/datetime/datetime_picker_tests.js
@@ -1031,13 +1031,13 @@ QUnit.module("Components", ({ beforeEach }) => {
                 DateTime.fromObject({ day: 20, hour: 8, minute: 43 }),
                 DateTime.fromObject({ day: 23, hour: 17, minute: 16 }),
             ],
-            focusedDateIndex: 0,
+            focusedDateIndex: 1,
             onSelect: (values) => assert.step(formatForStep(values)),
         });
 
         await click(getPickerCell("27").at(1));
 
-        assert.verifySteps(["2023-04-27T08:43:00,2023-04-23T17:16:00"]);
+        assert.verifySteps(["2023-04-20T08:43:00,2023-05-27T17:16:00"]);
     });
 
     QUnit.test("focus proper month when changing props out of current month", async (assert) => {

--- a/addons/web/static/tests/views/fields/daterange_field_tests.js
+++ b/addons/web/static/tests/views/fields/daterange_field_tests.js
@@ -234,6 +234,7 @@ QUnit.module("Fields", (hooks) => {
 
         // Change date
         await click(getPickerCell("16").at(0));
+        await click(target.querySelector(".o_add_date"));
         await click(getPickerCell("12").at(1));
         // Close picker
         await click(document.querySelector(".o_form_view"));

--- a/addons/web/static/tests/views/fields/daterange_field_tests.js
+++ b/addons/web/static/tests/views/fields/daterange_field_tests.js
@@ -172,8 +172,8 @@ QUnit.module("Fields", (hooks) => {
         );
 
         // Select a new range and check that inputs are updated
-        await click(getPickerCell("8").at(0)); // 02/08/2017
         await click(getPickerCell("9").at(0)); // 02/09/2017
+        await click(getPickerCell("8").at(0)); // 02/08/2017
         assert.equal(
             target.querySelector("input[data-field=datetime]").value,
             "02/08/2017 15:30:00"
@@ -233,8 +233,8 @@ QUnit.module("Fields", (hooks) => {
         );
 
         // Change date
-        await click(getPickerCell("12").at(1));
         await click(getPickerCell("16").at(0));
+        await click(getPickerCell("12").at(1));
         // Close picker
         await click(document.querySelector(".o_form_view"));
 
@@ -268,8 +268,8 @@ QUnit.module("Fields", (hooks) => {
         );
 
         // Change date
-        await click(getPickerCell("13").at(0));
         await click(getPickerCell("18").at(1));
+        await click(getPickerCell("13").at(0));
         // Close picker
         await click(document.querySelector(".o_form_view"));
 


### PR DESCRIPTION
Steps to reproduce the weird behavior:
- Open the daterange widget
- select the start date - it will highlight only one day in hover
- select the end date - it will highlight a period at the hover
- Now click on the start date and try to select the bigger date than period,
  instead of changing the start date, end date will be changed.
- Same problem with end date, try to select smaller date than period,
  instead of changing the end date, start date will be changed.

Observed behavior:
The User is not able to change the date that he wants to change,
instead of changing the desired date, it will change other date.

Expected behavior:
The User should be able to change the date that he wants to change.

Task-3433683

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
