### PR TITLE
[FIX] website_slides: animeted links now visible in fullscreen

### DIFF
--- a/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
+++ b/addons/website_slides/static/src/scss/slides_slide_fullscreen.scss
@@ -115,6 +115,10 @@
             pointer-events: none;
         }
     }
+
+    .o_animate {
+        visibility: visible;
+    }
 }
 
 .modal-open {


### PR DESCRIPTION
### [FIX] website_slides: animeted text now visible in fullscreen

After opening fullscreen view of the course page, animated texts were
not visible. This comit ensures that they are visible.

### [Reproduce]
- Install -i website_slides
- Open a course
- Add content "Website" in the editor
- Select text, Make it animated (click "Animate Text")
- Save -> Open Fullscreen view of the course page
- BUG: Animated link is not visible

opw-3760272
