### PR TITLE
[FIX] website_sale: fix multi-checkbox selection with one value

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -360,13 +360,16 @@ class SaleOrderLine(models.Model):
         :return: the description related to special variant attributes/values
         :rtype: string
         """
-        if not self.product_custom_attribute_value_ids and not self.product_no_variant_attribute_value_ids:
+        no_variant_ptavs = self.product_no_variant_attribute_value_ids._origin.filtered(
+            # Only describe the attributes where a choice was made by the customer
+            lambda ptav: ptav.display_type == 'multi' or ptav.attribute_line_id.value_count > 1
+        )
+        if not self.product_custom_attribute_value_ids and not no_variant_ptavs:
             return ""
 
         name = "\n"
 
         custom_ptavs = self.product_custom_attribute_value_ids.custom_product_template_attribute_value_id
-        no_variant_ptavs = self.product_no_variant_attribute_value_ids._origin
         multi_ptavs = no_variant_ptavs.filtered(lambda ptav: ptav.display_type == 'multi').sorted()
 
         # display the no_variant attributes, except those that are also

--- a/addons/sale_product_configurator/models/product_template.py
+++ b/addons/sale_product_configurator/models/product_template.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models
+from odoo import fields, models
 
 
 class ProductTemplate(models.Model):
@@ -18,19 +18,6 @@ class ProductTemplate(models.Model):
              "whenever the customer hits *Add to Cart* (cross-sell strategy, "
              "e.g. for computers: warranty, software, etc.).",
         check_company=True)
-
-    @api.depends('attribute_line_ids.value_ids.is_custom', 'attribute_line_ids.attribute_id.create_variant')
-    def _compute_has_configurable_attributes(self):
-        """ A product is considered configurable if:
-        - It has dynamic attributes
-        - It has any attribute line with at least 2 attribute values configured
-        - It has at least one custom attribute value """
-        for product in self:
-            product.has_configurable_attributes = (
-                any(attribute.create_variant == 'dynamic' for attribute in product.attribute_line_ids.attribute_id)
-                or any(len(attribute_line_id.value_ids) >= 2 for attribute_line_id in product.attribute_line_ids)
-                or any(attribute_value.is_custom for attribute_value in product.attribute_line_ids.value_ids)
-            )
 
     def get_single_product_variant(self):
         """ Method used by the product configurator to check if the product is configurable or not.

--- a/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.js
+++ b/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.js
@@ -133,7 +133,12 @@ export class ProductTemplateAttributeLine extends Component {
             ptav => this.props.selected_attribute_value_ids.includes(ptav.id)
         )?.is_custom;
     }
-    
+
+    get showValuesChoice() {
+        return this.props.attribute_values.length > 1
+            || this.props.attribute.display_type == 'multi'
+    }
+
     /**
      * Check if the line has a custom ptav or not.
      *

--- a/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
+++ b/addons/sale_product_configurator/static/src/js/product_template_attribute_line/product_template_attribute_line.xml
@@ -9,10 +9,11 @@
              template are rendered. -->
             <div class="d-flex flex-column flex-lg-row gap-2 mb-2">
                 <label
-                    t-if="this.props.attribute_values.length === 1 &amp;&amp; isSelectedPTAVCustom() || this.props.attribute_values.length &gt; 1"
+                    t-if="showValuesChoice || (
+                        this.props.attribute_values.length === 1 &amp;&amp; isSelectedPTAVCustom())"
                     t-out="this.props.attribute.name"
                     t-attf-class="fw-bold text-break #{this.props.attribute_values.length === 1 &amp;&amp; hasPTAVCustom() ? '' : 'w-lg-25'}"/>
-                <t t-if="this.props.attribute_values.length > 1" t-call="{{getPTAVTemplate()}}"/>
+                <t t-if="showValuesChoice" t-call="{{getPTAVTemplate()}}"/>
             </div>
             <input
                 class="o_input w-75 mb-4 ms-lg-auto"

--- a/addons/sale_product_configurator/static/src/js/sale_product_field.js
+++ b/addons/sale_product_configurator/static/src/js/sale_product_field.js
@@ -28,7 +28,7 @@ async function applyProduct(record, product) {
     }
 
     const noVariantPTAVIds = product.attribute_lines.filter(
-        ptal => ptal.create_variant === "no_variant" && ptal.attribute_values.length > 1
+        ptal => ptal.create_variant === "no_variant"
     ).flatMap(ptal => ptal.selected_attribute_value_ids);
 
     await record.update({

--- a/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
+++ b/addons/test_sale_product_configurators/static/tests/tours/product_attribute_with_multi_type.js
@@ -1,0 +1,40 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("product_attribute_multi_type", {
+    url: "/web",
+    test: true,
+    steps: () => [stepUtils.showAppsMenuItem(),
+    {
+        content: "navigate to the sale app",
+        trigger: '.o_app[data-menu-xmlid="sale.sale_menu_root"]',
+    }, {
+        content: "create a new order",
+        trigger: '.o_list_button_add',
+        extra_trigger: ".o_sale_order"
+    }, {
+        content: "search the partner",
+        trigger: 'div[name="partner_id"] input',
+        run: 'text Azure'
+    }, {
+        content: "select the partner",
+        trigger: 'ul.ui-autocomplete > li > a:contains(Azure)',
+    }, {
+        content: "Add a product",
+        trigger: "a:contains('Add a product')",
+    }, {
+        trigger: 'div[name="product_template_id"] input',
+        run: 'text Big Burger'
+    }, {
+        content: "Choose item",
+        trigger: '.ui-menu-item-wrapper:contains("Big Burger")',
+    }, {
+        content: "Select the attribute value",
+        trigger: 'main.modal-body input[type="checkbox"]',
+    }, {
+        content: "Click on Confirm",
+        trigger: 'button:contains(Confirm)',
+    }, ...stepUtils.saveForm()
+]});

--- a/addons/website_sale/models/product_template_attribute_line.py
+++ b/addons/website_sale/models/product_template_attribute_line.py
@@ -18,7 +18,9 @@ class ProductTemplateAttributeLine(models.Model):
         The returned attributes are ordered as they appear in `self`, so based
         on the order of the attribute lines.
         """
-        single_value_lines = self.filtered(lambda ptal: len(ptal.value_ids) == 1)
+        single_value_lines = self.filtered(
+            lambda ptal: len(ptal.value_ids) == 1 and ptal.attribute_id.display_type != 'multi'
+        )
         single_value_attributes = OrderedDict([(pa, self.env['product.template.attribute.line']) for pa in single_value_lines.attribute_id])
         for ptal in single_value_lines:
             single_value_attributes[ptal.attribute_id] |= ptal

--- a/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_multi_checkbox.js
@@ -58,3 +58,37 @@ registry.category("web_tour.tours").add('tour_shop_multi_checkbox', {
         isCheck: true,
     },
 ]});
+
+registry.category("web_tour.tours").add('tour_shop_multi_checkbox_single_value', {
+    test: true,
+    url: '/shop?search=Burger',
+    steps: () => [
+    {
+        content: "select Product",
+        trigger: '.oe_product_cart a:containsExact("Burger")',
+    },
+    {
+        content: "check price",
+        trigger: '.oe_currency_value:contains("750")',
+        isCheck: true,
+    },
+    {
+        content: 'click on the first option to select it',
+        trigger: 'input[data-attribute_name="Toppings"][data-value_name="cheese"]',
+    },
+    {
+        content: "check price of options is correct",
+        trigger: '.oe_currency_value:contains("750")',
+        isCheck: true,
+    },
+    {
+        content: "add to cart",
+        trigger: 'a:contains(Add to cart)',
+    },
+        tourUtils.goToCart(),
+    {
+        content: "check choice was correctly saved",
+        trigger: '#cart_products div div.text-muted>span:contains("Toppings: cheese")',
+        isCheck: true,
+    },
+]});

--- a/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
@@ -23,12 +23,6 @@ registry.category("web_tour.tours").add('tour_shop_no_variant_attribute', {
     },
         tourUtils.goToCart(),
     {
-        content: "check no_variant value is present",
-        trigger: 'div>span:contains(No Variant Attribute: No Variant Value)',
-        extra_trigger: '#cart_products',
-        run: function () {},
-    },
-    {
         content: "check price is correct",
         trigger: 'div[name="website_sale_cart_line_price"]:contains(11.0)',
         run: function () {},

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -307,6 +307,12 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
 
         self.start_tour("/", 'tour_shop_no_variant_attribute', login="demo")
 
+        sol = self.env['sale.order.line'].search([
+            ('product_id', '=', product_template.product_variant_id.id)
+        ])
+        self.assertTrue(sol)
+        self.assertEqual(sol.product_no_variant_attribute_value_ids, ptal.product_template_value_ids)
+
     def test_06_admin_list_view_b2c(self):
         self.env.ref('product.group_product_variant').write({'users': [(4, self.env.ref('base.user_admin').id)]})
 
@@ -499,3 +505,26 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
 
     def test_11_shop_editor_set_product_ribbon(self):
         self.start_tour("/", 'shop_editor_set_product_ribbon', login="admin")
+
+    def test_12_multi_checkbox_attribute_single_value(self):
+        attribute = self.env['product.attribute'].create([
+            {
+                'name': 'Toppings',
+                'create_variant': 'no_variant',
+                'display_type': 'multi',
+                'value_ids': [(0, 0, {'name': 'cheese'})],
+            },
+        ])
+        self.env['product.template'].create({
+            'name': 'Burger',
+            'is_published': True,
+            'list_price': 750,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': attribute.id,
+                    'value_ids': [(6, 0, attribute.value_ids.ids)],
+                }),
+            ],
+        })
+
+        self.start_tour("/", 'tour_shop_multi_checkbox_single_value', login="admin")

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -8,7 +8,11 @@
                 <li t-att-data-attribute_id="ptal.attribute_id.id"
                     t-att-data-attribute_name="ptal.attribute_id.name"
                     t-att-data-attribute_display_type="ptal.attribute_id.display_type"
-                    t-attf-class="variant_attribute #{'d-none' if len(ptal.product_template_value_ids._only_active()) == 1 and not ptal.product_template_value_ids._only_active()[0].is_custom else ''}">
+                    t-attf-class="variant_attribute #{
+                        'd-none' if len(ptal.product_template_value_ids._only_active()) == 1
+                        and not ptal.product_template_value_ids._only_active()[0].is_custom
+                        and not ptal.attribute_id.display_type == 'multi' else ''
+                    }">
 
                     <!-- Used to customize layout if the only available attribute value is custom -->
                     <t t-set="single" t-value="len(ptal.product_template_value_ids._only_active()) == 1"/>
@@ -51,7 +55,7 @@
                                                 t-att-data-value_name="ptav.name"
                                                 t-att-data-attribute_name="ptav.attribute_id.name"
                                                 t-att-data-is_custom="ptav.is_custom"
-                                                t-att-data-is_single="single"
+                                                t-att-data-is_single="single if ptal.attribute_id.display_type != 'multi' else False"
                                                 t-att-data-is_single_and_custom="single_and_custom"/>
                                             <div class="radio_input_value form-check-label">
                                                 <span t-field="ptav.name"/>


### PR DESCRIPTION
**Steps:**
Go to Sales > Products > Products
Move to the tab of attributes and variants
Create a new attribute with display type as multi-checkbox Add only one value for the attribute created
Click on the website stat button

**Issue:**
When multi-checkbox has single value, it is not displayed on website

**Cause:**
Attributes selection is hidden if there is only one value available and it's not a custom value

**Fix:**
Disabling the feature of hiding attributes with single value when display type is multi-checkbox

**Affected Version:** 17.0 ~ master

**Task**-3753005