### PR TITLE
[FIX] web: undefined field value in domain

### DIFF
--- a/addons/web/static/src/core/domain.js
+++ b/addons/web/static/src/core/domain.js
@@ -188,6 +188,9 @@ function matchCondition(record, condition) {
     }
     const [field, operator, value] = condition;
     const fieldValue = typeof field === "number" ? field : record[field];
+    if (fieldValue === undefined) {
+        return false;
+    }
     switch (operator) {
         case "=?":
             if ([false, null].includes(value)) {


### PR DESCRIPTION
## Description
The `fieldValue` can be `undefined` due to searching for a field which a record doesn't contain.
For instance, creating a `loyalty.reward` with a domain searching on `product_variant_ids, ilike, 3` would crash the PoS service.

## Before this commit:
Matching a condition on a field that is not present in the record would crash the process depending on the operator used.

## After this commit:
If a field is not present in the record, we return 'false'. This is consistent with the previous behavior of the domain evaluation when using operators different than 'like', 'ilike' and 'in' or their negations.

## References
opw-3782212

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr