### PR TITLE
[FIX] base: action_id set to none on filters after action deletion

### DIFF
--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -90,6 +90,8 @@ class IrActions(models.Model):
            NOTE: ondelete cascade will not work on ir.actions.actions so we will need to do it manually."""
         todos = self.env['ir.actions.todo'].search([('action_id', 'in', self.ids)])
         todos.unlink()
+        filters = self.env['ir.filters'].search([('action_id', 'in', self.ids)])
+        filters.action_id = None
         res = super(IrActions, self).unlink()
         # self.get_bindings() depends on action records
         self.env.registry.clear_cache()

--- a/odoo/addons/base/tests/test_ir_filters.py
+++ b/odoo/addons/base/tests/test_ir_filters.py
@@ -328,3 +328,15 @@ class TestAllFilters(TransactionCase):
                     order=','.join(ast.literal_eval(filter_.sort)),
                     context=context,
                 )
+
+    def test_filters_dont_have_action_on_action_delete(self):
+        res_partner_model = self.env.ref('base.model_res_partner')
+        action = self.env['ir.actions.server'].create({
+            'name': 'test_action',
+            'model_id': res_partner_model.id,
+            'state': 'object_write',
+        })
+        Filters = self.env['ir.filters']
+        filter = Filters.create(dict(name="Test Filter", model_id="ir.filters", action_id=action.id))
+        action.unlink()
+        self.assertFalse(filter.action_id, "We should set the action_id to False/None when action is deleted.")


### PR DESCRIPTION
Issue: When deleting an action, we still will preserve the action in the filter even thought this one doesn't exist anymore, this Issue is present in cases where we delete modules that contains filters.

Steps to reproduce:

1. Install any module (CRM, Contacts..)
2. Create a custom search (filter) in this module
3. Now uninstall the module
4. Go to User-defined filters

Solution: We make sure in the actions unlink that when this action.unlink() is called we also unlink the filters that contains this action by setting their action_id to None.

opw-3770569
