### PR TITLE
[FIX] mrp_subonctracting_landed_costs: apply landed costs

### DIFF
--- a/addons/mrp_subonctracting_landed_costs/__init__.py
+++ b/addons/mrp_subonctracting_landed_costs/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/mrp_subonctracting_landed_costs/__manifest__.py
+++ b/addons/mrp_subonctracting_landed_costs/__manifest__.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'Landed Costs With Subcontracting order',
+    'version': '1.0',
+    'summary': 'manage landed cost for subcontracting orders',
+    'depends': ['stock_landed_costs', 'mrp_subcontracting'],
+    'category': 'Manufacturing/Manufacturing',
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/mrp_subonctracting_landed_costs/models/__init__.py
+++ b/addons/mrp_subonctracting_landed_costs/models/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import stock_landed_cost

--- a/addons/mrp_subonctracting_landed_costs/models/stock_landed_cost.py
+++ b/addons/mrp_subonctracting_landed_costs/models/stock_landed_cost.py
@@ -1,0 +1,12 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class StockLandedCost(models.Model):
+    _inherit = 'stock.landed.cost'
+
+    def _get_targeted_move_ids(self):
+        moves = super()._get_targeted_move_ids()
+        return moves.filtered(lambda m: not m.is_subcontract) | moves.filtered('is_subcontract').move_orig_ids

--- a/addons/mrp_subonctracting_landed_costs/tests/__init__.py
+++ b/addons/mrp_subonctracting_landed_costs/tests/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import test_subcontracting

--- a/addons/mrp_subonctracting_landed_costs/tests/test_subcontracting.py
+++ b/addons/mrp_subonctracting_landed_costs/tests/test_subcontracting.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import Form
+from odoo.addons.mrp_subcontracting.tests.common import TestMrpSubcontractingCommon
+
+
+class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
+    def test_subcontracted_landed_cost(self):
+        self.finished.product_tmpl_id.categ_id.property_cost_method = 'fifo'
+        self.finished.product_tmpl_id.categ_id.property_valuation = 'real_time'
+
+        # Create a receipt picking from the subcontractor
+        picking_form = Form(self.env['stock.picking'])
+        picking_form.picking_type_id = self.env.ref('stock.picking_type_in')
+        picking_form.partner_id = self.subcontractor_partner1
+        with picking_form.move_ids_without_package.new() as move:
+            move.product_id = self.finished
+            move.product_uom_qty = 1
+        picking_receipt = picking_form.save()
+        picking_receipt.action_confirm()
+        picking_receipt.move_lines.quantity_done = 1
+        picking_receipt.button_validate()
+
+        productlc = self.env['product.product'].create({
+            'name': 'product landed cost',
+            'type': 'service',
+        })
+
+        lc = Form(self.env['stock.landed.cost'])
+        lc.account_journal_id = self.env['account.journal'].create({
+            'name': 'Stock Journal',
+            'code': 'STJTEST',
+            'type': 'general',
+        })
+        lc.picking_ids.add(picking_receipt)
+        with lc.cost_lines.new() as cost_line:
+            cost_line.product_id = productlc
+            cost_line.price_unit = 500
+        lc = lc.save()
+        lc.compute_landed_cost()
+        lc.button_validate()
+
+        self.assertEqual(self.finished.value_svl, 500)


### PR DESCRIPTION
Steps to reproduce:
- Purchase a subcontracted product (auto/AVCO)
- Apply a landed cost to the picking

Bug:
the valuation is not affected because the wrong move is selected

opw-3727255