### PR TITLE
[FIX] website_sale: don't reset catgory when clearing filters on mobile view

### DIFF
--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -665,7 +665,7 @@
             <div class="offcanvas-body d-flex justify-content-between flex-grow-0 border-top overflow-hidden">
                 <a t-attf-class="btn btn-{{navClass}} d-flex py-1 mb-2 {{(not attrib_values and not isFilteringByPrice) and 'disabled' }}"
                    t-att-aria-disabled="(not attrib_values and not isFilteringByPrice) and 'true' or 'false'"
-                   href="/shop"
+                   t-att-href="keep('/shop'+ ('/category/'+slug(category)) if category else None, attrib=0)"
                    title="Clear Filters">
                     Clear Filters
                 </a>


### PR DESCRIPTION
### Steps to reproduce:
- Install **eCommerce** app.
- Go to **Website** > **Shop**.
- Switch to **Mobile** view.
- Under **Categories**, choose **Chairs**.
- Under **Legs**, choose **Steel**.
- Click on **Clear Filters**, The Category is reset to **All Products**! which is not the expected behavior.

### Investigation:
- The **Clear Filters** button navigates back to the `/shop` which reset the category to the default **All Products**.

opw-3802828