### PR TITLE
[FIX] utm: correct write method

### DIFF
--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -458,12 +458,15 @@ class TestMassMailValues(MassMailCommon):
         self.assertEqual(mailing_6.name, 'Second subject (Mass Mailing created on 2022-01-02)')
 
         mailing_0.subject = 'First subject'
-        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02) [4]',
+        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)',
             msg='The name must have been re-generated')
 
-        mailing_0.name = 'Second subject (Mass Mailing created on 2022-01-02)'
+        mailing_0.name = 'Second subject (Mass Mailing created on 2022-01-02) [2]'
         self.assertEqual(mailing_0.name, 'Second subject (Mass Mailing created on 2022-01-02) [2]',
             msg='The name must be unique')
+
+        mailing_0.subject = 'First subject'
+        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02) [4]')
 
 
 @tagged('mass_mailing')

--- a/addons/utm/i18n/utm.pot
+++ b/addons/utm/i18n/utm.pot
@@ -366,6 +366,13 @@ msgid "Mediums"
 msgstr ""
 
 #. module: utm
+#. odoo-python
+#: code:addons/utm/models/utm_source.py:0
+#, python-format
+msgid "Multiple records with the same name. The name should be unique!"
+msgstr ""
+
+#. module: utm
 #: model:ir.model.fields,field_description:utm.field_utm_source_mixin__name
 #: model:ir.model.fields,field_description:utm.field_utm_stage__name
 #: model:ir.model.fields,field_description:utm.field_utm_tag__name

--- a/addons/utm/models/utm_mixin.py
+++ b/addons/utm/models/utm_mixin.py
@@ -73,6 +73,22 @@ class UtmMixin(models.AbstractModel):
 
         return record
 
+    @staticmethod
+    def _split_name_and_count(name):
+        """
+        Return the name part and the counter based on the given name.
+
+        e.g.
+            "Medium" -> "Medium", 1
+            "Medium [1234]" -> "Medium", 1234
+        """
+        name = name or ''
+        name_counter_re = r'(.*)\s+\[([0-9]+)\]'
+        match = re.match(name_counter_re, name)
+        if match:
+            return match.group(1), int(match.group(2) or '1')
+        return name, 1
+
     @api.model
     def _get_unique_names(self, model_name, names):
         """Generate unique names for the given model.
@@ -89,23 +105,9 @@ class UtmMixin(models.AbstractModel):
         :param names: list of names, we will ensure that each name will be unique
         :return: a list of new values for each name, in the same order
         """
-        def _split_name_and_count(name):
-            """
-            Return the name part and the counter based on the given name.
-
-            e.g.
-                "Medium" -> "Medium", 1
-                "Medium [1234]" -> "Medium", 1234
-            """
-            name = name or ''
-            name_counter_re = r'(.*)\s+\[([0-9]+)\]'
-            match = re.match(name_counter_re, name)
-            if match:
-                return match.group(1), int(match.group(2) or '1')
-            return name, 1
 
         # Remove potential counter part in each names
-        names_without_counter = {_split_name_and_count(name)[0] for name in names}
+        names_without_counter = {self._split_name_and_count(name)[0] for name in names}
 
         # Retrieve existing similar names
         seach_domain = expression.OR([[('name', 'ilike', name)] for name in names_without_counter])
@@ -116,7 +118,7 @@ class UtmMixin(models.AbstractModel):
         count_per_names = defaultdict(lambda: 0)
         count_per_names.update({
             name: max((
-                _split_name_and_count(existing_name)[1] + 1
+                self._split_name_and_count(existing_name)[1] + 1
                 for existing_name in existing_names
                 if existing_name == name or existing_name.startswith(f'{name} [')
             ), default=1)
@@ -129,7 +131,7 @@ class UtmMixin(models.AbstractModel):
                 result.append(False)
                 continue
 
-            name_without_counter = _split_name_and_count(name)[0]
+            name_without_counter = self._split_name_and_count(name)[0]
             counter = count_per_names[name_without_counter]
             result.append(f'{name_without_counter} [{counter}]' if counter > 1 else name)
             count_per_names[name_without_counter] += 1


### PR DESCRIPTION
When update happens on record and updating value is the same as already
assigned value, [2] gets appended to the value, because write function
doesn't take into account the written value.

task-3837272

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
