### PR TITLE
[FIX] account: Do not allow customers to change the reconcile value.

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -308,6 +308,8 @@ class AccountChartTemplate(models.AbstractModel):
                                 'noupdate': True,
                             }])
 
+                    if 'reconcile' in values:
+                        del values['reconcile']
                     # on existing accounts, only tag_ids are to be updated using default data
                     if account and 'tag_ids' in data[model_name][xmlid]:
                         data[model_name][xmlid] = {'tag_ids': data[model_name][xmlid]['tag_ids']}


### PR DESCRIPTION
In some databases, customers have changed the `reconcile` value of an account from its standard `False` value to `True`. This action causes related journal items, which are partially reconciled, to become fully reconciled. During the upgrade of the account record, an exception is raised because we do not allow partially reconciled journal items to be set as fully reconciled.
so we should be adapte the code to not change the reconcile flag by removing value of `reconcile` from `_pre_reload_data`.
```
 File "/home/odoo/src/odoo/17.0/addons/account/models/account_account.py", line 707, in write
    self.filtered(lambda r: r.reconcile)._toggle_reconcile_to_false()
  File "/home/odoo/src/odoo/17.0/addons/account/models/account_account.py", line 670, in _toggle_reconcile_to_false
    raise UserError(_('You cannot switch an account to prevent the reconciliation '
odoo.exceptions.UserError: You cannot switch an account to prevent the reconciliation if some partial reconciliations are still pending.

```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
