### PR TITLE
[FIX] mrp : add move type value for procurement group creation

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -871,6 +871,9 @@ class MrpProduction(models.Model):
                 vals['name'] = self.env['stock.picking.type'].browse(picking_type_id).sequence_id.next_by_id()
             if not vals.get('procurement_group_id'):
                 procurement_group_vals = self._prepare_procurement_group_vals(vals)
+                field = self.env['procurement.group']._fields.get('move_type')
+                if field and field.default and 'move_type' not in procurement_group_vals:
+                    procurement_group_vals['move_type'] = field.default(self.env['procurement.group'])
                 vals['procurement_group_id'] = self.env["procurement.group"].create(procurement_group_vals).id
         res = super().create(vals_list)
         # Make sure that the date passed in vals_list are taken into account and not modified by a compute

--- a/addons/mrp/tests/test_byproduct.py
+++ b/addons/mrp/tests/test_byproduct.py
@@ -479,3 +479,18 @@ class TestMrpByProduct(common.TransactionCase):
         mo.button_mark_done()
         self.assertEqual(len(mo.move_byproduct_ids.move_line_ids), 2)
         self.assertEqual(mo.move_byproduct_ids.product_id, mo.move_byproduct_ids.move_line_ids.product_id)
+
+    def test_create_mrp_production_with_context(self):
+        """
+        Test creating MRP production while passing default value
+        for 'move_type' in context.
+        """
+        mp = self.env['mrp.production'].with_context(default_move_type="out_invoice").create({
+            'product_id': self.product_a.id,
+            'product_qty': 1.0,
+            'bom_id': self.bom_byproduct.id,
+        })
+
+        self.assertTrue(mp.procurement_group_id, 'The procurement group should have been created '
+                                                 'with its default value')
+        self.assertEqual(mp.procurement_group_id.move_type, 'direct')


### PR DESCRIPTION
Steps to reproduce:
	1- Navigate to Inventory > Configuration > Warehouses and select the warehouse
	2- Click on the Routes smart button and filter by archived routes
	3- Unarchive the Replenish on Order (MTO) route
	4- Navigate to Sales > Products > Products and create a new product
	5- Make the product a Recurring product that has the product type set to storable and the invoicing policy set to ordered quantities
	6- Navigate to the Inventory tab and enable the Replenish on Order (MTO) and Manufacture Routes
	7- Navigate to Sales and create a new quote and confirm it with the newly created product
	8- Click on Create Invoice and then Create Draft Invoice
	9- Click on Confirm

Current behavior before PR:
This is happening because while creating the draft invoice we pass the default move type for the invoice in the context and because the attribute 'move_type' has the same name in 'account.move' and 'procurement.group' so when getting the default value to create the procurement group it gets the value in the context which is for the account move so this value is incorrect for the move_type in procurement group

Desired behavior after PR is merged:
We solved this by checking while getting the default value from the context if the value in the context is a possible value for the attribute in the object we are creating or not.

Other solutions:
To just add the move_type value to the procurement group values but this has two issues. First the value will be hard coded so if at any time the default value of 'move_type' gets changed we will need to change it in this scenario too. Second this will just solve this flow but if the same problem happens in any other flow it will have the same bug.

opw-3718420
