### PR TITLE
[FIX] pos_self_order: self order show receipt screen when nothing to pay

### DIFF
--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -167,6 +167,10 @@ export class SelfOrder extends Reactive {
         if (order.amount_total === 0 && order.lines.length > 0) {
             await this.sendDraftOrderToServer();
             this.confirmationPage("order", device);
+            await this.rpc(`/pos-self-order/make-payment-zero-amount-order`, {
+                order_id: order.id,
+                access_token: this.access_token,
+            });
             return;
         }
 
@@ -195,22 +199,10 @@ export class SelfOrder extends Reactive {
     }
 
     get currentOrder() {
-        if (
-            this.editedOrder &&
-            (this.editedOrder.state === "draft" ||
-                (this.editedOrder.state === "paid" &&
-                    this.editedOrder.amount_total === 0 &&
-                    this.config.self_ordering_mode === "kiosk"))
-        ) {
+        if (this.editedOrder && this.editedOrder.state === "draft") {
             return this.editedOrder;
         }
-        const existingOrder = this.orders.find(
-            (o) =>
-                o.state === "draft" ||
-                (o.state === "paid" &&
-                    o.amount_total === 0 &&
-                    this.config.self_ordering_mode === "kiosk")
-        );
+        const existingOrder = this.orders.find((o) => o.state === "draft");
         if (!existingOrder) {
             const newOrder = new Order({
                 pos_config_id: this.pos_config_id,
@@ -531,7 +523,10 @@ export class SelfOrder extends Reactive {
         this.notification.add(message, {
             type: "success",
         });
-        this.router.navigate("default");
+        this.router.navigate("confirmation", {
+            orderAccessToken: access_token,
+            screenMode: "order",
+        });
     }
 
     updateOrderFromServer(order) {


### PR DESCRIPTION
Before this commit:
===================
- If there is an order with a total amount of 0 in self-order, then after the cart page it is redirected to the home page without a confirmation page.
- Zero amount order is not sent to kitchen display in case of online payment for kiosk and self-order.
- Confirmation screen is not visible in case of online payment for self-order.

After this commit:
==================
- with this commit, if an order amount is 0 then it will redirect to the confirmation/receipt page like a normal order with the amount without redirecting to the payment page.
- Order will be displayed in the kitchen display.
- confirmation screen will displayed in case of online payment as well as paying at the cashier.

Task- 3782601

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
