### PR TITLE
[FIX] web: bugfix project user add properties traceback

### DIFF
--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -580,7 +580,7 @@ export class PropertiesField extends Component {
     }
 
     async onPropertyCreate() {
-        if (!(await this.checkDefinitionWriteAccess())) {
+        if (!this.state.canChangeDefinition || !(await this.checkDefinitionWriteAccess())) {
             this.notification.add(
                 _t("You need edit access on the parent document to update these property fields"),
                 { type: "warning" }


### PR DESCRIPTION
Currently if there are no IR rules preventing a low right user to write on a record, no error notification
will appear when the user tries to add a property field to the child model since no error is raised in the
checkDefinitionWriteAccess method.

If this user does not have access rights on the model of the parent record an unwanted traceback will appear
since nothing prevents him from trying to add a property field to the model

Here we're using the canChangeDefinition which is loaded by checkingAccessRight on the user at the start of
the component startup

Task-3815748

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
