### PR TITLE
[FIX] website_crm_partner_assign: cannot edit desc

### DIFF
--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -160,10 +160,10 @@
                             <div class="card-body">
                                 <h5 class="card-title m-0" t-attf-href="/partners/#{slug(partner)}?#{current_grade and 'grade_id=%s&amp;' % current_grade.id}#{current_country and 'country_id=%s' % current_country.id}" t-field="partner.display_name"/>
                                 <small id="o_wcrm_partners_address"/>
-                                <small class="o_wcrm_short_description text-muted overflow-hidden" t-field="partner.website_short_description"/>
                                 <small t-if="not partner.website_short_description" class="css_editable_mode_hidden text-muted fst-italic" groups="website.group_website_restricted_editor">
                                     Edit to add a short description
                                 </small>
+                                <small class="o_wcrm_short_description text-muted overflow-hidden" t-field="partner.website_short_description"/>
                             </div>
                         </a>
                     </div>


### PR DESCRIPTION
Current behavior:
---
After removing a reseller's description, you cannot edit it again

Steps to reproduce:
---
1. Go to Configuration > Menus
2. Create a new menu
3. Set URL as /partners
4. Set Parent menu as Top menu for website
5. Set Website as My website
6. Save and go back to homepage
7. Click on the new menu item
8. Edit a partner's description
9. Remove its content entirely
10. Select the empty description
11. Try to enter text in it
12. No text is being displayed

opw-3793263

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
