### PR TITLE
[IMP] project: set assignee of new sub-task to that of parent task

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -639,7 +639,9 @@ class Project(models.Model):
     def action_project_sharing(self):
         self.ensure_one()
         action = self.env['ir.actions.act_window']._for_xml_id('project.project_sharing_project_task_action')
+        action_context = ast.literal_eval(action['context']) if action['context'] else {}
         action['context'] = {
+            **action_context,
             'default_project_id': self.id,
             'delete': False,
             'search_default_open_tasks': True,

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -312,6 +312,7 @@
         <field name="view_mode">kanban,tree,form</field>
         <field name="search_view_id" ref="project.project_sharing_project_task_view_search"/>
         <field name="domain">[('project_id', '=', active_id), ('display_in_project', '=', True)]</field>
+        <field name="context">{'set_default_user': True}</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No tasks found. Let's create one!


### PR DESCRIPTION
**Prior to this commit:**
Assignee of the sub task is not set by default for portal user

**Post this commit:**
By default, the assignee of the sub task is set to that of the parent task

**Task**-3690788