### PR TITLE
[FIX] base_vat: properly display in context

### DIFF
--- a/addons/base_vat/views/res_partner_views.xml
+++ b/addons/base_vat/views/res_partner_views.xml
@@ -13,8 +13,10 @@
                 </xpath>
                 <xpath expr="//div[@name='vat_vies_container']" position="inside">
                     <xpath expr="//field[@name='vat']" position="move"/>
-                    <label for="vies_valid" invisible="not perform_vies_validation"/>
-                    <field name="vies_valid" invisible="not perform_vies_validation" class="oe_inline"/>
+                    <span class="text-nowrap ps-2">
+                        <label for="vies_valid" invisible="not perform_vies_validation"/>
+                        <field name="vies_valid" invisible="not perform_vies_validation" class="oe_inline"/>
+                    </span>
                 </xpath>
                 <xpath expr="//field[@name='vat']" position="attributes">
                     <attribute name="class" position="add" separator=" ">oe_inline</attribute>


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Having the VAT VIES Check valid field directly next to the VAT number as an inline element becomes unreadable, so we add a line break before

**Current behavior before PR:**
![Screenshot from 2024-03-26 15-26-06](https://github.com/odoo/odoo/assets/362478/a307f9d6-30b0-452f-b5ad-f6efc912e9e2)


**Desired behavior after PR is merged:**
![image](https://github.com/odoo/odoo/assets/362478/64339b68-7f63-4801-b302-b4dc23d19a34)


Info: @wt-io-it

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
