### PR TITLE
[IMP] base, account: remove the localisation install blue label from country, and auto install l10n on company country write

### DIFF
--- a/addons/account/demo/account_demo.xml
+++ b/addons/account/demo/account_demo.xml
@@ -10,6 +10,7 @@
             <value eval="[]"/>
             <value>generic_coa</value>
             <value model="res.company" search="[('partner_id.country_id.code', 'in', ['US', False])]"/>
+            <value name="install_demo" eval="True"/>
         </function>
 
         <!-- TAGS FOR RETRIEVING THE DEMO ACCOUNTS -->

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -131,7 +131,7 @@ class AccountChartTemplate(models.AbstractModel):
     # Loading
     # --------------------------------------------------------------------------------
 
-    def try_loading(self, template_code, company, install_demo=True):
+    def try_loading(self, template_code, company, install_demo=False):
         """Check if the chart template can be loaded then proceeds installing it.
 
         :param template_code: code of the chart template to be loaded.

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -637,6 +637,22 @@ class ResCompany(models.Model):
             raise RedirectWarning(msg, action.id, _("Go to the configuration panel"))
         return account
 
+    def install_l10n_modules(self):
+        if res := super().install_l10n_modules():
+            self.env.flush_all()
+            self.env.reset()     # clear the set of environments
+            env = self.env()     # get an environment that refers to the new registry
+            for company in self.filtered(lambda c: c.country_id and not c.chart_template):
+                template_code = self.env['account.chart.template']._guess_chart_template(company.country_id)
+                if template_code != 'generic_coa':
+                    @self.env.cr.precommit.add
+                    def try_loading(template_code=template_code, company=company):
+                        env['account.chart.template'].try_loading(
+                            template_code,
+                            env['res.company'].browse(company.id),
+                        )
+        return res
+
     def _existing_accounting(self) -> bool:
         """Return True iff some accounting entries have already been made for the current company."""
         self.ensure_one()

--- a/addons/l10n_ae/demo/demo_company.xml
+++ b/addons/l10n_ae/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>ae</value>
         <value model="res.company" eval="obj().env.ref('l10n_ae.demo_company_ae')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ar/demo/account_demo.py
+++ b/addons/l10n_ar/demo/account_demo.py
@@ -19,8 +19,10 @@ class AccountChartTemplate(models.AbstractModel):
             return {}
 
         if company.account_fiscal_country_id.code == "AR":
-            demo_data.setdefault('res.partner', {})
-            demo_data['account.move'] = demo_data.pop('account.move')
+            demo_data = {
+                'res.partner': demo_data.pop('res.partner', {}),
+                **demo_data,
+            }
             demo_data['res.partner'].setdefault('base.res_partner_2', {})
             demo_data['res.partner']['base.res_partner_2']['l10n_ar_afip_responsibility_type_id'] = 'l10n_ar.res_IVARI'
             demo_data['res.partner'].setdefault('base.res_partner_12', {})
@@ -33,6 +35,8 @@ class AccountChartTemplate(models.AbstractModel):
         if company.account_fiscal_country_id.code == "AR":
             data['demo_invoice_5']['l10n_latam_document_number'] = '1-1'
             data['demo_invoice_equipment_purchase']['l10n_latam_document_number'] = '1-2'
+            data['demo_move_auto_reconcile_3']['l10n_latam_document_number'] = '1-3'
+            data['demo_move_auto_reconcile_4']['l10n_latam_document_number'] = '1-4'
         return data
 
     def _post_load_demo_data(self, company=False):

--- a/addons/l10n_ar/demo/exento_demo.xml
+++ b/addons/l10n_ar/demo/exento_demo.xml
@@ -33,6 +33,7 @@
         <value eval="[]"/>
         <value>ar_ex</value>
         <value model="res.company" eval="obj().env.ref('l10n_ar.company_exento')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 
     <data noupdate="1">

--- a/addons/l10n_ar/demo/mono_demo.xml
+++ b/addons/l10n_ar/demo/mono_demo.xml
@@ -33,6 +33,7 @@
         <value eval="[]"/>
         <value>ar_base</value>
         <value model="res.company" eval="obj().env.ref('l10n_ar.company_mono')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 
     <data noupdate="1">

--- a/addons/l10n_ar/demo/respinsc_demo.xml
+++ b/addons/l10n_ar/demo/respinsc_demo.xml
@@ -34,6 +34,7 @@
         <value eval="[]"/>
         <value>ar_ri</value>
         <value model="res.company" eval="obj().env.ref('l10n_ar.company_ri')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 
     <record id="bank_account_ri" model="res.partner.bank">

--- a/addons/l10n_at/demo/demo_company.xml
+++ b/addons/l10n_at/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>at</value>
         <value model="res.company" eval="obj().env.ref('l10n_at.demo_company_at')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_au/demo/demo_company.xml
+++ b/addons/l10n_au/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>au</value>
         <value model="res.company" eval="obj().env.ref('l10n_au.demo_company_au')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_be/demo/demo_company.xml
+++ b/addons/l10n_be/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>be_comp</value>
         <value model="res.company" eval="obj().env.ref('l10n_be.demo_company_be')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_bf/demo/demo_company.xml
+++ b/addons/l10n_bf/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>bf</value>
         <value model="res.company" eval="obj().env.ref('l10n_bf.demo_company_bf')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_bg/demo/demo_company.xml
+++ b/addons/l10n_bg/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>bg</value>
         <value model="res.company" eval="obj().env.ref('l10n_bg.demo_company_bg')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_bj/demo/demo_company.xml
+++ b/addons/l10n_bj/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>bj</value>
         <value model="res.company" eval="obj().env.ref('l10n_bj.demo_company_bj')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_bo/demo/demo_company.xml
+++ b/addons/l10n_bo/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">Calle Chovena</field>
         <field name="city">Municipio Santa Cruz de la Sierra</field>
         <field name="country_id" ref="base.bo"/>
-        
+
         <field name="zip">6495</field>
         <field name="phone">+591 71234567</field>
         <field name="email">info@company.boexample.com</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>bo</value>
         <value model="res.company" eval="obj().env.ref('l10n_bo.demo_company_bo')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_br/demo/demo_company.xml
+++ b/addons/l10n_br/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>br</value>
         <value model="res.company" eval="obj().env.ref('l10n_br.demo_company_br')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ca/demo/demo_company.xml
+++ b/addons/l10n_ca/demo/demo_company.xml
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>ca_2023</value>
         <value model="res.company" eval="obj().env.ref('l10n_ca.demo_company_ca')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_cd/demo/demo_company.xml
+++ b/addons/l10n_cd/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>cd</value>
         <value model="res.company" eval="obj().env.ref('l10n_cd.demo_company_cd')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_cf/demo/demo_company.xml
+++ b/addons/l10n_cf/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>cf</value>
         <value model="res.company" eval="obj().env.ref('l10n_cf.demo_company_cf')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_cg/demo/demo_company.xml
+++ b/addons/l10n_cg/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>cg</value>
         <value model="res.company" eval="obj().env.ref('l10n_cg.demo_company_cg')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ch/demo/demo_company.xml
+++ b/addons/l10n_ch/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">14 Meierskappelerstrasse</field>
         <field name="city">Risch-Rotkreuz</field>
         <field name="country_id" ref="base.ch"/>
-        
+
         <field name="zip">6343</field>
         <field name="phone">+41 78 123 45 67</field>
         <field name="email">info@company.chexample.com</field>
@@ -38,5 +38,6 @@
         <value eval="[]"/>
         <value>ch</value>
         <value model="res.company" eval="obj().env.ref('l10n_ch.demo_company_ch')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ci/demo/demo_company.xml
+++ b/addons/l10n_ci/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>ci</value>
         <value model="res.company" eval="obj().env.ref('l10n_ci.demo_company_ci')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_cl/demo/demo_company.xml
+++ b/addons/l10n_cl/demo/demo_company.xml
@@ -33,5 +33,6 @@
         <value eval="[]"/>
         <value>cl</value>
         <value model="res.company" eval="obj().env.ref('l10n_cl.demo_company_cl')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_cm/demo/demo_company.xml
+++ b/addons/l10n_cm/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>cm</value>
         <value model="res.company" eval="obj().env.ref('l10n_cm.demo_company_cm')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_cn/demo/demo_company.xml
+++ b/addons/l10n_cn/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>cn</value>
         <value model="res.company" eval="obj().env.ref('l10n_cn.demo_company_cn')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_co/demo/demo_company.xml
+++ b/addons/l10n_co/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>co</value>
         <value model="res.company" eval="obj().env.ref('l10n_co.demo_company_co')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_cr/demo/demo_company.xml
+++ b/addons/l10n_cr/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>cr</value>
         <value model="res.company" eval="obj().env.ref('l10n_cr.demo_company_cr')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_de/demo/demo_company.xml
+++ b/addons/l10n_de/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>de_skr03</value>
         <value model="res.company" eval="obj().env.ref('l10n_de.demo_company_de')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_dk/demo/demo_company.xml
+++ b/addons/l10n_dk/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">G</field>
         <field name="city">Aalborg</field>
         <field name="country_id" ref="base.dk"/>
-        
+
         <field name="zip">9430</field>
         <field name="phone">+45 32 12 34 56</field>
         <field name="email">info@company.dkexample.com</field>
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>dk</value>
         <value model="res.company" eval="obj().env.ref('l10n_dk.demo_company_dk')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_do/demo/demo_company.xml
+++ b/addons/l10n_do/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>do</value>
         <value model="res.company" eval="obj().env.ref('l10n_do.demo_company_do')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_dz/demo/demo_company.xml
+++ b/addons/l10n_dz/demo/demo_company.xml
@@ -30,5 +30,6 @@
         <value eval="[]"/>
         <value>dz</value>
         <value model="res.company" eval="obj().env.ref('l10n_dz.l10n_dz_demo_company_company')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ec/demo/demo_company.xml
+++ b/addons/l10n_ec/demo/demo_company.xml
@@ -7,7 +7,7 @@
         <field name="street">Av. de las Americas 505</field>
         <field name="city">Quito</field>
         <field name="country_id" ref="base.ec"/>
-        
+
         <field name="zip">170112</field>
         <field name="phone">+593 99 123 4567</field>
         <field name="email">info@company.ecexample.com</field>
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>ec</value>
         <value model="res.company" eval="obj().env.ref('l10n_ec.demo_company_ec')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ee/demo/demo_company.xml
+++ b/addons/l10n_ee/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>ee</value>
         <value model="res.company" eval="obj().env.ref('l10n_ee.demo_company_ee')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_eg/demo/demo_company.xml
+++ b/addons/l10n_eg/demo/demo_company.xml
@@ -30,6 +30,7 @@
         <value eval="[]"/>
         <value>eg</value>
         <value model="res.company" eval="obj().env.ref('l10n_eg.demo_company_eg')"/>
+        <value name="install_demo" eval="True"/>
     </function>
     </data>
 </odoo>

--- a/addons/l10n_es/demo/demo_company.xml
+++ b/addons/l10n_es/demo/demo_company.xml
@@ -38,5 +38,6 @@
         <value eval="[]"/>
         <value>es_pymes</value>
         <value model="res.company" eval="obj().env.ref('l10n_es.demo_company_es')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_et/demo/demo_company.xml
+++ b/addons/l10n_et/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>et</value>
         <value model="res.company" eval="obj().env.ref('l10n_et.demo_company_et')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_fi/demo/demo_company.xml
+++ b/addons/l10n_fi/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>fi</value>
         <value model="res.company" eval="obj().env.ref('l10n_fi.demo_company_fi')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_fr/demo/demo_company.xml
+++ b/addons/l10n_fr/demo/demo_company.xml
@@ -7,7 +7,7 @@
         <field name="city">Rennes</field>
         <field name="country_id" ref="base.fr"/>
         <field name="siret">96851575905808</field>
-        
+
         <field name="zip">35043</field>
         <field name="phone">+33 6 12 34 56 78</field>
         <field name="email">info@company.frexample.com</field>
@@ -38,5 +38,6 @@
         <value eval="[]"/>
         <value>fr</value>
         <value model="res.company" eval="obj().env.ref('l10n_fr.demo_company_fr')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ga/demo/demo_company.xml
+++ b/addons/l10n_ga/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>ga</value>
         <value model="res.company" eval="obj().env.ref('l10n_ga.demo_company_ga')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_gn/demo/demo_company.xml
+++ b/addons/l10n_gn/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>gn</value>
         <value model="res.company" eval="obj().env.ref('l10n_gn.demo_company_gn')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_gq/demo/demo_company.xml
+++ b/addons/l10n_gq/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>gq</value>
         <value model="res.company" eval="obj().env.ref('l10n_gq.demo_company_gq')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_gr/demo/demo_company.xml
+++ b/addons/l10n_gr/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">a</field>
         <field name="city">Κως</field>
         <field name="country_id" ref="base.gr"/>
-        
+
         <field name="zip">85300</field>
         <field name="phone">+30 691 234 5678</field>
         <field name="email">info@company.grexample.com</field>
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>gr</value>
         <value model="res.company" eval="obj().env.ref('l10n_gr.demo_company_gr')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_gt/demo/demo_company.xml
+++ b/addons/l10n_gt/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>gt</value>
         <value model="res.company" eval="obj().env.ref('l10n_gt.demo_company_gt')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_gw/demo/demo_company.xml
+++ b/addons/l10n_gw/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>gw</value>
         <value model="res.company" eval="obj().env.ref('l10n_gw.demo_company_gw')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_hk/demo/demo_company.xml
+++ b/addons/l10n_hk/demo/demo_company.xml
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>hk</value>
         <value model="res.company" eval="obj().env.ref('l10n_hk.demo_company_hk')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_hn/demo/demo_company.xml
+++ b/addons/l10n_hn/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">CA-1</field>
         <field name="city">Nacaome</field>
         <field name="country_id" ref="base.hn"/>
-        
+
         <field name="zip"/>
         <field name="phone">+504 9123-4567</field>
         <field name="email">info@company.hnexample.com</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>hn</value>
         <value model="res.company" eval="obj().env.ref('l10n_hn.demo_company_hn')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_hr/demo/demo_company.xml
+++ b/addons/l10n_hr/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">Vukasi</field>
         <field name="city">Ježdovec</field>
         <field name="country_id" ref="base.hr"/>
-        
+
         <field name="zip">10250</field>
         <field name="phone">+385 92 123 4567</field>
         <field name="email">info@company.hrexample.com</field>
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>hr</value>
         <value model="res.company" eval="obj().env.ref('l10n_hr.demo_company_hr')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_hr_kuna/demo/demo_company.xml
+++ b/addons/l10n_hr_kuna/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">Vukasi</field>
         <field name="city">Ježdovec</field>
         <field name="country_id" ref="base.hr"/>
-        
+
         <field name="zip">10250</field>
         <field name="phone">+385 92 123 4567</field>
         <field name="email">info@company.hrexample.com</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>hr_kuna</value>
         <value model="res.company" eval="obj().env.ref('l10n_hr_kuna.demo_company_hr')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_hu/demo/demo_company.xml
+++ b/addons/l10n_hu/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>hu</value>
         <value model="res.company" eval="obj().env.ref('l10n_hu.demo_company_hu')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_id/demo/demo_company.xml
+++ b/addons/l10n_id/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>id</value>
         <value model="res.company" eval="obj().env.ref('l10n_id.demo_company_id')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ie/demo/demo_company.xml
+++ b/addons/l10n_ie/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>ie</value>
         <value model="res.company" eval="obj().env.ref('l10n_ie.demo_company_ie')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_il/demo/demo_company.xml
+++ b/addons/l10n_il/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">500 </field>
         <field name="city">תל אביב-יפו</field>
         <field name="country_id" ref="base.il"/>
-        
+
         <field name="zip">no</field>
         <field name="phone">+972 50-234-5678</field>
         <field name="email">info@company.ilexample.com</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>il</value>
         <value model="res.company" eval="obj().env.ref('l10n_il.demo_company_il')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_in/demo/demo_company.xml
+++ b/addons/l10n_in/demo/demo_company.xml
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>in</value>
         <value model="res.company" eval="obj().env.ref('l10n_in.demo_company_in')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_it/demo/demo_company.xml
+++ b/addons/l10n_it/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>it</value>
         <value model="res.company" eval="obj().env.ref('l10n_it.demo_company_it')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_jp/demo/demo_company.xml
+++ b/addons/l10n_jp/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>jp</value>
         <value model="res.company" eval="obj().env.ref('l10n_jp.demo_company_jp')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ke/demo/demo_company.xml
+++ b/addons/l10n_ke/demo/demo_company.xml
@@ -30,5 +30,6 @@
         <value eval="[]"/>
         <value>ke</value>
         <value model="res.company" eval="obj().env.ref('l10n_ke.demo_company_ke')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_km/demo/demo_company.xml
+++ b/addons/l10n_km/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>km</value>
         <value model="res.company" eval="obj().env.ref('l10n_km.demo_company_km')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_kz/demo/demo_company.xml
+++ b/addons/l10n_kz/demo/demo_company.xml
@@ -29,5 +29,6 @@
         <value eval="[]"/>
         <value>kz</value>
         <value model="res.company" eval="obj().env.ref('l10n_kz.demo_company_kz')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_lt/demo/demo_company.xml
+++ b/addons/l10n_lt/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">Išvykimas</field>
         <field name="city">Vilnius</field>
         <field name="country_id" ref="base.lt"/>
-        
+
         <field name="zip">02188</field>
         <field name="phone">+370 612 34567</field>
         <field name="email">info@company.ltexample.com</field>
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>lt</value>
         <value model="res.company" eval="obj().env.ref('l10n_lt.demo_company_lt')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_lu/demo/demo_company.xml
+++ b/addons/l10n_lu/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">A</field>
         <field name="city">Clervaux</field>
         <field name="country_id" ref="base.lu"/>
-        
+
         <field name="zip">9839</field>
         <field name="phone">+352 628 123 456</field>
         <field name="email">info@company.luexample.com</field>
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>lu</value>
         <value model="res.company" eval="obj().env.ref('l10n_lu.demo_company_lu')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_lv/demo/demo_company.xml
+++ b/addons/l10n_lv/demo/demo_company.xml
@@ -5,7 +5,7 @@
         <field name="street">Mana iela</field>
         <field name="city">Rīga</field>
         <field name="country_id" ref="base.lv"/>
-        
+
         <field name="zip">LV-1010</field>
         <field name="phone">+371 20 00 00 00</field>
         <field name="email">info@uznemums.lv</field>
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>lv</value>
         <value model="res.company" eval="obj().env.ref('l10n_lv.demo_company_lv')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ma/demo/demo_company.xml
+++ b/addons/l10n_ma/demo/demo_company.xml
@@ -30,5 +30,6 @@
         <value eval="[]"/>
         <value>ma</value>
         <value model="res.company" eval="obj().env.ref('l10n_ma.l10n_ma_demo_company_company')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ml/demo/demo_company.xml
+++ b/addons/l10n_ml/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>ml</value>
         <value model="res.company" eval="obj().env.ref('l10n_ml.demo_company_ml')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_mn/demo/demo_company.xml
+++ b/addons/l10n_mn/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>mn</value>
         <value model="res.company" eval="obj().env.ref('l10n_mn.demo_company_mn')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_mu_account/demo/demo_company.xml
+++ b/addons/l10n_mu_account/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>mu</value>
         <value model="res.company" eval="obj().env.ref('l10n_mu_account.demo_company_mu')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_mx/demo/demo_company.xml
+++ b/addons/l10n_mx/demo/demo_company.xml
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>mx</value>
         <value model="res.company" eval="obj().env.ref('l10n_mx.demo_company_mx')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_my/demo/demo_company.xml
+++ b/addons/l10n_my/demo/demo_company.xml
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>my</value>
         <value model="res.company" eval="obj().env.ref('l10n_my.demo_company_my')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_mz/demo/demo_company.xml
+++ b/addons/l10n_mz/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">692 Eileen Knoll</field>
         <field name="city">Niassa Province</field>
         <field name="country_id" ref="base.mz"/>
-        
+
         <field name="zip">6343</field>
         <field name="phone">+258 78 123 45 67</field>
         <field name="email">info@example.mz</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>mz</value>
         <value model="res.company" eval="obj().env.ref('l10n_mz.demo_company_mz')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ne/demo/demo_company.xml
+++ b/addons/l10n_ne/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>ne</value>
         <value model="res.company" eval="obj().env.ref('l10n_ne.demo_company_ne')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_nl/demo/demo_company.xml
+++ b/addons/l10n_nl/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>nl</value>
         <value model="res.company" eval="obj().env.ref('l10n_nl.demo_company_nl')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_no/demo/demo_company.xml
+++ b/addons/l10n_no/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street"/>
         <field name="city">Åmot</field>
         <field name="country_id" ref="base.no"/>
-        
+
         <field name="zip"/>
         <field name="phone">+47 406 12 345</field>
         <field name="email">info@company.noexample.com</field>
@@ -38,5 +38,6 @@
         <value eval="[]"/>
         <value>no</value>
         <value model="res.company" eval="obj().env.ref('l10n_no.demo_company_no')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_nz/demo/demo_company.xml
+++ b/addons/l10n_nz/demo/demo_company.xml
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>nz</value>
         <value model="res.company" eval="obj().env.ref('l10n_nz.demo_company_nz')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_pa/demo/demo_company.xml
+++ b/addons/l10n_pa/demo/demo_company.xml
@@ -30,5 +30,6 @@
         <value eval="[]"/>
         <value>pa</value>
         <value model="res.company" eval="obj().env.ref('l10n_pa.demo_company_pa')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_pe/demo/demo_company.xml
+++ b/addons/l10n_pe/demo/demo_company.xml
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>pe</value>
         <value model="res.company" eval="obj().env.ref('l10n_pe.demo_company_pe')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ph/demo/demo_company.xml
+++ b/addons/l10n_ph/demo/demo_company.xml
@@ -30,5 +30,6 @@
         <value eval="[]"/>
         <value>ph</value>
         <value model="res.company" eval="obj().env.ref('l10n_ph.demo_company_ph')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_pk/demo/demo_company.xml
+++ b/addons/l10n_pk/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>pk</value>
         <value model="res.company" eval="obj().env.ref('l10n_pk.demo_company_pk')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_pl/demo/demo_company.xml
+++ b/addons/l10n_pl/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street"/>
         <field name="city">Racibórz</field>
         <field name="country_id" ref="base.pl"/>
-        
+
         <field name="zip">47-400</field>
         <field name="phone">+48 512 345 678</field>
         <field name="email">info@company.plexample.com</field>
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>pl</value>
         <value model="res.company" eval="obj().env.ref('l10n_pl.demo_company_pl')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_pt/demo/demo_company.xml
+++ b/addons/l10n_pt/demo/demo_company.xml
@@ -38,5 +38,6 @@
         <value eval="[]"/>
         <value>pt</value>
         <value model="res.company" eval="obj().env.ref('l10n_pt.demo_company_pt')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ro/demo/demo_company.xml
+++ b/addons/l10n_ro/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>ro</value>
         <value model="res.company" eval="obj().env.ref('l10n_ro.demo_company_ro')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_rs/demo/demo_company.xml
+++ b/addons/l10n_rs/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>rs</value>
         <value model="res.company" eval="obj().env.ref('l10n_rs.demo_company_rs')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_rw/demo/demo_company.xml
+++ b/addons/l10n_rw/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>rw</value>
         <value model="res.company" eval="obj().env.ref('l10n_rw.demo_company_rw')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_sa/demo/demo_company.xml
+++ b/addons/l10n_sa/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">Al Amir Mohammed Bin Abdul Aziz Street</field>
         <field name="city">المدينة المنورة</field>
         <field name="country_id" ref="base.sa"/>
-        
+
         <field name="zip">42317</field>
         <field name="phone">+966 51 234 5678</field>
         <field name="email">info@company.saexample.com</field>
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>sa</value>
         <value model="res.company" eval="obj().env.ref('l10n_sa.demo_company_sa')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_se/demo/demo_company.xml
+++ b/addons/l10n_se/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street"/>
         <field name="city">Ängelholms kommun</field>
         <field name="country_id" ref="base.se"/>
-        
+
         <field name="zip">262 64</field>
         <field name="phone">+46 70 123 45 67</field>
         <field name="email">info@company.seexample.com</field>
@@ -38,5 +38,6 @@
         <value eval="[]"/>
         <value>se</value>
         <value model="res.company" eval="obj().env.ref('l10n_se.demo_company_se')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_sg/demo/demo_company.xml
+++ b/addons/l10n_sg/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>sg</value>
         <value model="res.company" eval="obj().env.ref('l10n_sg.demo_company_sg')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_si/demo/demo_company.xml
+++ b/addons/l10n_si/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>si</value>
         <value model="res.company" eval="obj().env.ref('l10n_si.demo_company_si')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_sk/demo/demo_company.xml
+++ b/addons/l10n_sk/demo/demo_company.xml
@@ -36,5 +36,6 @@
         <value eval="[]"/>
         <value>sk</value>
         <value model="res.company" eval="obj().env.ref('l10n_sk.demo_company_sk')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_sn/demo/demo_company.xml
+++ b/addons/l10n_sn/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>sn</value>
         <value model="res.company" eval="obj().env.ref('l10n_sn.demo_company_sn')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_td/demo/demo_company.xml
+++ b/addons/l10n_td/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>td</value>
         <value model="res.company" eval="obj().env.ref('l10n_td.demo_company_td')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_tg/demo/demo_company.xml
+++ b/addons/l10n_tg/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>tg</value>
         <value model="res.company" eval="obj().env.ref('l10n_tg.demo_company_tg')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_th/demo/demo_company.xml
+++ b/addons/l10n_th/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">A5</field>
         <field name="city">บ้านสันทราย</field>
         <field name="country_id" ref="base.th"/>
-        
+
         <field name="zip">50220</field>
         <field name="phone">+66 81 234 5678</field>
         <field name="email">info@company.thexample.com</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>th</value>
         <value model="res.company" eval="obj().env.ref('l10n_th.demo_company_th')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_tn/demo/demo_company.xml
+++ b/addons/l10n_tn/demo/demo_company.xml
@@ -29,5 +29,6 @@
         <value eval="[]"/>
         <value>tn</value>
         <value model="res.company" eval="obj().env.ref('l10n_tn.demo_company_tn')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_tr/demo/demo_company.xml
+++ b/addons/l10n_tr/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>tr</value>
         <value model="res.company" eval="obj().env.ref('l10n_tr.demo_company_tr')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_tw/demo/demo_company.xml
+++ b/addons/l10n_tw/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>tw</value>
         <value model="res.company" eval="obj().env.ref('l10n_tw.demo_company_tw')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ua/demo/demo_company.xml
+++ b/addons/l10n_ua/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">10/2 Мечникова вулиця</field>
         <field name="city">Київ</field>
         <field name="country_id" ref="base.ua"/>
-        
+
         <field name="zip">01133</field>
         <field name="phone">+380 50 123 4567</field>
         <field name="email">info@company.uaexample.com</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>ua_psbo</value>
         <value model="res.company" eval="obj().env.ref('l10n_ua.demo_company_ua')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ug/demo/demo_company.xml
+++ b/addons/l10n_ug/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">Mutesa 1 Road</field>
         <field name="city">Kampala</field>
         <field name="country_id" ref="base.ug"/>
-        
+
         <field name="zip">10101</field>
         <field name="phone">+256 77 403614</field>
         <field name="email">info@company.ugexample.com</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>ug</value>
         <value model="res.company" eval="obj().env.ref('l10n_ug.demo_company_ug')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_uk/demo/demo_company.xml
+++ b/addons/l10n_uk/demo/demo_company.xml
@@ -37,5 +37,6 @@
         <value eval="[]"/>
         <value>uk</value>
         <value model="res.company" eval="obj().env.ref('l10n_uk.demo_company_uk')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_uy/demo/demo_company.xml
+++ b/addons/l10n_uy/demo/demo_company.xml
@@ -32,5 +32,6 @@
         <value eval="[]"/>
         <value>uy</value>
         <value model="res.company" eval="obj().env.ref('l10n_uy.demo_company_uy')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_ve/demo/demo_company.xml
+++ b/addons/l10n_ve/demo/demo_company.xml
@@ -6,7 +6,7 @@
         <field name="street">a</field>
         <field name="city">Maracaibo</field>
         <field name="country_id" ref="base.ve"/>
-        
+
         <field name="zip">4032</field>
         <field name="phone">+58 412-1234567</field>
         <field name="email">info@company.veexample.com</field>
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>ve</value>
         <value model="res.company" eval="obj().env.ref('l10n_ve.demo_company_ve')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_vn/demo/demo_company.xml
+++ b/addons/l10n_vn/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>vn</value>
         <value model="res.company" eval="obj().env.ref('l10n_vn.demo_company_vn')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_za/demo/demo_company.xml
+++ b/addons/l10n_za/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>za</value>
         <value model="res.company" eval="obj().env.ref('l10n_za.demo_company_za')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/addons/l10n_zm_account/demo/demo_company.xml
+++ b/addons/l10n_zm_account/demo/demo_company.xml
@@ -31,5 +31,6 @@
         <value eval="[]"/>
         <value>zm</value>
         <value model="res.company" eval="obj().env.ref('l10n_zm_account.demo_company_zm')"/>
+        <value name="install_demo" eval="True"/>
     </function>
 </odoo>

--- a/odoo/addons/base/models/res_company.py
+++ b/odoo/addons/base/models/res_company.py
@@ -112,8 +112,7 @@ class Company(models.Model):
             company.parent_ids = self.browse(int(id) for id in company.parent_path.split('/') if id) if company.parent_path else company
             company.root_id = company.parent_ids[0]
 
-    # TODO @api.depends(): currently now way to formulate the dependency on the
-    # partner's contact address
+    @api.depends(lambda self: ['partner_id.%s' % fname for fname in self._get_company_address_field_names()])
     def _compute_address(self):
         for company in self.filtered(lambda company: company.partner_id):
             address_data = company.partner_id.sudo().address_get(adr_pref=['contact'])
@@ -221,7 +220,14 @@ class Company(models.Model):
             company.uninstalled_l10n_module_ids = self.env['ir.module.module'].browse(mapping.get(company.country_id.id))
 
     def install_l10n_modules(self):
-        return self.uninstalled_l10n_module_ids.button_immediate_install()
+        uninstalled_modules = self.uninstalled_l10n_module_ids
+        is_ready_and_not_test = (
+            not tools.config['test_enable']
+            and (self.env.registry.ready or not self.env.registry._init)
+        )
+        if uninstalled_modules and is_ready_and_not_test:
+            return uninstalled_modules.button_immediate_install()
+        return is_ready_and_not_test
 
     @api.model
     def _get_view(self, view_id=None, view_type='form', **options):
@@ -309,6 +315,10 @@ class Company(models.Model):
         # Make sure that the selected currencies are enabled
         companies.currency_id.sudo().filtered(lambda c: not c.active).active = True
 
+        companies_needs_l10n = companies.filtered('country_id')
+        if companies_needs_l10n:
+            companies_needs_l10n.install_l10n_modules()
+
         return companies
 
     def cache_invalidation_fields(self):
@@ -326,6 +336,12 @@ class Company(models.Model):
     def write(self, values):
         invalidation_fields = self.cache_invalidation_fields()
         asset_invalidation_fields = {'font', 'primary_color', 'secondary_color', 'external_report_layout_id'}
+
+        companies_needs_l10n = (
+            values.get('country_id')
+            and self.filtered(lambda company: not company.country_id)
+            or self.browse()
+        )
         if not invalidation_fields.isdisjoint(values):
             self.env.registry.clear_cache()
 
@@ -357,6 +373,9 @@ class Company(models.Model):
                 ])
                 for fname in sorted(changed):
                     branches[fname] = company[fname]
+
+        if companies_needs_l10n:
+            companies_needs_l10n.install_l10n_modules()
 
         # invalidate company cache to recompute address based on updated partner
         company_address_fields = self._get_company_address_field_names()

--- a/odoo/addons/base/views/res_company_views.xml
+++ b/odoo/addons/base/views/res_company_views.xml
@@ -7,15 +7,6 @@
             <field name="arch" type="xml">
                 <form string="Company" duplicate="0">
                   <field name="all_child_ids" invisible="1"/>
-                  <field name="uninstalled_l10n_module_ids" invisible="1"/>
-
-                  <div class="alert alert-info" role="alert" invisible="not uninstalled_l10n_module_ids">
-                    Localization features are available for this country:
-                    <button name="install_l10n_modules"
-                            type="object"
-                            string="Install"
-                            class="btn btn-link p-0 align-baseline"/>
-                  </div>
                   <sheet>
                     <div class="oe_button_box" name="button_box">
                         <button class="oe_stat_button"


### PR DESCRIPTION
Before this PR
--------------------
When creating a new company and selecting the country
localisation available to install `alert` was visible,
on clicking the install button it installed the l10n
modules available for that country but the COA
was not set

After this PR
-----------------
The alert has been removed once the
country is selected on company and it is
saved the available `l10n` modules are installed
and sets the COA as per the country


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
