### PR TITLE
[FIX] mrp: bom overview debug mode

### DIFF
--- a/addons/mrp/static/tests/tours/mrp_bom_overview_tour.js
+++ b/addons/mrp/static/tests/tours/mrp_bom_overview_tour.js
@@ -1,0 +1,66 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add("test_bom_overview_tour", {
+    url: "/web",
+    test: true,
+    steps: () => [
+        stepUtils.showAppsMenuItem(),
+        {
+            trigger: '.o_app[data-menu-xmlid="mrp.menu_mrp_root"]',
+        },
+        {
+            trigger: '.dropdown-toggle[data-menu-xmlid="mrp.menu_mrp_bom"]',
+        },
+        {
+            trigger: '.dropdown-item[data-menu-xmlid="mrp.menu_mrp_bom_form_action"]',
+        },
+        {
+            trigger: 'td.o_data_cell:contains("finish")',
+        },
+        {
+            trigger: 'div.o_stat_info:contains("BoM Overview")',
+        },
+        {
+            trigger: 'table>tbody>tr>td>div>a:contains("finish")',
+            extra_trigger: 'h2>a:contains("finish")',
+            isCheck: true,
+        },
+        {
+            trigger: 'table>tbody>tr:nth-child(1)>td:nth-child(6)>span:contains("$ 50.00")',
+            isCheck: true,
+        },
+        {
+            trigger: 'div.o_control_panel_navigation>div>div>div>button',
+        },
+        {
+            trigger: 'div.o_popover>span:contains("Availabilities")',
+        },
+        {
+            trigger: 'table>tbody>tr:nth-child(1)>td:nth-child(9)>span:contains("$ 50.00")',
+            isCheck: true,
+        },
+        {
+            trigger: 'input[id="bom_quantity"]',
+            run: 'text 2',
+        },
+        {
+            trigger: 'table>tbody>tr:nth-child(1)>td:nth-child(9)>span:contains("$ 100.00")',
+            isCheck: true,
+        },
+        {
+            trigger: 'table>tbody>tr:nth-child(1)>td:nth-child(8):contains("$ 70.00")',
+            isCheck: true,
+        },
+        {
+            trigger: 'table>tbody>tr:nth-child(1)>td>span:contains("Not Available")',
+            isCheck: true,
+        },
+        {
+            trigger: 'table>tbody>tr:nth-child(2)>td:nth-child(2):contains("4.00")',
+            isCheck: true,
+        },
+    ],
+});

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -2126,3 +2126,34 @@ class TestTourBoM(HttpCase):
 
         self.start_tour(url, 'test_mrp_bom_product_catalog', login='admin')
         self.assertEqual(len(bom.bom_line_ids), 1)
+
+    def test_mrp_bom_overview_tour(self):
+        Product = self.env['product.product']
+        product_finish = Product.create({
+            'name': 'finish',
+            'type': 'product',
+            'tracking': 'none',
+            })
+        product_finish.product_tmpl_id.standard_price = 50
+        compo1 = Product.create({
+            'name': 'compo1',
+            'type': 'product',
+            'tracking': 'none',})
+        compo1.product_tmpl_id.standard_price = 10
+        compo2 = Product.create({
+            'name': 'compo2',
+            'type': 'product',
+            'tracking': 'none',})
+        compo2.product_tmpl_id.standard_price = 15
+        self.env['mrp.bom'].create({
+            'product_id': product_finish.id,
+            'product_tmpl_id': product_finish.product_tmpl_id.id,
+            'product_qty': 1,
+            'type': 'normal',
+            'bom_line_ids': [
+                (0, 0, {'product_id': compo1.id, 'product_qty': 2}),
+                (0, 0, {'product_id': compo2.id, 'product_qty': 1}),
+            ],
+        })
+
+        self.start_tour("/web", "test_bom_overview_tour", login="admin", step_delay=1000, watch=True)


### PR DESCRIPTION
In this [commit](https://github.com/odoo/odoo/commit/3ad4fd65387f60b524e5f786556963ead8ae9dfe#diff-552aefb62246b1f4fe6a2607ec8f0a01773e53de2d68293266b38bc99c5cb56dR569-R577), the updateResId has been added to the action props. This did not trigger any error as the props are not validated, except if in debug mode.

Adding the standardActionServiceProps solves this problem.

This bug highlighted another problem: the component does not appear in a tour.

opw-3822623

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
