### PR TITLE
[15.0][FIX] web: Avoid multiple clicks on links

### DIFF
--- a/addons/web/static/src/legacy/js/fields/relational_fields.js
+++ b/addons/web/static/src/legacy/js/fields/relational_fields.js
@@ -765,8 +765,17 @@ var FieldMany2One = AbstractField.extend({
         var self = this;
         if (this.mode === 'readonly') {
             event.preventDefault();
+            if ($(event.currentTarget).hasClass('o_link_disabled')) {
+                // If someone presses a disabled button, you do not want them
+                // to perform any action.
+                event.stopPropagation();
+                return;
+            }
             if (!this.noOpen) {
                 event.stopPropagation();
+                // All visible links are disabled to avoid launching a double redirect,
+                // which may cause a double save and duplicate lines in a form.
+                $("a.o_form_uri").addClass("o_link_disabled")
                 this._rpc({
                     model: this.field.relation,
                     method: 'get_formview_action',

--- a/addons/web/static/src/legacy/scss/form_view.scss
+++ b/addons/web/static/src/legacy/scss/form_view.scss
@@ -141,6 +141,10 @@ $o-form-label-margin-right: 0px;
                 color: darken($link-color, 15%);
             }
         }
+        &.o_link_disabled {
+            cursor: not-allowed;
+            opacity: 0.5;
+        }
     }
 
     // Editable specific rules


### PR DESCRIPTION
Before this PR, when creating a record with lines, such as a sales order, there was a possibility of clicking a link that redirected to another screen multiple times. This triggered a creation action on the first click and a write action on the second click, resulting in duplicated lines in the record. See next gif:
![duplicate_lines](https://github.com/odoo/odoo/assets/35952655/29b94bff-83ef-4a10-a6cb-033d05735f47)

After this PR, on the first click, the link becomes disabled, preventing the execution of the second action that causes the duplication of those lines.
![no_duplicate_lines](https://github.com/odoo/odoo/assets/35952655/0d2b6465-4cea-4a36-9d4e-8285cb4ac339)

cc @Tecnativa TT48276
ping @pedrobaeza @sergio-teruel 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
