### PR TITLE
[FIX] website: conditional visibility on popup

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -1636,8 +1636,9 @@ var SnippetsMenu = Widget.extend({
             .removeProp('contentEditable');
         this.getEditableArea().find('.o_we_selected_image')
             .removeClass('o_we_selected_image');
+        // s_popup manages is always invisible at the start of edit mode
         [...this.getEditableArea()].forEach(editableAreaEl => {
-            editableAreaEl.querySelectorAll("[data-visibility='conditional']")
+            editableAreaEl.querySelectorAll("[data-visibility='conditional']:not(.s_popup)")
                             .forEach(invisibleEl => delete invisibleEl.dataset.invisible);
         });
     },
@@ -2356,6 +2357,12 @@ var SnippetsMenu = Widget.extend({
                 el.setAttribute('string', '⌙ ' + el.getAttribute('string'));
             }
             $logoHeightOptions.insertAfter($logoTypeSelector);
+        }
+
+        // TODO: in master, update the data-selector of ConditionalVisibility
+        const $conditionalVisibilityOption = $html.find("[data-js='ConditionalVisibility']");
+        if ($conditionalVisibilityOption.length) {
+            $conditionalVisibilityOption[0].dataset.selector += ', .s_popup';
         }
 
         this.templateOptions = [];

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3146,12 +3146,18 @@ options.registry.ConditionalVisibility = options.Class.extend({
      * @override
      */
     async onTargetHide() {
+        if (this.$target[0].dataset.visibility !== "conditional") {
+            return;
+        }
         this.$target[0].classList.add('o_conditional_hidden');
     },
     /**
      * @override
      */
     async onTargetShow() {
+        if (this.$target[0].dataset.visibility !== "conditional") {
+            return;
+        }
         this.$target[0].classList.remove('o_conditional_hidden');
     },
     // Todo: remove me in master.

--- a/addons/website/static/src/snippets/s_popup/000.js
+++ b/addons/website/static/src/snippets/s_popup/000.js
@@ -103,7 +103,8 @@ const PopupWidget = publicWidget.Widget.extend({
      */
     start: function () {
         this._popupAlreadyShown = !!utils.get_cookie(this.$el.attr('id'));
-        if (!this._popupAlreadyShown) {
+        this._visibilitySelector = this.$target[0].dataset.visibilitySelectors;
+        if (!this._popupAlreadyShown && !this.$target[0].matches(this._visibilitySelector)) {
             this._bindPopup();
         }
         return this._super(...arguments);


### PR DESCRIPTION
Prior to this commit, the Conditional Visibility option was not
available on Popup block because it is not in a section block.

This was a known limitation at the time, but since content inside the
popup could be hidden conditionally, you could end up displaying a blank
popup to website visitors.

It seems fairly simple to support the conditional visibility on popups,
so these changes makes it possible.

opw-3734501