### PR TITLE
[FIX] hw_drivers: Delete old iot_handlers

### DIFF
--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -285,6 +285,18 @@ def load_certificate():
     subprocess.check_call(["sudo", "service", "nginx", "restart"])
     return True
 
+def unlink_iot_handlers():
+    """
+    Unlink the drivers, interfaces and the contents of "lib" folder
+    """
+    try:
+        subprocess.run(["rm", "-rf", "/home/pi/odoo/addons/hw_drivers/iot_handlers/drivers/*"], check=True)
+        subprocess.run(["rm", "-rf", "/home/pi/odoo/addons/hw_drivers/iot_handlers/interfaces/*"], check=True)
+        subprocess.run(["rm", "-rf", "/home/pi/odoo/addons/hw_drivers/iot_handlers/lib/*"], check=True)
+        _logger.info("Deleted old iot_handlers")
+    except subprocess.CalledProcessError:
+        _logger.exception("Failed to unlink iot_handlers")
+
 def download_iot_handlers(auto=True):
     """
     Get the drivers from the configured Odoo server
@@ -298,6 +310,7 @@ def download_iot_handlers(auto=True):
             resp = pm.request('POST', server, fields={'mac': get_mac_address(), 'auto': auto})
             if resp.data:
                 subprocess.call(["sudo", "mount", "-o", "remount,rw", "/"])
+                unlink_iot_handlers()
                 drivers_path = Path.home() / 'odoo/addons/hw_drivers/iot_handlers'
                 zip_file = zipfile.ZipFile(io.BytesIO(resp.data))
                 zip_file.extractall(drivers_path)


### PR DESCRIPTION
Currently, on IoT Box when we change db from one version to another we simply download new drivers and interfaces. Since we don't delete those already present on the IoT Box this can lead to a situation where we have two conflicting versions of drivers/interfaces.

We need to delete all the present drivers and interfaces from the virtual IoT before downloading the new ones

task-3729890

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
