### PR TITLE
[FIX] calendar: quick create event duration

### DIFF
--- a/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
+++ b/addons/calendar/static/src/views/calendar_form/calendar_quick_create.js
@@ -15,7 +15,8 @@ const QUICK_CREATE_CALENDAR_EVENT_FIELDS = {
     allday: { type: "boolean" },
     partner_ids: { type: "many2many" },
     videocall_location: { type: "string" },
-    description: { type: "string" }
+    description: { type: "string" },
+    duration: { type: "Number" },
 };
 
 function getDefaultValuesFromRecord(data) {
@@ -45,6 +46,8 @@ export class CalendarQuickCreateFormController extends CalendarFormController {
 
     goToFullEvent() {
         const context = getDefaultValuesFromRecord(this.model.root.data)
+        const milliseconds_diff = new Date(context['default_stop']) - new Date(context['default_start']);
+        context['default_duration'] = milliseconds_diff / (1000 * 60 * 60);
         this.props.goToFullEvent(context);
     }
 }


### PR DESCRIPTION
Before this commit when creating an event using quick create view, and changing the event stop time. the event duration didn't update at all. 
This commit aims to fix this issue by

- adding duration to the context when moving from quick_create to the full event view.

Task: 3681668
