### PR TITLE
[FIX] stock: provide correct model to show move lines

### DIFF
--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -18,7 +18,7 @@ export class SMLX2ManyField extends X2ManyField {
         this.selectCreate = (params) => {
             return selectCreate(params);
         };
-        this.openRecord = useOpenMany2XRecord({
+        this.openQuantRecord = useOpenMany2XRecord({
             resModel: "stock.quant",
             activeActions: this.activeActions,
             onRecordSaved: (resId) => this.selectRecord([resId.data.id]),
@@ -56,7 +56,7 @@ export class SMLX2ManyField extends X2ManyField {
 
     createOpenRecord() {
         const activeElement = document.activeElement;
-        this.openRecord({
+        this.openQuantRecord({
             context: {
                 ...this.props.context,
                 form_view_ref: "stock.view_stock_quant_form",


### PR DESCRIPTION
### Steps to reproduce:
- Install **Manufacturing** app.
- Go to **Manufacturing** > **Manufacturing Orders**.
- Open a **Done** order
- Under the **components** tab, click on the details button (list icon).
- Click on one of the move lines to open it.
- An error arises: `Missing field string information for the field 'state' from the 'stock.quant' model`

### Investigation:
- the move lines are shown via https://github.com/odoo/odoo/blob/fd207320dff0bf6a91bf962fd3eb4da858d07854/addons/stock/views/stock_move_views.xml#L179-L182 notice the use of `sml_x2_many`
- and each move line is shown via https://github.com/odoo/odoo/blob/fd207320dff0bf6a91bf962fd3eb4da858d07854/addons/stock/views/stock_move_line_views.xml#L61 which uses a `stock.move.line` model
- However the stock `SMLX2ManyField` provides the `stock.quant` in `this.openRecord` instead causing the error of missing properties.

### Fix:
- follow v**17.0** and prevent opening the line in DONE state

opw-3789242