### PR TITLE
[IMP] base: validate mail server SSL certificates (stable)

### DIFF
--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -502,13 +502,6 @@ class IrMailServer(models.Model):
                 "or provide the SMTP parameters explicitly.",
             ))
 
-        if smtp_encryption in ('ssl', 'ssl_strict'):
-            if 'SMTP_SSL' not in smtplib.__all__:
-                raise UserError(
-                    _("Your Odoo Server does not support SMTP-over-SSL. "
-                      "You could use STARTTLS instead. "
-                       "If SSL is needed, an upgrade to Python 2.6 on the server-side "
-                       "should do the trick."))
         connection = SMTPConnection(smtp_server, smtp_port, smtp_encryption, context=ssl_context)
         connection.set_debuglevel(smtp_debug)
         if smtp_encryption in ('starttls', 'starttls_strict'):


### PR DESCRIPTION
The default SSL context created by Python in the `SMTP_SSL` class and
the `starttls` method is very permissive: it doesn't validate the
server certificate, nor its hostname. Python would accept any
self-signed certificate even for well known services such as Google or
Microsoft making man-in-the-middle attacks possible.

This is not *as bad* as it sounds: the connections are established by
the server, not the clients. Servers usually sit in a datacenter and
have enhanced security (static IP, static DNS, firewall, ...) making
mitm attacks unlikely. Still, it is a very bad practice to just accept
any certificate: the connection is only safe when both encryption and
authentification are in place.

This work adds two new encryption methods, namely "ssl_strict"
and "starttls_strict". Both act exactly the same as their "not strict"
variant with the exception that they validate peers certificates. They
validate that (1) the peer certificate is signed by a trusted authority
and that (2) the Subject Alternative Name (SAN) of the certificate
matches the smtp server hostname.

It was not possible to "just" enforce those validation on the
existing "ssl" and "starttls" encryption methods: there are many smtp
servers in the wild that use expired, or self-signed, or
hostname-mismatching certificates. The connection to those server is
still encrypted if not authenticated. We considere it is much better
than clear-text and breaking the connection to those servers would be
too disruptive to the customers.

task-2861790