### PR TITLE
[IMP] stock_account: add lot valuation

### DIFF
--- a/addons/mrp_subcontracting_account/models/mrp_production.py
+++ b/addons/mrp_subcontracting_account/models/mrp_production.py
@@ -12,5 +12,5 @@ class MrpProduction(models.Model):
         # Take the price unit of the reception move
         last_done_receipt = finished_move.move_dest_ids.filtered(lambda m: m.state == 'done')[-1:]
         if last_done_receipt.is_subcontract:
-            self.extra_cost = last_done_receipt._get_price_unit()
+            self.extra_cost = next(iter(last_done_receipt._get_price_unit().values()))
         return super()._cal_price(consumed_moves=consumed_moves)

--- a/addons/purchase_mrp/models/stock_move.py
+++ b/addons/purchase_mrp/models/stock_move.py
@@ -36,7 +36,7 @@ class StockMove(models.Model):
         # Convert uom from bom_line_uom to product_uom for bom_line
         uom_factor = bom_line.product_id.uom_id._compute_quantity(uom_factor, bom_line.product_uom_id)
 
-        return float_round(kit_price_unit * cost_share * uom_factor * bom.product_qty / bom_line.product_qty, precision_digits=price_unit_prec)
+        return {self.env['stock.lot']: float_round(kit_price_unit * cost_share * uom_factor * bom.product_qty / bom_line.product_qty, precision_digits=price_unit_prec)}
 
     def _get_valuation_price_and_qty(self, related_aml, to_curr):
         valuation_price_unit_total, valuation_total_qty = super()._get_valuation_price_and_qty(related_aml, to_curr)

--- a/addons/purchase_stock/data/purchase_stock_demo.xml
+++ b/addons/purchase_stock/data/purchase_stock_demo.xml
@@ -36,6 +36,8 @@
 
         <record id="product.product_product_20" model="product.product">
             <field name="route_ids" eval="[(4,ref('route_warehouse0_buy'))]"></field>
+            <field name="tracking">lot</field>
+            <field name="lot_valuated">1</field>
         </record>
 
         <record id="purchase_order_8" model="purchase.order">
@@ -50,6 +52,13 @@
                     'name': obj().env.ref('product.product_product_25').partner_ref,
                     'price_unit': 286.80,
                     'product_qty': 20.0,
+                    'product_uom': ref('uom.product_uom_unit'),
+                    'date_planned': DateTime.today()}),
+                (0, 0, {
+                    'product_id': ref('product.product_product_20'),
+                    'name': obj().env.ref('product.product_product_20').partner_ref,
+                    'price_unit': 120.00,
+                    'product_qty': 10.0,
                     'product_uom': ref('uom.product_uom_unit'),
                     'date_planned': DateTime.today()}),
             ]"/>

--- a/addons/purchase_stock/models/account_invoice.py
+++ b/addons/purchase_stock/models/account_invoice.py
@@ -134,6 +134,13 @@ class AccountMove(models.Model):
             if not float_is_zero(product.quantity_svl, precision_rounding=product.uom_id.rounding):
                 product.sudo().with_context(disable_auto_svl=True).write({'standard_price': product.value_svl / product.quantity_svl})
 
+        for (lot, company), dummy in groupby(stock_valuation_layers, key=lambda svl: (svl.lot_id, svl.company_id)):
+            if not lot:
+                continue
+            lot = lot.with_company(company.id)
+            if not float_is_zero(lot.quantity_svl, precision_rounding=lot.product_id.uom_id.rounding):
+                lot.sudo().with_context(disable_auto_svl=True).write({'standard_price': lot.value_svl / lot.quantity_svl})
+
         posted = super(AccountMove, self.with_context(skip_cogs_reconciliation=True))._post(soft)
 
         # The invoice reference is set during the super call

--- a/addons/purchase_stock/models/account_move_line.py
+++ b/addons/purchase_stock/models/account_move_line.py
@@ -278,7 +278,7 @@ class AccountMoveLine(models.Model):
             'description': self.move_id.name and '%s - %s' % (self.move_id.name, self.product_id.name) or self.product_id.name,
         }
         return {
-            **self.product_id._prepare_in_svl_vals(quantity, unit_cost),
+            **self.product_id._prepare_in_svl_vals(quantity, unit_cost, corrected_layer.lot_id),
             **common_svl_vals,
             'stock_valuation_layer_id': corrected_layer.id,
             'price_diff_value': self.currency_id.round(pdiff * quantity),

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -100,7 +100,9 @@ class StockMove(models.Model):
             # https://github.com/odoo/odoo/blob/2f789b6863407e63f90b3a2d4cc3be09815f7002/addons/stock/models/stock_move.py#L36
             price_unit = order.currency_id._convert(
                 price_unit, order.company_id.currency_id, order.company_id, fields.Date.context_today(self), round=False)
-        return price_unit
+        if self.product_id.lot_valuated:
+            return dict.fromkeys(self.lot_ids, price_unit)
+        return {self.env['stock.lot']: price_unit}
 
     def _generate_valuation_lines_data(self, partner_id, qty, debit_value, credit_value, debit_account_id, credit_account_id, svl_id, description):
         """ Overridden from stock_account to support amount_currency on valuation lines generated from po

--- a/addons/purchase_stock/tests/__init__.py
+++ b/addons/purchase_stock/tests/__init__.py
@@ -6,6 +6,7 @@ from . import test_average_price
 from . import test_create_picking
 from . import test_fifo_price
 from . import test_fifo_returns
+from . import test_lot_valuation
 from . import test_onchange_product
 from . import test_purchase_delete_order
 from . import test_purchase_lead_time

--- a/addons/purchase_stock/tests/test_lot_valuation.py
+++ b/addons/purchase_stock/tests/test_lot_valuation.py
@@ -1,0 +1,25 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.stock_account.tests.test_lot_valuation import TestLotValuation
+
+
+class TestLotValuationPurchase(TestLotValuation):
+    def test_poline_price_unit(self):
+        """ Purchase order line price unit is the average of the lots from the product form """
+        partner = self.env['res.partner'].create({
+            'name': 'partner'
+        })
+        self.product1.categ_id.property_cost_method = 'fifo'
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product1, 10, 7, lot_ids=[self.lot3])
+        po = self.env['purchase.order'].create({
+            'partner_id': partner.id,
+            'order_line': [
+                (0, 0, {
+                    'product_id': self.product1.id,
+                    'product_qty': 10,
+                    'product_uom': self.product1.uom_id.id,
+                }),
+            ],
+        })
+        self.assertEqual(po.order_line[0].price_unit, 6.0)

--- a/addons/stock_account/__manifest__.py
+++ b/addons/stock_account/__manifest__.py
@@ -22,6 +22,9 @@ Dashboard / Reports for Warehouse Management includes:
     'depends': ['stock', 'account'],
     'category': 'Hidden',
     'sequence': 16,
+    'demo': [
+        'data/stock_account_demo.xml',
+    ],
     'data': [
         'security/stock_account_security.xml',
         'security/ir.model.access.csv',
@@ -33,6 +36,7 @@ Dashboard / Reports for Warehouse Management includes:
         'views/stock_valuation_layer_views.xml',
         'views/stock_quant_views.xml',
         'views/product_views.xml',
+        'views/stock_lot_views.xml',
         'wizard/stock_request_count.xml',
         'wizard/stock_valuation_layer_revaluation_views.xml',
         'wizard/stock_quantity_history.xml',
@@ -43,7 +47,7 @@ Dashboard / Reports for Warehouse Management includes:
     'post_init_hook': '_configure_journals',
     'assets': {
         'web.assets_backend': [
-            'stock_account/static/src/stock_account_forecasted/*',
+            'stock_account/static/src/**/*',
         ],
     },
     'license': 'LGPL-3',

--- a/addons/stock_account/data/stock_account_demo.xml
+++ b/addons/stock_account/data/stock_account_demo.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="product_category_avco" model="product.category">
+            <field name="parent_id" ref="product.product_category_all"/>
+            <field name="property_valuation">manual_periodic</field>
+            <field name="property_cost_method">average</field>
+            <field name="name">AVCO</field>
+        </record>
+        <record id="product_category_fifo" model="product.category">
+            <field name="parent_id" ref="product.product_category_all"/>
+            <field name="property_valuation">manual_periodic</field>
+            <field name="property_cost_method">fifo</field>
+            <field name="name">FIFO</field>
+        </record>
+    </data>
+</odoo>

--- a/addons/stock_account/models/__init__.py
+++ b/addons/stock_account/models/__init__.py
@@ -7,6 +7,7 @@ from . import analytic_account
 from . import product
 from . import stock_move
 from . import stock_location
+from . import stock_lot
 from . import stock_move_line
 from . import stock_picking
 from . import stock_quant

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -15,6 +15,21 @@ class ProductTemplate(models.Model):
 
     cost_method = fields.Selection(related="categ_id.property_cost_method", readonly=True)
     valuation = fields.Selection(related="categ_id.property_valuation", readonly=True)
+    lot_valuated = fields.Boolean(
+        "Valuation by Lot/Serial number",
+        help="If checked, the valuation will be specific by Lot/Serial number.",
+    )
+
+    @api.onchange('standard_price')
+    def _onchange_standard_price(self):
+        if self.lot_valuated and any(p.quantity_svl for p in self.product_variant_ids):
+            return {
+                'warning': {
+                    'title': _("Warning"),
+                    'message': _("This product is valuated by lot/serial number. Changing the cost \
+will update the cost of every lot/serial number in stock."),
+                }
+            }
 
     def write(self, vals):
         impacted_templates = {}
@@ -31,6 +46,9 @@ class ProductTemplate(models.Model):
                 product_template = product_template.with_company(product_template.company_id)
                 valuation_impacted = False
                 if product_template.cost_method != new_product_category.property_cost_method:
+                    if product_template.lot_valuated and not 'lot_valuated' in vals\
+                            and any(p.stock_valuation_layer_ids for p in product_template.product_variant_ids):
+                        raise UserError(_("You cannot change the product category of a product valuated by lot/serial number."))
                     valuation_impacted = True
                 if product_template.valuation != new_product_category.property_valuation:
                     valuation_impacted = True
@@ -51,6 +69,17 @@ class ProductTemplate(models.Model):
                 if product_template.valuation == 'real_time':
                     move_vals_list += Product._svl_empty_stock_am(out_stock_valuation_layers)
                 impacted_templates[product_template] = (products, description, products_orig_quantity_svl)
+
+        if 'lot_valuated' in vals:
+            for tmpl in self:
+                if tmpl.lot_valuated != vals['lot_valuated'] and tmpl not in impacted_templates:
+                    description = _("Updating lot valuation for product %s.", tmpl.display_name)
+                    out_svl_vals_list, products_orig_quantity_svl, products = Product\
+                        ._svl_empty_stock(description, product_template=tmpl)
+                    out_stock_valuation_layers = SVL.create(out_svl_vals_list)
+                    if tmpl.valuation == 'real_time':
+                        move_vals_list += Product._svl_empty_stock_am(out_stock_valuation_layers)
+                impacted_templates[tmpl] = (products, description, products_orig_quantity_svl)
 
         res = super(ProductTemplate, self).write(vals)
 
@@ -113,7 +142,18 @@ class ProductProduct(models.Model):
     def write(self, vals):
         if 'standard_price' in vals and not self.env.context.get('disable_auto_svl'):
             self.filtered(lambda p: p.cost_method != 'fifo')._change_standard_price(vals['standard_price'])
-        return super(ProductProduct, self).write(vals)
+        return super().write(vals)
+
+    @api.onchange('standard_price')
+    def _onchange_standard_price(self):
+        if self.lot_valuated:
+            return {
+                'warning': {
+                    'title': _("Warning"),
+                    'message': _("This product is valuated by lot/serial number. Changing the cost \
+will update the cost of every lot/serial number in stock."),
+                }
+            }
 
     @api.depends('stock_valuation_layer_ids')
     @api.depends_context('to_date', 'company')
@@ -163,7 +203,7 @@ class ProductProduct(models.Model):
     # -------------------------------------------------------------------------
     # SVL creation helpers
     # -------------------------------------------------------------------------
-    def _prepare_in_svl_vals(self, quantity, unit_cost):
+    def _prepare_in_svl_vals(self, quantity, unit_cost, lot=False):
         """Prepare the values for a stock valuation layer created by a receipt.
 
         :param quantity: the quantity to value, expressed in `self.uom_id`
@@ -182,9 +222,11 @@ class ProductProduct(models.Model):
             'quantity': quantity,
             'remaining_qty': quantity,
             'remaining_value': value,
+            'company_id': company_id,
+            'lot_id': lot.id if lot else False,
         }
 
-    def _prepare_out_svl_vals(self, quantity, company):
+    def _prepare_out_svl_vals(self, quantity, company, lot=False):
         """Prepare the values for a stock valuation layer created by a delivery.
 
         :param quantity: the quantity to value, expressed in `self.uom_id`
@@ -197,18 +239,22 @@ class ProductProduct(models.Model):
         currency = company.currency_id
         # Quantity is negative for out valuation layers.
         quantity = -1 * quantity
+        cost = self.standard_price
+        if lot and lot.standard_price:
+            cost = lot.standard_price
         vals = {
             'product_id': self.id,
-            'value': currency.round(quantity * self.standard_price),
-            'unit_cost': self.standard_price,
+            'value': currency.round(quantity * cost),
+            'unit_cost': cost,
             'quantity': quantity,
+            'lot_id': lot.id if lot else False,
         }
-        fifo_vals = self._run_fifo(abs(quantity), company)
+        fifo_vals = self._run_fifo(abs(quantity), company, lot=lot)
         vals['remaining_qty'] = fifo_vals.get('remaining_qty')
         # In case of AVCO, fix rounding issue of standard price when needed.
         if self.product_tmpl_id.cost_method == 'average' and not float_is_zero(self.quantity_svl, precision_rounding=self.uom_id.rounding):
             rounding_error = currency.round(
-                (self.standard_price * self.quantity_svl - self.value_svl) * abs(quantity / self.quantity_svl)
+                (cost * self.quantity_svl - self.value_svl) * abs(quantity / self.quantity_svl)
             )
             if rounding_error:
                 # If it is bigger than the (smallest number of the currency * quantity) / 2,
@@ -242,6 +288,9 @@ class ProductProduct(models.Model):
         for product in self:
             if product.cost_method not in ('standard', 'average'):
                 continue
+            if product.lot_valuated:
+                self.env['stock.lot'].search([('product_id', '=', product.id)]).standard_price = new_price
+                continue
             quantity_svl = product.sudo().quantity_svl
             if float_compare(quantity_svl, 0.0, precision_rounding=product.uom_id.rounding) <= 0:
                 continue
@@ -263,85 +312,26 @@ class ProductProduct(models.Model):
             }
             svl_vals_list.append(svl_vals)
         stock_valuation_layers = self.env['stock.valuation.layer'].sudo().create(svl_vals_list)
+        stock_valuation_layers._change_standart_price_accounting_entries(new_price)
 
-        # Handle account moves.
-        product_accounts = {product.id: product.product_tmpl_id.get_product_accounts() for product in self}
-        am_vals_list = []
-        for stock_valuation_layer in stock_valuation_layers:
-            product = stock_valuation_layer.product_id
-            value = stock_valuation_layer.value
-
-            if not product.is_storable or product.valuation != 'real_time':
-                continue
-
-            # Sanity check.
-            if not product_accounts[product.id].get('expense'):
-                raise UserError(_('You must set a counterpart account on your product category.'))
-            if not product_accounts[product.id].get('stock_valuation'):
-                raise UserError(_('You don\'t have any stock valuation account defined on your product category. You must define one before processing this operation.'))
-
-            if value < 0:
-                debit_account_id = product_accounts[product.id]['expense'].id
-                credit_account_id = product_accounts[product.id]['stock_valuation'].id
-            else:
-                debit_account_id = product_accounts[product.id]['stock_valuation'].id
-                credit_account_id = product_accounts[product.id]['expense'].id
-
-            move_vals = {
-                'journal_id': product_accounts[product.id]['stock_journal'].id,
-                'company_id': company_id.id,
-                'ref': product.default_code,
-                'stock_valuation_layer_ids': [(6, None, [stock_valuation_layer.id])],
-                'move_type': 'entry',
-                'line_ids': [(0, 0, {
-                    'name': _(
-                        '%(user)s changed cost from %(previous)s to %(new_price)s - %(product)s',
-                        user=self.env.user.name,
-                        previous=product.standard_price,
-                        new_price=new_price,
-                        product=product.display_name
-                    ),
-                    'account_id': debit_account_id,
-                    'debit': abs(value),
-                    'credit': 0,
-                    'product_id': product.id,
-                }), (0, 0, {
-                    'name': _(
-                        '%(user)s changed cost from %(previous)s to %(new_price)s - %(product)s',
-                        user=self.env.user.name,
-                        previous=product.standard_price,
-                        new_price=new_price,
-                        product=product.display_name
-                    ),
-                    'account_id': credit_account_id,
-                    'debit': 0,
-                    'credit': abs(value),
-                    'product_id': product.id,
-                })],
-            }
-            am_vals_list.append(move_vals)
-
-        account_moves = self.env['account.move'].sudo().create(am_vals_list)
-        if account_moves:
-            account_moves._post()
-
-    def _get_fifo_candidates_domain(self, company):
+    def _get_fifo_candidates_domain(self, company, lot=False):
         return [
             ("product_id", "=", self.id),
             ("remaining_qty", ">", 0),
             ("company_id", "=", company.id),
+            ("lot_id", "=", lot.id if lot else False),
         ]
 
-    def _get_fifo_candidates(self, company):
-        candidates_domain = self._get_fifo_candidates_domain(company)
+    def _get_fifo_candidates(self, company, lot=False):
+        candidates_domain = self._get_fifo_candidates_domain(company, lot=lot)
         return self.env["stock.valuation.layer"].sudo().search(candidates_domain)
 
-    def _run_fifo(self, quantity, company):
+    def _run_fifo(self, quantity, company, lot=False):
         self.ensure_one()
 
         # Find back incoming stock valuation layers (called candidates here) to value `quantity`.
         qty_to_take_on_candidates = quantity
-        candidates = self._get_fifo_candidates(company)
+        candidates = self._get_fifo_candidates(company, lot=lot)
         new_standard_price = 0
         tmp_value = 0  # to accumulate the value taken on the candidates
         for candidate in candidates:
@@ -425,6 +415,7 @@ class ProductProduct(models.Model):
             svls_to_vacuum_by_product[group[0].id] = group[1].sorted(key=lambda r: (r.create_date, r.id))
             min_create_date = min(min_create_date, group[2])
         all_candidates_by_product = defaultdict(lambda: ValuationLayer)
+        lot_to_update = []
         res = ValuationLayer._read_group([
             ('product_id', 'in', self.ids),
             ('remaining_qty', '>', 0),
@@ -448,6 +439,8 @@ class ProductProduct(models.Model):
                     or r.create_date == svl_to_vacuum.create_date
                     and r.id > svl_to_vacuum.id
                 )
+                if product.lot_valuated:
+                    candidates = candidates.filtered(lambda r: r.lot_id == svl_to_vacuum.lot_id)
                 if not candidates:
                     break
                 qty_to_take_on_candidates = abs(svl_to_vacuum.remaining_qty)
@@ -501,7 +494,9 @@ class ProductProduct(models.Model):
                     'company_id': move.company_id.id,
                     'description': 'Revaluation of %s (negative inventory)' % (move.picking_id.name or move.name),
                     'stock_valuation_layer_id': svl_to_vacuum.id,
+                    'lot_id': svl_to_vacuum.lot_id.id,
                 })
+                lot_to_update.append(svl_to_vacuum.lot_id)
                 if product.valuation == 'real_time':
                     current_real_time_svls |= svl_to_vacuum
             real_time_svls_to_vacuum |= current_real_time_svls
@@ -513,9 +508,17 @@ class ProductProduct(models.Model):
             product = product.with_company(company.id)
             if not svls_to_vacuum_by_product[product.id]:
                 continue
-            if product.cost_method in ['average', 'fifo'] and not float_is_zero(product.quantity_svl,
+            if product.cost_method not in ['average', 'fifo'] or float_is_zero(product.quantity_svl,
                                                                       precision_rounding=product.uom_id.rounding):
-                product.sudo().with_context(disable_auto_svl=True).write({'standard_price': product.value_svl / product.quantity_svl})
+                continue
+            if product.lot_valuated:
+                for lot in lot_to_update:
+                    if float_is_zero(lot.quantity_svl, precision_rounding=product.uom_id.rounding):
+                        continue
+                    lot.sudo().with_context(disable_auto_svl=True).write(
+                        {'standard_price': lot.value_svl / lot.quantity_svl}
+                    )
+            product.sudo().with_context(disable_auto_svl=True).write({'standard_price': product.value_svl / product.quantity_svl})
 
         vacuum_svls._validate_accounting_entries()
         self._create_fifo_vacuum_anglo_saxon_expense_entries(zip(vacuum_svls, real_time_svls_to_vacuum))
@@ -646,27 +649,71 @@ class ProductProduct(models.Model):
             if float_is_zero(product.quantity_svl, precision_rounding=product.uom_id.rounding):
                 # FIXME: create an empty layer to track the change?
                 continue
-            if float_compare(product.quantity_svl, 0, precision_rounding=product.uom_id.rounding) > 0:
-                svsl_vals = product._prepare_out_svl_vals(product.quantity_svl, self.env.company)
+            if product.lot_valuated:
+                if float_compare(product.quantity_svl, 0, precision_rounding=product.uom_id.rounding) > 0:
+                    for lot in product.stock_valuation_layer_ids.filtered(lambda l: l.remaining_qty).lot_id:
+                        svsl_vals = product._prepare_out_svl_vals(lot.quantity_svl, self.env.company, lot=lot)
+                        svsl_vals['description'] = description + svsl_vals.pop('rounding_adjustment', '')
+                        svsl_vals['company_id'] = self.env.company.id
+                        empty_stock_svl_list.append(svsl_vals)
+                else:
+                    for lot in product.stock_valuation_layer_ids.filtered(lambda l: l.remaining_qty).lot_id:
+                        svsl_vals = product._prepare_in_svl_vals(abs(lot.quantity_svl), lot.value_svl / lot.quantity_svl, lot=lot)
+                        svsl_vals['description'] = description + svsl_vals.pop('rounding_adjustment', '')
+                        svsl_vals['company_id'] = self.env.company.id
+                        empty_stock_svl_list.append(svsl_vals)
             else:
-                svsl_vals = product._prepare_in_svl_vals(abs(product.quantity_svl), product.value_svl / product.quantity_svl)
-            svsl_vals['description'] = description + svsl_vals.pop('rounding_adjustment', '')
-            svsl_vals['company_id'] = self.env.company.id
-            empty_stock_svl_list.append(svsl_vals)
+                if float_compare(product.quantity_svl, 0, precision_rounding=product.uom_id.rounding) > 0:
+                    svsl_vals = product._prepare_out_svl_vals(product.quantity_svl, self.env.company)
+                else:
+                    svsl_vals = product._prepare_in_svl_vals(abs(product.quantity_svl), product.value_svl / product.quantity_svl)
+                svsl_vals['description'] = description + svsl_vals.pop('rounding_adjustment', '')
+                svsl_vals['company_id'] = self.env.company.id
+                empty_stock_svl_list.append(svsl_vals)
         return empty_stock_svl_list, products_orig_quantity_svl, impacted_products
 
     def _svl_replenish_stock(self, description, products_orig_quantity_svl):
         refill_stock_svl_list = []
+        lot_by_product = defaultdict(lambda: defaultdict(float))
+        neg_lots = self.env['stock.quant']._read_group([
+            ('product_id', 'in', self.product_variant_ids.ids),
+            ('lot_id', '!=', False),
+            ], ['product_id', 'location_id', 'lot_id'], ['quantity:sum'],
+            having=[('quantity:sum', '<', 0)])
+        lots = self.env['stock.quant']._read_group([
+            ('product_id', 'in', self.product_variant_ids.ids),
+            ('lot_id', '!=', False),
+            ], ['product_id', 'location_id', 'lot_id'], ['quantity:sum'],
+            having=[('quantity:sum', '>', 0)])
+        for product, location, lot, qty in lots:
+            if location._should_be_valued():
+                lot_by_product[product][lot] += qty
+        for product, location, lot, qty in neg_lots:
+            if location._should_be_valued():
+                raise UserError(_("Lot %(lot)s has a negative quantity in stock. Correct this \
+                        quantity before enabling lot valuation", lot=lot))
+
         for product in self:
             quantity_svl = products_orig_quantity_svl[product.id]
-            if quantity_svl:
-                if float_compare(quantity_svl, 0, precision_rounding=product.uom_id.rounding) > 0:
-                    svl_vals = product._prepare_in_svl_vals(quantity_svl, product.standard_price)
+            if not quantity_svl:
+                continue
+            rounding = product.uom_id.rounding
+            price_unit = product.standard_price
+            if not product.lot_valuated:
+                lot_by_product[product] = {False: quantity_svl}
+            for lot, qty in lot_by_product[product].items():
+                if float_compare(quantity_svl, 0, precision_rounding=rounding) > 0:
+                    qty_to_remove = min(qty, quantity_svl)
+                    quantity_svl -= qty_to_remove
+                    svl_vals = product._prepare_in_svl_vals(qty_to_remove, price_unit, lot=lot)
+
                 else:
-                    svl_vals = product._prepare_out_svl_vals(abs(quantity_svl), self.env.company)
+                    svl_vals = product._prepare_out_svl_vals(abs(quantity_svl), self.env.company, lot=lot)
                 svl_vals['description'] = description
                 svl_vals['company_id'] = self.env.company.id
                 refill_stock_svl_list.append(svl_vals)
+                if float_is_zero(quantity_svl, precision_rounding=rounding):
+                    break
         return refill_stock_svl_list
 
     @api.model
@@ -938,6 +985,9 @@ class ProductCategory(models.Model):
         SVL = self.env['stock.valuation.layer']
 
         if 'property_cost_method' in vals or 'property_valuation' in vals:
+            categ_products = self.env['product.product'].search([('categ_id', 'in', self.ids)])
+            if any(p.lot_valuated and p.stock_valuation_layer_ids for p in categ_products):
+                raise UserError(_("You cannot change the costing method of product valuated by lot/serial number."))
             # When the cost method or the valuation are changed on a product category, we empty
             # out and replenish the stock for each impacted products.
             new_cost_method = vals.get('property_cost_method')

--- a/addons/stock_account/models/stock_lot.py
+++ b/addons/stock_account/models/stock_lot.py
@@ -1,0 +1,136 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from ast import literal_eval
+
+from odoo import _, api, fields, models
+from odoo.exceptions import UserError
+from odoo.tools import float_compare, float_round
+
+
+class StockLot(models.Model):
+    _inherit = 'stock.lot'
+
+    value_svl = fields.Float(compute='_compute_value_svl', compute_sudo=True)
+    quantity_svl = fields.Float(compute='_compute_value_svl', compute_sudo=True)
+    avg_cost = fields.Monetary(string="Average Cost", compute='_compute_value_svl', compute_sudo=True, currency_field='company_currency_id')
+    total_value = fields.Monetary(string="Total Value", compute='_compute_value_svl', compute_sudo=True, currency_field='company_currency_id')
+    company_currency_id = fields.Many2one('res.currency', 'Valuation Currency', compute='_compute_value_svl', compute_sudo=True)
+    stock_valuation_layer_ids = fields.One2many('stock.valuation.layer', 'lot_id')
+    standard_price = fields.Float(
+        "Cost", company_dependent=True,
+        digits='Product Price', groups="base.group_user",
+        help="""Value of the lot (automatically computed in AVCO).
+        Used to value the product when the purchase cost is not known (e.g. inventory adjustment).
+        Used to compute margins on sale orders."""
+    )
+
+    @api.depends('stock_valuation_layer_ids', 'product_id.lot_valuated')
+    @api.depends_context('to_date', 'company')
+    def _compute_value_svl(self):
+        """Compute totals of multiple svl related values"""
+        self.value_svl = 0
+        self.quantity_svl = 0
+        self.avg_cost = 0
+        self.total_value = 0
+        self.company_currency_id = False
+        lots = self.filtered(lambda l: l.product_id.lot_valuated)
+        if not lots:
+            return
+        company_id = self.env.company
+        self.company_currency_id = company_id.currency_id
+        domain = [
+            *self.env['stock.valuation.layer']._check_company_domain(company_id),
+            ('lot_id', 'in', lots.ids),
+        ]
+        if self.env.context.get('to_date'):
+            to_date = fields.Datetime.to_datetime(self.env.context['to_date'])
+            domain.append(('create_date', '<=', to_date))
+        groups = self.env['stock.valuation.layer']._read_group(
+            domain,
+            groupby=['lot_id'],
+            aggregates=['value:sum', 'quantity:sum'],
+        )
+        # Browse all lots and compute lots' quantities_dict in batch.
+        group_mapping = {lot: aggregates for lot, *aggregates in groups}
+        for lot in lots:
+            value_sum, quantity_sum = group_mapping.get(lot._origin, (0, 0))
+            value_svl = self.company_currency_id.round(value_sum)
+            avg_cost = value_svl / quantity_sum if quantity_sum else 0
+            lot.value_svl = value_svl
+            lot.quantity_svl = quantity_sum
+            lot.avg_cost = avg_cost
+            lot.total_value = avg_cost * quantity_sum
+
+    def write(self, vals):
+        if 'standard_price' in vals and not self.env.context.get('disable_auto_svl'):
+            self._change_standard_price(vals['standard_price'])
+        return super().write(vals)
+
+    def _change_standard_price(self, new_price):
+        """Helper to create the stock valuation layers and the account moves
+        after an update of standard price.
+
+        :param new_price: new standard price
+        """
+        if self.product_id.filtered(lambda p: p.valuation == 'real_time') and not self.env['stock.valuation.layer'].check_access_rights('read', raise_exception=False):
+            raise UserError(_("You cannot update the cost of a product in automated valuation as it leads to the creation of a journal entry, for which you don't have the access rights."))
+
+        svl_vals_list = []
+        company_id = self.env.company
+        price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
+        rounded_new_price = float_round(new_price, precision_digits=price_unit_prec)
+        for lot in self:
+            if lot.product_id.cost_method not in ('standard', 'average'):
+                continue
+            quantity_svl = lot.sudo().quantity_svl
+            if float_compare(quantity_svl, 0.0, precision_rounding=lot.product_id.uom_id.rounding) <= 0:
+                continue
+            value_svl = lot.sudo().value_svl
+            value = company_id.currency_id.round((rounded_new_price * quantity_svl) - value_svl)
+            if company_id.currency_id.is_zero(value):
+                continue
+
+            svl_vals = {
+                'company_id': company_id.id,
+                'product_id': lot.product_id.id,
+                'description': _('Lot value manually modified (from %(old)s to %(new)s)', old=lot.standard_price, new=rounded_new_price),
+                'value': value,
+                'quantity': 0,
+                'lot_id': lot.id,
+            }
+            svl_vals_list.append(svl_vals)
+        layers = self.env['stock.valuation.layer'].sudo().create(svl_vals_list)
+        layers._change_standart_price_accounting_entries(new_price)
+        for product in self.with_context(disable_auto_svl=True).product_id:
+            if product.cost_method == 'standard':
+                continue
+            if product.quantity_svl:
+                product.standard_price = product.value_svl / product.quantity_svl
+
+    # # -------------------------------------------------------------------------
+    # # Actions
+    # # -------------------------------------------------------------------------
+    def action_revaluation(self):
+        # Cannot hide the button in list view for non required field in groupby
+        if not self:
+            raise UserError(_("Select an existing lot/serial number to be reevaluated"))
+        self.ensure_one()
+        ctx = dict(self._context, default_lot_id=self.id, default_company_id=self.env.company.id)
+        return {
+            'name': _("Lot/Serial number Revaluation"),
+            'view_mode': 'form',
+            'res_model': 'stock.valuation.layer.revaluation',
+            'view_id': self.env.ref('stock_account.stock_valuation_layer_revaluation_form_view').id,
+            'type': 'ir.actions.act_window',
+            'context': ctx,
+            'target': 'new'
+        }
+
+    def action_view_stock_valuation_layers(self):
+        self.ensure_one()
+        domain = [('lot_id', '=', self.ids)]
+        action = self.env["ir.actions.actions"]._for_xml_id("stock_account.stock_valuation_layer_action")
+        context = literal_eval(action['context'])
+        context.update(self.env.context)
+        context['no_at_date'] = True
+        return dict(action, domain=domain, context=context)

--- a/addons/stock_account/models/stock_move_line.py
+++ b/addons/stock_account/models/stock_move_line.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, models
+from odoo import _, api, models
 from odoo.tools import float_compare, float_is_zero
+from odoo.exceptions import UserError
 
 
 class StockMoveLine(models.Model):
@@ -24,7 +25,7 @@ class StockMoveLine(models.Model):
             diff = move.product_uom._compute_quantity(move_line.quantity, move.product_id.uom_id)
             if float_is_zero(diff, precision_rounding=rounding):
                 continue
-            self._create_correction_svl(move, diff)
+            move_line._create_correction_svl(move, diff)
         if analytic_move_to_recompute:
             self.env['stock.move'].browse(
                 analytic_move_to_recompute)._account_analytic_entry_move()
@@ -48,7 +49,35 @@ class StockMoveLine(models.Model):
                 if float_is_zero(diff, precision_rounding=rounding):
                     continue
                 self._create_correction_svl(move, diff)
-        res = super(StockMoveLine, self).write(vals)
+        new_lot = False
+        if 'lot_id' in vals:
+            new_lot = vals.get('lot_id')
+        if 'quant_id' in vals:
+            new_quant = vals.get('quant_id')
+            new_lot = self.env['stock.quant'].browse(new_quant).lot_id.id
+        if new_lot:
+            # remove quantity of old lot
+            for move_line in self:
+                if move_line.state != 'done':
+                    continue
+                move = move_line.move_id
+                rounding = move.product_id.uom_id.rounding
+                diff = move.product_uom._compute_quantity(move_line.quantity, move.product_id.uom_id, rounding_method='HALF-UP')
+                if float_is_zero(diff, precision_rounding=rounding):
+                    continue
+                self._create_correction_svl(move, -diff)
+        res = super().write(vals)
+        if new_lot:
+            # add quantity of new lot
+            for move_line in self:
+                if move_line.state != 'done':
+                    continue
+                move = move_line.move_id
+                rounding = move.product_id.uom_id.rounding
+                diff = move.product_uom._compute_quantity(vals.get('quantity', move_line.quantity), move.product_id.uom_id, rounding_method='HALF-UP')
+                if float_is_zero(diff, precision_rounding=rounding):
+                    continue
+                self._create_correction_svl(move, diff)
         if analytic_move_to_recompute:
             self.env['stock.move'].browse(analytic_move_to_recompute)._account_analytic_entry_move()
         return res
@@ -59,23 +88,32 @@ class StockMoveLine(models.Model):
         analytic_move_to_recompute._account_analytic_entry_move()
         return res
 
+    def _action_done(self):
+        for line in self:
+            if not line.lot_id and not line.lot_name and line.product_id.lot_valuated:
+                raise UserError(_("Lot/Serial number is mandatory for product valuated by lot"))
+        return super()._action_done()
+
     # -------------------------------------------------------------------------
     # SVL creation helpers
     # -------------------------------------------------------------------------
-    @api.model
     def _create_correction_svl(self, move, diff):
+        lot = self.lot_id if self.product_id.lot_valuated else self.env['stock.lot']
+        qty = (lot, abs(diff))
         stock_valuation_layers = self.env['stock.valuation.layer']
-        if move._is_in() and diff > 0 or move._is_out() and diff < 0:
-            move.product_price_update_before_done(forced_qty=diff)
-            stock_valuation_layers |= move._create_in_svl(forced_quantity=abs(diff))
+        if (move._is_in() and diff > 0) or (move._is_out() and diff < 0):
+            move.product_price_update_before_done(forced_qty=(lot, diff))
+            stock_valuation_layers |= move._create_in_svl(forced_quantity=qty)
             if move.product_id.cost_method in ('average', 'fifo'):
                 move.product_id._run_fifo_vacuum(move.company_id)
-        elif move._is_in() and diff < 0 or move._is_out() and diff > 0:
-            stock_valuation_layers |= move._create_out_svl(forced_quantity=abs(diff))
-        elif move._is_dropshipped() and diff > 0 or move._is_dropshipped_returned() and diff < 0:
-            stock_valuation_layers |= move._create_dropshipped_svl(forced_quantity=abs(diff))
-        elif move._is_dropshipped() and diff < 0 or move._is_dropshipped_returned() and diff > 0:
-            stock_valuation_layers |= move._create_dropshipped_returned_svl(forced_quantity=abs(diff))
+        elif (move._is_in() and diff < 0) or (move._is_out() and diff > 0):
+            stock_valuation_layers |= move._create_out_svl(forced_quantity=qty)
+            if move.product_id.lot_valuated:
+                move._product_price_update_after_done()
+        elif (move._is_dropshipped() and diff > 0) or (move._is_dropshipped_returned() and diff < 0):
+            stock_valuation_layers |= move._create_dropshipped_svl(forced_quantity=qty)
+        elif (move._is_dropshipped() and diff < 0) or (move._is_dropshipped_returned() and diff > 0):
+            stock_valuation_layers |= move._create_dropshipped_returned_svl(forced_quantity=qty)
 
         stock_valuation_layers._validate_accounting_entries()
 

--- a/addons/stock_account/static/src/fields/boolean_confirm.js
+++ b/addons/stock_account/static/src/fields/boolean_confirm.js
@@ -1,0 +1,59 @@
+/** @odoo-module **/
+
+import { _t } from "@web/core/l10n/translation";
+import { registry } from '@web/core/registry';
+import { useService } from "@web/core/utils/hooks";
+
+import { CheckBox } from "@web/core/checkbox/checkbox";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import {
+    BooleanToggleField,
+    booleanToggleField,
+} from "@web/views/fields/boolean_toggle/boolean_toggle_field";
+
+export class ConfirmCheckBox extends CheckBox {
+    onClick(ev) {
+        ev.preventDefault();
+
+        if (ev.target.tagName !== "INPUT") {
+            return;
+        }
+        this.props.onChange(ev.target.checked);
+    }
+}
+
+export class BooleanToggleConfirm extends BooleanToggleField {
+    static template = "stock_account.BooleanToggleConfirm";
+    static components = { ConfirmCheckBox };
+
+    setup() {
+        super.setup();
+        this.dialogService = useService('dialog');
+    }
+
+    onChange(value) {
+        const record = this.props.record.data;
+        const updateAndSave = () => {
+            this.props.record.update({ [this.props.name]: value }, { save: true });
+        };
+
+        if (record.lot_valuated && !value) {
+            this.dialogService.add(ConfirmationDialog, {
+                body: _t("This operation might lead in a loss of data. Valuation will be identical for all lots/SN. Do you want to proceed ? "),
+                confirm: updateAndSave,
+                cancel: () => {},
+            });
+
+        }
+        else {
+            updateAndSave();
+        }
+    }
+}
+
+export const booleanToggleConfirm = {
+    ...booleanToggleField,
+    component: BooleanToggleConfirm,
+};
+
+registry.category("fields").add("confirm_boolean", booleanToggleConfirm);

--- a/addons/stock_account/static/src/fields/boolean_confirm.xml
+++ b/addons/stock_account/static/src/fields/boolean_confirm.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+    <t t-name="stock_account.BooleanToggleConfirm">
+        <ConfirmCheckBox
+            className="'o_field_boolean o_boolean_toggle'"
+            id="props.id"
+            value="props.record.data[props.name] or false"
+            disabled="isReadonly"
+            onChange="(value) => this.onChange(value)"
+        />
+    </t>
+</templates>

--- a/addons/stock_account/tests/__init__.py
+++ b/addons/stock_account/tests/__init__.py
@@ -1,5 +1,6 @@
 from . import test_account_move
 from . import test_anglo_saxon_valuation_reconciliation_common
+from . import test_lot_valuation
 from . import test_stockvaluation
 from . import test_stockvaluationlayer
 from . import test_stock_valuation_layer_revaluation

--- a/addons/stock_account/tests/test_lot_valuation.py
+++ b/addons/stock_account/tests/test_lot_valuation.py
@@ -1,0 +1,513 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.stock_account.tests.test_stockvaluationlayer import TestStockValuationCommon
+from odoo.exceptions import UserError
+from odoo.tests import Form
+from odoo import Command
+
+
+class TestLotValuation(TestStockValuationCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.product1.product_tmpl_id.categ_id.property_cost_method = 'average'
+        cls.product1.write({
+            'lot_valuated': True,
+            'tracking': 'lot',
+        })
+        cls.lot1, cls.lot2, cls.lot3 = cls.env['stock.lot'].create([
+            {'name': 'lot1', 'product_id': cls.product1.id},
+            {'name': 'lot2', 'product_id': cls.product1.id},
+            {'name': 'lot3', 'product_id': cls.product1.id},
+        ])
+
+    def test_lot_normal_1(self):
+        """ Lots have their own valuation """
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product1, 10, 7, lot_ids=[self.lot3])
+        self.assertEqual(self.product1.standard_price, 6.0)
+        self.assertEqual(self.lot1.standard_price, 5)
+        self._make_out_move(self.product1, 2, lot_ids=[self.lot1])
+
+        # lot1 has a cost different than the product it self. So a out move should recompute the
+        # product cost
+        self.assertEqual(self.product1.standard_price, 6.11)
+        self.assertEqual(len(self.lot1.stock_valuation_layer_ids), 2)
+        self.assertEqual(self.lot1.stock_valuation_layer_ids.mapped('lot_id'), self.lot1)
+        self.assertEqual(self.lot1.value_svl, 15)
+        self.assertEqual(self.lot1.quantity_svl, 3)
+        self.assertEqual(self.lot1.standard_price, 5)
+        quant = self.lot1.quant_ids.filtered(lambda q: q.location_id.usage == 'internal')
+        self.assertEqual(quant.value, 15)
+        self.assertEqual(len(self.lot2.stock_valuation_layer_ids), 1)
+        self.assertEqual(self.lot2.stock_valuation_layer_ids.mapped('lot_id'), self.lot2)
+        self.assertEqual(self.lot2.value_svl, 25)
+        self.assertEqual(self.lot2.quantity_svl, 5)
+        self.assertEqual(self.lot2.standard_price, 5)
+        quant = self.lot2.quant_ids.filtered(lambda q: q.location_id.usage == 'internal')
+        self.assertEqual(quant.value, 25)
+        self.assertEqual(len(self.lot3.stock_valuation_layer_ids), 1)
+        self.assertEqual(self.lot3.stock_valuation_layer_ids.mapped('lot_id'), self.lot3)
+        self.assertEqual(self.lot3.value_svl, 70)
+        self.assertEqual(self.lot3.quantity_svl, 10)
+        self.assertEqual(self.lot3.standard_price, 7)
+        quant = self.lot3.quant_ids.filtered(lambda q: q.location_id.usage == 'internal')
+        self.assertEqual(quant.value, 70)
+
+    def test_lot_normal_2(self):
+        """ Product valuation is a fallback in case lot is created at delivery """
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        out_move = self._make_out_move(self.product1, 2, lot_ids=[self.lot3])
+
+        self.assertEqual(self.product1.value_svl, 40)
+        self.assertEqual(self.product1.quantity_svl, 8)
+
+        self.assertEqual(out_move.stock_valuation_layer_ids.unit_cost, 5)
+        self.assertEqual(self.lot3.value_svl, -10)
+        self.assertEqual(self.lot3.quantity_svl, -2)
+
+    def test_lot_normal_3(self):
+        """ Test lot valuation and dropship"""
+        self._make_dropship_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+
+        layers1 = self.lot1.stock_valuation_layer_ids
+        layers2 = self.lot2.stock_valuation_layer_ids
+        self.assertEqual(len(layers1), 2)
+        self.assertEqual(len(layers2), 2)
+        product_layers = self.product1.stock_valuation_layer_ids
+        self.assertEqual(product_layers, layers1 | layers2)
+        self.assertEqual(layers1[0].value, 25)
+        self.assertEqual(layers1[1].value, -25)
+        self.assertEqual(layers2[0].value, 25)
+        self.assertEqual(layers2[1].value, -25)
+
+    def test_real_time_valuation(self):
+        """ Test account move lines contains lot """
+        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product1, 10, 7, lot_ids=[self.lot3])
+        self._make_out_move(self.product1, 2, lot_ids=[self.lot1])
+        aml = self.product1.stock_valuation_layer_ids.account_move_id.line_ids
+        self.assertRecordValues(aml, [
+            {'debit': 0.0, 'credit': 25.0},
+            {'debit': 25.0, 'credit': 0.0},
+            {'debit': 0.0, 'credit': 25.0},
+            {'debit': 25.0, 'credit': 0.0},
+            {'debit': 0.0, 'credit': 70.0},
+            {'debit': 70.0, 'credit': 0.0},
+            {'debit': 0.0, 'credit': 10.0},
+            {'debit': 10.0, 'credit': 0.0},
+            ])
+
+    def test_disable_lot_valuation(self):
+        """ Disabling lot valuation should compansate lots layer untouched a one product only layer.
+            product valuation is standard """
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'standard'
+        self.product1.product_tmpl_id.standard_price = 10
+
+        m_in1 = self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        m_in2 = self._make_in_move(self.product1, 10, 7, lot_ids=[self.lot3])
+        m_out1 = self._make_out_move(self.product1, 2, lot_ids=[self.lot1])
+        m_out2 = self._make_out_move(self.product1, 2, lot_ids=[self.lot3])
+        m_in3 = self._make_in_move(self.product1, 9, 8, lot_ids=[self.lot1, self.lot2, self.lot3])
+
+        self.assertEqual(self.product1.value_svl, 250)
+        self.assertEqual(self.product1.quantity_svl, 25)
+        self.assertEqual(self.product1.stock_valuation_layer_ids.mapped('lot_id'), self.lot1 | self.lot2 | self.lot3)
+        self.assertEqual(len(self.product1.stock_valuation_layer_ids), 8)
+        self.assertEqual(self.lot1.value_svl, 60)
+        self.assertEqual(self.lot1.quantity_svl, 6)
+        self.assertEqual(self.lot2.value_svl, 80)
+        self.assertEqual(self.lot2.quantity_svl, 8)
+        self.assertEqual(self.lot3.value_svl, 110)
+        self.assertEqual(self.lot3.quantity_svl, 11)
+        self.assertEqual(len(m_in1.stock_valuation_layer_ids), 2)
+        self.assertEqual(len(m_in2.stock_valuation_layer_ids), 1)
+        self.assertEqual(len(m_out1.stock_valuation_layer_ids), 1)
+        self.assertEqual(len(m_out2.stock_valuation_layer_ids), 1)
+        self.assertEqual(len(m_in3.stock_valuation_layer_ids), 3)
+
+        self.product1.product_tmpl_id.lot_valuated = False
+
+        self.assertEqual(self.product1.value_svl, 250)
+        self.assertEqual(self.product1.quantity_svl, 25)
+        self.assertEqual(len(self.product1.stock_valuation_layer_ids), 12)
+        self.assertEqual(self.lot1.value_svl, 0)
+        self.assertEqual(self.lot1.quantity_svl, 0)
+        self.assertEqual(self.lot2.value_svl, 0)
+        self.assertEqual(self.lot2.quantity_svl, 0)
+        self.assertEqual(self.lot3.value_svl, 0)
+        self.assertEqual(self.lot3.quantity_svl, 0)
+        remaining_qty_layers = self.env['stock.valuation.layer'].search([
+            ('product_id', '=', self.product1.id),
+            ('remaining_qty', '>', 0),
+        ])
+        self.assertTrue(remaining_qty_layers)
+        self.assertFalse(remaining_qty_layers.lot_id)
+
+    def test_enable_lot_valuation(self):
+        """ Disabling lot valuation should left the lots layer untouched.
+            product valuation is standard """
+        self.product1.product_tmpl_id.categ_id.property_cost_method = 'standard'
+        self.product1.product_tmpl_id.standard_price = 10
+
+        self.product1.lot_valuated = False
+
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product1, 10, 7, lot_ids=[self.lot3])
+        self._make_out_move(self.product1, 2, lot_ids=[self.lot1])
+        self._make_out_move(self.product1, 2, lot_ids=[self.lot3])
+        self._make_in_move(self.product1, 9, 8, lot_ids=[self.lot1, self.lot2, self.lot3])
+
+        self.assertEqual(self.product1.value_svl, 250)
+        self.assertEqual(self.product1.quantity_svl, 25)
+        self.assertEqual(len(self.product1.stock_valuation_layer_ids), 5)
+        self.assertEqual(self.lot1.value_svl, 0)
+        self.assertEqual(self.lot1.quantity_svl, 0)
+        self.assertEqual(self.lot2.value_svl, 0)
+        self.assertEqual(self.lot2.quantity_svl, 0)
+        self.assertEqual(self.lot3.value_svl, 0)
+        self.assertEqual(self.lot3.quantity_svl, 0)
+
+        self.product1.product_tmpl_id.lot_valuated = True
+
+        self.assertEqual(self.product1.value_svl, 250)
+        self.assertEqual(self.product1.quantity_svl, 25)
+        self.assertEqual(self.product1.stock_valuation_layer_ids.lot_id, self.lot1 | self.lot2 | self.lot3)
+
+        # 5 original + 1 empty stock + 3 for the lots
+        self.assertEqual(len(self.product1.stock_valuation_layer_ids), 9)
+        self.assertEqual(self.lot1.value_svl, 60)
+        self.assertEqual(self.lot1.quantity_svl, 6)
+        self.assertEqual(self.lot2.value_svl, 80)
+        self.assertEqual(self.lot2.quantity_svl, 8)
+        self.assertEqual(self.lot3.value_svl, 110)
+        self.assertEqual(self.lot3.quantity_svl, 11)
+
+    def test_enable_lot_valuation_variant(self):
+        """ test enabling the lot valuation for template with multiple variant"""
+        self.size_attribute = self.env['product.attribute'].create({
+            'name': 'Size',
+            'value_ids': [
+                Command.create({'name': 'S'}),
+                Command.create({'name': 'M'}),
+                Command.create({'name': 'L'}),
+            ]
+        })
+        template = self.env['product.template'].create({
+            'name': 'Sofa',
+            'tracking': 'lot',
+            'is_storable': True,
+            'uom_id': self.uom_unit.id,
+            'uom_po_id': self.uom_unit.id,
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': self.size_attribute.id,
+                    'value_ids': [
+                        Command.link(self.size_attribute.value_ids[0].id),
+                        Command.link(self.size_attribute.value_ids[1].id),
+                ]}),
+            ],
+        })
+        productA, productB = template.product_variant_ids
+        lotA_1, lotA_2, lotB_1, lotB_2 = self.env['stock.lot'].create([
+            {'name': 'lot1', 'product_id': productA.id},
+            {'name': 'lot2', 'product_id': productA.id},
+            {'name': 'lot1', 'product_id': productB.id},
+            {'name': 'lot2', 'product_id': productB.id},
+        ])
+        self._make_in_move(productA, 10, 5, lot_ids=[lotA_1, lotA_2])
+        self._make_in_move(productA, 10, 7, lot_ids=[lotA_2])
+        self._make_in_move(productB, 10, 4, lot_ids=[lotB_1, lotB_2])
+        self._make_in_move(productB, 10, 8, lot_ids=[lotB_2])
+        self._make_out_move(productA, 2, lot_ids=[lotA_1, lotA_2])
+        self._make_out_move(productB, 4, lot_ids=[lotB_1, lotB_2])
+        self._make_in_move(productA, 6, 8, lot_ids=[lotA_1, lotA_2])
+        self._make_in_move(productB, 6, 8, lot_ids=[lotB_1, lotB_2])
+
+        self.assertEqual(productA.value_svl, 156)
+        self.assertEqual(productA.quantity_svl, 24)
+        self.assertEqual(len(productA.stock_valuation_layer_ids), 4)
+        self.assertEqual(productB.value_svl, 144)
+        self.assertEqual(productB.quantity_svl, 22)
+        self.assertEqual(len(productB.stock_valuation_layer_ids), 4)
+
+        template.lot_valuated = True
+
+        self.assertEqual(productA.value_svl, 156)
+        self.assertEqual(productA.quantity_svl, 24)
+        self.assertEqual(productB.value_svl, 144.1)  # 144.1 because of multiplying quantity with rounded standard price
+        self.assertEqual(productB.quantity_svl, 22)
+
+        # 4 original + 1 empty stock + 2 for the lots
+        self.assertEqual(len(productA.stock_valuation_layer_ids), 7)
+        self.assertEqual(len(productB.stock_valuation_layer_ids), 7)
+        self.assertEqual(lotA_1.value_svl, 45.5)
+        self.assertEqual(lotA_1.quantity_svl, 7)
+        self.assertEqual(lotA_2.value_svl, 110.5)
+        self.assertEqual(lotA_2.quantity_svl, 17)
+        self.assertEqual(lotB_1.value_svl, 39.3)
+        self.assertEqual(lotB_1.quantity_svl, 6)
+        self.assertEqual(lotB_2.value_svl, 104.8)
+        self.assertEqual(lotB_2.quantity_svl, 16)
+
+    def test_enforce_lot_receipt(self):
+        """ lot/sn is mandatory on receipt if the product is lot valuated """
+        with self.assertRaises(UserError):
+            self._make_in_move(self.product1, 10, 5)
+
+    def test_enforce_lot_inventory(self):
+        """ lot/sn is mandatory on quant if the product is lot valuated """
+        inventory_quant = self.env['stock.quant'].create({
+            'location_id': self.stock_location.id,
+            'product_id': self.product1.id,
+            'inventory_quantity': 10
+        })
+        with self.assertRaises(UserError):
+            stock_confirmation_action = inventory_quant.action_apply_inventory()
+            stock_confirmation_wizard_form = Form(
+                self.env['stock.track.confirmation'].with_context(
+                    **stock_confirmation_action['context'])
+            )
+
+            stock_confirmation_wizard = stock_confirmation_wizard_form.save()
+            stock_confirmation_wizard.action_confirm()
+
+    def test_inventory_adjustment_existing_lot(self):
+        """ If a lot exist, inventory takes its cost, if not, takes standard price """
+        self.product1.product_tmpl_id.standard_price = 10
+        shelf1 = self.env['stock.location'].create({
+            'name': 'Shelf 1',
+            'usage': 'internal',
+            'location_id': self.stock_location.id,
+        })
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1])
+        inventory_quant = self.env['stock.quant'].create({
+            'location_id': shelf1.id,
+            'product_id': self.product1.id,
+            'lot_id': self.lot1.id,
+            'inventory_quantity': 1
+        })
+
+        inventory_quant.action_apply_inventory()
+        layers = self.lot1.stock_valuation_layer_ids
+        self.assertEqual(len(layers), 2)
+        self.assertEqual(layers.mapped('unit_cost'), [5, 5])
+
+    def test_inventory_adjustment_new_lot(self):
+        """ If a lot exist, inventory takes its cost, if not, takes standard price """
+        shelf1 = self.env['stock.location'].create({
+            'name': 'Shelf 1',
+            'usage': 'internal',
+            'location_id': self.stock_location.id,
+        })
+        lot4 = self.env['stock.lot'].create({
+            'name': 'lot4',
+            'product_id': self.product1.id,
+        })
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1])
+        self._make_in_move(self.product1, 10, 9, lot_ids=[self.lot2])
+        self.assertEqual(self.product1.standard_price, 7)
+        inventory_quant = self.env['stock.quant'].create({
+            'location_id': shelf1.id,
+            'product_id': self.product1.id,
+            'lot_id': lot4.id,
+            'inventory_quantity': 1,
+        })
+
+        inventory_quant.action_apply_inventory()
+        layers = lot4.stock_valuation_layer_ids
+        self.assertEqual(len(layers), 1)
+        self.assertEqual(layers.unit_cost, 7)
+
+    def test_change_standard_price(self):
+        """ Changing product's standard price will reevaluate all lots """
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product1, 8, 7, lot_ids=[self.lot3])
+        self._make_in_move(self.product1, 6, 8, lot_ids=[self.lot2, self.lot3])
+        self.assertEqual(self.lot1.value_svl, 25)
+        self.assertEqual(self.lot2.value_svl, 49)
+        self.assertEqual(self.lot3.value_svl, 80)
+        self.product1.product_tmpl_id.standard_price = 10
+
+        self.assertEqual(self.lot1.value_svl, 50)
+        self.assertEqual(self.lot1.standard_price, 10)
+        self.assertEqual(self.lot2.value_svl, 80)
+        self.assertEqual(self.lot2.standard_price, 10)
+        self.assertEqual(self.lot3.value_svl, 110)
+        self.assertEqual(self.lot3.standard_price, 10)
+
+    def test_value_multicompanies(self):
+        """ Test having multiple layers on different companies give a correct value"""
+        c1 = self.env.company
+        c2 = self.env.companies - c1
+        self.product1.product_tmpl_id.with_company(c2).categ_id.property_cost_method = 'average'
+        # c1 moves
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product1, 8, 7, lot_ids=[self.lot3])
+        self._make_in_move(self.product1, 6, 8, lot_ids=[self.lot2, self.lot3])
+        # c2 move
+        c2_stock_loc = self.env['stock.warehouse'].search([('company_id', '=', c2.id)], limit=1).lot_stock_id
+        move1 = self.env['stock.move'].with_company(c2).create({
+            'name': 'IN 10 units @ 10.00 per unit',
+            'location_id': self.supplier_location.id,
+            'location_dest_id': c2_stock_loc.id,
+            'product_id': self.product1.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 9.0,
+            'price_unit': 6.0,
+        })
+        move1._action_confirm()
+        move1.move_line_ids.unlink()
+        move1.move_line_ids = [Command.create({
+            'product_id': self.product1.id,
+            'quantity': 3.0,
+            'lot_id': lot.id,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': c2_stock_loc.id,
+        }) for lot in [self.lot1, self.lot2, self.lot3]]
+        move1.picked = True
+        move1._action_done()
+        self.assertEqual(self.lot1.with_company(c1).value_svl, 25)
+        self.assertEqual(self.lot2.with_company(c1).value_svl, 49)
+        self.assertEqual(self.lot3.with_company(c1).value_svl, 80)
+        self.assertEqual(self.lot1.with_company(c2).value_svl, 18)
+        self.assertEqual(self.lot2.with_company(c2).value_svl, 18)
+        self.assertEqual(self.lot3.with_company(c2).value_svl, 18)
+
+    def test_prevent_change_cost_method(self):
+        """ Prevent changing cost method if lot valuated """
+        # change cost method on category
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        with self.assertRaises(UserError):
+            self.product1.categ_id.property_cost_method = 'fifo'
+
+        new_cat = self.env['product.category'].create({
+            'name': 'New Category',
+            'property_cost_method': 'fifo',
+        })
+        with self.assertRaises(UserError):
+            self.product1.categ_id = new_cat
+
+    def test_change_lot_cost(self):
+        """ Changing the cost of a lot will reevaluate the lot """
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product1, 10, 7, lot_ids=[self.lot3])
+        self._make_out_move(self.product1, 2, lot_ids=[self.lot1])
+        self.lot1.standard_price = 10
+        self.assertEqual(len(self.lot1.stock_valuation_layer_ids), 3)
+        self.assertEqual(self.lot1.stock_valuation_layer_ids.mapped('lot_id'), self.lot1)
+        self.assertEqual(self.lot1.value_svl, 30)
+        self.assertEqual(self.lot1.quantity_svl, 3)
+        self.assertEqual(self.lot1.standard_price, 10)
+        # product cost should be updated al well
+        self.assertEqual(self.product1.standard_price, 6.94)
+        # rest remains unchanged
+        self.assertEqual(len(self.lot2.stock_valuation_layer_ids), 1)
+        self.assertEqual(self.lot2.stock_valuation_layer_ids.mapped('lot_id'), self.lot2)
+        self.assertEqual(self.lot2.value_svl, 25)
+        self.assertEqual(self.lot2.quantity_svl, 5)
+        self.assertEqual(self.lot2.standard_price, 5)
+        self.assertEqual(len(self.lot3.stock_valuation_layer_ids), 1)
+        self.assertEqual(self.lot3.stock_valuation_layer_ids.mapped('lot_id'), self.lot3)
+        self.assertEqual(self.lot3.value_svl, 70)
+        self.assertEqual(self.lot3.quantity_svl, 10)
+        self.assertEqual(self.lot3.standard_price, 7)
+
+    def test_average_manual_lot_revaluation(self):
+        self.product1.categ_id.property_cost_method = 'average'
+
+        self._make_in_move(self.product1, 8, 5, lot_ids=[self.lot1, self.lot2])
+        self._make_in_move(self.product1, 6, 7, lot_ids=[self.lot1])
+        self.assertEqual(self.lot1.standard_price, 6.2)
+        self.assertEqual(self.lot1.value_svl, 62)
+        self.assertEqual(self.product1.standard_price, 5.86)
+
+        Form(self.env['stock.valuation.layer.revaluation'].with_context({
+            'default_product_id': self.product1.id,
+            'default_company_id': self.env.company.id,
+            'default_added_value': 8.0,
+            'default_lot_id': self.lot1.id,
+        })).save().action_validate_revaluation()
+
+        layers = self.lot1.stock_valuation_layer_ids
+        self.assertEqual(len(layers), 3)
+        self.assertEqual(layers.lot_id, self.lot1)
+        self.assertEqual(self.lot1.standard_price, 7, "lot1 cost changed")
+        self.assertEqual(self.lot1.value_svl, 70, "lot1 value changed")
+        self.assertEqual(self.lot2.standard_price, 5, "lot2 cost remains unchanged")
+        self.assertEqual(self.product1.standard_price, 6.43, "product cost changed too")
+
+    def test_lot_move_update_after_done(self):
+        """validate a stock move. Edit the move line in done state."""
+        move = self._make_in_move(self.product1, 8, 5, create_picking=True, lot_ids=[self.lot1, self.lot2])
+        move.picking_id.action_toggle_is_locked()
+        move.move_line_ids = [
+            Command.update(move.move_line_ids[1].id, {'quantity': 6}),
+            Command.create({
+                'product_id': self.product1.id,
+                'product_uom_id': self.product1.uom_id.id,
+                'quantity': 3,
+                'lot_id': self.lot3.id,
+            }),
+        ]
+        self.assertRecordValues(self.lot1.stock_valuation_layer_ids, [
+            {'value': 20, 'lot_id': self.lot1.id, 'quantity': 4},
+        ])
+        self.assertRecordValues(self.lot2.stock_valuation_layer_ids, [
+            {'value': 20, 'lot_id': self.lot2.id, 'quantity': 4},
+            {'value': 10, 'lot_id': self.lot2.id, 'quantity': 2},
+        ])
+        self.assertRecordValues(self.lot3.stock_valuation_layer_ids, [
+            {'value': 15, 'lot_id': self.lot3.id, 'quantity': 3},
+        ])
+
+    def test_lot_change_lot_after_done(self):
+        """validate a stock move. Change the lot or a quant on a move line in done state should
+        update the valuation accordingly. The product standard_price should be updated as well."""
+        move = self._make_in_move(self.product1, 8, 5, create_picking=True, lot_ids=[self.lot1, self.lot2])
+        move.picking_id.action_toggle_is_locked()
+        move.move_line_ids = [
+            Command.update(move.move_line_ids[1].id, {'lot_id': self.lot3.id}),
+        ]
+        self.assertRecordValues(move.stock_valuation_layer_ids, [
+            {'value': 20, 'lot_id': self.lot1.id, 'quantity': 4},
+            {'value': 20, 'lot_id': self.lot2.id, 'quantity': 4},
+            {'value': -20, 'lot_id': self.lot2.id, 'quantity': -4},
+            {'value': 20, 'lot_id': self.lot3.id, 'quantity': 4},
+        ])
+        self.assertEqual(self.product1.standard_price, 5)
+
+        self._make_in_move(self.product1, 4, 4, create_picking=True, lot_ids=[self.lot3])
+        self.assertEqual(self.product1.standard_price, 4.67)
+
+        move = self._make_out_move(self.product1, 3, create_picking=True, lot_ids=[self.lot1])
+        self.assertEqual(self.product1.standard_price, 4.56)
+
+        quant = self.env['stock.quant'].search([
+            ('lot_id', '=', self.lot3.id),
+            ('location_id', '=', self.stock_location.id),
+        ])
+        move.picking_id.action_toggle_is_locked()
+        move.move_line_ids = [
+            Command.update(move.move_line_ids.id, {'quant_id': quant.id}),
+        ]
+        self.assertEqual(self.product1.standard_price, 4.72)
+
+        self.assertRecordValues(move.stock_valuation_layer_ids, [
+            {'value': -15, 'lot_id': self.lot1.id, 'quantity': -3},
+            {'value': 15, 'lot_id': self.lot1.id, 'quantity': 3},
+            {'value': -13.5, 'lot_id': self.lot3.id, 'quantity': -3},
+        ])
+
+    def test_lot_fifo_vaccum(self):
+        """ Test lot fifo vacuum"""
+        self.product1.standard_price = 9
+        self._make_out_move(self.product1, 2, lot_ids=[self.lot1])
+        self._make_out_move(self.product1, 3, lot_ids=[self.lot2])
+        self._make_in_move(self.product1, 10, 7, lot_ids=[self.lot3])
+        self.assertEqual(self.lot1.standard_price, 9)
+        self.assertEqual(self.lot3.standard_price, 7)
+        self._make_in_move(self.product1, 10, 5, lot_ids=[self.lot1, self.lot2])
+        self.assertEqual(self.lot1.standard_price, 5)
+        self.assertEqual(self.lot3.standard_price, 7)

--- a/addons/stock_account/tests/test_stockvaluationlayer.py
+++ b/addons/stock_account/tests/test_stockvaluationlayer.py
@@ -3,6 +3,7 @@
 
 """ Implementation of "INVENTORY VALUATION TESTS (With valuation layers)" spreadsheet. """
 
+from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.addons.stock_account.tests.test_stockvaluation import _create_accounting_data
 from odoo.tests import Form, tagged
@@ -31,7 +32,7 @@ class TestStockValuationCommon(TransactionCase):
         # Counter automatically incremented by `_make_in_move` and `_make_out_move`.
         self.days = 0
 
-    def _make_in_move(self, product, quantity, unit_cost=None, create_picking=False, loc_dest=None, pick_type=None):
+    def _make_in_move(self, product, quantity, unit_cost=None, create_picking=False, loc_dest=None, pick_type=None, lot_ids=False):
         """ Helper to create and validate a receipt move.
         """
         unit_cost = unit_cost or product.standard_price
@@ -57,14 +58,25 @@ class TestStockValuationCommon(TransactionCase):
             in_move.write({'picking_id': picking.id})
 
         in_move._action_confirm()
-        in_move._action_assign()
+        if lot_ids:
+            in_move.move_line_ids.unlink()
+            in_move.move_line_ids = [Command.create({
+                'location_id': self.supplier_location.id,
+                'location_dest_id': loc_dest.id,
+                'quantity': quantity / len(lot_ids),
+                'product_id': product.id,
+                'lot_id': lot.id,
+            }) for lot in lot_ids]
+        else:
+            in_move._action_assign()
+
         in_move.picked = True
         in_move._action_done()
 
         self.days += 1
         return in_move.with_context(svl=True)
 
-    def _make_out_move(self, product, quantity, force_assign=None, create_picking=False, loc_src=None, pick_type=None):
+    def _make_out_move(self, product, quantity, force_assign=None, create_picking=False, loc_src=None, pick_type=None, lot_ids=False):
         """ Helper to create and validate a delivery move.
         """
         loc_src = loc_src or self.stock_location
@@ -97,14 +109,24 @@ class TestStockValuationCommon(TransactionCase):
                 'location_id': out_move.location_id.id,
                 'location_dest_id': out_move.location_dest_id.id,
             })
-        out_move.move_line_ids.quantity = quantity
+        if lot_ids:
+            out_move.move_line_ids.unlink()
+            out_move.move_line_ids = [Command.create({
+                'location_id': loc_src.id,
+                'location_dest_id': self.customer_location.id,
+                'quantity': quantity / len(lot_ids),
+                'product_id': product.id,
+                'lot_id': lot.id,
+            }) for lot in lot_ids]
+        else:
+            out_move.move_line_ids.quantity = quantity
         out_move.picked = True
         out_move._action_done()
 
         self.days += 1
         return out_move.with_context(svl=True)
 
-    def _make_dropship_move(self, product, quantity, unit_cost=None):
+    def _make_dropship_move(self, product, quantity, unit_cost=None, lot_ids=False):
         dropshipped = self.env['stock.move'].create({
             'name': 'dropship %s units' % str(quantity),
             'product_id': product.id,
@@ -118,7 +140,17 @@ class TestStockValuationCommon(TransactionCase):
             dropshipped.price_unit = unit_cost
         dropshipped._action_confirm()
         dropshipped._action_assign()
-        dropshipped.move_line_ids.quantity = quantity
+        if lot_ids:
+            dropshipped.move_line_ids = [Command.clear()]
+            dropshipped.move_line_ids = [Command.create({
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.customer_location.id,
+                'quantity': quantity / len(lot_ids),
+                'product_id': product.id,
+                'lot_id': lot.id,
+            }) for lot in lot_ids]
+        else:
+            dropshipped.move_line_ids.quantity = quantity
         dropshipped.picked = True
         dropshipped._action_done()
         return dropshipped

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -50,6 +50,17 @@
         </record>
 
         <!-- Stock Report View -->
+        <record model="ir.ui.view" id="view_template_property_form_stock_account">
+            <field name="name">view.template.property.form.stock.account</field>
+            <field name="model">product.template</field>
+            <field name="inherit_id" ref="stock.view_template_property_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='product_tooltip']" position="after">
+                    <field name="lot_valuated" invisible="tracking == 'none'" widget="confirm_boolean"/>
+                </xpath>
+            </field>
+        </record>
+
         <record model="ir.ui.view" id="product_product_stock_tree_inherit_stock_account">
             <field name="name">product.product.stock.list.inherit.stock.account</field>
             <field name="model">product.product</field>

--- a/addons/stock_account/views/stock_lot_views.xml
+++ b/addons/stock_account/views/stock_lot_views.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+<data>
+<record id="view_production_lot_form_stock_account" model="ir.ui.view">
+        <field name="name">view.production.lot.form.stock.account</field>
+        <field name="model">stock.lot</field>
+        <field name="inherit_id" ref="stock.view_production_lot_form"/>
+        <field name="arch" type="xml">
+        <xpath expr="//div[@name='button_box']" position="inside">
+            <field name="stock_valuation_layer_ids" invisible="1"/>
+            <button type="object"
+                name="action_view_stock_valuation_layers"
+                class="oe_stat_button" icon="fa-dollar" groups="account.group_account_invoice"
+                invisible="not stock_valuation_layer_ids">
+                <div class="o_stat_info">
+                    <span class="o_stat_text">Valuation</span>
+                </div>
+            </button>
+        </xpath>
+        <xpath expr="//group[@name='main_group']/group[2]" position="inside">
+            <field name="company_currency_id" invisible="1"/>
+            <label for="total_value"/>
+            <div class="o_row">
+                <field name="total_value" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
+            </div>
+            <label for="avg_cost"/>
+            <div class="o_row">
+                <field name="avg_cost" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
+            </div>
+            <label for="standard_price"/>
+            <div class="o_row">
+                <field name="standard_price" widget='monetary' class="oe_inline" options="{'currency_field': 'company_currency_id'}"/>
+            </div>
+            </xpath>
+        </field>
+        </record>
+        </data>
+</odoo>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -9,6 +9,7 @@
                         <group>
                             <field name="create_date" string="Date" />
                             <field name="product_id" />
+                            <field name="lot_id" invisible="not lot_id"/>
                             <field name="stock_move_id" invisible="not stock_move_id" />
                         </group>
                     </group>
@@ -55,6 +56,7 @@
                 <field name="account_move_id" optional="hide" groups="account.group_account_user"/>
                 <button name="action_open_journal_entry" groups="account.group_account_user" type="object" title="Journal Entry" icon="fa-book" invisible="not account_move_id"/>
                 <field name="product_id" />
+                <field name="lot_id" optional="hide"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                 <field name="quantity" string="Quantity" optional="show" sum="Total Moved Quantity"/>
                 <field name="remaining_qty" type="measure" optional="hide" sum="Total Remaining Quantity"/>
@@ -68,6 +70,9 @@
                     <field name="cost_method" invisible="1"/>
                     <field name="quantity_svl" invisible="1"/>
                     <button name="action_revaluation" icon="fa-plus" title="Add Manual Valuation" type="object" invisible="cost_method == 'standard' or quantity_svl &lt;= 0" />
+                </groupby>
+                <groupby name="lot_id">
+                    <button name="action_revaluation" icon="fa-plus" title="Add Manual Valuation" type="object"/>
                 </groupby>
             </list>
         </field>
@@ -146,6 +151,7 @@
                 <filter string="Has Remaining Qty" name="has_remaining_qty" domain="[('remaining_qty', '>', 0)]"/>
                 <group expand='0' string='Group by...'>
                     <filter string='Product' name="group_by_product_id" context="{'group_by': 'product_id'}"/>
+                    <filter string='Lot/Serial Number' name="group_by_lot_id" context="{'group_by': 'lot_id'}"/>
                     <filter string='Product Category' name="group_by_categ_id" context="{'group_by': 'categ_id'}"/>
                     <filter string='Date' name="group_by_created_date" context="{'group_by': 'create_date'}"/>
                     <filter string='Company' name="group_by_company_id" context="{'group_by': 'company_id'}" groups="base.group_multi_company"/>

--- a/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
+++ b/addons/stock_account/wizard/stock_valuation_layer_revaluation_views.xml
@@ -32,6 +32,7 @@
                         <field name="company_id" invisible="1"/>
                         <field name="currency_id" invisible="1"/>
                         <field name="product_id" invisible="1"/>
+                        <field name="lot_id" invisible="1"/>
                     </group>
                     <group>
                         <field name="property_valuation" invisible="1"/>

--- a/addons/stock_landed_costs/tests/__init__.py
+++ b/addons/stock_landed_costs/tests/__init__.py
@@ -2,6 +2,7 @@
 
 from . import test_stock_landed_costs
 from . import test_stock_landed_costs_branches
+from . import test_stock_landed_costs_lots
 from . import test_stock_landed_costs_purchase
 from . import test_stock_landed_costs_rounding
 from . import test_stockvaluationlayer

--- a/addons/stock_landed_costs/tests/test_stock_landed_costs_lots.py
+++ b/addons/stock_landed_costs/tests/test_stock_landed_costs_lots.py
@@ -1,0 +1,103 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.stock_account.tests.test_lot_valuation import TestLotValuation
+from odoo.tests import tagged, Form
+from odoo import Command
+
+
+@tagged('post_install', '-at_install')
+class TestStockLandedCostsLots(TestLotValuation):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.productlc1 = cls.env['product.product'].create({
+            'name': 'product1',
+            'type': 'service',
+            'landed_cost_ok': True,
+        })
+
+    def test_stock_landed_costs_lots(self):
+        self.product1.product_tmpl_id.categ_id.property_valuation = 'real_time'
+        picking_1 = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'move_ids': [Command.create({
+                'name': 'Picking 1',
+                'product_id': self.product1.id,
+                'product_uom_qty': 15,
+                'product_uom': self.ref('uom.product_uom_unit'),
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+                'price_unit': 10,
+            })],
+        })
+        picking_2 = self.env['stock.picking'].create({
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'move_ids': [Command.create({
+                'name': 'Picking 2',
+                'product_id': self.product1.id,
+                'product_uom_qty': 10,
+                'product_uom': self.ref('uom.product_uom_unit'),
+                'location_id': self.supplier_location.id,
+                'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+                'price_unit': 11,
+            })],
+        })
+
+        # Confirm and assign picking
+        (picking_1 | picking_2).action_confirm()
+        picking_1.move_ids.move_line_ids = [Command.clear()] + [Command.create({
+            'product_id': self.product1.id,
+            'lot_name': lot_name,
+            'quantity': 5,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+        }) for lot_name in ['LClot1', 'LClot2', 'LClot3']]
+        picking_2.move_ids.move_line_ids = [Command.clear()] + [Command.create({
+            'product_id': self.product1.id,
+            'lot_name': lot_name,
+            'quantity': 5,
+            'location_id': self.supplier_location.id,
+            'location_dest_id': self.env.ref('stock.stock_location_stock').id,
+        }) for lot_name in ['LClot1', 'LClot2']]
+        (picking_1 | picking_2).move_ids.picked = True
+        (picking_1 | picking_2).button_validate()
+
+        og_layer = picking_2.move_ids.stock_valuation_layer_ids | picking_1.move_ids.stock_valuation_layer_ids
+        lc_form = Form(self.env['stock.landed.cost'])
+        lc_form.picking_ids = (picking_1 | picking_2)
+        with lc_form.cost_lines.new() as cost_line:
+            cost_line.product_id = self.productlc1
+            cost_line.price_unit = 6
+        lc = lc_form.save()
+        lc.compute_landed_cost()
+        lc.button_validate()
+        for valuation in lc.valuation_adjustment_lines:
+            if valuation.cost_line_id.name == 'equal split':
+                self.assertEqual(valuation.additional_landed_cost, 5)
+
+        # I check that the landed cost is now "Closed" and that it has an accounting entry
+        self.assertEqual(lc.state, "done")
+        self.assertTrue(lc.account_move_id)
+        self.assertEqual(len(lc.account_move_id.line_ids), 4)
+
+        lc_value = sum(lc.account_move_id.line_ids.filtered(lambda aml: aml.account_id.name.startswith('Expenses')).mapped('debit'))
+        product_value = abs(self.productlc1.value_svl)
+        self.assertEqual(lc_value, product_value)
+        lot = self.env['stock.lot'].search([('name', 'ilike', 'LClot')])
+
+        self.assertRecordValues(lc.stock_valuation_layer_ids.sorted('id'), [
+            {'lot_id': lot[0].id, 'product_id': self.product1.id, 'stock_valuation_layer_id': og_layer[0].id, 'quantity': 0, 'value': 1.5},
+            {'lot_id': lot[1].id, 'product_id': self.product1.id, 'stock_valuation_layer_id': og_layer[1].id, 'quantity': 0, 'value': 1.5},
+            {'lot_id': lot[0].id, 'product_id': self.product1.id, 'stock_valuation_layer_id': og_layer[2].id, 'quantity': 0, 'value': 1},
+            {'lot_id': lot[1].id, 'product_id': self.product1.id, 'stock_valuation_layer_id': og_layer[3].id, 'quantity': 0, 'value': 1},
+            {'lot_id': lot[2].id, 'product_id': self.product1.id, 'stock_valuation_layer_id': og_layer[4].id, 'quantity': 0, 'value': 1},
+        ])
+
+        for l, price in zip(lot, [10.75, 10.75, 10.2]):
+            self.assertEqual(l.standard_price, price)
+        outs = self._make_out_move(self.product1, 9, lot_ids=[lot[0], lot[1], lot[2]])
+        self.assertRecordValues(outs.stock_valuation_layer_ids.sorted('id'), [
+            {'lot_id': lot[0].id, 'product_id': self.product1.id, 'quantity': -3, 'value': -32.25},
+            {'lot_id': lot[1].id, 'product_id': self.product1.id, 'quantity': -3, 'value': -32.25},
+            {'lot_id': lot[2].id, 'product_id': self.product1.id, 'quantity': -3, 'value': -30.6},
+        ])

--- a/addons/stock_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/stock_landed_costs/views/stock_landed_cost_views.xml
@@ -18,7 +18,7 @@
                         <div class="oe_button_box" name="button_box">
                             <button type="object"
                                 name="action_view_stock_valuation_layers"
-                                class="oe_stat_button" icon="fa-dollar" groups="stock.group_stock_manager"
+                                class="oe_stat_button" icon="fa-dollar" groups="account.group_account_invoice"
                                 invisible="state != 'done' or not stock_valuation_layer_ids">
                                 <div class="o_stat_info">
                                     <span class="o_stat_text">Valuation</span>


### PR DESCRIPTION
Ability to track valuation by lot or serial numbers. This is an optional setting on each product. The valuation layers will be linked to a stock.lot record. A stock move may generate multiple valuation layers if constituted of different lots among their stock move line.

Task : 3079384

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
