### PR TITLE
[IMP] stock_account: accounting date on new quants

### DIFF
--- a/addons/stock/tests/test_inventory.py
+++ b/addons/stock/tests/test_inventory.py
@@ -315,7 +315,7 @@ class TestInventory(TransactionCase):
 
     def test_inventory_request_count_quantity(self):
         """ Ensures when a request to count a quant for tracked product is done, other quants for
-        the same product in the same location are also marked as to count."""
+        the same product in the same location are not marked as to count."""
         # Config: enable tracking and multilocations.
         self.env.user.group_ids = [
             Command.link(self.env.ref('stock.group_production_lot').id),
@@ -361,19 +361,19 @@ class TestInventory(TransactionCase):
                 'inventory_quantity': 1,
             }
         ])
-        # Request count for 1 quant => The other quant in the same location
-        # should also be updated, other quants shouldn't
+        # Request count for first and second quant => The other quant in the same location
+        # shouldn't be updated, also other quants shouldn't
         request_wizard = self.env['stock.request.count'].create({
-            'quant_ids': quants[1].ids,
+            'quant_ids': [quants[1].id, quants[3].id],
             'set_count': 'empty',
             'user_id': self.env.user.id,
         })
         request_wizard.action_request_count()
         self.assertRecordValues(quants, [
-            {'lot_id': serial_numbers[0].id, 'user_id': self.env.user.id, 'location_id': self.stock_location.id},
+            {'lot_id': serial_numbers[0].id, 'user_id': False, 'location_id': self.stock_location.id},
             {'lot_id': serial_numbers[1].id, 'user_id': self.env.user.id, 'location_id': self.stock_location.id},
             {'lot_id': serial_numbers[2].id, 'user_id': False, 'location_id': sub_location.id},
-            {'lot_id': serial_numbers[3].id, 'user_id': False, 'location_id': stock_location_2.id},
+            {'lot_id': serial_numbers[3].id, 'user_id': self.env.user.id, 'location_id': stock_location_2.id},
         ])
 
     def test_inventory_outdate_1(self):

--- a/addons/stock/wizard/stock_request_count.py
+++ b/addons/stock/wizard/stock_request_count.py
@@ -19,11 +19,10 @@ class StockRequestCount(models.TransientModel):
 
     def action_request_count(self):
         for count_request in self:
-            quants_to_count = count_request._get_quants_to_count()
             if count_request.set_count == 'set':
-                quants_to_count.filtered(lambda q: not q.inventory_quantity_set).action_set_inventory_quantity()
-            values = count_request._get_values_to_write()
-            quants_to_count.with_context(inventory_mode=True).write(values)
+                count_request.quant_ids.filtered(lambda q: not q.inventory_quantity_set).action_set_inventory_quantity()
+            count_request.quant_ids.with_context(inventory_mode=True).write(
+                count_request._get_values_to_write())
 
     def _get_quants_to_count(self):
         self.ensure_one()

--- a/addons/stock_account/wizard/stock_request_count.py
+++ b/addons/stock_account/wizard/stock_request_count.py
@@ -1,11 +1,21 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class StockRequestCount(models.TransientModel):
     _inherit = 'stock.request.count'
+
+    @api.model
+    def default_get(self, default_fields):
+        res = super().default_get(default_fields)
+        stock_quants = self.env['stock.quant'].browse(self.env.context.get('active_ids')).exists()
+        res['accounting_date'] = max(
+            stock_quants.filtered(lambda q: q.accounting_date and q.accounting_date <= fields.Date.today()).mapped('accounting_date'),
+            default=fields.Date.today()
+        )
+        return res
 
     accounting_date = fields.Date('Accounting Date')
 


### PR DESCRIPTION
Before this commit:
==================
- When similar type of quant exists(with the same product(tracked) and location)
  with accounting date and we create a new of quant with same product and
  location accounting will not be set for newly created quant.
- When we apply counts of multiple similar(same product (tracked) and location)
  quants of tracked product and they have different accounting dates then these
  different dates will used as accounting date (in case of automatic valuation).

After this commit:
==================
- When creating new quant of tracked product accounting date will we set for new
  quant if similar(same product(tracked) and location) quants exist and these
  quants have accounting date, date will be selected.
  For Example: let's say today is 10th and accounting date for different quants
  4,6,7,10, 11, empty for 6 similar quants. then 7 will be selected as
  accounting date.
- Similarly accounting date will be selected when we apply counts of
  similar(same product and location) quants of tracked product accounting date
  will be set which will be used as accounting date in case of automatic
  valuation. So accounting date of all quants will be same.

task  3817532
