### PR TITLE
[FIX] base: prevent text wrap contact widget

### DIFF
--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -36,7 +36,7 @@
                     </div>
                 </span>
             </div>
-            <div class="d-flex align-items-center gap-1" t-if="phone and 'phone' in fields">
+            <div class="d-flex align-items-center gap-1" t-if="phone and 'phone' in fields" style="white-space: nowrap">
                 <i t-if="not options.get('no_marker') or options.get('phone_icons')" class='fa fa-phone fa-fw' role="img" aria-label="Phone" title="Phone"/> <span class="o_force_ltr" itemprop="telephone" t-esc="phone"/>
             </div>
             <div class="d-flex align-items-center gap-1" t-if="mobile and 'mobile' in fields">


### PR DESCRIPTION
**Current behavior:**
In the din5008 style quotation, certain phone number values will
wrap to a second line below the one where they begin.

**Expected behavior:**
A phone number will not occupy more than 1 line, vertically.

**Steps to reproduce:**
1. Build the latest version of Odoo's wkhtmltopdf fork and
     ensure it has a higher priority in $PATH than one installed
     with apt-get

2. Set the DB document layout use din5008 and open sans font

3. Change a contact's country to Austria and give them the phone
     number "+43 4846 0000"

4. Create a new quotation for this client, print it as a
     `PDF Quote` or `Quotation/Order`, look at the line
     displaying the client phone number to see the bad text wrap

**Cause of the issue:**
There was a portal redesign in which the `Contact` qweb widget
was modified, this inadvertently cause some style issues in
certain cases.

Underlying problem with wkhtmltopdf(?)

**Fix:**
Add a strict style attribute to this div which prevents text
wrapping.

opw-3764486