### PR TITLE
[IMP] web: pivot: keep horizontal scrollbar inside viewport

### DIFF
--- a/addons/web/static/src/views/pivot/pivot_renderer.xml
+++ b/addons/web/static/src/views/pivot/pivot_renderer.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.PivotRenderer">
         <t t-call="{{ props.buttonTemplate }}"/>
-        <div t-if="model.hasData() and model.metaData.activeMeasures.length" class="o_pivot table-responsive mx-3">
+        <div t-if="model.hasData() and model.metaData.activeMeasures.length" class="o_pivot mx-3">
             <table
                 class="table-hover table table-sm table-bordered table-borderless"
                 t-att-class="{ o_enable_linking: !model.metaData.disableLinking }"

--- a/addons/web/static/src/views/pivot/pivot_view.scss
+++ b/addons/web/static/src/views/pivot/pivot_view.scss
@@ -38,6 +38,9 @@
 }
 
 // ------- Sample mode -------
-.o_pivot_view .o_view_sample_data .o_pivot {
-    @include o-sample-data-disabled;
+.o_pivot_view .o_view_sample_data {
+    overflow: hidden !important;
+    .o_pivot {
+        @include o-sample-data-disabled;
+    }
 }


### PR DESCRIPTION
This commit simply removes the table-responsive class from the pivot view so that its eventual horizontal scrollbar will remain inside the viewport inside of being positioned at the very bottom of the page.
