### PR TITLE
[IMP] pricelist: pricelist revamp

### DIFF
--- a/addons/delivery/tests/test_delivery_cost.py
+++ b/addons/delivery/tests/test_delivery_cost.py
@@ -150,7 +150,6 @@ class TestDeliveryCost(DeliveryCommon, SaleCommon):
                 'applied_on': '0_product_variant',
                 'product_id': self.normal_delivery.product_id.id,
             })],
-            'discount_policy': 'without_discount',
         })
 
         # Create sales order with Normal Delivery Charges

--- a/addons/event_booth_sale/models/sale_order_line.py
+++ b/addons/event_booth_sale/models/sale_order_line.py
@@ -109,8 +109,7 @@ class SaleOrderLine(models.Model):
     def _get_display_price(self):
         if self.event_booth_pending_ids and self.event_id:
             company = self.event_id.company_id or self.env.company
-            pricelist = self.order_id.pricelist_id
-            if pricelist.discount_policy == "with_discount":
+            if not self.pricelist_item_id._is_percentage():
                 event_booths = self.event_booth_pending_ids.with_context(**self._get_pricelist_price_context())
                 total_price = sum(booth.booth_category_id.price_reduce for booth in event_booths)
             else:

--- a/addons/event_booth_sale/tests/common.py
+++ b/addons/event_booth_sale/tests/common.py
@@ -37,7 +37,6 @@ class TestEventBoothSaleCommon(TestEventBoothCommon):
         })
         cls.test_pricelist_with_discount_included = cls.env['product.pricelist'].sudo().create({
             'name': 'Test Pricelist',
-            'discount_policy': 'with_discount',
             'item_ids': [
                 Command.create({
                     'compute_price': 'percentage',

--- a/addons/event_sale/models/sale_order_line.py
+++ b/addons/event_sale/models/sale_order_line.py
@@ -99,8 +99,7 @@ class SaleOrderLine(models.Model):
         if self.event_ticket_id and self.event_id:
             event_ticket = self.event_ticket_id
             company = event_ticket.company_id or self.env.company
-            pricelist = self.order_id.pricelist_id
-            if pricelist.discount_policy == "with_discount":
+            if not self.pricelist_item_id._is_percentage():
                 price = event_ticket.with_context(**self._get_pricelist_price_context()).price_reduce
             else:
                 price = event_ticket.price

--- a/addons/event_sale/tests/test_event_sale.py
+++ b/addons/event_sale/tests/test_event_sale.py
@@ -470,8 +470,6 @@ class TestEventSale(TestEventSaleCommon):
             'product_tmpl_id': event_product.id,
         })
 
-        pricelist.discount_policy = 'without_discount'
-
         so = self.env['sale.order'].create({
             'partner_id': self.env.user.partner_id.id,
             'pricelist_id': pricelist.id,

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -231,7 +231,11 @@ class PosOrder(models.Model):
             line = line_values['record']
             invoice_lines_values = self._get_invoice_lines_values(line_values, line)
             invoice_lines.append((0, None, invoice_lines_values))
-            if line.order_id.pricelist_id.discount_policy == 'without_discount' and float_compare(line.price_unit, line.product_id.lst_price, precision_rounding=self.currency_id.rounding) < 0:
+            is_percentage = self.pricelist_id and any(
+                self.pricelist_id.item_ids.filtered(
+                    lambda rule: rule.compute_price == "percentage")
+            )
+            if is_percentage and float_compare(line.price_unit, line.product_id.lst_price, precision_rounding=self.currency_id.rounding) < 0:
                 invoice_lines.append((0, None, {
                     'name': _('Price discount from %(original_price)s to %(discounted_price)s',
                               original_price=float_repr(line.product_id.lst_price, self.currency_id.decimal_places),
@@ -1204,8 +1208,7 @@ class PosOrderLine(models.Model):
     def _load_pos_data_fields(self, config_id):
         return [
             'qty', 'attribute_value_ids', 'custom_attribute_value_ids', 'price_unit', 'skip_change', 'uuid', 'price_subtotal', 'price_subtotal_incl', 'order_id', 'note', 'price_type',
-            'product_id', 'discount', 'tax_ids', 'combo_line_id', 'pack_lot_ids', 'customer_note', 'refunded_qty', 'price_extra', 'full_product_name', 'refunded_orderline_id', 'combo_parent_id', 'combo_line_ids', 'combo_line_id', 'refund_orderline_ids'
-        ]
+            'product_id', 'discount', 'tax_ids', 'combo_line_id', 'pack_lot_ids', 'customer_note', 'refunded_qty', 'price_extra', 'full_product_name', 'refunded_orderline_id', 'combo_parent_id', 'combo_line_ids', 'combo_line_id', 'refund_orderline_ids']
 
     @api.model
     def _is_field_accepted(self, field):

--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -342,7 +342,7 @@ class ProductPricelist(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['id', 'name', 'display_name', 'discount_policy', 'item_ids']
+        return ['id', 'name', 'display_name', 'item_ids']
 
 
 class ProductPricelistItem(models.Model):

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -517,9 +517,18 @@ export class PosOrderline extends Base {
     }
 
     display_discount_policy() {
-        return this.order_id.pricelist_id
-            ? this.order_id.pricelist_id.discount_policy
-            : "with_discount";
+        // Sales dropped `discount_policy`, and we only show discount if applied pricelist rule
+        // is a percentage discount. However we don't have that information in pos
+        // so this is heuristic used to imitate the same behavior.
+        if (
+            this.order_id.pricelist_id &&
+            this.order_id.pricelist_id.item_ids
+                .map((rule) => rule.compute_price)
+                .includes("percentage")
+        ) {
+            return "without_discount";
+        }
+        return "with_discount";
     }
 
     get_lst_price() {

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -847,7 +847,6 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         pricelist = self.env['product.pricelist'].create({
             'name': 'Test Pricelist',
-            'discount_policy': 'without_discount',
         })
 
         self.main_pos_config.write({
@@ -957,28 +956,26 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         base_pricelist = self.env['product.pricelist'].create({
             'name': 'base_pricelist',
-            'discount_policy': 'without_discount',
         })
 
         self.env['product.pricelist.item'].create({
             'pricelist_id': base_pricelist.id,
             'product_tmpl_id': test_product.product_tmpl_id.id,
-            'compute_price': 'fixed',
+            'compute_price': 'percentage',
             'applied_on': '1_product',
-            'fixed_price': 7,
+            'percent_price': 30,
         })
 
         special_pricelist = self.env['product.pricelist'].create({
             'name': 'special_pricelist',
-            'discount_policy': 'without_discount',
         })
         self.env['product.pricelist.item'].create({
             'pricelist_id': special_pricelist.id,
             'base': 'pricelist',
             'base_pricelist_id': base_pricelist.id,
-            'compute_price': 'formula',
+            'compute_price': 'percentage',
             'applied_on': '3_global',
-            'price_discount': 10,
+            'percent_price': 10,
         })
 
         self.main_pos_config.write({

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -217,10 +217,6 @@
                             <setting id="multiple_prices_setting" string="Flexible Pricelists" help="Set multiple prices per product, automated discounts, etc." documentation="/applications/sales/point_of_sale/pricing/pricelists.html">
                                 <field name="pos_use_pricelist" readonly="pos_has_active_session"/>
                                 <div class="content-group" invisible="not pos_use_pricelist">
-                                    <div class="mt16">
-                                        <field name="group_sale_pricelist" invisible="1"/>
-                                        <field name="product_pricelist_setting" widget="radio" class="o_light_label"/>
-                                    </div>
                                     <div class="row mt16">
                                         <label string="Available" for="pos_available_pricelist_ids" class="col-lg-3 o_light_label"/>
                                         <field name="pos_available_pricelist_ids" widget="many2many_tags" domain="['|',('company_id', '=', company_id),('company_id', '=', False)]" readonly="pos_has_active_session"/>

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -643,7 +643,6 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         pricelist = self.env["product.pricelist"].create({
             "name": "Test multi-currency",
-            "discount_policy": "without_discount",
             "currency_id": self.env.ref("base.USD").id,
             "item_ids": [
                 (0, 0, {

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -58,7 +58,8 @@ class Pricelist(models.Model):
     @api.depends('currency_id')
     def _compute_display_name(self):
         for pricelist in self:
-            pricelist.display_name = f'{pricelist.name} ({pricelist.currency_id.name})'
+            pricelist_name = pricelist.name and pricelist.name or _('New')
+            pricelist.display_name = f'{pricelist_name} ({pricelist.currency_id.name})'
 
     def write(self, values):
         res = super().write(values)

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, _
+from odoo import _, api, fields, models
 from odoo.exceptions import UserError
 
 
@@ -10,7 +9,7 @@ class Pricelist(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
     _description = "Pricelist"
     _rec_names_search = ['name', 'currency_id']  # TODO check if should be removed
-    _order = "sequence asc, id asc"
+    _order = "sequence, id, name"
 
     def _default_currency_id(self):
         return self.env.company.currency_id.id

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -45,16 +45,6 @@ class Pricelist(models.Model):
         tracking=10,
     )
 
-    discount_policy = fields.Selection(
-        selection=[
-            ('with_discount', "Discount included in the price"),
-            ('without_discount', "Show public price & discount to the customer"),
-        ],
-        default='with_discount',
-        required=True,
-        tracking=15,
-    )
-
     item_ids = fields.One2many(
         comodel_name='product.pricelist.item',
         inverse_name='pricelist_id',

--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import api, fields, models, tools, _
+from odoo import _, api, fields, models, tools
 from odoo.exceptions import ValidationError
 from odoo.tools import format_datetime, formatLang
 
@@ -56,9 +55,18 @@ class PricelistItem(models.Model):
         required=True,
         help="Pricelist Item applicable on selected option")
 
+    display_applied_on = fields.Selection(
+        selection=[
+            ('1_product', "Product"),
+            ('2_product_category', "Category"),
+        ],
+        default='1_product',
+        required=True,
+        help="Pricelist Item applicable on selected option")
+
     categ_id = fields.Many2one(
         comodel_name='product.category',
-        string="Product Category",
+        string="Category",
         ondelete='cascade',
         help="Specify a product category if this rule only applies to products belonging to this category or its children categories. Keep empty otherwise.")
     product_tmpl_id = fields.Many2one(
@@ -68,9 +76,12 @@ class PricelistItem(models.Model):
         help="Specify a template if this rule only applies to one product template. Keep empty otherwise.")
     product_id = fields.Many2one(
         comodel_name='product.product',
-        string="Product Variant",
+        string="Variant",
         ondelete='cascade', check_company=True,
+        domain="[('product_tmpl_id', '=', product_tmpl_id)]",
         help="Specify a product if this rule only applies to one product. Keep empty otherwise.")
+    product_uom = fields.Char(related='product_tmpl_id.uom_name')
+    product_variant_count = fields.Integer(related='product_tmpl_id.product_variant_count')
 
     base = fields.Selection(
         selection=[
@@ -89,9 +100,9 @@ class PricelistItem(models.Model):
 
     compute_price = fields.Selection(
         selection=[
-            ('fixed', "Fixed Price"),
             ('percentage', "Discount"),
             ('formula', "Formula"),
+            ('fixed', "Fixed Price"),
         ],
         index=True, default='fixed', required=True)
 
@@ -110,11 +121,17 @@ class PricelistItem(models.Model):
         digits='Product Price',
         help="Sets the price so that it is a multiple of this value.\n"
              "Rounding is applied after the discount and before the surcharge.\n"
-             "To have prices that end in 9.99, set rounding 10, surcharge -0.01")
+             "To have prices that end in 9.99, round off to 10.00 and set an extra at -0.01")
     price_surcharge = fields.Float(
-        string="Price Surcharge",
+        string="Extra Fee",
         digits='Product Price',
         help="Specify the fixed amount to add or subtract (if negative) to the amount calculated with the discount.")
+
+    price_markup = fields.Float(
+        string="Markup",
+        default=0,
+        digits=(16, 2),
+        help="You can apply a mark-up on the cost")
 
     price_min_margin = fields.Float(
         string="Min. Price Margin",
@@ -145,7 +162,7 @@ class PricelistItem(models.Model):
             if item.categ_id and item.applied_on == '2_product_category':
                 item.name = _("Category: %s", item.categ_id.display_name)
             elif item.product_tmpl_id and item.applied_on == '1_product':
-                item.name = _("Product: %s", item.product_tmpl_id.display_name)
+                item.name = item.product_tmpl_id.display_name
             elif item.product_id and item.applied_on == '0_product_variant':
                 item.name = _("Variant: %s", item.product_id.display_name)
             else:
@@ -155,9 +172,23 @@ class PricelistItem(models.Model):
                 item.price = formatLang(
                     item.env, item.fixed_price, monetary=True, dp="Product Price", currency_obj=item.currency_id)
             elif item.compute_price == 'percentage':
-                item.price = _("%s %% discount", item.percent_price)
+                percentage = self._get_integer(item.percent_price)
+                item.price = _("%s %% discount", percentage)
             else:
-                item.price = _("%(percentage)s %% discount and %(price)s surcharge", percentage=item.price_discount, price=item.price_surcharge)
+                discount_type, percentage = self._get_displayed_discount(item)
+                if not (surcharge := item.price_surcharge):
+                    item.price = _(
+                        "%(percentage)s %% %(discount_type)s",
+                        percentage=percentage,
+                        discount_type=discount_type,
+                    )
+                else:
+                    item.price = _(
+                        "%(percentage)s %% %(discount_type)s and %(price)s surcharge",
+                        percentage=percentage,
+                        price=surcharge,
+                        discount_type=discount_type,
+                    )
 
     @api.depends_context('lang')
     @api.depends('compute_price', 'price_discount', 'price_surcharge', 'base', 'price_round')
@@ -173,11 +204,14 @@ class PricelistItem(models.Model):
             if item.price_round:
                 discounted_price = tools.float_round(discounted_price, precision_rounding=item.price_round)
             surcharge = tools.format_amount(item.env, item.price_surcharge, item.currency_id)
+            discount_type, discount = self._get_displayed_discount(item)
+
             item.rule_tip = _(
-                "%(base)s with a %(discount)s %% discount and %(surcharge)s extra fee\n"
+                "%(base)s with a %(discount)s %% %(discount_type)s and %(surcharge)s extra fee\n"
                 "Example: %(amount)s * %(discount_charge)s + %(price_surcharge)s → %(total_amount)s",
                 base=base_selection_vals[item.base],
-                discount=item.price_discount,
+                discount=discount,
+                discount_type=discount_type,
                 surcharge=surcharge,
                 amount=tools.format_amount(item.env, 100, item.currency_id),
                 discount_charge=discount_factor,
@@ -185,6 +219,14 @@ class PricelistItem(models.Model):
                 total_amount=tools.format_amount(
                     item.env, discounted_price + item.price_surcharge, item.currency_id),
             )
+
+    def _get_integer(self, percentage):
+        return int(percentage) if percentage.is_integer() else percentage
+
+    def _get_displayed_discount(self, item):
+        if item.base == 'standard_price':
+            return "markup", self._get_integer(item.price_markup)
+        return "discount", self._get_integer(item.price_discount)
 
     #=== CONSTRAINT METHODS ===#
 
@@ -221,6 +263,13 @@ class PricelistItem(models.Model):
                 raise ValidationError(_("Please specify the product variant for which this rule should be applied"))
 
     #=== ONCHANGE METHODS ===#
+    @api.onchange('base')
+    def _onchange_base(self):
+        for item in self:
+            item.update({
+                'price_discount': 0.0,
+                'price_markup': 0.0,
+            })
 
     @api.onchange('compute_price')
     def _onchange_compute_price(self):
@@ -233,10 +282,37 @@ class PricelistItem(models.Model):
                 'base': 'list_price',
                 'price_discount': 0.0,
                 'price_surcharge': 0.0,
+                'price_markup': 0.0,
                 'price_round': 0.0,
                 'price_min_margin': 0.0,
                 'price_max_margin': 0.0,
             })
+
+    @api.onchange('display_applied_on')
+    def _onchange_display_applied_on(self):
+        for item in self:
+            if not (item.product_tmpl_id or item.categ_id):
+                item.update(dict(
+                    applied_on='3_global',
+                ))
+            elif item.display_applied_on == '1_product':
+                item.update(dict(
+                    applied_on='1_product',
+                    categ_id=None,
+                ))
+            elif item.display_applied_on == '2_product_category':
+                item.update(dict(
+                    product_id=None,
+                    product_tmpl_id=None,
+                    applied_on='2_product_category',
+                    product_uom=None,
+                ))
+
+    @api.onchange('price_markup')
+    def _onchange_price_markup(self):
+        for item in self:
+            if item.price_markup:
+                item.price_discount = -item.price_markup
 
     @api.onchange('product_id')
     def _onchange_product_id(self):
@@ -258,19 +334,25 @@ class PricelistItem(models.Model):
 
     @api.onchange('product_id', 'product_tmpl_id', 'categ_id')
     def _onchange_rule_content(self):
-        if not self.env.user.has_group('product.group_sale_pricelist') and not self.env.context.get('default_applied_on', False):
-            # If advanced pricelists are disabled (applied_on field is not visible)
-            # AND we aren't coming from a specific product template/variant.
+        if not self.env.context.get('default_applied_on', False):
+            # If we aren't coming from a specific product template/variant.
             variants_rules = self.filtered('product_id')
             template_rules = (self-variants_rules).filtered('product_tmpl_id')
+            category_rules = self.filtered(lambda cat: cat.categ_id and cat.categ_id.name != 'All')
             variants_rules.update({'applied_on': '0_product_variant'})
             template_rules.update({'applied_on': '1_product'})
-            (self-variants_rules-template_rules).update({'applied_on': '3_global'})
+            category_rules.update({'applied_on': '2_product_category'})
+            global_rules = self - variants_rules - template_rules - category_rules
+            global_rules.update({'applied_on': '3_global'})
 
     @api.onchange('price_round')
     def _onchange_price_round(self):
         if any(item.price_round and item.price_round < 0.0 for item in self):
             raise ValidationError(_("The rounding method must be strictly positive."))
+
+    @api.onchange('date_start', 'date_end')
+    def _onchange_validity_period(self):
+        self._check_date_range()
 
     #=== CRUD METHODS ===#
 

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -310,6 +310,7 @@ class ProductProduct(models.Model):
                 '|',
                     '&', ('product_tmpl_id', '=', product.product_tmpl_id.id), ('applied_on', '=', '1_product'),
                     '&', ('product_id', '=', product.id), ('applied_on', '=', '0_product_variant'),
+                ('compute_price', '=', 'fixed'),
             ]
             product.pricelist_item_count = self.env['product.pricelist.item'].search_count(domain)
 
@@ -597,7 +598,9 @@ class ProductProduct(models.Model):
         self.ensure_one()
         domain = ['|',
             '&', ('product_tmpl_id', '=', self.product_tmpl_id.id), ('applied_on', '=', '1_product'),
-            '&', ('product_id', '=', self.id), ('applied_on', '=', '0_product_variant')]
+            '&', ('product_id', '=', self.id), ('applied_on', '=', '0_product_variant'),
+            ('compute_price', '=', 'fixed'),
+        ]
         return {
             'name': _('Price Rules'),
             'view_mode': 'tree,form',

--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -175,6 +175,7 @@ class ProductTemplate(models.Model):
                 '&',
                 '|', ('product_tmpl_id', '=', template.id), ('product_id', 'in', template.product_variant_ids.ids),
                 ('pricelist_id.active', '=', True),
+                ('compute_price', '=', 'fixed'),
             ])
 
     def _compute_product_document_count(self):
@@ -592,7 +593,9 @@ class ProductTemplate(models.Model):
         self.ensure_one()
         domain = ['|',
             ('product_tmpl_id', '=', self.id),
-            ('product_id', 'in', self.product_variant_ids.ids)]
+            ('product_id', 'in', self.product_variant_ids.ids),
+            ('compute_price', '=', 'fixed'),
+        ]
         return {
             'name': _('Price Rules'),
             'view_mode': 'tree,form',

--- a/addons/product/models/res_config_settings.py
+++ b/addons/product/models/res_config_settings.py
@@ -13,15 +13,6 @@ class ResConfigSettings(models.TransientModel):
         implied_group='product.group_stock_packaging')
     group_product_pricelist = fields.Boolean("Pricelists",
         implied_group='product.group_product_pricelist')
-    group_sale_pricelist = fields.Boolean("Advanced Pricelists",
-        implied_group='product.group_sale_pricelist',
-        help="""Allows to manage different prices based on rules per category of customers.
-                Example: 10% for retailers, promotion of 5 EUR on this product, etc.""")
-    product_pricelist_setting = fields.Selection([
-            ('basic', 'Multiple prices per product'),
-            ('advanced', 'Advanced price rules (discounts, formulas)')
-            ], default='basic', string="Pricelists Method", config_parameter='product.product_pricelist_setting',
-            help="Multiple prices: Pricelists with fixed price rules by product,\nAdvanced rules: enables advanced price rules for pricelists.")
     product_weight_in_lbs = fields.Selection([
         ('0', 'Kilograms'),
         ('1', 'Pounds'),
@@ -34,8 +25,6 @@ class ResConfigSettings(models.TransientModel):
     @api.onchange('group_product_pricelist')
     def _onchange_group_sale_pricelist(self):
         if not self.group_product_pricelist:
-            if self.group_sale_pricelist:
-                self.group_sale_pricelist = False
             active_pricelist = self.env['product.pricelist'].sudo().search_count(
                 [('active', '=', True)], limit=1
             )
@@ -45,13 +34,6 @@ class ResConfigSettings(models.TransientModel):
                     'message': _("You are deactivating the pricelist feature. "
                                  "Every active pricelist will be archived.")
                 }}
-
-    @api.onchange('product_pricelist_setting')
-    def _onchange_product_pricelist_setting(self):
-        if self.product_pricelist_setting == 'basic':
-            self.group_sale_pricelist = False
-        else:
-            self.group_sale_pricelist = True
 
     def set_values(self):
         had_group_pl = self.default_get(['group_product_pricelist'])['group_product_pricelist']

--- a/addons/product/populate/product_pricelist.py
+++ b/addons/product/populate/product_pricelist.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import date, timedelta
 
 from odoo import models
 from odoo.tools import populate
-from datetime import timedelta, date
 
 
 class Pricelist(models.Model):
@@ -16,7 +16,6 @@ class Pricelist(models.Model):
         # Reflect the settings with data created
         self.env['res.config.settings'].create({
             'group_product_pricelist': True,  # Activate pricelist
-            'group_sale_pricelist': True,  # Activate advanced pricelist
         }).execute()
 
         return super()._populate(size)

--- a/addons/product/populate/product_pricelist.py
+++ b/addons/product/populate/product_pricelist.py
@@ -29,7 +29,6 @@ class Pricelist(models.Model):
             ("name", populate.constant('product_pricelist_{counter}')),
             ("currency_id", populate.randomize(self.env["res.currency"].search([("active", "=", True)]).ids)),
             ("sequence", populate.randomize([False] + [i for i in range(1, 101)])),
-            ("discount_policy", populate.randomize(["with_discount", "without_discount"])),
             ("active", populate.randomize([True, False], [0.8, 0.2])),
         ]
 

--- a/addons/product/security/product_security.xml
+++ b/addons/product/security/product_security.xml
@@ -6,12 +6,6 @@
         <field name="category_id" ref="base.module_category_hidden"/>
     </record>
 
-    <record id="group_sale_pricelist" model="res.groups">
-        <field name="name">Advanced Pricelists</field>
-        <field name="category_id" ref="base.module_category_hidden"/>
-        <field name="implied_ids" eval="[(4, ref('product.group_product_pricelist'))]"/>
-    </record>
-
     <record id="group_stock_packaging" model="res.groups">
         <field name="name">Manage Product Packaging</field>
         <field name="category_id" ref="base.module_category_hidden"/>

--- a/addons/product/tests/test_common.py
+++ b/addons/product/tests/test_common.py
@@ -23,4 +23,3 @@ class TestProduct(ProductCommon):
             self.pricelist,
         )
         self.assertEqual(self.pricelist.currency_id.name, self.currency.name)
-        self.assertEqual(self.pricelist.discount_policy, 'with_discount')

--- a/addons/product/views/product_pricelist_item_views.xml
+++ b/addons/product/views/product_pricelist_item_views.xml
@@ -129,7 +129,6 @@
                                     options="{'currency_field': 'currency_id'}"/>
                                 <span class="d-flex gap-2 p-0" invisible="not product_uom ">per<field
                                         name="product_uom"/></span>
-                                <span class="p-0" invisible="product_uom or display_applied_on != '1_product'">per Unit</span>
                             </div>
                             <label for="percent_price" string="Discount"
                                 invisible="compute_price != 'percentage'"/>
@@ -154,7 +153,7 @@
                                 invisible="base != 'pricelist'"
                                 readonly="base != 'pricelist'"
                                 required="compute_price == 'formula' and base == 'pricelist'"
-                                string="Base Price"/>
+                                string="Other Pricelist"/>
                             <label for="price_discount" string="Discount"
                                 invisible="base == 'standard_price'"/>
                             <div class="o_row" invisible="base == 'standard_price'" style="width: 40% !important;">

--- a/addons/product/views/product_pricelist_item_views.xml
+++ b/addons/product/views/product_pricelist_item_views.xml
@@ -56,7 +56,18 @@
             <tree string="Pricelist Rules" editable="bottom">
                 <!-- Scope = coming from a product/product template -->
                 <field name="pricelist_id" string="Pricelist" options="{'no_create_edit':1, 'no_open': 1}"/>
-                <field name="name" string="Applied On"/>
+                <field name="product_id"
+                    groups="product.group_product_variant"
+                    readonly="context.get('active_model') == 'product.product'"
+                    column_invisible="context.get('product_without_variants', False)"
+                    required="applied_on == '0_product_variant'"
+                    domain="['|', '|',
+                    ('id', '=', context.get('default_product_id', 0)),
+                    ('product_tmpl_id', '=', context.get('default_product_tmpl_id', 0)),
+                    ('categ_id', '=', context.get('default_categ_id', 0)), '|', ('company_id', '=', company_id), ('company_id', '=', False)
+                    ]"
+                    placeholder="All variants"
+                    options="{'no_create_edit':1, 'no_open': 1}"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="categ_id" column_invisible="True"/>
                 <field name="product_tmpl_id"
@@ -64,24 +75,17 @@
                   required="applied_on == '1_product'"
                   domain="[('categ_id', '=', context.get('default_categ_id', True)), '|', ('company_id', '=', company_id), ('company_id', '=', False)]"
                   options="{'no_create_edit':1, 'no_open': 1}"/>
-                <field name="product_id"
-                  groups="product.group_product_variant"
-                  readonly="context.get('active_model') == 'product.product'"
-                  column_invisible="context.get('product_without_variants', False)"
-                  required="applied_on == '0_product_variant'"
-                  domain="['|', '|',
-                    ('id', '=', context.get('default_product_id', 0)),
-                    ('product_tmpl_id', '=', context.get('default_product_tmpl_id', 0)),
-                    ('categ_id', '=', context.get('default_categ_id', 0)), '|', ('company_id', '=', company_id), ('company_id', '=', False)
-                  ]"
-                  options="{'no_create_edit':1, 'no_open': 1}"/>
+                <field name="fixed_price"
+                        widget="monetary"
+                        string="Price"
+                        options="{'currency_field': 'currency_id'}"
+                        required='1'/>
                 <field name="min_quantity" colspan="4"/>
                 <field name="currency_id" column_invisible="True"/>
-                <field name="fixed_price" string="Price" required='1'/>
                 <field name="date_start" optional="show"/>
                 <field name="date_end" optional="show"/>
                 <field name="applied_on" column_invisible="True"/>
-                <field name="company_id" groups="base.group_multi_company" optional="show" options="{'no_create':1, 'no_open': 1}"/>
+                <field name="company_id" groups="base.group_multi_company" optional="hide" options="{'no_create':1, 'no_open': 1}"/>
             </tree>
         </field>
     </record>
@@ -94,43 +98,87 @@
                 <sheet>
                     <field name="name" invisible="1"/>
                     <field name="company_id" invisible="1"/>
-                    <group name="pricelist_rule_computation" groups="product.group_sale_pricelist" string="Price Computation">
+                    <field name="price" invisible="1"/>
+                    <group name="pricelist_rule_computation">
                         <group name="pricelist_rule_method">
-                            <field name="compute_price" string="Computation" widget="radio"/>
-                        </group>
-                        <div class="alert alert-info" role="alert" groups="uom.group_uom">
-                            The computed price is expressed in the default Unit of Measure of the product.
-                        </div>
-                    </group>
-                    <group name="pricelist_rule_base" groups="product.group_sale_pricelist">
-                        <group>
-                            <field name="price" invisible="1"/>
-                            <field name="fixed_price"
-                                widget="monetary"
-                                invisible="compute_price != 'fixed'"
-                                options="{'field_digits': True}"/>
-                            <label for="percent_price" string="Discount" invisible="compute_price != 'percentage'"/>
-                            <div class="o_row" invisible="compute_price != 'percentage'">
-                                <field name="percent_price" class="oe_inline" invisible="compute_price != 'percentage'"/>%
+                            <field name="display_applied_on"
+                                string="Apply To"
+                                widget="radio"
+                                options="{'horizontal': true}"/>
+                            <field name="categ_id"
+                                options="{'no_create':1}"
+                                invisible="display_applied_on != '2_product_category'"
+                                placeholder="All categories"/>
+                            <field name="product_tmpl_id"
+                                options="{'no_create':1}"
+                                invisible="display_applied_on != '1_product'"
+                                placeholder="All products"/>
+                            <field name="product_variant_count" invisible="1"/>
+                            <field name="product_id"
+                                options="{'no_create':1}"
+                                invisible="product_variant_count &lt; 2"
+                                placeholder="All variants"/>
+                            <field name="compute_price"
+                                string="Price Type"
+                                widget="radio"
+                                options="{'horizontal': true}"
+                                invisible="display_applied_on == '1_product' and compute_price == 'fixed_price'"/>
+                            <label for="fixed_price" invisible="compute_price != 'fixed'"/>
+                            <div class="o_row" invisible="compute_price != 'fixed'" style="width: 40% !important;">
+                                <field name="fixed_price" widget="monetary"
+                                    options="{'currency_field': 'currency_id'}"/>
+                                <span class="d-flex gap-2 p-0" invisible="not product_uom ">per<field
+                                        name="product_uom"/></span>
+                                <span class="p-0" invisible="product_uom or display_applied_on != '1_product'">per Unit</span>
                             </div>
-                            <field name="base" invisible="compute_price != 'formula'"/>
-                            <field name="base_pricelist_id" invisible="compute_price != 'formula' or base != 'pricelist'" readonly="base != 'pricelist'" required="compute_price == 'formula' and base == 'pricelist'"/>
-                            <label for="price_discount" string="Discount" invisible="compute_price != 'formula'"/>
-                            <div class="o_row" invisible="compute_price != 'formula'">
+                            <label for="percent_price" string="Discount"
+                                invisible="compute_price != 'percentage'"/>
+                            <div class="o_row" invisible="compute_price != 'percentage'" style="width: 40% !important;">
+                                <field name="percent_price"/>
+                                <span>%</span>
+                            </div>
+                        </group>
+                        <group name="pricelist_rule_limits">
+                            <field name="min_quantity" string="Min Qty"/>
+                            <field name="date_start"
+                                string="Validity Period"
+                                widget="daterange"
+                                options="{'end_date_field': 'date_end'}"/>
+                            <field name="date_end" invisible="1"/>
+                        </group>
+                    </group>
+                    <group name="pricelist_rule_base" invisible="compute_price != 'formula'">
+                        <group>
+                            <field name="base" string="Based price"/>
+                            <field name="base_pricelist_id"
+                                invisible="base != 'pricelist'"
+                                readonly="base != 'pricelist'"
+                                required="compute_price == 'formula' and base == 'pricelist'"
+                                string="Base Price"/>
+                            <label for="price_discount" string="Discount"
+                                invisible="base == 'standard_price'"/>
+                            <div class="o_row" invisible="base == 'standard_price'" style="width: 40% !important;">
                                 <field name="price_discount"/>
                                 <span>%</span>
                             </div>
-                            <field name="price_surcharge" widget="monetary" string="Extra Fee" invisible="compute_price != 'formula'"/>
-                            <field name="price_round" string="Rounding Method" invisible="compute_price != 'formula'"/>
-                            <label string="Margins" for="price_min_margin" invisible="compute_price != 'formula'"/>
-                            <div class="o_row" invisible="compute_price != 'formula'">
+                            <label for="price_markup" string="Markup"
+                                invisible="base != 'standard_price'"/>
+                            <div class="o_row" invisible="base != 'standard_price'" style="width: 40% !important;">
+                                <field name="price_markup"/>
+                                <span>%</span>
+                            </div>
+                            <field name="price_round" string="Round off to"/>
+                            <field name="price_surcharge" widget="monetary" options="{'currency_field': 'currency_id'}"/>
+                            <label string="Margins" for="price_min_margin"
+                                groups="base.group_no_one"/>
+                            <div class="d-flex align-items-baseline" groups="base.group_no_one">
                                 <field name="price_min_margin"
                                     string="Min. Margin"
                                     class="oe_inline"
                                     widget="monetary"
-                                    nolabel="1"
                                     options="{'field_digits': True}"/>
-                                <i class="fa fa-long-arrow-right mx-2 oe_edit_only" aria-label="Arrow icon" title="Arrow"/>
+                                <i class="fa fa-long-arrow-right mx-2 oe_edit_only"
+                                    aria-label="Arrow icon" title="Arrow"/>
                                 <field name="price_max_margin"
                                     string="Max. Margin"
                                     class="oe_inline"
@@ -139,24 +187,21 @@
                                     options="{'field_digits': True}"/>
                             </div>
                         </group>
-                        <div class="alert alert-info" role="alert" style="white-space: pre;" invisible="compute_price != 'formula'">
-                            <field name="rule_tip"/>
+                        <div>
+                            <div class="alert alert-info" role="alert" style="white-space: pre;">
+                                <field name="rule_tip"/>
+                            </div>
+                            <div class="alert alert-info"
+                                role="alert"
+                                style="white-space: pre;">
+                                <b>Tip: want to round at 9.99?</b>
+                                <div>round off to 10.00 and set an extra at -0.01</div>
+                            </div>
                         </div>
                     </group>
 
-                    <group string="Conditions">
-                        <group name="pricelist_rule_target">
-                            <field name="applied_on" widget="radio"/>
-                            <field name="categ_id" options="{'no_create':1}" invisible="applied_on != '2_product_category'" required="applied_on == '2_product_category'"/>
-                            <field name="product_tmpl_id" options="{'no_create':1}" invisible="applied_on != '1_product'" required="applied_on == '1_product'"/>
-                            <field name="product_id" options="{'no_create':1}" invisible="applied_on != '0_product_variant'" required="applied_on == '0_product_variant'"/>
-                        </group>
-                        <group name="pricelist_rule_limits">
-                            <field name="min_quantity"/>
-                            <field name="date_start" string="Validity" widget="daterange" options="{'end_date_field': 'date_end'}" />
-                            <field name="date_end" invisible="1" />
-                        </group>
-                        <group name="pricelist_rule_related" groups="base.group_no_one">
+                    <group string="Company Settings" groups="base.group_no_one">
+                        <group name="pricelist_rule_related">
                             <field name="pricelist_id" invisible="1"/>
                             <field name="currency_id" groups="base.group_multi_currency"/>
                             <field name="company_id" groups="base.group_multi_company"/>

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -20,7 +20,6 @@
             <tree string="Products Price List" sample="1">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
-                <field name="discount_policy"/>
                 <field name="currency_id" groups="base.group_multi_currency"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
@@ -45,7 +44,6 @@
                                     <i class="fa fa-money" role="img" aria-label="Currency" title="Currency"></i> <field name="currency_id"/>
                                 </strong>
                             </div>
-                            <field name="discount_policy"/>
                         </div>
                     </t>
                 </templates>
@@ -111,9 +109,6 @@
                             <group>
                                 <group name="pricelist_availability" string="Availability">
                                     <field name="country_group_ids" widget="many2many_tags"/>
-                                </group>
-                                <group name="pricelist_discounts" string="Discounts">
-                                    <field name="discount_policy" widget="radio"/>
                                 </group>
                             </group>
                         </page>

--- a/addons/product/views/product_pricelist_views.xml
+++ b/addons/product/views/product_pricelist_views.xml
@@ -20,6 +20,7 @@
             <tree string="Products Price List" sample="1">
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
+                <field name="country_group_ids" widget="many2many_tags"/>
                 <field name="currency_id" groups="base.group_multi_currency"/>
                 <field name="company_id" groups="base.group_multi_company"/>
             </tree>
@@ -67,35 +68,18 @@
                             <field name="active" invisible="1"/>
                             <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
                         </group>
+                        <group>
+                            <field name="country_group_ids" widget="many2many_tags"/>
+                        </group>
                     </group>
                     <notebook>
                         <page name="pricelist_rules" string="Price Rules">
                             <field name="item_ids" nolabel="1" context="{'default_base':'list_price'}">
-                                <tree groups="!product.group_sale_pricelist" string="Pricelist Rules" editable="bottom">
-                                    <field name="product_tmpl_id" string="Products" required="1"/>
-                                    <field name="product_id" string="Variants"
-                                    groups="product.group_product_variant"
-                                    domain="[('product_tmpl_id', '=', product_tmpl_id)]"
-                                    options="{'no_create':1}"/>
-                                    <field name="min_quantity"/>
-                                    <field name="fixed_price" string="Price"/>
-                                    <field name="currency_id" column_invisible="True"/>
-                                    <field name="pricelist_id" column_invisible="True"/>
-                                    <!-- Pricelist ID is here only for related fields to be correctly computed -->
-                                    <field name="date_start"/>
-                                    <field name="date_end"/>
-                                    <field name="base" column_invisible="True"/>
-                                    <field name="applied_on" column_invisible="True"/>
-                                    <field name="company_id" column_invisible="True"/>
-                                </tree>
-                                <!-- When in advanced pricelist mode : pricelist rules
-                                    Should open in a form view and not be editable inline anymore.
-                                -->
-                                <tree groups="product.group_sale_pricelist" string="Pricelist Rules">
+                                <tree string="Pricelist Rules">
                                     <field name="product_tmpl_id" column_invisible="True"/>
-                                    <field name="name" string="Applicable On"/>
-                                    <field name="min_quantity"/>
+                                    <field name="name" string="Apply on"/>
                                     <field name="price" string="Price"/>
+                                    <field name="min_quantity"/>
                                     <field name="date_start"/>
                                     <field name="date_end"/>
                                     <field name="base" column_invisible="True"/>
@@ -104,13 +88,6 @@
                                     <field name="compute_price" column_invisible="True"/>
                                 </tree>
                             </field>
-                        </page>
-                        <page name="pricelist_config" string="Configuration">
-                            <group>
-                                <group name="pricelist_availability" string="Availability">
-                                    <field name="country_group_ids" widget="many2many_tags"/>
-                                </group>
-                            </group>
                         </page>
                     </notebook>
                 </sheet>

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -27,14 +27,20 @@
                                groups="product.group_product_pricelist"
                                type="object">
                                <div class="o_field_widget o_stat_info">
-                                    <span class="o_stat_value">
+                                    <span class="o_stat_value o_row">
                                         <field name="pricelist_item_count"/>
+                                        <span class="o_stat_text" invisible="pricelist_item_count == 1">
+                                            Rules
+                                        </span>
+                                        <span class="o_stat_text" invisible="pricelist_item_count != 1">
+                                            Rule
+                                        </span>
                                     </span>
                                     <span class="o_stat_text" invisible="pricelist_item_count == 1">
-                                        Extra Prices
+                                        Pricelists
                                     </span>
                                     <span class="o_stat_text" invisible="pricelist_item_count != 1">
-                                        Extra Price
+                                        Pricelist
                                     </span>
                                </div>
                         </button>

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -2,10 +2,11 @@
 
 from collections import defaultdict
 
-from odoo import api, fields, models, _
-from odoo.addons.base.models.res_partner import WARNING_MESSAGE, WARNING_HELP
+from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
 from odoo.tools import float_round, format_list
+
+from odoo.addons.base.models.res_partner import WARNING_HELP, WARNING_MESSAGE
 
 
 class ProductTemplate(models.Model):
@@ -175,7 +176,7 @@ class ProductTemplate(models.Model):
     def get_import_templates(self):
         res = super(ProductTemplate, self).get_import_templates()
         if self.env.context.get('sale_multi_pricelist_product_template'):
-            if self.env.user.has_group('product.group_sale_pricelist'):
+            if self.env.user.has_group('product.group_product_pricelist'):
                 return [{
                     'label': _("Import Template for Products"),
                     'template': '/product/static/xls/product_template.xls'

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1187,7 +1187,7 @@ class SaleOrder(models.Model):
         lines_to_recompute._compute_price_unit()
         # Special case: we want to overwrite the existing discount on _recompute_prices call
         # i.e. to make sure the discount is correctly reset
-        # if pricelist discount_policy is different than when the price was first computed.
+        # if pricelist rule is different than when the price was first computed.
         lines_to_recompute.discount = 0.0
         lines_to_recompute._compute_discount()
         self.show_update_pricelist = False

--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -545,10 +545,7 @@ class SaleOrderLine(models.Model):
 
         pricelist_price = self._get_pricelist_price()
 
-        if self.order_id.pricelist_id.discount_policy == 'with_discount':
-            return pricelist_price
-
-        if not self.pricelist_item_id:
+        if not self.pricelist_item_id or not self.pricelist_item_id._is_percentage():
             # No pricelist rule found => no discount from pricelist
             return pricelist_price
 
@@ -622,7 +619,7 @@ class SaleOrderLine(models.Model):
 
             if not (
                 line.order_id.pricelist_id
-                and line.order_id.pricelist_id.discount_policy == 'without_discount'
+                and line.pricelist_item_id._is_percentage()
             ):
                 continue
 

--- a/addons/sale/tests/product_configurator_common.py
+++ b/addons/sale/tests/product_configurator_common.py
@@ -112,18 +112,3 @@ class TestProductConfiguratorCommon(TransactionCase):
                 'compute_price': 'formula'
             })]
         })
-
-    @classmethod
-    def _create_pricelist(cls, pricelists):
-        for pricelist in pricelists:
-            if not pricelist.item_ids.filtered(lambda i: i.product_tmpl_id == cls.product_product_custo_desk and i.price_discount == 20):
-                cls.env['product.pricelist.item'].create({
-                    'base': 'list_price',
-                    'applied_on': '1_product',
-                    'pricelist_id': pricelist.id,
-                    'product_tmpl_id': cls.product_product_custo_desk.id,
-                    'price_discount': 20,
-                    'min_quantity': 2,
-                    'compute_price': 'formula',
-                })
-            pricelist.discount_policy = 'without_discount'

--- a/addons/sale/wizard/res_config_settings.py
+++ b/addons/sale/wizard/res_config_settings.py
@@ -120,11 +120,6 @@ class ResConfigSettings(models.TransientModel):
         if self.default_invoice_policy != 'order':
             self.env['ir.config_parameter'].set_param(key='sale.automatic_invoice', value=False)
 
-        if not self.group_discount_per_so_line:
-            self.env['product.pricelist'].search([
-                ('discount_policy', '=', 'without_discount')
-            ]).write({'discount_policy': 'with_discount'})
-
         send_invoice_cron = self.env.ref('sale.send_invoice_cron', raise_if_not_found=False)
         if send_invoice_cron and send_invoice_cron.active != self.automatic_invoice:
             send_invoice_cron.active = self.automatic_invoice

--- a/addons/sale/wizard/res_config_settings_views.xml
+++ b/addons/sale/wizard/res_config_settings_views.xml
@@ -40,17 +40,13 @@
                       <setting id="discount_sale_order_lines" title="Apply manual discounts on sales order lines or display discounts computed from pricelists (option to activate in the pricelist configuration)." help="Grant discounts on sales order lines">
                             <field name="group_discount_per_so_line"/>
                        </setting>
-                        <setting id="coupon_settings" title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products." string="Discounts, Loyalty &amp; Gift Card" help="Manage Promotions, coupons, loyalty cards, Gift cards &amp; eWallet">
+                        <setting id="coupon_settings" title="Boost your sales with multiple kinds of programs: Coupons, Promotions, Gift Card, Loyalty. Specific conditions can be set (products, customers, minimum purchase amount, period). Rewards can be discounts (% or amount) or free products." string="Promotions, Loyalty &amp; Gift Card" help="Manage Promotions, Coupons, Loyalty cards, Gift cards &amp; eWallet">
                             <field name="module_loyalty"/>
                         </setting>
                         <setting id="pricelist_configuration" documentation="/applications/sales/sales/products_prices/prices/pricing.html" help="Set multiple prices per product, automated discounts, etc.">
                             <field name="group_product_pricelist"/>
                             <div class="content-group" invisible="not group_product_pricelist">
                                 <div class="mt16">
-                                    <field name="group_sale_pricelist" invisible="1"/>
-                                    <field name="product_pricelist_setting" widget="radio" class="o_light_label"/>
-                                </div>
-                                <div class="mt8">
                                     <button name="%(product.product_pricelist_action2)d" icon="oi-arrow-right" type="action" string="Pricelists" groups="product.group_product_pricelist" class="btn-link"/>
                                 </div>
                             </div>

--- a/addons/sale_loyalty/tests/test_program_with_code_operations.py
+++ b/addons/sale_loyalty/tests/test_program_with_code_operations.py
@@ -126,7 +126,6 @@ class TestProgramWithCodeOperations(TestSaleCouponCommon):
 
         first_pricelist = self.env['product.pricelist'].create({
             'name': 'First pricelist',
-            'discount_policy': 'with_discount',
             'item_ids': [(0, 0, {
                 'compute_price': 'percentage',
                 'base': 'list_price',

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -144,7 +144,7 @@ class SaleOrder(models.Model):
         super()._recompute_prices()
         # Special case: we want to overwrite the existing discount on _recompute_prices call
         # i.e. to make sure the discount is correctly reset
-        # if pricelist discount_policy is different than when the price was first computed.
+        # if pricelist rule is different than when the price was first computed.
         self.sale_order_option_ids.discount = 0.0
         self.sale_order_option_ids._compute_price_unit()
         self.sale_order_option_ids._compute_discount()

--- a/addons/sale_management/tests/test_sale_order.py
+++ b/addons/sale_management/tests/test_sale_order.py
@@ -70,6 +70,22 @@ class TestSaleOrder(SaleManagementCommon):
                 'fixed_price': cls.pl_option_price,
             }),
         ]
+        percentage_pricelist_rule_values = [
+            Command.create({
+                'name': 'Product 1 premium price',
+                'applied_on': '1_product',
+                'product_tmpl_id': cls.product_1.product_tmpl_id.id,
+                'compute_price': 'percentage',
+                'percent_price': cls.pl_discount,
+            }),
+            Command.create({
+                'name': 'Optional product premium price',
+                'applied_on': '1_product',
+                'product_tmpl_id': cls.optional_product.product_tmpl_id.id,
+                'compute_price': 'percentage',
+                'percent_price': cls.pl_option_discount,
+            }),
+        ]
 
         (
             cls.discount_included_price_list,
@@ -77,12 +93,10 @@ class TestSaleOrder(SaleManagementCommon):
         ) = cls.env['product.pricelist'].create([
             {
                 'name': 'Discount included Pricelist',
-                'discount_policy': 'with_discount',
                 'item_ids': pricelist_rule_values,
             }, {
                 'name': 'Discount excluded Pricelist',
-                'discount_policy': 'without_discount',
-                'item_ids': pricelist_rule_values,
+                'item_ids': percentage_pricelist_rule_values,
             }
         ])
 

--- a/addons/sale_stock/tests/test_create_perf.py
+++ b/addons/sale_stock/tests/test_create_perf.py
@@ -134,15 +134,6 @@ class TestPERF(TransactionCaseWithUserDemo):
         # (Seems to be a time-based problem, everytime happening around 10PM)
         self._test_complex_sales_orders_batch_creation_perf(1504)
 
-    @users('admin')
-    @warmup
-    def ___test_complex_sales_orders_batch_creation_perf_with_discount_computation(self):
-        """Cover the "complex" logic triggered inside the `_compute_discount`"""
-        self.env['product.pricelist'].search([]).discount_policy = 'without_discount'
-
-        # Verify any modification to this count on nightly runbot builds
-        self._test_complex_sales_orders_batch_creation_perf(1546)
-
     def _test_complex_sales_orders_batch_creation_perf(self, query_count):
         MSG = "Model %s, %i records, %s, time %.2f"
 
@@ -170,8 +161,6 @@ class TestPERF(TransactionCaseWithUserDemo):
         """Make sure the price and discounts computation are complexified
         and do not gain from any prefetch/batch gains during the price computation
         """
-        # Enable discounts
-        self.env['product.pricelist'].search([]).discount_policy = 'without_discount'
 
         vals_list = [{
             "partner_id": self.partners[i].id,

--- a/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
+++ b/addons/website_event_booth_sale/static/tests/tours/website_event_booth_sale_pricelists.js
@@ -44,26 +44,12 @@ registry.category("web_tour.tours").add('event_booth_sale_pricelists_different_c
     },
     wsTourUtils.goToCheckout(),
     ...getPriceListChecksSteps({
-        pricelistName: "EUR With Discount Included",
-        eventName: "Test Event Booths",
-        price: "99.00",
-        priceSelected: "99",
-        priceCart: "99.00",
-    }),
-    ...getPriceListChecksSteps({
         pricelistName: "EUR Without Discount Included",
         eventName: "Test Event Booths",
         price: "99.00",
         priceSelected: "99",
         priceCart: "99.00",
         priceBeforeDiscount: "110.00",
-    }),
-    ...getPriceListChecksSteps({
-        pricelistName: "EX With Discount Included",
-        eventName: "Test Event Booths",
-        price: "990.00",
-        priceSelected: "990",
-        priceCart: "990.00",
     }),
     ...getPriceListChecksSteps({
         pricelistName: "EX Without Discount Included",

--- a/addons/website_event_booth_sale/tests/test_website_event_booth_sale_pricelist.py
+++ b/addons/website_event_booth_sale/tests/test_website_event_booth_sale_pricelist.py
@@ -31,9 +31,8 @@ class TestWebsiteBoothPriceList(TestEventBoothSaleCommon, TestWebsiteEventSaleCo
         self.env['product.pricelist'].search([('id', '!=', self.pricelist.id)]).action_archive()
         self.pricelist.write({
             'currency_id': self.env.company.currency_id.id,
-            'discount_policy': 'with_discount',
             'item_ids': [(5, 0, 0)],
-            'name': 'With Discount Included',
+            'name': 'Test Pricelist (no discount)',
         })
         so_line = self.env['sale.order.line'].create({
             'event_booth_category_id': self.event_booth_category_1.id,
@@ -47,21 +46,12 @@ class TestWebsiteBoothPriceList(TestEventBoothSaleCommon, TestWebsiteEventSaleCo
         # set pricelist to 10% - without discount
         pl2 = self.pricelist.copy({
             'currency_id': self.currency_test.id,
-            'discount_policy': 'without_discount',
             'item_ids': [(5, 0, 0), (0, 0, {
                 'applied_on': '3_global',
                 'compute_price': 'percentage',
                 'percent_price': 10,
             })],
-            'name': 'Without Discount Included',
+            'name': 'Test pricelist (with discount)',
         })
         self.so._cart_update_pricelist(pricelist_id=pl2.id)
         self.assertEqual(so_line.price_reduce_taxexcl, 360, 'Incorrect amount based on the pricelist "Without Discount" and its currency.')
-
-        # set pricelist to 10% - with discount
-        pl3 = pl2.copy({
-            'discount_policy': 'with_discount',
-            'name': 'With Discount Included',
-        })
-        self.so._cart_update_pricelist(pricelist_id=pl3.id)
-        self.assertEqual(so_line.price_reduce_taxexcl, 360, 'Incorrect amount based on the pricelist "With Discount" and its currency.')

--- a/addons/website_event_booth_sale/views/event_booth_templates.xml
+++ b/addons/website_event_booth_sale/views/event_booth_templates.xml
@@ -4,7 +4,7 @@
     <template id="event_booth_registration" inherit_id="website_event_booth.event_booth_registration">
         <xpath expr="//label//span[hasclass('booth_category_price')]" position="replace">
             <t t-if="booth_category.price">
-                <t t-if="(booth_category.price - booth_category.price_reduce) &gt; 0 and website.pricelist_id.discount_policy == 'without_discount'">
+                <t t-if="(booth_category.price - booth_category.price_reduce) &gt; 0">
                     <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                          class="text-danger me-1"
                          t-field="booth_category.price"

--- a/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
+++ b/addons/website_event_sale/static/tests/tours/website_event_sale_pricelists.js
@@ -66,20 +66,10 @@ registry.category("web_tour.tours").add("event_sale_pricelists_different_currenc
             trigger: "body:not(:has(.modal#modal_attendees_registration))",
         },
         ...getPriceListChecksSteps({
-            pricelistName: "EUR With Discount Included",
-            eventName: "Pycon",
-            price: "90.00",
-        }),
-        ...getPriceListChecksSteps({
             pricelistName: "EUR Without Discount Included",
             eventName: "Pycon",
             price: "90.00",
             priceBeforeDiscount: "100.00",
-        }),
-        ...getPriceListChecksSteps({
-            pricelistName: "EX With Discount Included",
-            eventName: "Pycon",
-            price: "900.00",
         }),
         ...getPriceListChecksSteps({
             pricelistName: "EX Without Discount Included",

--- a/addons/website_event_sale/tests/common.py
+++ b/addons/website_event_sale/tests/common.py
@@ -62,10 +62,9 @@ class TestWebsiteEventSaleCommon(TransactionCase):
             'pricelist_id': cls.pricelist.id,
         })
 
-        def create_pricelist(currency, name, policy):
+        def create_pricelist(currency, name):
             return cls.env['product.pricelist'].create({
                 'currency_id': currency.id,
-                'discount_policy': policy,
                 'item_ids': [(5, 0, 0), (0, 0, {
                     'applied_on': '3_global',
                     'compute_price': 'percentage',
@@ -75,7 +74,5 @@ class TestWebsiteEventSaleCommon(TransactionCase):
                 'selectable': True,
             })
 
-        cls.pricelist_with_discount = create_pricelist(currency=cls.env.company.currency_id, name='EUR With Discount Included', policy='with_discount')
-        cls.pricelist_without_discount = create_pricelist(currency=cls.env.company.currency_id, name='EUR Without Discount Included', policy='without_discount')
-        cls.ex_pricelist_with_discount = create_pricelist(currency=cls.currency_test, name='EX With Discount Included', policy='with_discount')
-        cls.ex_pricelist_without_discount = create_pricelist(currency=cls.currency_test, name='EX Without Discount Included', policy='without_discount')
+        cls.pricelist_without_discount = create_pricelist(currency=cls.env.company.currency_id, name='EUR Without Discount Included')
+        cls.ex_pricelist_without_discount = create_pricelist(currency=cls.currency_test, name='EX Without Discount Included')

--- a/addons/website_event_sale/tests/test_website_event_sale_pricelist.py
+++ b/addons/website_event_sale/tests/test_website_event_sale_pricelist.py
@@ -20,9 +20,8 @@ class TestWebsiteEventPriceList(TestWebsiteEventSaleCommon):
         self.env['product.pricelist'].search([('id', '!=', self.pricelist.id)]).action_archive()
         self.pricelist.write({
             'currency_id': self.env.company.currency_id.id,
-            'discount_policy': 'with_discount',
             'item_ids': [Command.clear()],
-            'name': 'With Discount Included',
+            'name': 'No discount',
         })
         so_line = self.env['sale.order.line'].create({
             'event_id': self.event.id,
@@ -37,21 +36,12 @@ class TestWebsiteEventPriceList(TestWebsiteEventSaleCommon):
         # set pricelist to 10% - without discount
         pl2 = self.pricelist.copy({
             'currency_id': self.currency_test.id,
-            'discount_policy': 'without_discount',
             'item_ids': [(5, 0, 0), (0, 0, {
                 'applied_on': '3_global',
                 'compute_price': 'percentage',
                 'percent_price': 10,
             })],
-            'name': 'Without Discount Included',
+            'name': 'Percentage Discount',
         })
         self.so._cart_update_pricelist(pricelist_id=pl2.id)
-        self.assertEqual(so_line.price_reduce_taxexcl, 900, 'Incorrect amount based on the pricelist and its currency.')
-
-        # set pricelist to 10% - with discount
-        pl3 = pl2.copy({
-            'discount_policy': 'with_discount',
-            'name': 'With Discount Included',
-        })
-        self.so._cart_update_pricelist(pricelist_id=pl3.id)
         self.assertEqual(so_line.price_reduce_taxexcl, 900, 'Incorrect amount based on the pricelist and its currency.')

--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -13,7 +13,7 @@
     <!-- Add price information on tickets (multi tickets, aka in collapse) -->
     <xpath expr="//div[hasclass('o_wevent_registration_multi_select')]" position="inside">
         <t t-if="ticket.price">
-            <t t-if="(ticket.price - ticket.price_reduce) &gt; 0 and website.pricelist_id.discount_policy == 'without_discount'">
+            <t t-if="(ticket.price - ticket.price_reduce) &gt; 0">
                 <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                      class="text-danger me-1"
                      t-field="ticket.price"
@@ -56,7 +56,7 @@
     <xpath expr="//div[hasclass('o_wevent_registration_single_select')]" position="before">
         <div class="flex-md-grow-1 me-2 text-end">
             <t t-if="tickets.price">
-                <t t-if="(tickets.price - tickets.price_reduce) &gt;0 and website.pricelist_id.discount_policy == 'without_discount'">
+                <t t-if="(tickets.price - tickets.price_reduce) &gt;0">
                     <del t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'"
                          class="text-danger me-1"
                          t-field="tickets.price"

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -210,7 +210,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
     def shop(self, page=0, category=None, search='', min_price=0.0, max_price=0.0, ppg=False, **post):
         if not request.website.has_ecommerce_access():
             return request.redirect('/web/login')
-        add_qty = int(post.get('add_qty', 1))
         try:
             min_price = float(min_price)
         except ValueError:
@@ -376,9 +375,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
                 layout_mode = 'grid'
             request.session['website_sale_shop_layout_mode'] = layout_mode
 
-        # Try to fetch geoip based fpos or fallback on partner one
-        fiscal_position_sudo = website.fiscal_position_id.sudo()
-        products_prices = lazy(lambda: products._get_sales_prices(pricelist, fiscal_position_sudo))
+        products_prices = lazy(lambda: products._get_sales_prices(website))
 
         attributes_values = request.env['product.attribute.value'].browse(attrib_set)
         sorted_attributes_values = attributes_values.sorted('sequence')
@@ -399,9 +396,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'attrib_values': attrib_values,
             'attrib_set': attrib_set,
             'pager': pager,
-            'pricelist': pricelist,
-            'fiscal_position': fiscal_position_sudo,
-            'add_qty': add_qty,
             'products': products,
             'search_product': search_product,
             'search_count': product_count,  # common for all searchbox
@@ -638,7 +632,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return {
             'search': search,
             'category': category,
-            'pricelist': request.website.pricelist_id,
             'keep': keep,
             'categories': ProductCategory.search([('parent_id', '=', False)]),
             'main_object': product,

--- a/addons/website_sale/models/res_config_settings.py
+++ b/addons/website_sale/models/res_config_settings.py
@@ -22,6 +22,8 @@ class ResConfigSettings(models.TransientModel):
         string="Comparison Price",
         implied_group="website_sale.group_product_price_comparison",
         group='base.group_portal,base.group_user,base.group_public',
+        help="Add a strikethrough price to your /shop and product pages for comparison purposes."
+             "It will not be displayed if pricelists apply."
     )
 
     # Modules

--- a/addons/website_sale/static/src/js/sale_variant_mixin.js
+++ b/addons/website_sale/static/src/js/sale_variant_mixin.js
@@ -511,6 +511,7 @@ var VariantMixin = {
         var self = this;
         var $price = $parent.find(".oe_price:first .oe_currency_value");
         var $default_price = $parent.find(".oe_default_price:first .oe_currency_value");
+        var $compare_price = $parent.find(".oe_compare_list_price")
         $price.text(self._priceToStr(combination.price));
         $default_price.text(self._priceToStr(combination.list_price));
 
@@ -525,11 +526,13 @@ var VariantMixin = {
                 .closest('.oe_website_sale')
                 .addClass("discount");
             $default_price.parent().removeClass('d-none');
+            $compare_price.addClass("d-none");
         } else {
             $default_price
                 .closest('.oe_website_sale')
                 .removeClass("discount");
             $default_price.parent().addClass('d-none');
+            $compare_price.removeClass("d-none");
         }
 
         var rootComponentSelectors = [

--- a/addons/website_sale/static/tests/tours/website_sale_shop_compare_list_price_pricelist.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_compare_list_price_pricelist.js
@@ -21,7 +21,7 @@ registry.category("web_tour.tours").add('compare_list_price_price_list_display',
         tourUtils.assertProductPrice("base_price",   "2,500", "test_product_with_compare_list_price"),
         tourUtils.assertProductPrice("price_reduce", "1,500", "test_product_with_pricelist"),
         tourUtils.assertProductPrice("price_reduce", "3,500", "test_product_with_pricelist_and_compare_list_price"),
-        tourUtils.assertProductPrice("base_price",   "4,500", "test_product_with_pricelist_and_compare_list_price"),
+        tourUtils.assertProductPrice("base_price",   "4,000", "test_product_with_pricelist_and_compare_list_price"),
 
         ...tourUtils.selectPriceList('pricelist_without_discount'),
 
@@ -31,7 +31,7 @@ registry.category("web_tour.tours").add('compare_list_price_price_list_display',
         tourUtils.assertProductPrice("price_reduce", "1,500", "test_product_with_pricelist"),
         tourUtils.assertProductPrice("base_price",   "2,000", "test_product_with_pricelist"),
         tourUtils.assertProductPrice("price_reduce", "3,500", "test_product_with_pricelist_and_compare_list_price"),
-        tourUtils.assertProductPrice("base_price",   "4,500", "test_product_with_pricelist_and_compare_list_price"),
+        tourUtils.assertProductPrice("base_price",   "4,000", "test_product_with_pricelist_and_compare_list_price"),
 
     ]
 });

--- a/addons/website_sale/tests/test_customize.py
+++ b/addons/website_sale/tests/test_customize.py
@@ -79,7 +79,6 @@ class TestCustomize(HttpCaseWithUserDemo, HttpCaseWithUserPortal, TestProductCon
         # Make sure pricelist rule exist
         self.env['product.pricelist'].create({
             'name': 'Base Pricelist',
-            'discount_policy': 'without_discount',
             'item_ids': [Command.create({
                 'base': 'list_price',
                 'applied_on': '1_product',

--- a/addons/website_sale/tests/test_website_sale_cart.py
+++ b/addons/website_sale/tests/test_website_sale_cart.py
@@ -196,7 +196,6 @@ class TestWebsiteSaleCart(BaseUsersCommon, ProductAttributesCommon, WebsiteSaleC
 
         # Add discount of 50% for pricelist
         pricelist.write({
-            'discount_policy': 'without_discount',
             'item_ids': [
                 Command.create({
                     'base': "list_price",

--- a/addons/website_sale/tests/test_website_sale_configurator.py
+++ b/addons/website_sale/tests/test_website_sale_configurator.py
@@ -276,7 +276,6 @@ class TestWebsiteSaleProductConfigurator(TestProductConfiguratorCommon, HttpCase
             'optional_product_ids': [Command.set(optional_product.ids)],
         })
         self.env['website'].get_current_website().pricelist_id.write({
-            'discount_policy': 'without_discount',
             'item_ids': [
                 Command.create({
                     'applied_on': "1_product",

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -204,7 +204,6 @@ class TestWebsitePriceList(WebsiteSaleCommon):
             'taxes_id': False,
         })
         self.website.pricelist_id.write({
-            'discount_policy': 'with_discount',
             'item_ids': [Command.clear(), Command.create({
                 'applied_on': '1_product',
                 'product_tmpl_id': product.product_tmpl_id.id,
@@ -215,7 +214,6 @@ class TestWebsitePriceList(WebsiteSaleCommon):
         })
         promo_pricelist = self.env['product.pricelist'].create({
             'name': 'Super Pricelist',
-            'discount_policy': 'without_discount',
             'item_ids': [Command.create({
                 'applied_on': '1_product',
                 'product_tmpl_id': product.product_tmpl_id.id,
@@ -252,7 +250,6 @@ class TestWebsitePriceList(WebsiteSaleCommon):
             'taxes_id': False,
         })
         self.website.pricelist_id.write({
-            'discount_policy': 'without_discount',
             'item_ids': [
                 Command.clear(),
                 Command.create({
@@ -283,25 +280,6 @@ class TestWebsitePriceList(WebsiteSaleCommon):
         self.assertEqual(sol.price_unit, 10.0, 'Pricelist price should be applied')
         self.assertEqual(sol.discount, 0, 'Pricelist price should be applied')
         self.assertEqual(sol.price_total, 60.0)
-
-    def test_get_right_discount(self):
-        """ Test that `_get_sales_prices` from `product_template`
-        returns a dict with just `price_reduce` (no discount) as key
-        when the product is tax included.
-        """
-        self.env.company.country_id = self.env.ref('base.us')
-
-        product = self.env['product.template'].create({
-            'name': 'Event Product',
-            'list_price': 10.0,
-            'taxes_id': [Command.create({
-                'name': "Tax 10",
-                'amount': 10,
-            })],
-        })
-
-        prices = product._get_sales_prices(self.list_christmas, self.env['account.fiscal.position'])
-        self.assertFalse('base_price' in prices[product.id])
 
     def test_pricelist_item_based_on_cost_for_templates(self):
         """ Test that `_get_sales_prices` from `product_template` computes the correct price when
@@ -376,7 +354,6 @@ class TestWebsitePriceList(WebsiteSaleCommon):
             'is_published': True,
         })
         self.pricelist.write({
-            'discount_policy': 'without_discount',
             'item_ids': [Command.create({
                 'price_discount': 20,
                 'compute_price': 'formula',

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -336,7 +336,6 @@ class TestWebsitePriceList(WebsiteSaleCommon):
         """
         self.env['res.config.settings'].create({                  # Set Settings:
             'show_line_subtotals_tax_selection': 'tax_included',  # Set "Tax Included" on the "Display Product Prices"
-            'product_pricelist_setting': 'advanced',              # advanced pricelist (discounts, etc.)
             'group_product_price_comparison': True,               # price comparison
         }).execute()
 

--- a/addons/website_sale/tests/test_website_sale_pricelist.py
+++ b/addons/website_sale/tests/test_website_sale_pricelist.py
@@ -304,8 +304,9 @@ class TestWebsitePriceList(WebsiteSaleCommon):
             'name': 'Product Template', 'list_price': 10.0, 'standard_price': 5.0
         })
         self.assertEqual(product_template.standard_price, 5)
-        price = product_template._get_sales_prices(
-            pricelist, self.env['account.fiscal.position'])[product_template.id]['price_reduce']
+        # Hack to enforce the use of this pricelist in the call to `_get_sales_price`
+        self.website.pricelist_id = pricelist
+        price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
         msg = "Template has no variants, the price should be computed based on the template's cost."
         self.assertEqual(price, 4.5, msg)
 
@@ -316,14 +317,14 @@ class TestWebsitePriceList(WebsiteSaleCommon):
         self.assertEqual(product_template.standard_price, 0, msg)
         self.assertEqual(product_template.product_variant_ids[0].standard_price, 0)
 
-        price = product_template._get_sales_prices(
-            pricelist, self.env['account.fiscal.position'])[product_template.id]['price_reduce']
+        self.website.pricelist_id = pricelist
+        price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
         msg = "Template has variants, the price should be computed based on the 1st variant's cost."
         self.assertEqual(price, 0, msg)
 
         product_template.product_variant_ids[0].standard_price = 20
-        price = product_template._get_sales_prices(
-            pricelist, self.env['account.fiscal.position'])[product_template.id]['price_reduce']
+        self.website.pricelist_id = pricelist
+        price = product_template._get_sales_prices(self.website)[product_template.id]['price_reduce']
         self.assertEqual(price, 18, msg)
 
     def test_base_price_with_discount_on_pricelist_tax_included(self):
@@ -359,7 +360,9 @@ class TestWebsitePriceList(WebsiteSaleCommon):
                 'product_tmpl_id': product_tmpl.id,
             })],
         })
-        res = product_tmpl._get_sales_prices(self.pricelist, self.env['account.fiscal.position'])
+        # Hack to enforce the use of this pricelist in the call to `_get_sales_price`
+        self.website.pricelist_id = self.pricelist
+        res = product_tmpl._get_sales_prices(self.website)
         self.assertEqual(res[product_tmpl.id]['base_price'], 75)
 
 def simulate_frontend_context(self, website_id=1):

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -24,7 +24,6 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         pricelist = self.env['product.pricelist'].create({
             'name': "test_get_combination_info",
             'currency_id': self.other_currency.id,
-            'discount_policy': 'with_discount',
             'company_id': self.env.company.id,
             'item_ids': [Command.create({
                 'price_discount': 10,
@@ -56,7 +55,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         self.assertEqual(combination_info['price'], 2222 * discount_rate * currency_ratio)
         self.assertEqual(combination_info['list_price'], 2222 * discount_rate * currency_ratio)
         self.assertEqual(combination_info['price_extra'], 222 * currency_ratio)
-        self.assertEqual(combination_info['has_discounted_price'], False)
+        self.assertEqual(combination_info['has_discounted_price'], True)
 
         # CASE: B2C setting
         website.show_line_subtotals_tax_selection = 'tax_included'
@@ -65,11 +64,16 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         self.assertEqual(combination_info['price'], 2222 * discount_rate * currency_ratio * tax_ratio)
         self.assertEqual(combination_info['list_price'], 2222 * discount_rate * currency_ratio * tax_ratio)
         self.assertEqual(combination_info['price_extra'], round(222 * currency_ratio * tax_ratio, 2))
-        self.assertEqual(combination_info['has_discounted_price'], False)
+        self.assertEqual(combination_info['has_discounted_price'], True)
 
         # CASE: pricelist 'without_discount'
-        pricelist.discount_policy = 'without_discount'
-
+        pricelist.write({
+            'item_ids': [
+                Command.create({
+                    'percent_price': 10,
+                    'compute_price': 'percentage',
+                })],
+        })
         combination_info = product_template._get_combination_info()
         self.assertEqual(combination_info['price'], pricelist.currency_id.round(2222 * discount_rate * currency_ratio * tax_ratio), 0)
         self.assertEqual(combination_info['list_price'], pricelist.currency_id.round(2222 * currency_ratio * tax_ratio), 0)

--- a/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
+++ b/addons/website_sale/tests/test_website_sale_product_attribute_value_config.py
@@ -53,7 +53,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         # CASE: B2B setting (default)
         combination_info = product_template._get_combination_info()
         self.assertEqual(combination_info['price'], 2222 * discount_rate * currency_ratio)
-        self.assertEqual(combination_info['list_price'], 2222 * discount_rate * currency_ratio)
+        self.assertEqual(combination_info['list_price'], 2222 * currency_ratio)
         self.assertEqual(combination_info['price_extra'], 222 * currency_ratio)
         self.assertEqual(combination_info['has_discounted_price'], True)
 
@@ -62,22 +62,8 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
 
         combination_info = product_template._get_combination_info()
         self.assertEqual(combination_info['price'], 2222 * discount_rate * currency_ratio * tax_ratio)
-        self.assertEqual(combination_info['list_price'], 2222 * discount_rate * currency_ratio * tax_ratio)
+        self.assertAlmostEqual(combination_info['list_price'], 2222 * currency_ratio * tax_ratio)
         self.assertEqual(combination_info['price_extra'], round(222 * currency_ratio * tax_ratio, 2))
-        self.assertEqual(combination_info['has_discounted_price'], True)
-
-        # CASE: pricelist 'without_discount'
-        pricelist.write({
-            'item_ids': [
-                Command.create({
-                    'percent_price': 10,
-                    'compute_price': 'percentage',
-                })],
-        })
-        combination_info = product_template._get_combination_info()
-        self.assertEqual(combination_info['price'], pricelist.currency_id.round(2222 * discount_rate * currency_ratio * tax_ratio), 0)
-        self.assertEqual(combination_info['list_price'], pricelist.currency_id.round(2222 * currency_ratio * tax_ratio), 0)
-        self.assertEqual(combination_info['price_extra'], pricelist.currency_id.round(222 * currency_ratio * tax_ratio), 0)
         self.assertEqual(combination_info['has_discounted_price'], True)
 
     def test_get_combination_info_with_fpos(self):
@@ -129,7 +115,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
 
         combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 575, "500$ + 15% tax")
-        self.assertEqual(combination_info['list_price'], 575, "500$ + 15% tax (2)")
+        self.assertEqual(combination_info['list_price'], 2530, "500$ + 15% tax (2)")
         self.assertEqual(combination_info['price_extra'], 230, "200$ + 15% tax")
 
         # Setup fiscal position 15% => 0%.
@@ -150,7 +136,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         website.invalidate_recordset(['fiscal_position_id'])
         combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "500% + 0% tax (mapped from fp 15% -> 0%)")
-        self.assertEqual(combination_info['list_price'], 500, "500% + 0% tax (mapped from fp 15% -> 0%)")
+        self.assertEqual(combination_info['list_price'], 2200, "500% + 0% tax (mapped from fp 15% -> 0%)")
         self.assertEqual(combination_info['price_extra'], 200, "200% + 0% tax (mapped from fp 15% -> 0%)")
 
         # Try same flow with tax included
@@ -161,7 +147,7 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         website.invalidate_recordset(['fiscal_position_id'])
         combination_info = product._get_combination_info()
         self.assertEqual(combination_info['price'], 500, "434.78$ + 15% tax")
-        self.assertEqual(combination_info['list_price'], 500, "434.78$ + 15% tax (2)")
+        self.assertEqual(combination_info['list_price'], 2200, "434.78$ + 15% tax (2)")
         self.assertEqual(combination_info['price_extra'], 200, "173.91$ + 15% tax")
 
         # Now with fiscal position, taxes should be mapped
@@ -169,12 +155,12 @@ class TestWebsiteSaleProductAttributeValueConfig(TestSaleProductAttributeValueCo
         website.invalidate_recordset(['fiscal_position_id'])
         combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")
-        self.assertEqual(round(combination_info['list_price'], 2), 434.78, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")
+        self.assertEqual(round(combination_info['list_price'], 2), 1913.04, "434.78$ + 0% tax (mapped from fp 15% -> 0%)")
         self.assertEqual(combination_info['price_extra'], 173.91, "173.91$ + 0% tax (mapped from fp 15% -> 0%)")
 
         # Try same flow with tax included for apply tax
         tax0.write({'name': "Test tax 5", 'amount': 5, 'price_include': True})
         combination_info = product._get_combination_info()
         self.assertEqual(round(combination_info['price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
-        self.assertEqual(round(combination_info['list_price'], 2), 456.52, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
+        self.assertEqual(round(combination_info['list_price'], 2), 2008.7, "434.78$ + 5% tax (mapped from fp 15% -> 5% for BE)")
         self.assertEqual(combination_info['price_extra'], 182.61, "173.91$ + 5% tax (mapped from fp 15% -> 5% for BE)")

--- a/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
+++ b/addons/website_sale/tests/test_website_sale_show_compare_list_price.py
@@ -65,7 +65,6 @@ class WebsiteSaleShopPriceListCompareListPriceDispayTests(AccountTestInvoicingHt
             'company_id': cls.env.company.id,
             'selectable': True,
             'sequence': 2,
-            'discount_policy': 'with_discount',
             'item_ids': [
                 Command.create({
                     'applied_on': '1_product',
@@ -87,7 +86,6 @@ class WebsiteSaleShopPriceListCompareListPriceDispayTests(AccountTestInvoicingHt
             'company_id': cls.env.company.id,
             'selectable': True,
             'sequence': 3,
-            'discount_policy': 'without_discount',
             'item_ids': [
                 Command.create({
                     'applied_on': '1_product',

--- a/addons/website_sale/views/product_pricelist_views.xml
+++ b/addons/website_sale/views/product_pricelist_views.xml
@@ -6,14 +6,16 @@
         <field name="inherit_id" ref="product.product_pricelist_view"/>
         <field name="model">product.pricelist</field>
         <field name="arch" type="xml">
-            <group name="pricelist_availability" position="after">
-                <group name="pricelist_website" string="Website">
-                    <field name="company_id" invisible="1"/>
-                    <field name="website_id" options="{'no_create': True}"/>
-                    <field name="selectable"/>
-                    <field name="code"/>
-                </group>
-            </group>
+            <notebook position="inside">
+                <page name="pricelist_config" string="Ecommerce">
+                    <group name="pricelist_website">
+                        <field name="company_id" invisible="1"/>
+                        <field name="website_id" options="{'no_create': True}"/>
+                        <field name="selectable"/>
+                        <field name="code"/>
+                    </group>
+                </page>
+            </notebook>
         </field>
     </record>
 

--- a/addons/website_sale/views/res_config_settings_views.xml
+++ b/addons/website_sale/views/res_config_settings_views.xml
@@ -72,18 +72,18 @@
                     </setting>
                     <setting
                         id="pricelists_setting"
-                        title="With the first mode you can set several prices in the product config form (from Sales tab). With the second one, you set prices and computation rules from Pricelists."
                         help="Manage pricelists to apply specific prices per country, customer, products, etc"
                         documentation="/applications/sales/sales/products_prices/prices/pricing.html"
                     >
                         <field name="group_product_pricelist"/>
                         <div class="content-group mt16" invisible="not group_product_pricelist">
-                            <field name="group_sale_pricelist" invisible="1"/>
-                            <field name="group_product_pricelist" invisible="1"/>
-                            <field name="product_pricelist_setting" class="o_light_label w-75" widget="radio"/>
-                        </div>
-                        <div invisible="not group_product_pricelist">
-                            <button type="action" name="%(product.product_pricelist_action2)d" string="Pricelists" class="btn-link" icon="oi-arrow-right"/>
+                            <button
+                                name="%(product.product_pricelist_action2)d"
+                                icon="oi-arrow-right"
+                                type="action"
+                                string="Pricelists"
+                                groups="product.group_product_pricelist"
+                                class="btn-link"/>
                         </div>
                     </setting>
                     <setting help="Add a strikethrough price, as a comparison">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1330,7 +1330,7 @@
                 />
                 <t t-if="is_view_active('website_sale.tax_indication')" t-call="website_sale.tax_indication"/>
                 <del t-if="combination_info['compare_list_price'] and (combination_info['compare_list_price'] &gt; combination_info['price'])"
-                    class="text-danger ms-1 h5">
+                    class="text-danger ms-1 h5 oe_compare_list_price">
                     <bdi dir="inherit">
                     <span t-esc="combination_info['compare_list_price']"
                           groups="website_sale.group_product_price_comparison"


### PR DESCRIPTION
- no more discount policy -> only show discount if compute price of rule is percentage
- show discounted value automatically on website
- no more "multiple prices per product" advanced settings turned on by default
- move pricelist settings related to website to website_sale and delete configuration tab

task-3061255

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
