### PR TITLE
[FIX] mail: properly support sort on Record.attr

### DIFF
--- a/addons/mail/static/src/core/common/record.js
+++ b/addons/mail/static/src/core/common/record.js
@@ -353,10 +353,12 @@ export function makeStore(env) {
                                 sort: () => {
                                     field.sortOnNeed = false;
                                     field.sorting = true;
-                                    sortRecordList(
-                                        proxy2._fields.get(name).value._proxy,
-                                        fieldDefinition.sort.bind(proxy2)
-                                    );
+                                    const func = fieldDefinition.sort.bind(proxy2);
+                                    if (Record.isRelation(field)) {
+                                        sortRecordList(proxy2._fields.get(name).value._proxy, func);
+                                    } else {
+                                        proxy2[name].sort(func);
+                                    }
                                     field.sorting = false;
                                 },
                                 requestSort: ({ force } = {}) => {


### PR DESCRIPTION
This was not working because the internal code of handling sorted assume the field is necessarily a relation, as it always attempt to sort a record list.

Thankfully this doesn't crash because the sort was never triggered on `activityGroups`.

This commit fixes the issue by adapting the inner-code of sort to take non-relational fields into account.