### PR TITLE
[IMP] payment_xendit: tokenization

### DIFF
--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -498,7 +498,7 @@ class PaymentTransaction(models.Model):
             'tokenize': False,
         })
         _logger.info(
-            "created token with id %(token_id)s for partner with id %(partner_id)s from "
+            "Created token with id %(token_id)s for partner with id %(partner_id)s from "
             "transaction with reference %(ref)s",
             {
                 'token_id': token.id,

--- a/addons/payment_xendit/README.md
+++ b/addons/payment_xendit/README.md
@@ -2,22 +2,42 @@
 
 ## Technical details
 
-API: [Invoices API](https://developers.xendit.co/api-reference/#create-invoice) version `2`
+APIs:
+- [Invoices API](https://developers.xendit.co/api-reference/#create-invoice) version `2`
+- [Credit Charge API](https://developers.xendit.co/api-reference/#create-charge) version `1`
 
-This module integrates Xendit using the generic payment with redirection flow based on form
-submission provided by the `payment` module.
+SDK: [Xendit.js](https://docs.xendit.co/credit-cards/integrations/tokenization)
+
+This module integrates Xendit with different payment flows depending on the payment method:
+
+- For `Card` payments, it renders a self-hosted payment form with regular (non-iframe) inputs and 
+  relies on the Xendit.js SDK to create a (single-use or multiple-use) token that is used to make
+  the payment. When the payment is successful, and the user opts to save the payment method, the
+  token is saved in Odoo. Other communications with Xendit are performed via server-to-server API
+  calls.
+
+  The JS assets are loaded in JavaScript when the payment form is submitted.
+
+  As payment details are retrieved in clear but are immediately passed to the Xendit.js SDK, the
+  solution qualifies for SAQ A-EP.
+
+- For other payment methods, this module uses the generic payment with redirection flow based on
+  form submission provided by the `payment` module.
+
+This implementation allows supporting tokenization for `Card` payments whilst retaining support for
+other payment methods via the redirection flow.
 
 ## Supported features
 
-- Payment with redirection flow
+- Direct Payment flow for `Card` payment methods
+- Payment with redirection flow for other payment methods
 - Webhook notifications
-
-## Not implemented features
-
-- Tokenization
+- Tokenization with or without payment
 
 ## Module history
 
+- `17.4`
+  - The support for tokenization via `Card` is added. odoo/odoo#158445
 - `17.0`
   - The first version of the module is merged. odoo/odoo#141661
 

--- a/addons/payment_xendit/__manifest__.py
+++ b/addons/payment_xendit/__manifest__.py
@@ -16,5 +16,10 @@
     ],
     'post_init_hook': 'post_init_hook',
     'uninstall_hook': 'uninstall_hook',
+    'assets': {
+        'web.assets_frontend': [
+            'payment_xendit/static/src/**/*',
+        ]
+    },
     'license': 'LGPL-3',
 }

--- a/addons/payment_xendit/const.py
+++ b/addons/payment_xendit/const.py
@@ -32,7 +32,7 @@ PAYMENT_METHODS_MAPPING = {
 PAYMENT_STATUS_MAPPING = {
     'draft': (),
     'pending': ('PENDING'),
-    'done': ('SUCCEEDED', 'PAID'),
+    'done': ('SUCCEEDED', 'PAID', 'CAPTURED'),
     'cancel': ('CANCELLED', 'EXPIRED'),
     'error': ('FAILED',)
 }

--- a/addons/payment_xendit/controllers/main.py
+++ b/addons/payment_xendit/controllers/main.py
@@ -18,6 +18,17 @@ class XenditController(http.Controller):
 
     _webhook_url = '/payment/xendit/webhook'
 
+    @http.route('/payment/xendit/payment', type='json', auth='public')
+    def xendit_payment(self, reference, token_ref):
+        """ Make a payment by token request and handle the response.
+
+        :param str reference: The reference of the transaction.
+        :param str token_ref: The reference of the Xendit token to use to make the payment.
+        :return: None
+        """
+        tx_sudo = request.env['payment.transaction'].sudo().search([('reference', '=', reference)])
+        tx_sudo._xendit_create_charge(token_ref)
+
     @http.route(_webhook_url, type='http', methods=['POST'], auth='public', csrf=False)
     def xendit_webhook(self):
         """ Process the notification data sent by Xendit to the webhook.

--- a/addons/payment_xendit/data/payment_provider_data.xml
+++ b/addons/payment_xendit/data/payment_provider_data.xml
@@ -4,6 +4,8 @@
     <record id="payment.payment_provider_xendit" model="payment.provider">
         <field name="code">xendit</field>
         <field name="redirect_form_view_id" ref="redirect_form"/>
+        <field name="inline_form_view_id" ref="inline_form"/>
+        <field name="allow_tokenization">True</field>
     </record>
 
 </odoo>

--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -27,13 +27,13 @@ class PaymentTransaction(models.Model):
         :rtype: dict
         """
         res = super()._get_specific_rendering_values(processing_values)
-        if self.provider_code != 'xendit':
+        if self.provider_code != 'xendit' and self.payment_method_code != 'card':
             return res
 
         # Initiate the payment and retrieve the invoice data.
         payload = self._xendit_prepare_invoice_request_payload()
         _logger.info("Sending invoice request for link creation:\n%s", pprint.pformat(payload))
-        invoice_data = self.provider_id._xendit_make_request(payload)
+        invoice_data = self.provider_id._xendit_make_request('v2/invoices', payload=payload)
         _logger.info("Received invoice request response:\n%s", pprint.pformat(invoice_data))
 
         # Extract the payment link URL and embed it in the redirect form.
@@ -84,6 +84,40 @@ class PaymentTransaction(models.Model):
             payload['customer']['addresses'] = [address_details]
 
         return payload
+
+    def _send_payment_request(self):
+        """ Override of `payment` to send a payment request to Xendit.
+
+        Note: self.ensure_one()
+
+        :return: None
+        :raise UserError: If the transaction is not linked to a token.
+        """
+        super()._send_payment_request()
+        if self.provider_code != 'xendit':
+            return
+
+        if not self.token_id:
+            raise ValidationError("Xendit: " + _("The transaction is not linked to a token."))
+
+        self._xendit_create_charge(self.token_id.provider_ref)
+
+    def _xendit_create_charge(self, token_ref):
+        """ Create a charge on Xendit using the `credit_card_charges` endpoint.
+
+        :param str token_ref: The reference of the Xendit token to use to make the payment.
+        :return: None
+        """
+        payload = {
+            'token_id': token_ref,
+            'external_id': self.reference,
+            'amount': self.amount,
+            'currency': self.currency_id.name,
+        }
+        charge_notification_data = self.provider_id._xendit_make_request(
+            'credit_card_charges', payload=payload
+        )
+        self._handle_notification_data('xendit', charge_notification_data)
 
     def _get_tx_from_notification_data(self, provider_code, notification_data):
         """ Override of `payment` to find the transaction based on the notification data.
@@ -140,11 +174,43 @@ class PaymentTransaction(models.Model):
         if payment_status in const.PAYMENT_STATUS_MAPPING['pending']:
             self._set_pending()
         elif payment_status in const.PAYMENT_STATUS_MAPPING['done']:
+            if self.tokenize:
+                self._xendit_tokenize_from_notification_data(notification_data)
             self._set_done()
         elif payment_status in const.PAYMENT_STATUS_MAPPING['cancel']:
             self._set_canceled()
         elif payment_status in const.PAYMENT_STATUS_MAPPING['error']:
+            failure_reason = notification_data.get('failure_reason')
             self._set_error(_(
-                "An error occurred during the processing of your payment (status %s). Please try "
-                "again."
+                "An error occurred during the processing of your payment (%s). Please try again.",
+                failure_reason,
             ))
+
+    def _xendit_tokenize_from_notification_data(self, notification_data):
+        """ Create a new token based on the notification data.
+
+        :param dict notification_data: Xendit's response to a charge API request.
+        :return: None
+        """
+        card_info = notification_data['masked_card_number'][-4:]  # Xendit pads details with X's.
+        token_id = notification_data['credit_card_token_id']
+        token = self.env['payment.token'].create({
+            "provider_id": self.provider_id.id,
+            "payment_method_id": self.payment_method_id.id,
+            "payment_details": card_info,
+            "partner_id": self.partner_id.id,
+            "provider_ref": token_id,
+        })
+        self.write({
+            'token_id': token.id,
+            'tokenize': False,
+        })
+        _logger.info(
+            "created token with id %(token_id)s for partner with id %(partner_id)s from "
+            "transaction with reference %(ref)s",
+            {
+                'token_id': token.id,
+                'partner_id': self.partner_id.id,
+                'ref': self.reference,
+            },
+        )

--- a/addons/payment_xendit/static/src/js/auth_service.js
+++ b/addons/payment_xendit/static/src/js/auth_service.js
@@ -1,0 +1,12 @@
+import { registry } from '@web/core/registry';
+import { AuthUI } from './auth_ui';
+import { EventBus } from '@odoo/owl';
+
+const bus = new EventBus();
+
+export const authService = {
+    start(env) {
+        registry.category('main_components').add('AuthUI', { Component: AuthUI, props: { bus } });
+    }
+}
+registry.category('services').add('auth_ui', authService);

--- a/addons/payment_xendit/static/src/js/auth_ui.js
+++ b/addons/payment_xendit/static/src/js/auth_ui.js
@@ -1,0 +1,29 @@
+import { EventBus, Component, xml } from '@odoo/owl';
+
+export class AuthUI extends Component {
+    static props = {
+        bus: EventBus,
+    }
+
+    // Has to be in front of the block UI layer (which is z-index: 1070).
+    static template = xml`
+        <div
+            id="three-ds-container"
+            style="width: 500px;
+            height: 600px;
+            line-height: 200px;
+            position: fixed;
+            top: 25%;
+            left: 40%;
+            display: none;
+            margin-top: -100px;
+            margin-left: -150px;
+            background-color: #ffffff;
+            border-radius: 5px;mon
+            text-align: center;
+            z-index: 1072 !important;"
+        >
+            <iframe height="600" width="450" id="authorization-form" name="authorization-form"/>
+        </div>
+    `;
+}

--- a/addons/payment_xendit/static/src/js/payment_form.js
+++ b/addons/payment_xendit/static/src/js/payment_form.js
@@ -1,0 +1,206 @@
+/* global Xendit */
+
+import { loadJS } from '@web/core/assets'
+import { _t } from '@web/core/l10n/translation';
+import { rpc, RPCError } from '@web/core/network/rpc';
+
+import paymentForm from '@payment/js/payment_form';
+
+paymentForm.include({
+    xenditData: undefined,
+
+    // #=== DOM MANIPULATION ===#
+
+    /**
+     * Prepare the inline form of Xendit for direct payment.
+     *
+     * @override method from @payment/js/payment_form
+     * @private
+     * @param {number} providerId - The id of the selected payment option's provider.
+     * @param {string} providerCode - The code of the selected payment option's provider.
+     * @param {number} paymentOptionId - The id of the selected payment option.
+     * @param {string} paymentMethodCode - The code of the selected payment method, if any.
+     * @param {string} flow - The online payment flow of the selected payment option.
+     * @return {void}
+     */
+    async _prepareInlineForm(providerId, providerCode, paymentOptionId, paymentMethodCode, flow) {
+        if (providerCode !== 'xendit' || paymentMethodCode !== 'card') {
+            this._super(...arguments);
+            return;
+        }
+
+        // Check if instantiation of the inline form is needed.
+        this.xenditData ??= {}; // Store the form and public key of each instantiated Card method.
+        if (flow === 'token') {
+            return; // No inline form for tokens.
+        } else if (this.xenditData[paymentOptionId]) {
+            this._setPaymentFlow('direct'); // Overwrite the flow even if no re-instantiation.
+            return; // Don't re-extract the data if already done for this payment method.
+        }
+
+        // Overwrite the flow of the selected payment method.
+        this._setPaymentFlow('direct');
+
+        // Extract and store the public key.
+        const radio = document.querySelector('input[name="o_payment_radio"]:checked');
+        const inlineForm = this._getInlineForm(radio);
+        const xenditInlineForm = inlineForm.querySelector('[name="o_xendit_form"]');
+        this.xenditData[paymentOptionId] = {
+            publicKey: xenditInlineForm.dataset['xenditPublicKey'],
+            inlineForm: xenditInlineForm,
+        };
+
+        // Load the SDK.
+        await loadJS('https://js.xendit.co/v1/xendit.min.js');
+        Xendit.setPublishableKey(this.xenditData[paymentOptionId].publicKey)
+    },
+
+    // #=== PAYMENT FLOW ===#
+
+    /**
+     * Validate the form inputs before initiating the payment flow.
+     *
+     * @override method from @payment/js/payment_form
+     * @private
+     * @param {string} providerCode - The code of the selected payment option's provider.
+     * @param {number} paymentOptionId - The id of the selected payment option.
+     * @param {string} paymentMethodCode - The code of the selected payment method, if any.
+     * @param {string} flow - The payment flow of the selected payment option.
+     * @return {void}
+     */
+    async _initiatePaymentFlow(providerCode, paymentOptionId, paymentMethodCode, flow) {
+        if (providerCode !== 'xendit' || flow === 'token' || paymentMethodCode !== 'card') {
+            // Tokens are handled by the generic flow and other payment methods have no inline form.
+            this._super(...arguments);
+            return;
+        }
+
+        const formInputs = this._xenditGetInlineFormInputs(paymentOptionId)
+        const details = this._xenditGetPaymentDetails(paymentOptionId)
+
+        // Set custom validity messages on inputs based on Xendit's feedback.
+        Object.keys(formInputs).forEach(el => formInputs[el].setCustomValidity(""))
+        if (!Xendit.card.validateCardNumber(details.card_number)){
+            formInputs['card'].setCustomValidity(_t("Invalid Card Number"))
+        }
+        if (!Xendit.card.validateExpiry(details.card_exp_month, details.card_exp_year)) {
+            formInputs['month'].setCustomValidity(_t("Invalid Date"))
+            formInputs['year'].setCustomValidity(_t("Invalid Date"))
+        }
+        if (!Xendit.card.validateCvn(details.card_cvn)){
+            formInputs['cvn'].setCustomValidity(_t("Invalid CVN"))
+        }
+
+        // Ensure that all inputs are valid.
+        if (!Object.values(formInputs).every(element => element.reportValidity())) {
+            this._enableButton(); // The submit button is disabled at this point, enable it.
+            return;
+        }
+        await this._super(...arguments);
+    },
+
+    /**
+     * Process the direct payment flow by creating a token and proceeding with a token payment flow.
+     *
+     * @override method from @payment/js/payment_form
+     * @private
+     * @param {string} providerCode - The code of the selected payment option's provider.
+     * @param {number} paymentOptionId - The id of the selected payment option.
+     * @param {string} paymentMethodCode - The code of the selected payment method, if any.
+     * @param {object} processingValues - The processing values of the transaction.
+     * @return {void}
+     */
+    async _processDirectFlow(providerCode, paymentOptionId, paymentMethodCode, processingValues) {
+        if (providerCode !== 'xendit') {
+            this._super(...arguments);
+            return;
+        }
+
+        Xendit.card.createToken(
+            {
+                ...this._xenditGetPaymentDetails(paymentOptionId),
+                // Allow reusing tokens when the users wants to tokenize.
+                is_multiple_use: this.paymentContext.tokenizationRequested,
+                amount: processingValues.amount,
+            },
+            (err, token) => this._xenditHandleResponse(err, token, processingValues),
+        );
+    },
+
+    /**
+     * Handle the token creation response and initiate the token payment.
+     *
+     * @private
+     * @param {object} err - The error with the cause.
+     * @param {object} token - The created token's data.
+     * @param {object} processingValues - The processing values of the transaction.
+     * @return {void}
+     */
+    _xenditHandleResponse(err, token, processingValues) {
+        if (err) {
+            this._displayErrorDialog(_t("Payment processing failed"), err.message);
+            this._enableButton();
+            return;
+        }
+        if (token.status === 'VERIFIED') {
+            rpc('/payment/xendit/payment', {
+                'reference': processingValues.reference,
+                'partner_id': processingValues.partner_id,
+                'token_ref': token.id,
+            }).then(() => {
+                window.location = '/payment/status'
+            }).catch(error => {
+                if (error instanceof RPCError) {
+                    this._displayErrorDialog(_t("Payment processing failed"), error.data.message);
+                    this._enableButton();
+                } else {
+                    return Promise.reject(error);
+                }
+            })
+        } else if (token.status === 'FAILED') {
+            this._displayErrorDialog(_t("Payment processing failed"), token.failure_reason);
+            document.querySelector('#three-ds-container').style.display = 'none';
+            this._enableButton();
+        } else if (token.status === 'IN_REVIEW') {
+            document.querySelector('#three-ds-container').style.display = 'block';
+            window.open(token.payer_authentication_url, 'authorization-form');
+        }
+    },
+
+    // #=== GETTERS ===#
+
+    /**
+     * Return all relevant inline form inputs of the provided payment option.
+     *
+     * @private
+     * @param {number} paymentOptionId - The id of the selected payment option.
+     * @return {Object} - An object mapping the name of inline form inputs to their DOM element.
+     */
+    _xenditGetInlineFormInputs(paymentOptionId) {
+        const form = this.xenditData[paymentOptionId]['inlineForm'];
+        return {
+            card: form.querySelector('#o_xendit_card'),
+            month: form.querySelector('#o_xendit_month'),
+            year: form.querySelector('#o_xendit_year'),
+            cvn: form.querySelector('#o_xendit_cvn'),
+        };
+    },
+
+    /**
+     * Return the credit card data to prepare the payload for the create token request.
+     *
+     * @private
+     * @param {number} paymentOptionId - The id of the selected payment option.
+     * @return {Object} - Data to pass to the Xendit createToken request.
+     */
+    _xenditGetPaymentDetails(paymentOptionId) {
+        const inputs = this._xenditGetInlineFormInputs(paymentOptionId);
+        return {
+            card_number: inputs.card.value.replace(/ /g, ''),
+            card_exp_month: inputs.month.value,
+            card_exp_year: inputs.year.value,
+            card_cvn: inputs.cvn.value,
+        };
+    },
+
+})

--- a/addons/payment_xendit/tests/common.py
+++ b/addons/payment_xendit/tests/common.py
@@ -10,6 +10,7 @@ class XenditCommon(PaymentCommon):
         super().setUpClass()
 
         cls.xendit = cls._prepare_provider('xendit', update_values={
+            'xendit_public_key': 'xnd_public_key',
             'xendit_secret_key': 'xnd_secret_key',
             'xendit_webhook_token': 'xnd_webhook_token',
         })
@@ -31,4 +32,30 @@ class XenditCommon(PaymentCommon):
             'payment_method': 'BANK_TRANSFER',
             'payment_channel': 'BNI',
             'payment_destination': '880891384013',
+        }
+        cls.charge_notification_data = {
+            'status': 'CAPTURED',
+            'authorized_amount': 11100,
+            'capture_amount': 11100,
+            'currency': 'IDR',
+            'metadata': {},
+            'credit_card_token_id': '6645aaa2f00da60017cdc669',
+            'business_id': '64118d86854d7d89206e732d',
+            'merchant_id': 'samplemerchant',
+            'merchant_reference_code': '6645aaa3f00da60017cdc66a',
+            'external_id': 'ABC00026',
+            'eci': '00',
+            'charge_type': 'MULTIPLE_USE_TOKEN',
+            'masked_card_number': '520000XXXXXX2151',
+            'card_brand': 'MASTERCARD',
+            'card_type': 'CREDIT',
+            'descriptor': 'XDT*ODOO',
+            'authorization_id': '6645aaa3f00da60017cdc66b',
+            'bank_reconciliation_id': '7158417004836852803955',
+            'issuing_bank_name': 'PT BANK NEGARA INDONESIA TBK',
+            'cvn_code': 'M',
+            'approval_code': '831000',
+            'created': '2024-05-16T06:41:41.176Z',
+            'id': '6645aaa5f00da60017cdc66c',
+            'card_fingerprint': '652e1897a273b700164639a7'
         }

--- a/addons/payment_xendit/views/payment_provider_views.xml
+++ b/addons/payment_xendit/views/payment_provider_views.xml
@@ -8,15 +8,22 @@
         <field name="arch" type="xml">
             <group name="provider_credentials" position="inside">
                 <group invisible="code != 'xendit'">
-                    <field name="xendit_secret_key"
-                           string="Secret Key"
-                           required="code == 'xendit' and state != 'disabled'"
-                           password="True"
+                    <field
+                        name="xendit_public_key"
+                        string="Public Key"
+                        required="code == 'xendit' and state != 'disabled'"
                     />
-                    <field name="xendit_webhook_token"
-                           string="Webhook Token"
-                           required="code == 'xendit' and state != 'disabled'"
-                           password="True"
+                    <field
+                        name="xendit_secret_key"
+                        string="Secret Key"
+                        required="code == 'xendit' and state != 'disabled'"
+                        password="True"
+                    />
+                    <field
+                        name="xendit_webhook_token"
+                        string="Webhook Token"
+                        required="code == 'xendit' and state != 'disabled'"
+                        password="True"
                     />
                 </group>
             </group>

--- a/addons/payment_xendit/views/payment_xendit_templates.xml
+++ b/addons/payment_xendit/views/payment_xendit_templates.xml
@@ -5,4 +5,60 @@
         <form t-att-action="api_url" method="get"/>
     </template>
 
+    <template id="inline_form">
+        <div name="o_xendit_form" t-att-data-xendit-public-key="provider_sudo.xendit_public_key">
+            <t t-if="pm_sudo.code == 'card'">
+                <div class="mb-3">
+                    <label for="o_xendit_card" class="col-form-label">Card Number</label>
+                    <input
+                        id="o_xendit_card"
+                        type="text"
+                        required=""
+                        maxlength="19"
+                        autocomplete="cc-number"
+                        class="form-control"
+                    />
+                </div>
+                <div class="row">
+                    <div class="col-sm-8 mb-3">
+                        <label for="o_xendit_month">Expiration</label>
+                        <div class="input-group">
+                            <input
+                                id="o_xendit_month"
+                                type="number"
+                                placeholder="MM"
+                                min="1"
+                                max="12"
+                                autocomplete="cc-exp-month"
+                                required=""
+                                class="form-control"
+                            />
+                            <input
+                                id="o_xendit_year"
+                                type="number"
+                                placeholder="YYYY"
+                                min="1000"
+                                max="9999"
+                                autocomplete="cc-exp-year"
+                                required=""
+                                class="form-control"
+                            />
+                        </div>
+                    </div>
+                    <div class="col-sm-4 mb-3">
+                        <label for="o_xendit_cvn">Card Code</label>
+                        <input
+                            id="o_xendit_cvn"
+                            type="number"
+                            max="9999"
+                            autocomplete="cc-csc"
+                            required=""
+                            class="form-control"
+                        />
+                    </div>
+                </div>
+            </t>
+        </div>
+    </template>
+
 </odoo>


### PR DESCRIPTION
Currently, in the APAC region, there are no payment providers
implemented that support tokenization. This commit adds tokenization
support for the `Card` payment method through Xendit. As tokenization
can not be implemented via form redirect, `Card` payments will
specifically be using a direct flow. The changes made here will only
affect `Card` payments, while other payment methods will continue using
redirect implementation.

task-3704600
