### PR TITLE
[FIX] core: update column if no en_US translation

### DIFF
--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1636,8 +1636,13 @@ class _String(Field):
                 update_column = True
                 update_trans = True
             elif lang != 'en_US' and lang is not None:
-                # update the translations only except if emptying
-                update_column = not cache_value
+                # update the translations only except if emptying or if we don't have a base ('en_US') translation value
+                update_column = (not cache_value or
+                                 not records.env['ir.translation'].search([
+                                     ('lang', '=', 'en_US'),
+                                     ('name', '=', self.model_name + ',' + self.name),
+                                     ('res_id', 'in', records.mapped('id'))
+                                 ], limit=1).value)
                 update_trans = True
             # else: lang = None
 


### PR DESCRIPTION
**Current behavior:**
While in a non-default language, duplicating a record and
writing new data to it will not update the src values of fields
with translate=True arguments, even if there is no translation
value for the default language.

**Expected behavior:**
When there is no default/src value for a field, the one written
in the current env lang will used as the src value.

**Steps to reproduce:**
1. Install l10n_be (for example) and the Accounting app

2. Duplicate an existing tax, update all it's form fields to
     some new value, ensure to update its translatable fields'
     translation values

3. Create a new invoice with the tax created in step 2 applied

4. Go to the Tax Report view in Accounting, in the top right
     change the `Tax Report:` option to 'Global Summary', and
     ensure the date range is including the invoice created in
     step 3

5. In the top left, go to the CLOSING ENTRY view, observe that
     the label for the duplicated tax is the old name "..(Copie)"

**Cause of the issue:**
The field value is only updated with respect to the lang context
being the current (non default, non en_US) language. This means
that in the actual database, the field value is still the one
created during the copy() ORM call.

**Fix:**
Update the src field value if one does not currently exist in
the default language.

opw-3787287