### PR TITLE
[IMP] l10n_id_efaktur: NPWP and NIK

### DIFF
--- a/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
+++ b/addons/l10n_id_efaktur/tests/test_l10n_id_efaktur.py
@@ -23,7 +23,8 @@ class TestIndonesianEfaktur(common.TransactionCase):
         self.env.company.street = "test"
         self.env.company.phone = "12345"
 
-        self.partner_id = self.env['res.partner'].create({"name": "l10ntest", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "12345"})
+        self.partner_id = self.env['res.partner'].create({"name": "l10ntest", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "12345", "vat": "000000000000000"})
+        self.partner_id_vat = self.env['res.partner'].create({"name": "l10ntest3", "l10n_id_pkp": True, "l10n_id_kode_transaksi": "01", "l10n_id_nik": "67890", "vat": "010000000000000"})
         self.env['account.tax.group'].create({
             'name': 'tax_group',
             'country_id': self.env.ref('base.id').id,
@@ -69,7 +70,7 @@ class TestIndonesianEfaktur(common.TransactionCase):
             _csv_row(OF_HEAD_LIST, ','),
         )
         # remaining lines
-        line_4 = '"FK","01","0","0000000000001","5","2019","1/5/2019","12345","l10ntest","","100","10","0","","0","0","0","0","INV/2019/00001 12345","0"\n'
+        line_4 = '"FK","01","0","0000000000001","5","2019","1/5/2019","000000000000000","12345#NIK#NAMA#l10ntest","","100","10","0","","0","0","0","0","INV/2019/00001 ","0"\n'
         line_5 = '"OF","","","100.00","1.0","100.00","0","100.00","10.00","0","0"\n'
 
         efaktur_csv_expected = output_head + line_4 + line_5
@@ -92,7 +93,7 @@ class TestIndonesianEfaktur(common.TransactionCase):
             _csv_row(LT_HEAD_LIST, ','),
             _csv_row(OF_HEAD_LIST, ','),
         )
-        line_4 = '"FK","01","0","0000000000002","5","2019","1/5/2019","12345","l10ntest","","40040","4004","0","","0","0","0","0","INV/2019/00002 12345","0"\n'
+        line_4 = '"FK","01","0","0000000000002","5","2019","1/5/2019","000000000000000","12345#NIK#NAMA#l10ntest","","40040","4004","0","","0","0","0","0","INV/2019/00002 ","0"\n'
         line_5 = '"OF","","","100.10","400.0","40040.00","0","40040.00","4004.00","0","0"\n'
 
         efaktur_csv_expected = output_head + line_4 + line_5
@@ -209,3 +210,29 @@ class TestIndonesianEfaktur(common.TransactionCase):
         self.assertEqual(self.efaktur.available, available_code - 1)
         # No error is raised when downloading.
         out_invoice_no_taxes.download_efaktur()
+
+    def test_efaktur_use_vat(self):
+        """ Test to ensure that the e-faktur uses the VAT on NPWP column of efaktur when
+        VAT is non-zeros """
+        out_invoice = self.env['account.move'].create({
+            'move_type': 'out_invoice',
+            'partner_id': self.partner_id_vat.id,
+            'invoice_date': '2019-05-01',
+            'date': '2019-05-01',
+            'invoice_line_ids': [
+                (0, 0, {'name': 'line1', 'price_unit': 110.11, 'quantity': 400, 'tax_ids': self.tax_id.ids})
+            ],
+            'l10n_id_kode_transaksi': '01'
+        })
+        out_invoice.action_post()
+        efaktur_csv_output = out_invoice._generate_efaktur_invoice(',')
+        output_head = '%s%s%s' % (
+            _csv_row(FK_HEAD_LIST, ','),
+            _csv_row(LT_HEAD_LIST, ','),
+            _csv_row(OF_HEAD_LIST, ','),
+        )
+        line_4 = '"FK","01","0","0000000000003","5","2019","1/5/2019","010000000000000","l10ntest3","","40040","4004","0","","0","0","0","0","INV/2019/00003 ","0"\n'
+        line_5 = '"OF","","","100.10","400.0","40040.00","0","40040.00","4004.00","0","0"\n'
+
+        efaktur_csv_expected = output_head + line_4 + line_5
+        self.assertEqual(efaktur_csv_expected, efaktur_csv_output)


### PR DESCRIPTION
Due to recent rule changes for E-faktur, now NIK and NPWP are complement to each other. Which means now, when the person is filling in 000000000000000, e-faktur should be taking the NIK as NPWP column in e-Faktur

3815006

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
