### PR TITLE
[IMP] l10n_de: Fixed taxes with wrong tax group

### DIFF
--- a/addons/l10n_de_skr03/data/account_tax_fiscal_position_data.xml
+++ b/addons/l10n_de_skr03/data/account_tax_fiscal_position_data.xml
@@ -48,7 +48,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_61_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_eu_7_purchase_skr03" model="account.tax.template">
         <field name="sequence">25</field>
@@ -98,7 +98,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_61_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_eu_19_purchase_no_vst_skr03" model="account.tax.template">
         <field name="sequence">20</field>
@@ -228,7 +228,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_59_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_eu_sale_skr03" model="account.tax.template">
         <field name="sequence">21</field>
@@ -1032,7 +1032,7 @@
                     'minus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_26_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_eu_skr03" model="account.tax.template">
         <field name="sequence">22</field>
@@ -1068,7 +1068,7 @@
                     'minus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_27_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_ust_19_13b_ausland_ohne_vst_skr03" model="account.tax.template">
         <field name="sequence">23</field>
@@ -1104,7 +1104,7 @@
                     'account_id': ref('account_1787'),
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_7_13b_ausland_ohne_vst_skr03" model="account.tax.template">
         <field name="sequence">24</field>
@@ -1140,7 +1140,7 @@
                     'account_id': ref('account_1785'),
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_ust_19_13b_eu_ohne_vst_skr03" model="account.tax.template">
         <field name="sequence">25</field>
@@ -1176,7 +1176,7 @@
                     'account_id': ref('account_1787'),
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_7_13b_eu_ohne_vst_skr03" model="account.tax.template">
         <field name="sequence">26</field>
@@ -1212,7 +1212,7 @@
                     'account_id': ref('account_1785'),
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_ust_19_13b_bau_ohne_vst_skr03" model="account.tax.template">
         <field name="sequence">27</field>
@@ -1248,7 +1248,7 @@
                     'account_id': ref('account_1787'),
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_7_13b_bau_ohne_vst_skr03" model="account.tax.template">
         <field name="sequence">28</field>
@@ -1284,7 +1284,7 @@
                     'account_id': ref('account_1785'),
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_free_eu_skr03" model="account.tax.template">
         <field name="sequence">20</field>
@@ -1502,7 +1502,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_47_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_eu_7_purchase_goods_skr03" model="account.tax.template">
         <field name="sequence">21</field>
@@ -1552,7 +1552,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_47_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_ust_vst_19_purchase_13b_bau_skr03" model="account.tax.template">
         <field name="sequence">22</field>
@@ -1602,7 +1602,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_85_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_vst_7_purchase_13b_bau_skr03" model="account.tax.template">
         <field name="sequence">23</field>
@@ -1652,7 +1652,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_85_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_vst_ust_19_purchase_13b_mobil_skr03" model="account.tax.template">
         <field name="sequence">24</field>
@@ -1702,7 +1702,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_85_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_vst_ust_19_purchase_3eck_last_skr03" model="account.tax.template">
         <field name="sequence">105</field>
@@ -1746,7 +1746,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_69_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_vst_ust_19_purchase_13b_werk_ausland_skr03" model="account.tax.template">
         <field name="sequence">25</field>
@@ -1796,7 +1796,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_85_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_vst_ust_7_purchase_13b_werk_ausland_skr03" model="account.tax.template">
         <field name="sequence">26</field>
@@ -1846,7 +1846,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_85_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_vst_ust_19_purchase_13a_auslagerung_skr03" model="account.tax.template">
         <field name="sequence">27</field>
@@ -1890,7 +1890,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_69_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_vst_ust_7_purchase_13a_auslagerung_skr03" model="account.tax.template">
         <field name="sequence">28</field>
@@ -1934,7 +1934,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_69_tag')],
                 }),
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="fiscal_position_domestic_skr03" model="account.fiscal.position.template">
         <field name="sequence">1</field>

--- a/addons/l10n_de_skr04/data/account_tax_fiscal_position_data.xml
+++ b/addons/l10n_de_skr04/data/account_tax_fiscal_position_data.xml
@@ -48,7 +48,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_61_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_eu_7_purchase_skr04" model="account.tax.template">
         <field name="sequence">25</field>
@@ -98,7 +98,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_61_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_eu_19_purchase_no_vst_skr04" model="account.tax.template">
         <field name="sequence">20</field>
@@ -228,7 +228,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_59_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_eu_sale_skr04" model="account.tax.template">
         <field name="sequence">21</field>
@@ -1027,7 +1027,7 @@
                     'minus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_26_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_eu_skr04" model="account.tax.template">
         <field name="sequence">22</field>
@@ -1063,7 +1063,7 @@
                     'minus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_27_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_ust_19_13b_ausland_ohne_vst_skr04" model="account.tax.template">
         <field name="sequence">23</field>
@@ -1099,7 +1099,7 @@
                     'account_id': ref('chart_skr04_3837'),
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_7_13b_ausland_ohne_vst_skr04" model="account.tax.template">
         <field name="sequence">24</field>
@@ -1135,7 +1135,7 @@
                     'account_id': ref('chart_skr04_3835'),
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_ust_19_13b_eu_ohne_vst_skr04" model="account.tax.template">
         <field name="sequence">25</field>
@@ -1171,7 +1171,7 @@
                     'account_id': ref('chart_skr04_3837'),
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_7_13b_eu_ohne_vst_skr04" model="account.tax.template">
         <field name="sequence">26</field>
@@ -1207,7 +1207,7 @@
                     'account_id': ref('chart_skr04_3835'),
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_ust_19_13b_bau_ohne_vst_skr04" model="account.tax.template">
         <field name="sequence">27</field>
@@ -1243,7 +1243,7 @@
                     'account_id': ref('chart_skr04_3837'),
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_7_13b_bau_ohne_vst_skr04" model="account.tax.template">
         <field name="sequence">28</field>
@@ -1279,7 +1279,7 @@
                     'account_id': ref('chart_skr04_3835'),
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_free_eu_skr04" model="account.tax.template">
         <field name="sequence">20</field>
@@ -1497,7 +1497,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_47_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_eu_7_purchase_goods_skr04" model="account.tax.template">
         <field name="sequence">21</field>
@@ -1547,7 +1547,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_47_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_ust_vst_19_purchase_13b_bau_skr04" model="account.tax.template">
         <field name="sequence">22</field>
@@ -1597,7 +1597,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_85_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_ust_vst_7_purchase_13b_bau_skr04" model="account.tax.template">
         <field name="sequence">23</field>
@@ -1647,7 +1647,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_85_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_vst_ust_19_purchase_13b_mobil_skr04" model="account.tax.template">
         <field name="sequence">24</field>
@@ -1698,7 +1698,7 @@
                 }),
 
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_vst_ust_19_purchase_3eck_last_skr04" model="account.tax.template">
         <field name="sequence">25</field>
@@ -1742,7 +1742,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_69_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_vst_ust_19_purchase_13b_werk_ausland_skr04" model="account.tax.template">
         <field name="sequence">25</field>
@@ -1792,7 +1792,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_85_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_vst_ust_7_purchase_13b_werk_ausland_skr04" model="account.tax.template">
         <field name="sequence">26</field>
@@ -1843,7 +1843,7 @@
                 }),
 
             ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="tax_vst_ust_19_purchase_13a_auslagerung_skr04" model="account.tax.template">
         <field name="sequence">27</field>
@@ -1887,7 +1887,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_69_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_19"/>
     </record>
     <record id="tax_vst_ust_7_purchase_13a_auslagerung_skr04" model="account.tax.template">
         <field name="sequence">28</field>
@@ -1931,7 +1931,7 @@
                     'plus_report_expression_ids': [ref('l10n_de.tax_report_de_tag_69_tag')],
                 }),
              ]"/>
-        <field name="tax_group_id" ref="tax_group_0"/>
+        <field name="tax_group_id" ref="tax_group_7"/>
     </record>
     <record id="fiscal_position_domestic_skr04" model="account.fiscal.position.template">
         <field name="sequence">1</field>


### PR DESCRIPTION
Some taxes of skr03 and skr04 were not set for the appropriate tax group. This was fixed, and each tax was set to its appropriate tax group.

Taxes should not be set with wrong tax groups.

task-3800915

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
