### PR TITLE
[IMP] web, base, *: remove cids from URL

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -982,7 +982,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
             return vals_list
         raise UserError(_('A time off cannot be duplicated.'))
 
-    def _get_mail_redirect_suggested_company(self):
+    def _get_redirect_suggested_company(self):
         return self.holiday_status_id.company_id
 
     ####################################################

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -709,7 +709,7 @@ class HolidaysAllocation(models.Model):
         if any(allocation.holiday_status_id.requires_allocation == 'yes' and allocation.leaves_taken > 0 for allocation in self):
             raise UserError(_('You cannot delete an allocation request which has some validated leaves.'))
 
-    def _get_mail_redirect_suggested_company(self):
+    def _get_redirect_suggested_company(self):
         return self.holiday_status_id.company_id
 
     ####################################################

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -427,21 +427,3 @@ class BaseModel(models.AbstractModel):
         end of the list.
         """
         return []
-
-# ------------------------------------------------------
-    # CONTROLLERS
-    # ------------------------------------------------------
-
-    def _get_mail_redirect_suggested_company(self):
-        """ Return the suggested company to be set on the context
-        in case of a mail redirection to the record. To avoid multi
-        company issues when clicking on a link sent by email, this
-        could be called to try setting the most suited company on
-        the allowed_company_ids in the context. This method can be
-        overridden, for example on the hr.leave model, where the
-        most suited company is the company of the leave type, as
-        specified by the ir.rule.
-        """
-        if 'company_id' in self:
-            return self.company_id
-        return False

--- a/addons/test_mail_full/tests/test_portal.py
+++ b/addons/test_mail_full/tests/test_portal.py
@@ -51,7 +51,7 @@ class TestPortalControllers(TestPortal):
 
         fragment = url_parse(response.url).fragment
         params = url_decode(fragment)
-        self.assertEqual(params['cids'], '%s' % self.user_admin.company_id.id)
+        self.assertEqual(response.request._cookies.get('cids'), '%s' % self.user_admin.company_id.id)
         self.assertEqual(params['id'], '%s' % self.record_portal.id)
         self.assertEqual(params['model'], self.record_portal._name)
 

--- a/addons/web/static/src/webclient/company_service.js
+++ b/addons/web/static/src/webclient/company_service.js
@@ -7,19 +7,15 @@ import { cookie } from "@web/core/browser/cookie";
 import { user } from "@web/core/user";
 import { router } from "@web/core/browser/router";
 
-const CIDS_SEARCH_SEPARATOR = "-";
+const CIDS_SEPARATOR = "-";
 
-function parseCompanyIds(cids, separator = ",") {
+function parseCompanyIds(cids, separator = CIDS_SEPARATOR) {
     if (typeof cids === "string") {
         return cids.split(separator).map(Number);
     } else if (typeof cids === "number") {
         return [cids];
     }
     return [];
-}
-
-function formatCompanyIds(cids, separator = ",") {
-    return cids.join(separator);
 }
 
 function computeActiveCompanyIds(cids) {
@@ -36,16 +32,19 @@ function computeActiveCompanyIds(cids) {
     return activeCompanyIds;
 }
 
-function getCompanyIdsFromBrowser(state) {
+function getCompanyIds() {
     let cids;
+    // backward compatibility, in old urls cid was still used.
+    // deprecated as of saas-17.3
+    const state = router.current;
     if ("cids" in state) {
         // backward compatibility s.t. old urls (still using "," as separator) keep working
         // deprecated as of 17.0
-        let separator = CIDS_SEARCH_SEPARATOR;
-        if (typeof state.cids === "string" && !state.cids.includes(CIDS_SEARCH_SEPARATOR)) {
-            separator = ",";
+        if (typeof state.cids === "string" && !state.cids.includes(CIDS_SEPARATOR)) {
+            cids = parseCompanyIds(state.cids, ",");
+        } else {
+            cids = parseCompanyIds(state.cids);
         }
-        cids = parseCompanyIds(state.cids, separator);
     } else if (cookie.get("cids")) {
         cids = parseCompanyIds(cookie.get("cids"));
     }
@@ -61,13 +60,10 @@ export const companyService = {
             ...allowedCompanies,
             ...disallowedAncestorCompanies,
         };
-        const activeCompanyIds = computeActiveCompanyIds(getCompanyIdsFromBrowser(router.current));
+        const activeCompanyIds = computeActiveCompanyIds(getCompanyIds());
 
         // update browser data
-        const cidsSearch = formatCompanyIds(activeCompanyIds, CIDS_SEARCH_SEPARATOR);
-        router.addLockedKey("cids");
-        router.replaceState({ cids: cidsSearch });
-        cookie.set("cids", formatCompanyIds(activeCompanyIds));
+        cookie.set("cids", activeCompanyIds.join(CIDS_SEPARATOR));
         user.updateContext({ allowed_company_ids: activeCompanyIds });
 
         // reload the page if changes are being done to `res.company`
@@ -121,14 +117,11 @@ export const companyService = {
                     );
                 }
 
-                const cidsSearch = formatCompanyIds(newCompanyIds, CIDS_SEARCH_SEPARATOR);
-                cookie.set("cids", formatCompanyIds(newCompanyIds));
+                cookie.set("cids", newCompanyIds.join(CIDS_SEPARATOR));
                 user.updateContext({ allowed_company_ids: newCompanyIds });
 
                 const controller = action.currentController;
-                const state = {
-                    cids: cidsSearch,
-                };
+                const state = {};
                 const options = { reload: true };
                 if (controller?.props.resId && controller?.props.resModel) {
                     let hasReadRights = true;

--- a/addons/web/static/tests/core/router.test.js
+++ b/addons/web/static/tests/core/router.test.js
@@ -61,10 +61,9 @@ describe("parseHash", () => {
     });
 
     test("can parse a realistic hash", () => {
-        expect(parseHash("#action=114&active_id=mail.box_inbox&cids=1&menu_id=91")).toEqual({
+        expect(parseHash("#action=114&active_id=mail.box_inbox&menu_id=91")).toEqual({
             action: 114,
             active_id: "mail.box_inbox",
-            cids: 1,
             menu_id: 91,
         });
     });
@@ -465,7 +464,9 @@ describe("stateToUrl", () => {
                     { active_id: 5, action: "module.xml_id", resId: 2 },
                 ],
             })
-        ).toBe("/odoo/action-module.xml_id/5/action-module.xml_id/2", { message: "actions as xml_ids" });
+        ).toBe("/odoo/action-module.xml_id/5/action-module.xml_id/2", {
+            message: "actions as xml_ids",
+        });
         // model
         expect(
             stateToUrl({ actionStack: [{ model: "some.model" }, { model: "other.model" }] })

--- a/addons/web/static/tests/legacy/webclient/company_service_tests.js
+++ b/addons/web/static/tests/legacy/webclient/company_service_tests.js
@@ -8,7 +8,7 @@ import { companyService } from "@web/webclient/company_service";
 import { makeTestEnv } from "../helpers/mock_env";
 import { patchWithCleanup } from "../helpers/utils";
 import { patchRPCWithCleanup } from "../helpers/mock_services";
-import { browser } from "@web/core/browser/browser";
+import { cookie } from "@web/core/browser/cookie";
 
 const serviceRegistry = registry.category("services");
 
@@ -68,7 +68,7 @@ QUnit.test(
     }
 );
 
-QUnit.test("extract allowed company ids from url search", async (assert) => {
+QUnit.test("extract allowed company ids from cookies", async (assert) => {
     patchWithCleanup(session.user_companies, {
         allowed_companies: {
             1: { id: 1, name: "Company 1", sequence: 1, parent_id: false, child_ids: [] },
@@ -79,19 +79,12 @@ QUnit.test("extract allowed company ids from url search", async (assert) => {
 
     serviceRegistry.add("company", companyService);
 
-    Object.assign(browser.location, { search: "cids=3-1" });
-    let env = await makeTestEnv();
+    cookie.set("cids", "3-1");
+    const env = await makeTestEnv();
     assert.deepEqual(
         Object.values(env.services.company.allowedCompanies).map((c) => c.id),
         [1, 2, 3]
     );
-    assert.deepEqual(env.services.company.activeCompanyIds, [3, 1]);
-    assert.strictEqual(env.services.company.currentCompany.id, 3);
-
-    // backward compatibility
-    registry.category("error_handlers").remove("accessErrorHandlerCompanies");
-    Object.assign(browser.location, { search: "cids=3%2C1" });
-    env = await makeTestEnv();
     assert.deepEqual(env.services.company.activeCompanyIds, [3, 1]);
     assert.strictEqual(env.services.company.currentCompany.id, 3);
 });

--- a/addons/web/static/tests/webclient/actions/client_action.test.js
+++ b/addons/web/static/tests/webclient/actions/client_action.test.js
@@ -271,12 +271,8 @@ test("test display_notification client action", async () => {
     });
     await animationFrame(); // wait for the notification to be displayed
     expect(".o_notification_manager .o_notification").toHaveCount(1);
-    expect(".o_notification_manager .o_notification .o_notification_title").toHaveText(
-        "title"
-    );
-    expect(".o_notification_manager .o_notification .o_notification_content").toHaveText(
-        "message"
-    );
+    expect(".o_notification_manager .o_notification .o_notification_title").toHaveText("title");
+    expect(".o_notification_manager .o_notification .o_notification_content").toHaveText("message");
     expect(".o_kanban_view").toHaveCount(1);
     await contains(".o_notification_close").click();
     expect(".o_notification_manager .o_notification").toHaveCount(0);
@@ -304,9 +300,7 @@ test("test display_notification client action with links", async () => {
     });
     await animationFrame(); // wait for the notification to be displayed
     expect(".o_notification_manager .o_notification").toHaveCount(1);
-    expect(".o_notification_manager .o_notification .o_notification_title").toHaveText(
-        "title"
-    );
+    expect(".o_notification_manager .o_notification .o_notification_title").toHaveText("title");
     expect(".o_notification_manager .o_notification .o_notification_content").toHaveText(
         "message test <R&D> <R&D>"
     );
@@ -362,8 +356,8 @@ test("test next action on display_notification client action", async () => {
 });
 
 test("test reload client action", async () => {
-    redirect("/odoo?cids=1&test=42");
-    browser.location.search = "?cids=1&test=42";
+    redirect("/odoo?test=42");
+    browser.location.search = "?test=42";
 
     patchWithCleanup(browser.location, {
         assign: (url) => {
@@ -408,20 +402,20 @@ test("test reload client action", async () => {
     });
     await runAllTimers();
     expect([
-        // "/odoo?cids=1&test=42", // This one was not push to the history because it's the current url (see router.js)
+        // "/odoo?test=42", // This one was not push to the history because it's the current url (see router.js)
         "window_reload",
-        "/odoo/action-2?cids=1",
+        "/odoo/action-2",
         "window_reload",
-        "/odoo?cids=1&menu_id=1",
+        "/odoo?menu_id=1",
         "window_reload",
-        "/odoo/action-1?cids=1&menu_id=2",
+        "/odoo/action-1?menu_id=2",
         "window_reload",
     ]).toVerifySteps();
 });
 
 test("test home client action", async () => {
-    redirect("/odoo?cids=1");
-    browser.location.search = "?cids=1";
+    redirect("/odoo");
+    browser.location.search = "";
 
     patchWithCleanup(browser.location, {
         assign: (url) => expect.step(`assign ${url}`),
@@ -439,5 +433,5 @@ test("test home client action", async () => {
     });
     await runAllTimers();
     await animationFrame();
-    expect(["/web/webclient/version_info", "assign /?cids=1"]).toVerifySteps();
+    expect(["/web/webclient/version_info", "assign /"]).toVerifySteps();
 });

--- a/addons/web/static/tests/webclient/actions/misc.test.js
+++ b/addons/web/static/tests/webclient/actions/misc.test.js
@@ -345,7 +345,6 @@ test("document's title is updated when an action is executed", async () => {
     let currentTitle = getService("title").getParts();
     expect(currentTitle).toEqual({});
     let currentState = router.current;
-    expect(currentState).toEqual({ cids: 1 });
     await getService("action").doAction(4);
     await animationFrame();
     currentTitle = getService("title").getParts();
@@ -360,7 +359,6 @@ test("document's title is updated when an action is executed", async () => {
                 view_type: "kanban",
             },
         ],
-        cids: 1,
     });
 
     await getService("action").doAction(8);
@@ -382,7 +380,6 @@ test("document's title is updated when an action is executed", async () => {
                 view_type: "list",
             },
         ],
-        cids: 1,
     });
 
     await contains(".o_data_row .o_data_cell").click();
@@ -411,7 +408,6 @@ test("document's title is updated when an action is executed", async () => {
                 view_type: "form",
             },
         ],
-        cids: 1,
     });
 });
 

--- a/addons/web/static/tests/webclient/actions/window_action.test.js
+++ b/addons/web/static/tests/webclient/actions/window_action.test.js
@@ -638,7 +638,6 @@ test.tags("desktop")("A new form view can be reloaded after a failed one", async
                 view_type: "list",
             },
         ],
-        cids: 1,
     });
 
     // Click on the first record

--- a/odoo/addons/test_access_rights/tests/test_feedback.py
+++ b/odoo/addons/test_access_rights/tests/test_feedback.py
@@ -168,6 +168,7 @@ class TestIRRuleFeedback(Feedback):
         cls.record = cls.env['test_access_right.some_obj'].create({
             'val': 0,
         }).with_user(cls.user)
+        cls.maxDiff = None
 
     def _make_rule(self, name, domain, global_=False, attr='write'):
         res = self.env['ir.rule'].create({
@@ -328,8 +329,6 @@ Sorry, %s (id=%s) doesn't have 'write' access to:
 Blame the following rules:
 - rule 0
 
-Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!
-
 If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies."""
         % (self.user.name, self.user.id, self.record._description, self.record.display_name, self.record._name, self.record.id))
 
@@ -361,8 +360,6 @@ Sorry, %s (id=%s) doesn't have 'read' access to:
 Blame the following rules:
 - rule 0
 
-Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!
-
 If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies."""
         % (self.user.name, self.user.id, child_record._description, child_record.display_name, child_record._name, child_record.id))
 
@@ -385,10 +382,10 @@ Sorry, %s (id=%s) doesn't have 'read' access to:
 Blame the following rules:
 - rule 0
 
-Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!
+If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.
 
-If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies."""
-        % (self.user.name, self.user.id, self.record._description, self.record.display_name, self.record._name, self.record.id, self.record.sudo().company_id.display_name))
+This seems to be a multi-company issue, you might be able to access the record by switching to the company: %s."""
+        % (self.user.name, self.user.id, self.record._description, self.record.display_name, self.record._name, self.record.id, self.record.sudo().company_id.display_name, self.record.sudo().company_id.display_name))
         p = self.env['test_access_right.inherits'].create({'some_id': self.record.id})
         self.env.flush_all()
         self.env.invalidate_all()
@@ -397,6 +394,38 @@ If you really, really need access, perhaps you can win over your friendly admini
             r"Implicitly accessed through 'Object for testing related access rights' \(test_access_right.inherits\)\.",
         ):
             p.with_user(self.user).val
+
+    def test_warn_company_access_multi_record(self):
+        """ Test that AccessError handle correctly several companies """
+        company_1, company_2 = self.env['res.company'].create([
+            {'name': 'Brosse Inc.'},
+            {'name': 'Brosse Inc. 2'},
+        ])
+        records = self.env["test_access_right.some_obj"].create([
+            {"val": 1, "company_id": company_1.id},
+            {"val": 2, "company_id": company_2.id},
+        ])
+        record_1, record_2 = records
+        self.user.sudo().company_ids = [Command.link(company_1.id), Command.link(company_2.id)]
+        self._make_rule('rule 0', "[('company_id', '=', False)]", attr='read')
+        self.env.invalidate_all()
+        with self.debug_mode(), self.assertRaises(AccessError) as ctx:
+            _ = records.with_user(self.user).read(["val"])
+        self.assertEqual(
+            ctx.exception.args[0],
+            f"""Uh-oh! Looks like you have stumbled upon some top-secret records.
+
+Sorry, {self.user.name} (id={self.user.id}) doesn't have 'read' access to:
+- {record_1._description}, {record_1.display_name} ({record_1._name}: {record_1.id}, company={record_1.company_id.display_name})
+- {record_2._description}, {record_2.display_name} ({record_2._name}: {record_2.id}, company={record_2.company_id.display_name})
+
+Blame the following rules:
+- rule 0
+
+If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.
+
+Note: this might be a multi-company issue. Switching company may help - in Odoo, not in real life!""")
+
 
 class TestFieldGroupFeedback(Feedback):
 

--- a/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
+++ b/odoo/addons/test_main_flows/static/tests/tours/test_company_access_error_redirect_tour.js
@@ -1,0 +1,38 @@
+/** @odoo-module **/
+import { cookie } from "@web/core/browser/cookie";
+import { registry } from "@web/core/registry";
+
+function assertEqual(actual, expected) {
+    if (actual !== expected) {
+        throw new Error(`Assert failed: expected: ${expected} ; got: ${actual}`);
+    }
+}
+
+registry.category("web_tour.tours").add("test_company_access_error_redirect", {
+    test: true,
+    steps: () => [
+        {
+            trigger: ".o_form_view .o_last_breadcrumb_item:contains(p2)",
+            isCheck: true,
+        },
+        {
+            trigger: ".o_switch_company_menu button",
+        },
+        {
+            trigger: ".o-dropdown--menu",
+            run() {
+                assertEqual(
+                    document.querySelectorAll(".o-dropdown-item .toggle_company[aria-checked=true]")
+                        .length,
+                    2
+                );
+                assertEqual(
+                    cookie.get("cids"),
+                    [...document.querySelectorAll(".o-dropdown-item [data-company-id]")]
+                        .flatMap((x) => x.getAttribute("data-company-id"))
+                        .join("-")
+                );
+            },
+        },
+    ],
+});

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -5774,6 +5774,20 @@ class BaseModel(metaclass=MetaModel):
     def _unregister_hook(self):
         """ Clean up what `~._register_hook` has done. """
 
+    def _get_redirect_suggested_company(self):
+        """Return the suggested company to be set on the context
+        in case of a URL redirection to the record. To avoid multi
+        company issues when clicking on a shared link, this
+        could be called to try setting the most suited company on
+        the allowed_company_ids in the context. This method can be
+        overridden, for example on the hr.leave model, where the
+        most suited company is the company of the leave type, as
+        specified by the ir.rule.
+        """
+        if 'company_id' in self:
+            return self.company_id
+        return False
+
     #
     # Instance creation
     #


### PR DESCRIPTION
*: [hr_holidays, mail, test_mail, test_access_rights, test_main_flows,
exceptions, http, models]

The aim of this commit is to remove the companies IDs from the URL, and
use only the cookies to store the selected companies.
This commit will also improve the handling of access errors. If a user
encounters an access error, if one of its allowed companies has access
to the record, a button to switch to the correct company is shown.

The purpose of this is double: to have more human-readable URLs (part of
the task id : 3557575), and to avoid modifying the current selected
companies when clicking on a shared URL.

Note that this commit also modify the way the companies IDs are encoded
on the cookies. Before this commit, the IDs were separated by a comma
(",") and they were encoded as \054 by the server side but not by the
client side. Now, we use a dash ("-") to have the same encoding in both,
server side and client side.

task-id 3792021

Co-authored-by: Damien Bouvy <dbo@odoo.com>
