### PR TITLE
[IMP] Reduce access to res.groups model.

### DIFF
--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -53,7 +53,7 @@
 "access_res_currency_group_system","res_currency group_system","model_res_currency","group_system",1,1,1,1
 "access_res_currency_rate_group_system","res_currency_rate group_system","model_res_currency_rate","group_system",1,1,1,1
 "access_res_groups_group_erp_manager","res_groups group_erp_manager","model_res_groups","group_erp_manager",1,1,1,1
-"access_res_groups_group_user","res_groups group_user","model_res_groups",group_user,1,0,0,0
+"access_res_groups_group_user","res_groups group_user","model_res_groups",group_user,0,0,0,0
 "access_res_lang_group_all","res_lang group_all","model_res_lang",,1,0,0,0
 "access_res_lang_group_user","res_lang group_user","model_res_lang","group_system",1,1,1,1
 "access_res_partner_public","res_partner group_public","model_res_partner","group_public",1,0,0,0


### PR DESCRIPTION
It is unclear to me why base.group_user needs read access to the res.groups model. This is almost certainly going to burst into flames, but let's see exactly how and learn from it.