### PR TITLE
[FIX] hr_holidays: display employee information on allocation

### DIFF
--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -98,6 +98,7 @@
                         <group>
                             <field name="type_request_unit" invisible="1"/>
                             <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}" options="{'always_reload': True}"/>
+                            <field name="employee_info" attrs="{'invisible': [('employee_info', '=', False)]}" nolabel="1" colspan="2"/>
                             <field name="allocation_type" invisible="1" widget="radio"
                                 attrs="{'readonly': ['|', ('is_officer', '=', False), ('state', 'not in', ('draft', 'confirm'))]}"/>
                             <field name="is_officer" invisible="1"/>


### PR DESCRIPTION
Issue (display issue):
----------------------

Commit [^1] introduces a limitation which removes record related data from the context. As a result, `employee_id` is no longer passed when calling `name_get`. The result is that we no longer have access to the number of holidays the employee currently has on the form view of an allocation.

This poses a problem, for example, for people who need to validate allocations.

Solution:
---------
Add a compute no-stored field to dynamically construct a string containing information about the employee.

opw-3753011

[^1]: fa11f330b8554350a48a099669b5cf36421918b8