### PR TITLE
[IMP] hr_holidays: close activities on time off cancellation

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -1417,6 +1417,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                 )
         leave_sudo = self.sudo()
         leave_sudo.state = 'cancel'
+        leave_sudo.activity_update()
         leave_sudo._post_leave_cancel()
 
     def _post_leave_cancel(self):
@@ -1572,7 +1573,7 @@ Attempting to double-book your time off won't magically make your vacation 2x be
                         })
             elif holiday.state == 'validate':
                 to_do |= holiday
-            elif holiday.state == 'refuse':
+            elif holiday.state in ['refuse', 'cancel']:
                 to_clean |= holiday
         if to_clean:
             to_clean.activity_unlink(['hr_holidays.mail_act_leave_approval', 'hr_holidays.mail_act_leave_second_approval'])


### PR DESCRIPTION
This commit fixes the behavior where activities linked to a time off request remained open in the activity summary even after the time off was cancelled. Now, when a time off request is cancelled, all linked activities are properly closed and removed from the activity summary.

Task-3820296

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
