### PR TITLE
[FIX] account_journal: avoid duplicate mail alias

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -605,6 +605,26 @@ class AccountJournal(models.Model):
         return self.env['mail.alias']._sanitize_alias_name(alias_name)
 
     @api.model
+    def _ensure_unique_alias(self, vals, company):
+        """ Check uniqueness of the alias name within the given alias domain.
+        :param vals: the values of the journal.
+        :return: a unique alias name.
+        """
+        alias_name = vals['alias_name']
+        alias_domain_name = company.alias_domain_id.name
+
+        domain = [('alias_name', '=', alias_name)]
+        if alias_domain_name:
+            domain.append(('alias_domain', '=', alias_domain_name))
+
+        existing_alias = self.env['mail.alias'].search_count(domain, limit=1)
+
+        if existing_alias:
+            alias_name = f"{alias_name}-{vals.get('code')}"
+
+        return self.env['mail.alias']._sanitize_alias_name(alias_name)
+
+    @api.model
     def get_next_bank_cash_default_code(self, journal_type, company, cache=None, protected_codes=False):
         prefix_map = {'cash': 'CSH', 'general': 'GEN', 'bank': 'BNK'}
         journal_code_base = prefix_map.get(journal_type)
@@ -693,10 +713,12 @@ class AccountJournal(models.Model):
             vals['refund_sequence'] = vals['type'] in ('sale', 'purchase')
 
         # === Fill missing alias name for sale / purchase, to force alias creation ===
-        if journal_type in {'sale', 'purchase'} and 'alias_name' not in vals:
-            vals['alias_name'] = self._alias_prepare_alias_name(
+        if journal_type in {'sale', 'purchase'}:
+            if 'alias_name' not in vals:
+                vals['alias_name'] = self._alias_prepare_alias_name(
                 False, vals.get('name'), vals.get('code'), journal_type, company
             )
+            vals['alias_name'] = self._ensure_unique_alias(vals, company)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/account/tests/test_account_journal.py
+++ b/addons/account/tests/test_account_journal.py
@@ -294,3 +294,19 @@ class TestAccountJournalAlias(AccountTestInvoicingCommon, MailCommon):
                          'Journal alias owned by journal itself')
         self.assertEqual(journal_alias_2.alias_parent_thread_id, journal.id,
                          'Journal alias owned by journal itself')
+
+    def test_alias_create_unique(self):
+        """ Make auto-generated alias_name unique when needed """
+        company_name = self.company_data['company'].name
+        journal = self.env['account.journal'].create({
+            'name': 'Test Journal',
+            'type': 'sale',
+            'code': 'A',
+        })
+        journal2 = self.env['account.journal'].create({
+            'name': 'Test Journal',
+            'type': 'sale',
+            'code': 'B',
+        })
+        self.assertEqual(journal.alias_name, f'test-journal-{company_name}')
+        self.assertEqual(journal2.alias_name, f'test-journal-{company_name}-b')


### PR DESCRIPTION
Steps to reproduce:
- Create an account journal.
- Rename the created journal (let's say from A to B).
- Create a new account journal named A.

Changing the name of a journal doesn't change the name of the alias, An error caused by duplicate mail alias names will occur. Additionally the error can happen if the user has manually added aliases with the same name before upgrading to 17.0.

Adding the code and company id of the journal to the alias to ensure uniqueness when an alias with the same name is already in the DB (as the combo `company_id`,`code` is unique).

Other possible fixes: (I'm not sure what's better here)

- Automatically rename an alias when its journal is renamed (only when they are identical after being sanitized)
- Add numbers as suffix to alias names

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
