### PR TITLE
[FIX] web: fix gradient colorpicker traceback

### DIFF
--- a/addons/web/static/src/core/colorpicker/colorpicker.js
+++ b/addons/web/static/src/core/colorpicker/colorpicker.js
@@ -85,6 +85,9 @@ export class Colorpicker extends Component {
             this.start();
         });
         onWillUpdateProps((newProps) => {
+            if (!this.el) {
+                return;
+            }
             if (newProps.selectedColor) {
                 this.setSelectedColor(newProps.selectedColor);
             }


### PR DESCRIPTION
Issue:
======
traceback when clicking on gradient colorpicker in mass_mailing

Steps to reproduce the issue:
=============================
- Got to email marketing
- Add some text
- Select the text and go to graadient and activate custom
- click any color in the colorpalette -> traceback

Origin of the issue:
====================
There are some colorpickers being created but never gets assigned a valid `el` so the promise in `onMounted` is never resolved, when we click on a color , `onWillUpdateProps` will be triggered which uses `el` inside.

task-3834112