### PR TITLE
[FIX] stock: check Lot_id only on SML that have done quantity

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1058,7 +1058,7 @@ class Picking(models.Model):
 
         def get_line_with_done_qty_ids(move_lines):
             # Get only move_lines that has some quantity set.
-            return move_lines.filtered(lambda ml: ml.product_id and ml.product_id.tracking != 'none' and float_compare(ml.quantity, 0, precision_rounding=ml.product_uom_id.rounding)).ids
+            return move_lines.filtered(lambda ml: ml.product_id and ml.product_id.tracking != 'none' and ml.picked and float_compare(ml.quantity, 0, precision_rounding=ml.product_uom_id.rounding)).ids
 
         if separate_pickings:
             # If pickings are checked independently, get full/partial move_lines depending if each picking has no quantity set.


### PR DESCRIPTION
Steps to reproduce:
- Create a PO for two products one of them tracked sy SN
- Open reciept in barcode
- Set the qty on the not tracked product and leave the tracked to 0
- Validate the picking
- Prompt to create back order (correct)
- Confirm

Bug:
Error during check
 the done QTY should be checked not the demand

opw-3761580
