### PR TITLE
[FIX] stock: ensures serial number content fits

### DIFF
--- a/addons/product_expiry/report/report_lot_barcode.xml
+++ b/addons/product_expiry/report/report_lot_barcode.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 <template id="report_lot_label_expiry" inherit_id="stock.report_lot_label">
-    <xpath expr="//span[@name='lot_name']" position="after">
+    <xpath expr="//div[@name='lot_name']" position="after">
         <t t-if="o.use_expiration_date">
             <div class="o_label_4x12" t-if="o.use_date">
                 B.b. <t t-out="o.use_date" t-options='{"widget": "date"}'/>

--- a/addons/stock/report/report_lot_barcode.xml
+++ b/addons/stock/report/report_lot_barcode.xml
@@ -19,15 +19,22 @@
                                 <t t-set="o" t-value="page_docs[0]"/>
                             </t>
                             <td t-att-style="barcode_index &gt;= len(page_docs) and 'visibility:hidden'">
-                                <div t-att-style="'position:relative; width:43mm; height:34mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black')">
+                                <div t-att-style="'position:relative; width:43mm; height:19mm; border: 1px solid %s;' % (o.env.user.company_id.primary_color or 'black')">
                                     <t t-set="final_barcode" t-value="''"/>
                                     <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
                                         <t t-if="o.product_id.valid_ean" t-set="final_barcode" t-value="'01' + '0' * (14 - len(o.product_id.barcode)) + o.product_id.barcode"/>
                                         <t name="gs1_datamatrix_lot" t-if="o.product_id.tracking == 'lot'" t-set="final_barcode" t-value="(final_barcode or '') + '10' + o.name"/>
                                         <t t-elif="o.product_id.tracking == 'serial'" t-set="final_barcode" t-value="(final_barcode or '') + '21' + o.name"/>
                                     </t>
-                                    <span class="o_label_4x12" t-field="o.product_id.display_name" t-att-style="'width:22mm' if final_barcode else ''">Demo Product</span>
-                                    <span class="o_label_4x12" name="lot_name" t-field="o.name" t-att-style="'width:22mm' if final_barcode else ''">Demo Name</span>
+                                    <div t-if="o.product_id.default_code" class="o_label_4x12" t-att-style="'width:22mm' if final_barcode else ''">
+                                        <span class="o_label_4x12 lh-1">[<t t-out="o.product_id.default_code"/>]</span>
+                                    </div>
+                                    <div class="o_label_4x12" t-att-style="'width:22mm' if final_barcode else ''">
+                                        <span class="o_label_4x12 lh-1" t-field="o.product_id.name" >Demo Product</span>
+                                    </div>
+                                    <div class="o_label_4x12" name="lot_name" t-att-style="'width:22mm; ' if final_barcode else ''">
+                                        <span class="o_label_4x12 lh-1" name="lot_name" t-field="o.name">Demo Name</span>
+                                    </div>
                                     <t t-if="env.user.has_group('stock.group_stock_lot_print_gs1')">
                                         <div t-if="final_barcode" t-att-style="'position:absolute; right:.5px; bottom:.5px'">
                                             <span t-out="final_barcode" t-options="{'widget': 'barcode', 'symbology': 'ECC200DataMatrix', 'img_style': 'width:17mm; height:17mm'}">12345678901</span>


### PR DESCRIPTION
Current behavior:
---
When printing a Lot/Serial Number, if the product name is too long, the content overlaps.

Steps to reproduce:
---
1. Go to Inventory > Products > Lots/Serial Numbers
2. Open one Serial Number > open its product
3. Rename product with long name 
4. Go back to Lots/Serial Numbers
5. Select the Serial Number with renamed product
6. Click on Print > PDF
7. Barcode is out of the box 

Cause of the issue:
---
Caused by: https://github.com/odoo/odoo/commit/95880f43c59c061f2a971ba8f41f9912139b798a
div was changed to span without changing the css

opw-3819349

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
