### PR TITLE
[FIX] account: fixed import name for account test case

### DIFF
--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
 from odoo import Command
-from odoo.addons.account.models.chart_template import code_translations
+from odoo.tools.translate import code_translations
 from odoo.addons.account.models.chart_template import AccountChartTemplate
 from odoo.addons.account.models.chart_template import TEMPLATE_MODELS
 from odoo.addons.account.tests.common import instantiate_accountman
@@ -663,7 +663,7 @@ class TestChartTemplate(TransactionCase):
         with patch.object(AccountChartTemplate, '_get_chart_template_mapping', side_effect=local_get_mapping, autospec=True):
             with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=local_get_data, autospec=True):
                 with patch.object(AccountChartTemplate, '_post_load_data', wraps=test_post_load_data):
-                    with patch.object(code_translations, 'python_translations', mock_python_translations):
+                    with patch.object(code_translations, 'get_python_translations', mock_python_translations):
                         self.env['account.chart.template'].try_loading('translation', company=company, install_demo=False)
 
         # Check translations


### PR DESCRIPTION
During upgrade got the import name error:
```ImportError: cannot import name 'code_translations' from
'odoo.addons.account.models.chart_template' ```

`code_translations` function defined in odoo.tools.translate
and there is function `get_python_translations`
by mistake give `from odoo.tools.translate import code_translations`
to correct that.

```
 File "/home/odoo/src/odoo/17.0/addons/stock_account/tests/test_account_move.py", line 4, in <module>
    from odoo.addons.account.tests.common import AccountTestInvoicingCommon
  File "/home/odoo/src/odoo/17.0/addons/account/tests/__init__.py", line 22, in <module>
    from . import test_chart_template
  File "/home/odoo/src/odoo/17.0/addons/account/tests/test_chart_template.py", line 4, in <module>
    from odoo.addons.account.models.chart_template import code_translations
ImportError: cannot import name 'code_translations' from 'odoo.addons.account.models.chart_template' (/home/odoo/src/odoo/17.0/addons/account/models/chart_template.py)
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
