### PR TITLE
[I18N] base: Update module translations for es_MX

### DIFF
--- a/odoo/addons/base/i18n/es_MX.po
+++ b/odoo/addons/base/i18n/es_MX.po
@@ -22564,7 +22564,7 @@ msgstr "Estadísticas de Leads y generación en social"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.module_view_kanban
 msgid "Learn More"
-msgstr "Más información"
+msgstr "Aprenda más"
 
 #. module: base
 #: model:res.country,name:base.lb
@@ -24064,7 +24064,7 @@ msgstr "Categoría de módulo"
 #. module: base
 #: model_terms:ir.ui.view,arch_db:base.module_view_kanban
 msgid "Module Info"
-msgstr "Más información"
+msgstr "Información del módulo"
 
 #. module: base
 #: model:ir.model.fields,field_description:base.field_ir_module_module__shortdesc


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently, in the es_MX language, there is the same translation for "Learn more" and "Module info," which is confusing when you are viewing the modules.

Current behavior before PR:
"Learn more" and "Module info" translates to "Más información".

Desired behavior after PR is merged:
"Learn more" and "Module info" translates to "Aprenda más" and "Información del módulo" respectively.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
