### PR TITLE
[FIX] hr_holidays: display employee information on allocation

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -136,6 +136,7 @@ class HolidaysAllocation(models.Model):
     max_leaves = fields.Float(compute='_compute_leaves')
     leaves_taken = fields.Float(compute='_compute_leaves', string='Time off Taken')
     taken_leave_ids = fields.One2many('hr.leave', 'holiday_allocation_id', domain="[('state', 'in', ['confirm', 'validate1', 'validate'])]")
+    employee_info = fields.Char(string="Employee Information", compute='_compute_employee_info', readonly=True)
 
     _sql_constraints = [
         ('type_value',
@@ -514,6 +515,23 @@ class HolidaysAllocation(models.Model):
             '|', ('date_to', '=', False), ('date_to', '>', fields.Datetime.now()),
             '|', ('nextcall', '=', False), ('nextcall', '<=', today)])
         allocations._process_accrual_plans()
+
+    @api.depends('employee_id', 'holiday_status_id')
+    def _compute_employee_info(self):
+        allocation_no_info = self.filtered(lambda a:
+            not a.employee_id or len(a.employee_id) > 1
+            or not a.holiday_status_id
+        )
+        allocation_no_info.employee_info = False
+        self = self - allocation_no_info
+
+        data_days = self.holiday_status_id.get_employees_days(self.employee_id.ids)
+        for allocation in self:
+            data = data_days[allocation.employee_id.id][allocation.holiday_status_id.id]
+            allocation.employee_info = _('%g remaining out of %g') % (
+                float_round(data.get('virtual_remaining_leaves', 0), precision_digits=2) or 0.0,
+                float_round(data.get('max_leaves', 0), precision_digits=2) or 0.0,
+            ) + (_(' hours') if allocation.type_request_unit == 'hour' else _(' days'))
 
     ####################################################
     # ORM Overrides methods

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -82,6 +82,7 @@
                         <group>
                             <field name="type_request_unit" invisible="1"/>
                             <field name="holiday_status_id" context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}" options="{'always_reload': True}"/>
+                            <field name="employee_info" attrs="{'invisible': [('employee_info', '=', False)]}" nolabel="1" colspan="2"/>
                             <field name="allocation_type" invisible="1" widget="radio"
                                 attrs="{'readonly': ['|', ('is_officer', '=', False), ('state', 'not in', ('draft', 'confirm'))]}"/>
                             <field name="is_officer" invisible="1"/>


### PR DESCRIPTION
Issue (display issue):
----------------------
Commit [^1] introduces a limitation which removes record related data from the context. As a result, `employee_id` is no longer passed when calling `name_get`. The result is that we no longer have access to the number of holidays the employee currently has on the form view of an allocation.

This poses a problem, for example, for people who need to validate allocations.

Solution:
---------
Add a compute no-stored field to dynamically construct a string containing information about the employee.

opw-3753011

[^1]: fa11f330b8554350a48a099669b5cf36421918b8