### PR TITLE
[IMP] account: allow to set programmatically another template for inv…

### DIFF
--- a/addons/account/wizard/account_move_send.py
+++ b/addons/account/wizard/account_move_send.py
@@ -305,6 +305,10 @@ class AccountMoveSend(models.Model):
         """
         self.ensure_one()
 
+    def _get_invoice_pdf_report_template(self):
+        """To override to set a custom pdf template."""
+        return 'account.account_invoices'
+
     def _prepare_invoice_pdf_report(self, invoice, invoice_data):
         """ Prepare the pdf report for the invoice passed as parameter.
 
@@ -316,7 +320,7 @@ class AccountMoveSend(models.Model):
         if invoice.invoice_pdf_report_id:
             return
 
-        content, _report_format = self.env['ir.actions.report']._render('account.account_invoices', invoice.ids)
+        content, _report_format = self.env['ir.actions.report']._render(self._get_invoice_pdf_report_template(), invoice.ids)
 
         invoice_data['pdf_attachment_values'] = {
             'raw': content,
@@ -335,7 +339,7 @@ class AccountMoveSend(models.Model):
         """
         self.ensure_one()
 
-        content, _report_format = self.env['ir.actions.report']._render('account.account_invoices', invoice.ids, data={'proforma': True})
+        content, _report_format = self.env['ir.actions.report']._render(self._get_invoice_pdf_report_template(), invoice.ids, data={'proforma': True})
 
         invoice_data['proforma_pdf_attachment_values'] = {
             'raw': content,


### PR DESCRIPTION
…oices

Add the possibility to easily change the default template used for invoices.
To do so, you'll only need to override the `_get_invoice_pdf_report_template`
method from the `account.move.send`

It's a first step to help PS tech but `account.account_invoices` is still
hardcoded in many places and we'll need more changes to make it coherent
everywhere.
