### PR TITLE
[IMP] tests, module, *: better test detection

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -529,7 +529,7 @@ class AccountMoveSend(models.TransientModel):
         """ Helper to know if we can commit the current transaction or not.
         :return: True if commit is accepted, False otherwise.
         """
-        return not tools.config['test_enable'] and not modules.module.current_test
+        return not modules.module.current_test
 
     @api.model
     def _call_web_service_before_invoice_pdf_render(self, invoices_data):

--- a/addons/account_peppol/models/account_edi_proxy_user.py
+++ b/addons/account_peppol/models/account_edi_proxy_user.py
@@ -38,7 +38,7 @@ class AccountEdiProxyClientUser(models.Model):
                     'account_peppol_migration_key': False,
                 })
                 # commit the above changes before raising below
-                if not tools.config['test_enable'] and not modules.module.current_test:
+                if not modules.module.current_test:
                     self.env.cr.commit()
             raise AccountEdiProxyError(e.code, e.message)
         return result

--- a/addons/account_peppol/models/res_config_settings.py
+++ b/addons/account_peppol/models/res_config_settings.py
@@ -168,7 +168,7 @@ class ResConfigSettings(models.TransientModel):
         # the client side is rolled back and the edi user is deleted on the client side
         # but remains on the proxy side.
         # it is important to keep these two in sync, so commit before activating.
-        if not tools.config['test_enable'] and not modules.module.current_test:
+        if not modules.module.current_test:
             self.env.cr.commit()
 
         company_details = {
@@ -268,7 +268,7 @@ class ResConfigSettings(models.TransientModel):
         self.ensure_one()
         # check if the participant has been already registered
         self.account_peppol_edi_user._peppol_get_participant_status()
-        if not tools.config['test_enable'] and not modules.module.current_test:
+        if not modules.module.current_test:
             self.env.cr.commit()
 
         if self.account_peppol_proxy_state == 'active':
@@ -316,7 +316,7 @@ class ResConfigSettings(models.TransientModel):
         # so that the invoices are acknowledged
         self.env['account_edi_proxy_client.user']._cron_peppol_get_message_status()
         self.env['account_edi_proxy_client.user']._cron_peppol_get_new_documents()
-        if not tools.config['test_enable'] and not modules.module.current_test:
+        if not modules.module.current_test:
             self.env.cr.commit()
 
         self._call_peppol_proxy(endpoint='/api/peppol/1/cancel_peppol_registration')

--- a/addons/account_peppol/tools/demo_utils.py
+++ b/addons/account_peppol/tools/demo_utils.py
@@ -167,6 +167,6 @@ def handle_demo(func, self, *args, **kwargs):
     }
     demo_mode = get_demo_mode.get(self._name) and get_demo_mode[self._name](self, args, kwargs) or False
 
-    if not demo_mode or tools.config['test_enable'] or modules.module.current_test:
+    if not demo_mode or modules.module.current_test:
         return func(self, *args, **kwargs)
     return _demo_behaviour[func.__name__](func, self, *args, **kwargs)

--- a/addons/web/controllers/session.py
+++ b/addons/web/controllers/session.py
@@ -64,7 +64,7 @@ class Session(http.Controller):
     @http.route('/web/session/modules', type='json', auth='user', readonly=True)
     def modules(self):
         # return all installed modules. Web client is smart enough to not load a module twice
-        return list(request.env.registry._init_modules.union([module.current_test] if module.current_test else []))
+        return list(request.env.registry._init_modules)
 
     @http.route('/web/session/check', type='json', auth='user', readonly=True)
     def check(self):

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -253,8 +253,6 @@ class IrHttp(models.AbstractModel):
         _logger.info("Generating routing map for key %s", str(key))
         registry = Registry(threading.current_thread().dbname)
         installed = registry._init_modules.union(odoo.conf.server_wide_modules)
-        if tools.config['test_enable'] and odoo.modules.module.current_test:
-            installed.add(odoo.modules.module.current_test)
         mods = sorted(installed)
         # Note : when routing map is generated, we put it on the class `cls`
         # to make it available for all instance. Since `env` create an new instance

--- a/odoo/modules/loading.py
+++ b/odoo/modules/loading.py
@@ -280,7 +280,7 @@ def load_module_graph(env, graph, status=None, perform_checks=True,
                     registry.setup_models(env.cr)
                 # Python tests
                 tests_t0, tests_q0 = time.time(), odoo.sql_db.sql_counter
-                test_results = loader.run_suite(suite, module_name)
+                test_results = loader.run_suite(suite)
                 report.update(test_results)
                 test_time = time.time() - tests_t0
                 test_queries = odoo.sql_db.sql_counter - tests_q0

--- a/odoo/modules/module.py
+++ b/odoo/modules/module.py
@@ -425,7 +425,7 @@ def adapt_version(version):
     return version
 
 
-current_test = None
+current_test = False
 
 
 def check_python_external_dependency(pydep):

--- a/odoo/tests/loader.py
+++ b/odoo/tests/loader.py
@@ -76,17 +76,17 @@ def make_suite(module_names, position='at_install'):
     return OdooSuite(sorted(tests, key=lambda t: t.test_sequence))
 
 
-def run_suite(suite, module_name=None):
+def run_suite(suite):
     # avoid dependency hell
     from ..modules import module
-    module.current_test = module_name
+    module.current_test = True
     threading.current_thread().testing = True
 
     results = OdooTestResult()
     suite(results)
 
     threading.current_thread().testing = False
-    module.current_test = None
+    module.current_test = False
     return results
 
 


### PR DESCRIPTION
It is currently always a pain to know for sure if a test is running when writing conditional (mainly for commits).

- `config['test-tags']` is one of the more reliable, but if starting a server with tests (test-tags, ...) will result in a special state. This is sometime visible when truing to render a report after executing test, the report will be rendered in html.

- `module.current_test` will only work for at install tests, because it's main purpose was initially to give the module being currently loaded.

- `threading.current_thread().testing` will only work for the main thread, not the one of a thread serving an http request.

- `registry.in_test_mode`, only when explicitly entering test mode, as in HTTPCase, this is mostly the signal for test cursors

The easiest solution is to have a global flag that will always be thruthy when executing a test, no mater if it is at install or post install.

The `current_test` flag is actually the closest one that could cover all cases. It just need to be thruthy when running a post install test.

The main reason this flag contains the currently loading module is to fill the `_init_modules` in some cases, but this shouldn't be useful if the module is already in the `_init_modules` list

This is actually the case since #53499, and some of the hack regarding `_init_modules` and `current_test` can be removed. This will allow to recycle this flag to make it True when in test mode, False otherwise.