### PR TITLE
[FIX] l10n_fr_pos_cert: inalterability check report performance

### DIFF
--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -76,7 +76,11 @@ class pos_order(models.Model):
             field_value = obj[field_str]
             if obj._fields[field_str].type == 'many2one':
                 field_value = field_value.id
-            if obj._fields[field_str].type in ['many2many', 'one2many']:
+            if field_str == "payment_ids":
+                # optimization: pos.payment.sorted() can be slow. Exploit the fact that we know its
+                # _order to use a faster sorting method.
+                field_value = sorted(field_value.ids, reverse=True)
+            elif obj._fields[field_str].type in ['many2many', 'one2many']:
                 field_value = field_value.sorted().ids
             return str(field_value)
 


### PR DESCRIPTION
The reason for this fix is upgrade request 1418835. When the mock crawler opens this report, the request times out on it after 3d. This database has ~1.2M pos.order. When looping over these in `_compute_string_to_hash()`, each iteration spends ~5.5s in the call to `field_value.sorted()` for the field `payment_ids`, cummulating to >76 days!

This patch applies a more efficient sort method for field `payment_ids`, reducing the runtime of the entire loop to ~18h.

upg-1418835