### PR TITLE
[FIX] website_mass_mailing: not allow grid mode for newsletter block

### DIFF
--- a/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
+++ b/addons/website_mass_mailing/static/src/js/website_mass_mailing.editor.js
@@ -3,11 +3,26 @@ odoo.define('website_mass_mailing.editor', function (require) {
 
 var core = require('web.core');
 const Dialog = require('web.Dialog');
+const weSnippetEditor = require('web_editor.snippet.editor');
 var options = require('web_editor.snippets.options');
 
 const qweb = core.qweb;
 var _t = core._t;
 
+// TODO Remove in master: this is a stable patch to remove the "Layout" option
+// for the "Newsletter Block" snippet.
+weSnippetEditor.SnippetsMenu.include({
+    /**
+     * @override
+     */
+    _patchForComputeSnippetTemplates($html) {
+        this._super(...arguments);
+        const layoutOptionEl = $html.find("div[data-js='layout_column']:has(*[data-select-layout='grid'])")[0];
+        if (layoutOptionEl) {
+            layoutOptionEl.dataset.exclude += ",.s_newsletter_block";
+        }
+    },
+});
 
 options.registry.mailing_list_subscribe = options.Class.extend({
     /**

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -209,6 +209,9 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
         </t>
         <div data-selector=".js_subscribe" data-drop-near="p, h1, h2, h3, blockquote, .card"/>
     </xpath>
+    <xpath expr="//div[@data-js='layout_column'][.//@data-select-layout='grid']" position="attributes">
+        <attribute name="data-exclude" add=".s_newsletter_block" separator=","/>
+    </xpath>
 </template>
 
 <template id="newsletter_subscribe_options_common">


### PR DESCRIPTION
The "Layout" option is available for the "Newsletter Block" snippet. It should not.

This commit excludes the "Newsletter Block" snippet from "Layout" option selector.

Steps to reproduce:
- Drop a "Newsletter Block" snippet.
- Select it.

=> The "Layout" option did give access to grid mode.

task-3802877
