### PR TITLE
[FIX] sale_purchase_stock_margin: MTO update margins

### DIFF
--- a/addons/sale_stock_margin/models/sale_order_line.py
+++ b/addons/sale_stock_margin/models/sale_order_line.py
@@ -7,10 +7,14 @@ from odoo import api, fields, models
 class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
-    @api.depends('move_ids', 'move_ids.stock_valuation_layer_ids', 'move_ids.picking_id.state')
+    @api.depends('move_ids', 'move_ids.stock_valuation_layer_ids', 'move_ids.picking_id.state',
+    'product_id.standard_price')
     def _compute_purchase_price(self):
         lines_without_moves = self.browse()
+        manual_cost = self.env['ir.config_parameter'].get_param('sale_stock_margin.manual_cost')
         for line in self:
+            if line.purchase_price and manual_cost:
+                continue
             product = line.product_id.with_company(line.company_id)
             if not line.move_ids:
                 lines_without_moves |= line

--- a/addons/sale_stock_margin/tests/test_sale_stock_margin.py
+++ b/addons/sale_stock_margin/tests/test_sale_stock_margin.py
@@ -170,6 +170,7 @@ class TestSaleStockMargin(TestStockValuationCommon):
 
     def test_sale_stock_margin_6(self):
         """ Test that the purchase price doesn't change when there is a service product in the SO"""
+        self.env['ir.config_parameter'].set_param('sale_stock_margin.manual_cost', True)
         service = self.env['product.product'].create({
             'name': 'Service',
             'type': 'service',


### PR DESCRIPTION
Steps to reproduce:
- Enable Sale Margin in Sales Configuration
- Create an SO for an MTO product (FIFO/automated valuation)
- Confirm PO and receive product
- Cost/margins updated correctly on SO line
- Create a bill for the PO with a different price
- Cost is not updated

Fix:
retrigger the compute for purchase price when stock valuation of the linked PO moves are updated

opw-3745893

