### PR TITLE
[FIX] project: make project editable

### DIFF
--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -677,7 +677,7 @@
                     <field name="priority" widget="priority" nolabel="1"/>
                     <field name="state" widget="project_task_state_selection" nolabel="1" options="{'is_toggle_mode': false}"/>
                     <field name="name" string="Title" widget="name_with_subtask_count"/>
-                    <field name="project_id" widget="project" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')"/>
+                    <field name="project_id" widget="project" force_save="1" optional="show" options="{'no_open': 1}" readonly="1" column_invisible="context.get('default_project_id')"/>
                     <field name="milestone_id" invisible="not allow_milestones" context="{'default_project_id': project_id}" groups="project.group_project_milestone" optional="hide"/>
                     <field name="partner_id" optional="hide" widget="res_partner_many2one" invisible="not project_id" options="{'no_open': True}"/>
                     <field name="user_ids" optional="show" widget="many2many_avatar_user"/>


### PR DESCRIPTION
## Issue:
    - user can't edit the project when project tasks are added as a o2m field to a contact form using studio.
 
## Steps to reproduce:
    - create a project.
    - In a contact form open Studio and add a O2M field Customer (Task)
    - Add a line in the O2M and set Project to the one you created.
    - On save notice that the project is reset to private and that you
      can't change it

## Explantion:
    - `project_id` is not passed to the `web_save` method, because it is readonly.

opw-3713885



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
