### PR TITLE
[FIX] account: fix traceback when creating new journal through payments

### DIFF
--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -205,7 +205,7 @@ class AccountPayment(models.Model):
         return lines
 
     def _get_valid_liquidity_accounts(self):
-        journal_comp = self.journal_id.company_id
+        journal_comp = self.journal_id.company_id or self.env.company
         accessible_branches = journal_comp.with_company(journal_comp)._accessible_branches()
         return (
             self.journal_id.default_account_id |


### PR DESCRIPTION
This traceback arises when the user tries to create a new journal from the payment.

To reproduce this issue:

1) Install `accounting`
2) Create a new payment from `Accounting/vendors/payments` 
3) save the record and now remove the `journal` or make the `journal` field empty
5) A traceback arises.

Error:- 
```
KeyError: ('res.company', <function Company.__accessible_branches at 0x7fabdfc69c60>, (1,), False, 2)
  File "odoo/tools/cache.py", line 99, in lookup
    r = d[key]
  File "<decorator-gen-8>", line 2, in __getitem__
  File "odoo/tools/func.py", line 87, in locked
    return func(inst, *args, **kwargs)
  File "odoo/tools/lru.py", line 34, in __getitem__
    a = self.d[obj]
ValueError: not enough values to unpack (expected 1, got 0)
  File "odoo/models.py", line 5941, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: res.company()
  File "odoo/http.py", line 2251, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1826, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1847, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1824, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1832, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2057, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 30, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 1074, in onchange
    todo = [
  File "addons/web/models/models.py", line 1077, in <listcomp>
    if field_name not in done and snapshot0.has_changed(field_name)
  File "addons/web/models/models.py", line 1190, in has_changed
    return self[field_name] != self.record[field_name]
  File "odoo/models.py", line 6664, in __getitem__
    return self._fields[key].__get__(self, self.env.registry[self._name])
  File "odoo/fields.py", line 1138, in __get__
    self.recompute(record)
  File "odoo/fields.py", line 1353, in recompute
    apply_except_missing(self.compute_value, recs)
  File "odoo/fields.py", line 1326, in apply_except_missing
    func(records)
  File "odoo/fields.py", line 1375, in compute_value
    records._compute_field_value(self)
  File "addons/mail/models/mail_thread.py", line 416, in _compute_field_value
    return super()._compute_field_value(field)
  File "odoo/models.py", line 4982, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 102, in determine
    return needle(*args)
  File "addons/account/models/account_payment.py", line 369, in _compute_reconciliation_status
    liquidity_lines, counterpart_lines, writeoff_lines = pay._seek_for_lines()
  File "addons/account/models/account_payment.py", line 192, in _seek_for_lines
    if line.account_id in self._get_valid_liquidity_accounts():
  File "addons/account/models/account_payment.py", line 211, in _get_valid_liquidity_accounts
    accessible_branches = journal_comp.with_company(journal_comp)._accessible_branches()
  File "odoo/addons/base/models/res_company.py", line 420, in _accessible_branches
    return self.browse(self.__accessible_branches())
  File "<decorator-gen-107>", line 2, in __accessible_branches
  File "odoo/tools/cache.py", line 104, in lookup
    value = d[key] = self.method(*args, **kwargs)
  File "odoo/addons/base/models/res_company.py", line 402, in __accessible_branches
    self.ensure_one()
  File "odoo/models.py", line 5944, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
```
When the user removes the journal, the company ID is taken from the journal, which leads to a traceback  from the line below.

https://github.com/odoo/odoo/blob/53d6d795ddf6cc9e470bfeb48bb31bc728acedbe/addons/account/models/account_payment.py#L207-L208

After applying this commit, resolve this issue by taking the default company, 
when there is no journal.

sentry-5054332731

