### PR TITLE
[FIX] web, web_editor: issues with hex color

### DIFF
--- a/addons/web/static/src/legacy/js/widgets/colorpicker.js
+++ b/addons/web/static/src/legacy/js/widgets/colorpicker.js
@@ -5,6 +5,8 @@ var core = require('web.core');
 var utils = require('web.utils');
 var Dialog = require('web.Dialog');
 var Widget = require('web.Widget');
+var timingUtils = require('@web/core/utils/timing');
+var debounce = timingUtils.debounce;
 
 var _t = core._t;
 
@@ -426,7 +428,7 @@ var ColorpickerWidget = Widget.extend({
      * @private
      * @param {Event} ev
      */
-    _onChangeInputs: function (ev) {
+    _onChangeInputs: debounce(function (ev) {
         switch ($(ev.target).data('colorMethod')) {
             case 'hex':
                 this._updateHex(this.$('.o_hex_input').val());
@@ -451,7 +453,7 @@ var ColorpickerWidget = Widget.extend({
         }
         this._updateUI();
         this._colorSelected();
-    },
+    }, 10, true),
 });
 
 //--------------------------------------------------------------------------

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1615,6 +1615,7 @@ const Wysiwyg = Widget.extend({
                         this.odooEditor.historyPauseSteps();
                         try {
                             this._processAndApplyColor(eventName, ev.data.color);
+                            this.odooEditor._computeHistorySelection();
                         } finally {
                             this.odooEditor.historyUnpauseSteps();
                         }


### PR DESCRIPTION
Current behavior before PR:

- Selecting the last text of a paragraph and applying hex color on it resulted
  in a traceback.
- Selecting the initial text of a long paragraph and applying hex color resulted
  in unintended coloring of other unselected text.

Desired behavior after PR is merged:

- Applying a hex color on text will no longer lead to a traceback.
- Only the selected text will be colored.

task-3578454
