### PR TITLE
[FIX] l10n_sa_edi: Compare date and not datetime

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_format.py
+++ b/addons/l10n_sa_edi/models/account_edi_format.py
@@ -436,11 +436,13 @@ class AccountEdiFormat(models.Model):
             errors.append(_set_missing_partner_fields(supplier_missing_info, _("Supplier")))
         if customer_missing_info:
             errors.append(_set_missing_partner_fields(customer_missing_info, _("Customer")))
+
         user_timezone = pytz.timezone(self.env.user.tz or 'utc')
         invoice_datetime = datetime.combine(invoice.invoice_date, datetime.min.time())
         user_invoice_datetime = user_timezone.localize(invoice_datetime)
-        utcnow = pytz.utc.localize(datetime.now())
-        if user_invoice_datetime > utcnow:
+        invoice_date_utc = user_invoice_datetime.astimezone(pytz.timezone('utc'))
+        # We should compare dates instead of datetime as it will result in inequalities.
+        if invoice_date_utc.date() > date.today():
             errors.append(_("- Please, make sure the invoice date is set to either the same as or before Today."))
         if invoice.move_type in ('in_refund', 'out_refund') and not invoice._l10n_sa_check_refund_reason():
             errors.append(


### PR DESCRIPTION
This commit [1] introduces a new way to compare the invoice date with the current date by using
the time zone (which is important).
The problem is that for now we're comparing datetime and we we should compare date instead.

[1]: https://github.com/odoo/odoo/commit/63c0f87349b4264f4f89284a7f9510745acb3801

no task id


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
