### PR TITLE
[FIX] web: `formView` mobile gaps

### DIFF
--- a/addons/web/static/src/views/fields/fields.scss
+++ b/addons/web/static/src/views/fields/fields.scss
@@ -93,6 +93,7 @@
     // Default display and alignment of widget and internal <input/>
     text-align: inherit;
     display: var(--fieldWidget-display, inline-block);
+    margin-bottom: var(--fieldWidget-margin-bottom);
 
     textarea.o_input,
     input.o_input {

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -12,10 +12,13 @@
     }
 }
 
-// XXS form view specific rules
-@mixin form-break-table {
+// Form view rules to break the default table layout
+@mixin form-break-table($-is-editable: false) {
+    --fieldWidget-margin-bottom: 0;
+
     grid-template-columns: 1fr;
     margin-bottom: $o-form-spacing-unit * 4;
+    row-gap: 0;
 
     .o_wrap_field {
         .o_cell {
@@ -26,14 +29,8 @@
             }
 
             .o_field_widget {
-                margin-bottom: $o-form-spacing-unit * 2;
-
                 &:not(.o_field_boolean){
                     width: 100%;
-                }
-
-                > .o_field_widget {
-                    margin-bottom: 0;
                 }
 
                 &.o_field_boolean {
@@ -47,9 +44,17 @@
             }
         }
     }
+
+    @if $-is-editable {
+        .o_address_type, .o_address_format {
+            --fieldWidget-margin-bottom: #{$o-form-spacing-unit * 2};
+        }
+    }
 }
 
 .o_form_view {
+    --fieldWidget-margin-bottom: #{$o-form-spacing-unit};
+
     @include media-breakpoint-up(md) {
         display: flex;
         flex-flow: column nowrap;
@@ -314,8 +319,9 @@
         }
 
         > .o_field_widget {
+            --fieldWidget-margin-bottom: 0;
+
             align-self: flex-start;
-            margin-bottom: 0px;
         }
     }
 
@@ -567,11 +573,8 @@
         }
     }
 
-    // Form fields
+    // One2Many List views
     .o_field_widget {
-        margin-bottom: $o-form-spacing-unit;
-
-        // One2Many List views
         .o_list_table {
             &.table-striped {
                 > tbody {
@@ -595,7 +598,7 @@
     }
     .o_field_widget, .btn {
         .o_field_widget {
-            margin-bottom: 0px;
+            --fieldWidget-margin-bottom: 0;
         }
     }
     .o_cell:not(.o_field_cell) .o_form_uri > span:first-child {
@@ -1054,6 +1057,10 @@
         .o_inner_group {
             @include form-break-table;
         }
+
+        .o_form_editable .o_inner_group {
+            @include form-break-table($-is-editable: true);
+        }
     }
 }
 
@@ -1109,7 +1116,7 @@
             @include media-breakpoint-down(md) {
                 &:not(.oe_subtotal_footer) > .o_cell {
                     > .o_field_widget {
-                        margin-bottom: $o-form-spacing-unit * 4;
+                        --fieldWidget-margin-bottom: #{$o-form-spacing-unit * 4};
                     }
                 }
             }
@@ -1126,6 +1133,10 @@
 .o_form_view.o_xxs_form_view {
     .o_inner_group {
         @include form-break-table;
+    }
+
+    .o_form_editable .o_inner_group {
+        @include form-break-table($-is-editable: true);
     }
 }
 

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -174,7 +174,7 @@
 
                     <group>
                         <group>
-                            <span class="o_form_label o_td_label" name="address_name">
+                            <span class="o_form_label o_td_label o_address_type" name="address_name">
                                 <field name="type" invisible="is_company" readonly="user_ids" required="not is_company" class="fw-bold"/>
                                 <b invisible="not is_company">Address</b>
                             </span>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -176,7 +176,7 @@
                         <group>
                             <span class="o_form_label o_td_label o_address_type" name="address_name">
                                 <field name="type" invisible="is_company" readonly="user_ids" required="not is_company" class="fw-bold"/>
-                                <b invisible="not is_company">Address</b>
+                                <span invisible="not is_company">Address</span>
                             </span>
                             <div class="o_address_format">
                                 <field name="street" placeholder="Street..." class="o_address_street"


### PR DESCRIPTION
---
**NOTE: this PR is handled by mano-odoo**

---

Prior to this PR, there was undesired vertical gap between fields in the formView (mobile only).

Adds a custom property on the generic `.o_field_widget` component to increase flexibility on its margin-bottom property. Thus we adapt the rules which were overriding the margin-bottom property to use the new custom property instead.

The form-break-table mixin is adapted to remove the unwanted extra spacing. 
To handle the `o_address_type` and `o_address_format` exception a new boolean parameter is introduced in the mixin to differentiate editable form views: `$-is-editable`.

This PR also changes the `type` field label tag to better fit label styling.

task-3806250

![image](https://github.com/odoo/odoo/assets/108661430/a09085dd-a38b-489c-a670-62a8f3ce5248)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
