### PR TITLE
[PERF] product: speed up _create_variant_ids with lots of exclusions

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -712,15 +712,11 @@ class ProductTemplate(models.Model):
                     ptal.product_template_value_ids._only_active() for ptal in lines_without_no_variants
                 ])
                 # For each possible variant, create if it doesn't exist yet.
-                for combination_tuple in all_combinations:
-                    combination = self.env['product.template.attribute.value'].concat(*combination_tuple)
-                    is_combination_possible = tmpl_id._is_combination_possible_by_config(combination, ignore_no_variant=True)
-                    if not is_combination_possible:
-                        continue
-                    if combination in existing_variants:
-                        current_variants_to_activate += existing_variants[combination]
+                for possible_combination in tmpl_id._filter_combinations_impossible_by_config(all_combinations, ignore_no_variant=True):
+                    if possible_combination in existing_variants:
+                        current_variants_to_activate += existing_variants[possible_combination]
                     else:
-                        current_variants_to_create.append(tmpl_id._prepare_variant_values(combination))
+                        current_variants_to_create.append(tmpl_id._prepare_variant_values(possible_combination))
                         if len(current_variants_to_create) > 1000:
                             raise UserError(_(
                                 'The number of variants to generate is too high. '
@@ -730,13 +726,10 @@ class ProductTemplate(models.Model):
                 variants_to_activate += current_variants_to_activate
 
             else:
-                for variant in existing_variants.values():
-                    is_combination_possible = self._is_combination_possible_by_config(
-                        combination=variant.product_template_attribute_value_ids,
-                        ignore_no_variant=True,
-                    )
-                    if is_combination_possible:
-                        current_variants_to_activate += variant
+                variants_combinations = Product.concat(*existing_variants.values()).product_template_attribute_value_ids
+                current_variants_to_activate += Product.concat(*[existing_variants[possible_combination]
+                    for possible_combination in tmpl_id._filter_combinations_impossible_by_config(variants_combinations, ignore_no_variant = True)
+                ])
                 variants_to_activate += current_variants_to_activate
 
             variants_to_unlink += all_variants - current_variants_to_activate
@@ -922,6 +915,39 @@ class ProductTemplate(models.Model):
             for attribute_value in all_product_attribute_values
         }
 
+    def _filter_combinations_impossible_by_config(self, combination_tuples, ignore_no_variant=False):
+        """ Filter combination_tuples according to the config of attributes on the template
+
+        :return: iterator over possible combinations
+        :rtype: generator
+        """
+        self.ensure_one()
+        attribute_lines = self.valid_product_template_attribute_line_ids
+        attribute_lines_active_values = attribute_lines.product_template_value_ids._only_active()
+        if ignore_no_variant:
+            attribute_lines = attribute_lines._without_no_variant_attributes()
+        exclusions = self._get_own_attribute_exclusions()
+        for combination_tuple in combination_tuples:
+            combination = self.env['product.template.attribute.value'].concat(*combination_tuple)
+            if len(combination) != len(attribute_lines):
+                # number of attribute values passed is different than the
+                # configuration of attributes on the template
+                continue
+            if attribute_lines != combination.attribute_line_id:
+                # combination has different attributes than the ones configured on the template
+                continue
+            if not (attribute_lines_active_values >= combination):
+                # combination has different values than the ones configured on the template
+                continue
+            if exclusions:
+                # exclude if the current value is in an exclusion,
+                # and the value excluding it is also in the combination
+                combination_ids = set(combination.ids)
+                combination_excluded_ids = set(itertools.chain(*[exclusions.get(ptav_id) for ptav_id in combination.ids]))
+                if combination_ids & combination_excluded_ids:
+                    continue
+            yield combination
+
     def _is_combination_possible_by_config(self, combination, ignore_no_variant=False):
         """Return whether the given combination is possible according to the config of attributes on the template
 
@@ -935,35 +961,8 @@ class ProductTemplate(models.Model):
         :rtype: bool
         """
         self.ensure_one()
-
-        attribute_lines = self.valid_product_template_attribute_line_ids
-
-        if ignore_no_variant:
-            attribute_lines = attribute_lines._without_no_variant_attributes()
-
-        if len(combination) != len(attribute_lines):
-            # number of attribute values passed is different than the
-            # configuration of attributes on the template
-            return False
-
-        if attribute_lines != combination.attribute_line_id:
-            # combination has different attributes than the ones configured on the template
-            return False
-
-        if not (attribute_lines.product_template_value_ids._only_active() >= combination):
-            # combination has different values than the ones configured on the template
-            return False
-
-        exclusions = self._get_own_attribute_exclusions()
-        if exclusions:
-            # exclude if the current value is in an exclusion,
-            # and the value excluding it is also in the combination
-            for ptav in combination:
-                for exclusion in exclusions.get(ptav.id):
-                    if exclusion in combination.ids:
-                        return False
-
-        return True
+        # Returns False on StopIteration. Empty combination should return True.
+        return isinstance(next(self._filter_combinations_impossible_by_config([combination], ignore_no_variant), False), models.BaseModel)
 
     def _is_combination_possible(self, combination, parent_combination=None, ignore_no_variant=False):
         """


### PR DESCRIPTION
When there are a relatively high number of exclusions + a lot of combinations for a given product_template, `create_variant_ids` can become slow. The main bottlneck is the call to `_is_combination_possible_by_config`. More specifically, calling `attribute_lines.product_template_value_ids` and
`self._get_own_attribute_exclusions` for each combination is pretty slow.

To speed that up, this commit introduces a new method, `_filter_combinations_impossible_by_config`. This method accepts a sequence of combinations and yield those that are valid w.r.t. the exclusions. Because values that only depends on self are computed once before looping through the combinations, this lead to a significant speedup. This method is a generator to avoid MemoryErrors, be able to raise a UserError after "creating" 1000 variants and be consistent with choices made in `_create_variant_ids`. https://github.com/odoo/odoo/blob/0042b9d3eece219d4e89fe9c6ecb9971a1f3bf12/addons/product/models/product_template.py#L710

#### speedup

Customer saas-16.4 database with 378 templates, 3832 products, 44 product.attributes, 186 product.attribute.values, 79 product.template.attribute.lines, 484 product.template.attribute.values, 374 product.template.attribute.exclusions. No dynamic attributes.

Timing to write on product.template, adding a new attribute value on a ProductTemplate Form increasing the number of combinations.

| Combinations | Before PR        | After PR |
|:------------:|:----------------:|:--------:|
|        4     |       219ms      |   218ms  |
|       55     |       785ms      |   440ms  |
|      216     |       1.36s      |   592ms  |
|    1 944     |       28s        |   809ms  |
|   33 048     |     5min30s      |   3.78s  |
|  231 336     | +15min (timeout) |   12s    |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
