### PR TITLE
[FIX] product_expiry: fix zpl lot with product_expiry

### DIFF
--- a/addons/product_expiry/report/__init__.py
+++ b/addons/product_expiry/report/__init__.py
@@ -1,5 +1,4 @@
+# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import models
-from . import wizard
-from . import report
+from . import lot_label_report

--- a/addons/product_expiry/report/lot_label_report.py
+++ b/addons/product_expiry/report/lot_label_report.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+import markupsafe
+
+class ReportLotLabelInherit(models.AbstractModel):
+    _inherit = 'report.stock.label_lot_template_view'
+
+    def _get_report_values(self, docids, data):
+        lots = super(ReportLotLabelInherit, self)._get_report_values(docids, data)
+
+        for lot in lots.get('docs', []):
+            lot_id = self.env['stock.production.lot'].browse(lot['lot_id'])
+
+            lot.update({
+                'use_expiration_date': markupsafe.Markup(lot_id.use_expiration_date),
+                'use_date': markupsafe.Markup(lot_id.use_date),
+                'expiration_date': markupsafe.Markup(lot_id.expiration_date),
+            })
+
+        return lots

--- a/addons/product_expiry/report/report_lot_barcode.xml
+++ b/addons/product_expiry/report/report_lot_barcode.xml
@@ -23,36 +23,36 @@
             <t t-translation="off">
 ^XA
 ^FO100,50
-^A0N,44,33^FD<t t-esc="lot.product_id.display_name"/>^FS
+^A0N,44,33^FD<t t-out="lot['display_name_markup']"/>^FS
 ^FO100,100
-^A0N,44,33^FDLN/SN: <t t-esc="lot.name"/>^FS
-<t t-if="lot.use_expiration_date and lot.use_date">
+^A0N,44,33^FDLN/SN: <t t-out="lot['name']"/>^FS
+<t t-if="lot['use_expiration_date'] and lot['use_date']">
 ^FO100,150
-^A0N,44,33^FDBest before: <t t-esc="lot.use_date" t-options='{"widget": "date"}'/>^FS
-<t t-if="lot.expiration_date">
+^A0N,44,33^FDBest before: <t t-out="lot['use_date']" t-options='{"widget": "date"}'/>^FS
+<t t-if="lot['expiration_date']">
 ^FO100,200
-^A0N,44,33^FDUse by: <t t-esc="lot.expiration_date" t-options='{"widget": "date"}'/>^FS
+^A0N,44,33^FDUse by: <t t-out="lot['expiration_date']" t-options='{"widget": "date"}'/>^FS
 ^FO100,250^BY3
 ^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
+^FD<t t-out="lot['name']"/>^FS
 </t>
 <t t-else="">
 ^FO100,200^BY3
 ^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
+^FD<t t-out="lot['name']"/>^FS
 </t>
 </t>
-<t t-elif="lot.use_expiration_date and lot.expiration_date">
+<t t-elif="lot['use_expiration_date'] and lot['expiration_date']">
 ^FO100,150
-^A0N,44,33^FDUse by: <t t-esc="lot.expiration_date" t-options='{"widget": "date"}'/>^FS
+^A0N,44,33^FDUse by: <t t-out="lot['expiration_date']" t-options='{"widget": "date"}'/>^FS
 ^FO100,200^BY3
 ^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
+^FD<t t-out="lot['name']"/>^FS
 </t>
 <t t-else="">
 ^FO100,150^BY3
 ^BCN,100,Y,N,N
-^FD<t t-esc="lot.name"/>^FS
+^FD<t t-out="lot['name']"/>^FS
 </t>
 ^XZ
             </t>

--- a/addons/product_expiry/tests/__init__.py
+++ b/addons/product_expiry/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_stock_production_lot
+from . import test_report

--- a/addons/product_expiry/tests/test_report.py
+++ b/addons/product_expiry/tests/test_report.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo.addons.stock.tests.test_report import TestReportsCommon
+
+
+class TestReports(TestReportsCommon):
+
+    def test_reports_expiry(self):
+        lot1 = self.env['stock.production.lot'].create({
+            'name': 'Volume-Beta"',
+            'product_id': self.product1.id,
+            'company_id': self.env.company.id,
+            'use_date': "2024-03-20 13:30:06",
+            'use_expiration_date': True,
+            'expiration_date': "2024-03-21 13:30:06",
+        })
+        report = self.env.ref('stock.label_lot_template')
+        target = b'\n\n^XA\n^FO100,50\n^A0N,44,33^FD[C4181234""154654654654]Mellohi"^FS\n^FO100,100\n^A0N,44,33^FDLN/SN:Volume-Beta\"^FS\n\n^FO100,150\n^A0N,44,33^FDBestbefore:03/20/2024^FS\n\n^FO100,200\n^A0N,44,33^FDUseby:03/21/2024^FS\n^FO100,250^BY3\n^BCN,100,Y,N,N\n^FDVolume-Beta\"^FS\n\n\n^XZ\n\n'
+        rendering, qweb_type = report._render_qweb_text(lot1.id)
+        self.assertEqual(target, rendering.replace(b' ', b''), 'The rendering is not good')
+        self.assertEqual(qweb_type, 'text', 'the report type is not good')

--- a/addons/stock/report/product_label_report.py
+++ b/addons/stock/report/product_label_report.py
@@ -57,6 +57,7 @@ class ReportLotLabel(models.AbstractModel):
         lot_list = []
         for lot in lots:
             lot_list.append({
+                'lot_id': lot.id,
                 'display_name_markup': markupsafe.Markup(lot.product_id.display_name),
                 'name': markupsafe.Markup(lot.name),
             })


### PR DESCRIPTION
Current behavior:
Impossible to print ZPL lots when product_expiry module is installed

Steps to reproduce:
- Install product_expiry
- Select a lot
- Print it as ZPL

Bug was introduced by this [commit].

[commit]: https://github.com/odoo/odoo/commit/4c2e92dd543c336f59b34fb34348f246725148fa

opw-3784251
