### PR TITLE
wip, fix1: make sure qty_to_order is computed after qty_forecast

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -253,6 +253,7 @@ class StockWarehouseOrderpoint(models.Model):
             for orderpoint in orderpoints_by_context:
                 orderpoint.qty_on_hand = products_qty[orderpoint.product_id.id]['qty_available']
                 orderpoint.qty_forecast = products_qty[orderpoint.product_id.id]['virtual_available'] + products_qty_in_progress[orderpoint.id]
+        orderpoints_by_context._compute_qty_to_order()
 
     @api.depends('qty_multiple', 'qty_forecast', 'product_min_qty', 'product_max_qty')
     def _compute_qty_to_order(self):


### PR DESCRIPTION
# BUG

https://github.com/odoo/odoo/assets/33809926/440b79e7-0380-4cfd-8e7b-7e89cd8fbbdc



# Fixes

## fix A
`to_refill` [here](https://github.com/odoo/odoo/blob/83c6ab495995254dbe1806580efe5c99fb1c7633/addons/stock/models/stock_orderpoint.py#L421) doesn't include location, (and I can't grab add it easily because `stock.warehouse.orderpoint` doesn't have it)
should we include location in the `to_refill` somehow ? That would fix the issue at its source

## fix B
later on 2 computes are triggered:
1st is `_compute_qty_to_order` which uses already wrong `qty_forecast` and displays it
2nd is `_compute_qty` which sets correct `qty_forecast`
Question here is if we can set the order of the compute functions, because if only order was revered, it would all worked okay.

## fix I applied
Recalculate `_compute_qty` after `qty_forecast` with additional trigger of the compute
`_compute_qty_to_order()`


