### PR TITLE
[FIX] stock: check picked line before check quantity

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1058,7 +1058,7 @@ class Picking(models.Model):
 
         def get_line_with_done_qty_ids(move_lines):
             # Get only move_lines that has some quantity set.
-            return move_lines.filtered(lambda ml: ml.product_id and ml.product_id.tracking != 'none' and float_compare(ml.quantity, 0, precision_rounding=ml.product_uom_id.rounding)).ids
+            return move_lines.filtered(lambda ml: ml.picked and ml.product_id and ml.product_id.tracking != 'none' and float_compare(ml.quantity, 0, precision_rounding=ml.product_uom_id.rounding)).ids
 
         if separate_pickings:
             # If pickings are checked independently, get full/partial move_lines depending if each picking has no quantity set.


### PR DESCRIPTION
Steps to reproduce:
-------------------
- install stock, bacode and purchase;
- create a tracked product (by lots) and a untracked product;
- create a purchase order with these two products;
- confirm the order (and take the warehouse of the receipt);
- go to barcode in the correct receipt;
- validate the untracked product only;
- validate the receipt;

Issue:
------
An "Invalid Operation" error message appears.

Cause:
------
This is a case of separate picking.
We therefore need to check the picking lines.

To do this, we want to retrieve the move lines with the quantities received. We therefore compare the quantity of the move line with 0 in order to determine whether or not we are taking the line into account.

Currently, `quantity` field is used.
The field used to determine this information in versions < 17 is `qty_done` (which is a dummy field[^1]).
This field took into account whether the line was picked or not.

As this is no longer the case, the line of the tracked product is taken into account even though it is not picked.
As a result, the picking sanity check will not be check.

Solution:
---------
Check that the line is picked before testing the value of the quantity field.

opw-3794140