### PR TITLE
[FIX] l10n_br: support Pix codes with a None amount

### DIFF
--- a/addons/l10n_br/models/res_partner_bank.py
+++ b/addons/l10n_br/models/res_partner_bank.py
@@ -81,7 +81,8 @@ class ResPartnerBank(models.Model):
         there is always some comment set."""
         res = super()._get_qr_code_vals_list(*args, **kwargs)
         if self.country_code == "BR":
-            res[5] = (res[5][0], float_repr(res[5][1], 2))  # amount
+            if res[5][1] is not None:
+                res[5] = (res[5][0], float_repr(res[5][1], 2))  # amount
             res[7] = (res[7][0], res[7][1].upper())  # merchant_name
             res[8] = (res[8][0], res[8][1].upper())  # merchant_city
             if not res[9][1]:

--- a/addons/l10n_br/tests/test_l10n_br_pix.py
+++ b/addons/l10n_br/tests/test_l10n_br_pix.py
@@ -75,3 +75,11 @@ class TestL10nBrPix(AccountTestInvoicingCommon):
             self._get_qr_code_string(),
             "00020101021226580014br.gov.bcb.pix013671d6c6e1-64ea-4a11-9560-a10870c40ca2520400005303986540512.305802BR5914COMPANY_1_DATA62070503***6304B27F",
         )
+
+    def test_get_qr_vals_for_pos_default_qr(self):
+        self.partner_bank.include_reference = False
+        self.invoice.invoice_line_ids.write({"price_unit": 0})
+        self.assertEqual(
+            self._get_qr_code_string(),
+            "00020101021226580014br.gov.bcb.pix013671d6c6e1-64ea-4a11-9560-a10870c40ca25204000053039865802BR5914COMPANY_1_DATA62070503***63044FC8"
+        )


### PR DESCRIPTION
QR code support was added to the POS [1]. A fallback QR code with a None amount is downloaded when the POS loads. This is used when the POS is offline.

This commit ensures we don't float_repr() None which results in:

TypeError: must be real number, not NoneType

[1] https://github.com/odoo/odoo/pull/148803
