### PR TITLE
[IMP] sql_db: execute and fetch in one operation

### DIFF
--- a/odoo/addons/base/tests/test_db_cursor.py
+++ b/odoo/addons/base/tests/test_db_cursor.py
@@ -62,6 +62,11 @@ class TestRealCursor(BaseCase):
             self.assertEqual(cr.fetchone(), ('on',))
             self.assertTrue(cr._cnx.readonly)
 
+    def test_fetchexecute(self):
+        with registry().cursor() as cr:
+            self.assertEqual(cr.fetchall('SELECT 1'), [(1,)])
+            self.assertEqual(cr.fetchall('SELECT %s', [42]), [(42,)])
+
 
 class TestHTTPCursor(HttpCase):
     def test_cursor_keeps_readwriteness(self):

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -301,8 +301,13 @@ class Cursor(BaseCursor):
     def dictfetchmany(self, size):
         return [self.__build_dict(row) for row in self._obj.fetchmany(size)]
 
-    def dictfetchall(self):
-        return [self.__build_dict(row) for row in self._obj.fetchall()]
+    def dictfetchall(self, query=None, params=None, log_exceptions=True):
+        return [self.__build_dict(row) for row in self.fetchall(query, params, log_exceptions)]
+
+    def fetchall(self, query=None, params=None, log_exceptions=True):
+        if query:
+            self.execute(query, params, log_exceptions)
+        return self._obj.fetchall()
 
     def __del__(self):
         if not self._closed and not self._cnx.closed:


### PR DESCRIPTION
Allow to do 2 operations in one go.
This syntactic sugar can help in multiple ways:
* ensure that we fetch the query that we actually want by making it more atomic and avoiding another query being run by the ORM in between the execute and the fetch
* allow inlining conditional queries, like the following

```python
result = cr.fetchall("""
    SELECT name FROM res_user WHERE id IN %s
""", [tuple(self.ids)]) if self.ids else []
```

Instead of
```python
result = []
if self.ids:
    cr.execute("""
        SELECT name FROM res_user WHERE id IN %s
    """, [tuple(self.ids)])
    result = cr.fetchall()
```
