### PR TITLE
[FIX] gs1_barcode_nomenclature: standardise js + python behaviour

### DIFF
--- a/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
+++ b/addons/barcodes_gs1_nomenclature/static/src/js/barcode_parser.js
@@ -169,6 +169,10 @@ BarcodeParser.include({
      */
     _convertGS1Separators: function (barcode) {
         barcode = barcode.replace(this.gs1SeparatorRegex, FNC1_CHAR);
+        if (barcode.charAt(0) === FNC1_CHAR) {
+            /** Code128 will have a start character, but is otherwise compatible */
+            barcode = barcode.substring(1);
+        }
         return barcode;
     },
 });

--- a/doc/cla/individual/gdgellatly.md
+++ b/doc/cla/individual/gdgellatly.md
@@ -8,4 +8,4 @@ declaration.
 
 Signed,
 
-Graeme Gellatly gdgellatly@gmail.com https://github.com/gdgellatly
+Graeme Gellatly graeme@o4sb.com https://github.com/gdgellatly


### PR DESCRIPTION
Prior to this change the Javascript barcode parser would substitute the gs1_separator regex with FNC1. However the python parser would either use the regex or FNC1 if no regex. This meant that FNC1 would not work with Python, which then lead to a rather weird default that included FNC1 which should be unnecessary.

Furthermore there is no justification for the regex default and it is likely to be problematic. Testing scanners from Honeywell, Datalogic, Zebra, Motorola and cheap brands ranging in age from new to 8 years all  have the option of sending Alt029 but is not standard. Also the entirely arbitrary choice of # in the default is problematic as it is not uncommon in variable length codes.

The simple fact is the vast majority of scanners do not require a different separator.

Finally, Code128 provides a start character, Odoo does not allow for this making 2 otherwise compatible schemes incompatible. So we strip the leading seperator if it is found.

OPW to come

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
