### PR TITLE
[FIX] website_sale: prevent error unpublished product add for wishlist

### DIFF
--- a/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
+++ b/addons/website_sale_wishlist/static/tests/tours/website_sale_wishlist.js
@@ -450,3 +450,25 @@ registry.category("web_tour.tours").add('shop_wishlist', {
         },
     ]
 });
+
+registry.category("web_tour.tours").add('check_shop_wishlist_icon', {
+    test: true,
+    checkDelay: 250,
+    url: '/shop?&search=flipover',
+    steps: () => [
+        {
+            content: "check add to wishlist is diable or not",
+            trigger: '.o_add_wishlist:disabled',
+            isCheck: true,
+        },
+        {
+            content: "click on the product",
+            trigger: '.oe_product_cart',
+        },
+        {
+            content: "check value of wishlist",
+            trigger: ":not(.my_wish_quantity)",
+            isCheck: true,
+        },
+    ]
+})

--- a/addons/website_sale_wishlist/tests/test_wishlist_process.py
+++ b/addons/website_sale_wishlist/tests/test_wishlist_process.py
@@ -80,3 +80,42 @@ class TestWishlistProcess(HttpCase):
             ],
         })
         self.start_tour("/", 'shop_wishlist_admin', login="admin")
+
+    def test_03_wishlist_tour_for_unpublished_product(self):
+
+        self.env['product.template'].search([]).write({'website_published': False})
+        # Setup attributes and attributes values
+        product_attribute_2 = self.env['product.attribute'].create({
+            'name': 'Color',
+            'sequence': 20,
+        })
+        product_attribute_value_3 = self.env['product.attribute.value'].create({
+            'name': 'White',
+            'attribute_id': product_attribute_2.id,
+            'sequence': 1,
+        })
+        product_attribute_value_4 = self.env['product.attribute.value'].create({
+            'name': 'Black',
+            'attribute_id': product_attribute_2.id,
+            'sequence': 2,
+        })
+
+        # Create product template
+        self.product_product_4_product_template = self.env['product.template'].create({
+            'name': 'Flipover (TEST)',
+            'standard_price': 1959.0,
+            'list_price': 750.0,
+            'website_published': False,
+        })
+
+        # Generate variants
+        self.env['product.template.attribute.line'].create([{
+            'product_tmpl_id': self.product_product_4_product_template.id,
+            'attribute_id': product_attribute_2.id,
+            'value_ids': [(4, product_attribute_value_3.id), (4, product_attribute_value_4.id)],
+
+        }])
+
+        self.env.ref('base.user_admin').name = 'Mitchell Admin'
+
+        self.start_tour("/", 'check_shop_wishlist_icon', login="admin")

--- a/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
+++ b/addons/website_sale_wishlist/views/website_sale_wishlist_template.xml
@@ -9,7 +9,7 @@
                     type="button"
                     role="button"
                     class="btn btn-outline-primary bg-white o_add_wishlist"
-                    t-att-disabled='in_wish or None' title="Add to Wishlist"
+                    t-att-disabled='not product.website_published or in_wish or None' title="Add to Wishlist"
                     t-att-data-product-template-id="product.id"
                     t-att-data-product-product-id="product_variant_id"
                     data-action="o_wishlist">
@@ -23,7 +23,7 @@
             <t t-nocache="The wishlist depends on the user and must not be shared with other users. The product come from the controller.">
                 <t t-set="product_variant" t-value="product_variant or product._create_first_product_variant()"/>
                 <t t-set="in_wish" t-value="product_variant and product_variant._is_in_wishlist()"/>
-                <button t-if="product_variant" type="button" role="button" class="btn btn-link px-0 pe-3 o_add_wishlist_dyn" t-att-disabled='in_wish or None' t-att-data-product-template-id="product.id" t-att-data-product-product-id="product_variant.id" data-action="o_wishlist" title="Add to wishlist"><i class="fa fa-heart-o me-2" role="img" aria-label="Add to wishlist"/>Add to wishlist</button>
+                <button t-if="product_variant and product.website_published" type="button" role="button" class="btn btn-link px-0 pe-3 o_add_wishlist_dyn" t-att-disabled='in_wish or None' t-att-data-product-template-id="product.id" t-att-data-product-product-id="product_variant.id" data-action="o_wishlist" title="Add to wishlist"><i class="fa fa-heart-o me-2" role="img" aria-label="Add to wishlist"/>Add to wishlist</button>
             </t>
         </xpath>
     </template>


### PR DESCRIPTION
Currently, the error arises due to adding an unpublished product to wishlist for multiple times.

Steps to reproduce:

- Install a 'website_sale_wishlist' module (with demo data).
- Open a website and go to the shop.
-  Add an unpublished product to the wishlist, then refresh the webpage and again try to add that unpublished product to the wishlist, An error is generated in the backend.

```
UniqueViolation: duplicate key value violates unique constraint "product_wishlist_product_unique_partner_id"
DETAIL:  Key (product_id, partner_id)=(2, 3) already exists.

  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1824, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1832, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2057, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale_wishlist/controllers/main.py", line 25, in add_to_wishlist
    wish = Wishlist._add_to_wishlist(
  File "addons/website_sale_wishlist/models/product_wishlist.py", line 44, in _add_to_wishlist
    wish = self.env['product.wishlist'].create({
  File "<decorator-gen-30>", line 2, in create
  File "odoo/api.py", line 420, in _model_create_multi
    return create(self, [arg])
  File "odoo/models.py", line 4716, in create
    records = self._create(data_list)
  File "odoo/models.py", line 4904, in _create
    cr.execute(SQL(
  File "odoo/sql_db.py", line 346, in execute
    res = self._obj.execute(query, params)
TypeError: 'NoneType' object is not subscriptable
  File "odoo/http.py", line 2251, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1826, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1847, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 153, in retrying
    raise _as_validation_error(env, exc) from exc
  File "odoo/service/model.py", line 112, in _as_validation_error
    translate_sql_constraint(env.cr, exc.diag.constraint_name, env.context.get('lang', 'en_US'))
  File "odoo/tools/translate.py", line 429, in translate_sql_constraint
    return cr.fetchone()[0]

```

An issue arises when clicking on the 'add to wishlist' icon for unpublished products. After refreshing the webpage, the 'add to wishlist' icon remains enabled, allowing users to add the same unpublished product to their wishlist multiple times. Consequently, duplicate records are inserted into the 'product_wishlist' table, An issue arises due to this.

To resolve this issue, the 'Add wishlist' button is now disabled for unpublished products.

sentry-5065439065

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
