### PR TITLE
[FIX] spreadsheet: invalid pivot error message

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_functions.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_functions.js
@@ -45,7 +45,7 @@ function getPivotId(pivotFormulaId, getters) {
 function assertMeasureExist(pivotId, measure, getters) {
     const { measures } = getters.getPivotDefinition(pivotId);
     if (!measures.includes(measure)) {
-        const validMeasures = `(${measures.map((m) => m.name).join(", ")})`;
+        const validMeasures = `(${measures.join(", ")})`;
         throw new EvaluationError(
             sprintf(
                 _t("The argument %s is not a valid measure. Here are the measures: %s"),

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
@@ -638,6 +638,25 @@ QUnit.module("spreadsheet > pivot plugin", {}, () => {
         assert.strictEqual(F10.format, "0");
     });
 
+    QUnit.test("invalid pivot measure", async function (assert) {
+        const { model } = await createSpreadsheetWithPivot({
+            arch: /* xml */ `
+                <pivot>
+                    <field name="product_id" type="col"/>
+                    <field name="foo" type="row"/>
+                    <field name="probability" type="measure"/>
+                </pivot>`,
+        });
+        const formula = '=ODOO.PIVOT(1, "count")';
+        setCellContent(model, "F10", formula);
+        assert.equal(getCellValue(model, "F10"), "#ERROR", formula);
+        assert.equal(
+            getEvaluatedCell(model, "F10").message,
+            "The argument count is not a valid measure. Here are the measures: (probability)",
+            formula
+        );
+    });
+
     QUnit.test("can import/export sorted pivot", async (assert) => {
         const spreadsheetData = {
             pivots: {

--- a/odoo/release.py
+++ b/odoo/release.py
@@ -12,7 +12,7 @@ RELEASE_LEVELS_DISPLAY = {ALPHA: ALPHA,
 # properly comparable using normal operators, for example:
 #  (6,1,0,'beta',0) < (6,1,0,'candidate',1) < (6,1,0,'candidate',2)
 #  (6,1,0,'candidate',2) < (6,1,0,'final',0) < (6,1,2,'final',0)
-version_info = (17, 2, 0, ALPHA, 1, '')
+version_info = (17, 3, 0, ALPHA, 1, '')
 version = '.'.join(str(s) for s in version_info[:2]) + RELEASE_LEVELS_DISPLAY[version_info[3]] + str(version_info[4] or '') + version_info[5]
 series = serie = major_version = '.'.join(str(s) for s in version_info[:2])
 


### PR DESCRIPTION
Before this commit, applying a pivot formula with an invalid measure returns an error message without
showing possible measures.
This commit fixed that

Task 3754942





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
