### PR TITLE
[FIX] l10n_ec_pos: Add support for Ecuadorian Invoicing in POS

### DIFF
--- a/addons/l10n_ec_pos/__init__.py
+++ b/addons/l10n_ec_pos/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models

--- a/addons/l10n_ec_pos/__manifest__.py
+++ b/addons/l10n_ec_pos/__manifest__.py
@@ -1,0 +1,23 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Ecuadorian Point of Sale',
+    'countries': ['ec'],
+    'version': '1.0',
+    'category': 'Accounting/Localizations/Website',
+    'description': """Make Point of Sale work for Ecuador.""",
+    'depends': [
+        'point_of_sale',
+        'l10n_ec',
+    ],
+    'data': [
+        'views/pos_payment_method_views.xml',
+    ],
+    'assets': {
+        'web.assets_tests': [
+            'l10n_ec_pos/static/tests/**/*',
+        ],
+    },
+    'installable': True,
+    'auto_install': True,
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_ec_pos/models/__init__.py
+++ b/addons/l10n_ec_pos/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import pos_order
+from . import pos_payment_method

--- a/addons/l10n_ec_pos/models/pos_order.py
+++ b/addons/l10n_ec_pos/models/pos_order.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+from odoo import models
+
+class PosOrder(models.Model):
+    _inherit = "pos.order"
+
+    def _create_invoice(self, move_vals):
+        invoice = super(PosOrder, self)._create_invoice(move_vals)
+        if self.payment_ids:
+            sri_payment_methods = self.payment_ids.sudo().mapped('payment_method_id.l10n_ec_sri_payment_id')
+            if len(sri_payment_methods) == 1:
+                invoice.l10n_ec_sri_payment_id = sri_payment_methods
+        return invoice

--- a/addons/l10n_ec_pos/models/pos_payment_method.py
+++ b/addons/l10n_ec_pos/models/pos_payment_method.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+class PoSPaymentMethod(models.Model):
+    _inherit = 'pos.payment.method'
+
+    l10n_ec_sri_payment_id = fields.Many2one(
+        comodel_name="l10n_ec.sri.payment",
+        string="SRI Payment Method",
+    )
+
+    fiscal_country_codes = fields.Char(compute="_compute_fiscal_country_codes")
+
+    @api.depends_context('allowed_company_ids')
+    def _compute_fiscal_country_codes(self):
+        for record in self:
+            record.fiscal_country_codes = ",".join(self.env.companies.mapped('account_fiscal_country_id.code'))

--- a/addons/l10n_ec_pos/tests/__init__.py
+++ b/addons/l10n_ec_pos/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_frontend

--- a/addons/l10n_ec_pos/tests/test_frontend.py
+++ b/addons/l10n_ec_pos/tests/test_frontend.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
+
+
+@odoo.tests.tagged('post_install_l10n', 'post_install', '-at_install')
+class TestUi(TestPointOfSaleHttpCommon):
+    def test_ecuadorian_pos(self):
+        self.company_data["company"].country_id = self.env.ref("base.ec").id
+        bank = self.main_pos_config.payment_method_ids.filtered(lambda pm: pm.name == 'Bank')[0]
+        bank.l10n_ec_sri_payment_id = self.env['l10n_ec.sri.payment'].search([], limit=1)
+        self.main_pos_config.with_user(self.pos_user).open_ui()
+        current_session = self.main_pos_config.current_session_id
+        # I create a new PoS order with 2 lines
+        order = self.env['pos.order'].create({
+            'company_id': self.env.company.id,
+            'session_id': current_session.id,
+            'partner_id': self.partner_a.id,
+            'pricelist_id': self.partner_a.property_product_pricelist.id,
+            'lines': [(0, 0, {
+                'name': "OL/0001",
+                'product_id': self.desk_pad.id,
+                'price_unit': 50,
+                'discount': 0,
+                'qty': 1.0,
+                'tax_ids': False,
+                'price_subtotal': 50,
+                'price_subtotal_incl': 50,
+            })],
+            'amount_total': 50.0,
+            'amount_tax': 0.0,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+            'last_order_preparation_change': '{}',
+            'to_invoice': True,
+        })
+
+        payment_context = {"active_ids": order.ids, "active_id": order.id}
+        order_payment = self.env['pos.make.payment'].with_context(**payment_context).create({
+            'amount': order.amount_total,
+            'payment_method_id': bank.id
+        })
+        order_payment.with_context(**payment_context).check()
+        self.assertEqual(order.account_move.l10n_ec_sri_payment_id, bank.l10n_ec_sri_payment_id, "The SRI Payment Method should be set on the invoice")

--- a/addons/l10n_ec_pos/views/pos_payment_method_views.xml
+++ b/addons/l10n_ec_pos/views/pos_payment_method_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="pos_payment_method_view_form" model="ir.ui.view">
+        <field name="name">pos.payment.method.form</field>
+        <field name="model">pos.payment.method</field>
+        <field name="inherit_id" ref="point_of_sale.pos_payment_method_view_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_id']" position="after">
+                <field name="fiscal_country_codes" invisible="1"/>
+                <field name="l10n_ec_sri_payment_id" invisible="'EC' not in fiscal_country_codes"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Current behavior:
When trying to invoice an order from an Ecuadorian POS, you had an error because the SRI payment method was not set on the invoice.

Steps to reproduce:
- Install the l10n_ec module
- Open a POS session
- Create an order and invoice it
- You will get an error

To fix it we needed to create a new module to add the SRI payment method to the POS payment method and to the invoices.
To do this we needed to add a new field to the POS payment method model to allow the user to select the SRI payment method. Then we needed to set this SRI payment method on the invoice when invoicing an order from the POS.

This is based on what was done for the eCommerce here (https://github.com/odoo/odoo/pull/142730)

opw-3765274
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
