### PR TITLE
[FIX] web_editor: line breaks at edges of block anchor nested within li

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3408,10 +3408,15 @@ export class OdooEditor extends EventTarget {
                     if (anchor.nodeName === 'A') {
                         if (brs.includes(anchor.firstChild)) {
                             brs.forEach(br => anchor.before(br));
-                            setSelection(...rightPos(brs[brs.length - 1]));
                         } else if (brs.includes(anchor.lastChild)) {
+                            const brToRemove = isBlock(anchor) ? brs.shift() : null;
                             brs.forEach(br => anchor.after(br));
-                            setSelection(...rightPos(brs[0]));
+                            if (brToRemove) {
+                                brToRemove.remove();
+                                setSelection(...leftPos(brs[0]));
+                            } else {
+                                setSelection(...rightPos(brs[0]));
+                            }
                         }
                     }
                     this.historyStep();

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1270,11 +1270,9 @@ const Wysiwyg = Widget.extend({
                         [anchorNode, focusNode] = isDirectionRight
                             ? [selection.anchorNode, selection.focusNode]
                             : [selection.focusNode, selection.anchorNode];
-                    } else {
-                        [anchorNode, focusNode] = [link, link];
                     }
                 }
-                if (!focusOffset) {
+                if (focusNode && !focusOffset) {
                     focusOffset = focusNode.childNodes.length || focusNode.length;
                 }
             }

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -2388,7 +2388,7 @@ const Wysiwyg = Widget.extend({
         }
     },
     _onSelectionChange() {
-        if (this.odooEditor.autohideToolbar && this.linkPopover) {
+        if (this.linkPopover) {
             const selectionInLink = getInSelection(this.odooEditor.document, 'a') === this.linkPopover.target;
             const isVisible = this.linkPopover.el.offsetParent;
             if (isVisible && !selectionInLink) {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

I. Commit [1] handled cases of pressing enter at the edge of an anchor, which is a
child of an unbreakable element. The commit inserted the `br`'s after anchors;
however, it missed the situation where the anchor tags are block elements nested
inside an unbreakable element inside a `li`. In this specific case, inserting
two `br` tags after a anchor block resulted in the creation of two new lines.
This commit handles that case by only inserting one `br` tag after the anchor,
rather than both.

II. Previously when changing selection between links in website, when clicking on a
link the previous link used to get selected. This commit makes sure that when
changing selection in between links it selects the correct link.

III. Commit [2] made sure that when moving out of the link the link popover should be
closed but it did not worked in website. This commit makes sure the it works for
website popover too.

[1]: https://github.com/odoo/odoo/commit/df6f8dd0c54c40ea7edbd3821ae068d79b1b7af7
[2]: https://github.com/odoo/odoo/commit/e9ada60cb1f6986a578e17ddce1f5ae6a6fe95dc

task-3631910