### PR TITLE
[FIX] remove surplus encodeURIComponent() in shapes URL return

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -7229,7 +7229,7 @@ registry.BackgroundShape = SnippetOptionWidget.extend({
         if (flip.length) {
             searchParams.push(`flip=${encodeURIComponent(flip.sort().join(''))}`);
         }
-        return `/web_editor/shape/${encodeURIComponent(shape)}.svg?${searchParams.join('&')}`;
+        return `/web_editor/shape/${shape}.svg?${searchParams.join('&')}`;
     },
     /**
      * Retrieves current shape data from the target's dataset.


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Remove surplus encodeURIComponent() function in URL generation

Current behavior before PR:
It currently results in `/web_editor/shape/web_editor%2FFloats%2F11.svg?[...]`

Desired behavior after PR is merged:
It should result in `/web_editor/shape/web_editor/Floats/11.svg?[...]`

Issue [#129873](https://github.com/odoo/odoo/issues/129873)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
