### PR TITLE
[FIX] web_editor: prevent TypeError while compute image src without checksum

### DIFF
--- a/addons/web_editor/models/ir_attachment.py
+++ b/addons/web_editor/models/ir_attachment.py
@@ -38,7 +38,7 @@ class IrAttachment(models.Model):
                 attachment.image_src = attachment.url
             else:
                 # Adding unique in URLs for cache-control
-                unique = attachment.checksum[:8]
+                unique = (attachment.checksum or '')[:8]
                 if attachment.url:
                     # For attachments-by-url, unique is used as a cachebuster. They
                     # currently do not leverage max-age headers.


### PR DESCRIPTION


Currently, an error is generated when [1] tries to access the first eight strings of the `attachment.checksum` but we got False.

Stack Trace:
```
TypeError: 'bool' object is not subscriptable
  File "odoo/http.py", line 2252, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1828, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1848, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1826, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1833, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2058, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web_editor/controllers/main.py", line 601, in modify_image
    return attachment.image_src
  File "odoo/fields.py", line 1193, in __get__
    self.compute_value(recs)
  File "odoo/fields.py", line 1375, in compute_value
    records._compute_field_value(self)
  File "odoo/models.py", line 4984, in _compute_field_value
    fields.determine(field.compute, self)
  File "odoo/fields.py", line 102, in determine
    return needle(*args)
  File "addons/web_editor/models/ir_attachment.py", line 53, in _compute_image_src
    unique = attachment.checksum[:8]

```

This commit will prevent the above issue by indexing the empty string instead of False.

[1]-https://github.com/odoo/odoo/blob/631e2bb1d3f9583200d6fe2f70006397425d5bd2/addons/web_editor/models/ir_attachment.py#L41

sentry-4185609374

