### PR TITLE
[IMP] mail: cleanup thread.messages and thread.allMessages

### DIFF
--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_model.js
@@ -70,7 +70,7 @@ export class Chatbot extends Record {
             { html: true }
         );
         if (this.currentStep.message) {
-            this.thread.messages.add(this.currentStep.message);
+            this.thread.messagesListed.add(this.currentStep.message);
         }
     }
 
@@ -162,7 +162,7 @@ export class Chatbot extends Record {
             channel_id: this.thread.id,
         });
         if (message) {
-            this.thread.messages.add({ ...message, body: markup(message.body) });
+            this.thread.messagesListed.add({ ...message, body: markup(message.body) });
         }
         return success;
     }

--- a/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
+++ b/addons/im_livechat/static/src/embed/common/chatbot/chatbot_service.js
@@ -92,7 +92,7 @@ export class ChatBotService {
         if (!this.livechatService.thread) {
             return;
         }
-        this.livechatService.thread.messages.add(message);
+        this.livechatService.thread.messagesListed.add(message);
         this.chatbot.restart();
         this._triggerNextStep();
     }

--- a/addons/mail/static/src/chatter/web_portal/chatter.js
+++ b/addons/mail/static/src/chatter/web_portal/chatter.js
@@ -252,8 +252,8 @@ export class Chatter extends Component {
         this.state.thread.name = webRecord?.data?.display_name || undefined;
         this.attachmentUploader.thread = this.state.thread;
         if (threadId === false) {
-            if (this.state.thread.messages.length === 0) {
-                this.state.thread.messages.push({
+            if (this.state.thread.messagesListed.length === 0) {
+                this.state.thread.messagesListed.push({
                     id: this.messageService.getNextTemporaryId(),
                     author: this.store.self,
                     body: _t("Creating a new record..."),

--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -11,6 +11,7 @@ declare module "models" {
     import { Follower as FollowerClass } from "@mail/core/common/follower_model";
     import { LinkPreview as LinkPreviewClass } from "@mail/core/common/link_preview_model";
     import { Message as MessageClass } from "@mail/core/common/message_model";
+    import { MessageList as MessageListClass } from "@mail/core/common/message_list_model";
     import { MessageReactions as MessageReactionsClass } from "@mail/core/common/message_reactions_model";
     import { Notification as NotificationClass } from "@mail/core/common/notification_model";
     import { Persona as PersonaClass } from "@mail/core/common/persona_model";
@@ -32,6 +33,7 @@ declare module "models" {
     export interface Follower extends FollowerClass {}
     export interface LinkPreview extends LinkPreviewClass {}
     export interface Message extends MessageClass {}
+    export interface MessageList extends MessageListClass {}
     export interface MessageReactions extends MessageReactionsClass {}
     export interface Notification extends NotificationClass {}
     export interface Persona extends PersonaClass {}
@@ -54,6 +56,7 @@ declare module "models" {
         "Follower": Follower,
         "LinkPreview": LinkPreview,
         "Message": Message,
+        "MessageList": MessageList,
         "MessageReactions": MessageReactions,
         "Notification": Notification,
         "Persona": Persona,

--- a/addons/mail/static/src/core/common/discuss.js
+++ b/addons/mail/static/src/core/common/discuss.js
@@ -92,6 +92,10 @@ export class Discuss extends Component {
         onWillUnmount(() => (this.store.discuss.isActive = false));
     }
 
+    get messageList() {
+        return this.store.discuss.messageList;
+    }
+
     get thread() {
         return this.store.discuss.thread;
     }

--- a/addons/mail/static/src/core/common/discuss.xml
+++ b/addons/mail/static/src/core/common/discuss.xml
@@ -62,7 +62,7 @@
             </div>
             <div class="overflow-auto bg-view d-flex flex-grow-1" t-ref="core">
                 <div class="d-flex flex-column flex-grow-1">
-                    <Thread thread="thread" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/>
+                    <Thread t-if="messageList" thread="thread" messageList="messageList" t-key="thread.localId" jumpPresent="state.jumpThreadPresent" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo"/>
                     <Composer t-if="thread.model !== 'mail.box' or thread.eq(messageToReplyTo.thread)" t-key="thread.localId" composer="thread.composer" autofocus="true" messageEdition="messageEdition" messageToReplyTo="messageToReplyTo" onDiscardCallback="() => messageToReplyTo.cancel()" onPostCallback.bind="() => this.state.jumpThreadPresent++" dropzoneRef="contentRef" type="messageToReplyTo?.message ? (messageToReplyTo.message.is_note ? 'note' : 'message') : undefined"/>
                 </div>
                 <div t-if="threadActions.activeAction?.componentCondition" t-attf-class="{{ threadActions.activeAction.panelOuterClass }}" class="h-100 border-start o-mail-Discuss-inspector">

--- a/addons/mail/static/src/core/common/discuss_app_model.js
+++ b/addons/mail/static/src/core/common/discuss_app_model.js
@@ -52,6 +52,7 @@ export class DiscussApp extends Record {
                 : c1.name.localeCompare(c2.name),
     });
     thread = Record.one("Thread");
+    messageList = Record.one("MessageList");
     channels = Record.one("DiscussAppCategory");
     chats = Record.one("DiscussAppCategory");
     // mailboxes in sidebar

--- a/addons/mail/static/src/core/common/mail_core_common_service.js
+++ b/addons/mail/static/src/core/common/mail_core_common_service.js
@@ -49,11 +49,11 @@ export class MailCoreCommon {
                     if (starred) {
                         starredBox.counter++;
                         message.starredPersonas.add(this.store.self);
-                        starredBox.messages.add(message);
+                        starredBox.messagesListed.add(message);
                     } else {
                         starredBox.counter--;
                         message.starredPersonas.delete(this.store.self);
-                        starredBox.messages.delete(message);
+                        starredBox.messagesListed.delete(message);
                     }
                 }
             });

--- a/addons/mail/static/src/core/common/message_list_model.js
+++ b/addons/mail/static/src/core/common/message_list_model.js
@@ -1,0 +1,153 @@
+import { AND, Record } from "@mail/core/common/record";
+const FETCH_LIMIT = 30;
+
+export class MessageList extends Record {
+    static id = AND("thread", "source");
+
+    source = Record.attr();
+    messages = Record.many("Message");
+    thread = Record.one("Thread");
+    newestMessage = Record.many("Message", {
+        compute() {
+            return [...this.messages].reverse().find((msg) => !msg.isEmpty);
+        },
+    });
+    newestPersistentMessage = Record.one("Message", {
+        compute() {
+            return [...this.messages].reverse().find((msg) => Number.isInteger(msg.id));
+        },
+    });
+    oldestPersistentMessage = Record.one("Message", {
+        compute() {
+            return this.messages.find((msg) => Number.isInteger(msg.id));
+        },
+    });
+    isEmpty = Record.attr(false, {
+        compute() {
+            return !this.messages.some((message) => !message.isEmpty);
+        },
+    });
+    nonEmptyMessages = Record.many("Message", {
+        compute() {
+            return this.messages.filter((message) => !message.isEmpty);
+        },
+    });
+    persistentMessages = Record.many("Message", {
+        compute() {
+            return this.messages.filter((message) => !message.is_transient);
+        },
+    });
+
+    /**
+     * @param {import("models").Thread} thread
+     */
+    async fetchNewMessages() {
+        if (
+            this.thread.status === "loading" ||
+            (this.thread.isLoaded && ["discuss.channel", "mail.box"].includes(this.thread.model))
+        ) {
+            return;
+        }
+        const after = this.thread.isLoaded ? this.newestPersistentMessage?.id : undefined;
+        try {
+            const fetched = await this._store.env.services["mail.thread"].fetchMessages(
+                this.thread,
+                { after }
+            );
+            // feed messages
+            // could have received a new message as notification during fetch
+            // filter out already fetched (e.g. received as notification in the meantime)
+            let startIndex;
+            if (after === undefined) {
+                startIndex = 0;
+            } else {
+                const afterIndex = this.messages.findIndex((message) => message.id === after);
+                if (afterIndex === -1) {
+                    // there might have been a jump to message during RPC fetch.
+                    // Abort feeding messages as to not put holes in message list.
+                    return;
+                } else {
+                    startIndex = afterIndex + 1;
+                }
+            }
+            const alreadyKnownMessages = new Set(this.messages.map((m) => m.id));
+            const filtered = fetched.filter(
+                (message) =>
+                    !alreadyKnownMessages.has(message.id) &&
+                    (this.persistentMessages.length === 0 ||
+                        message.id < this.oldestPersistentMessage.id ||
+                        message.id > this.newestPersistentMessage.id)
+            );
+            this.messages.splice(startIndex, 0, ...filtered);
+            Object.assign(this.thread, {
+                loadOlder:
+                    after === undefined && fetched.length === FETCH_LIMIT
+                        ? true
+                        : after === undefined && fetched.length !== FETCH_LIMIT
+                        ? false
+                        : this.thread.loadOlder,
+            });
+        } catch {
+            // handled in fetchMessages
+        }
+    }
+
+    /**
+     * @param {import("models").Thread} thread
+     * @param {"older"|"newer"} epoch
+     */
+    async fetchMoreMessages(epoch = "older") {
+        if (
+            this.thread.status === "loading" ||
+            (epoch === "older" && !this.thread.loadOlder) ||
+            (epoch === "newer" && !this.thread.loadNewer)
+        ) {
+            return;
+        }
+        const before = epoch === "older" ? this.oldestPersistentMessage?.id : undefined;
+        const after = epoch === "newer" ? this.newestPersistentMessage?.id : undefined;
+        try {
+            const fetched = await this._store.env.services["mail.thread"].fetchMessages(
+                this.thread,
+                { after, before }
+            );
+            if (
+                (after !== undefined && !this.messages.some((message) => message.id === after)) ||
+                (before !== undefined && !this.messages.some((message) => message.id === before))
+            ) {
+                // there might have been a jump to message during RPC fetch.
+                // Abort feeding messages as to not put holes in message list.
+                return;
+            }
+            const alreadyKnownMessages = new Set(this.messages.map(({ id }) => id));
+            const messagesToAdd = fetched.filter(
+                (message) => !alreadyKnownMessages.has(message.id)
+            );
+            if (epoch === "older") {
+                this.messages.unshift(...messagesToAdd);
+            } else {
+                this.messages.push(...messagesToAdd);
+            }
+            if (fetched.length < FETCH_LIMIT) {
+                if (epoch === "older") {
+                    this.thread.loadOlder = false;
+                } else if (epoch === "newer") {
+                    this.thread.loadNewer = false;
+                    const missingMessages = this.thread.pendingNewMessages.filter(
+                        ({ id }) => !alreadyKnownMessages.has(id)
+                    );
+                    if (missingMessages.length > 0) {
+                        this.messages.push(...missingMessages);
+                        this.messages.sort((m1, m2) => m1.id - m2.id);
+                    }
+                }
+            }
+            this._enrichMessagesWithTransient(this.thread);
+        } catch {
+            // handled in fetchMessages
+        }
+        this.thread.pendingNewMessages = [];
+    }
+}
+
+MessageList.register();

--- a/addons/mail/static/src/core/common/message_service.js
+++ b/addons/mail/static/src/core/common/message_service.js
@@ -54,7 +54,7 @@ export class MessageService {
     async delete(message) {
         if (message.isStarred) {
             this.store.discuss.starred.counter--;
-            this.store.discuss.starred.messages.delete(message);
+            this.store.discuss.starred.messagesListed.delete(message);
         }
         message.body = "";
         message.attachments = [];
@@ -130,7 +130,7 @@ export class MessageService {
     async unstarAll() {
         // apply the change immediately for faster feedback
         this.store.discuss.starred.counter = 0;
-        this.store.discuss.starred.messages = [];
+        this.store.discuss.starred.messagesListed = [];
         await this.orm.call("mail.message", "unstar_all");
     }
 

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -44,6 +44,8 @@ export class Store extends BaseStore {
     LinkPreview;
     /** @type {typeof import("@mail/core/common/message_model").Message} */
     Message;
+    /** @type {typeof import("@mail/core/common/message_list_model").MessageList} */
+    MessageList;
     /** @type {typeof import("@mail/core/common/message_reactions_model").MessageReactions} */
     MessageReactions;
     /** @type {typeof import("@mail/core/common/notification_model").Notification} */

--- a/addons/mail/static/src/core/common/thread.js
+++ b/addons/mail/static/src/core/common/thread.js
@@ -33,6 +33,7 @@ export const PRESENT_THRESHOLD = 2500;
  * @property {import("models").Thread} thread
  * @property {string} [searchTerm]
  * @property {import("@web/core/utils/hooks").Ref} [scrollRef]
+ * @property {import("models").MessageList} messageList
  * @extends {Component<Props, Env>}
  */
 export class Thread extends Component {
@@ -49,6 +50,7 @@ export class Thread extends Component {
         "showEmptyMessage?",
         "showJumpPresent?",
         "messageActions?",
+        "messageList",
     ];
     static defaultProps = {
         isInChatWindow: false,
@@ -87,7 +89,7 @@ export class Thread extends Component {
             "load-older",
             () => {
                 if (this.loadOlderState.isVisible) {
-                    this.threadService.fetchMoreMessages(this.props.thread);
+                    this.props.messageList.fetchMoreMessages();
                 }
             },
             { ready: false }
@@ -96,7 +98,7 @@ export class Thread extends Component {
             "load-newer",
             () => {
                 if (this.loadNewerState.isVisible) {
-                    this.threadService.fetchMoreMessages(this.props.thread, "newer");
+                    this.props.messageList.fetchMoreMessages("newer");
                 }
             },
             { ready: false }
@@ -147,7 +149,7 @@ export class Thread extends Component {
                 if (this.env.chatter) {
                     this.env.chatter.fetchMessages = false;
                 }
-                this.threadService.fetchNewMessages(this.props.thread);
+                this.props.messageList.fetchNewMessages();
             }
         });
         useEffect(
@@ -371,7 +373,7 @@ export class Thread extends Component {
     }
 
     onClickLoadOlder() {
-        this.threadService.fetchMoreMessages(this.props.thread);
+        this.props.messageList.fetchMoreMessages();
     }
 
     async onClickPreferences() {

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.Thread">
     <t t-if="env.inChatter" t-call="mail.Thread.jumpPresent"/> <!-- chatter has its own scrollable, this ensures proper sticky showing -->
     <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-4':  props.showJumpPresent and !state.showJumpPresent, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
-        <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
+        <t t-if="(props.messageList and !props.messageList.isEmpty) or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
                 <span class="position-absolute w-100 invisible" t-att-class="props.order === 'asc' ? 'bottom-0' : 'top-0'" t-ref="present-treshold" t-att-style="`height: Min(${PRESENT_THRESHOLD}px, 100%)`"/>
                 <t t-set="currentDay" t-value="0"/>
@@ -17,7 +17,7 @@
                     <span t-ref="load-newer"/>
                     <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
                 </t>
-                <t t-if="state.mountedAndLoaded" t-foreach="props.order === 'asc' ? props.thread.nonEmptyMessages : [...props.thread.nonEmptyMessages].reverse()" t-as="msg" t-key="msg.id">
+                <t t-if="state.mountedAndLoaded" t-foreach="props.order === 'asc' ? props.messageList.nonEmptyMessages : [...props.messageList.nonEmptyMessages].reverse()" t-as="msg" t-key="msg.id">
                     <t t-if="msg.dateDay !== currentDay and props.showDates">
                         <DateSection date="msg.dateDay" className="'pt-2'"/>
                         <t t-set="currentDay" t-value="msg.dateDay"/>

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -208,7 +208,7 @@ export class Thread extends Record {
      *
      * Content should be fetched and inserted in a controlled way.
      */
-    messagesListed = Record.many("Message");
+    listedMessages = Record.many("MessageList");
     /** @type {string} */
     modelName;
     /** @type {string} */
@@ -433,13 +433,13 @@ export class Thread extends Record {
         return this.isChatChannel ? this.message_unread_counter : this.message_needaction_counter;
     }
 
-    get newestMessage() {
-        return [...this.messagesListed].reverse().find((msg) => !msg.isEmpty);
-    }
+    // get newestMessage() {
+    //     return [...this.messagesListed].reverse().find((msg) => !msg.isEmpty);
+    // }
 
-    get newestPersistentMessage() {
-        return [...this.messagesListed].reverse().find((msg) => Number.isInteger(msg.id));
-    }
+    // get newestPersistentMessage() {
+    //     return [...this.messagesListed].reverse().find((msg) => Number.isInteger(msg.id));
+    // }
 
     newestPersistentNotEmptyOfAllMessage = Record.one("Message", {
         compute() {
@@ -451,9 +451,9 @@ export class Thread extends Record {
         },
     });
 
-    get oldestPersistentMessage() {
-        return this.messagesListed.find((msg) => Number.isInteger(msg.id));
-    }
+    // get oldestPersistentMessage() {
+    //     return this.messagesListed.find((msg) => Number.isInteger(msg.id));
+    // }
 
     onPinStateUpdated() {}
 
@@ -468,9 +468,9 @@ export class Thread extends Record {
         return `${window.location.origin}/chat/${this.id}/${this.uuid}`;
     }
 
-    get isEmpty() {
-        return !this.messagesListed.some((message) => !message.isEmpty);
-    }
+    // get isEmpty() {
+    //     return !this.messagesListed.some((message) => !message.isEmpty);
+    // }
 
     offlineMembers = Record.many("ChannelMember", {
         /** @this {import("models").Thread} */
@@ -480,13 +480,13 @@ export class Thread extends Record {
         sort: (m1, m2) => (m1.persona?.name < m2.persona?.name ? -1 : 1),
     });
 
-    get nonEmptyMessages() {
-        return this.messagesListed.filter((message) => !message.isEmpty);
-    }
+    // get nonEmptyMessages() {
+    //     return this.messagesListed.filter((message) => !message.isEmpty);
+    // }
 
-    get persistentMessages() {
-        return this.messagesListed.filter((message) => !message.is_transient);
-    }
+    // get persistentMessages() {
+    //     return this.messagesListed.filter((message) => !message.is_transient);
+    // }
 
     get prefix() {
         return this.isChatChannel ? "@" : "#";

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -60,7 +60,7 @@ export class Thread extends Record {
     uuid;
     /** @type {string} */
     model;
-    allMessages = Record.many("Message", {
+    messages = Record.many("Message", {
         inverse: "thread",
     });
     /** @type {boolean} */
@@ -208,7 +208,7 @@ export class Thread extends Record {
      *
      * Content should be fetched and inserted in a controlled way.
      */
-    messages = Record.many("Message");
+    messagesListed = Record.many("Message");
     /** @type {string} */
     modelName;
     /** @type {string} */
@@ -433,18 +433,17 @@ export class Thread extends Record {
         return this.isChatChannel ? this.message_unread_counter : this.message_needaction_counter;
     }
 
-    /** @returns {import("models").Message | undefined} */
     get newestMessage() {
-        return [...this.messages].reverse().find((msg) => !msg.isEmpty);
+        return [...this.messagesListed].reverse().find((msg) => !msg.isEmpty);
     }
 
     get newestPersistentMessage() {
-        return [...this.messages].reverse().find((msg) => Number.isInteger(msg.id));
+        return [...this.messagesListed].reverse().find((msg) => Number.isInteger(msg.id));
     }
 
     newestPersistentNotEmptyOfAllMessage = Record.one("Message", {
         compute() {
-            const allPersistentMessages = this.allMessages.filter(
+            const allPersistentMessages = this.messages.filter(
                 (message) => Number.isInteger(message.id) && !message.isEmpty
             );
             allPersistentMessages.sort((m1, m2) => m2.id - m1.id);
@@ -453,7 +452,7 @@ export class Thread extends Record {
     });
 
     get oldestPersistentMessage() {
-        return this.messages.find((msg) => Number.isInteger(msg.id));
+        return this.messagesListed.find((msg) => Number.isInteger(msg.id));
     }
 
     onPinStateUpdated() {}
@@ -470,7 +469,7 @@ export class Thread extends Record {
     }
 
     get isEmpty() {
-        return !this.messages.some((message) => !message.isEmpty);
+        return !this.messagesListed.some((message) => !message.isEmpty);
     }
 
     offlineMembers = Record.many("ChannelMember", {
@@ -482,11 +481,11 @@ export class Thread extends Record {
     });
 
     get nonEmptyMessages() {
-        return this.messages.filter((message) => !message.isEmpty);
+        return this.messagesListed.filter((message) => !message.isEmpty);
     }
 
     get persistentMessages() {
-        return this.messages.filter((message) => !message.is_transient);
+        return this.messagesListed.filter((message) => !message.is_transient);
     }
 
     get prefix() {

--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -100,10 +100,10 @@ export class ThreadService {
      * @param {import("models").Thread} thread
      */
     updateSeen(thread, lastSeen = thread.newestPersistentNotEmptyOfAllMessage) {
-        const lastReadIndex = thread.messagesListed.findIndex((message) => message.eq(lastSeen));
+        const lastReadIndex = thread.messages.findIndex((message) => message.eq(lastSeen));
         let newNeedactionCounter = 0;
         let newUnreadCounter = 0;
-        for (const message of thread.messagesListed.slice(lastReadIndex + 1)) {
+        for (const message of thread.messages.slice(lastReadIndex + 1)) {
             if (message.isNeedaction) {
                 newNeedactionCounter++;
             }
@@ -234,7 +234,7 @@ export class ThreadService {
                         message.id < thread.oldestPersistentMessage.id ||
                         message.id > thread.newestPersistentMessage.id)
             );
-            thread.messagesListed.splice(startIndex, 0, ...filtered);
+            thread.listedMessages[0].messages.splice(startIndex, 0, ...filtered);
             Object.assign(thread, {
                 loadOlder:
                     after === undefined && fetched.length === FETCH_LIMIT
@@ -556,6 +556,10 @@ export class ThreadService {
             pushState = thread.localId !== this.store.discuss.thread?.localId;
         }
         this.store.discuss.thread = thread;
+        this.store.discuss.messageList = this.store.MessageList.insert({
+            thread,
+            source: "discuss",
+        });
         const activeId =
             typeof thread.id === "string"
                 ? `mail.box_${thread.id}`

--- a/addons/mail/static/src/core/web/mail_core_web_service.js
+++ b/addons/mail/static/src/core/web/mail_core_web_service.js
@@ -39,10 +39,10 @@ export class MailCoreWeb {
                 const alreadyInNeedaction = message?.in(message.thread.needactionMessages);
                 message = this.store.Message.insert(payload, { html: true });
                 const inbox = this.store.discuss.inbox;
-                if (message.notIn(inbox.messages)) {
+                if (message.notIn(inbox.messagesListed)) {
                     inbox.counter++;
                 }
-                inbox.messages.add(message);
+                inbox.messagesListed.add(message);
                 if (!alreadyInNeedaction) {
                     message.thread.message_needaction_counter++;
                 }
@@ -73,12 +73,12 @@ export class MailCoreWeb {
                     if (index >= 0) {
                         message.needaction_partner_ids.splice(index, 1);
                     }
-                    inbox.messages.delete({ id: messageId });
+                    inbox.messagesListed.delete({ id: messageId });
                     const history = this.store.discuss.history;
-                    history.messages.add(message);
+                    history.messagesListed.add(message);
                 }
                 inbox.counter = needaction_inbox_counter;
-                if (inbox.counter > inbox.messages.length) {
+                if (inbox.counter > inbox.messagesListed.length) {
                     this.threadService.fetchMoreMessages(inbox);
                 }
             });

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -54,20 +54,18 @@ export class DiscussCoreCommon {
                         starredCounter++;
                     }
                 }
-                this.store.discuss.starred.messages = filteredStarredMessages;
+                this.store.discuss.starred.messagesListed = filteredStarredMessages;
                 this.store.discuss.starred.counter -= starredCounter;
-                this.store.discuss.inbox.messages = this.store.discuss.inbox.messages.filter(
-                    (msg) => !msg.thread?.eq(thread)
-                );
+                this.store.discuss.inbox.messagesListed =
+                    this.store.discuss.inbox.messagesListed.filter((msg) => !msg.thread?.eq(thread));
                 this.store.discuss.inbox.counter -= thread.message_needaction_counter;
-                this.store.discuss.history.messages = this.store.discuss.history.messages.filter(
-                    (msg) => !msg.thread?.eq(thread)
-                );
+                this.store.discuss.history.messagesListed =
+                    this.store.discuss.history.messagesListed.filter((msg) => !msg.thread?.eq(thread));
                 this.threadService.closeChatWindow?.(thread);
                 if (thread.eq(this.store.discuss.thread)) {
                     this.threadService.setDiscussThread(this.store.discuss.inbox);
                 }
-                thread.messages.splice(0, thread.messages.length);
+                thread.messagesListed.splice(0, thread.messagesListed.length);
                 thread.delete();
             });
             this.busService.subscribe("discuss.channel/new_message", (payload, metadata) =>
@@ -87,7 +85,7 @@ export class DiscussCoreCommon {
                     },
                     { html: true }
                 );
-                message.thread.messages.push(message);
+                message.thread.messagesListed.push(message);
                 message.thread.transientMessages.push(message);
             });
             this.busService.subscribe("discuss.channel/unpin", (payload) => {
@@ -197,9 +195,9 @@ export class DiscussCoreCommon {
         let message = this.store.Message.get(messageData.id);
         const alreadyInNeedaction = message?.in(message.thread?.needactionMessages);
         message = this.store.Message.insert(messageData, { html: true });
-        if (message.notIn(channel.messages)) {
+        if (message.notIn(channel.messagesListed)) {
             if (!channel.loadNewer) {
-                channel.messages.push(message);
+                channel.messagesListed.push(message);
             } else if (channel.status === "loading") {
                 channel.pendingNewMessages.push(message);
             }


### PR DESCRIPTION
This PR rename thread.allMessages and thread.messages to thread.displayedMessages and keep thread.messages as main storage.