### PR TITLE
[FIX] point_of_sale: translate partner editor

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.js
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.js
@@ -31,6 +31,15 @@ export class PartnerDetailsEdit extends Component {
             vat: partner.vat || "",
             property_product_pricelist: this.setDefaultPricelist(partner),
         });
+        this.translatedItems = {
+            'Street': _t('Street'),
+            'City': _t('City'),
+            'Zip': _t('Zip'),
+            'Email': _t('Email'),
+            'Phone': _t('Phone'),
+            'Mobile': _t('Mobile'),
+            'Barcode': _t('Barcode')
+        }
         Object.assign(this.props.imperativeHandle, {
             save: () => this.saveChanges(),
         });

--- a/addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.xml
+++ b/addons/point_of_sale/static/src/app/screens/partner_list/partner_editor/partner_editor.xml
@@ -18,13 +18,13 @@
                 <div class="partner-details-box row row-cols-1 row-cols-sm-2 gy-3 mt-3">
                     <t t-foreach="['Street', 'City', 'Zip', 'Email', 'Phone', 'Mobile', 'Barcode' ]" t-as="item" t-key="item">
                         <div class="partner-detail col">
-                            <label class="form-label label" t-attf-for="{{item}}" t-esc="item"/>
+                            <label class="form-label label" t-attf-for="{{item}}" t-esc="translatedItems[item]"/>
                             <input
                                 class="detail form-control"
                                 t-attf-id="{{item}}"
                                 t-attf-name="{{item}}"
                                 t-model="changes[item.toLowerCase()]"
-                                t-attf-placeholder="{{item}}"
+                                t-attf-placeholder="{{translatedItems[item]}}"
                                 t-att="{'disabled': isFieldCommercialAndPartnerIsChild(item)}"
                                 t-att-class="{'border-danger': missingFields.includes(item.toLowerCase())}" />
                         </div>


### PR DESCRIPTION
Steps
-----
1. In a POS session, with a language different than english, create a new client or edit the details of a client. 
** Some of the fields are not translated **


**opw-3793566**