### PR TITLE
[IMP] account: add reco models to generate invoice/bill

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -50,19 +50,32 @@ class AccountReconcileModelLine(models.Model):
     company_id = fields.Many2one(related='model_id.company_id', store=True)
     sequence = fields.Integer(required=True, default=10)
     account_id = fields.Many2one('account.account', string='Account', ondelete='cascade',
-        domain="[('deprecated', '=', False), ('account_type', '!=', 'off_balance')]",
-        required=True, check_company=True)
+        domain="[('deprecated', '=', False), ('account_type', '!=', 'off_balance')]", check_company=True)
 
     # This field is ignored in a bank statement reconciliation.
-    journal_id = fields.Many2one('account.journal', string='Journal', ondelete='cascade',
-        domain="[('type', '=', 'general')]", check_company=True)
+    journal_id = fields.Many2one(
+        comodel_name='account.journal',
+        string="Journal",
+        ondelete='cascade',
+        check_company=True,
+        store=True,
+        readonly=False,
+        compute='_compute_journal_id',
+    )
     label = fields.Char(string='Journal Item Label', translate=True)
-    amount_type = fields.Selection([
-        ('fixed', 'Fixed'),
-        ('percentage', 'Percentage of balance'),
-        ('percentage_st_line', 'Percentage of statement line'),
-        ('regex', 'From label'),
-    ], required=True, default='percentage')
+    amount_type = fields.Selection(
+        selection=[
+            ('fixed', 'Fixed'),
+            ('percentage', 'Percentage of balance'),
+            ('percentage_st_line', 'Percentage of statement line'),
+            ('regex', 'From label'),
+        ],
+        required=True,
+        store=True,
+        precompute=True,
+        compute='_compute_amount_type',
+        readonly=False,
+    )
 
     # used to show the force tax included button'
     show_force_tax_included = fields.Boolean(compute='_compute_show_force_tax_included')
@@ -73,7 +86,15 @@ class AccountReconcileModelLine(models.Model):
     * Percentage: Percentage of the balance, between 0 and 100.
     * Fixed: The fixed value of the writeoff. The amount will count as a debit if it is negative, as a credit if it is positive.
     * From Label: There is no need for regex delimiter, only the regex is needed. For instance if you want to extract the amount from\nR:9672938 10/07 AX 9415126318 T:5L:NA BRT: 3358,07 C:\nYou could enter\nBRT: ([\\d,]+)""")
-    tax_ids = fields.Many2many('account.tax', string='Taxes', ondelete='restrict', check_company=True)
+    tax_ids = fields.Many2many(
+        comodel_name='account.tax',
+        string="Taxes",
+        ondelete='restrict',
+        check_company=True,
+        compute='_compute_tax_ids',
+        readonly=False,
+        store=True,
+    )
 
     @api.onchange('tax_ids')
     def _onchange_tax_ids(self):
@@ -102,6 +123,37 @@ class AccountReconcileModelLine(models.Model):
                 record.amount = float(record.amount_string)
             except ValueError:
                 record.amount = 0
+
+    @api.depends('rule_type', 'model_id.counterpart_type')
+    def _compute_amount_type(self):
+        for line in self:
+            if line.rule_type == 'writeoff_button' and line.model_id.counterpart_type in ('sale', 'purchase'):
+                line.amount_type = line.amount_type or 'percentage_st_line'
+            else:
+                line.amount_type = line.amount_type or 'percentage'
+
+    @api.depends('model_id.counterpart_type')
+    def _compute_journal_id(self):
+        for line in self:
+            if line.journal_id.type != line.model_id.counterpart_type:
+                line.journal_id = None
+            else:
+                line.journal_id = line.journal_id
+
+    @api.depends('model_id.counterpart_type', 'rule_type', 'account_id', 'company_id', 'company_id.account_purchase_tax_id')
+    def _compute_tax_ids(self):
+        for line in self:
+            if line.rule_type == 'writeoff_button' and line.model_id.counterpart_type in ('sale', 'purchase'):
+                line.tax_ids = line.tax_ids.filtered(lambda x: x.type_tax_use == line.model_id.counterpart_type)
+                if not line.tax_ids:
+                    line.tax_ids = line.account_id.tax_ids.filtered(lambda x: x.type_tax_use == line.model_id.counterpart_type)
+                if not line.tax_ids:
+                    if line.model_id.counterpart_type == 'purchase' and line.company_id.account_purchase_tax_id:
+                        line.tax_ids = line.company_id.account_purchase_tax_id
+                    elif line.model_id.counterpart_type == 'sale' and line.company_id.account_sale_tax_id:
+                        line.tax_ids = line.company_id.account_sale_tax_id
+            else:
+                line.tax_ids = line.tax_ids
 
     @api.constrains('amount_string')
     def _validate_amount(self):
@@ -152,6 +204,15 @@ class AccountReconcileModel(models.Model):
         required=True,
         default='old_first',
         tracking=True,
+    )
+    counterpart_type = fields.Selection(
+        selection=[
+            ('general', 'Journal Entry'),
+            ('sale', 'Customer Invoices'),
+            ('purchase', 'Vendor Bills'),
+        ],
+        string="Counterpart Type",
+        default='general',
     )
 
     # ===== Conditions =====

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -1033,7 +1033,19 @@ class AccountChartTemplate(models.AbstractModel):
                 "match_same_currency": True,
                 "allow_payment_tolerance": False,
                 "match_partner": True,
-            }
+            },
+            "reconcile_bill": {
+                "name": 'Create Bill',
+                "sequence": 5,
+                "rule_type": 'writeoff_button',
+                'counterpart_type': 'purchase',
+                'line_ids': [
+                    Command.create({
+                        'amount_type': 'percentage_st_line',
+                        'amount_string': '100',
+                    }),
+                ],
+            },
         }
 
     # --------------------------------------------------------------------------------

--- a/addons/account/views/account_reconcile_model_views.xml
+++ b/addons/account/views/account_reconcile_model_views.xml
@@ -84,6 +84,9 @@
                                 <field name="to_check" invisible="rule_type != 'writeoff_button'"/>
                                 <field name="past_months_limit" invisible="rule_type != 'invoice_matching'"/>
                                 <field name="matching_order" invisible="rule_type != 'invoice_matching'"/>
+                                <field name="counterpart_type"
+                                       required="rule_type == 'writeoff_button'"
+                                       invisible="rule_type != 'writeoff_button'"/>
                             </group>
                         </group>
                         <notebook>
@@ -168,7 +171,7 @@
                                                invisible="not match_partner or rule_type == 'writeoff_button'"/>
                                     </group>
                                 </group>
-                                <group string="Counterpart Entries" colespan="4"
+                                <group string="Counterpart Items" colespan="4"
                                        class="oe_inline"
                                        invisible="rule_type == 'invoice_matching' and (not allow_payment_tolerance or allow_payment_tolerance and payment_tolerance_param == 0.0)">
                                     <group>
@@ -186,21 +189,25 @@
 
                                             <field name="sequence"
                                                    widget="handle"/>
-                                            <field name="account_id"/>
+                                            <field name="account_id"
+                                                   required="(parent.counterpart_type == 'general' and parent.rule_type == 'writeoff_button') or parent.rule_type == 'writeoff_suggestion'"/>
                                             <field name="amount_type"/>
                                             <field name="journal_id"
                                                    column_invisible="parent.rule_type != 'writeoff_button'"
-                                                   optional="hide"/>
+                                                   optional="hide"
+                                                   domain="[('type', '=', parent.counterpart_type)]"/>
                                             <field name="amount_string"/>
                                             <field name="tax_ids"
                                                    widget="many2many_tags"
-                                                   optional="hide"/>
+                                                   optional="hide"
+                                                   domain="[('type_tax_use', '=?', parent.counterpart_type if parent.counterpart_type in ('sale', 'purchase') and rule_type == 'writeoff_button' else None)]"/>
                                             <field name="analytic_distribution" widget="analytic_distribution"
                                                    groups="analytic.group_analytic_accounting"
                                                    options="{'account_field': 'account_id', 'business_domain': 'general'}"/>
                                             <field name="force_tax_included"
                                                    widget="boolean_toggle"
                                                    invisible="not show_force_tax_included"
+                                                   column_invisible="parent.rule_type == 'writeoff_button' and parent.counterpart_type != 'general'"
                                                    optional="hide"/>
                                             <field name="label"/>
                                         </tree>

--- a/addons/l10n_be/models/template_be.py
+++ b/addons/l10n_be/models/template_be.py
@@ -79,25 +79,6 @@ class AccountChartTemplate(models.AbstractModel):
                 'name@nl': 'Bankkosten (Geen BTW)',
                 'name@de': 'Bankgebühren (Ohne MwSt.)',
             },
-            'frais_bancaires_tva21_template': {
-                'name': 'Bank Fees (21% VAT)',
-                'line_ids': [
-                    Command.create({
-                        'account_id': 'a6560',
-                        'amount_type': 'percentage',
-                        'tax_ids': [
-                            Command.set([
-                                'attn_TVA-21-inclus-dans-prix',
-                            ]),
-                        ],
-                        'amount_string': '100',
-                        'label': 'Bank Fees (21% VAT)',
-                    }),
-                ],
-                'name@fr': 'Frais bancaires (21% TVA)',
-                'name@nl': 'Bankkosten (21% BTW)',
-                'name@de': 'Bankgebühren (21 % MwSt.)',
-            },
             'virements_internes_template': {
                 'name': 'Internal Transfers',
                 'to_check': False,


### PR DESCRIPTION
As of now, it is not possible to create a commercial move directly from the bank reconciliation widget. This commit aims to facilitate the workflow to create invoices or bills and reconcile them with existing bank statement lines.

Before this commit, if the user has a bank statement line for a unregistered commercial event, they have to:
1. Make a note of the amount, date and potentially a label
2. Navigate to Customers/Vendors > Invoices/Credit Notes/Bills/Refunds > New
3. Go back to the reconciliation widget (no breadcrumbs available)

After this commit, the user will be able to create a move through a button in the bank reconciliation widget. The move is pre-filled with relevant information, such as amount, date and partner (if available). The user can return to the bank reconciliation widget through the breadcrumbs, and proceed to validate the created and added move.

This commit:
- Changes writeoff button reconciliation type to include different counterpart types: journal entries, invoices and bills.
- Adds two default reconciliation models: Create Invoice and Create Bill.

task-3768742

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
