### PR TITLE
[FIX] mail: fix typing of mail services

### DIFF
--- a/addons/mail/static/src/js/tooling/types/services.d.ts
+++ b/addons/mail/static/src/js/tooling/types/services.d.ts
@@ -23,26 +23,26 @@ declare module "services" {
     import { threadService } from "@mail/core/common/thread_service";
 
     export interface Services {
-        "discuss.channel.member": typeof channelMemberService;
-        "discuss.core.common": typeof discussCoreCommon;
-        "discuss.core.public": typeof discussCorePublic;
-        "discuss.core.web": typeof discussCoreWeb;
-        "discuss.rtc": typeof rtcService;
-        "discuss.typing": typeof discussTypingService;
-        "mail.activity": typeof activityService;
-        "mail.attachment": typeof attachmentService;
-        "mail.attachment_upload": typeof attachmentUploadService;
-        "mail.chat_window": typeof chatWindowService;
-        "mail.core.common": typeof mailCoreCommon;
-        "mail.core.web": typeof mailCoreWeb;
-        "mail.message": typeof messageService;
-        "mail.messaging": typeof messagingService;
-        "mail.notification.permission": typeof notificationPermissionService;
-        "mail.out_of_focus": typeof outOfFocusService;
-        "mail.persona": typeof personaService;
-        "mail.sound_effects": typeof soundEffects;
-        "mail.store": typeof storeService;
-        "mail.suggestion": typeof suggestionService;
-        "mail.thread": typeof threadService;
+        "discuss.channel.member": ReturnType<typeof channelMemberService.start>;
+        "discuss.core.common": ReturnType<typeof discussCoreCommon.start>;
+        "discuss.core.public": ReturnType<typeof discussCorePublic.start>;
+        "discuss.core.web": ReturnType<typeof discussCoreWeb.start>;
+        "discuss.rtc": ReturnType<typeof rtcService.start>;
+        "discuss.typing": ReturnType<typeof discussTypingService.start>;
+        "mail.activity": ReturnType<typeof activityService.start>;
+        "mail.attachment": ReturnType<typeof attachmentService.start>;
+        "mail.attachment_upload": ReturnType<typeof attachmentUploadService.start>;
+        "mail.chat_window": ReturnType<typeof chatWindowService.start>;
+        "mail.core.common": ReturnType<typeof mailCoreCommon.start>;
+        "mail.core.web": ReturnType<typeof mailCoreWeb.start>;
+        "mail.message": ReturnType<typeof messageService.start>;
+        "mail.messaging": ReturnType<typeof messagingService.start>;
+        "mail.notification.permission": ReturnType<typeof notificationPermissionService.start>;
+        "mail.out_of_focus": ReturnType<typeof outOfFocusService.start>;
+        "mail.persona": ReturnType<typeof personaService.start>;
+        "mail.sound_effects": ReturnType<typeof soundEffects.start>;
+        "mail.store": ReturnType<typeof storeService.start>;
+        "mail.suggestion": ReturnType<typeof suggestionService.start>;
+        "mail.thread": ReturnType<typeof threadService.start>;
     }
 }


### PR DESCRIPTION
Before this PR, the return type of the useService function with mail
services was wrong. Indeed, the type definitions are wrong: the
service API type is actually the return type of the start function of
the service in the registry, not the service itself.


Before:
![image](https://github.com/odoo/odoo/assets/48757558/b057f537-7d0c-42c0-b99d-3d1e32740a56)

After:
![image](https://github.com/odoo/odoo/assets/48757558/23d214dc-9e75-4d5c-a839-7c3e6c2b698a)
