### PR TITLE
[IMP] base, website: use short url_code when possible

### DIFF
--- a/addons/website/tests/test_page.py
+++ b/addons/website/tests/test_page.py
@@ -520,6 +520,36 @@ class WithContext(HttpCase):
             self.assertEqual(alternate_en_url, f'{self.base_url()}/page_1')
             self.assertEqual(alternate_fr_url, f'{self.base_url()}/fr/page_1')
 
+    def test_alternate_hreflang(self):
+        website = self.env['website'].browse(1)
+        lang_en = self.env.ref('base.lang_en')
+        lang_fr = self.env['res.lang']._activate_lang('fr_FR')
+        with MockRequest(self.env, website=website):
+            # Only one region per lang, the hreflang should be the short code
+            website.language_ids = [Command.set((lang_en + lang_fr).ids)]
+            langs = self.env['res.lang']._get_frontend()
+            self.assertEqual(langs['en_US']['hreflang'], 'en')
+            self.assertEqual(langs['fr_FR']['hreflang'], 'fr')
+            # Multiple regions per lang, one lang from the same region should be
+            # the short code, others should keep the full code
+            lang_be = self.env['res.lang']._activate_lang('fr_BE')
+            lang_ca = self.env['res.lang']._activate_lang('fr_CA')
+            website.language_ids = [Command.set((lang_en + lang_fr + lang_be + lang_ca).ids)]
+            langs = self.env['res.lang']._get_frontend()
+            self.assertEqual(langs['en_US']['hreflang'], 'en')
+            self.assertEqual(langs['fr_FR']['hreflang'], 'fr-fr')
+            self.assertEqual(langs['fr_BE']['hreflang'], 'fr')
+            self.assertEqual(langs['fr_CA']['hreflang'], 'fr-ca')
+            # Special case for es_419: if there is multiple regions for spanish,
+            # including es_419, es_419 should be the one shortened
+            lang_es = self.env['res.lang']._activate_lang('es_ES')
+            lang_419 = self.env['res.lang']._activate_lang('es_419')
+            website.language_ids = [Command.set((lang_en + lang_es + lang_419).ids)]
+            langs = self.env['res.lang']._get_frontend()
+            self.assertEqual(langs['en_US']['hreflang'], 'en')
+            self.assertEqual(langs['es_ES']['hreflang'], 'es-es')
+            self.assertEqual(langs['es_419']['hreflang'], 'es')
+
     def test_07_not_authorized(self):
         # Create page that requires specific user role.
         specific_page = self.page.copy({'website_id': self.env['website'].get_current_website().id})

--- a/odoo/addons/base/data/res_lang_data.xml
+++ b/odoo/addons/base/data/res_lang_data.xml
@@ -4,9 +4,18 @@
         <function name="install_lang" model="res.lang"/>
     </data>
     <data>
+        <!-- /my is for the portal -->
         <record id="base.lang_my" model="res.lang">
             <field name="url_code">mya</field>
         </record>
+        <!-- es_419 is the new "generic" spanish -->
+        <record id="base.lang_es" model="res.lang">
+            <field name="url_code">es_ES</field>
+        </record>
+        <record id="base.lang_es_419" model="res.lang">
+            <field name="url_code">es</field>
+        </record>
+
         <record id="base.lang_ar" model="res.lang">
             <field name="flag_image" type="base64" file="base/static/img/lang_flags/lang_ar.png"/>
         </record>


### PR DESCRIPTION
1. When activating a language, sets it's url_code to the short form, if possible. Exemple, if installing fr_BE, it might reset fr_FR to fr_FR if it's not installed (instead of fr), and use the short code fr for fr_BE.

2. There should always be a shortened hreflang code, regardless if there is only one or multiple lang for this "group" of lang. For instance, if fr_BE and fr_FR are enabled for the french group of lang, one of them should be shortened and considered the default french lang for all the one not matching a sub-french lang.

3. Special case of previous point 2. for es_419, which is not a valid hreflang and always need to be the one shortened even if there is other spanish lang. For other langs, we don't care which one is shortened as long as one is, but for this one we need to be sure it's es_419 which is shortened.

4. Spanish LATAM should be the one with default /es url code.

Courtesy of fpodoo for first point.
