### PR TITLE
[IMP] purchase: rfq management at portal view

### DIFF
--- a/addons/purchase/controllers/portal.py
+++ b/addons/purchase/controllers/portal.py
@@ -157,7 +157,9 @@ class CustomerPortal(portal.CustomerPortal):
         if confirm_type == 'reminder':
             order_sudo.confirm_reminder_mail(kw.get('confirmed_date'))
         if confirm_type == 'reception':
-            order_sudo._confirm_reception_mail()
+            order_sudo.confirm_reception_mail()
+        if confirm_type == 'decline':
+            order_sudo.decline_reception_mail()
 
         values = self._purchase_order_get_page_view_values(order_sudo, access_token, **kw)
         update_date = kw.get('update')

--- a/addons/purchase/data/mail_template_data.xml
+++ b/addons/purchase/data/mail_template_data.xml
@@ -23,6 +23,16 @@
         <br/><br/>
         If you have any questions, please do not hesitate to contact us.
         <br/><br/>
+            <a t-att-href="object.get_confirm_url(confirm_type='reception')"
+                target="_blank"
+                style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
+                Accept</a>
+
+            <a t-att-href="object.get_confirm_url(confirm_type='decline')"
+                target="_blank"
+                style="padding: 5px 10px; color: #FFFFFF; text-decoration: none; background-color: #875A7B; border: 1px solid #875A7B; border-radius: 3px">
+                Decline</a>
+        <br/><br/>
         Best regards,
         <t t-if="not is_html_empty(object.user_id.signature)">
             <br/><br/>

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -151,6 +151,7 @@ class PurchaseOrder(models.Model):
 
     mail_reminder_confirmed = fields.Boolean("Reminder Confirmed", default=False, readonly=True, copy=False, help="True if the reminder email is confirmed by the vendor.")
     mail_reception_confirmed = fields.Boolean("Reception Confirmed", default=False, readonly=True, copy=False, help="True if PO reception is confirmed by the vendor.")
+    mail_reception_declined = fields.Boolean("Reception Declined", readonly=True, copy=False, help="True if PO reception is declined by the vendor.")
 
     receipt_reminder_email = fields.Boolean('Receipt Reminder Email', compute='_compute_receipt_reminder_email')
     reminder_date_before_receipt = fields.Integer('Days Before Receipt', compute='_compute_receipt_reminder_email')
@@ -396,7 +397,7 @@ class PurchaseOrder(models.Model):
                 ])
             else:
                 access_opt['title'] = _('View Quotation') if self.state in ('draft', 'sent') else _('View Order')
-                access_opt['url'] = self.get_confirm_url(confirm_type='reception')
+                access_opt['url'] = self.get_confirm_url()
 
         return groups
 
@@ -940,7 +941,7 @@ class PurchaseOrder(models.Model):
     def get_confirm_url(self, confirm_type=None):
         """Create url for confirm reminder or purchase reception email for sending
         in mail."""
-        if confirm_type in ['reminder', 'reception']:
+        if confirm_type in ['reminder', 'reception', 'decline']:
             param = url_encode({
                 'confirm': confirm_type,
                 'confirmed_date': self.date_planned and self.date_planned.date(),
@@ -972,11 +973,26 @@ class PurchaseOrder(models.Model):
                     self.date_order or fields.Date.today()))
             or self.env.user.has_group('purchase.group_purchase_manager'))
 
-    def _confirm_reception_mail(self):
+    def confirm_reception_mail(self):
         for order in self:
             if order.state in ['purchase', 'done'] and not order.mail_reception_confirmed:
                 order.mail_reception_confirmed = True
-                order.message_post(body=_("The order receipt has been acknowledged by %s.", order.partner_id.name))
+                order.sudo().message_post(body=_("The order receipt has been acknowledged by %s.", order.partner_id.name))
+            elif order.state == 'sent' and not order.mail_reception_confirmed:
+                order.mail_reception_confirmed = True
+                order.sudo().message_post(body=_("The RFQ has been acknowledged by %s.", order.partner_id.name))
+
+    def decline_reception_mail(self):
+        for order in self:
+            if order.state in ['purchase', 'done'] and not order.mail_reception_declined:
+                order.mail_reception_declined = True
+                order.sudo().activity_schedule(
+                    'mail.mail_activity_data_todo',
+                    note=_('The vendor asked to decline this confirmed RfQ, if you agree on that, cancel this PO'))
+                order.sudo().message_post(body=_("The order receipt has been declined by %s.", order.partner_id.name))
+            elif order.state  == 'sent' and not order.mail_reception_declined:
+                order.mail_reception_declined = True
+                order.sudo().message_post(body=_("The RFQ has been declined by %s.", order.partner_id.name))
 
     def get_localized_date_planned(self, date_planned=False):
         """Returns the localized date planned in the timezone of the order's user or the

--- a/addons/purchase/static/src/js/purchase_portal_sidebar.js
+++ b/addons/purchase/static/src/js/purchase_portal_sidebar.js
@@ -6,6 +6,10 @@ import { uniqueId } from "@web/core/utils/functions";
 
 publicWidget.registry.PurchasePortalSidebar = PortalSidebar.extend({
     selector: ".o_portal_purchase_sidebar",
+    events: {
+        'click .o_portal_decline': '_onDecline',
+        'click .o_portal_accept': '_onAccept',
+    },
 
     /**
      * @constructor
@@ -14,6 +18,7 @@ publicWidget.registry.PurchasePortalSidebar = PortalSidebar.extend({
         this._super.apply(this, arguments);
         this.authorizedTextTag = ["em", "b", "i", "u"];
         this.spyWatched = $('body[data-target=".navspy"]');
+        this.orm = this.bindService("orm");
     },
     /**
      * @override
@@ -133,5 +138,13 @@ publicWidget.registry.PurchasePortalSidebar = PortalSidebar.extend({
             }
         });
         return rawText.join(" ");
+    },
+    _onDecline: function (ev) {
+        const orderId = parseInt(ev.currentTarget.dataset.orderId);
+        this.orm.call("purchase.order", "decline_reception_mail", [orderId]);
+    },
+    _onAccept: function (ev) {
+        const orderId = parseInt(ev.currentTarget.dataset.orderId);
+        this.orm.call("purchase.order", "confirm_reception_mail", [orderId]);
     },
 });

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -342,7 +342,7 @@
                                 <span>Taxes</span>
                             </th>
                             <th t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">Disc.%</th>
-                            <th class="text-end" t-if="order.state in ['purchase', 'done']" >
+                            <th class="text-end" t-if="not update_dates and order.state in ['purchase', 'done']" >
                                 <span>Amount</span>
                             </th>
                         </tr>

--- a/addons/purchase/views/portal_templates.xml
+++ b/addons/purchase/views/portal_templates.xml
@@ -133,6 +133,36 @@
                   <t t-set="backend_url" t-value="'/web#model=%s&amp;id=%s&amp;action=%s&amp;view_type=form' % (order._name, order.id, order.env.ref('purchase.purchase_rfq').id)"/>
               </t>
           </t>
+          <div class="modal fade" id="accept_quotation" role="dialog">
+              <div class="modal-dialog">
+                  <div class="modal-content">
+                      <div class="modal-header">
+                          <h3 class="modal-title">Quotation Accepted</h3>
+                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                      </div>
+                      <div class="modal-body">
+                          <div class="alert alert-warning">
+                              <strong>Quotation has been acknowledged</strong><br/>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </div>
+          <div class="modal fade" id="decline_quotation" role="dialog">
+              <div class="modal-dialog">
+                  <div class="modal-content">
+                      <div class="modal-header">
+                          <h3 class="modal-title">Quotation Declined</h3>
+                          <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                      </div>
+                      <div class="modal-body">
+                          <div class="alert alert-warning">
+                              <strong>Quotation has been Declined</strong><br/>
+                          </div>
+                      </div>
+                  </div>
+              </div>
+          </div>
 
           <div class="row o_portal_purchase_sidebar">
               <!-- Sidebar -->
@@ -143,8 +173,17 @@
                       <h2 t-field="order.amount_total" data-id="total_amount" class="mb-0 text-break"/>
                   </t>
                   <t t-set="entries">
+                    <div t-if="not request.env.user._is_public() and order.state in ['sent']" class="flex-grow-1 d-flex gap-2">
+                        <div class="btn-group flex-grow-1 mb-1">
+                            <a t-att-data-order-id="order.id" class="btn btn-secondary btn-block o_print_btn o_portal_invoice_print o_portal_accept px-3" data-bs-target="#accept_quotation" data-bs-toggle="modal" id="accept" name="accept" title="Accept" style="background-color: #875A7B;"> Accept</a>
+                        </div>
+                        <div class="btn-group flex-grow-1 mb-1">
+                            <a t-att-data-order-id="order.id" class="btn btn-secondary btn-block o_print_btn o_portal_invoice_print o_portal_decline px-3" data-bs-target="#decline_quotation" data-bs-toggle="modal" id="decline" name="decline" title="View Details"> Decline</a>
+                        </div>
+                    </div>
+
                       <div class="d-flex flex-column gap-4 mt-3">
-                        <a class="btn btn-secondary o_print_btn o_portal_invoice_print" t-att-href="order.get_portal_url(report_type='pdf')" id="print_invoice_report" title="View Details" role="button" target="_blank"><i class="fa fa-print me-1"/> View Details</a>
+                        <a class="btn btn-secondary o_print_btn o_portal_invoice_print" t-att-href="order.get_portal_url(report_type='pdf')" id="print_invoice_report" title="View Details" role="button" target="_blank"><i class="fa fa-print me-1"/>Download / Print</a>
                           <div class="navspy flex-grow-1 ps-0" t-ignore="true" role="complementary">
                               <ul class="nav flex-column bs-sidenav"></ul>
                           </div>
@@ -292,15 +331,17 @@
 
               <div class="table-responsive">
                 <table t-att-data-order-id="order.id" t-att-data-token="order.access_token" class="table table-sm" id="purchase_order_table">
+                    <t t-set="display_price_and_taxes" t-value="not update_dates and order.state in ['sent', 'purchase', 'done']"/>
                     <thead class="bg-100">
                         <tr>
                             <th class="text-start">Products</th>
                             <th class="text-end">Quantity</th>
                             <th t-if="update_dates" class="text-end">Scheduled Date</th>
-                            <th t-if="not update_dates and order.state in ['purchase', 'done']" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">Unit Price</th>
-                            <th t-if="not update_dates and order.state in ['purchase', 'done']" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                            <th t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">Unit Price</th>
+                            <th t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                 <span>Taxes</span>
                             </th>
+                            <th t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">Disc.%</th>
                             <th class="text-end" t-if="order.state in ['purchase', 'done']" >
                                 <span>Amount</span>
                             </th>
@@ -341,14 +382,17 @@
                                           </div>
                                         </div>
                                     </td>
-                                    <td t-if="not update_dates and order.state in ['purchase', 'done']" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
+                                    <td t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
                                         <div
                                             t-field="line.price_unit"
                                             class="text-end"
                                         />
                                     </td>
-                                    <td t-if="not update_dates and order.state in ['purchase', 'done']" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
+                                    <td t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-md-table-cell' if report_type == 'html' else '' }}">
                                         <span t-esc="', '.join(map(lambda x: (x.description or x.name), line.taxes_id))"/>
+                                    </td>
+                                    <td t-if="display_price_and_taxes" t-attf-class="text-end {{ 'd-none d-sm-table-cell' if report_type == 'html' else '' }}">
+                                        <div t-field="line.discount" class="text-end"/>
                                     </td>
                                     <td class="text-end" t-if="not update_dates and order.state in ['purchase', 'done']">
                                         <span class="oe_order_line_price_subtotal" t-field="line.price_subtotal"/>

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -184,8 +184,6 @@
                             <label for="date_approve" invisible="state not in ('purchase', 'done')"/>
                             <div name="date_approve" invisible="state not in ('purchase', 'done')" class="o_row">
                                 <field name="date_approve"/>
-                                <field name="mail_reception_confirmed" invisible="1"/>
-                                <span class="text-muted" invisible="not mail_reception_confirmed">(confirmed by vendor)</span>
                             </div>
                             <label for="date_planned"/>
                             <div name="date_planned_div" class="o_row">
@@ -434,6 +432,7 @@
                     <filter string="Starred" name="starred" domain="[('priority', '=', '1')]"/>
                     <separator/>
                     <filter name="draft" string="RFQs" domain="[('state', 'in', ('draft', 'sent', 'to approve'))]"/>
+                    <filter name="unconfirmed" string="Not Acknowledged" domain="[('mail_reception_confirmed', '=', False), ('mail_reception_declined', '=', False), ('state', 'in', ('draft', 'sent'))]"/>
                     <separator/>
                     <filter name="approved" string="Purchase Orders" domain="[('state', 'in', ('purchase', 'done'))]"/>
                     <filter name="to_approve" string="To Approve" domain="[('state', '=', 'to approve')]"/>
@@ -475,7 +474,6 @@
                     <filter name="my_Orders" string="My Orders" domain="[('user_id', '=', uid)]"/>
                     <filter string="Starred" name="starred" domain="[('priority', '=', '1')]"/>
                     <separator/>
-                    <filter name="unconfirmed" string="Not Acknowledged" domain="[('mail_reception_confirmed', '=', False), ('state', '=', 'purchase')]"/>
                     <filter name="not_invoiced" string="Waiting Bills" domain="[('invoice_status', '=', 'to invoice')]" help="Purchase orders that include lines not invoiced."/>
                     <filter name="invoiced" string="Bills Received" domain="[('invoice_status', '=', 'invoiced')]" help="Purchase orders that have been invoiced."/>
                     <separator/>


### PR DESCRIPTION
Before this commit
===============
Vendors could only acknowledge purchase orders by clicking the 'View Order' button in emails. However, there were no 'Accept' or 'Decline' buttons available either in emails or directly in the portal for vendors to use.

After this commit
==============
Vendors can now view the order using the 'View Order' button. Additionally, they have dedicated 'Accept' and 'Decline' buttons available in the portal for easier selection and response to orders.

TaskId: 3604768
