### PR TITLE
[FIX] tools/convert : display the actual error title instead Parse Error

### DIFF
--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -693,11 +693,12 @@ form: module.record_id""" % (xml_id,)
                 _logger.debug(msg, exc_info=True)
                 raise ParseError(msg) from None  # Restart with "--log-handler odoo.tools.convert:DEBUG" for complete traceback
             except Exception as e:
-                raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
+                message = 'while parsing %s:%s, somewhere inside\n%s' % (
                     rec.getroottree().docinfo.URL,
                     rec.sourceline,
                     etree.tostring(rec, encoding='unicode').rstrip()
-                )) from e
+                )
+                raise type(e)(message) from e
             finally:
                 self._noupdate.pop()
                 self.envs.pop()


### PR DESCRIPTION
When the view of a particular external ID is deleted and trying to upgrade the module at that time traceback gets generated

Steps to produce:
- Install ``MRP`` module
- Manufacturing -> Configuration -> Setting -> Enable ``Quality`` and ``Quality Worksheet``
- From the main dashboard search for ``worksheet_page`` views and delete it
- Go to apps and upgrade ``quality_mrp_workorder`` module

Traceback:
```KeyError: ('ir.model.data', <function IrModelData._xmlid_lookup at 0x7f9751603a30>, 'quality_mrp.worksheet_page')
  File "odoo/tools/cache.py", line 99, in lookup
    r = d[key]
  File "<decorator-gen-5>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
ValueError: External ID not found in the system: quality_mrp.worksheet_page
  File "odoo/tools/convert.py", line 556, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 533, in _tag_template
    return self._tag_record(record)
  File "odoo/tools/convert.py", line 421, in _tag_record
    f_val = self.id_get(f_ref, raise_if_not_found=nodeattr2bool(rec, 'forcecreate', True))
  File "odoo/tools/convert.py", line 538, in id_get
    res = self.model_id_get(id_str, raise_if_not_found)
  File "odoo/tools/convert.py", line 544, in model_id_get
    return self.env['ir.model.data']._xmlid_to_res_model_res_id(id_str, raise_if_not_found=raise_if_not_found)
  File "odoo/addons/base/models/ir_model.py", line 2182, in _xmlid_to_res_model_res_id
    return self._xmlid_lookup(xmlid)
  File "<decorator-gen-43>", line 2, in _xmlid_lookup
  File "odoo/tools/cache.py", line 104, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/ir_model.py", line 2175, in _xmlid_lookup
    raise ValueError('External ID not found in the system: %s' % xmlid)
ParseError: while parsing None:4, somewhere inside
<data inherit_id="quality_mrp.worksheet_page">
            <xpath expr="//div[@name='production_order']" position="attributes">
                <attribute name="t-if">
                    doc.production_id and not doc.workorder_id
                </attribute>
            </xpath>
            <xpath expr="//t[@name='origin']" position="inside">
                <div name="workorder" t-if="doc.workorder_id">
                    <strong>Work Order: </strong>
           ...
  File "odoo/modules/registry.py", line 113, in new
    odoo.modules.load_modules(registry, force_demo, status, update_module)
  File "odoo/modules/loading.py", line 480, in load_modules
    processed_modules += load_marked_modules(env, graph,
  File "odoo/modules/loading.py", line 364, in load_marked_modules
    loaded, processed = load_module_graph(
  File "odoo/modules/loading.py", line 227, in load_module_graph
    load_data(env, idref, mode, kind='data', package=package)
  File "odoo/modules/loading.py", line 71, in load_data
    tools.convert_file(env, package.name, filename, idref, mode, noupdate, kind)
  File "odoo/tools/convert.py", line 627, in convert_file
    convert_xml_import(env, module, fp, idref, mode, noupdate)
  File "odoo/tools/convert.py", line 693, in convert_xml_import
    obj.parse(doc.getroot())
  File "odoo/tools/convert.py", line 613, in parse
    self._tag_root(de)
  File "odoo/tools/convert.py", line 556, in _tag_root
    f(rec)
  File "odoo/tools/convert.py", line 569, in _tag_root
    raise ParseError('while parsing %s:%s, somewhere inside\n%s' % (
 ```

Currently, it shows users a Parse Error instead of the precise error title or name that users expect. It would be better to display the exact error title/name.

sentry-4798333562

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
