### PR TITLE
[IMP] account_edi_ubl_cii: use endpoint and EAS to retrieve partner

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_common.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_common.py
@@ -349,10 +349,10 @@ class AccountEdiCommon(models.AbstractModel):
 
         return True
 
-    def _import_retrieve_and_fill_partner(self, invoice, name, phone, mail, vat, country_code=False):
+    def _import_retrieve_and_fill_partner(self, invoice, name, phone, mail, vat, country_code=False, domain=False):
         """ Retrieve the partner, if no matching partner is found, create it (only if he has a vat and a name)
         """
-        invoice.partner_id = self.env['res.partner']._retrieve_partner(name=name, phone=phone, mail=mail, vat=vat)
+        invoice.partner_id = self.env['res.partner']._retrieve_partner(name=name, phone=phone, mail=mail, vat=vat, domain=domain)
         if not invoice.partner_id and name and vat:
             partner_vals = {'name': name, 'email': mail, 'phone': phone}
             country = self.env.ref(f'base.{country_code.lower()}', raise_if_not_found=False) if country_code else False

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -591,6 +591,16 @@ class AccountEdiXmlUBL20(models.AbstractModel):
     # IMPORT
     # -------------------------------------------------------------------------
 
+    def _import_retrieve_partner_vals(self, tree, role):
+        """ Returns a dict of values that will be used to retrieve the partner """
+        return {
+            'vat': self._find_value(f'//cac:Accounting{role}Party/cac:Party//cbc:CompanyID[string-length(text()) > 5]', tree),
+            'phone': self._find_value(f'//cac:Accounting{role}Party/cac:Party//cbc:Telephone', tree),
+            'mail': self._find_value(f'//cac:Accounting{role}Party/cac:Party//cbc:ElectronicMail', tree),
+            'name': self._find_value(f'//cac:Accounting{role}Party/cac:Party//cbc:Name', tree),
+            'country_code': self._find_value(f'//cac:Accounting{role}Party/cac:Party//cac:Country//cbc:IdentificationCode', tree),
+        }
+
     def _import_fill_invoice_form(self, invoice, tree, qty_factor):
         logs = []
 
@@ -600,12 +610,7 @@ class AccountEdiXmlUBL20(models.AbstractModel):
         # ==== partner_id ====
 
         role = "Customer" if invoice.journal_id.type == 'sale' else "Supplier"
-        vat = self._find_value(f'//cac:Accounting{role}Party/cac:Party//cbc:CompanyID[string-length(text()) > 5]', tree)
-        phone = self._find_value(f'//cac:Accounting{role}Party/cac:Party//cbc:Telephone', tree)
-        mail = self._find_value(f'//cac:Accounting{role}Party/cac:Party//cbc:ElectronicMail', tree)
-        name = self._find_value(f'//cac:Accounting{role}Party/cac:Party//cbc:Name', tree)
-        country_code = self._find_value(f'//cac:Accounting{role}Party/cac:Party//cac:Country//cbc:IdentificationCode', tree)
-        self._import_retrieve_and_fill_partner(invoice, name=name, phone=phone, mail=mail, vat=vat, country_code=country_code)
+        self._import_retrieve_and_fill_partner(invoice, **self._import_retrieve_partner_vals(tree, role))
 
         # ==== currency_id ====
 

--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -426,3 +426,16 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
                 ) if not mva.is_valid(vat) or len(vat) != 14 or vat[:2] != 'NO' or vat[-3:] != 'MVA' else "",
             })
         return constraints
+
+    def _import_retrieve_partner_vals(self, tree, role):
+        # EXTENDS account.edi.xml.ubl_20
+        partner_vals = super()._import_retrieve_partner_vals(tree, role)
+        nsmap = {k: v for k, v in tree.nsmap.items() if k is not None}
+        endpoint_node = tree.find(f'.//cac:Accounting{role}Party/cac:Party/cbc:EndpointID', nsmap)
+        if endpoint_node is not None:
+            peppol_eas = endpoint_node.attrib.get('schemeID')
+            peppol_endpoint = endpoint_node.text
+            if peppol_eas and peppol_endpoint:
+                # include the EAS and endpoint in the search domain when retrieving the partner
+                partner_vals['domain'] = [('peppol_eas', '=', peppol_eas), ('peppol_endpoint', '=', peppol_endpoint)]
+        return partner_vals

--- a/addons/account_edi_ubl_cii/models/account_move.py
+++ b/addons/account_edi_ubl_cii/models/account_move.py
@@ -26,12 +26,6 @@ class AccountMove(models.Model):
         customization_id = tree.find('{*}CustomizationID')
         if tree.tag == '{urn:un:unece:uncefact:data:standard:CrossIndustryInvoice:100}CrossIndustryInvoice':
             return self.env['account.edi.xml.cii']
-        ubl_version = tree.find('{*}UBLVersionID')
-        if ubl_version is not None:
-            if ubl_version.text == '2.0':
-                return self.env['account.edi.xml.ubl_20']
-            if ubl_version.text in ('2.1', '2.2', '2.3'):
-                return self.env['account.edi.xml.ubl_21']
         if customization_id is not None:
             if 'xrechnung' in customization_id.text:
                 return self.env['account.edi.xml.ubl_de']
@@ -43,6 +37,12 @@ class AccountMove(models.Model):
                 return self.env['account.edi.xml.ubl_sg']
             if 'urn:cen.eu:en16931:2017' in customization_id.text:
                 return self.env['account.edi.xml.ubl_bis3']
+        ubl_version = tree.find('{*}UBLVersionID')
+        if ubl_version is not None:
+            if ubl_version.text == '2.0':
+                return self.env['account.edi.xml.ubl_20']
+            if ubl_version.text in ('2.1', '2.2', '2.3'):
+                return self.env['account.edi.xml.ubl_21']
 
     def _get_edi_decoder(self, file_data, new=False):
         # EXTENDS 'account'


### PR DESCRIPTION
When importing an xml inheriting from EN16931 (Peppol Bis 3, A-NZ, E-FFF, NLCIUS, etc), use the peppol endpoint and eas to retrieve the correct partner, by passing a search domain to `_retrieve_partner` (through the `domain` argument).

Hence, when retrieving the partner (using `_retrieve_partner`), we will sequentially:

1. search for a partner with a matching VAT

2. if there's a domain provided, search a partner matching the domain

3. search for a partner with a matching phone or email

4. search for a partner with a matching name

If not partner is found, we create a new one.

opw-3815296
