### PR TITLE
[FIX] purchase_stock: block purchase order creation

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -631,7 +631,7 @@ class ProductProduct(models.Model):
     #=== BUSINESS METHODS ===#
 
     def _prepare_sellers(self, params=False):
-        sellers = self.seller_ids.filtered(lambda s: s.partner_id.active and (not s.product_id or s.product_id == self))
+        sellers = self.seller_ids.filtered(lambda s: s.partner_id.active and s.partner_id.purchase_warn != 'block' and (not s.product_id or s.product_id == self))
         return sellers.sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
 
     def _get_filtered_sellers(self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False):

--- a/addons/purchase_stock/i18n/purchase_stock.pot
+++ b/addons/purchase_stock/i18n/purchase_stock.pot
@@ -456,6 +456,13 @@ msgid "Product"
 msgstr ""
 
 #. module: purchase_stock
+#. odoo-python
+#: code:addons/purchase_stock/models/stock_rule.py:0
+#, python-format
+msgid "Product %s cannot be purchased because of blocking message: %s"
+msgstr ""
+
+#. module: purchase_stock
 #: model:ir.model,name:purchase_stock.model_product_category
 #: model:ir.model.fields,field_description:purchase_stock.field_vendor_delay_report__category_id
 msgid "Product Category"
@@ -698,7 +705,7 @@ msgstr ""
 #, python-format
 msgid ""
 "There is no matching vendor price to generate the purchase order for product"
-" %s (no vendor defined, minimum quantity not reached, dates not valid, ...)."
+" %s (no vendor defined, minimum quantity not reached, dates not valid, vendor is blocked, ...)."
 " Go on the product form and complete the list of vendors."
 msgstr ""
 
@@ -726,6 +733,13 @@ msgid ""
 " purchase request for quotation once the sales order confirmed. This is a "
 "on-demand flow. The requested delivery address will be the customer delivery"
 " address and not your warehouse."
+msgstr ""
+
+#. module: purchase_stock
+#. odoo-python
+#: code:addons/purchase_stock/models/product.py:0
+#, python-format
+msgid "This vendor cannot be set as a supplier: %s"
 msgstr ""
 
 #. module: purchase_stock

--- a/addons/purchase_stock/models/product.py
+++ b/addons/purchase_stock/models/product.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import api, fields, models, _
 from odoo.osv import expression
+from odoo.exceptions import UserError
 
 
 class ProductCategory(models.Model):
@@ -126,6 +127,8 @@ class SupplierInfo(models.Model):
         orderpoint = self.env['stock.warehouse.orderpoint'].browse(orderpoint_id)
         if not orderpoint:
             return
+        if self.partner_id.purchase_warn == 'block':
+            raise UserError(_('This vendor cannot be set as a supplier: %s', self.partner_id.purchase_warn_msg))
         if 'buy' not in orderpoint.route_id.rule_ids.mapped('action'):
             orderpoint.route_id = self.env['stock.rule'].search([('action', '=', 'buy')], limit=1).route_id.id
         orderpoint.supplier_id = self

--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -72,7 +72,11 @@ class StockRule(models.Model):
             )[:1]
 
             if not supplier:
-                msg = _('There is no matching vendor price to generate the purchase order for product %s (no vendor defined, minimum quantity not reached, dates not valid, ...). Go on the product form and complete the list of vendors.', procurement.product_id.display_name)
+                msg = _('There is no matching vendor price to generate the purchase order for product %s (no vendor defined, minimum quantity not reached, dates not valid, vendor is blocked, ...). Go on the product form and complete the list of vendors.', procurement.product_id.display_name)
+                errors.append((procurement, msg))
+
+            if procurement.product_id.purchase_line_warn == 'block':
+                msg = _('Product %s cannot be purchased because of blocking message: %s', procurement.product_id.display_name, procurement.product_id.purchase_line_warn_msg)
                 errors.append((procurement, msg))
 
             partner = supplier.partner_id

--- a/addons/purchase_stock/wizard/product_replenish.py
+++ b/addons/purchase_stock/wizard/product_replenish.py
@@ -24,10 +24,10 @@ class ProductReplenish(models.TransientModel):
                 ], limit=1).id
             orderpoint = self.env['stock.warehouse.orderpoint'].search([('product_id', 'in', [product_tmpl_id.product_variant_id.id, product_id.id]), ("warehouse_id", "=", res['warehouse_id'])], limit=1)
             res['supplier_id'] = False
-            if orderpoint:
+            if orderpoint and orderpoint.supplier_id.partner_id.purchase_warn != 'block':
                 res['supplier_id'] = orderpoint.supplier_id.id
             elif product_tmpl_id.seller_ids:
-                res['supplier_id'] = product_tmpl_id.seller_ids[0].id
+                res['supplier_id'] = next((seller.id for seller in product_tmpl_id.seller_ids if seller.partner_id.purchase_warn != 'block'), False)
         return res
 
     @api.depends('route_id', 'supplier_id')

--- a/addons/purchase_stock/wizard/product_replenish_views.xml
+++ b/addons/purchase_stock/wizard/product_replenish_views.xml
@@ -9,7 +9,7 @@
                 <label for="supplier_id" invisible="not show_vendor"/>
                 <div class="o_row">
                     <field name="show_vendor" invisible="1"/>
-                    <field name="supplier_id" invisible="not show_vendor" required="show_vendor" domain="[('product_tmpl_id', '=', product_tmpl_id)]" options="{'no_open': 1, 'no_create': 1}"/>
+                    <field name="supplier_id" invisible="not show_vendor" required="show_vendor" domain="[('product_tmpl_id', '=', product_tmpl_id), ('partner_id.purchase_warn', '!=', 'block')]" options="{'no_open': 1, 'no_create': 1}"/>
                 </div>
             </xpath>
         </field>


### PR DESCRIPTION
Steps to reproduce the bug:

- Create a contact and set WARNING ON THE PURCHASE ORDER in internal notes to Blocking Message
- Create a product with routes set to Buy and/or MTO
- Add earlier created contact as a vendor for the product
- Replenishing product via Buy or MTO route will result in generating a PO order with a vendor regardless of a blocking message
- Creating SO for this product will result in generating PO with a vendor regardless of a blocking message

To prevent this behavior, we
- Always filter out sellers that have a blocking message set
- Prevent setting a vendor with a blocking message as a supplier

Task: 3768299