### PR TITLE
[FIX] mail: racing condition in message post

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -600,18 +600,7 @@ class Channel(models.Model):
         message_format = message.message_format()[0]
         if "temporary_id" in self.env.context:
             message_format["temporary_id"] = self.env.context["temporary_id"]
-        # Last interest and is_pinned are updated for a channel when posting a message.
-        # So a notification is needed to update UI, and it should come before the
-        # notification of the message itself to ensure the channel automatically opens.
-        payload = {
-            "Thread": {
-                "id": self.id,
-                "last_interest_dt": fields.Datetime.now(),
-                "model": "discuss.channel",
-            },
-        }
         bus_notifications = [
-            (self, "mail.record/insert", payload),
             ((self, "members"), "mail.record/insert", {
                 "Thread": {"id": self.id, "is_pinned": True, "model": "discuss.channel"}
             }),


### PR DESCRIPTION
Currently, the message post is done in two steps: first writing the last_interest_dt to the channel, then creating the message, second triggering the notify_thread to send the message to the followers.

In the first step, the last_interest_dt will be directly sent to the client if it differs from the old value. So there is no need to send the message to the client if the last_interest_dt has not changed in the second step. Also, this can lead to a racing condition in the testing files.

This commit removes the notif in the second step and changes the testing files related.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
