### PR TITLE
[IMP] l10n_au: send Activity Statement SBR

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -832,7 +832,7 @@ class AccountReportExpression(models.Model):
                     totals_by_code[line_code].add(total_name)
 
             if expression.subformula:
-                if_other_expr_match = re.match(r'if_other_expr_(above|below)\((?P<line_code>.+)[.](?P<expr_label>.+),.+\)', expression.subformula)
+                if_other_expr_match = re.match(r'if_other_expr_(above|below|equals)\((?P<line_code>.+)[.](?P<expr_label>.+),.+\)', expression.subformula)
                 if if_other_expr_match:
                     totals_by_code[if_other_expr_match['line_code']].add(if_other_expr_match['expr_label'])
 

--- a/addons/l10n_au/__manifest__.py
+++ b/addons/l10n_au/__manifest__.py
@@ -20,7 +20,9 @@ Also:
     'depends': ['account'],
     'auto_install': ['account'],
     'data': [
-        'data/account_tax_report_data.xml',
+        'data/tax_report/section_1.xml',
+        'data/tax_report/section_2.xml',
+        'data/tax_report/account_tax_report_data.xml',
         'data/account_tax_template_data.xml',
         'data/res_currency_data.xml',
         'data/account.account.tag.csv',

--- a/addons/l10n_au/data/tax_report/account_tax_report_data.xml
+++ b/addons/l10n_au/data/tax_report/account_tax_report_data.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_report" model="account.report">
+        <field name="name">BAS Report</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="country_id" ref="base.au"/>
+        <field name="allow_foreign_vat" eval="True"/>
+        <field name="availability_condition">country</field>
+        <field name="use_sections" eval="True"/>
+        <field name="section_report_ids" eval="[Command.set([ref('l10n_au.l10n_au_tax_report_section_1'),
+                                                            ref('l10n_au.l10n_au_tax_report_section_2')])]"/>
+    </record>
+</odoo>

--- a/addons/l10n_au/data/tax_report/section_1.xml
+++ b/addons/l10n_au/data/tax_report/section_1.xml
@@ -1,0 +1,512 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="l10n_au_tax_report_section_1" model="account.report">
+        <field name="name">Simple BAS</field>
+        <field name="sequence">1</field>
+        <field name="country_id" ref="base.au"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_report_section_1_ato" model="account.report.column">
+                <field name="name">ATO</field>
+                <field name="expression_label">ato</field>
+            </record>
+            <record id="tax_report_section_1_balance" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="account_tax_report_gstrpt_sale_total" model="account.report.line">
+                <field name="name">GST amounts you owe the Tax Office from sales</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_gstrpt_g1" model="account.report.line">
+                        <field name="name">G1: Total Sales (including any GST)</field>
+                        <field name="code">AU_G1</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_g1_tag" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">G1</field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g1_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_gstrpt_g2" model="account.report.line">
+                                <field name="name">G2: Export sales</field>
+                                <field name="code">AU_G2</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_g2_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">G2</field>
+                                    </record>
+                                    <record id="account_tax_report_gstrpt_g2_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g3" model="account.report.line">
+                                <field name="name">G3: Other GST-free sales</field>
+                                <field name="code">AU_G3</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_g3_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">G3</field>
+                                    </record>
+                                    <record id="account_tax_report_gstrpt_g3_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g4" model="account.report.line">
+                                <field name="name">G4: Input taxed sales</field>
+                                <field name="code">AU_G4</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_g4_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">G4</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g5" model="account.report.line">
+                        <field name="name">G5: G2 + G3 + G4</field>
+                        <field name="code">AU_G5</field>
+                        <field name="aggregation_formula">AU_G2.balance+AU_G3.balance+AU_G4.balance</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g6" model="account.report.line">
+                        <field name="name">G6: Total sales subject to GST (G1 minus G5)</field>
+                        <field name="code">AU_G6</field>
+                        <field name="aggregation_formula">AU_G1.balance-AU_G5.balance</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_gstrpt_g7" model="account.report.line">
+                                <field name="name">G7: Adjustments (if applicable)</field>
+                                <field name="code">AU_G7</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_g7_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">G7</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g8" model="account.report.line">
+                        <field name="name">G8: Total sales subject to GST after adjustments (G6 + G7)</field>
+                        <field name="code">AU_G8</field>
+                        <field name="aggregation_formula">AU_G6.balance+AU_G7.balance</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g9" model="account.report.line">
+                        <field name="name">G9: GST on sales (G8 divided by eleven)</field>
+                        <field name="code">AU_G9</field>
+                        <field name="aggregation_formula">AU_G8.balance/11</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_g9_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_gstrpt_purchase_total" model="account.report.line">
+                <field name="name">GST amounts the Tax Office owes you from purchases</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_gstrpt_g10" model="account.report.line">
+                        <field name="name">G10: Capital purchases (including any GST)</field>
+                        <field name="code">AU_G10</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_g10_tag" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">G10</field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g10_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g11" model="account.report.line">
+                        <field name="name">G11: Non-capital purchases (including GST)</field>
+                        <field name="code">AU_G11</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_g11_tag" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">G11</field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g11_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g12" model="account.report.line">
+                        <field name="name">G12: G10 + G11</field>
+                        <field name="code">AU_G12</field>
+                        <field name="aggregation_formula">AU_G10.balance+AU_G11.balance</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_gstrpt_g13" model="account.report.line">
+                                <field name="name">G13: Purchases for making input taxed sales</field>
+                                <field name="code">AU_G13</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_g13_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">G13</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g14" model="account.report.line">
+                                <field name="name">G14: Purchases without GST in the price</field>
+                                <field name="code">AU_G14</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_g14_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">G14</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_g15" model="account.report.line">
+                                <field name="name">G15: Estimated purchases for private use or not income tax deductible</field>
+                                <field name="code">AU_G15</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_g15_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">G15</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g16" model="account.report.line">
+                        <field name="name">G16: G13 + G14 + G15</field>
+                        <field name="code">AU_G16</field>
+                        <field name="aggregation_formula">AU_G13.balance+AU_G14.balance+AU_G15.balance</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g17" model="account.report.line">
+                        <field name="name">G17: Total purchases subject to GST (G12 minus G16) </field>
+                        <field name="code">AU_G17</field>
+                        <field name="aggregation_formula">AU_G12.balance-AU_G16.balance</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_gstrpt_g18" model="account.report.line">
+                                <field name="name">G18: Adjustments (if applicable)</field>
+                                <field name="code">AU_G18</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_g18_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">G18</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g19" model="account.report.line">
+                        <field name="name">G19: Total purchases subject to GST after adjustments (G17 + G18) </field>
+                        <field name="code">AU_G19</field>
+                        <field name="aggregation_formula">AU_G17.balance+AU_G18.balance</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g20a" model="account.report.line">
+                        <field name="name">GST on purchases (G19 divided by eleven)</field>
+                        <field name="code">AU_GP</field>
+                        <field name="aggregation_formula">AU_G19.balance/11</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_gstonly" model="account.report.line">
+                        <field name="name">GST only purchases</field>
+                        <field name="code">AU_ONLY</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_gstonly_tag" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">ONLY</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_g20b" model="account.report.line">
+                        <field name="name">G20: GST on purchases</field>
+                        <field name="code">AU_G20</field>
+                        <field name="aggregation_formula">AU_GP.balance+AU_ONLY.balance</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_paygw" model="account.report.line">
+                <field name="name">PAYG Tax Withheld</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_payg_w1" model="account.report.line">
+                        <field name="name">W1: Total salaries, wages and other payments</field>
+                        <field name="code">AU_W1</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_payg_w1_tag" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">W1</field>
+                            </record>
+                            <record id="account_tax_report_payg_w1_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_payg_w2" model="account.report.line">
+                        <field name="name">W2: Amounts withheld from salaries or wages and other payments shown at W1</field>
+                        <field name="code">AU_W2</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_payg_w2_tag" model="account.report.expression">
+                                <field name="label">sub_balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">W2</field>
+                            </record>
+                            <record id="account_tax_report_payg_w2_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">-AU_W2.sub_balance</field>
+                            </record>
+                            <record id="account_tax_report_payg_w2_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_payg_w4" model="account.report.line">
+                        <field name="name">W4: Amounts withheld where no ABN is quoted</field>
+                        <field name="code">AU_W4</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_payg_w4_tag" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">W4</field>
+                            </record>
+                            <record id="account_tax_report_payg_w4_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_payg_w3" model="account.report.line">
+                        <field name="name">W3: Other amounts withheld (excluding any amount shown at W2 or W4)</field>
+                        <field name="code">AU_W3</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_payg_w3_tag" model="account.report.expression">
+                                <field name="label">sub_balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">W3</field>
+                            </record>
+                            <record id="account_tax_report_payg_w3_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">-AU_W3.sub_balance</field>
+                            </record>
+                            <record id="account_tax_report_payg_w3_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_payg_w5" model="account.report.line">
+                        <field name="name">W5: Total amounts withheld (W2 + W4 + W3)</field>
+                        <field name="code">AU_W5</field>
+                        <field name="aggregation_formula">AU_W2.balance+AU_W3.balance+AU_W4.balance</field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_gstrpt_summary" model="account.report.line">
+                <field name="name">Summary</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_gstrpt_summary_8a" model="account.report.line">
+                        <field name="name">8A/ 2A/ P1: Amount you owe the Tax Office</field>
+                        <field name="code">AU_8A</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_summary_8a_cross_balance" model="account.report.expression">
+                                <field name="label">cross_balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AU_1C.balance + AU_1E.balance + AU_5A.balance + AU_6A.balance + AU_7.balance + AU_7C.balance</field>
+                                <field name="subformula">cross_report(l10n_au.l10n_au_tax_report_section_2)</field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_summary_8a_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AU_1A.balance + AU_4.balance + AU_7A.ato + AU_8A.cross_balance</field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_summary_8a_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_gstrpt_summary_1a" model="account.report.line">
+                                <field name="name">1A: GST on sales</field>
+                                <field name="code">AU_1A</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_summary_1a_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_G9.balance</field>
+                                    </record>
+                                    <record id="account_tax_report_gstrpt_summary_1a_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_payg_summary_4" model="account.report.line">
+                                <field name="name">4: PAYG Tax Withheld</field>
+                                <field name="code">AU_4</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_summary_4_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_W5.balance</field>
+                                    </record>
+                                    <record id="account_tax_report_gstrpt_summary_4_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_summary_7a" model="account.report.line">
+                                <field name="name">7A: Deferred GST on imported goods</field>
+                                <field name="code">AU_7A</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_7a_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">7A</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_7a_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_summary_8b" model="account.report.line">
+                        <field name="name">8B/ 2B: Amount the Tax Office owes you</field>
+                        <field name="code">AU_8B</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_summary_8b_cross_balance" model="account.report.expression">
+                                <field name="label">cross_balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AU_1D.balance + AU_1F.balance + AU_5B.balance + AU_6B.balance + AU_7D.balance</field>
+                                <field name="subformula">cross_report(l10n_au.l10n_au_tax_report_section_2)</field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_summary_8b_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AU_8B.cross_balance + AU_1B.balance</field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_summary_8b_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_gstrpt_summary_1b" model="account.report.line">
+                                <field name="name">1B: GST on purchases</field>
+                                <field name="code">AU_1B</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_gstrpt_summary_1b_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_G20.balance+AU_7A.balance</field>
+                                    </record>
+                                    <record id="account_tax_report_gstrpt_summary_1b_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_summary_9" model="account.report.line">
+                        <field name="name">9: Your payment or refund amount</field>
+                        <field name="code">AU_9</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_summary_9_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">AU_8A.balance-AU_8B.balance</field>
+                                <field name="subformula">cross_report(l10n_au.l10n_au_tax_report_section_2)</field>
+                            </record>
+                            <record id="account_tax_report_gstrpt_summary_9_ato" model="account.report.expression">
+                                <field name="label">ato</field>
+                                <field name="engine">external</field>
+                                <field name="formula">sum</field>
+                                <field name="subformula">rounding=2</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_gstrpt_comparison" model="account.report.line">
+                <field name="name">Comparison</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_gstrpt_comparison_worksheet" model="account.report.line">
+                        <field name="name">GST from worksheet (G20-G9)</field>
+                        <field name="aggregation_formula">AU_G20.balance-AU_G9.balance</field>
+                    </record>
+                    <record id="account_tax_report_gstrpt_comparison_gl" model="account.report.line">
+                        <field name="name">GST from General Ledger</field>
+                        <field name="expression_ids">
+                            <record id="account_tax_report_gstrpt_comparison_gl_tag" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">GST from General Ledger</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_au/data/tax_report/section_2.xml
+++ b/addons/l10n_au/data/tax_report/section_2.xml
@@ -1,0 +1,734 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="l10n_au_tax_report_section_2" model="account.report">
+        <field name="name">Additional BAS Info</field>
+        <field name="sequence">2</field>
+        <field name="country_id" ref="base.au"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_report_ato" model="account.report.column">
+                <field name="name">ATO</field>
+                <field name="expression_label">ato</field>
+            </record>
+            <record id="tax_report_section_2_balance" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="account_tax_report_additional_gst" model="account.report.line">
+                <field name="name">Goods and Service Tax</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_additional_gst_commissioner" model="account.report.line">
+                        <field name="name">GST Commissioner Chosen</field>
+                        <field name="code">AU_GSTCC</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_gst_g21" model="account.report.line">
+                                <field name="name">G21: ATO instalment amount</field>
+                                <field name="code">AU_G21</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_gst_g21_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_gst_estimation" model="account.report.line">
+                        <field name="name">GST Business Estimation</field>
+                        <field name="code">AU_GSTBE</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_gst_g22" model="account.report.line">
+                                <field name="name">G22: Estimated net GST for the year</field>
+                                <field name="code">AU_G22</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_gst_g22_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_gst_g22_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_gst_variation" model="account.report.line">
+                        <field name="name">GST Business Variation</field>
+                        <field name="code">AU_GSTBV</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_gst_g23" model="account.report.line">
+                                <field name="name">G23: Varied GST amount for the quarter</field>
+                                <field name="code">AU_G23</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_gst_g23_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_gst_g23_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_gst_g24" model="account.report.line">
+                                <field name="name">G24: Reason code for GST variation</field>
+                                <field name="code">AU_G24</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_gst_g24_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_additional_fbt" model="account.report.line">
+                <field name="name">Fringe Benefits Tax</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_additional_ftb_commissioner" model="account.report.line">
+                        <field name="name">FBT Commissioner Chosen</field>
+                        <field name="code">AU_FTBCC</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_ftb_f1" model="account.report.line">
+                                <field name="name">F1: Tax Office FBT instalment amount</field>
+                                <field name="code">AU_F1</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_ftb_f1_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_ftb_estimation" model="account.report.line">
+                        <field name="name">FBT Business Estimation</field>
+                        <field name="code">AU_FTBBE</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_ftb_f2" model="account.report.line">
+                                <field name="name">F2: Estimated FBT for the year</field>
+                                <field name="code">AU_F2</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_ftb_f2_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_ftb_f2_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_ftb_variation" model="account.report.line">
+                        <field name="name">FBT Business Variation</field>
+                        <field name="code">AU_FTBBV</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_ftb_f3" model="account.report.line">
+                                <field name="name">F3: Varied FBT amount for the quarter</field>
+                                <field name="code">AU_F3</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_ftb_f3_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_ftb_f3_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_ftb_f4" model="account.report.line">
+                                <field name="name">F4: Reason code for FBT variation</field>
+                                <field name="code">AU_F4</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_ftb_f4_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_ftb_f4_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_additional_paygw" model="account.report.line">
+                <field name="name">PAYG Tax Withheld</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_additional_paygw_stpreported" model="account.report.line">
+                        <field name="name">STP Reported</field>
+                        <field name="code">AU_STP_REPORTED</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_paygw_stpreported_w1" model="account.report.line">
+                                <field name="name">STP Reported W1</field>
+                                <field name="code">AU_STP_REPORTED_W1</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygw_stpreported_w1_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_paygw_stpreported_w2" model="account.report.line">
+                                <field name="name">STP Reported W2</field>
+                                <field name="code">AU_STP_REPORTED_W2</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygw_stpreported_w2_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_additional_paygi" model="account.report.line">
+                <field name="name">PAYG Income Tax Instalment</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_additional_paygi_paygi" model="account.report.line">
+                        <field name="name">PAYGI</field>
+                        <field name="code">AU_PAYGI</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_paygi_reporting" model="account.report.line">
+                                <field name="name">PAYG income tax instalment reporting option</field>
+                                <field name="code">AU_PAYGI_REPORTING</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_reporting_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_paygi_reporting_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_paygi_t1" model="account.report.line">
+                                <field name="name">T1: PAYG instalment income</field>
+                                <field name="code">AU_T1</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_t1_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_paygi_t1_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_paygi_t4" model="account.report.line">
+                                <field name="name">T4: Reason code for PAYG income tax instalment variation</field>
+                                <field name="code">AU_T4</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_t4_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_paygi_t4_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_paygi_commissioner" model="account.report.line">
+                        <field name="name">Commissioner Chosen</field>
+                        <field name="code">AU_PAYGICC</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_paygi_t5" model="account.report.line">
+                                <field name="name">T5/ T7: Tax Office PAYG income tax instalment amount</field>
+                                <field name="code">AU_T5</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_t5_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_paygi_t5_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_paygi_calculation" model="account.report.line">
+                        <field name="name">Calculation</field>
+                        <field name="code">AU_PAYGIC</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_paygi_t11" model="account.report.line">
+                                <field name="name">T11 = T1 x T2 (or T1 x T3)</field>
+                                <field name="code">AU_T11</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_t11_criterium_balance" model="account.report.expression">
+                                        <field name="label">tax_criterium_balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_T2.ato</field>
+                                        <field name="subformula">if_other_expr_equals(AU_T3.balance, AUD(0))</field>
+                                    </record>
+                                    <!-- <record id="account_tax_report_additional_paygi_t11_criterium_ato" model="account.report.expression">
+                                        <field name="label">tax_criterium_ato</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_T2.ato</field>
+                                        <field name="subformula">if_other_expr_equals(AU_T3.ato, AUD(0))</field>
+                                    </record> -->
+                                    <record id="account_tax_report_additional_paygi_t11_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_T1.balance * (AU_T11.tax_criterium_balance + AU_T3.balance)</field>
+                                    </record>
+                                    <!-- <record id="account_tax_report_additional_paygi_t11_ato" model="account.report.expression">      TODO check if ATO gives us this info or if we have to compute it
+                                        <field name="label">ato</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_T1.ato * (AU_T11.tax_criterium_ato + AU_T3.ato)</field>
+                                    </record> -->
+                                    <!-- <record id="account_tax_report_additional_summary_1h_criterium" model="account.report.expression">
+                                        <field name="label">tax_criterium</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_G21.balance</field>
+                                        <field name="subformula">if_other_expr_equals(AU_G23.balance, AUD(0))</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_1h_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_G23.balance + AU_1H.tax_criterium</field>
+                                    </record> -->
+                                    <record id="account_tax_report_additional_paygi_t11_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_paygi_estimation" model="account.report.line">
+                        <field name="name">Business Estimation</field>
+                        <field name="code">AU_PAYGIBE</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_paygi_t8" model="account.report.line">
+                                <field name="name">T8: Estimated PAYG income tax for the year</field>
+                                <field name="code">AU_T8</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_t8_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_paygi_t8_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_paygi_variation" model="account.report.line">
+                        <field name="name">Business Variation</field>
+                        <field name="code">AU_PAYGIBV</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_paygi_t6" model="account.report.line">
+                                <field name="name">T6/T9: Varied PAYG income tax instalment amount</field>
+                                <field name="code">AU_T6</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_t6_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_paygi_t6_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_paygi_paygi_commissioner" model="account.report.line">
+                        <field name="name">PAYG Instalment Commissioner Chosen</field>
+                        <field name="code">AU_PAYGIPAYGICC</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_paygi_t2" model="account.report.line">
+                                <field name="name">T2: Commissioner Chosen - Instalment rate</field>
+                                <field name="code">AU_T2</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_t2_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_paygi_paygi_variation" model="account.report.line">
+                        <field name="name">PAYG Instalment Business Variation</field>
+                        <field name="code">AU_PAYGIPAYGIBV</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_paygi_t3" model="account.report.line">
+                                <field name="name">T3: Business Variation - New varied rate</field>
+                                <field name="code">AU_T3</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_paygi_t3_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_paygi_t3_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+            <record id="account_tax_report_additional_summary" model="account.report.line">
+                <field name="name">Summary</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="account_tax_report_additional_summary_owed_to" model="account.report.line">
+                        <field name="name">Amounts you owe the ATO</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_summary_1c" model="account.report.line">
+                                <field name="name">1C: Wine equalisation tax</field>
+                                <field name="code">AU_1C</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_1c_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_1c_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_1e" model="account.report.line">
+                                <field name="name">1E: Luxury car tax</field>
+                                <field name="code">AU_1E</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_1e_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_1e_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_5a" model="account.report.line">
+                                <field name="name">5A: PAYG Income tax instalment</field>
+                                <field name="code">AU_5A</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_5a_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_5a_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_6a" model="account.report.line">
+                                <field name="name">6A: FBT instalment</field>
+                                <field name="code">AU_6A</field>
+                                <!-- <field name="aggregation_formula">AU_F3.balance or AU_F1.balance</field> -->
+                                <field name="expression_ids">
+                                    <!-- <record id="account_tax_report_additional_summary_6a_criterium" model="account.report.expression">
+                                        <field name="label">test_crit</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_F1.balance</field>
+                                        <field name="subformula">if_other_expr_equals(AU_F3.balance, AUD(0))</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_6a_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_F3.balance + AU_6A.test_crit</field>
+                                    </record> -->
+                                    <record id="account_tax_report_additional_summary_6a_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_6a_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_7" model="account.report.line">   <!-- TODO Check if necessary to keep as it is for when they changed to the new tax system-->
+                                <field name="name">7: Deferred company/fund instalment</field>
+                                <field name="code">AU_7</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_7_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_7_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_7c" model="account.report.line">
+                                <field name="name">7C: Fuel tax credit over claim</field>
+                                <field name="code">AU_7C</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_7c_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_7c_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="account_tax_report_additional_summary_owed_by" model="account.report.line">
+                        <field name="name">Amounts the ATO owes you</field>
+                        <field name="hierarchy_level">1</field>
+                        <field name="children_ids">
+                            <record id="account_tax_report_additional_summary_1d" model="account.report.line">
+                                <field name="name">1D: Wine equalisation tax refundable</field>
+                                <field name="code">AU_1D</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_1d_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_1d_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_1f" model="account.report.line">
+                                <field name="name">1F: Luxury car tax refundable</field>
+                                <field name="code">AU_1F</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_1f_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_1f_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_1h" model="account.report.line">
+                                <field name="name">1H: GST instalments</field>
+                                <field name="code">AU_1H</field>
+                                <!-- <field name="aggregation_formula">AU_G23.balance or AU_G21.balance</field> -->
+                                <field name="expression_ids">
+                                    <!-- <record id="account_tax_report_additional_summary_1h_criterium" model="account.report.expression">
+                                        <field name="label">tax_criterium</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_G21.balance</field>
+                                        <field name="subformula">if_other_expr_equals(AU_G23.balance, AUD(0))</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_1h_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">AU_G23.balance + AU_1H.tax_criterium</field>
+                                    </record> -->
+                                    <record id="account_tax_report_additional_summary_1h_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_1h_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_5b" model="account.report.line">
+                                <field name="name">5B: Credit from PAYG income tax instalment variation</field>
+                                <field name="code">AU_5B</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_5b_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_5b_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_6b" model="account.report.line">
+                                <field name="name">6B: Credit from FBT instalment variation</field>
+                                <field name="code">AU_6B</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_6b_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_6b_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="account_tax_report_additional_summary_7d" model="account.report.line">
+                                <field name="name">7D: Fuel tax credit</field>
+                                <field name="code">AU_7D</field>
+                                <field name="expression_ids">
+                                    <record id="account_tax_report_additional_summary_7d_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                    <record id="account_tax_report_additional_summary_7d_ato" model="account.report.expression">
+                                        <field name="label">ato</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
The Australian Taxation Office (ATO) allow Australian businesses to lodge some reports through their digital provider. This commit implements the communication with the ATO to allow our clients to lodge their Activity Statement (AS) through Odoo.

This communication consists of getting the wanted document pre-filled with data from the ATO, then fill and check with data in the client's Odoo DB in order to submit and send it back to the ATO.

This commit adds the values the user is suspected to send to the ATO in the Tax Report. For the values that aren't (yet ?) computable in Odoo, they are editable so that the user can send a correct and full report to the ATO.

