### PR TITLE
[FIX] purchase_stock: merge POs more often

### DIFF
--- a/addons/purchase_stock/models/stock_rule.py
+++ b/addons/purchase_stock/models/stock_rule.py
@@ -94,8 +94,11 @@ class StockRule(models.Model):
 
             # Get the set of procurement origin for the current domain.
             origins = set([p.origin for p in procurements])
-            # Check if a PO exists for the current domain.
-            po = self.env['purchase.order'].sudo().search([dom for dom in domain], limit=1)
+            # Check if a PO exists for the current domain or if a merge-able one exists (equal without respect group_id)
+            po = (
+                    self.env['purchase.order'].sudo().search(list(domain), limit=1) or
+                    self.env['purchase.order'].sudo().search([dom for dom in domain if dom[0] != 'group_id'], limit=1)
+            )
             company_id = procurements[0].company_id
             if not po:
                 positive_values = [p.values for p in procurements if float_compare(p.product_qty, 0.0, precision_rounding=p.product_uom.rounding) >= 0]


### PR DESCRIPTION
**Current behavior:**
Creating an RFQ for multiple products which have the same vendor for their BOM components which have the `Dropship Subcontractor on Order` will not bundle the orders together.

**Expected behavior:**
Purchase lines which come from the same vendor and are shipped to the same subcontractor will bundle into the same order.

**Steps to reproduce:**
1. Create two products which are subcontracted by the same subcontractor

2. Create a BOM for the first product which is comprised of Component-1 and Component-2; create a BOM for the second product which is comprised of Component-2 and Component-3

3. Ensure all the components have the Dropship subcontractor route and all come from the same vendor

4. Create a purchase order for product-1 and product-2 and confirm, observe the multiple purchase orders created

**Cause of the issue:**
The procurements leading to the creation of the orders have different group_ids which prevents them from bundling.

**Fix:**
Look for a bundle-able order without respect to the group_id.

opw-3725714