### PR TITLE
[IMP] fleet: odometer can only increase

### DIFF
--- a/addons/fleet/models/fleet_vehicle.py
+++ b/addons/fleet/models/fleet_vehicle.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
-from odoo.osv import expression
+from odoo.exceptions import UserError
 from odoo.addons.fleet.models.fleet_vehicle_model import FUEL_TYPES
 
 
@@ -301,6 +301,9 @@ class FleetVehicle(models.Model):
         return vehicles
 
     def write(self, vals):
+        if 'odometer' in vals and any(vehicle.odometer > vals['odometer'] for vehicle in self):
+            raise UserError(_('The odometer value cannot be lower than the previous one.'))
+
         if 'driver_id' in vals and vals['driver_id']:
             driver_id = vals['driver_id']
             for vehicle in self.filtered(lambda v: v.driver_id.id != driver_id):


### PR DESCRIPTION
When an odometer is created in fleet_vehicle, il's value is now check to be greater than the previous value. If not, a UserError is raised.
The reason for this is that the odometer should only increase, and if it decreases, it means that the
odometer has been tampered with.

Task-3722420
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
