### PR TITLE
[PERF] stock: only compute orderpoint qty_to_order on demand

### DIFF
--- a/addons/purchase_requisition_stock/models/stock.py
+++ b/addons/purchase_requisition_stock/models/stock.py
@@ -37,15 +37,3 @@ class StockMove(models.Model):
             return [(requisition_line.requisition_id, requisition_line.requisition_id.user_id, visited) for requisition_line in requisition_lines_sudo if requisition_line.requisition_id.state not in ('done', 'cancel')]
         else:
             return super(StockMove, self)._get_upstream_documents_and_responsibles(visited)
-
-
-class Orderpoint(models.Model):
-    _inherit = "stock.warehouse.orderpoint"
-
-    def _quantity_in_progress(self):
-        res = super(Orderpoint, self)._quantity_in_progress()
-        for op in self:
-            for pr in self.env['purchase.requisition'].search([('state', '=', 'draft'), ('reference', '=', op.name)]):
-                for prline in pr.line_ids.filtered(lambda l: l.product_id.id == op.product_id.id and not l.move_dest_id):
-                    res[op.id] += prline.product_uom_id._compute_quantity(prline.product_qty, op.product_uom, round=False)
-        return res

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -578,9 +578,6 @@ class ProcurementGroup(models.Model):
         # Minimum stock rules
         domain = self._get_orderpoint_domain(company_id=company_id)
         orderpoints = self.env['stock.warehouse.orderpoint'].search(domain)
-        # ensure that qty_* which depends on datetime.now() are correctly
-        # recomputed
-        orderpoints.sudo()._compute_qty_to_order()
         if use_new_cursor:
             self._cr.commit()
         orderpoints.sudo()._procure_orderpoint_confirm(use_new_cursor=use_new_cursor, company_id=company_id, raise_user_error=False)

--- a/addons/stock/tests/test_proc_rule.py
+++ b/addons/stock/tests/test_proc_rule.py
@@ -31,7 +31,7 @@ class TestProcRule(TransactionCase):
         orderpoint_form.product_max_qty = 5.1
         orderpoint_form.qty_multiple = 0.1
         orderpoint = orderpoint_form.save()
-        self.assertEqual(orderpoint.qty_to_order, orderpoint.product_max_qty)
+        self.assertAlmostEqual(orderpoint.qty_to_order, orderpoint.product_max_qty)
 
     def test_endless_loop_rules_from_location(self):
         """ Creates and configure a rule the way, when trying to get rules from
@@ -310,17 +310,14 @@ class TestProcRule(TransactionCase):
             'product_max_qty': 30.0,
             'qty_multiple': 10,
         })
-        orderpoint._compute_qty_to_order()
         self.assertEqual(orderpoint.qty_to_order, 10.0)  # 15.0 < 14.5 + 10 <= 30.0
         orderpoint.write({
             'qty_multiple': 1,
         })
-        orderpoint._compute_qty_to_order()
         self.assertEqual(orderpoint.qty_to_order, 15.0)  # 15.0 < 14.5 + 15 <= 30.0
         orderpoint.write({
             'qty_multiple': 0,
         })
-        orderpoint._compute_qty_to_order()
         self.assertEqual(orderpoint.qty_to_order, 15.5)  # 15.0 < 14.5 + 15.5 <= 30.0
 
     def test_orderpoint_replenishment_view_1(self):

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -60,6 +60,9 @@
                 <field name="product_max_qty" string="Max" optional="show"/>
                 <field name="qty_multiple" optional="hide"/>
                 <field name="qty_to_order"/>
+                <field name="qty_to_order_manual" column_invisible="True"/>
+                <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="Remove manually entered value and replace by the quantity to order based on the forecasted quantities" invisible="not qty_to_order_manual"/>
+                <button name="action_remove_manual_qty_to_order" type="object" icon="fa-undo" title="-" class="disabled opacity-0" invisible="qty_to_order_manual"/>
                 <field name="product_uom_name" string="UoM" groups="uom.group_uom"/>
                 <field name="company_id" optional="hide" readonly="1" groups="base.group_multi_company"/>
                 <button name="action_replenish" string="Order" type="object" class="o_replenish_buttons" icon="fa-truck"


### PR DESCRIPTION
Due to the `qty_to_order` field on `stock.orderpoint` being a stored computed field, it needs to be recalculated every time one or more of its dependencies could have changed, to keep a consistent record in the database.
It is, however, dependent on the `qty_forecast` field which is a non-stored computed field, depending itself on all the stock moves that are linked to the product set on the orderpoint.
This results in a complete recalculation of the `qty_on_hand`, `qty_forecast` and `qty_to_order` on ALL the orderpoints linked to a product every time some `stock.move ` has been touched or created with that product. Even if many of those orderpoints may not even be located in the concerned warehouse.
This situation can create a performance bottleneck when just processing pickings, as its constantly (and often pointlessly) recalculating these field values to store. This becomes a major issue in case the concerned database contains many warehouses with many different orderpoints.

To remedy this issue, we make the `qty_to_order` field on `stock.orderpoint` no longer stored. It will instead now be calculated 'on demand' when using the reordering rules.
We prefer to have a potential small performance decrease here instead of constantly pre-computing these values during day-to-day logistics operations.
To enable user modification of the qty_to_order field, it is split in a computed version of the field `qty_to_order_computed` and a noncomputed float field `qty_to_order_manual` where the manually adapted value is saved. The field `qty_to_order` provides the user provided value if available and the computed value otherwise.

task-3822497

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
