### PR TITLE
[FIX] calendar: set an active base_event_id for recurrence rule

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -1127,6 +1127,10 @@ class Meeting(models.Model):
         """ Delete the current recurrence, reactivate base event and apply updated recurrence values. """
         self.ensure_one()
         base_event = self.recurrence_id.base_event_id
+        # Edge case: needed when the base_event is archived (recurrence_id = False), to ensure events gets archived
+        if not base_event.recurrence_id:
+            self.recurrence_id._select_new_base_event()
+            base_event = self.recurrence_id.base_event_id
         update_dict = self._get_time_update_dict(base_event, time_values)
         time_values.update(update_dict)
 

--- a/addons/google_calendar/models/calendar_recurrence_rule.py
+++ b/addons/google_calendar/models/calendar_recurrence_rule.py
@@ -118,6 +118,10 @@ class RecurrenceRule(models.Model):
                 attendees = existing_attendees.exists().filtered(lambda att: att.email == email_normalize(odoo_attendee_email) and att.partner_id not in organizers_partner_ids)
                 self.calendar_event_ids.write({'need_sync': False, 'partner_ids': [Command.unlink(att.partner_id.id) for att in attendees]})
 
+        # Edge case: needed when the base_event is archived
+        if not self.base_event_id.recurrence_id:
+            self._select_new_base_event()
+        # Update the recurrence values
         old_event_values = self.base_event_id and self.base_event_id.read(base_event_time_fields)[0]
         if old_event_values and any(new_event_values[key] != old_event_values[key] for key in base_event_time_fields):
             # we need to recreate the recurrence, time_fields were modified.


### PR DESCRIPTION
### Issue:
- When you set a recurring meeting to a new future date, it doesn't update the existing meetings. Instead, it creates a duplicate recurring meeting on the new date, resulting in two sets of meetings: one for the original date and another for the new date.

## Steps To Reproduce:
- ICreate a new meeting in the calendar.
- Set it to recur on the first day of each month for 12 months..
- Go to one of the scheduled meetings and edit it.
- Select the "all events" option and change the recurrence
   to the second day of each month.
- Observe that the original meetings remain in the calendar.

## Solution:
- When creating a meeting, the `_apply_recurrence_values` method assigns the `base_event_id` of the recurrence to the current event. If this event doesn't fall within the dates specified in the recurrence, it becomes detached `_detach_events`, and its `recurrence_id` is set to False.
- Editing a meeting triggers `action_mass_archive`, which, if the base event lacks a `recurrence_id`, retains the old scheduled meeting. To address this, I modified 'apply recurrence' to ensure there's always an active base event.

opw-3734702


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
