### PR TITLE
[IMP] payment: translate payment methods

### DIFF
--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -10,7 +10,7 @@ class PaymentMethod(models.Model):
     _description = "Payment Method"
     _order = 'active desc, sequence, name'
 
-    name = fields.Char(string="Name", required=True)
+    name = fields.Char(string="Name", required=True, translate=True)
     code = fields.Char(
         string="Code", help="The technical code of this payment method.", required=True
     )


### PR DESCRIPTION
Previously, payment methods were not translatable and could appear untranslated to the user.

opw-3766515