### PR TITLE
[FIX] web: fix useDebounced tests

### DIFF
--- a/addons/web/static/tests/core/utils/timing.test.js
+++ b/addons/web/static/tests/core/utils/timing.test.js
@@ -399,18 +399,18 @@ describe("useDebounced", () => {
         expect("button.c").toHaveCount(1);
 
         click(`button.c`);
-        await advanceTime(999);
+        await advanceTime(995);
         expect([]).toVerifySteps();
 
-        await advanceTime(1);
+        await advanceTime(5);
         expect(["debounced"]).toVerifySteps();
 
         click(`button.c`);
-        await advanceTime(999);
+        await advanceTime(995);
         expect([]).toVerifySteps();
 
         destroy(component);
-        await advanceTime(1);
+        await advanceTime(5);
         expect([]).toVerifySteps();
     });
 
@@ -429,14 +429,14 @@ describe("useDebounced", () => {
         expect(`button.c`).toHaveCount(1);
 
         click(`button.c`);
-        await advanceTime(999);
+        await advanceTime(995);
         expect([]).toVerifySteps();
 
-        await advanceTime(1);
+        await advanceTime(5);
         expect(["debounced: hello"]).toVerifySteps();
 
         click(`button.c`);
-        await advanceTime(999);
+        await advanceTime(995);
         expect([]).toVerifySteps();
 
         destroy(component);
@@ -458,10 +458,10 @@ describe("useDebounced", () => {
         expect(`button.c`).toHaveCount(1);
 
         click(`button.c`);
-        await advanceTime(999);
+        await advanceTime(995);
         expect([]).toVerifySteps();
 
-        await advanceTime(1);
+        await advanceTime(5);
         expect(["debounced"]).toVerifySteps();
 
         destroy(component);


### PR DESCRIPTION
Before this commit, tests for useDebounced were undeterministic. It was caused by the delays used in the tests.
The tests use a debounce of 1000ms, wait 999ms to check that nothing happens but sometimes the timeout can reach the 1000ms and triggers the callback. This commit changes the delays to 995ms to make sure we don't reach the 1000ms.