### PR TITLE
[FIX] calendar: prevent popup overflowing viewport border

### DIFF
--- a/addons/calendar/static/src/scss/calendar.scss
+++ b/addons/calendar/static/src/scss/calendar.scss
@@ -1,5 +1,4 @@
 .o_cw_popover .o_cw_popover_fields_secondary {
-    max-height: 75vh;
     & > li > div {
         min-width: 0;
     }


### PR DESCRIPTION
### [[FIX] calendar: prevent popup overflowing viewport border]

When creating events with long description, it may happen that the
bottom part of the popover box will go over the bottom border of the
viewport, making the "edit" button unavailable.

### [Reproduce]
- Install -i calendar
- Add an event from 20:00 to 21:00 (or just at the bottom of the screen)
- Fill its description with long content (50 lines of content )
    python -c "import pyperclip; pyperclip.copy('#\n'*50)"
- In calendar view, click on the event, scroll to the bottom
- BUG: Bottom event pane with buttons "Edit" "Delete" not visible

Note: Tested on viewport 1920 x 1080, 60% zoom.
The bug is not present after scrolling up, nor on different zoom levels.

opw-3756756
