### PR TITLE
[IMP] mass_mailing_event_{track}: propagate event name as subject

### DIFF
--- a/addons/mass_mailing_event/models/event_event.py
+++ b/addons/mass_mailing_event/models/event_event.py
@@ -16,7 +16,8 @@ class Event(models.Model):
             'target': 'current',
             'context': {
                 'default_mailing_model_id': self.env.ref('event.model_event_registration').id,
-                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', '!=', 'cancel')])
+                'default_mailing_domain': repr([('event_id', 'in', self.ids), ('state', '!=', 'cancel')]),
+                'default_subject': f"Event: {self.name}",
             },
         }
 
@@ -27,5 +28,8 @@ class Event(models.Model):
             'res_model': 'mailing.mailing',
             'view_mode': 'form',
             'target': 'current',
-            'context': {'default_mailing_model_id': self.env.ref('base.model_res_partner').id},
+            'context': {
+                'default_mailing_model_id': self.env.ref('base.model_res_partner').id,
+                'default_subject': f"Event: {self.name}",
+            },
         }

--- a/addons/mass_mailing_event_track/models/event_event.py
+++ b/addons/mass_mailing_event_track/models/event_event.py
@@ -17,6 +17,7 @@ class Event(models.Model):
             context=dict(
                 default_mailing_model_id=self.env.ref('website_event_track.model_event_track').id,
                 default_mailing_domain=repr([('event_id', 'in', self.ids), ('stage_id.is_cancel', '!=', True)]),
+                default_subject=f"Event: {self.name}",
             ),
         )
         return mass_mailing_action


### PR DESCRIPTION
**After this PR**

When opening a mailing from the event, the subject/title will be set as 
Event: event_name.

e.g. Event: Odoo Experience 2025

Task-3820754