### PR TITLE
[FIX] web, mail: adapt PWA scope for path-based url

### DIFF
--- a/addons/web/controllers/webmanifest.py
+++ b/addons/web/controllers/webmanifest.py
@@ -48,8 +48,8 @@ class WebManifest(http.Controller):
         web_app_name = request.env['ir.config_parameter'].sudo().get_param('web.web_app_name', 'Odoo')
         manifest = {
             'name': web_app_name,
-            'scope': '/web',
-            'start_url': '/web',
+            'scope': '/',
+            'start_url': '/odoo',
             'display': 'standalone',
             'background_color': '#714B67',
             'theme_color': '#714B67',
@@ -74,7 +74,7 @@ class WebManifest(http.Controller):
             self._get_service_worker_content(),
             [
                 ('Content-Type', 'text/javascript'),
-                ('Service-Worker-Allowed', '/web'),
+                ('Service-Worker-Allowed', '/'),
             ]
         )
         return response

--- a/addons/web/static/src/webclient/webclient.js
+++ b/addons/web/static/src/webclient/webclient.js
@@ -128,7 +128,7 @@ export class WebClient extends Component {
     registerServiceWorker() {
         if (navigator.serviceWorker) {
             navigator.serviceWorker
-                .register("/web/service-worker.js", { scope: "/web" })
+                .register("/web/service-worker.js", { scope: "/" })
                 .catch((error) => {
                     console.error("Service worker registration failed, error:", error);
                 });

--- a/addons/web/tests/test_webmanifest.py
+++ b/addons/web/tests/test_webmanifest.py
@@ -21,8 +21,8 @@ class WebManifestRoutesTest(HttpCaseWithUserDemo):
         self.assertEqual(response.headers["Content-Type"], "application/manifest+json")
         data = response.json()
         self.assertEqual(data["name"], "Odoo")
-        self.assertEqual(data["scope"], "/web")
-        self.assertEqual(data["start_url"], "/web")
+        self.assertEqual(data["scope"], "/")
+        self.assertEqual(data["start_url"], "/odoo")
         self.assertEqual(data["display"], "standalone")
         self.assertEqual(data["background_color"], "#714B67")
         self.assertEqual(data["theme_color"], "#714B67")
@@ -47,8 +47,8 @@ class WebManifestRoutesTest(HttpCaseWithUserDemo):
         self.assertEqual(response.headers["Content-Type"], "application/manifest+json")
         data = response.json()
         self.assertEqual(data["name"], "Odoo")
-        self.assertEqual(data["scope"], "/web")
-        self.assertEqual(data["start_url"], "/web")
+        self.assertEqual(data["scope"], "/")
+        self.assertEqual(data["start_url"], "/odoo")
         self.assertEqual(data["display"], "standalone")
         self.assertEqual(data["background_color"], "#714B67")
         self.assertEqual(data["theme_color"], "#714B67")
@@ -66,7 +66,7 @@ class WebManifestRoutesTest(HttpCaseWithUserDemo):
         response = self.url_open("/web/service-worker.js")
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.headers["Content-Type"], "text/javascript")
-        self.assertEqual(response.headers["Service-Worker-Allowed"], "/web")
+        self.assertEqual(response.headers["Service-Worker-Allowed"], "/")
 
     def test_offline_url(self):
         """
@@ -85,7 +85,7 @@ class WebManifestRoutesTest(HttpCaseWithUserDemo):
         response = self.url_open("/web/static/img/odoo-icon-ios.png")
         self.assertEqual(response.status_code, 200)
 
-        document = self.url_open("/web")
+        document = self.url_open("/odoo")
         self.assertIn(
             '<link rel="apple-touch-icon" href="/web/static/img/odoo-icon-ios.png"/>', document.text,
             "Icon for iOS is present in the head of the document.",


### PR DESCRIPTION
Since odoo/odoo@c63d14a0485a553b74a8457aee158384e9ae6d3f , the scope of the pwa was using the legacy mode and break the webpush notification.

This commit fix the web push notification with using the right pwa scope