### PR TITLE
[FIX] web: handle computed stored binary fields

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -73,6 +73,7 @@ class Base(models.AbstractModel):
             self = self.create(vals)
         if next_id:
             self = self.browse(next_id)
+        self.flush_recordset()
         return self.with_context(bin_size=True).web_read(specification)
 
     def web_read(self, specification: Dict[str, Dict]) -> List[Dict]:

--- a/odoo/addons/test_new_api/models/test_new_api.py
+++ b/odoo/addons/test_new_api/models/test_new_api.py
@@ -940,6 +940,16 @@ class BinarySvg(models.Model):
     name = fields.Char(required=True)
     image_attachment = fields.Binary(attachment=True)
     image_wo_attachment = fields.Binary(attachment=False)
+    image_wo_attachment_computed_stored = fields.Binary(
+        compute="_compute_image_wo_attachment",
+        store=True,
+        attachment=False
+    )
+
+    @api.depends('image_wo_attachment')
+    def _compute_image_wo_attachment(self):
+        for svg in self:
+            svg.image_wo_attachment_computed_stored = svg.image_wo_attachment
 
 
 class MonetaryBase(models.Model):

--- a/odoo/addons/test_new_api/tests/test_web_save.py
+++ b/odoo/addons/test_new_api/tests/test_web_save.py
@@ -36,3 +36,13 @@ class TestWebSave(TransactionCase):
         # Modify an existing record, with unity specification
         result = person.web_save({'name': 'lpe'}, {'display_name': {}})
         self.assertEqual(result, [{'id': person.id, 'display_name': 'lpe'}])
+
+    def test_web_save_computed_stored_binary_write(self):
+        from odoo.addons.base.tests.test_mimetypes import SVG, JPG
+        # This should work without problems
+        binary_svg = self.env['test_new_api.binary_svg'].create({
+            'name': 'Test without attachment',
+            'image_wo_attachment': SVG,
+        })
+        binary_svg.web_save({'image_wo_attachment': JPG}, {'image_wo_attachment': {}, 'image_wo_attachment_computed_stored': {}})
+        self.assertEqual(binary_svg.image_wo_attachment, binary_svg.image_wo_attachment_computed_stored)


### PR DESCRIPTION
Currently if you have a computed stored binary field, calling web_save will save the "bin_size" value to database instead of correctly storing the computed data.

Everything goes well until `web_read` triggers a re-compute with bin_size=True, this leads `compute_value` in `class Binary(field)` to store the "bin_size" value in cache.

As the compute from web_save has not yet been flushed by this point, the `_write` that happens after `web_save` is completed will use the new cache value instead of the one we want.

Issue is mitigated by flushing before the web_read.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
