### PR TITLE
[FIX] hr: fix read hr_employee fields from hr_employee_public

### DIFF
--- a/addons/hr/models/hr_employee.py
+++ b/addons/hr/models/hr_employee.py
@@ -198,7 +198,11 @@ class HrEmployeePrivate(models.Model):
         # copy them to the cache of self; non-public data will be missing from
         # cache, and interpreted as an access error
         self.flush_recordset(fields)
-        public = self.env['hr.employee.public'].browse(self._ids)
+        hr_employee_public = self.env['hr.employee.public']
+        public = hr_employee_public.browse(self._ids)
+        public_fields = hr_employee_public._fields.keys()
+        # keep only the fields that are available on the public model
+        fields = list(set(fields) & set(public_fields))
         public.read(fields)
         for fname in fields:
             values = self.env.cache.get_values(public, public._fields[fname])


### PR DESCRIPTION
To reproduce:
=============
- install `planning` and `pos_blackbox_be` modules
- change Demo's Employee permissions from Administrator to nothing
- connect as Demo and try to open planning application -> you will get an error

Problem:
========
- the `pos_blackbox_be` module inherits from `hr_employee` and introduces a new field `insz_or_bis_number` which is not in `hr_employee_public`, the `_read` method of `hr_employee` tries to read this field from the `hr_employee_public` model and fails

Solution:
=========
filter out the fields that are not in `hr_employee_public` before trying to read them.

opw-3772735
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
