### PR TITLE
[IMP] hr_holidays: restrict allocation type to leave type

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_demo.xml
+++ b/addons/hr_holidays/data/hr_holidays_demo.xml
@@ -32,6 +32,17 @@
         <field name="max_allowed_negative" eval="20"/>
     </record>
 
+    <record id="holiday_status_seniority" model="hr.leave.type">
+        <field name="name">Seniority Leaves</field>
+        <field name="requires_allocation">yes</field>
+        <field name="employee_requests">no</field>
+        <field name="leave_validation_type">both</field>
+        <field name="allocation_validation_type">officer</field>
+        <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
+        <field name="icon_id" ref="hr_holidays.icon_10"/>
+        <field name="allocation_type">accrual</field>
+    </record>
+
     <!-- Accrual Plan -->
     <record id="hr_accrual_plan_1" model="hr.leave.accrual.plan">
         <field name="name">Seniority Plan</field>

--- a/addons/hr_holidays/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays/tests/test_accrual_allocations.py
@@ -18,7 +18,12 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'name': 'Paid Time Off',
             'time_type': 'leave',
             'requires_allocation': 'yes',
+<<<<<<< HEAD
             'allocation_validation_type': 'hr',
+=======
+            'allocation_validation_type': 'officer',
+            'allocation_type': 'accrual',
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
         })
         cls.leave_type_hour = cls.env['hr.leave.type'].create({
             'name': 'Paid Time Off',
@@ -26,6 +31,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'requires_allocation': 'yes',
             'allocation_validation_type': 'hr',
             'request_unit': 'hour',
+            'allocation_type': 'accrual',
         })
 
     def setAllocationCreateDate(self, allocation_id, date):
@@ -83,7 +89,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
@@ -121,7 +126,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
@@ -176,7 +180,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
@@ -213,7 +216,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2021-09-03',
             })
             with freeze_time(datetime.date.today() + relativedelta(days=2)):
@@ -259,7 +261,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2021-09-03',
             })
             self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
@@ -302,7 +303,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2021-08-31',
             })
             self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
@@ -341,7 +341,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
             allocation.action_validate()
@@ -384,7 +383,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             self.setAllocationCreateDate(allocation.id, '2021-09-01 00:00:00')
             allocation.action_validate()
@@ -469,7 +467,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'state': 'confirm',
             })
             allocation_worked_time = self.env['hr.leave.allocation'].with_user(self.user_hrmanager_id).with_context(tracking_disable=True).create({
@@ -478,7 +475,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'state': 'confirm',
             })
             (allocation_not_worked_time | allocation_worked_time).action_validate()
@@ -544,7 +540,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
             allocation._update_accrual()
@@ -584,7 +579,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
             allocation._update_accrual()
@@ -633,7 +627,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
             next_date = datetime.date.today() + relativedelta(days=11)
@@ -669,7 +662,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
             next_date = datetime.date.today() + relativedelta(days=11)
@@ -698,7 +690,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 10,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
 
@@ -732,7 +723,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 10,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
 
@@ -765,7 +755,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
 
@@ -801,7 +790,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 10,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
 
@@ -834,7 +822,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
 
@@ -876,7 +863,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': datetime.date(2020, 8, 16),
             })
             allocation.action_validate()
@@ -924,7 +910,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': datetime.date(2022, 1, 31),
             })
             allocation.action_validate()
@@ -970,7 +955,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': datetime.date(2021, 1, 1),
             })
             allocation.action_validate()
@@ -1002,7 +986,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': datetime.date(2019, 1, 1),
             })
             allocation.action_validate()
@@ -1031,7 +1014,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2021-09-03',
             })
 
@@ -1060,7 +1042,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2021-09-03',
             })
 
@@ -1091,7 +1072,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2022-01-01',
             })
             allocation.action_validate()
@@ -1135,7 +1115,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type_hour.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2022-01-01',
             })
             allocation.action_validate()
@@ -1180,7 +1159,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2023-04-24',
             })
             allocation.action_validate()
@@ -1197,7 +1175,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2023-04-24',
             })
             allocation.action_validate()
@@ -1228,7 +1205,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2023-04-13',
             })
             allocation.action_validate()
@@ -1274,7 +1250,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2023-04-26',
             })
             allocation.action_validate()
@@ -1313,7 +1288,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2023-04-26',
             })
             allocation.action_validate()
@@ -1362,7 +1336,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
                 'date_from': '2023-04-20',
             })
             allocation.action_validate()
@@ -1425,7 +1398,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 9,
-                'allocation_type': 'accrual',
                 'date_from': '2023-04-4',
             })
             allocation.action_validate()
@@ -1454,7 +1426,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'holiday_status_id': self.leave_type.id,
                 'date_from': '2023-01-01',
                 'employee_id': self.employee_emp.id,
-                'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan.id,
             })
             # As the duration is set to a onchange, we need to force that onchange to run
@@ -1476,6 +1447,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'requires_allocation': 'yes',
             'allocation_validation_type': 'no_validation',
             'request_unit': 'hour',
+            'allocation_type': 'accrual',
         })
         with freeze_time("2023-12-31"):
             accrual_plan = self.env['hr.leave.accrual.plan'].create({
@@ -1499,7 +1471,11 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': leave_type.id,
                 'number_of_days': 0.125,
+<<<<<<< HEAD
                 'allocation_type': 'accrual',
+=======
+                'holiday_type': 'employee',
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
             })
             allocation.action_validate()
             allocation_data = leave_type.get_allocation_data(self.employee_emp, datetime.date(2024, 2, 1))
@@ -1551,7 +1527,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'holiday_status_id': self.leave_type.id,
                 'date_from': '2023-08-01',
                 'employee_id': self.employee_emp.id,
-                'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan.id,
             })
             # As the duration is set to a onchange, we need to force that onchange to run
@@ -1586,7 +1561,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'holiday_status_id': self.leave_type.id,
                 'date_from': '2024-03-01',
                 'employee_id': self.employee_emp.id,
-                'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan.id,
             })
             # As the duration is set to an onchange, we need to force that onchange to run
@@ -1626,7 +1600,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
                 'holiday_status_id': self.leave_type.id,
                 'date_from': '2024-03-01',
                 'employee_id': self.employee_emp.id,
-                'allocation_type': 'accrual',
                 'accrual_plan_id': accrual_plan.id,
             })
             # As the duration is set to an onchange, we need to force that onchange to run

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -17,7 +17,12 @@ class TestAllocations(TestHrHolidaysCommon):
             'name': 'Time Off with no validation for approval',
             'time_type': 'leave',
             'requires_allocation': 'yes',
+<<<<<<< HEAD
             'allocation_validation_type': 'no_validation',
+=======
+            'allocation_validation_type': 'no',
+            'allocation_type': 'regular',
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
         })
         cls.department = cls.env['hr.department'].create({
             'name': 'Test Department',
@@ -44,8 +49,12 @@ class TestAllocations(TestHrHolidaysCommon):
             'allocation_mode': 'company',
             'company_id': self.company.id,
             'holiday_status_id': self.leave_type.id,
+<<<<<<< HEAD
             'duration': 2,
             'allocation_type': 'regular',
+=======
+            'number_of_days': 2,
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
         })
 
         company_allocation.action_generate_allocations()
@@ -59,8 +68,12 @@ class TestAllocations(TestHrHolidaysCommon):
             'allocation_mode': 'employee',
             'employee_ids': [(4, self.employee.id), (4, self.employee_emp.id)],
             'holiday_status_id': self.leave_type.id,
+<<<<<<< HEAD
             'duration': 2,
             'allocation_type': 'regular',
+=======
+            'number_of_days': 2,
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
         })
 
         employee_allocation.action_generate_allocations()
@@ -74,8 +87,12 @@ class TestAllocations(TestHrHolidaysCommon):
             'allocation_mode': 'department',
             'department_id': self.department.id,
             'holiday_status_id': self.leave_type.id,
+<<<<<<< HEAD
             'duration': 2,
             'allocation_type': 'regular',
+=======
+            'number_of_days': 2,
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
         })
 
         department_allocation.action_generate_allocations()
@@ -89,8 +106,12 @@ class TestAllocations(TestHrHolidaysCommon):
             'allocation_mode': 'category',
             'category_id': self.category_tag.id,
             'holiday_status_id': self.leave_type.id,
+<<<<<<< HEAD
             'duration': 2,
             'allocation_type': 'regular',
+=======
+            'number_of_days': 2,
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
         })
 
         category_allocation.action_generate_allocations()

--- a/addons/hr_holidays/tests/test_hr_leave_type.py
+++ b/addons/hr_holidays/tests/test_hr_leave_type.py
@@ -1,10 +1,7 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 from datetime import date
 from dateutil.relativedelta import relativedelta
 
-from odoo.exceptions import AccessError
+from odoo.exceptions import AccessError, ValidationError
 from odoo.tools import date_utils
 
 from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
@@ -41,3 +38,49 @@ class TestHrLeaveType(TestHrHolidaysCommon):
                 'name': 'UserCheats',
                 'requires_allocation': 'no',
             })
+
+    def test_write_unchangeable_fields(self):
+        leave_type = self.env['hr.leave.type'].create({
+            'name': 'Paid Time Off',
+            'time_type': 'leave',
+            'requires_allocation': 'no',
+            'allocation_type': 'accrual',
+            'request_unit': 'hour',
+            'allows_negative': False,
+            'max_allowed_negative': '1',
+        })
+
+        leave_type.requires_allocation = 'yes'
+        leave_type.allocation_type = 'regular'
+
+        self.env['hr.leave.allocation'].create([{
+            'name': 'leave_type_regular allocation',
+            'holiday_status_id': leave_type.id,
+            'date_from': date(2024, 1, 1),
+            'date_to': date(2024, 12, 31),
+            'employee_id': self.employee_hruser_id,
+            'allocation_type': 'regular',
+            'number_of_days': 1,
+        }])
+
+        with self.assertRaises(ValidationError):
+            leave_type.requires_allocation = 'no'
+        with self.assertRaises(ValidationError):
+            leave_type.allocation_type = 'regular'
+
+        leave_type.allows_negative = True
+        leave_type.max_allowed_negative = 16
+
+        self.env['hr.leave'].create({
+            'holiday_status_id': leave_type.id,
+            'employee_id': self.employee_hruser_id,
+            'request_date_from': date(2024, 3, 18),
+            'request_date_to': date(2024, 3, 20),
+        })
+
+        leave_type.max_allowed_negative = 24
+        leave_type.max_allowed_negative = 16
+        with self.assertRaises(ValidationError):
+            leave_type.allows_negative = False
+        with self.assertRaises(ValidationError):
+            leave_type.max_allowed_negative = 15

--- a/addons/hr_holidays/tests/test_past_accruals.py
+++ b/addons/hr_holidays/tests/test_past_accruals.py
@@ -1,4 +1,3 @@
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
 from datetime import date
 from freezegun import freeze_time
 
@@ -17,6 +16,7 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
             'time_type': 'leave',
             'requires_allocation': 'yes',
             'allocation_validation_type': 'no',
+            'allocation_type': 'accrual',
         })
         cls.accrual_plan = cls.env['hr.leave.accrual.plan'].with_context(tracking_disable=True).create({
             'name': 'Test Seniority Plan',
@@ -55,7 +55,6 @@ class TestAccrualAllocations(TestHrHolidaysCommon):
         with freeze_time("2023-12-01"):
             allocation = self.env['hr.leave.allocation'].create({
                 'employee_id': self.employee_emp_id,
-                'allocation_type': 'accrual',
                 'accrual_plan_id': self.accrual_plan.id,
                 'holiday_status_id': self.leave_type.id,
                 'date_from': date(2000, 1, 1),

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -111,10 +111,7 @@
                             <field name="holiday_status_id"
                                 context="{'employee_id':employee_id, 'default_date_from':current_date, 'request_type':'allocation'}"
                                 readonly="state == 'validate'"/>
-                            <field name="allocation_type"
-                                widget="radio"
-                                invisible="1"
-                                readonly="not is_officer or state == 'validate'"/>
+                            <field name="allocation_type" invisible="1"/>
                             <field name="is_officer" invisible="1"/>
                             <field name="accrual_plan_id"
                                 invisible="allocation_type == 'regular'"
@@ -193,9 +190,6 @@
                     readonly="state in ['refuse', 'validate']"
                     widget="many2one_avatar_employee"/>
             </field>
-            <field name="allocation_type" position="attributes">
-                <attribute name="invisible">0</attribute>
-            </field>
             <label for="date_from" position="replace">
                 <label for="date_from" string="Validity Period" invisible="allocation_type == 'accrual'"/>
             </label>
@@ -269,7 +263,7 @@
                 <field name="duration_display" string="Amount"/>
                 <field name="date_from" string="Validity Start" optional="hide"/>
                 <field name="date_to" string="Validity Stop" optional="hide" readonly="state in ['refuse', 'validate', 'validate1']"/>
-                <field name="allocation_type" readonly="state not in ['confirm']"/>
+                <field name="allocation_type" optional="hide"/>
                 <field name="message_needaction" column_invisible="True"/>
                 <field name="active_employee" column_invisible="True"/>
                 <field name="state" widget="badge" decoration-warning="state == 'confirm'" decoration-success="state == 'validate'"/>

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -10,6 +10,8 @@
                 <field name="create_calendar_meeting"/>
                 <separator/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
+                <filter name="group_allocation_type" string="Allocation Type"
+                    context="{'group_by':'allocation_type'}"/>
             </search>
         </field>
     </record>
@@ -66,12 +68,13 @@
                         </group>
                         <group name="allocation_validation" id="allocation_requests" string="Allocation Requests">
                             <field name="requires_allocation" widget="radio" options="{'horizontal':true}"/>
+                            <field name="allocation_type" invisible="requires_allocation == 'no'"/>
                             <field name="employee_requests" widget="radio" invisible="requires_allocation == 'no'"/>
                             <field name="allocation_validation_type" string="Approval" widget="radio" invisible="requires_allocation == 'no'"/>
                         </group>
                     </group>
                     <group>
-                        <group name="configuration" id="configuration" string="Configuration">
+                        <group name="configuration" id="configuration" string="General">
                             <field name="responsible_ids"
                                 widget="many2many_tags"
                                 placeholder="Nobody will be notified"
@@ -135,6 +138,7 @@
                 <field name="leave_validation_type" optional="hide" string="Time Off Approval"/>
                 <field name="responsible_ids" widget="many2many_tags" invisible="leave_validation_type in ['no_validation', 'manager'] and (requires_allocation == 'no' or allocation_validation_type != 'hr')" optional="hide"/>
                 <field name="requires_allocation" optional="hide"/>
+                <field name="allocation_type" optional="hide"/>
                 <field name="allocation_validation_type" string="Allocation Approval"/>
                 <field name="employee_requests" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>

--- a/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
+++ b/addons/hr_holidays_attendance/tests/test_accrual_allocations.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-# Part of Odoo. See LICENSE file for full copyright and licensing details.
-
 import datetime
 from freezegun import freeze_time
 from dateutil.relativedelta import relativedelta
@@ -20,7 +17,12 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
             'name': 'Paid Time Off',
             'time_type': 'leave',
             'requires_allocation': 'yes',
+<<<<<<< HEAD
             'allocation_validation_type': 'hr',
+=======
+            'allocation_validation_type': 'officer',
+            'allocation_type': 'accrual',
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
         })
 
     def test_frequency_hourly_attendance(self):
@@ -45,7 +47,6 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
                 'employee_id': self.employee_emp.id,
                 'holiday_status_id': self.leave_type.id,
                 'number_of_days': 0,
-                'allocation_type': 'accrual',
             })
             allocation.action_validate()
             self.assertFalse(allocation.nextcall, 'There should be no nextcall set on the allocation.')
@@ -85,13 +86,17 @@ class TestAccrualAllocationsAttendance(TestHrHolidaysCommon):
             })],
         })
         self.env['hr.attendance'].create({
-                'employee_id': self.employee_emp.id,
-                'check_in': datetime.datetime(2024, 4, 1, 8, 0, 0),
-                'check_out': datetime.datetime(2024, 4, 1, 17, 0, 0),
-            })
+            'employee_id': self.employee_emp.id,
+            'check_in': datetime.datetime(2024, 4, 1, 8, 0, 0),
+            'check_out': datetime.datetime(2024, 4, 1, 17, 0, 0),
+        })
         with Form(self.env['hr.leave.allocation']) as allocation_form:
+<<<<<<< HEAD
             allocation_form.allocation_type = 'accrual'
             allocation_form.employee_id = self.employee_emp
+=======
+            allocation_form.employee_ids = self.employee_emp
+>>>>>>> f07d33b4bb23 ([IMP] hr_holidays: restrict allocation type to leave type)
             allocation_form.accrual_plan_id = accrual_plan
             allocation_form.holiday_status_id = self.leave_type
             allocation_form.date_from = datetime.date(2024, 3, 20)


### PR DESCRIPTION
Before this commit, the allocation type determining if the allocation is regular or linked to an accrual was chosen from the allocation directly. This means that for a same leave type, both allocation type could have been used. However, as both are very different in the way we compute the remaining leaves (for the time off dashboard for example) this might lead to some display issues.

This commit moves the allocation type selection to the leave type, ensuring only one type can be used instead.

task-3412869