### PR TITLE
[FIX] website_sale: ribbon bg_color key correctly checked

### DIFF
--- a/addons/website_sale/models/product_ribbon.py
+++ b/addons/website_sale/models/product_ribbon.py
@@ -21,7 +21,7 @@ class ProductRibbon(models.Model):
     @api.model_create_multi
     def create(self, vals_list):
         for vals in vals_list:
-            if 'bg_color' in vals and not '!important' in vals['bg_color']:
+            if vals['bg_color'] and not '!important' in vals['bg_color']:
                 vals['bg_color'] += ' !important'
         return super().create(vals_list)
 


### PR DESCRIPTION
Description:
Currently, the conditional will always try to append the string since the key 'bg_color' will always exist in the vals_list. We're really trying to check if there is a truthy value for said key, so we need to adjust the conditional slightly.

Desired behavior after PR is merged:
Conditional will correctly check if a value has been chosen for 'bg_color' before appending '!important'.

opw-3814399