### PR TITLE
[FIX] portal: display avatar when read access right are fulfilled

### DIFF
--- a/addons/portal/controllers/mail.py
+++ b/addons/portal/controllers/mail.py
@@ -115,6 +115,8 @@ class PortalChatter(http.Controller):
     @http.route('/mail/avatar/mail.message/<int:res_id>/author_avatar/<int:width>x<int:height>', type='http', auth='public')
     def portal_avatar(self, res_id=None, height=50, width=50, access_token=None, _hash=None, pid=None):
         """ Get the avatar image in the chatter of the portal """
+        # TODO adapt the code in master as the route is never called without an
+        # "access_token" or without a "_hash" and a "pid".
         if access_token or (_hash and pid):
             message = request.env['mail.message'].browse(int(res_id)).exists().filtered(
                 lambda msg: _check_special_access(msg.model, msg.res_id, access_token, _hash, pid and int(pid))

--- a/addons/portal/static/src/js/portal_chatter.js
+++ b/addons/portal/static/src/js/portal_chatter.js
@@ -110,7 +110,7 @@ var PortalChatter = publicWidget.Widget.extend({
             } else if (hash && pid) {
                 m['author_avatar_url'] = _.str.sprintf('/mail/avatar/mail.message/%s/author_avatar/50x50?_hash=%s&pid=%s', m.id, hash, pid);
             } else {
-                m['author_avatar_url'] = _.str.sprintf('/mail/avatar/mail.message/%s/author_avatar/50x50', m.id);
+                m['author_avatar_url'] = _.str.sprintf('/web/image/%s/%s/author_avatar/50x50', 'mail.message', m.id);
 
             }
             m['published_date_str'] = _.str.sprintf(_t('Published on %s'), moment(time.str_to_datetime(m.date)).format('MMMM Do YYYY, h:mm:ss a'));

--- a/addons/website_blog/static/tests/tours/blog_comment.js
+++ b/addons/website_blog/static/tests/tours/blog_comment.js
@@ -1,0 +1,65 @@
+/** @odoo-module **/
+
+import wTourUtils from "website.tour_utils";
+
+/**
+ * Makes sure that the avatar are visible when posting a comment.
+ */
+wTourUtils.registerWebsitePreviewTour("blog_avatar_comment", {
+    test: true,
+    url: "/blog",
+}, [
+    {
+        content: "Click on the 'Post Test' blog",
+        trigger: "iframe article a.o_blog_post_title:contains('Post Test')",
+    },
+    {
+        content: "Check that we are on the correct blog post",
+        trigger: "iframe [data-name='Blog Post Cover'] .o_wblog_post_title:contains('Post Test')",
+        run: () => {}, // It is a check
+    },
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    {
+        content: "Click on the 'Customize' button",
+        trigger: "#oe_snippets #snippets_menu .o_we_customize_snippet_btn",
+    },
+    {
+        content: "Allow the comment on the blog",
+        trigger: ".o_we_customize_panel we-button[data-customize-website-views='website_blog.opt_blog_post_comment']:not(.active)",
+    },
+    {
+        content: "Ensure the comments are enabled on the blog",
+        trigger: ".o_we_customize_panel we-button[data-customize-website-views='website_blog.opt_blog_post_comment'].active",
+        run: () => {}, // It is a check
+    },
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Write a comment on the blog post",
+        trigger: "iframe #o_wblog_post_comments .o_portal_chatter_composer_input textarea.form-control",
+        run: "text A nice comment",
+    },
+    {
+        content: "Click on 'Send'",
+        trigger: "iframe #o_wblog_post_comments .o_portal_chatter_composer_input button[data-action='/mail/chatter_post']",
+    },
+    {
+        content: "Check the image of the avatar",
+        trigger: "iframe #o_wblog_post_comments .o_portal_chatter_message:contains('A nice comment') img.o_portal_chatter_avatar",
+        run: () => {
+            const imgEl = document.querySelector("iframe").contentDocument.querySelector("#o_wblog_post_comments .o_portal_chatter_message img.o_portal_chatter_avatar");
+            fetch(imgEl.getAttribute("src")).then(function (answer) {
+                // Check that the avatar is not displayed as the default
+                // placeholder image.
+                if (answer.headers.get("Content-Disposition").match(/mail_message-\d+-author_avatar/)) {
+                    imgEl.dataset.showAvatar = "true";
+                }
+            });
+        },
+    },
+    {
+        content: "Check that the avatar is not the default placeholder",
+        trigger: "iframe #o_wblog_post_comments .o_portal_chatter_message img.o_portal_chatter_avatar[data-show-avatar='true']",
+        run: () => {}, // It is a check
+    },
+]
+);

--- a/addons/website_blog/tests/test_ui.py
+++ b/addons/website_blog/tests/test_ui.py
@@ -52,3 +52,6 @@ class TestUi(odoo.tests.HttpCase):
         self.env.ref('website_blog.opt_blog_sidebar_show').active = True
         self.env.ref('website_blog.opt_sidebar_blog_index_follow_us').active = False
         self.start_tour("/blog", 'blog_autocomplete_with_date')
+
+    def test_avatar_comment(self):
+        self.start_tour(self.env['website'].get_client_action_url('/blog'), 'blog_avatar_comment', login='admin')


### PR DESCRIPTION
[FIX] portal,*: display avatar when read access right are fulfilled

*website_blog

Steps to reproduce the bug:
- Enable the comments on a blog.
- Add a comment.

-> Problem: The avatar of the comment is the default placeholder image.

The problem appears since [1]. This commit was created to bypass the
read access of an image if a correct `token` was provided in the dataset
of the `.o_portal_chatter` element. The problem is that since [1], if
the `.o_portal_chatter` element does not have a `token` (or a `hash` and
a `pid` since [2]) in its dataset, the avatar images are displayed as
the default placeholder image by default. The goal of this commit is to
correct this behavior; if there is no token provided, the previously
used `/web/image` route is used to show the avatar. Thanks to this
route, the avatar is displayed if the read access is fulfilled. If it is
not the case, the default placeholder image is displayed.

[1]: https://github.com/odoo/odoo/commit/d4eb996cd3caea3fbb822437057a6a5a8a722293
[2]: https://github.com/odoo/odoo/commit/7f69708bcce3b3c4b096d89cb0ec354998eac191

opw-3749422