### PR TITLE
[FIX] web_tour: keep current debug mode when switching to tour's url

### DIFF
--- a/addons/web_tour/static/tests/tour_service_tests.js
+++ b/addons/web_tour/static/tests/tour_service_tests.js
@@ -611,4 +611,17 @@ QUnit.module("Tour service", (hooks) => {
             assert.containsNone(target, ".o_tour_pointer");
         }
     );
+
+    QUnit.test("debug mode is kept when a tour has a start url", async (assert) => {
+        browser.location.href = "http://myserver.com/web?debug=assets";
+        registry.category("web_tour.tours").add("Tour 1", {
+            sequence: 10,
+            url: "/tour?debug=tests",
+            steps: [{ trigger: "body" }],
+        });
+
+        const env = await makeTestEnv({});
+        env.services.tour_service.startTour("Tour 1");
+        assert.strictEqual(browser.location.href, "http://myserver.com/tour?debug=assets%2Ctests");
+    });
 });


### PR DESCRIPTION
Be in debug=assets. Start a tour that has a url (account_tour,mail_tour etc...)

Before this commit, the debug mode was lost.
This was impractical because most of the time one has entered that mode to debug something in the code, in relation with the tour. That is, one means to access the debug menu, see the source maps etc...

After this commit, the current url's debug mode and the tour's url's debug mode are merged.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
