### PR TITLE
[FIX] point_of_sale: fix traceback when the user tries to modify pricelists

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -429,8 +429,8 @@ class PosConfig(models.Model):
                         continue
                     if key == 'use_pricelist' and vals[key]:
                         continue
-                    if key == 'available_pricelist_ids':
-                        removed_pricelist = set(self.available_pricelist_ids.ids) - set(vals[key][0][2])
+                    if key == 'available_pricelist_ids' and vals[key]:
+                        removed_pricelist = set(self.available_pricelist_ids.ids) - {pricelist_ids[1] for pricelist_ids in vals[key]}
                         if len(removed_pricelist) == 0:
                             continue
                     field_name = self._fields[key].get_description(self.env)["string"]

--- a/addons/point_of_sale/tests/test_pos_basic_config.py
+++ b/addons/point_of_sale/tests/test_pos_basic_config.py
@@ -7,6 +7,7 @@ from odoo import fields
 from odoo.addons.point_of_sale.tests.common import TestPoSCommon
 from freezegun import freeze_time
 from dateutil.relativedelta import relativedelta
+from odoo.exceptions import UserError
 
 
 @odoo.tests.tagged('post_install', '-at_install')
@@ -547,6 +548,17 @@ class TestPoSBasicConfig(TestPoSCommon):
                 ],
             },
         })
+
+    def test_avilable_pricelist_ids_with_session_open(self):
+        # Test POS by adding a new pricelist while the session is open
+        new_pricelist_1 = self.env['product.pricelist'].create({
+            'name': 'New Pricelist 1',
+            'currency_id': self.other_currency.id,
+        })
+        self.open_new_session()
+
+        with self.assertRaises(UserError):
+            self.config.write({'available_pricelist_ids': [(4, new_pricelist_1.id)]})
 
     def test_rounding_method(self):
         # set the cash rounding method


### PR DESCRIPTION
Currently traceback is occurring in sentry when the user tries to modify the `avilable_pricelist_id` 
when the session is open.

steps to produce:-

1) Install `POS`
2) open POS and duplicate the tab
3) In the first tab open the settings of POS from the configuration
4) In another tab open a session from the POS dashboard
5) Now in the first tab save the record by applying some changes 
6) Traceback occurs

Traceback in sentry:
```
IndexError: list index out of range
  File "odoo/http.py", line 2251, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1826, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1847, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1824, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1832, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2057, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 30, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 74, in web_save
    self = self.create(vals)
  File "<decorator-gen-308>", line 2, in create
  File "odoo/api.py", line 420, in _model_create_multi
    return create(self, [arg])
  File "addons/point_of_sale/models/res_config_settings.py", line 155, in create
    pos_config.with_context(from_settings_view=True).write(pos_fields_vals)
  File "addons/point_of_sale/models/pos_config.py", line 433, in write
    removed_pricelist = set(self.available_pricelist_ids.ids) - set(vals[key][0][2])
```

After applying this commit will resolve this issue by making the code robust with an extra check 
of the `avilable_pricelist_id` value in vals.

sentry-4630816379
