### PR TITLE
[IMP] point_of_sale: move lineToRefund from pos_store to pos_order

### DIFF
--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -62,7 +62,6 @@ export class DataServiceOptions {
 
     get cascadeDeleteModels() {
         return [
-            "pos.order",
             "pos.order.line",
             "pos.payment",
             "product.attribute.custom.value",

--- a/addons/point_of_sale/static/src/app/models/pos_order.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order.js
@@ -34,6 +34,7 @@ export class PosOrder extends Base {
 
         // !!Keep all uiState in one object!!
         this.uiState = {
+            lineToRefund: {},
             displayed: true,
             booked: false,
             screen_data: {},
@@ -434,8 +435,8 @@ export class PosOrder extends Base {
     removeOrderline(line) {
         const linesToRemove = line.getAllLinesInCombo();
         for (const lineToRemove of linesToRemove) {
-            if (lineToRemove.refunded_orderline_id?.uuid in this.pos.lineToRefund) {
-                delete this.pos.lineToRefund[lineToRemove.refunded_orderline_id.uuid];
+            if (lineToRemove.refunded_orderline_id?.uuid in this.uiState.lineToRefund) {
+                delete this.uiState.lineToRefund[lineToRemove.refunded_orderline_id.uuid];
             }
 
             if (this.assert_editable()) {

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -195,8 +195,13 @@ export class PosOrderline extends Base {
         const quant =
             typeof quantity === "number" ? quantity : parseFloat("" + (quantity ? quantity : 0));
 
-        if (this.refunded_orderline_id?.uuid in this.pos.lineToRefund) {
-            const refundDetails = this.pos.lineToRefund[this.refunded_orderline_id.uuid];
+        const allLineToRefundUuids = this.models["pos.order"].reduce((acc, order) => {
+            Object.assign(acc, order.uiState.lineToRefund);
+            return acc;
+        }, {});
+
+        if (this.refunded_orderline_id?.uuid in allLineToRefundUuids) {
+            const refundDetails = allLineToRefundUuids[this.refunded_orderline_id.uuid];
             const maxQtyToRefund = refundDetails.line.qty - refundDetails.line.refunded_qty;
             if (quant > 0) {
                 return {

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.js
@@ -494,10 +494,8 @@ export class TicketScreen extends Component {
         if (this._doesOrderHaveSoleItem(order)) {
             return true;
         }
-        const total = Object.values(this.pos.lineToRefund).reduce((acc, val) => {
-            if (val.line.order_id.id === order.id && !val.order_id) {
-                acc += val.qty;
-            }
+        const total = Object.values(order.uiState.lineToRefund).reduce((acc, val) => {
+            acc += val.qty;
             return acc;
         }, 0);
 
@@ -564,7 +562,7 @@ export class TicketScreen extends Component {
      * @returns
      */
     getToRefundDetail(orderline) {
-        const { lineToRefund } = this.pos;
+        const lineToRefund = orderline.order_id.uiState.lineToRefund;
 
         if (orderline.uuid in lineToRefund) {
             return lineToRefund[orderline.uuid];
@@ -593,12 +591,12 @@ export class TicketScreen extends Component {
      * @returns {Array} refundableDetails
      */
     _getRefundableDetails(partner, order) {
-        return Object.values(this.pos.lineToRefund).filter(
+        return Object.values(this.pos.linesToRefund).filter(
             (refund) =>
                 !this.pos.isProductQtyZero(refund.qty) &&
-                (partner ? refund.line.order_id.partner_id.id === partner.id : true) &&
-                !refund.destination_order_id &&
-                refund.line.order_id.uuid === order.uuid
+                refund.line.order_id.uuid === order.uuid &&
+                (partner ? refund.line.order_id.partner_id?.id === partner.id : true) &&
+                !refund.destination_order_id
         );
     }
 

--- a/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/ticket_screen/ticket_screen.xml
@@ -141,19 +141,19 @@
                             <Orderline line="line.getDisplayData()"
                                 class="{'selected': line.id === getSelectedOrderlineId()}"
                                 t-on-click="() => this.onClickOrderline(line)">
-                                <t t-set="toRefundDetail" t-value="line.pos.lineToRefund[line.uuid]" />
-                                <li t-if="!line.pos.isProductQtyZero(line.refunded_qty)"
+                                <t t-set="toRefundDetail" t-value="line.order_id.uiState.lineToRefund[line.uuid]" />
+                                <li t-if="!pos.isProductQtyZero(line.refunded_qty)"
                                     class="info refund-note mt-1">
                                     <strong t-esc="env.utils.formatProductQty(line.refunded_qty)" />
                                     <span> Refunded</span>
                                 </li>
-                                <li t-if="!line.pos.isProductQtyZero(toRefundDetail?.qty)" class="info to-refund-highlight refund-note mt-1 fw-bold text-primary">
+                                <li t-if="!pos.isProductQtyZero(toRefundDetail?.qty)" class="info to-refund-highlight refund-note mt-1 fw-bold text-primary">
                                     <t t-set="_destinationOrderUid" t-value="toRefundDetail.destination_order_uuid"/>
                                     <t t-set="refundQty" t-value="env.utils.formatProductQty(toRefundDetail.qty)"/>
                                     <t t-if="_destinationOrderUid">
-                                        Refunding <t t-esc="refundQty" /> in 
+                                        Refunding <t t-esc="refundQty" /> in
                                         <span t-esc="_destinationOrderUid"
-                                            class="order-link ms-1 text-decoration-underline cursor-pointer" 
+                                            class="order-link ms-1 text-decoration-underline cursor-pointer"
                                             t-on-click.stop="() => this.onClickRefundOrderUid(_destinationOrderUid)" />
                                     </t>
                                     <t t-else="">

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -123,8 +123,6 @@ export class PosStore extends Reactive {
         this.ticket_screen_mobile_pane = "left";
         this.productListView = window.localStorage.getItem("productListView") || "grid";
 
-        // Record<orderlineId, { 'qty': number, 'orderline': { qty: number, refundedQty: number, orderUid: string }, 'destinationOrderUid': string }>
-        this.lineToRefund = {};
         this.ticketScreenState = {
             offsetByDomain: {},
             totalCount: 0,
@@ -912,11 +910,12 @@ export class PosStore extends Reactive {
                 }
 
                 for (const line of serverO.lines) {
-                    const refundDetail = this.lineToRefund[line.refunded_orderline_id?.uuid];
-                    if (refundDetail) {
-                        const currRefund = line.refunded_orderline_id.refunded_qty || 0;
-                        line.refunded_orderline_id.refunded_qty = currRefund + refundDetail.qty;
-                        delete this.lineToRefund[refundDetail.line_uuid];
+                    const refundedOrderLine = line.refunded_orderline_id;
+
+                    if (refundedOrderLine) {
+                        const order = refundedOrderLine.order_id;
+                        delete order.uiState.lineToRefund[refundedOrderLine.uuid];
+                        refundedOrderLine.refunded_qty += Math.abs(line.qty);
                     }
                 }
             }
@@ -1290,6 +1289,13 @@ export class PosStore extends Reactive {
         }
     }
 
+    get linesToRefund() {
+        return this.models["pos.order"].reduce((acc, order) => {
+            acc.push(...Object.values(order.uiState.lineToRefund));
+            return acc;
+        }, []);
+    }
+
     isProductQtyZero(qty) {
         const dp = this.models["decimal.precision"].find(
             (dp) => dp.name === "Product Unit of Measure"
@@ -1340,7 +1346,7 @@ export class PosStore extends Reactive {
         const isPrinted = await this.printer.print(
             OrderReceipt,
             {
-                data: this.orderExportForPrinting(),
+                data: this.orderExportForPrinting(this.get_order()),
                 formatCurrency: this.env.utils.formatCurrency,
             },
             { webPrintFallback: true }


### PR DESCRIPTION
lineToRefund is a property that is only used in pos_order, so it makes sense to move it to pos_order.

With this change we get rid of the pos_store dependency in the models.
