### PR TITLE
[FIX] mrp: do not append quantity to Draft MO

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -59,20 +59,15 @@ class StockRule(models.Model):
                 domain = (
                     ('bom_id', '=', bom.id),
                     ('product_id', '=', procurement.product_id.id),
-                    ('state', 'in', ['draft', 'confirmed']),
+                    ('state', '=', 'confirmed'),
                     ('is_planned', '=', False),
                     ('picking_type_id', '=', rule.picking_type_id.id),
                     ('company_id', '=', procurement.company_id.id),
                     ('user_id', '=', False),
                 )
                 if procurement.values.get('orderpoint_id'):
-                    procurement_date = datetime.combine(
-                        fields.Date.to_date(procurement.values['date_planned']) - relativedelta(days=int(bom.produce_delay)),
-                        datetime.max.time()
-                    )
-                    domain += ('|',
-                               '&', ('state', '=', 'draft'), ('date_deadline', '<=', procurement_date),
-                               '&', ('state', '=', 'confirmed'), ('date_start', '<=', procurement_date))
+                    procurement_date = fields.Date.to_date(procurement.values['date_planned']) - relativedelta(days=int(bom.produce_delay))
+                    domain += (('date_start', '<=', datetime.combine(procurement_date, datetime.max.time())),)
                 if group:
                     domain += (('procurement_group_id', '=', group.id),)
                 mo = self.env['mrp.production'].sudo().search(domain, limit=1)


### PR DESCRIPTION
The quantities produced by Draft Manufacturing Orders are not accounted for in the forecast quantity. Hence, if we select a Draft MO to compensate for a demand, it will not be fulfilled. And the scheduler will continue to try to fulfill the demand and keep increasing the quantity of this draft MO every day.

# How to reproduce:
- Unarchived "Replenish on Order" route
- Create new product P with route "Replenish on Order" & "Manufacture" selected
- Create Reordering rules auto, min 0, max 0, route Manufacture
- Create Sale Order for 100 units of P
- Run Scheduler multiple times

https://github.com/odoo/odoo/assets/29302288/4ea7c2df-7f0d-4117-aa39-efc1bff63dbd

OPW-3763875

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
