### PR TITLE
[FIX][17.0] account: fix error when delete the SO on form view

### DIFF
--- a/addons/account/static/src/components/tax_totals/tax_totals.js
+++ b/addons/account/static/src/components/tax_totals/tax_totals.js
@@ -150,6 +150,9 @@ export class TaxTotalsComponent extends Component {
 
     formatData(props) {
         let totals = JSON.parse(JSON.stringify(toRaw(props.record.data[this.props.name])));
+        if (!totals) {
+            return;
+        }
         const currencyFmtOpts = { currencyId: props.record.data.currency_id && props.record.data.currency_id[0] };
 
         let amount_untaxed = totals.amount_untaxed;


### PR DESCRIPTION
[[BUG][17.0] viin_sales_unlink- Xảy ra lỗi khi xóa SO](https://viindoo.com/web#id=51865&cids=1&menu_id=289&model=viin.helpdesk.ticket&view_type=form)
-

This PR
-

- Fix bug when delete SO

**Step**
- Create SO
- Confirm SO, add delivered If the product is a warehouse product
- Create Invoice
- Delete Invoice
- Cancel SO
- Delete SO

**Output**

- Displays the error totals.subtotals order is not iterable

**Reason**

- When unlink SO, tax value no longer exists, so, return value of totals is false, and when try loop totals.subtotals_order (undefine value) will be display this error

**Solution**

- Check the total input value. If there is no value or the return value is false, return it




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
