### PR TITLE
[IMP] project: collaborator-follower updates in project sharing

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -602,6 +602,7 @@ class ProjectProject(models.Model):
         return res
 
     def message_unsubscribe(self, partner_ids=None):
+        self.task_ids.message_unsubscribe(partner_ids=partner_ids)
         super().message_unsubscribe(partner_ids=partner_ids)
         if partner_ids:
             self.env['project.collaborator'].search([('partner_id', 'in', partner_ids), ('project_id', 'in', self.ids)]).unlink()

--- a/addons/project/tests/test_access_rights.py
+++ b/addons/project/tests/test_access_rights.py
@@ -208,8 +208,8 @@ class TestAllowedUsers(TestAccessRights):
         self.project_pigs.message_unsubscribe(partner_ids=[self.user.partner_id.id])
         self.assertIn(john.partner_id, self.task.message_partner_ids)
         self.assertNotIn(john.partner_id, task.message_partner_ids)
-        # Unsubscribing to a project should not cause unsubscription of existing tasks in the project.
-        self.assertIn(self.user.partner_id, task.message_partner_ids)
+        # Unsubscribing to a project should unsubscribing of existing tasks in the project.
+        self.assertNotIn(self.user.partner_id, task.message_partner_ids)
         self.assertNotIn(self.user.partner_id, self.task.message_partner_ids)
 
     def test_visibility_changed(self):

--- a/addons/project/wizard/project_share_wizard.py
+++ b/addons/project/wizard/project_share_wizard.py
@@ -114,6 +114,7 @@ class ProjectShareWizard(models.TransientModel):
             if collaborator_ids_to_add:
                 partners = project._get_new_collaborators(self.env['res.partner'].browse(collaborator_ids_to_add))
                 collaborator_ids_vals_list.extend(Command.create({'partner_id': partner_id}) for partner_id in partners.ids)
+                project.tasks.message_subscribe(partner_ids=partners.ids)
             if collaborator_ids_to_add_with_limited_access:
                 partners = project._get_new_collaborators(self.env['res.partner'].browse(collaborator_ids_to_add_with_limited_access))
                 collaborator_ids_vals_list.extend(


### PR DESCRIPTION
After this PR merge:

- Remove portal users from the list of collaborators if deleted from followers.
- If a collaborator is deleted from the list of collaborators, remove them from the followers list of all tasks.
-  When sharing a project should add the collaborator as a follower to all existing tasks.

task-3783469

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
