### PR TITLE
[FIX] resource_mail: added wrench icon for many2one_avatar_resource

### DIFF
--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.js
@@ -12,7 +12,7 @@ import { AvatarCardResourcePopover } from "@resource_mail/components/avatar_card
 import { Domain } from "@web/core/domain";
 
 
-class AvatarResourceMany2XAutocomplete extends AvatarMany2XAutocomplete {
+export class AvatarResourceMany2XAutocomplete extends AvatarMany2XAutocomplete {
     get optionsSource() {
         return {
             ...super.optionsSource,
@@ -27,7 +27,7 @@ class AvatarResourceMany2XAutocomplete extends AvatarMany2XAutocomplete {
         return this.orm.call(
             this.props.resModel,
             "search_read",
-            [this.getDomain(request), ["id", "display_name", "resource_type"]],
+            [this.getDomain(request), ["id", "display_name", "resource_type", "color"]],
             {
                 context: this.props.context,
                 limit: this.props.searchLimit + 1,
@@ -53,6 +53,7 @@ class AvatarResourceMany2XAutocomplete extends AvatarMany2XAutocomplete {
             value: result.id,
             resourceType: result.resource_type,
             label: result.display_name,
+            color: result.color,
         };
     }
 }

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.scss
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.scss
@@ -1,6 +1,6 @@
-.o_field_many2many_avatar_resource .o_avatar_many2x_autocomplete > i.o_material_resource {
-    width: 19px;
-    height: 19px;
+.o_field_many2many_avatar_resource .o_avatar.o_avatar_many2x_autocomplete > i.o_material_resource {
+    height: var(--Avatar-size, #{$o-avatar-size});
+    width: var(--Avatar-size, #{$o-avatar-size});
 }
 
 .o_m2o_avatar .o_material_resource {

--- a/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
+++ b/addons/resource_mail/static/src/views/fields/many2many_avatar_resource/many2many_avatar_resource_field.xml
@@ -2,7 +2,8 @@
 <templates>
     <t t-name="resource_mail.AvatarResourceMany2XAutocomplete" t-inherit="web.AvatarMany2XAutocomplete">
         <xpath expr="//span[hasclass('o_avatar_many2x_autocomplete')]/img" position="before">
-            <i t-if="option.resourceType === 'material'" class="o_material_resource fa fa-wrench rounded text-center me-1"/>
+            <i t-if="option.resourceType === 'material'" class="o_material_resource fa fa-wrench rounded text-center me-2
+            d-flex align-items-center justify-content-center" t-attf-class="o_colorlist_item_color_{{ option.color }}"/>
         </xpath>
         <xpath expr="//span[hasclass('o_avatar_many2x_autocomplete')]/img" position="attributes">
             <attribute name="t-if" add="&amp;&amp; option.resourceType !== 'material'" separator=" "/>

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.js
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.js
@@ -7,6 +7,7 @@ import {
     many2OneAvatarUserField,
 } from "@mail/views/web/fields/many2one_avatar_user_field/many2one_avatar_user_field";
 import { AvatarCardResourcePopover } from "@resource_mail/components/avatar_card_resource/avatar_card_resource_popover";
+import { AvatarResourceMany2XAutocomplete } from "@resource_mail/views/fields/many2many_avatar_resource/many2many_avatar_resource_field";
 
 
 const ExtendMany2OneAvatarToResource = (T) => class extends T {
@@ -24,6 +25,10 @@ const ExtendMany2OneAvatarToResource = (T) => class extends T {
 
 export class Many2OneAvatarResourceField extends ExtendMany2OneAvatarToResource(Many2OneAvatarUserField) {
     static template = "resource_mail.Many2OneAvatarResourceField";
+    static components = {
+        ...super.components,
+        Many2XAutocomplete: AvatarResourceMany2XAutocomplete,
+    };
 }
 
 export const many2OneAvatarResourceField = {

--- a/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.scss
+++ b/addons/resource_mail/static/src/views/fields/many2one_avatar_resource/many2one_avatar_resource_field.scss
@@ -1,0 +1,4 @@
+.o_field_many2one_avatar_resource .o_avatar.o_avatar_many2x_autocomplete > i.o_material_resource {
+    height: var(--Avatar-size, #{$o-avatar-size});
+    width: var(--Avatar-size, #{$o-avatar-size});
+}


### PR DESCRIPTION
Steps to reproduce:

- Open planning app and click on New.
- A form is opened and searched for a material resource in the Resource field ex. Crane
- An empty photo icon is displayed in the selection bar.

Issue:

- An empty photo icon is being displayed instead of a wrench.

Cause:

- Many2XAutocomplete which adds an image in the many2one selection field is not modified to display
- the wrench icon in the many2one_avatar_resource_field.

Solution:

- A similar modification is done in many2many_avatar_resource_field through class which extends Many2XAutocomplete which can be imported and added into components of many2one_avatar_resource_field.

fix the alignment between of icon and text in many2many_avatar_resource.

task-3801551