### PR TITLE
[FIX][16.0] mrp: split fails when user_id

### DIFF
--- a/addons/mrp/wizard/mrp_production_split.py
+++ b/addons/mrp/wizard/mrp_production_split.py
@@ -47,13 +47,13 @@ class MrpProductionSplit(models.TransientModel):
             for _ in range(wizard.counter - 1):
                 commands.append(Command.create({
                     'quantity': quantity,
-                    'user_id': wizard.production_id.user_id,
+                    'user_id': wizard.production_id.user_id.id,
                     'date': wizard.production_id.date_planned_start,
                 }))
                 remaining_quantity = float_round(remaining_quantity - quantity, precision_rounding=wizard.product_uom_id.rounding)
             commands.append(Command.create({
                 'quantity': remaining_quantity,
-                'user_id': wizard.production_id.user_id,
+                'user_id': wizard.production_id.user_id.id,
                 'date': wizard.production_id.date_planned_start,
             }))
             wizard.production_detailed_vals_ids = commands

--- a/doc/cla/corporate/braintec.md
+++ b/doc/cla/corporate/braintec.md
@@ -17,3 +17,5 @@ Raul Martin raul.martin@braintec.com https://github.com/BT-rmartin
 Frédéric Garbely frederic.garbely@braintec.com https://github.com/BT-fgarbely
 Carlos Serra Toro carlos.serra@braintec.com https://github.com/BT-cserra
 Cristian Rodriguez Navarro cristian.rodriguez@braintec.com https://github.com/BT-crodriguez
+Alberto Nieto de Pablos alberto.nieto@braintec.com https://github.com/BT-anieto
+


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a responsible (user_id) is set on the manufacturing order, the split (mass produce) action fails.

Current behavior before PR:
Yellow screen because of not properly object sent to command_create

Desired behavior after PR is merged:
The mass produce works



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
