### PR TITLE
[FIX] mail, website: Send mail from website using the correct base URL

### DIFF
--- a/addons/mail/models/mail_render_mixin.py
+++ b/addons/mail/models/mail_render_mixin.py
@@ -173,7 +173,7 @@ class MailRenderMixin(models.AbstractModel):
             # compute here to do it only if really necessary + cache will ensure it is done only once
             # if not base_url
             if not _sub_relative2absolute.base_url:
-                _sub_relative2absolute.base_url = self.env["ir.config_parameter"].sudo().get_param("web.base.url")
+                _sub_relative2absolute.base_url = self.get_base_url()
             return match.group(1) + urls.url_join(_sub_relative2absolute.base_url, match.group(2))
 
         _sub_relative2absolute.base_url = base_url

--- a/addons/website/models/ir_model.py
+++ b/addons/website/models/ir_model.py
@@ -3,6 +3,8 @@
 
 from odoo import models
 
+from odoo.addons.website.models import ir_http
+
 
 class BaseModel(models.AbstractModel):
     _inherit = 'base'
@@ -30,6 +32,10 @@ class BaseModel(models.AbstractModel):
             return self._get_http_domain() or super().get_base_url()
         if 'website_id' in self and self.website_id.domain:
             return self.website_id._get_http_domain()
+        # Before returning the ICP, use the related website if we are in the frontend
+        website = ir_http.get_request_website()
+        if website and website.domain:
+            return website._get_http_domain()
         if 'company_id' in self and self.company_id.website_id.domain:
             return self.company_id.website_id._get_http_domain()
         return super().get_base_url()


### PR DESCRIPTION
Currently if a mail is sent from the website and the email template has local links, it will pull the base URL value from the config parameters rather than the domain of the website it is on. This can be quite jarring if the Odoo instance is hosted on odoo.sh and even more so if there are multiple websites with specific email templates for each website

This will fix the issue and ensure the base URL is pulled from each website separately

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
