### PR TITLE
[FIX] l10n_in_pos: blank screen while payment

### DIFF
--- a/addons/l10n_in_pos/static/src/overrides/models/order.js
+++ b/addons/l10n_in_pos/static/src/overrides/models/order.js
@@ -40,7 +40,7 @@ patch(Order.prototype, {
                 price_unit: line.get_unit_price(),
                 quantity: line.get_quantity(),
                 uom: null,
-                taxes: this.pos.mapTaxValues(taxes),
+                tax_values_list: this.pos.mapTaxValues(taxes),
             });
         });
 


### PR DESCRIPTION
Steps:
- Install l10n_in_pos module
- Open POS and place order with products
- Select payment method
- Click validate button for the order

Issue:
- Blank screen appears when validating the order

Cause:
- Sort method called on an undefined variable

Fix:
- Rename the variable to tax_values_list as referenced in the l10n_in module

task - 3818336