### PR TITLE
[IMP] l10n_ar: Customer invoices with invoice date lower than lock date.

### DIFF
--- a/addons/l10n_ar/models/account_move.py
+++ b/addons/l10n_ar/models/account_move.py
@@ -406,3 +406,10 @@ class AccountMove(models.Model):
     def _l10n_ar_include_vat(self):
         self.ensure_one()
         return self.l10n_latam_document_type_id.l10n_ar_letter in ['B', 'C', 'X', 'R']
+
+    def action_post(self):
+        """ Prevent posting customer invoices with invoice date lower than lock date. """
+        lock_date_customer_invoices = self.filtered(lambda x: x.is_sale_document() and x.tax_lock_date_message and x.country_code == 'AR')
+        if lock_date_customer_invoices:
+            raise UserError(_('Is not allowed to post customer invoices with invoice date lower than lock date.'))
+        return super().action_post()


### PR DESCRIPTION
Impacted versions:
16, 17

Steps to reproduce:
Post customer invoice with invoice date lower than lock date.

Current behavior:
Customers invoices are posted if their invoice date is lower than lock date.

Expected behavior:
Customers invoices are not allowed to be posted if their invoice date is lower than lock date.

Ticket Adhoc side: 62698
Task latam: 1169
Manual fp of https://github.com/odoo/odoo/pull/126472

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
