### PR TITLE
[FIX] point_of_sale: fix traceback when multiple split payments

### DIFF
--- a/addons/point_of_sale/models/report_sale_details.py
+++ b/addons/point_of_sale/models/report_sale_details.py
@@ -149,7 +149,7 @@ class ReportSaleDetails(models.AbstractModel):
                         elif payment['id'] in account_payments.mapped('pos_payment_method_id.id'):
                             account_payment = account_payments.filtered(lambda p: p.pos_payment_method_id.id == payment['id'])
                             payment['final_count'] = payment['total']
-                            payment['money_counted'] = account_payment.amount
+                            payment['money_counted'] = sum(account_payment.mapped('amount'))
                             payment['money_difference'] = payment['money_counted'] - payment['final_count']
                             payment['cash_moves'] = []
                             if payment['money_difference'] > 0:


### PR DESCRIPTION
Current behavior:
When doing multiple payments with a split bank payments methods, when you try to generate a session report it will raise a traceback.

Steps to reproduce:
- Modify the bank payment method and activate the 'Identify Customer' option
- Open a new session and create 2 orders with different customers that you pay using the bank payment method
- Close the session and try to generate the session report
- It will raise a traceback

Note:
This was happening because the case of multiple payments with the same payment method was not handled correctly. To fix this we sum the amounts of all the payments.

Error introduced here : https://github.com/odoo/odoo/pull/156376/

opw-3801523
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
