### PR TITLE
[FIX] pos_self_order: use stored fields to check if product "has_image"

### DIFF
--- a/addons/pos_self_order/models/product_product.py
+++ b/addons/pos_self_order/models/product_product.py
@@ -96,7 +96,7 @@ class ProductProduct(models.Model):
         return [
             {
                 "price_info": product._get_price_info(pos_config),
-                "has_image": bool(product.image_1920),
+                "has_image": bool(product.product_tmpl_id.image_128 or product.image_variant_128),
                 "attributes": product._get_attributes(pos_config),
                 "name": product._get_name(),
                 "id": product.id,


### PR DESCRIPTION
(Please note that this is a backport of https://github.com/odoo/odoo/pull/157900)

Description of the issue/feature this PR addresses:

For method `_get_self_order_data` in pos_self_order's product.product extension, check fields `product_tmpl_id.image_128` and/or `image_variant_128` for the existance of an image on the product (`has_image` key).

Previously, the field `image_1920` was used which has two issues:

1.) The 128 sized image should be preferred because it is 15x smaller than 1920. The whole image is loaded at this point, so the smallest-sized one should be used.

2.) `image_1920` is a computed, non-stored, field. This has the implication that the image will be processed, thus consuming more memory (even leading to a MemoryError on the customer's DB). This happens like so: a.) `_compute_image_1920` is called, which sets a value into `record.image_1920`. https://github.com/odoo/odoo/blob/38f37edad3da4a4547b73d971e053b0634067fa1/addons/product/models/product_product.py#L157 b.) Eventually `_image_process` is called, which performs memory intensive computations on the image. https://github.com/odoo/odoo/blob/38f37edad3da4a4547b73d971e053b0634067fa1/odoo/fields.py#L2550

So this can be avoided by implementing this commit, which will check the stored, non-computed fields instead.

Current behavior before PR:

Uses more memory than necessary when checking for if products have an image or not.

Desired behavior after PR is merged:

Use less memory.
