### PR TITLE
[FIX] event: missing default event

### DIFF
--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -32,7 +32,7 @@ class EventRegistration(models.Model):
 
     # event
     event_id = fields.Many2one(
-        'event.event', string='Event', required=True)
+        'event.event', string='Event', default=lambda self: self.env.context.get('active_id'), required=True)
     event_ticket_id = fields.Many2one(
         'event.event.ticket', string='Event Ticket', ondelete='restrict')
     active = fields.Boolean(default=True)


### PR DESCRIPTION
**Steps to reproduce:**
- ​Open an event form
- ​Open the list of attendees through the stat button
- Click on 'New' to add an attendee.
- The value of event field is not set by default.

The issue mentioned above is faced only when both `event_social` and `event_sale` are installed together.

**Cause:**
The `onchange` method is called twice when both modules are installed. When `default_get` is called for the second time, 'default_event_id' is missing from the context and hence, the field 'event_id' is not set by default.

**Fix:**
This PR adds a default attribute to the field `event_id` to ensure that the field is always set by default.

Task: [3596663](https://www.odoo.com/web#id=3596663&menu_id=4722&cids=2&action=333&active_id=10888&model=project.task&view_type=form)
