### PR TITLE
[FIX] hr : kiosk users view employee schedule without debug mode

### DIFF
--- a/addons/hr/views/hr_employee_public_views.xml
+++ b/addons/hr/views/hr_employee_public_views.xml
@@ -79,7 +79,7 @@
                                         <group name="managers" string="Approvers" invisible="1">
                                             <!-- overridden in other modules -->
                                         </group>
-                                        <group string="Schedule" groups="base.group_no_one">
+                                        <group string="Schedule">
                                             <field name="resource_calendar_id"/>
                                         </group>
                                     </div>


### PR DESCRIPTION
### Current behavior:

The "Schedule" part of the employee Form is invisible for users whose Employee access rights are limited to the "group_hr_attendance_kiosk" group. By contrast, users with higher access rights such as "group_hr_attendance_user" and "group_hr_attendance_manager" do not need to activate the debug mode to see the "Schedule" part of the employee Form.

### Expected behavior:

Since users limited to the access rights given by the "group_hr_attendance_kiosk" group have the rights to read the fields displayed in the "Schedule" part of the employee Form, the behavior should be uniform amoung the three groups.

### Cause of the issue:

While users limited to the access rights given by the "group_hr_attendance_kiosk" access the "hr_employee_public_view_form" of the `hr.employee.public` model, users with higher access rights will access the "view_employee_form" of the `hr.employee` model by clicking on an employee. Since the "Schedule" part of the "hr_employee_public_view_form" view is restricted to the "base.group_no_one" group:
https://github.com/odoo/odoo/blob/f89f4a8f1ad0ee3fb62ba246ea17988955dbdc4b/addons/hr/views/hr_employee_public_views.xml#L82 it will only appear to be visible in debug mode (that is litterally the purpose of this `res.group`). By contrast, this part of the form is not restricted to this group and is therefore always visible in the form view of the `hr.employee` model:
https://github.com/odoo/odoo/blob/f89f4a8f1ad0ee3fb62ba246ea17988955dbdc4b/addons/hr/views/hr_employee_views.xml#L122

opw-3814539
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
