### PR TITLE
[FIX] point_of_sale: add new products to combo line

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -729,7 +729,14 @@ class PosConfig(models.Model):
             ('sale_ok', '=', True),
         ]
         if self.limit_categories and self.iface_available_categ_ids:
+            # Retrieve all combo products, combine restrict categories and combo product categories, and apply to the domain
+            valid_combos = self.env['product.product'].search([
+                ('detailed_type', '=', 'combo'),
+                ('pos_categ_ids', 'in', self.iface_available_categ_ids.ids)
+                ]).combo_ids
+            combo_product_ids = valid_combos.combo_line_ids.product_id
             domain.append(('pos_categ_ids', 'in', self.iface_available_categ_ids.ids))
+            domain = OR([domain, [('id', 'in', combo_product_ids.ids)]])
         if self.iface_tipproduct:
             domain = OR([domain, [('id', '=', self.tip_product_id.id)]])
         return domain


### PR DESCRIPTION
Steps:
=============================
- Install the point_of_sale.
- Create new products without pos categories or add those pos categories which are not present in restrict categories
in pos settings.
- Add the combo to office combo.
- Use office combo in pos.

Issue:
================================
- If new products are added to office combo then if the new products don't have product category then error occurred.

Cause:
==================================
- Domain is been restricted to pos_categ_ids, so if product does not have any category or have different category then iface_available_categ_ids then also error occurs.

Fix:
===================================
- Issue is been fixed by applying proper domain which allows product with and without product categories irrespective of iface_available_categ_ids.

task-3762862
