### PR TITLE
[IMP] hr, resource: Configure working calendars as flexible

### DIFF
--- a/addons/hr/models/hr_employee_base.py
+++ b/addons/hr/models/hr_employee_base.py
@@ -46,6 +46,8 @@ class HrEmployeeBase(models.AbstractModel):
     share = fields.Boolean(related='user_id.share')
     resource_id = fields.Many2one('resource.resource')
     resource_calendar_id = fields.Many2one('resource.calendar', check_company=True)
+    is_flexible = fields.Boolean(compute='_compute_is_flexible', store=True)
+    is_fully_flexible = fields.Boolean(compute='_compute_is_flexible', store=True)
     parent_id = fields.Many2one('hr.employee', 'Manager', compute="_compute_parent_id", store=True, readonly=False,
         domain="['|', ('company_id', '=', False), ('company_id', 'in', allowed_company_ids)]")
     coach_id = fields.Many2one(
@@ -262,6 +264,12 @@ class HrEmployeeBase(models.AbstractModel):
         for employee in self:
             employee.hr_icon_display = 'presence_' + employee.hr_presence_state
             employee.show_hr_icon_display = bool(employee.user_id)
+
+    @api.depends('resource_calendar_id')
+    def _compute_is_flexible(self):
+        for employee in self:
+            employee.is_fully_flexible = not employee.resource_calendar_id
+            employee.is_flexible = employee.is_fully_flexible or employee.resource_calendar_id.flexible_hours
 
     @api.model
     def _get_employee_working_now(self):

--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -326,7 +326,7 @@ class Contract(models.Model):
                 contract.state = 'close'
 
         if 'resource_calendar_id' in vals:
-            calendar = vals['resource_calendar_id']  # when False (fully flexible), sync the employee's calendar as well to False
+            calendar = vals['resource_calendar_id']
             self.filtered(
                 lambda c: c.state == 'open' or (c.state == 'draft' and c.kanban_state == 'done' and c.employee_id.contracts_count == 1)
             ).employee_id.resource_calendar_id = calendar

--- a/addons/hr_contract/tests/test_calendar_sync.py
+++ b/addons/hr_contract/tests/test_calendar_sync.py
@@ -25,11 +25,27 @@ class TestContractCalendars(TestContractCommon):
             'state': 'close',
         })
 
+        cls.contract_fully_flexible = cls.env['hr.contract'].create({
+            'date_end': Date.to_date('2015-11-15'),
+            'date_start': Date.to_date('2015-01-01'),
+            'name': 'Fully Flexible Contract for Richard',
+            'resource_calendar_id': False,
+            'wage': 5000.0,
+            'state': 'close',
+        })
+
     def test_contract_state_incoming_to_open(self):
         # Employee's calendar should change
         self.assertEqual(self.employee.resource_calendar_id, self.calendar_richard)
         self.contract_cdd.state = 'open'
         self.assertEqual(self.employee.resource_calendar_id, self.contract_cdd.resource_calendar_id, "The employee should have the calendar of its contract.")
+
+    def test_set_fully_flexible_contract_should_change_resource_calendar(self):
+        # Setting a running contract with fully flexible calendar should set the employee's calendar to False (fully flexible)
+        self.assertEqual(self.employee.resource_calendar_id, self.calendar_richard)
+        self.employee.contract_id = self.contract_fully_flexible
+        self.contract_fully_flexible.state = 'open'
+        self.assertFalse(self.employee.resource_calendar_id, "The employee should have a fully flexible calendar.")
 
     def test_contract_transfer_leaves(self):
 

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -18,7 +18,7 @@
                         <field name="calendar_mismatch" invisible="1"/>
                         <label for="resource_calendar_id"/>
                         <div class="d-flex align-items-center">
-                            <field name="resource_calendar_id" help="The default working hours are set in configuration."/>
+                            <field name="resource_calendar_id" help="The default working hours are set in configuration." placeholder="Fully Flexible"/>
                             <widget name="contract_warning_tooltip"
                                 invisible="not calendar_mismatch"/>
                         </div>
@@ -41,7 +41,11 @@
                             icon="fa-book"
                             type="object"
                             groups="hr_contract.group_hr_contract_manager"
-                            context="{'default_employee_id': id}"
+                            context="{
+                                'default_employee_id': id,
+                                'default_resource_calendar_id': resource_calendar_id.id or False,
+                                'from_action_open_contract': True,
+                            }"
                             invisible="employee_type not in ['employee', 'student', 'trainee']">
                             <div invisible="not first_contract_date" class="o_stat_info">
                                 <span class="o_stat_text text-success" invisible="contract_warning" title="In Contract Since"> In Contract Since</span>
@@ -203,11 +207,11 @@
                                 <div id="resource_calendar_warning" class="d-flex align-items-center">
                                         <field name="resource_calendar_id"
                                             groups="!hr_contract.group_hr_contract_manager"
-                                            required="1"
+                                            placeholder="Fully Flexible"
                                             options="{'no_open': True, 'no_create': True}"/>
                                         <field name="resource_calendar_id"
                                             groups="hr_contract.group_hr_contract_manager"
-                                            required="1"/>
+                                            placeholder="Fully Flexible"/>
                                         <widget
                                             name="contract_warning_tooltip"
                                             invisible="not calendar_mismatch or state != 'open'"/>

--- a/addons/hr_contract/views/resource_calendar_views.xml
+++ b/addons/hr_contract/views/resource_calendar_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <field name="contracts_count"/>
+                <field name="full_time_required_hours" widget="float_time" optional="hide"/>
             </field>
         </field>
     </record>

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1145,7 +1145,14 @@ class TestLeaveRequests(TestHrHolidaysCommon):
     def test_undefined_working_hours(self):
         """ Ensure time-off can also be allocated without ResourceCalendar. """
         employee = self.employee_emp
-        employee.resource_calendar_id = False
+
+        # set a flexible working schedule
+        calendar = self.env['resource.calendar'].create({
+            'name': 'Flexible 40h/week',
+            'hours_per_day': 8.0,
+            'flexible_hours': True,
+        })
+        employee.resource_calendar_id = calendar
         allocation = self.env['hr.leave.allocation'].create({
             'name': 'Annual Time Off',
             'employee_id': employee.id,

--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -174,8 +174,8 @@ class HrContract(models.Model):
             employee = contract.employee_id
             calendar = contract.resource_calendar_id
             resource = employee.resource_id
-            tz = pytz.timezone(calendar.tz)
-
+            # if the contract is fully flexible, we refer to the employee's timezone
+            tz = pytz.timezone(resource.tz) if contract._is_fully_flexible() else pytz.timezone(calendar.tz)
             attendances = attendances_by_resource[resource.id]
 
             # Other calendars: In case the employee has declared time off in another calendar

--- a/addons/hr_work_entry_contract/models/hr_contract.py
+++ b/addons/hr_work_entry_contract/models/hr_contract.py
@@ -33,6 +33,12 @@ class HrContract(models.Model):
         Planning: Work entries will be generated from the employee's planning. (requires Planning app)
     '''
     )
+    work_entry_source_calendar_invalid = fields.Boolean(compute='_compute_work_entry_source_calendar_invalid')
+
+    @api.depends('work_entry_source', 'resource_calendar_id')
+    def _compute_work_entry_source_calendar_invalid(self):
+        for contract in self:
+            contract.work_entry_source_calendar_invalid = contract.work_entry_source == 'calendar' and not contract.resource_calendar_id
 
     @ormcache('self.structure_type_id')
     def _get_default_work_entry_type_id(self):

--- a/addons/hr_work_entry_contract/static/src/components/work_entry_source_field/work_entry_source_field.js
+++ b/addons/hr_work_entry_contract/static/src/components/work_entry_source_field/work_entry_source_field.js
@@ -1,0 +1,27 @@
+import { registry } from "@web/core/registry";
+import { RadioField, radioField } from "@web/views/fields/radio/radio_field";
+import { _t } from "@web/core/l10n/translation";
+
+export class WorkEntrySourceField extends RadioField {
+    static template = "hr_work_entry_contract.WorkEntrySourceField";
+
+    get isFullyFlexible() {
+        return !this.props.record.data.resource_calendar_id;
+    }
+
+    get tooltipWarning() {
+        return JSON.stringify({
+            "text" : _t("Invalid option: For fully flexible calendars, the work entry source cannot be 'Working Hours'."),
+        })
+    }
+}
+
+export const workEntrySourceField = {
+    ...radioField,
+    component: WorkEntrySourceField,
+    fieldDependencies: [
+        { name: "resource_calendar_id", type: "many2one", relation: "resource.calendar" },
+    ],
+};
+
+registry.category("fields").add("work_entry_source_field", workEntrySourceField);

--- a/addons/hr_work_entry_contract/static/src/components/work_entry_source_field/work_entry_source_field.xml
+++ b/addons/hr_work_entry_contract/static/src/components/work_entry_source_field/work_entry_source_field.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="hr_work_entry_contract.WorkEntrySourceField" t-inherit="web.RadioField">
+        <xpath expr="//input[hasclass('o_radio_input')]" position="attributes">
+            <attribute name="t-att-disabled">props.readonly or (item[0] === 'calendar' and isFullyFlexible)</attribute>
+        </xpath>
+
+        <xpath expr="//div[hasclass('o_radio_item')]" position="inside">
+            <span t-if="props.readonly or (item[0] === 'calendar' and item[0] === value and isFullyFlexible)"
+                class="fa fa-exclamation-triangle text-danger o_work_entry_source_warning ms-3"
+                data-tooltip-template="hr_work_entry_contract.WorkEntrySourceWarning"
+                t-att-data-tooltip-info='tooltipWarning'/>
+        </xpath>
+
+    </t>
+</templates>

--- a/addons/hr_work_entry_contract/static/src/scss/work_entry_source_mismatch.scss
+++ b/addons/hr_work_entry_contract/static/src/scss/work_entry_source_mismatch.scss
@@ -1,0 +1,5 @@
+.o_form_view {
+    .o_work_entry_source_warning {
+        cursor: help;
+    }
+}

--- a/addons/hr_work_entry_contract/static/src/xml/hr_work_entry_source_templates.xml
+++ b/addons/hr_work_entry_contract/static/src/xml/hr_work_entry_source_templates.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="hr_work_entry_contract.WorkEntrySourceWarning">
+        <div class="o-tooltip px-1 py-2">
+            <p style="font-size: 12px;" class="text-danger"
+                t-esc="text"/>
+        </div>
+    </t>
+</templates>

--- a/addons/hr_work_entry_contract/views/hr_contract_views.xml
+++ b/addons/hr_work_entry_contract/views/hr_contract_views.xml
@@ -5,7 +5,22 @@
         <field name="model">hr.contract</field>
         <field name="inherit_id" ref="hr_contract.hr_contract_view_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//div[@id='resource_calendar_warning']" position="after">
+            <xpath expr="//div[@id='resource_calendar_warning']" position="replace">
+                <div id="resource_calendar_warning" class="d-flex align-items-center">
+                    <!-- resource calendar is only required when work_entry_source is set to 'calendar' -->
+                    <field name="resource_calendar_id"
+                        groups="!hr_contract.group_hr_contract_manager"
+                        placeholder="Fully Flexible"
+                        required="work_entry_source == 'calendar'"
+                        options="{'no_open': True, 'no_create': True}"/>
+                    <field name="resource_calendar_id"
+                        groups="hr_contract.group_hr_contract_manager"
+                        placeholder="Fully Flexible"
+                        required="work_entry_source == 'calendar'"/>
+                    <widget
+                        name="contract_warning_tooltip"
+                        invisible="not calendar_mismatch or state != 'open'"/>
+                </div>
                 <!-- Makes no sense to display only one possibility -->
                 <field name="work_entry_source" widget="radio" invisible="1"/>
             </xpath>

--- a/addons/hr_work_entry_contract/views/hr_contract_views.xml
+++ b/addons/hr_work_entry_contract/views/hr_contract_views.xml
@@ -22,7 +22,7 @@
                         invisible="not calendar_mismatch or state != 'open'"/>
                 </div>
                 <!-- Makes no sense to display only one possibility -->
-                <field name="work_entry_source" widget="radio" invisible="1"/>
+                <field name="work_entry_source" widget="work_entry_source_field" invisible="1"/>
             </xpath>
         </field>
     </record>

--- a/addons/resource/data/resource_data.xml
+++ b/addons/resource/data/resource_data.xml
@@ -4,6 +4,7 @@
         <record id="resource_calendar_std" model="resource.calendar">
             <field name="name">Standard 40 hours/week</field>
             <field name="company_id" ref="base.main_company"/>
+            <field name="full_time_required_hours">40</field>
         </record>
 
         <record id="base.main_company" model="res.company">

--- a/addons/resource/data/resource_demo.xml
+++ b/addons/resource/data/resource_demo.xml
@@ -23,6 +23,7 @@
                     (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16, 'day_period': 'afternoon'})
                 ]"
             />
+            <field name="full_time_required_hours">35</field>
         </record>
 
         <record id="resource_calendar_std_38h" model="resource.calendar">
@@ -48,6 +49,7 @@
                     (0, 0, {'name': 'Friday Afternoon', 'dayofweek': '4', 'hour_from': 13, 'hour_to': 16.6, 'day_period': 'afternoon'})
                 ]"
             />
+            <field name="full_time_required_hours">38</field>
         </record>
 
         <record id="resource_calendar_flex_40h" model="resource.calendar">
@@ -55,6 +57,7 @@
             <field name="company_id" ref="base.main_company"/>
             <field name="hours_per_day">8</field>
             <field name="flexible_hours" eval="True"/>
+            <field name="full_time_required_hours">40</field>
         </record>
 
     </data>

--- a/addons/resource/data/resource_demo.xml
+++ b/addons/resource/data/resource_demo.xml
@@ -49,5 +49,13 @@
                 ]"
             />
         </record>
+
+        <record id="resource_calendar_flex_40h" model="resource.calendar">
+            <field name="name">Flexible 40 hours/week</field>
+            <field name="company_id" ref="base.main_company"/>
+            <field name="hours_per_day">8</field>
+            <field name="flexible_hours" eval="True"/>
+        </record>
+
     </data>
 </odoo>

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -102,7 +102,8 @@ class ResourceCalendar(models.Model):
     two_weeks_calendar = fields.Boolean(string="Calendar in 2 weeks mode")
     two_weeks_explanation = fields.Char('Explanation', compute="_compute_two_weeks_explanation")
     flexible_hours = fields.Boolean(string="Flexible Hours",
-                                    help="When enabled, it will allow employees to work flexibly, without relying on company's working schedule (working hours).")
+                                    help="When enabled, it will allow employees to work flexibly, without relying on the company's working schedule (working hours).")
+    full_time_required_hours = fields.Float(string="Company Full Time", help="Number of hours to work on the company schedule to be considered as fulltime.")
 
     @api.depends('attendance_ids', 'attendance_ids.hour_from', 'attendance_ids.hour_to', 'two_weeks_calendar', 'flexible_hours')
     def _compute_hours_per_day(self):

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -45,7 +45,8 @@ class ResourceResource(models.Model):
     calendar_id = fields.Many2one(
         "resource.calendar", string='Working Time',
         default=lambda self: self.env.company.resource_calendar_id,
-        domain="[('company_id', '=', company_id)]")
+        domain="[('company_id', '=', company_id)]",
+        help="Define the working schedule of the resource. If not set, the resource will have a fully flexible working hours.")
     tz = fields.Selection(
         _tz_get, string='Timezone', required=True,
         default=lambda self: self._context.get('tz') or self.env.user.tz or 'UTC')
@@ -178,6 +179,8 @@ class ResourceResource(models.Model):
 
             This methods handle the eventuality of a resource having multiple resource calendars, see _get_calendars_validity_within_period method
             for further explanation.
+
+            For flexible calendars and fully flexible resources: -> return the whole interval
         """
         assert start.tzinfo and end.tzinfo
         resource_calendar_validity_intervals = {}
@@ -193,6 +196,11 @@ class ResourceResource(models.Model):
         for calendar in (calendars or []):
             calendar_resources[calendar] |= self.env['resource.resource']
         for calendar, resources in calendar_resources.items():
+            # If the calendar is flexible or resource has no calendar (fully flexible)
+            if not calendar:
+                for resource in resources:
+                    resource_work_intervals[resource.id] |= Intervals([(start, end, self.env['resource.calendar.attendance'])])
+                continue
             # For each calendar used by the resources, retrieve the work intervals for every resources using it
             work_intervals_batch = calendar._work_intervals_batch(start, end, resources=resources, compute_leaves=compute_leaves)
             for resource in resources:
@@ -201,3 +209,15 @@ class ResourceResource(models.Model):
             calendar_work_intervals[calendar.id] = work_intervals_batch[False]
 
         return resource_work_intervals, calendar_work_intervals
+
+    def _is_fully_flexible(self):
+        """ employee has a fully flexible schedule has no working calendar set """
+        self.ensure_one()
+        return not self.calendar_id
+
+    def _is_flexible(self):
+        """ An employee is considered flexible if the field flexible_hours is True on the calendar
+            or the employee is not assigned any calendar, in which case is considered as Fully flexible.
+        """
+        self.ensure_one()
+        return self._is_fully_flexible() or (self.calendar_id and self.calendar_id.flexible_hours)

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -46,7 +46,7 @@ class ResourceResource(models.Model):
         "resource.calendar", string='Working Time',
         default=lambda self: self.env.company.resource_calendar_id,
         domain="[('company_id', '=', company_id)]",
-        help="Define the working schedule of the resource. If not set, the resource will have a fully flexible working hours.")
+        help="Define the working schedule of the resource. If not set, the resource will have fully flexible working hours.")
     tz = fields.Selection(
         _tz_get, string='Timezone', required=True,
         default=lambda self: self._context.get('tz') or self.env.user.tz or 'UTC')
@@ -196,7 +196,7 @@ class ResourceResource(models.Model):
         for calendar in (calendars or []):
             calendar_resources[calendar] |= self.env['resource.resource']
         for calendar, resources in calendar_resources.items():
-            # If the calendar is flexible or resource has no calendar (fully flexible)
+            # for fully flexible resource, return the whole interval
             if not calendar:
                 for resource in resources:
                     resource_work_intervals[resource.id] |= Intervals([(start, end, self.env['resource.calendar.attendance'])])

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -20,7 +20,7 @@
             <form string="Working Time">
                 <field name="two_weeks_calendar" invisible="1"/>
                 <header>
-                    <button name="switch_calendar_type" invisible="two_weeks_calendar" string="Switch to 2 weeks calendar" type="object"
+                    <button name="switch_calendar_type" invisible="two_weeks_calendar or flexible_hours" string="Switch to 2 weeks calendar" type="object"
                         confirm="Are you sure you want to switch to a 2-week calendar? All work entries will be lost."
                         confirm-label="Switch"/>
                     <button name="switch_calendar_type" invisible="not two_weeks_calendar" string="Switch to 1 week calendar" type="object"
@@ -50,17 +50,20 @@
                     <div class="oe_title">
                         <h1><field name="name"/></h1>
                     </div>
-                    <group name="resource_details">
-                        <group>
+                    <group name="resource_details" col="2">
+                        <group name="resource_working_hours">
+                            <field name="flexible_hours"/>
+                            <field name="hours_per_day" widget="float_time" readonly="not flexible_hours"/>
+                        </group>
+                        <group name="resource_company">
                             <field name="active" invisible="1"/>
                             <field name="company_id" groups="base.group_multi_company"/>
-                            <field name="hours_per_day" widget="float_time"/>
                             <field name="tz" widget="timezone_mismatch" options="{'tz_offset_field': 'tz_offset', 'mismatch_title': 'Timezone Mismatch : This timezone is different from that of your browser.\nPlease, be mindful of this when setting the working hours or the time off.'}" />
                             <field name="tz_offset" invisible="1"/>
                         </group>
                     </group>
                     <notebook>
-                        <page string="Working Hours" name="working_hours">
+                        <page string="Working Hours" name="working_hours" invisible="flexible_hours">
                             <field name="two_weeks_explanation" invisible="not two_weeks_calendar"/>
                             <field name="attendance_ids" widget="section_one2many"/>
                         </page>

--- a/addons/resource/views/resource_calendar_views.xml
+++ b/addons/resource/views/resource_calendar_views.xml
@@ -53,6 +53,12 @@
                     <group name="resource_details" col="2">
                         <group name="resource_working_hours">
                             <field name="flexible_hours"/>
+                            <label for="full_time_required_hours" invisible="flexible_hours"/>
+                            <label for="full_time_required_hours" string="Hours per Week" invisible="not flexible_hours"/>
+                            <div>
+                                <field name="full_time_required_hours" style="width: 10%" widget="float_time"/>
+                                <span> hours/week</span>
+                            </div>
                             <field name="hours_per_day" widget="float_time" readonly="not flexible_hours"/>
                         </group>
                         <group name="resource_company">

--- a/addons/resource/views/resource_resource_views.xml
+++ b/addons/resource/views/resource_resource_views.xml
@@ -43,7 +43,7 @@
                     </group>
                     <group name="resource_details">
                         <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"/>
-                        <field name="calendar_id"/>
+                        <field name="calendar_id" placeholder="Fully Flexible"/>
                         <field name="tz"/>
                         <field name="time_efficiency"/>
                     </group>


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:
-------
In this commit, the flexible working hours (flexible contract) has been reworked in the resource calendar and the contract.

1. Definition of Flexible working calendars:
Flexible working calendars are defined by setting the `flexible_hours` field to True in resource calendar. Flexible resource are able to set the number of working hours per day freely, without referring to working intervals (attendance).
Added a helper function `is_flexible` in resource for readability and better maintenance of this definition.

2. Introduction of Fully Flexible working calendars
Fully Flexible working calendars are defined by not setting any value to the field `working calendar` in the resource/contract view. This type of flexible calendar has no limit to the working hours per day. This allows to have fully freedom on the length of shifts for resources. Note that for contracts, fully flexible can be selected only if the contract's working entry source is not 'working schedule'. A helper function `is_fully_flexible` is added in resource for readability and better maintenance of this definition. 

Other changes:
- Introduced `flexible_hours` field in resource calendar.
- Reordered resource calendar view field's order.
- In contract, resource_calendar no longer a required field.
- Demo Data added with fully flexible working calendar (Suman Oza)
- hr_attendance: if no calendar (=fully flex) refer to resource's timezone instead of calendar's tz.
- hr_attendance: Adapt calculation of max_hours for hr_attendance gantt view for flexible employees.
- Several tests added

Task-3762895

related PR
enterprise: https://github.com/odoo/enterprise/pull/58599

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
