### PR TITLE
[FIX] various: be defensive with activity types, define master data

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -104,7 +104,7 @@ class Meeting(models.Model):
         partners = self.env.user.partner_id
         active_id = self._context.get('active_id')
         if self._context.get('active_model') == 'res.partner' and active_id and active_id not in partners.ids:
-                partners |= self.env['res.partner'].browse(active_id)
+            partners |= self.env['res.partner'].browse(active_id)
         return partners
 
     @api.model
@@ -535,46 +535,61 @@ class Meeting(models.Model):
     def create(self, vals_list):
         # Prevent sending update notification when _inverse_dates is called
         self = self.with_context(is_calendar_event_new=True)
-        defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'res_model', 'partner_ids'])
+        defaults = self.default_get(['activity_ids', 'res_model_id', 'res_id', 'user_id', 'partner_ids'])
 
         vals_list = [  # Else bug with quick_create when we are filter on an other user
-            dict(vals, user_id=defaults.get('user_id', self.env.user.id)) if not 'user_id' in vals else vals
-            for vals in vals_list
+            {
+                **vals,
+                'activity_ids': vals.get('activity_ids', defaults.get('activity_ids')),
+                'res_id': vals.get('res_id', defaults.get('res_id')),
+                'res_model': vals.get('res_model', defaults.get('res_model')),
+                'res_model_id': vals.get('res_model_id', defaults.get('res_model_id')),
+                'user_id': vals.get('user_id', defaults.get('user_id', self.env.user.id)),
+             } for vals in vals_list
         ]
-        meeting_activity_type = self.env['mail.activity.type'].search([('category', '=', 'meeting')], limit=1)
+        meeting_activity_types = self.env['mail.activity.type'].search([('category', '=', 'meeting')])
         # get list of models ids and filter out None values directly
-        model_ids = list(filter(None, {values.get('res_model_id', defaults.get('res_model_id')) for values in vals_list}))
-        model_name = defaults.get('res_model')
-        valid_activity_model_ids = model_name and self.env[model_name].sudo().browse(model_ids).filtered(lambda m: 'activity_ids' in m).ids or []
+        model_ids = list(filter(None, {values['res_model_id'] for values in vals_list}))
+        all_models = self.env['ir.model'].sudo().browse(model_ids)
+        valid_models = all_models.filtered(lambda m: m.is_mail_activity)
 
         # if user is creating an event for an activity that already has one, create a second activity
-        existing_event = False
+        existing_event, existing_type = self.browse(), self.env['mail.activity.type']
         orig_activity_ids = self.env['mail.activity'].browse(self._context.get('orig_activity_ids', []))
         if len(orig_activity_ids) == 1:
             existing_event = orig_activity_ids.calendar_event_id
             if existing_event and orig_activity_ids.activity_type_id.category == 'meeting':
-                meeting_activity_type = orig_activity_ids.activity_type_id
+                existing_type = orig_activity_ids.activity_type_id
 
-        if meeting_activity_type and (not defaults.get('activity_ids') or existing_event):
+        if meeting_activity_types:
             for values in vals_list:
                 # created from calendar: try to create an activity on the related record
-                if values.get('activity_ids'):
+                if values['activity_ids'] and not existing_event:
                     continue
-                res_model_id = values.get('res_model_id', defaults.get('res_model_id'))
-                res_id = values.get('res_id', defaults.get('res_id'))
-                user_id = values.get('user_id', defaults.get('user_id'))
-                if not res_model_id or not res_id:
+                res_model = all_models.filtered(lambda m: m.id == values['res_model_id'])
+                res_id = values['res_id']
+                if not res_model or not res_id or res_model not in valid_models:
                     continue
-                if res_model_id not in valid_activity_model_ids:
+
+                meeting_activity_type = self.env['mail.activity.type']
+                if existing_type and existing_type.res_model in {False, res_model.model}:
+                    meeting_activity_type = existing_type
+                if not meeting_activity_type:
+                    meeting_activity_type = meeting_activity_types.filtered(
+                        lambda act: act.res_model in {False, res_model.model}
+                    )
+                if not meeting_activity_type:
                     continue
+
                 activity_vals = {
-                    'res_model_id': res_model_id,
+                    'res_model_id': values['res_model_id'],
                     'res_id': res_id,
-                    'activity_type_id': meeting_activity_type.id,
+                    'activity_type_id': meeting_activity_type[0].id,
                 }
-                if user_id:
-                    activity_vals['user_id'] = user_id
+                if values['user_id']:
+                    activity_vals['user_id'] = values['user_id']
                 values['activity_ids'] = [(0, 0, activity_vals)]
+
         self._set_videocall_location(vals_list)
 
         # Add commands to create attendees from partners (if present) if no attendee command

--- a/addons/calendar/tests/test_calendar.py
+++ b/addons/calendar/tests/test_calendar.py
@@ -184,47 +184,72 @@ class TestCalendar(SavepointCaseWithUserDemo):
     def test_activity_event_multiple_meetings(self):
         # Creating multiple meetings from an activity creates additional activities
         # ensure meeting activity type exists
-        meeting_act_type = self.env['mail.activity.type'].search([('category', '=', 'meeting')], limit=1)
-        if not meeting_act_type:
-            meeting_act_type = self.env['mail.activity.type'].create({
-                'name': 'Meeting Test',
-                'category': 'meeting',
-            })
+        meeting_act_type = self.env.ref('mail.mail_activity_data_meeting')
 
         # have a test model inheriting from activities
         test_record = self.env['res.partner'].create({
             'name': 'Test',
         })
 
-        activity_id = self.env['mail.activity'].create({
-            'summary': 'Meeting with partner',
+        activity_1 = self.env['mail.activity'].create({
+            'summary': 'Meeting 1 with partner',
             'activity_type_id': meeting_act_type.id,
             'res_model_id': self.env['ir.model']._get_id('res.partner'),
             'res_id': test_record.id,
         })
 
-        calendar_action = activity_id.with_context(default_res_model='res.partner', default_res_id=test_record.id).action_create_calendar_event()
-        event_1 = self.env['calendar.event'].with_context(calendar_action['context']).create({
+        # default usage in successive create
+        event_1_1 = self.env['calendar.event'].with_context(default_activity_ids=[(6, 0, activity_1.ids)]).create({
             'name': 'Meeting 1',
             'start': datetime(2025, 3, 10, 17),
             'stop': datetime(2025, 3, 10, 22),
         })
-
-        self.assertEqual(event_1.activity_ids, activity_id)
-
-        total_activities = self.env['mail.activity'].search_count(domain=[])
-
-        event_2 = self.env['calendar.event'].with_context(calendar_action['context']).create({
+        self.assertEqual(event_1_1.activity_ids, activity_1)
+        self.assertEqual(activity_1.calendar_event_id, event_1_1)
+        self.assertEqual(activity_1.date_deadline, date(2025, 3, 10))
+        event_1_2 = self.env['calendar.event'].with_context(default_activity_ids=[(6, 0, activity_1.ids)]).create({
             'name': 'Meeting 2',
-            'start': datetime(2025, 3, 11, 17),
-            'stop': datetime(2025, 3, 11, 22),
+            'start': datetime(2025, 3, 12, 17),
+            'stop': datetime(2025, 3, 12, 22),
         })
-        self.assertEqual(event_1.activity_ids, activity_id, "Event 1's activity should still be the first activity")
-        self.assertEqual(activity_id.calendar_event_id, event_1, "The first activity's event should still be event 1")
-        self.assertEqual(total_activities + 1, self.env['mail.activity'].search_count(domain=[]), "1 more activity record should have been created (by event 2)")
-        self.assertNotEqual(event_2.activity_ids, activity_id, "Event 2's activity should not be the first activity")
-        self.assertEqual(event_2.activity_ids.activity_type_id, activity_id.activity_type_id, "Event 2's activity should be the same activity type as the first activity")
-        self.assertEqual(test_record.activity_ids, activity_id | event_2.activity_ids, "Resource record should now have both activities")
+        self.assertFalse(event_1_1.activity_ids, 'Changes activity ownership')
+        self.assertEqual(event_1_2.activity_ids, activity_1, 'Changes activity ownership')
+        self.assertEqual(activity_1.calendar_event_id, event_1_2)
+        self.assertEqual(activity_1.date_deadline, date(2025, 3, 12))
+
+        activity_2 = self.env['mail.activity'].create({
+            'summary': 'Meeting 2 with partner',
+            'activity_type_id': meeting_act_type.id,
+            'res_model_id': self.env['ir.model']._get_id('res.partner'),
+            'res_id': test_record.id,
+        })
+        existing_activities = self.env['mail.activity'].search([])
+
+        # specific action that creates activities instead of replacing
+        calendar_action = activity_2.with_context(default_res_model='res.partner', default_res_id=test_record.id).action_create_calendar_event()
+        event_2_1 = self.env['calendar.event'].with_context(calendar_action['context']).create({
+            'name': 'Meeting 1',
+            'start': datetime(2025, 4, 10, 17),
+            'stop': datetime(2025, 4, 10, 22),
+        })
+        self.assertEqual(event_2_1.activity_ids, activity_2)
+        self.assertEqual(activity_2.calendar_event_id, event_2_1)
+        self.assertEqual(activity_2.date_deadline, date(2025, 4, 10))
+
+        event_2_2 = self.env['calendar.event'].with_context(calendar_action['context']).create({
+            'name': 'Meeting 2',
+            'start': datetime(2025, 4, 11, 17),
+            'stop': datetime(2025, 4, 11, 22),
+        })
+        new_existing_activities = self.env['mail.activity'].search([])
+        new_activity = new_existing_activities - existing_activities
+        self.assertEqual(event_2_1.activity_ids, activity_2, "Event 1's activity should still be the first activity")
+        self.assertEqual(activity_2.calendar_event_id, event_2_1, "The first activity's event should still be event 1")
+
+        self.assertEqual(len(new_activity), 1, "1 more activity record should have been created (by event 2)")
+        self.assertEqual(event_2_2.activity_ids, new_activity, "Event 2's activity should not be the first activity")
+        self.assertEqual(event_2_2.activity_ids.activity_type_id, activity_2.activity_type_id, "Event 2's activity should be the same activity type as the first activity")
+        self.assertEqual(test_record.activity_ids, activity_1 + activity_2 + new_activity, "Resource record should now have all activities")
 
     def test_event_allday(self):
         self.env.user.tz = 'Pacific/Honolulu'

--- a/addons/calendar/tests/test_res_partner.py
+++ b/addons/calendar/tests/test_res_partner.py
@@ -61,12 +61,12 @@ class TestResPartner(TransactionCase):
                                     'perm_read': True,
                                     'perm_create': False,
                                     'perm_write': False})
-
-        Event.create({'name': 'event_9',
+        # create generally requires read -> prevented by above test rule
+        Event.sudo().create({'name': 'event_9',
                       'partner_ids': [(6, 0, [test_partner_2.id,
                                               test_partner_3.id])]})
 
-        Event.create({'name': 'event_10',
+        Event.sudo().create({'name': 'event_10',
                       'partner_ids': [(6, 0, [test_partner_5.id])]})
 
         self.assertEqual(test_partner_1.meeting_count, 7)

--- a/addons/fleet/models/__init__.py
+++ b/addons/fleet/models/__init__.py
@@ -12,5 +12,6 @@ from . import fleet_vehicle_model_category
 from . import fleet_vehicle_odometer
 from . import fleet_vehicle_state
 from . import fleet_vehicle_tag
+from . import mail_activity_type
 from . import res_config_settings
 from . import res_partner

--- a/addons/fleet/models/fleet_vehicle_log_contract.py
+++ b/addons/fleet/models/fleet_vehicle_log_contract.py
@@ -123,7 +123,7 @@ class FleetVehicleLogContract(models.Model):
         delay_alert_contract = int(params.get_param('hr_fleet.delay_alert_contract', default=30))
         date_today = fields.Date.from_string(fields.Date.today())
         outdated_days = fields.Date.to_string(date_today + relativedelta(days=+delay_alert_contract))
-        reminder_activity_type = self.env.ref('fleet.mail_act_fleet_contract_to_renew', raise_if_not_found=False) or self.env['mail.activity.type']
+        reminder_activity_type = self.env.ref('fleet.mail_act_fleet_contract_to_renew')
         nearly_expired_contracts = self.search([
             ('state', '=', 'open'),
             ('expiration_date', '<', outdated_days),

--- a/addons/fleet/models/mail_activity_type.py
+++ b/addons/fleet/models/mail_activity_type.py
@@ -1,0 +1,15 @@
+from odoo import api, models
+
+
+class MailActivityType(models.Model):
+    _inherit = "mail.activity.type"
+
+    @api.model
+    def _get_model_info_by_xmlid(self):
+        info = super()._get_model_info_by_xmlid()
+        # used notably to generate activities only one time using a cron
+        info['fleet.mail_act_fleet_contract_to_renew'] = {
+            'res_model': 'fleet.vehicle.log.contract',
+            'unlink': False,
+        }
+        return info

--- a/addons/google_calendar/tests/test_sync_common.py
+++ b/addons/google_calendar/tests/test_sync_common.py
@@ -7,7 +7,8 @@ from odoo.addons.google_calendar.utils.google_calendar import GoogleCalendarServ
 from odoo.addons.google_account.models.google_service import GoogleService
 from odoo.addons.google_calendar.models.res_users import User
 from odoo.addons.google_calendar.models.google_sync import GoogleSync
-from odoo.tests.common import HttpCase, new_test_user
+from odoo.addons.mail.tests.common import mail_new_test_user
+from odoo.tests.common import HttpCase
 from freezegun import freeze_time
 from contextlib import contextmanager
 
@@ -27,8 +28,8 @@ class TestSyncGoogle(HttpCase):
         super().setUp()
         self.google_service = GoogleCalendarService(self.env['google.service'])
         self.env.user.sudo().unpause_google_synchronization()
-        self.organizer_user = new_test_user(self.env, login="organizer_user")
-        self.attendee_user = new_test_user(self.env, login='attendee_user')
+        self.organizer_user = mail_new_test_user(self.env, login="organizer_user")
+        self.attendee_user = mail_new_test_user(self.env, login='attendee_user')
 
     @contextmanager
     def mock_datetime_and_now(self, mock_dt):

--- a/addons/google_calendar/tests/test_sync_odoo2google.py
+++ b/addons/google_calendar/tests/test_sync_odoo2google.py
@@ -13,7 +13,8 @@ from odoo.tests.common import users, warmup
 from odoo.tests import tagged
 from odoo import tools
 
-@tagged('odoo2google')
+
+@tagged('odoo2google', 'calendar_performance')
 @patch.object(User, '_get_google_calendar_token', lambda user: 'dummy-token')
 class TestSyncOdoo2Google(TestSyncGoogle):
 
@@ -76,7 +77,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
         })
         partner_model = self.env.ref('base.model_res_partner')
         partner = self.env['res.partner'].search([], limit=1)
-        with self.assertQueryCount(__system__=615):
+        with self.assertQueryCount(__system__=721):
             events = self.env['calendar.event'].create([{
                 'name': "Event %s" % (i),
                 'start': datetime(2020, 1, 15, 8, 0),
@@ -94,7 +95,6 @@ class TestSyncOdoo2Google(TestSyncGoogle):
         with self.assertQueryCount(__system__=29):
             events.unlink()
 
-
     @patch_api
     @users('__system__')
     @warmup
@@ -107,7 +107,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
             'duration': 18,
         })
         partner_model = self.env.ref('base.model_res_partner')
-        with self.assertQueryCount(__system__=86):
+        with self.assertQueryCount(__system__=806):
             event = self.env['calendar.event'].create({
                 'name': "Event",
                 'start': datetime(2020, 1, 15, 8, 0),
@@ -124,7 +124,7 @@ class TestSyncOdoo2Google(TestSyncGoogle):
                 'res_id': partner.id,
             })
 
-        with self.assertQueryCount(__system__=37):
+        with self.assertQueryCount(__system__=34):  # gc: 33
             event.unlink()
 
     def test_event_without_user(self):

--- a/addons/hr_holidays/models/__init__.py
+++ b/addons/hr_holidays/models/__init__.py
@@ -11,6 +11,7 @@ from . import hr_leave_type
 from . import hr_leave_accrual_plan_level
 from . import hr_leave_accrual_plan
 from . import hr_leave_mandatory_day
+from . import mail_activity_type
 from . import mail_message_subtype
 from . import res_partner
 from . import res_users

--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1581,7 +1581,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
         approval_activity = self.env.ref('hr_holidays.mail_act_leave_second_approval')
         for holiday in self:
             if holiday.state == 'draft':
-                to_clean |= holiday
+                to_clean += holiday
             elif holiday.state in ['confirm', 'validate1']:
                 if holiday.holiday_status_id.leave_validation_type != 'no_validation':
                     if holiday.state == 'confirm':
@@ -1597,12 +1597,12 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                             'Second approval request for %(leave_type)s',
                             leave_type=holiday.holiday_status_id.name,
                         )
-                        to_do_confirm_activity |= holiday
+                        to_do_confirm_activity += holiday
                     user_ids = holiday.sudo()._get_responsible_for_approval().ids
                     for user_id in user_ids:
                         date_deadline = (
                             (holiday.date_from -
-                             relativedelta(**{activity_type.delay_unit: activity_type.delay_count or 0})).date()
+                             relativedelta(**{activity_type.delay_unit or 'days': activity_type.delay_count or 0})).date()
                             if holiday.date_from else today)
                         if date_deadline < today:
                             date_deadline = today
@@ -1616,9 +1616,9 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                             'res_model_id': model_id,
                         })
             elif holiday.state == 'validate':
-                to_do |= holiday
+                to_do += holiday
             elif holiday.state == 'refuse':
-                to_clean |= holiday
+                to_clean += holiday
         if to_clean:
             to_clean.activity_unlink(['hr_holidays.mail_act_leave_approval', 'hr_holidays.mail_act_leave_second_approval'])
         if to_do_confirm_activity:

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -914,22 +914,23 @@ class HolidaysAllocation(models.Model):
                     count=allocation.number_of_days,
                     allocation_type=allocation.holiday_status_id.name
                 )
+                activity_type = self.env.ref('hr_holidays.mail_act_leave_allocation_approval')
                 if allocation.state == 'confirm':
                     if allocation.holiday_status_id.responsible_ids:
                         user_ids = allocation.sudo()._get_responsible_for_approval().ids
                         for user_id in user_ids:
                             activity_vals.append({
-                                'activity_type_id': self.env.ref('hr_holidays.mail_act_leave_allocation_approval').id,
+                                'activity_type_id': activity_type.id,
                                 'automated': True,
                                 'note': note,
                                 'user_id': user_id,
                                 'res_id': allocation.id,
-                                'res_model_id': self.env.ref('hr_holidays.model_hr_leave_allocation').id,
+                                'res_model_id': self.env['ir.model']._get_id('hr.leave.allocation'),
                             })
                 elif allocation.state == 'validate':
-                    to_do |= allocation
+                    to_do += allocation
                 elif allocation.state == 'refuse':
-                    to_clean |= allocation
+                    to_clean += allocation
         if activity_vals:
             self.env['mail.activity'].create(activity_vals)
         if to_clean:

--- a/addons/hr_holidays/models/mail_activity_type.py
+++ b/addons/hr_holidays/models/mail_activity_type.py
@@ -1,0 +1,13 @@
+from odoo import api, models
+
+
+class MailActivityType(models.Model):
+    _inherit = "mail.activity.type"
+
+    @api.model
+    def _get_model_info_by_xmlid(self):
+        info = super()._get_model_info_by_xmlid()
+        info['hr_holidays.mail_act_leave_approval'] = {'res_model': 'hr.leave', 'unlink': False}
+        info['hr_holidays.mail_act_leave_second_approval'] = {'res_model': 'hr.leave', 'unlink': False}
+        info['hr_holidays.mail_act_leave_allocation_approval'] = {'res_model': 'hr.leave.allocation', 'unlink': False}
+        return info

--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -343,11 +343,9 @@ class MailActivity(models.Model):
 
         # subscribe (batch by model and user to speedup)
         for model, activity_data in activities._classify_by_model().items():
-            per_user = dict()
+            per_user = defaultdict(list)
             for activity in activity_data['activities'].filtered(lambda act: act.user_id):
-                if activity.user_id not in per_user:
-                    per_user[activity.user_id] = [activity.res_id]
-                else:
+                if activity.res_id not in per_user[activity.user_id]:
                     per_user[activity.user_id].append(activity.res_id)
             for user, res_ids in per_user.items():
                 pids = user.partner_id.ids if user.partner_id in readable_user_partners else user.sudo().partner_id.ids

--- a/addons/mail/models/mail_activity_mixin.py
+++ b/addons/mail/models/mail_activity_mixin.py
@@ -372,13 +372,17 @@ class MailActivityMixin(models.AbstractModel):
             _logger.warning("Scheduled deadline should be a date (got %s)", date_deadline)
         if act_type_xmlid:
             activity_type_id = self.env['ir.model.data']._xmlid_to_res_id(act_type_xmlid, raise_if_not_found=False)
-            if activity_type_id:
-                activity_type = self.env['mail.activity.type'].browse(activity_type_id)
-            else:
-                activity_type = self._default_activity_type()
         else:
             activity_type_id = act_values.get('activity_type_id', False)
-            activity_type = self.env['mail.activity.type'].browse(activity_type_id) if activity_type_id else self.env['mail.activity.type']
+        activity_type = self.env['mail.activity.type'].browse(activity_type_id)
+        invalid_model = activity_type.res_model and activity_type.res_model != self._name
+        if not activity_type or invalid_model:
+            if invalid_model:
+                _logger.warning(
+                    'Invalid activity type model %s used on %s (tried with xml id %s)',
+                    activity_type.res_model, self._name, act_type_xmlid or '',
+                )
+            activity_type = self._default_activity_type()
 
         model_id = self.env['ir.model']._get(self._name).id
         create_vals_list = []

--- a/addons/mail/tests/test_mail_activity.py
+++ b/addons/mail/tests/test_mail_activity.py
@@ -4,7 +4,7 @@ from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
 from unittest.mock import patch
 
-from odoo import fields
+from odoo import exceptions, fields
 from odoo.addons.mail.models.mail_activity import MailActivity
 from odoo.addons.mail.tests.common import MailCommon
 from odoo.tests.common import Form, tagged, HttpCase
@@ -147,38 +147,67 @@ class ActivityScheduleCase(MailCommon):
         }))
 
 
-@tagged("-at_install", "post_install")
+@tagged("-at_install", "post_install", "mail_activity")
 class TestMailActivityChatter(HttpCase):
 
-    def test_mail_activity_schedule_from_chatter(self):
-        testuser = self.env['res.users'].create({
-            'email': 'testuser@testuser.com',
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.test_partner = cls.env['res.partner'].create({
+            'email': 'test.partner@example.com',
             'name': 'Test User',
-            'login': 'testuser',
-            'password': 'testuser',
         })
-        self.start_tour(
-            f"/web#id={testuser.partner_id.id}&model=res.partner",
-            "mail_activity_schedule_from_chatter",
-            login="admin",
-        )
 
     def test_mail_activity_date_format(self):
         with freeze_time("2024-1-1 09:00:00 AM"):
             LANG_CODE = "en_US"
             self.env = self.env(context={"lang": LANG_CODE})
-            testuser = self.env['res.users'].create({
-                "email": "testuser@testuser.com",
-                "name": "Test User",
-                "login": "testuser",
-                "password": "testuser",
-            })
             lang = self.env["res.lang"].search([('code', '=', LANG_CODE)])
             lang.date_format = "%d/%b/%y"
             lang.time_format = "%I:%M:%S %p"
 
             self.start_tour(
-                f"/web#id={testuser.partner_id.id}&model=res.partner",
+                f"/web#id={self.test_partner.id}&model=res.partner",
                 "mail_activity_date_format",
                 login="admin",
             )
+
+    def test_mail_activity_schedule_from_chatter(self):
+        self.start_tour(
+            f"/web#id={self.test_partner.id}&model=res.partner",
+            "mail_activity_schedule_from_chatter",
+            login="admin",
+        )
+
+
+@tagged("-at_install", "post_install", "mail_activity")
+class TestMailActivityIntegrity(ActivityScheduleCase):
+
+    def test_mail_activity_type_master_data(self):
+        """ Test master data integrity
+
+          * 'call', 'meeting', 'todo', 'upload document' and 'warning' should always be cross model;
+          * 'call', 'meeting' and 'todo' cannot be removed
+        """
+        call = self.env.ref('mail.mail_activity_data_call')
+        meeting = self.env.ref('mail.mail_activity_data_meeting')
+        todo = self.env.ref('mail.mail_activity_data_todo')
+        upload = self.env.ref('mail.mail_activity_data_upload_document')
+        warning = self.env.ref('mail.mail_activity_data_warning')
+        with self.assertRaises(exceptions.UserError):
+            call.write({'res_model': 'res.partner'})
+        with self.assertRaises(exceptions.UserError):
+            meeting.write({'res_model': 'res.partner'})
+        with self.assertRaises(exceptions.UserError):
+            todo.write({'res_model': 'res.partner'})
+        with self.assertRaises(exceptions.UserError):
+            upload.write({'res_model': 'res.partner'})
+        with self.assertRaises(exceptions.UserError):
+            warning.write({'res_model': 'res.partner'})
+
+        with self.assertRaises(exceptions.UserError):
+            call.unlink()
+        with self.assertRaises(exceptions.UserError):
+            meeting.unlink()
+        with self.assertRaises(exceptions.UserError):
+            todo.unlink()

--- a/addons/test_mail/data/data.xml
+++ b/addons/test_mail/data/data.xml
@@ -43,4 +43,10 @@
         <field name="res_model">mail.test.activity</field>
     </record>
 
+    <record id="mail_act_test_todo_generic" model="mail.activity.type">
+        <field name="name">Do Stuff</field>
+        <field name="summary">Hey Zoidberg! Get in here!</field>
+        <field name="category">default</field>
+    </record>
+
 </odoo>

--- a/addons/test_mail/tests/test_mail_multicompany.py
+++ b/addons/test_mail/tests/test_mail_multicompany.py
@@ -263,8 +263,8 @@ class TestMultiCompanySetup(TestMailMCCommon):
                 {"name": "Test2", "company_id": self.company_2.id},
             ]
         )
-        test_records[0].activity_schedule("test_mail.mail_act_test_todo", user_id=user_admin.id)
-        test_records[1].activity_schedule("test_mail.mail_act_test_todo", user_id=user_admin.id)
+        test_records[0].activity_schedule("test_mail.mail_act_test_todo_generic", user_id=user_admin.id)
+        test_records[1].activity_schedule("test_mail.mail_act_test_todo_generic", user_id=user_admin.id)
         test_activity = next(
             a for a in user_admin.systray_get_activities()
             if a['model'] == 'mail.test.multi.company.with.activity'


### PR DESCRIPTION
Master data protection
======================

In general, be defensive with activity types: avoid crash when activity
type has been removed, try to gracefully recover from non existing
data, protect types linked to business code that should not be unlinked
or changed from model.

Introduce a generic way to mark some activity types as master data
 * model is fixed and should not be modified, because it is linked
   to specific flows e.g. todo should be generic;
 * data should not be unlinked, because it is used in automated flows
   like plans, business code, ... and cannot easily be replaced;

Mail: make "Call", "Meeting" and "Todo" activity types master data users
cannot remove as they are required in various flows: fleet, plans,
voip, ... Also force their model to be False (aka be cross model).

Mail: make "Warning" and "Upload document" activity types in addition
to "Call" and "Todo", always cross model. As they are used in various
apps it should not be specific to a model.

Hr holidays: prevent from modifying leave activity types, as they are
used in business flows and in automated code.

Fleet: prevent from modifying contract activity type (same reason).

Account Online Synchornization: make "Bank Synchronization" master
data as business behavior dependso on it. Also fix model used for
the type.

Account reports: make "Tax Closing" master data as business flow
depends on it.

Approvals: make "Approval" master data as business flow depends on it
and it is not easy to remove it in their usage.

Hr Payroll: make "Leaves to defer" master data as business flow
depends on it.

Voip: make "Call" activity type master data users cannot remove as it
is required in various flows of VOIP. Also force its model to be False
as it is used in various models and should not suddenly be limited to
a given model. Done in community, as activity is defined in 'mail'.

Studio: make "Approval" master data as approval flow depends on it.


Calendar: fix activities creation
=========================

Current event creation tries to create activities. However code coming
from https://github.com/odoo/odoo/pull/72043 seems quite broken: it tries to find if the
target model accepts activities, but does not by browsing the wrong
model with wrong ids ... which globally turns off activity creation.

This fix rewrites a bit code creating activities when creating an event so
that
  * check activity support on the right model;
  * it uses the right model on activity type: otherwise you may end up with
    models that do not match between record and activity type;
  * remove useless (or wrong) code trying to browse 'model ids' on a given
    model;
  * we now correctly check for activity inheritance using 'is_mail_activity'
    field on IrModel;

Task-3777606