### PR TITLE
[15.0][IMP] rating: Use with_company() in the rating controller

### DIFF
--- a/addons/rating/controllers/main.py
+++ b/addons/rating/controllers/main.py
@@ -45,7 +45,15 @@ class Rating(http.Controller):
         }
         rating.write({'rating': rate, 'consumed': True})
         lang = rating.partner_id.lang or get_lang(request.env).code
-        return request.env['ir.ui.view'].with_context(lang=lang)._render_template('rating.rating_external_page_submit', {
+        # Apply .sudo() to avoid error if public_user does not have this allowed company
+        view_model = request.env['ir.ui.view'].sudo()
+        if (
+            rating.resource_ref
+            and "company_id" in rating.resource_ref._fields
+            and rating.resource_ref.company_id
+        ):
+            view_model = view_model.with_company(rating.resource_ref.company_id)
+        return view_model.with_context(lang=lang)._render_template('rating.rating_external_page_submit', {
             'rating': rating, 'token': token,
             'rate_names': rate_names, 'rate': rate
         })
@@ -61,7 +69,15 @@ class Rating(http.Controller):
             record_sudo = request.env[rating.res_model].sudo().browse(rating.res_id)
             record_sudo.rating_apply(rate, token=token, feedback=kwargs.get('feedback'))
         lang = rating.partner_id.lang or get_lang(request.env).code
-        return request.env['ir.ui.view'].with_context(lang=lang)._render_template('rating.rating_external_page_view', {
+        # Apply .sudo() to avoid error if public_user does not have this allowed company
+        view_model = request.env['ir.ui.view'].sudo()
+        if (
+            rating.resource_ref
+            and "company_id" in rating.resource_ref._fields
+            and rating.resource_ref.company_id
+        ):
+            view_model = view_model.with_company(rating.resource_ref.company_id)
+        return view_model.with_context(lang=lang)._render_template('rating.rating_external_page_view', {
             'web_base_url': rating.get_base_url(),
             'rating': rating,
         })


### PR DESCRIPTION
If we use multi-company and create a rating related to a record that has a company_id set, that company must be used for the header to be correct (e.g. company logo).

**Example use case**:
- Create Company A and set a logo
- Create Company B and set a logo
- Creates a project linked to Company B
- Create a New and Done stage linked to the previous project.
- Go to Project > Configuration and activate Customer Ratings
- Set a rating template (Task: Rating Request) to the Done stage.
- Create a task linked to Company B and a customer.
- Change task to the Done stage.
- Click on the satisfaction icon in the email sent to the customer.

Current behavior before PR
- The correct logo (company B) is displayed.

@Tecnativa TT48498

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
