### PR TITLE
[IMP] project, _*: add path for various action

### DIFF
--- a/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
+++ b/addons/hr_timesheet_attendance/report/hr_timesheet_attendance_report_view.xml
@@ -56,6 +56,7 @@
         <record id="action_hr_timesheet_attendance_report" model="ir.actions.act_window">
             <field name="name">Timesheets / Attendance Analysis</field>
             <field name="res_model">hr.timesheet.attendance.report</field>
+            <field name="path">timesheets-attendance-analysis</field>
             <field name="view_mode">graph,pivot</field>
             <field name="view_id" eval="False"/>
             <field name="context">{}</field>

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -74,6 +74,7 @@
        <record id="action_project_task_user_tree" model="ir.actions.act_window">
             <field name="name">Tasks Analysis</field>
             <field name="res_model">report.project.task.user</field>
+            <field name="path">tasks-analysis</field>
             <field name="view_mode">graph,pivot</field>
             <field name="search_view_id" ref="view_task_project_user_search"/>
             <field name="context">{'group_by':[], 'graph_measure': '__count__'}</field>

--- a/addons/project/report/project_task_burndown_chart_report_views.xml
+++ b/addons/project/report/project_task_burndown_chart_report_views.xml
@@ -48,6 +48,7 @@
     <record id="action_project_task_burndown_chart_report" model="ir.actions.act_window">
         <field name="name">Burndown Chart</field>
         <field name="res_model">project.task.burndown.chart.report</field>
+        <field name="path">burndown-chart</field>
         <field name="view_mode">graph</field>
         <field name="search_view_id" ref="project_task_burndown_chart_report_view_search"/>
         <field name="context">{'search_default_project_id': active_id, 'search_default_date': 1, 'search_default_stage': 1, 'search_default_filter_date': 1}</field>

--- a/addons/project/views/mail_activity_plan_views.xml
+++ b/addons/project/views/mail_activity_plan_views.xml
@@ -21,6 +21,7 @@
         <record id="mail_activity_plan_action_config_project_task_plan" model="ir.actions.act_window">
             <field name="name">Activity Plans</field>
             <field name="res_model">mail.activity.plan</field>
+            <field name="path">project-activity-plans</field>
             <field name="view_mode">list,kanban,form</field>
             <field name="search_view_id" ref="mail.mail_activity_plan_view_search"/>
             <field name="context">{'default_res_model': 'project.task'}</field>

--- a/addons/project/views/mail_activity_plan_views.xml
+++ b/addons/project/views/mail_activity_plan_views.xml
@@ -51,23 +51,5 @@
             <field name="view_id" ref="project.mail_activity_plan_view_form_project_and_task"/>
             <field name="act_window_id" ref="project.mail_activity_plan_action_config_project_task_plan"/>
         </record>
-
-        <record id="mail_activity_plan_action_config_task_plan" model="ir.actions.act_window">
-            <field name="name">Task Plans</field>
-            <field name="res_model">mail.activity.plan</field>
-            <field name="view_mode">list,kanban,form</field>
-            <field name="search_view_id" ref="mail.mail_activity_plan_view_search"/>
-            <field name="context">{'default_res_model': 'project.task'}</field>
-            <field name="domain">[('res_model', '=', 'project.task')]</field>
-            <field name="help" type="html">
-                <p class="o_view_nocontent_smiling_face">
-                    Create a Task Activity Plan
-                </p>
-                <p>
-                    Activity plans are used to assign a list of activities in just a few clicks
-                    (e.g. "Progress Report", "Stand-up Meeting", ...)
-                </p>
-            </field>
-        </record>
     </data>
 </odoo>

--- a/addons/project/views/mail_activity_type_views.xml
+++ b/addons/project/views/mail_activity_type_views.xml
@@ -3,6 +3,7 @@
     <record id="mail_activity_type_action_config_project_types" model="ir.actions.act_window">
         <field name="name">Activity Types</field>
         <field name="res_model">mail.activity.type</field>
+        <field name="path">project-activity-types</field>
         <field name="view_mode">list,kanban,form</field>
         <field name="domain">['|', ('res_model', '=', False), ('res_model', '=', 'project.task')]</field>
         <field name="context">{'default_res_model': 'project.task'}</field>

--- a/addons/project/views/project_project_stage_views.xml
+++ b/addons/project/views/project_project_stage_views.xml
@@ -87,6 +87,7 @@
     <record id="project_project_stage_configure" model="ir.actions.act_window">
         <field name="name">Project Stages</field>
         <field name="res_model">project.project.stage</field>
+        <field name="path">project-stages</field>
         <field name="view_mode">list,kanban,form</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -616,6 +616,7 @@
         <record id="open_view_project_all_config" model="ir.actions.act_window">
             <field name="name">Projects</field>
             <field name="res_model">project.project</field>
+            <field name="path">project-configuration</field>
             <field name="domain">[]</field>
             <field name="view_mode">list,kanban,form</field>
             <field name="view_ids" eval="[(5, 0, 0),

--- a/addons/project/views/project_tags_views.xml
+++ b/addons/project/views/project_tags_views.xml
@@ -39,6 +39,7 @@
         <record id="project_tags_action" model="ir.actions.act_window">
             <field name="name">Tags</field>
             <field name="res_model">project.tags</field>
+            <field name="path">task-tags</field>
             <field name="help" type="html">
               <p class="o_view_nocontent_smiling_face">
                 No tags found. Let's create one!

--- a/addons/project/views/project_task_type_views.xml
+++ b/addons/project/views/project_task_type_views.xml
@@ -100,6 +100,7 @@
         <record id="open_task_type_form" model="ir.actions.act_window">
             <field name="name">Task Stages</field>
             <field name="res_model">project.task.type</field>
+            <field name="path">task-stages</field>
             <field name="view_mode">list,kanban,form</field>
             <field name="view_id" ref="task_type_tree_inherited"/>
             <field name="domain">[('user_id', '=', False)]</field>

--- a/addons/project/views/project_update_views.xml
+++ b/addons/project/views/project_update_views.xml
@@ -115,6 +115,7 @@
     <record id="project_update_all_action" model="ir.actions.act_window">
         <field name="name">Dashboard</field>
         <field name="res_model">project.update</field>
+        <field name="path">project-dashboard</field>
         <field name="view_mode">kanban,list,form</field>
         <field name="domain">[('project_id', '=', active_id)]</field>
         <field name="search_view_id" ref="project_update_view_search"/>

--- a/addons/project/views/rating_rating_views.xml
+++ b/addons/project/views/rating_rating_views.xml
@@ -252,6 +252,7 @@
     <record id="rating_rating_action_project_report" model="ir.actions.act_window">
         <field name="name">Customer Ratings</field>
         <field name="res_model">rating.rating</field>
+        <field name="path">task-ratings</field>
         <field name="view_mode">kanban,list,pivot,graph,form</field>
         <field name="domain">[('parent_res_model','=','project.project'), ('consumed', '=', True)]</field>
         <field name="search_view_id" ref="rating_rating_view_search_project"/>


### PR DESCRIPTION
_*= hr_timesheet_attendance, mail, im_livechat

after this commit:added path for that so many missing actions
Consider the following example with multiple actions:
 - the default kanban view for project
 - the project update of the project with id "2"

These actions would generate the following path segments respectively:
- /project (the default action for project, no res_id or active_id)
- 2/project-update (the project update for project 2: no res_id, active_id=2)
This would generate the following url: /odoo/project/2/project-update

For instance, in both the project and field service modules, the same action is
called for activity types. For accessing activity types in the project module
the path is straightforward: odoo/project/activity-types

However, to access activity types in the field service module, use the following
path: odoo/field-service/project-activity-types

Remove the Task Plans action
--------
This action is only used in FSM. We utilized Activity Plans rather
than this one. Generally speaking, Activity Plans and Task Plans are
similar, except for the domain.

task-3816177