### PR TITLE
[FIX] sale: set a default qty_delivered on new sol

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -418,6 +418,9 @@ class SaleOrderLine(models.Model):
         mapping = lines_by_analytic._get_delivered_quantity_by_analytic([('amount', '<=', 0.0)])
         for so_line in lines_by_analytic:
             so_line.qty_delivered = mapping.get(so_line.id or so_line._origin.id, 0.0)
+        # add a default value of 0.0 to other records if necessary
+        for so_line in self-lines_by_analytic:
+            so_line.qty_delivered = so_line.qty_delivered or 0.0
 
     def _get_delivered_quantity_by_analytic(self, additional_domain):
         """ Compute and write the delivered quantity of current SO lines, based on their related


### PR DESCRIPTION
Steps to reproduce:
-
- Create an SO with an SOL and save the record.

**The `qty_delivered` of that SOL will be null in the DB.**

Cause of the issue:
-
Since the `qty_delivered` field is computed, the default value set in the DB comes from the `_compute_qty_delivered` method at record creation. However, no default value is set here when the `qty_delivered_method` is not `'analytic'`.

Fix:
-
In 15.0, a default value was set because of these lines: https://github.com/odoo/odoo/blob/313418804ae5cb6a786488ffc174b8eebffb796e/addons/sale/models/sale_order_line.py#L350-L353 These were removed by this commit de4911a which IMO was a mistake. We therefore introduce them back.

opw-3771589
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
