### PR TITLE
[FIX] website_event_(track/exhibitor): fixed search-bar issues

### DIFF
--- a/addons/website_event_exhibitor/static/src/js/event_sponsor_search.js
+++ b/addons/website_event_exhibitor/static/src/js/event_sponsor_search.js
@@ -10,6 +10,7 @@ publicWidget.registry.websiteEventSearchSponsor = publicWidget.Widget.extend({
         'click .o_dropdown_reset_tags': '_onTagReset',
         'change .o_wevent_event_tags_form input': '_onTagAdd',
         'change .o_wevent_event_tags_mobile_form input': '_onTagAddMobile',
+        'search .o_wevent_event_search_box': '_onSearch',
     },
 
     start: function () {

--- a/addons/website_event_track/__manifest__.py
+++ b/addons/website_event_track/__manifest__.py
@@ -55,6 +55,7 @@
             'website_event_track/static/lib/idb-keyval/idb-keyval.js',
             'website_event_track/static/src/xml/event_track_proposal_templates.xml',
             'website_event_track/static/src/xml/website_event_pwa.xml',
+            'website_event_track/static/src/js/event_track_search.js',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/website_event_track/static/src/js/event_track_search.js
+++ b/addons/website_event_track/static/src/js/event_track_search.js
@@ -1,0 +1,15 @@
+import publicWidget from "@web/legacy/js/public/public_widget";
+
+publicWidget.registry.websiteEventSearchTrack = publicWidget.Widget.extend({
+    selector: '.o_wevent_event_track_search_box',
+    events: {
+        'search .search-query': '_onSearch',
+    },
+
+    _onSearch: function () {
+        const input = this.el.querySelector('input.search-query');
+        if(!input.value) {
+            this.el.querySelector('form.o_wevent_event_searchbar_form')?.submit();
+        }
+    }
+});

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -52,7 +52,7 @@
                     </a>
                 </div>
             </div>
-            <div class="o_wevent_search d-flex w-100 w-lg-auto">
+            <div class="o_wevent_search o_wevent_event_track_search_box d-flex w-100 w-lg-auto">
                 <t t-call="website_event.events_search_box">
                     <t t-set="_searches" t-value="searches"/>
                     <t t-set="action" t-value="'/event/%s/track' % (slug(event))"/>


### PR DESCRIPTION
Before this PR
==================
**issue 1**
-> When searching for an exhibitor and pressing enter, nothing happens (need to
 click on the button).

**issue 2**
->  When clicking on the cross to cancel the search on both pages (talks and exhibitor) nothing happens, we should be back on the page with all the results. 

Technical Reason
================
We are inheriting the website search box template in the primary mode so the website search box js is not working on the exhibitor page and talk page.

Enter key is not working on the exhibitor page because we have changed the type of the button from the submit -> button due to this our form is not submitted and search is not happening.

After this PR
=================
Now when searching on the exhibitor page and pressing enter we will get the search results.

Now cross the button to cancel the search will work properly.

Task-3758369