### PR TITLE
[IMP] web: display caret on hover for many2x values

### DIFF
--- a/addons/web/static/src/core/record_selectors/multi_record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/multi_record_selector.xml
@@ -16,6 +16,7 @@
                 getIds.bind="getIds"
                 update.bind="update"
             />
+            <span class="o_dropdown_button"/>
         </div>
     </t>
 

--- a/addons/web/static/src/core/record_selectors/record_selector.xml
+++ b/addons/web/static/src/core/record_selectors/record_selector.xml
@@ -2,18 +2,21 @@
 <templates xml:space="preserve">
 
     <t t-name="web.RecordSelector" >
-        <RecordAutocomplete
-            resModel="props.resModel"
-            value="displayName"
-            domain="props.domain"
-            context="props.context"
-            className="'h-100 o_record_selector'"
-            fieldString="props.fieldString"
-            placeholder="props.placeholder"
-            multiSelect="false"
-            getIds="() => []"
-            update.bind="update"
-        />
+        <div class="o_input d-flex flex-wrap gap-1 o_record_selector">
+            <RecordAutocomplete
+                resModel="props.resModel"
+                value="displayName"
+                domain="props.domain"
+                context="props.context"
+                className="'h-100 flex-grow-1'"
+                fieldString="props.fieldString"
+                placeholder="props.placeholder"
+                multiSelect="false"
+                getIds="() => []"
+                update.bind="update"
+            />
+            <span class="o_dropdown_button"/>
+        </div>
     </t>
 
 </templates>

--- a/addons/web/static/src/core/record_selectors/record_selectors.scss
+++ b/addons/web/static/src/core/record_selectors/record_selectors.scss
@@ -1,0 +1,9 @@
+.o_record_selector, .o_multi_record_selector {
+    &:hover, &:focus-within {
+        .o_dropdown_button {
+            &:after {
+                @include o-caret-down;
+            }
+        }
+    }
+}


### PR DESCRIPTION
Before this commit, the user was not able to see the caret icon to indicate 
autocomplete dropdown in many2one and many2many values.

Steps to reproduce:

- open documents and then navigate to actions from the configuration.
- click on any action and add a rule for any many2many field.
- then try to add many2many values to that rule.

Observed behavior:
No caret is displayed when adding the many2many values.

Expected behavior:
Now a caret is displayed on hover indicating a dropdown while adding many2many 
and many2one values.

After this commit, the user will be able to see the caret icon to indicate 
autocomplete dropdown in many2one and many2many values.

Task-3777903

