### PR TITLE
[FIX] mrp: fix bom with product_qty different from 1

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -403,7 +403,7 @@ class MrpBom(models.Model):
                 # We round up here because the user expects that if he has to consume a little more, the whole UOM unit
                 # should be consumed.
                 rounding = current_line.product_uom_id.rounding
-                line_quantity = float_round(line_quantity, precision_rounding=rounding, rounding_method='UP')
+                line_quantity = float_round(line_quantity / self.product_qty, precision_rounding=rounding, rounding_method='UP')
                 lines_done.append((current_line, {'qty': line_quantity, 'product': current_product, 'original_qty': quantity, 'parent_line': parent_line}))
 
         return boms_done, lines_done

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1154,7 +1154,7 @@ class MrpProduction(models.Model):
         for production in self:
             if not production.bom_id:
                 continue
-            factor = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id) / production.bom_id.product_qty
+            factor = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
             boms, lines = production.bom_id.explode(production.product_id, factor, picking_type=production.bom_id.picking_type_id)
             for bom_line, line_data in lines:
                 if bom_line.child_bom_id and bom_line.child_bom_id.type == 'phantom' or\

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -252,11 +252,11 @@ class ProductProduct(models.Model):
                 ratios_free_qty.append(component_res["free_qty"] / qty_per_kit)
             if bom_sub_lines and ratios_virtual_available:  # Guard against all cnsumable bom: at least one ratio should be present.
                 res[product.id] = {
-                    'virtual_available': min(ratios_virtual_available) * bom_kits[product].product_qty // 1,
-                    'qty_available': min(ratios_qty_available) * bom_kits[product].product_qty // 1,
-                    'incoming_qty': min(ratios_incoming_qty) * bom_kits[product].product_qty // 1,
-                    'outgoing_qty': min(ratios_outgoing_qty) * bom_kits[product].product_qty // 1,
-                    'free_qty': min(ratios_free_qty) * bom_kits[product].product_qty // 1,
+                    'virtual_available': min(ratios_virtual_available) // 1,
+                    'qty_available': min(ratios_qty_available) // 1,
+                    'incoming_qty': min(ratios_incoming_qty) // 1,
+                    'outgoing_qty': min(ratios_outgoing_qty) // 1,
+                    'free_qty': min(ratios_free_qty) // 1,
                 }
             else:
                 res[product.id] = {

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -378,9 +378,9 @@ class StockMove(models.Model):
                 moves_ids_to_return.add(move.id)
                 continue
             if float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding):
-                factor = move.product_uom._compute_quantity(move.quantity, bom.product_uom_id) / bom.product_qty
+                factor = move.product_uom._compute_quantity(move.quantity, bom.product_uom_id)
             else:
-                factor = move.product_uom._compute_quantity(move.product_uom_qty, bom.product_uom_id) / bom.product_qty
+                factor = move.product_uom._compute_quantity(move.product_uom_qty, bom.product_uom_id)
             boms, lines = bom.sudo().explode(move.product_id, factor, picking_type=bom.picking_type_id)
             for bom_line, line_data in lines:
                 if float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding) or self.env.context.get('is_scrap'):

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -258,7 +258,7 @@ class ProcurementGroup(models.Model):
             bom_kit = kits_by_company[procurement.company_id].get(procurement.product_id)
             if bom_kit:
                 order_qty = procurement.product_uom._compute_quantity(procurement.product_qty, bom_kit.product_uom_id, round=False)
-                qty_to_produce = (order_qty / bom_kit.product_qty)
+                qty_to_produce = order_qty
                 boms, bom_sub_lines = bom_kit.explode(procurement.product_id, qty_to_produce)
                 for bom_line, bom_line_data in bom_sub_lines:
                     bom_line_uom = bom_line.product_uom_id

--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -36,6 +36,6 @@ class AccountMoveLine(models.Model):
                     prod_qty_to_invoice = factor * qty_to_invoice
                     product = product.with_company(self.company_id)
                     average_price_unit += factor * product._compute_average_price(prod_qty_invoiced, prod_qty_to_invoice, prod_moves, is_returned=is_line_reversing)
-                price_unit = average_price_unit / bom.product_qty or price_unit
+                price_unit = average_price_unit or price_unit
                 price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom_id)
         return price_unit

--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -124,7 +124,7 @@ class SaleOrderLine(models.Model):
                 'incoming_moves': lambda m: m.location_dest_id.usage == 'customer' and (not m.origin_returned_move_id or (m.origin_returned_move_id and m.to_refund)),
                 'outgoing_moves': lambda m: m.location_dest_id.usage != 'customer' and m.to_refund
             }
-            order_qty = previous_product_uom_qty.get(self.id, 0) if previous_product_uom_qty else self.product_uom_qty
+            order_qty = self.product_uom_qty - previous_product_uom_qty.get(self.id, 0) if previous_product_uom_qty else self.product_uom_qty
             order_qty = self.product_uom._compute_quantity(order_qty, bom.product_uom_id)
             qty = moves._compute_kit_quantities(self.product_id, order_qty, bom, filters)
             return bom.product_uom_id._compute_quantity(qty, self.product_uom)

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -107,9 +107,9 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
         self.assertEqual(len(amls), 4)
         stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertAlmostEqual(stock_out_aml.credit, 1.53, "Should not include the value of consumable component")
+        self.assertAlmostEqual(stock_out_aml.credit, 1.58, msg="Should not include the value of consumable component")
         cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertAlmostEqual(cogs_aml.debit, 1.53, "Should not include the value of consumable component")
+        self.assertAlmostEqual(cogs_aml.debit, 1.58, msg="Should not include the value of consumable component")
         self.assertEqual(cogs_aml.credit, 0)
 
     def test_sale_mrp_anglo_saxon_variant(self):


### PR DESCRIPTION
wrong usage of bom product_qty, leading to bad stock move quantities when changing quantity of sale orders.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
