### PR TITLE
[REF] mail: all non-explicit record fields are Record.attr()

### DIFF
--- a/addons/mail/static/src/core/common/@types/models.d.ts
+++ b/addons/mail/static/src/core/common/@types/models.d.ts
@@ -14,6 +14,7 @@ declare module "models" {
     import { MessageReactions as MessageReactionsClass } from "@mail/core/common/message_reactions_model";
     import { Notification as NotificationClass } from "@mail/core/common/notification_model";
     import { Persona as PersonaClass } from "@mail/core/common/persona_model";
+    import { Record as RecordClass } from "@mail/core/common/record";
     import { Settings as SettingsClass } from "@mail/core/common/settings_model";
     import { Store as StoreClass } from "@mail/core/common/store_service";
     import { Thread as ThreadClass } from "@mail/core/common/thread_model";
@@ -35,6 +36,7 @@ declare module "models" {
     export interface MessageReactions extends MessageReactionsClass {}
     export interface Notification extends NotificationClass {}
     export interface Persona extends PersonaClass {}
+    export interface Record extends RecordClass {}
     export interface Settings extends SettingsClass {}
     export interface Store extends StoreClass {}
     export interface Thread extends ThreadClass {}
@@ -57,6 +59,7 @@ declare module "models" {
         "MessageReactions": MessageReactions,
         "Notification": Notification,
         "Persona": Persona,
+        "Record": Record,
         "Settings": Settings,
         "Store": Store,
         "Thread": Thread,

--- a/addons/mail/static/src/model/misc.js
+++ b/addons/mail/static/src/model/misc.js
@@ -25,6 +25,7 @@ export const IS_FIELD_SYM = Symbol("isField");
 export const IS_DELETING_SYM = Symbol("isDeleting");
 export const IS_DELETED_SYM = Symbol("isDeleted");
 export const STORE_SYM = Symbol("store");
+export const INTERNAL_SYM = Symbol("isInternalProp");
 
 export function AND(...args) {
     return [AND_SYM, ...args];
@@ -67,4 +68,20 @@ export function isRelation(Model, fieldName) {
 }
 export function isFieldDefinition(val) {
     return val?.[FIELD_DEFINITION_SYM];
+}
+
+/**
+ * Function to assign on class instance attributes that should not be treated as fields
+ * but instead internal values. These are usually technical attributes used for the
+ * internal working of fields, including updating them.
+ *
+ * These attributes are automatically registered in @see Record.INTERNAL_PROPS that enumerates
+ * the attributes that are considered as internal. All these props are not considered as fields.
+ *
+ * @template T
+ * @param {T} def
+ * @returns {T}
+ */
+export function recordInternal(def) {
+    return { [INTERNAL_SYM]: true, default: def };
 }

--- a/addons/mail/static/src/model/record.js
+++ b/addons/mail/static/src/model/record.js
@@ -13,6 +13,7 @@ import {
     isRecordList,
     isRelation,
     modelRegistry,
+    recordInternal,
 } from "./misc";
 
 /** @typedef {import("./misc").FieldDefinition} FieldDefinition */
@@ -23,12 +24,12 @@ export class Record {
     /** @type {import("./model_internal").ModelInternal} */
     static _;
     /** @type {import("./record_internal").RecordInternal} */
-    _;
+    _ = recordInternal();
     static id;
     /** @type {import("@web/env").OdooEnv} */
     static env;
     /** @type {import("@web/env").OdooEnv} */
-    env;
+    env = recordInternal();
     /** @type {Object<string, Record>} */
     static records;
     /** @type {import("models").Store} */
@@ -348,17 +349,24 @@ export class Record {
      *
      * @type {typeof Record}
      */
-    Model;
+    Model = recordInternal();
     /** @type {string} */
     get localId() {
         return toRaw(this)._.localId;
     }
     /** @type {this} */
-    _raw;
+    _raw = recordInternal();
     /** @type {this} */
-    _proxyInternal;
+    _proxyInternal = recordInternal();
     /** @type {this} */
-    _proxy;
+    _proxy = recordInternal();
+    /**
+     * Enumerates props that are internal and should not be considered as fields.
+     * They are automatically registered with @see recordInternal() function.
+     *
+     * @type {Object<string, true>}
+     */
+    static INTERNAL_PROPS = {};
 
     constructor() {
         this.setup();

--- a/addons/mail/static/src/model/record_internal.js
+++ b/addons/mail/static/src/model/record_internal.js
@@ -2,7 +2,7 @@
 /** @typedef {import("./record_list").RecordList} RecordList */
 
 import { onChange } from "@mail/utils/common/misc";
-import { IS_DELETED_SYM, IS_DELETING_SYM, IS_RECORD_SYM, isRelation } from "./misc";
+import { ATTR_SYM, IS_DELETED_SYM, IS_DELETING_SYM, IS_RECORD_SYM, isRelation } from "./misc";
 import { RecordList } from "./record_list";
 import { reactive, toRaw } from "@odoo/owl";
 import { RecordUses } from "./record_uses";
@@ -88,7 +88,7 @@ export class RecordInternal {
                 _store: record.store,
             });
             record[fieldName] = recordList;
-        } else {
+        } else if (record[fieldName]?.[ATTR_SYM]) {
             record[fieldName] = record[fieldName].default;
         }
         if (Model._.fieldsCompute.get(fieldName)) {

--- a/addons/mail/static/src/model/record_list.js
+++ b/addons/mail/static/src/model/record_list.js
@@ -1,6 +1,8 @@
 import { markRaw, reactive, toRaw } from "@odoo/owl";
 import { IS_RECORD_LIST_SYM, isRecord } from "./misc";
 
+/** @typedef {import("./record").Record} Record */
+
 /** @param {RecordList} reclist */
 function getInverse(reclist) {
     return reclist._.owner.Model._.fieldsInverse.get(reclist._.name);

--- a/addons/mail/static/src/model/store.js
+++ b/addons/mail/static/src/model/store.js
@@ -1,16 +1,16 @@
 import { Record } from "./record";
-import { IS_DELETED_SYM, STORE_SYM } from "./misc";
+import { IS_DELETED_SYM, STORE_SYM, recordInternal } from "./misc";
 import { reactive, toRaw } from "@odoo/owl";
 
 /** @typedef {import("./record_list").RecordList} RecordList */
 
 export class Store extends Record {
     /** @type {import("./store_internal").StoreInternal} */
-    _;
-    [STORE_SYM] = true;
+    _ = recordInternal();
+    [STORE_SYM] = recordInternal(true);
     /** @type {Map<string, Record>} */
-    recordByLocalId;
-    storeReady = false;
+    recordByLocalId = recordInternal();
+    storeReady = recordInternal(false);
     /**
      * @param {string} localId
      * @returns {Record}

--- a/addons/mail/static/src/model/store_internal.js
+++ b/addons/mail/static/src/model/store_internal.js
@@ -4,7 +4,7 @@
 import { markup, toRaw } from "@odoo/owl";
 import { RecordInternal } from "./record_internal";
 import { deserializeDate, deserializeDateTime } from "@web/core/l10n/dates";
-import { IS_DELETING_SYM, Markup, isCommand, isMany } from "./misc";
+import { ATTR_SYM, IS_DELETING_SYM, Markup, isCommand, isMany } from "./misc";
 
 export class StoreInternal extends RecordInternal {
     /**
@@ -187,8 +187,14 @@ export class StoreInternal extends RecordInternal {
      * @param {Object} vals
      */
     updateFields(record, vals) {
+        const Model = record.Model;
         for (const [fieldName, value] of Object.entries(vals)) {
-            if (!record.Model._.fields.get(fieldName) || record.Model._.fieldsAttr.get(fieldName)) {
+            if (!Model._.fields.get(fieldName)) {
+                // dynamically add attr field definition on the fly
+                Model._.prepareField(fieldName, { [ATTR_SYM]: true });
+                record._.prepareField(record, fieldName);
+            }
+            if (Model._.fieldsAttr.get(fieldName)) {
                 this.updateAttr(record, fieldName, value);
             } else {
                 this.updateRelation(record, fieldName, value);

--- a/addons/mail/static/tests/core/record.test.js
+++ b/addons/mail/static/tests/core/record.test.js
@@ -804,3 +804,19 @@ test("attr that are default [] should be isolated per record", async () => {
     expect(p1.names).toEqual(["John"]);
     expect(p2.names).toEqual([]);
 });
+
+test("[technical] record props without explicit Record.attr() definition are fully considered as Record.attr()", async () => {
+    // This gives high consistency of all props on records being fields, i.e. if it works for fields it works for everything.
+    (class Person extends Record {
+        static id = "id";
+        id;
+        name = Record.attr();
+    }).register(localRegistry);
+    const store = await start();
+    /** @type {import("models").Record} */
+    const person = store.Person.insert({ id: 1 });
+    expect(person.Model._.fields.get("name")).toBe(true);
+    expect(person.Model._.fields.get("extra")).toBe(undefined);
+    person.extra = true; // add prop "extra"
+    expect(person.Model._.fields.get("extra")).toBe(true);
+});


### PR DESCRIPTION
Before this commit, record fields were necessarily defined with explicit `Record.attr()/one()/many()` syntax. All other props were not considered as fields (with the exception of `updateFields()` treating them as attr fields, but it just happens the logic works on non-fields too).

With this commit, all non-explicitly defined fields are automatically registered as Record.attr() fields.
This allow to treat all read/write on business-code props as fields, which prepare work for follow-up commits as all props are consistently treated as fields.
