### PR TITLE
[FIX] calendar: fix chatter message error in the private event

### DIFF
--- a/addons/calendar/static/src/thread_patch.js
+++ b/addons/calendar/static/src/thread_patch.js
@@ -1,0 +1,24 @@
+/* @odoo-module */
+
+import { Thread } from "@mail/core_ui/thread";
+import { patch } from "@web/core/utils/patch";
+import { useService } from "@web/core/utils/hooks";
+import { onWillStart } from "@odoo/owl";
+
+patch(Thread.prototype, "calendar", {
+    setup() {
+        this._super();
+        this.orm = useService("orm");
+        this.user = useService("user");
+        onWillStart(async () => {
+            if (this.props.thread.model === 'calendar.event' && this.props.thread.id) {
+                const record = await this.orm.read(
+                    'calendar.event',
+                    [this.props.thread.id],
+                    ['privacy', 'user_id', 'partner_ids']
+                );
+                this.isAccesible = record[0].privacy === 'private' && !(this.user.userId === record[0].user_id[0]) && !(record[0].partner_ids.includes(this.user.partnerId));
+            }
+        });
+    },
+});

--- a/addons/calendar/static/src/thread_patch.xml
+++ b/addons/calendar/static/src/thread_patch.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-inherit="mail.Thread.loadingError" t-inherit-mode="extension">
+        <xpath expr="//div" position="replace">
+            <div class="d-flex flex-grow-1 align-items-center justify-content-center flex-column">
+                <t t-if="props.thread.model === 'calendar.event' and this.isAccesible">
+                    This event is private.
+                </t>
+                <t t-else="">
+                    <div class="o-mail-Thread-error">
+                        An error occurred while fetching messages.
+                    </div>
+                    <button class="btn btn-link" t-on-click="onClickLoadOlder">
+                        Click here to retry
+                    </button>
+                </t>
+            </div>
+        </xpath>
+    </t>
+    <t t-inherit="mail.Thread" t-inherit-mode="extension">
+        <xpath expr="//t[@t-if='props.thread.isLoaded']/t[@t-else='']" position="replace">
+            <t t-if="props.thread.model === 'calendar.event' and this.isAccesible">
+                This event is private.
+            </t>
+            <t t-else="">
+                There are no messages in this conversation.
+            </t>
+        </xpath>
+    </t>
+</templates>


### PR DESCRIPTION
### Version
- saas-16.3

### Steps to reproduce
- Create a event for one user with privacy as `private`
- Login with other user who is not attendee and try to open event

### Issue
-  A chatter error message ('An error occurred while fetching messages') 
will be displayed when the user tries to consult another user's private event 
because of access restrictions.

### Solution
- Replace the error message with an updated message stating 'This event is private' 
when attempting to view another user's private events.

task-3667696





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
