### PR TITLE
[IMP] calendar: refine "All events" update type

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -258,6 +258,7 @@ class CalendarEvent(models.Model):
     tentative_count = fields.Integer(compute='_compute_attendees_count')
     awaiting_count = fields.Integer(compute="_compute_attendees_count")
     user_can_edit = fields.Boolean(compute='_compute_user_can_edit')
+    show_all_events = fields.Boolean(compute='_compute_show_all_events')
 
     @api.depends("attendee_ids")
     def _compute_should_show_status(self):
@@ -380,6 +381,16 @@ class CalendarEvent(models.Model):
             event.stop = event.start and event.start + timedelta(minutes=round((event.duration or 1.0) * 60))
             if event.allday:
                 event.stop -= timedelta(seconds=1)
+
+    @api.depends('start')
+    def _compute_show_all_events(self):
+        for event in self:
+            if event.start and event._origin.start:
+                old_day = event._origin.start.date().day
+                new_day = event.start.date().day
+                event.show_all_events = old_day == new_day
+            else:
+                event.show_all_events = True
 
     @api.onchange('start_date', 'stop_date')
     def _onchange_date(self):

--- a/addons/calendar/static/src/views/ask_recurrence_update_policy_dialog.js
+++ b/addons/calendar/static/src/views/ask_recurrence_update_policy_dialog.js
@@ -10,9 +10,11 @@ export class AskRecurrenceUpdatePolicyDialog extends Component {
     static props = {
         confirm: Function,
         close: Function,
+        show_all_events: Boolean,
     };
 
     setup() {
+        super.setup();
         this.possibleValues = {
             self_only: {
                 checked: true,
@@ -22,11 +24,13 @@ export class AskRecurrenceUpdatePolicyDialog extends Component {
                 checked: false,
                 label: _t("This and following events"),
             },
-            all_events: {
+        };
+        if (this.props.show_all_events) {
+            this.possibleValues.all_events = {
                 checked: false,
                 label: _t("All events"),
-            },
-        };
+            }
+        }
     }
 
     get selected() {

--- a/addons/calendar/static/src/views/ask_recurrence_update_policy_hook.js
+++ b/addons/calendar/static/src/views/ask_recurrence_update_policy_hook.js
@@ -1,10 +1,11 @@
 import { useService } from "@web/core/utils/hooks";
 import { AskRecurrenceUpdatePolicyDialog } from "@calendar/views/ask_recurrence_update_policy_dialog";
 
-export function askRecurrenceUpdatePolicy(dialogService) {
+export function askRecurrenceUpdatePolicy(dialogService, show_all_events = true) {
     return new Promise((resolve) => {
         dialogService.add(AskRecurrenceUpdatePolicyDialog, {
             confirm: resolve,
+            show_all_events: show_all_events,
         }, {
             onClose: resolve.bind(null, false),
         });

--- a/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
+++ b/addons/calendar/static/src/views/attendee_calendar/attendee_calendar_model.js
@@ -45,10 +45,10 @@ export class AttendeeCalendarModel extends CalendarModel {
      *
      * Upon updating a record with recurrence, we need to ask how it will affect recurrent events.
      */
-    async updateRecord(record) {
+    async updateRecord(record, show_all_events = true) {
         const rec = this.records[record.id];
         if (rec.rawRecord.recurrency) {
-            const recurrenceUpdate = await askRecurrenceUpdatePolicy(this.dialog);
+            const recurrenceUpdate = await askRecurrenceUpdatePolicy(this.dialog, show_all_events);
             if (!recurrenceUpdate) {
                 return this.notify();
             }

--- a/addons/calendar/static/src/views/fields/recurrence_update_select.js
+++ b/addons/calendar/static/src/views/fields/recurrence_update_select.js
@@ -1,0 +1,59 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { Component, reactive, useState } from "@odoo/owl";
+import { registry } from "@web/core/registry";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+
+export class RecurrenceUpdateSelect extends Component {
+    static template = "calendar.RecurrenceUpdateSelect";
+    static props = {
+        ...standardFieldProps,
+    };
+    setup() {
+        this.reactiveRecord = reactive(this.props.record, () => {this.updatePossibleValues()})
+        this.state = useState({})
+        this.updatePossibleValues()
+    }
+
+    updatePossibleValues(){
+        this.state.possibleValues = {
+            self_only: {
+                checked: true,
+                label: _t("This event"),
+            },
+            future_events: {
+                checked: false,
+                label: _t("This and following events"),
+            }
+        }
+        if (this.reactiveRecord.data['show_all_events']){
+            this.state.possibleValues.all_events = {
+                checked: false,
+                label: _t("All events"),
+            }
+        }
+    }
+
+    get selected() {
+        return Object.entries(this.state.possibleValues).find((state) => state[1].checked)[0];
+    }
+
+    set selected(val) {
+        this.state.possibleValues[this.selected].checked = false;
+        this.state.possibleValues[val].checked = true;
+        this.updateRecord(this.selected)
+    }
+    async updateRecord(value) {
+        await this.props.record.update({ [this.props.name]: value });
+    }
+}
+
+export const recurrenceUpdateSelect = {
+    component: RecurrenceUpdateSelect,
+    displayName: _t("Recurrence Update Type"),
+    supportedTypes: ["selection"],
+}
+
+registry.category("fields").add("recurrence_update_select", recurrenceUpdateSelect);

--- a/addons/calendar/static/src/views/fields/recurrence_update_select.xml
+++ b/addons/calendar/static/src/views/fields/recurrence_update_select.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates>
+    <t t-name="calendar.RecurrenceUpdateSelect">
+        <t t-set="edit_recurrent_event">Edit Recurrent event</t>
+        <div size="'sm'" title="edit_recurrent_event">
+            <t t-foreach="Object.entries(state.possibleValues)" t-as="value" t-key="value[0]">
+                <t t-set="name" t-value="value[0]"/>
+                <t t-set="state" t-value="value[1]"/>
+                <div class="form-check o_radio_item">
+                    <input name="recurrence-update" type="radio" class="form-check-input o_radio_input" t-att-checked="state.checked" t-att-value="name" t-att-id="name" t-on-click="(ev) => this.selected = ev.target.value"/>
+                    <label class="form-check-label o_form_label" t-att-for="name" t-esc="state.label"/>
+                </div>
+            </t>
+        </div>
+    </t>
+</templates>

--- a/addons/calendar/tests/test_event_recurrence.py
+++ b/addons/calendar/tests/test_event_recurrence.py
@@ -489,17 +489,17 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         ])
         event.write({
             'recurrence_update': 'all_events',
-            'tue': False,
+            'tue': True,
             'fri': False,
-            'sat': True,
-            'start': event.start + relativedelta(days=4),
-            'stop': event.stop + relativedelta(days=5),
+            'sat': False,
+            'start': event.start + relativedelta(hours=4),
+            'stop': event.stop + relativedelta(hours=5),
         })
         recurrence = self.env['calendar.recurrence'].search([], limit=1)
         self.assertEventDates(recurrence.calendar_event_ids, [
-            (datetime(2019, 10, 26, 1, 0), datetime(2019, 10, 29, 18, 0)),
-            (datetime(2019, 11, 2, 1, 0), datetime(2019, 11, 5, 18, 0)),
-            (datetime(2019, 11, 9, 1, 0), datetime(2019, 11, 12, 18, 0)),
+            (datetime(2019, 10, 22, 5, 0), datetime(2019, 10, 24, 23, 0)),
+            (datetime(2019, 10, 29, 5, 0), datetime(2019, 10, 31, 23, 0)),
+            (datetime(2019, 11, 5, 5, 0), datetime(2019, 11, 7, 23, 0)),
         ])
 
     def test_shift_stop_all(self):
@@ -538,8 +538,8 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         event = self.events[1]
         event.write({
             'recurrence_update': 'all_events',
-            'start': event.start + relativedelta(days=4),
-            'stop': event.stop + relativedelta(days=5),
+            'start': event.start + relativedelta(hours=4),
+            'stop': event.stop + relativedelta(hours=5),
         })
         self.assertFalse(self.recurrence.exists(), "Inactive event should not create recurrent events")
 
@@ -553,16 +553,16 @@ class TestUpdateRecurrentEvents(TestRecurrentEvents):
         event = self.events[0]
         event.write({
             'recurrence_update': 'all_events',
-            'tue': False,
+            'tue': True,
             'fri': False,
-            'sat': True,
-            'start': event.start + relativedelta(days=4),
-            'stop': event.stop + relativedelta(days=4),
+            'sat': False,
+            'start': event.start + relativedelta(hours=4),
+            'stop': event.stop + relativedelta(hours=4),
         })
         self.assertEventDates(event.recurrence_id.calendar_event_ids, [
-            (datetime(2019, 10, 26, 1, 0), datetime(2019, 10, 28, 18, 0)),
-            (datetime(2019, 11, 2, 1, 0), datetime(2019, 11, 4, 18, 0)),
-            (datetime(2019, 11, 9, 1, 0), datetime(2019, 11, 11, 18, 0))
+            (datetime(2019, 10, 22, 5, 0), datetime(2019, 10, 24, 22, 0)),
+            (datetime(2019, 10, 29, 5, 0), datetime(2019, 10, 31, 22, 0)),
+            (datetime(2019, 11, 5, 5, 0), datetime(2019, 11, 7, 22, 0))
         ])
         self.assertTrue(outlier.exists(), 'The outlier should have its date and time updated according to the change.')
 
@@ -862,42 +862,6 @@ class TestUpdateMultiDayWeeklyRecurrentEvents(TestRecurrentEvents):
         # Tuesday datetime(2019, 10, 22, 1, 0)
         # Friday datetime(2019, 10, 25, 1, 0)
         # Tuesday datetime(2019, 10, 29, 1, 0)
-
-    def test_shift_all_multiple_weekdays(self):
-        event = self.events[0]  # Tuesday
-        # We go from 2 days a week Thuesday and Friday to one day a week, Thursday
-        event.write({
-            'recurrence_update': 'all_events',
-            'tue': False,
-            'thu': True,
-            'fri': False,
-            'start': event.start + relativedelta(days=2),
-            'stop': event.stop + relativedelta(days=2),
-        })
-        recurrence = self.env['calendar.recurrence'].search([], limit=1)
-        # We don't try to do magic tricks. First event is moved, other remain
-        self.assertEventDates(recurrence.calendar_event_ids, [
-            (datetime(2019, 10, 24, 1, 0), datetime(2019, 10, 26, 18, 0)),
-            (datetime(2019, 10, 31, 1, 0), datetime(2019, 11, 2, 18, 0)),
-            (datetime(2019, 11, 7, 1, 0), datetime(2019, 11, 9, 18, 0)),
-        ])
-
-    def test_shift_all_multiple_weekdays_duration(self):
-        event = self.events[0]  # Tuesday
-        event.write({
-            'recurrence_update': 'all_events',
-            'tue': False,
-            'thu': True,
-            'fri': False,
-            'start': event.start + relativedelta(days=2),
-            'stop': event.stop + relativedelta(days=3),
-        })
-        recurrence = self.env['calendar.recurrence'].search([], limit=1)
-        self.assertEventDates(recurrence.calendar_event_ids, [
-            (datetime(2019, 10, 24, 1, 0), datetime(2019, 10, 27, 18, 0)),
-            (datetime(2019, 10, 31, 1, 0), datetime(2019, 11, 3, 18, 0)),
-            (datetime(2019, 11, 7, 1, 0), datetime(2019, 11, 10, 18, 0)),
-        ])
 
     def test_shift_future_multiple_weekdays(self):
         event = self.events[1]  # Friday

--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -105,7 +105,7 @@
             <form string="Meetings" js_class="calendar_form">
                 <div invisible="not recurrence_id" class="alert alert-info oe_edit_only" role="status">
                     <p>Edit recurring event</p>
-                    <field name="recurrence_update" widget="radio"/>
+                    <field name="recurrence_update" widget="recurrence_update_select"/>
                 </div>
                 <sheet>
                     <div class="oe_button_box" name="button_box">
@@ -148,7 +148,7 @@
                             </div>
                             <field name="event_tz" invisible="not recurrency" readonly="not user_can_edit"/>
 
-
+                            <field name="show_all_events" invisible="1"/>
                             <field name="recurrence_id" invisible="1" />
                             <field name="rrule_type" invisible="1" />
                             <field name="recurrency" readonly="not user_can_edit"/>

--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -163,6 +163,12 @@ export class CalendarCommonRenderer extends Component {
         }
     }
 
+    isSameDay(date1, date2) {
+        const date_str_1 = new Date(date1).toDateString();
+        const date_str_2 = new Date(date2).toDateString();
+        return date_str_1 === date_str_2;
+    }
+
     getStartTime(record) {
         const timeFormat = is24HourFormat() ? "HH:mm" : "hh:mm a";
         return record.start.toFormat(timeFormat);
@@ -324,7 +330,14 @@ export class CalendarCommonRenderer extends Component {
     }
     onEventDrop(info) {
         this.fc.api.unselect();
-        this.props.model.updateRecord(this.fcEventToRecord(info.event), { moved: true });
+        const updatedRecord = this.fcEventToRecord(info.event);
+        let show_all_events = true;
+        if (info.event.id){
+            const newStart = updatedRecord.start;
+            const oldStart = this.props.model.records[info.event.id].start;
+            show_all_events = this.isSameDay(oldStart, newStart);
+        }
+        this.props.model.updateRecord(updatedRecord, show_all_events, { moved: true });
     }
     onEventResize(info) {
         this.fc.api.unselect();

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -3813,7 +3813,7 @@ test(`drag and drop on month mode with all_day mapping`, async () => {
 });
 
 test(`drag and drop on month mode with date_start and date_delay`, async () => {
-    onRpc("write", ({ args }) => {
+    onRpc("write", async ({ args }) => {
         expect.step("write");
         expect(args[1].delay).toBe(undefined);
     });


### PR DESCRIPTION
This PR aims to handle "All events" updates as in Google Calendar
Changes:
- When updating recurrent events either by drag and drop or in the form view, hide the "All events" option if the new start day has changed.
- Refactor the tests which consider this update type.

Task: 3321882