### PR TITLE
[FIX] mail: handle mail traking values without field_id

### DIFF
--- a/addons/mail/models/mail_tracking_value.py
+++ b/addons/mail/models/mail_tracking_value.py
@@ -38,7 +38,7 @@ class MailTracking(models.Model):
     @api.depends('mail_message_id', 'field_id')
     def _compute_field_groups(self):
         for tracking in self:
-            model = self.env[tracking.field_id.model]
+            model = self.env[tracking.field_id.model] if tracking.field_id else self.env[tracking.mail_message_id.model]
             field = model._fields.get(tracking.field_id.name)
             tracking.field_groups = field.groups if field else 'base.group_system'
 


### PR DESCRIPTION
Sine the following fix: https://github.com/odoo/odoo/pull/155034/files, we get a traceback when we are reading tracking values that does not have field_id.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
