### PR TITLE
[FIX] sale_loyalty: Fix inconsistent discount display

### DIFF
--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -202,9 +202,10 @@ class SaleOrder(models.Model):
         assert reward.discount_applicability == 'cheapest'
 
         cheapest_line = self._cheapest_line()
-        discountable = cheapest_line.price_unit * (1 - (cheapest_line.discount or 0) / 100)
+        discount_percent = (cheapest_line.discount or 0) / 100
         taxes = cheapest_line.tax_id.filtered(lambda t: t.amount_type != 'fixed')
-        return discountable, {taxes: discountable}
+
+        return cheapest_line.price_total * (1 - discount_percent), {taxes: cheapest_line.price_unit * (1 - discount_percent)}
 
     def _get_specific_discountable_lines(self, reward):
         """


### PR DESCRIPTION
Fix the display inconsistency in discount amounts across
discount types (Cheapest product, Order, Specific product).

Corrects the display of discount amounts to include tax considerations,
ensuring uniformity in how discounts are shown to the customer.

opw-3704883