### PR TITLE
[IMP] website_event: add ongoing events filter to snippet

### DIFF
--- a/addons/website_event/data/website_snippet_data.xml
+++ b/addons/website_event/data/website_snippet_data.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo><data>
 
+    <!-- Dynamic Event Snippet: Upcoming Events Filter -->
     <record id="ir_filters_event_list_snippet" model="ir.filters">
         <field name="name">Upcoming Events</field>
         <field name="model_id">event.event</field>
@@ -8,12 +9,26 @@
         <field name="domain">[('date_begin', '&gt;=', context_today())]</field>
         <field name="sort">['date_begin asc']</field>
     </record>
-
     <record id="website_snippet_filter_event_list" model="website.snippet.filter">
         <field name="filter_id" ref="website_event.ir_filters_event_list_snippet"/>
         <field name="field_names">name,subtitle</field>
         <field name="limit" eval="16"/>
         <field name="name">Upcoming Events</field>
+    </record>
+
+    <!-- Dynamic Event Snippet : Upcoming and Ongoing Events Filter -->
+    <record id="ir_filters_event_list_snippet_unfinished" model="ir.filters">
+        <field name="name">Upcoming and Ongoing Events</field>
+        <field name="model_id">event.event</field>
+        <field name="user_id" eval="False" />
+        <field name="domain">[('is_finished', '=', False)]</field>
+        <field name="sort">['date_begin asc']</field>
+    </record>
+    <record id="website_snippet_filter_event_list_unfinished" model="website.snippet.filter">
+        <field name="filter_id" ref="website_event.ir_filters_event_list_snippet_unfinished"/>
+        <field name="field_names">name,subtitle</field>
+        <field name="limit" eval="16"/>
+        <field name="name">Upcoming and Ongoing Events</field>
     </record>
 
 </data></odoo>

--- a/addons/website_event/static/src/snippets/s_events/000.js
+++ b/addons/website_event/static/src/snippets/s_events/000.js
@@ -4,6 +4,8 @@ import publicWidget from 'web.public.widget';
 import DynamicSnippet from 'website.s_dynamic_snippet';
 
 const DynamicSnippetEvents = DynamicSnippet.extend({
+    // While the selector has 'upcoming_snippet' in its name, it now has a filter
+    // option to include ongoing events. The name is kept for backward compatibility.
     selector: '.s_event_upcoming_snippet',
     disabledInEditableMode: false,
 


### PR DESCRIPTION
Backport of 609140963d55115f315d19eae47a804b69c4e3c0

In the s_events dynamic snippet, the only filter that was automatically applied was the 'upcoming events' one.

In order to give the user more flexibility, we add a filter 'upcoming and ongoing events'. As there is more than one filter, the filter dropdown will appear in the snippet custom options, hinting a possible choice between both filters. The upcoming events is still appearing first as filters are searched for in id ASC order.

Task-3628185
opw-3774019