### PR TITLE
[FIX] stock: generate serial numbers for by-products

### DIFF
--- a/addons/stock/static/src/widgets/generate_serial.js
+++ b/addons/stock/static/src/widgets/generate_serial.js
@@ -32,7 +32,11 @@ export class GenerateDialog extends Component {
     async _onGenerate() {
         const count = parseInteger(this.nextSerialCount.el?.value || '0');
         const move_line_vals = await this.orm.call("stock.move", "action_generate_lot_line_vals", [
-            {...this.props.move.context, default_product_id: this.props.move.data.product_id[0]},
+            {...this.props.move.context,
+                default_product_id: this.props.move.data.product_id[0],
+                default_location_id: this.props.move.data.location_id[0],
+                default_location_dest_id: this.props.move.data.location_dest_id[0],
+            },
             this.props.type,
             this.nextSerial.el?.value,
             count,


### PR DESCRIPTION
Steps to reproduce:
-
- Create a storable product P1
- Create a storable product P2 with a tracking by unique serial numbers.
- Activate By-products in the settings.
- Create a BOM for P1, with a positive qty of P2 as a By-product.
- Create and confirm a manufacturing order for 1 unit of P1. Note: At this point, you will not be able to Produce ALL since the units of P2 do not have any serial numbers yet. We are going to add these.
- Go to the Shop Floor app
- Click on register P2 (for your MO) > Generate Serials
- Chose a First SN and click on Generate

**Traceback error : `location_dest_id` Key error in dictionary**

Cause of the issue:
-
Cliking on Generate will generate the serial numbers of the P2 products and will update the `stok.move.line` associated to these. To compute the `move_line_vals`, js will call the `action_generate_lot_line_vals` method of the `stock.move` model:
https://github.com/odoo/odoo/blob/aed0e74462b15085c09d9ab5ff029810f1238aeb/addons/stock/static/src/widgets/generate_serial.js#L34-L40 Some informations such as the `location_dest_id` of these stock move lines should be obtained from the context argument of this method call: https://github.com/odoo/odoo/blob/aed0e74462b15085c09d9ab5ff029810f1238aeb/addons/stock/models/stock_move.py#L883-L891 
However, no `default_location_dest_id` was passed in the context so that we will have a key error:
https://github.com/odoo/odoo/blob/aed0e74462b15085c09d9ab5ff029810f1238aeb/addons/stock/models/stock_move.py#L901

Fix:
-
To fix the traceback error, we add this `default_location_dest_id` in the context argument.

Second issue:
-
If we apply the same flow as before, we will now be able to generate the serial numbers of the P2 products. However, when clicking on save to properly update the `stock.move.lines` associated with our P2 products, a Validation error will be raised: update: the mandatory field `location_id` is not set in the stock move lines.

Cause of the issue:
-
The result of the `action_generate_lot_line_vals` is a dictionary that will be used to update the stock move lines in this method: https://github.com/odoo/odoo/blob/aed0e74462b15085c09d9ab5ff029810f1238aeb/addons/stock/static/src/widgets/generate_serial.js#L32 However, no values was provided to the `location_id` of the stock move lines.

Fix:
-
We have chosen to add the information of the `location_id` in the context argument of the `action_generate_lot_line_vals` method call and to update the output accordingly.

Alternatively we could have added the `location_id` directly in the `move_line_vals` in the JS. But it made more sense to me to ensure that the `action_generate_lot_line_vals` call was self sufficient.

opw-3790930
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
