### PR TITLE
[IMP] project,hr_timesheet,sale_timesheet: hide fields/filters/aggregations from project/task views

### DIFF
--- a/addons/hr_timesheet/report/project_report.py
+++ b/addons/hr_timesheet/report/project_report.py
@@ -7,14 +7,14 @@ from odoo import fields, models, api
 class ReportProjectTaskUser(models.Model):
     _inherit = "report.project.task.user"
 
-    allocated_hours = fields.Float('Allocated Time', readonly=True)
-    effective_hours = fields.Float('Time Spent', readonly=True)
-    remaining_hours = fields.Float('Time Remaining', readonly=True)
-    remaining_hours_percentage = fields.Float('Time Remaining Percentage', readonly=True)
-    progress = fields.Float('Progress', aggregator='avg', readonly=True)
-    overtime = fields.Float(readonly=True, export_string_translation=False)
-    total_hours_spent = fields.Float("Total Time Spent", help="Time spent on this task, including its sub-tasks.")
-    subtask_effective_hours = fields.Float("Time Spent on Sub-Tasks", help="Time spent on the sub-tasks (and their own sub-tasks) of this task.")
+    allocated_hours = fields.Float('Allocated Time', readonly=True, groups="hr_timesheet.group_hr_timesheet_user")
+    effective_hours = fields.Float('Time Spent', readonly=True, groups="hr_timesheet.group_hr_timesheet_user")
+    remaining_hours = fields.Float('Time Remaining', readonly=True, groups="hr_timesheet.group_hr_timesheet_user")
+    remaining_hours_percentage = fields.Float('Time Remaining Percentage', readonly=True, groups="hr_timesheet.group_hr_timesheet_user")
+    progress = fields.Float('Progress', aggregator='avg', readonly=True, groups="hr_timesheet.group_hr_timesheet_user")
+    overtime = fields.Float(readonly=True, export_string_translation=False, groups="hr_timesheet.group_hr_timesheet_user")
+    total_hours_spent = fields.Float("Total Time Spent", help="Time spent on this task, including its sub-tasks.", groups="hr_timesheet.group_hr_timesheet_user")
+    subtask_effective_hours = fields.Float("Time Spent on Sub-Tasks", help="Time spent on the sub-tasks (and their own sub-tasks) of this task.", groups="hr_timesheet.group_hr_timesheet_user")
 
     def _select(self):
         return super()._select() +  """,

--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -31,7 +31,7 @@
                     </group>
                 </xpath>
                 <xpath expr="//field[@name='date']" position="after">
-                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" invisible="not allow_timesheets"/>
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" invisible="not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
                 <xpath expr="//group[@name='group_time_managment']" position="attributes">
                     <attribute name="invisible">0</attribute>
@@ -51,13 +51,14 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='date']" position="after">
                     <field name="allow_timesheets" column_invisible="1"/>
-                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" optional="hide" invisible="allocated_hours == 0 or not allow_timesheets"/>
-                    <field name="effective_hours" widget="timesheet_uom_no_toggle" optional="hide" invisible="effective_hours == 0 or not allow_timesheets"/>
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" optional="hide" invisible="allocated_hours == 0 or not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="effective_hours" widget="timesheet_uom_no_toggle" optional="hide" invisible="effective_hours == 0 or not allow_timesheets" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="remaining_hours" widget="timesheet_uom_no_toggle"
                         decoration-danger="remaining_hours &lt; 0"
                         decoration-warning="allocated_hours > 0 and (remaining_hours / allocated_hours) &lt; 0.2"
                         optional="hide"
                         invisible="allocated_hours == 0 or not allow_timesheets"
+                        groups="hr_timesheet.group_hr_timesheet_user"
                     />
                 </xpath>
             </field>
@@ -99,7 +100,7 @@
             <field name="inherit_id" ref="project.view_project_project_filter"/>
             <field name="arch" type="xml">
                 <filter name="late_milestones" position="before">
-                    <filter string="Timesheets &gt;100%" name="projects_in_overtime" domain="[('is_project_overtime', '=', True)]"/>
+                    <filter string="Timesheets &gt;100%" name="projects_in_overtime" domain="[('is_project_overtime', '=', True)]" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </filter>
             </field>
         </record>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -155,11 +155,11 @@
                 <field name="date_deadline" position="before">
                     <field name="progress" column_invisible="True"/>
                     <field name="effective_hours" column_invisible="True"/>
-                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="allocated_hours == 0" optional="hide"/>
-                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Time Spent on Sub-Tasks" optional="hide"/>
-                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide"/>
-                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining on SO" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" invisible="allocated_hours == 0"/>
+                    <field name="allocated_hours" widget="timesheet_uom_no_toggle" sum="Total Allocated Time" invisible="allocated_hours == 0" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="effective_hours" widget="timesheet_uom" sum="Effective Hours" optional="show" invisible="effective_hours == 0" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" sum="Time Spent on Sub-Tasks" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" sum="Total Time Spent" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" sum="Time Remaining on SO" optional="hide" decoration-danger="progress &gt;= 1" decoration-warning="progress &gt;= 0.8 and progress &lt; 1" invisible="allocated_hours == 0" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <field name="progress" widget="project_task_progressbar" avg="Average of Progress" optional="show" groups="hr_timesheet.group_hr_timesheet_user" invisible="allocated_hours == 0" options="{'overflow_class': 'bg-danger'}" />
                 </field>
             </field>
@@ -199,8 +199,8 @@
             <field name="priority">10</field>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@name='blocking']/following-sibling::separator[1]" position="after">
-                    <filter string="Timesheets 80%" name="timesheet_80" domain="[('remaining_hours_percentage', '&gt;', 0.0), ('remaining_hours_percentage', '&lt;=', 0.2)]"/>
-                    <filter string="Timesheets &gt;100%" name="timesheet_exceeded" domain="[('overtime', '&gt;', 0)]"/>
+                    <filter string="Timesheets 80%" name="timesheet_80" domain="[('remaining_hours_percentage', '&gt;', 0.0), ('remaining_hours_percentage', '&lt;=', 0.2)]" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <filter string="Timesheets &gt;100%" name="timesheet_exceeded" domain="[('overtime', '&gt;', 0)]" groups="hr_timesheet.group_hr_timesheet_user"/>
                     <separator/>
                 </xpath>
             </field>
@@ -215,12 +215,20 @@
                     <attribute name="js_class">hr_timesheet_graphview</attribute>
                 </xpath>
                 <xpath expr="//field[@name='stage_id']" position='after'>
-                    <field name="allocated_hours" widget="timesheet_uom"/>
-                    <field name="remaining_hours" widget="timesheet_uom"/>
-                    <field name="effective_hours" widget="timesheet_uom"/>
-                    <field name="total_hours_spent" widget="timesheet_uom"/>
-                    <field name="overtime" widget="timesheet_uom"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom"/>
+                    <field name="allocated_hours" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="allocated_hours" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="effective_hours" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="effective_hours" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="overtime" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="overtime" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="progress" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="progress" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
             </field>
         </record>
@@ -232,13 +240,22 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='allocated_hours']" position='attributes'>
                     <attribute name="widget">timesheet_uom</attribute>
+                    <attribute name="groups">hr_timesheet.group_hr_timesheet_user</attribute>
                 </xpath>
                 <xpath expr="//field[@name='allocated_hours']" position='after'>
-                    <field name="remaining_hours" widget="timesheet_uom"/>
-                    <field name="effective_hours" widget="timesheet_uom"/>
-                    <field name="total_hours_spent" widget="timesheet_uom"/>
-                    <field name="overtime" widget="timesheet_uom"/>
-                    <field name="subtask_effective_hours" widget="timesheet_uom"/>
+                    <field name="allocated_hours" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="remaining_hours" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="effective_hours" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="effective_hours" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="total_hours_spent" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="overtime" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="overtime" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="subtask_effective_hours" widget="timesheet_uom" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="progress" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <field name="progress" invisible="1" groups="!hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
             </field>
         </record>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -842,7 +842,7 @@
                     <field name="stage_id" invisible="not project_id or not stage_id"/>
                     <field name="state" widget="project_task_state_selection" readonly="1"/>
                     <field name="personal_stage_id" string="Personal Stage" options="{'no_open': True}" invisible="project_id or not personal_stage_id"/>
-                    <field name="task_properties"/>
+                    <field name="task_properties" invisible="not task_properties"/>
                 </calendar>
             </field>
         </record>

--- a/addons/sale_timesheet/report/project_report.py
+++ b/addons/sale_timesheet/report/project_report.py
@@ -6,7 +6,7 @@ from odoo import fields, models
 class ReportProjectTaskUser(models.Model):
     _inherit = 'report.project.task.user'
 
-    remaining_hours_so = fields.Float('Time Remaining on SO', readonly=True)
+    remaining_hours_so = fields.Float('Time Remaining on SO', readonly=True, groups="hr_timesheet.group_hr_timesheet_user")
 
     def _select(self):
         return super()._select() + """,

--- a/addons/sale_timesheet/views/project_task_views.xml
+++ b/addons/sale_timesheet/views/project_task_views.xml
@@ -161,7 +161,7 @@
                 <xpath expr="//field[@name='remaining_hours']" position="after">
                     <field name="sale_line_id" column_invisible="True"/>
                     <field name="remaining_hours_available" column_invisible="True"/>
-                    <field name="remaining_hours_so" invisible="not sale_line_id or not remaining_hours_available" widget="timesheet_uom" optional="hide"/>
+                    <field name="remaining_hours_so" invisible="not sale_line_id or not remaining_hours_available" widget="timesheet_uom" optional="hide" groups="hr_timesheet.group_hr_timesheet_user"/>
                 </xpath>
             </field>
         </record>


### PR DESCRIPTION
After this commit, time fields (e.g. allocated_hours, effective_hours, ...) related to projects and tasks in the Project module are only visible if the user has the "hr_timesheet.group_hr_timesheet_user" group. Moreover, the corresponding filters and aggregations are only visible in such case.

related-https://github.com/odoo/enterprise/pull/59040
task-3815771

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
