### PR TITLE
[FIX] partner_autocomplete: fix traceback in vat number matching

### DIFF
--- a/addons/partner_autocomplete/models/res_partner.py
+++ b/addons/partner_autocomplete/models/res_partner.py
@@ -5,6 +5,7 @@ import base64
 import json
 import logging
 import requests
+import re
 
 from stdnum.eu.vat import check_vies
 
@@ -142,8 +143,9 @@ class ResPartner(models.Model):
                 if vies_result['valid'] and name != '---':
                     address = list(filter(bool, vies_result['address'].split('\n')))
                     street = address[0]
-                    zip_city = address[-1].split(' ', 1) if len(address) > 1 else [None, None]
-                    street2 = address[1] if len(address) > 2 else None
+                    zip_city_record = next(filter(lambda addr: re.match(r'^\d.*', addr), address[1:]), None)
+                    zip_city = zip_city_record.split(' ', 1) if zip_city_record else [None, None]
+                    street2 = next((addr for addr in filter(lambda addr: addr != zip_city_record, address[1:])), None)
                     return [self._iap_replace_location_codes({
                         'name': name,
                         'vat': vat,


### PR DESCRIPTION
This issue is occurring when the user tries to add a `VAT` number,
 while creating a new contact

To reproduce this issue:
1) Install `contacts` and `partner_autocomplete`
2) Create a new contact from `Contacts`
3) Give a valid `VAT` number e.g:- `SK2120312645`(got it from sentry)
4) Traceback occurs in the terminal

Error:- 
```
IndexError: list index out of range
  File "odoo/http.py", line 2251, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1826, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1847, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1824, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1832, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2057, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 34, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 30, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/partner_autocomplete/models/res_partner.py", line 158, in read_by_vat
    'city': zip_city[1],

```

In some cases, the expected `zip_city` value is not at the last of the address list , 
which leads to above traceback. As `zip_city` must contain both zip and city values.

https://github.com/odoo/odoo/blob/382b64c2f14073cfff1a8ef9290b5c7834d52188/addons/partner_autocomplete/models/res_partner.py#L143-L156


After applying this commit will resolve this issue by searching `zip_city` based on regex.

sentry-5058467547