### PR TITLE
[16.0][IMP] sale_stock, sale_mrp: Reuse of outgoing and incoming moves filters

### DIFF
--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -32,6 +32,15 @@ class SaleOrderLine(models.Model):
 
     def _compute_qty_delivered(self):
         super(SaleOrderLine, self)._compute_qty_delivered()
+        filters = self._get_outgoing_incoming_moves_filters()
+        # Switch filters since _compute_kit_quantities counts
+        # incoming as increase and outgoing as decrease
+        # but for the computation of qty_delivered
+        # outgoing moves should increase and incoming should decrease the qty
+        filters = {
+            "outgoing_moves": filters["incoming_moves"],
+            "incoming_moves": filters["outgoing_moves"],
+        }
         for order_line in self:
             if order_line.qty_delivered_method == 'stock_move':
                 boms = order_line.move_ids.filtered(lambda m: m.state != 'cancel').mapped('bom_line_id.bom_id')
@@ -65,10 +74,6 @@ class SaleOrderLine(models.Model):
                             order_line.qty_delivered = order_line.product_uom_qty
                         continue
                     moves = order_line.move_ids.filtered(lambda m: m.state == 'done' and not m.scrapped)
-                    filters = {
-                        'incoming_moves': lambda m: m.location_dest_id.usage == 'customer' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
-                        'outgoing_moves': lambda m: m.location_dest_id.usage != 'customer' and m.to_refund
-                    }
                     order_qty = order_line.product_uom._compute_quantity(order_line.product_uom_qty, relevant_bom.product_uom_id)
                     qty_delivered = moves._compute_kit_quantities(order_line.product_id, order_qty, relevant_bom, filters)
                     order_line.qty_delivered += relevant_bom.product_uom_id._compute_quantity(qty_delivered, order_line.product_uom)

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -265,19 +265,25 @@ class SaleOrderLine(models.Model):
             qty -= move.product_uom._compute_quantity(move.product_uom_qty, self.product_uom, rounding_method='HALF-UP')
         return qty
 
+    @api.model
+    def _get_outgoing_incoming_moves_filters(self):
+        return {
+            "outgoing_moves": lambda m: m.location_dest_id.usage == 'customer' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
+            "incoming_moves": lambda m: m.location_dest_id.usage != 'customer' and m.to_refund
+        }
+
     def _get_outgoing_incoming_moves(self):
         outgoing_moves = self.env['stock.move']
         incoming_moves = self.env['stock.move']
-
+        filters = self._get_outgoing_incoming_moves_filters()
         moves = self.move_ids.filtered(lambda r: r.state != 'cancel' and not r.scrapped and self.product_id == r.product_id)
         if self._context.get('accrual_entry_date'):
             moves = moves.filtered(lambda r: fields.Date.context_today(r, r.date) <= self._context['accrual_entry_date'])
 
         for move in moves:
-            if move.location_dest_id.usage == "customer":
-                if not move.origin_returned_move_id or (move.origin_returned_move_id and move.to_refund):
-                    outgoing_moves |= move
-            elif move.location_dest_id.usage != "customer" and move.to_refund:
+            if filters["outgoing_moves"](move):
+                outgoing_moves |= move
+            elif filters["incoming_moves"](move):
                 incoming_moves |= move
 
         return outgoing_moves, incoming_moves


### PR DESCRIPTION
Since _get_outgoing_incoming_moves filters the moves the same way as sale_mrp does
i refactored this part of code and moved the filters into sale_stock and used it then in both addons. 


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
