### PR TITLE
[IMP] event: set the author on the event mails

### DIFF
--- a/addons/event/data/mail_template_data.xml
+++ b/addons/event/data/mail_template_data.xml
@@ -6,7 +6,7 @@
             <field name="name">Event: Registration Badge</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">Your badge for {{ object.event_id.name }}</field>
-            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
+            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.company_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
             <field name="description">Sent automatically to someone after they registered to an event</field>
             <field name="body_html" type="html">
@@ -238,7 +238,7 @@
             <field name="name">Event: Registration Confirmation</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">Your registration at {{ object.event_id.name }}</field>
-            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
+            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.company_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
             <field name="description">Sent to attendees after registering to an event</field>
             <field name="body_html" type="html">
@@ -488,7 +488,7 @@
             <field name="name">Event: Reminder</field>
             <field name="model_id" ref="event.model_event_registration"/>
             <field name="subject">{{ object.event_id.name }}: {{ object.get_date_range_str() }}</field>
-            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.user_id.email_formatted or '') }}</field>
+            <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.company_id.email_formatted or user.email_formatted or '') }}</field>
             <field name="email_to">{{ (object.email and '"%s" &lt;%s&gt;' % (object.name, object.email) or object.partner_id.email_formatted or '') }}</field>
             <field name="description">Sent automatically to attendees if there is a reminder defined on the event</field>
             <field name="body_html" type="html">

--- a/addons/mail/models/mail_template.py
+++ b/addons/mail/models/mail_template.py
@@ -623,6 +623,11 @@ class MailTemplate(models.Model):
         # add a protection against void email_from
         if 'email_from' in values and not values.get('email_from'):
             values.pop('email_from')
+
+        if not values.get('email_from') or not values.get('author_id'):
+            values['author_id'], values['email_from'] = self.env['mail.thread']._message_compute_author(
+                values.get('author_id'), values.get('email_from'), raise_on_email=False)
+
         # encapsulate body
         email_layout_xmlid = email_layout_xmlid or self.email_layout_xmlid
         if email_layout_xmlid and values['body_html']:

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -200,6 +200,16 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         self.assertEqual(mail.subject, f'EnglishSubject for {self.test_record.name}')
 
     @mute_logger('odoo.addons.mail.models.mail_mail')
+    def test_template_send_default_author(self):
+        """Test that the author is computed based on the email from."""
+        self.env.invalidate_all()
+        self.test_template.email_from = self.user_employee.email
+        mail_id = self.test_template.with_env(self.env).send_mail(
+            self.test_record.id, email_values={'email_from': self.user_employee.email})
+        mail = self.env['mail.mail'].sudo().browse(mail_id)
+        self.assertEqual(mail.author_id, self.user_employee.partner_id)
+
+    @mute_logger('odoo.addons.mail.models.mail_mail')
     def test_template_send_email_nolayout(self):
         """ Test without layout, just to check impact """
         self.test_template.email_layout_xmlid = False

--- a/addons/website_event_track/data/mail_template_data.xml
+++ b/addons/website_event_track/data/mail_template_data.xml
@@ -4,6 +4,7 @@
         <field name="name">Event: Track Confirmation</field>
         <field name="model_id" ref="website_event_track.model_event_track"/>
         <field name="subject">Confirmation of {{ object.name }}</field>
+        <field name="email_from">{{ (object.event_id.organizer_id.email_formatted or object.event_id.company_id.email_formatted or user.email_formatted or '') }}</field>
         <field name="use_default_to" eval="True"/>
         <field name="description">Sent to speakers whose track proposal is accepted (set the template on the right stage)</field>
         <field name="body_html" type="html">


### PR DESCRIPTION
Purpose
=======
Event
-----
Fallback on the company when sending event mail

Mail
----
Calculate the author based on the email from (and vice-versa).

When sending an email with a mail template, using `send_mail`, if the `author_id`
is not set, then it will always be the current user instead of being computed based
on the email from.


Task-3815627