### PR TITLE
[IMP] stock: store forecast_availability & forecast_expected_date

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -326,9 +326,6 @@ class MrpProduction(models.Model):
         other_productions.components_availability = False
         other_productions.components_availability_state = False
 
-        all_raw_moves = productions.move_raw_ids
-        # Force to prefetch more than 1000 by 1000
-        all_raw_moves._fields['forecast_availability'].compute_value(all_raw_moves)
         for production in productions:
             if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in production.move_raw_ids):
                 production.components_availability = _('Not Available')

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -178,8 +178,8 @@ class StockMove(models.Model):
     next_serial = fields.Char('First SN')
     next_serial_count = fields.Integer('Number of SN')
     orderpoint_id = fields.Many2one('stock.warehouse.orderpoint', 'Original Reordering Rule', check_company=True, index=True)
-    forecast_availability = fields.Float('Forecast Availability', compute='_compute_forecast_information', digits='Product Unit of Measure', compute_sudo=True)
-    forecast_expected_date = fields.Datetime('Forecasted Expected date', compute='_compute_forecast_information', compute_sudo=True)
+    forecast_availability = fields.Float('Forecast Availability', compute='_compute_forecast_information', digits='Product Unit of Measure', compute_sudo=True, store=True)
+    forecast_expected_date = fields.Datetime('Forecasted Expected date', compute='_compute_forecast_information', compute_sudo=True, store=True)
     lot_ids = fields.Many2many('stock.lot', compute='_compute_lot_ids', inverse='_set_lot_ids', string='Serial Numbers', readonly=False)
     reservation_date = fields.Date('Date to Reserve', compute='_compute_reservation_date', store=True,
         help="Computes when a move should be reserved")

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -515,9 +515,6 @@ class Picking(models.Model):
         other_pickings.products_availability = False
         other_pickings.products_availability_state = False
 
-        all_moves = pickings.move_ids
-        # Force to prefetch more than 1000 by 1000
-        all_moves._fields['forecast_availability'].compute_value(all_moves)
         for picking in pickings:
             # In case of draft the behavior of forecast_availability is different : if forecast_availability < 0 then there is a issue else not.
             if any(float_compare(move.forecast_availability, 0 if move.state == 'draft' else move.product_qty, precision_rounding=move.product_id.uom_id.rounding) == -1 for move in picking.move_ids):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Make stock.move's `forecast_availability` and `forecast_expected_date` fields stored fields due to potentially expensive computation method.

Also, removes any now unnecessary forced computations of forecast_availability that were present.

This may be considered a workaround patch to account for the slow computation of `stock.move._compute_forecast_information`. Specifically, `_compute_forecast_information` `calls stock.move._get_forecast_availability_outgoing`, which in turn calls `stock.forecasted_product_product._get_report_lines`. `_get_report_lines` can be slow because it exhibits an N+1 problem around this loop: https://github.com/odoo/odoo/blob/2ce67da4c2e07d14a7b77147ba54c11d22d4a4e1/addons/stock/report/stock_forecasted.py#L296

The loop will trigger N calls into stock.move database table within the function calls to `_get_out_move_reserved_data` and `_get_out_move_taken_from_stock_data` (for each move in `linked_moves`)

This can potentially cause a slowdown, recently Help project tickets 3818495 and 3769280 had this as an issue when loading mrp orders.

A better solution would be to fix the N+1 problem, but I wanted to submit this commit as a simpler workaround.

opw-3818495
