### PR TITLE
[IMP] website, *: add support for "Header Position" for events, blogs...

### DIFF
--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -153,6 +153,24 @@ class WebsiteCover_PropertiesMixin(models.AbstractModel):
         return True
 
 
+class WebsitePageVisibilityOptionsMixin(models.AbstractModel):
+    _name = 'website.page_visibility_options.mixin'
+    _description = "Website page/record specific visibility options"
+
+    header_visible = fields.Boolean(default=True)
+    footer_visible = fields.Boolean(default=True)
+
+
+class WebsitePageOptionsMixin(models.AbstractModel):
+    _name = 'website.page_options.mixin'
+    _inherit = ['website.page_visibility_options.mixin']
+    _description = "Website page/record specific options"
+
+    header_overlay = fields.Boolean()
+    header_color = fields.Char()
+    header_text_color = fields.Char()
+
+
 class WebsiteMultiMixin(models.AbstractModel):
     _name = 'website.multi.mixin'
 

--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -176,19 +176,15 @@ class ThemeWebsiteMenu(models.Model):
 class ThemeWebsitePage(models.Model):
     _name = 'theme.website.page'
     _description = 'Website Theme Page'
+    _inherit = [
+        'website.page_options.mixin',
+    ]
 
     url = fields.Char()
     view_id = fields.Many2one('theme.ir.ui.view', required=True, ondelete="cascade")
     website_indexed = fields.Boolean('Page Indexed', default=True)
     is_published = fields.Boolean()
     is_new_page_template = fields.Boolean(string="New Page Template")
-
-    # Page options
-    header_overlay = fields.Boolean()
-    header_color = fields.Char()
-    header_text_color = fields.Char()
-    header_visible = fields.Boolean(default=True)
-    footer_visible = fields.Boolean(default=True)
 
     copy_ids = fields.One2many('website.page', 'theme_template_id', 'Page using a copy of me', copy=False, readonly=True)
 

--- a/addons/website/models/theme_models.py
+++ b/addons/website/models/theme_models.py
@@ -186,6 +186,7 @@ class ThemeWebsitePage(models.Model):
     # Page options
     header_overlay = fields.Boolean()
     header_color = fields.Char()
+    header_text_color = fields.Char()
     header_visible = fields.Boolean(default=True)
     footer_visible = fields.Boolean(default=True)
 
@@ -206,6 +207,7 @@ class ThemeWebsitePage(models.Model):
             'is_new_page_template': self.is_new_page_template,
             'header_overlay': self.header_overlay,
             'header_color': self.header_color,
+            'header_text_color': self.header_text_color,
             'header_visible': self.header_visible,
             'footer_visible': self.footer_visible,
             'theme_template_id': self.id,

--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -15,6 +15,7 @@ class WebsitePage(models.Model):
     _inherit = [
         'website.published.multi.mixin',
         'website.searchable.mixin',
+        'website.page_options.mixin',
     ]
     _description = 'Page'
     _order = 'website_id'
@@ -28,13 +29,6 @@ class WebsitePage(models.Model):
     is_homepage = fields.Boolean(compute='_compute_is_homepage', string='Homepage')
     is_visible = fields.Boolean(compute='_compute_visible', string='Is Visible')
     is_new_page_template = fields.Boolean(string="New Page Template", help='Add this page to the "+New" page templates. It will be added to the "Custom" category.')
-
-    # Page options
-    header_overlay = fields.Boolean()
-    header_color = fields.Char()
-    header_text_color = fields.Char()
-    header_visible = fields.Boolean(default=True)
-    footer_visible = fields.Boolean(default=True)
 
     # don't use mixin website_id but use website_id on ir.ui.view instead
     website_id = fields.Many2one(related='view_id.website_id', store=True, readonly=False, ondelete='cascade')

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -678,8 +678,11 @@ export class WysiwygAdapterComponent extends Wysiwyg {
         const actionName = event.data.actionName;
         const params = event.data.params;
         switch (actionName) {
-            case 'get_page_option':
-                 return event.data.onSuccess(this.pageOptions[params[0]].value);
+            case 'get_page_option': {
+                const optionName = params[0];
+                const value = optionName in this.pageOptions ? this.pageOptions[optionName].value : null;
+                return event.data.onSuccess(value);
+            }
             case 'toggle_page_option':
                 this._togglePageOption(...params);
                 return event.data.onSuccess();
@@ -704,6 +707,12 @@ export class WysiwygAdapterComponent extends Wysiwyg {
      */
     _togglePageOption(params) {
         const pageOption = this.pageOptions[params.name];
+        if (!pageOption) {
+            // The option does not exist... we might want to warn to ease
+            // development but it is a correct use case at the moment ("toggle
+            // the page option if it exists").
+            return;
+        }
         pageOption.value = params.value === undefined ? !pageOption.value : params.value;
     }
     /**

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -2844,6 +2844,24 @@ options.registry.TopMenuVisibility = VisibilityPageOptionUpdate.extend({
         }
         return _super(...arguments);
     },
+    /**
+     * @override
+     */
+    async _computeWidgetVisibility(widgetName, params) {
+        if (widgetName === 'over_content_header_visibility_opt') {
+            let value;
+            this.trigger_up('action_demand', {
+                actionName: 'get_page_option',
+                params: ['header_overlay'],
+                onSuccess: v => value = v,
+            });
+            // The option might not even be available on this specific page
+            // (while the 'header_visible' one is), in this case the retrieved
+            // value is `null`
+            return value !== null;
+        }
+        return this._super(...arguments);
+    },
 });
 
 options.registry.topMenuColor = options.Class.extend({

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1290,7 +1290,7 @@
     </div>
 
     <div data-js="TopMenuVisibility"
-         data-selector="[data-main-object^='website.page('] #wrapwrap > header"
+         data-selector="[data-main-object]:has(input.o_page_option_data[name='header_visible']) #wrapwrap > header"
          data-no-check="true">
         <we-select string="Header Position" data-no-preview="true"
                    data-dependencies="!header_sidebar_opt">
@@ -1303,7 +1303,7 @@
     </div>
 
     <div data-js="topMenuColor"
-         data-selector="[data-main-object^='website.page('] #wrapwrap > header"
+         data-selector="[data-main-object]:has(input.o_page_option_data[name='header_color']):has(input.o_page_option_data[name='header_text_color']) #wrapwrap > header"
          data-no-check="true">
         <we-colorpicker string="Background"
             class="o_we_sublevel_1"
@@ -1578,7 +1578,7 @@
     </div>
 
     <div data-js="HideFooter"
-        data-selector="[data-main-object^='website.page('] #wrapwrap > footer"
+        data-selector="[data-main-object]:has(input.o_page_option_data[name='footer_visible']) #wrapwrap > footer"
         data-no-check="true"
         groups="website.group_website_designer">
         <we-checkbox string="Page Visibility"

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -231,10 +231,7 @@
         <attribute name="data-name">Footer</attribute>
         <!-- Background now controlled by css configuration, using color combinations -->
         <attribute name="t-attf-class" add="o_colored_level o_cc" remove="bg-light" separator=" "/>
-        <!-- Add the main object as a cache key so that the footer_visible page
-        option is properly reflected across pages. Controllers and other objects
-        do not have any page option (yet) so they can share the same cache -->
-        <attribute name="t-cache" add="website,main_object._name == 'website.page' and main_object"/>
+        <attribute name="t-cache" add="website" separator=","/>
     </xpath>
     <xpath expr="//div[hasclass('o_footer_copyright')]" position="attributes">
         <attribute name="data-name">Copyright</attribute>
@@ -339,6 +336,7 @@
     <xpath expr="//footer[@id='bottom']" position="attributes">
         <attribute name="t-attf-class" add="#{'d-none o_snippet_invisible' if 'footer_visible' in main_object and not main_object.footer_visible else ''}" separator=" "/>
         <attribute name="t-att-data-invisible">'1' if 'footer_visible' in main_object and not main_object.footer_visible else None</attribute>
+        <attribute name="t-cache" add="main_object.footer_visible if 'footer_visible' in main_object else True" separator=","/>
     </xpath>
 </template>
 

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -160,6 +160,7 @@ class BlogPost(models.Model):
     _name = 'blog.post'
     _description = "Blog Post"
     _inherit = ['mail.thread', 'website.seo.metadata', 'website.published.multi.mixin',
+        'website.page_visibility_options.mixin',
         'website.cover_properties.mixin', 'website.searchable.mixin']
     _order = 'id DESC'
     _mail_post_access = 'read'

--- a/addons/website_event/models/event_event.py
+++ b/addons/website_event/models/event_event.py
@@ -24,6 +24,7 @@ class EventEvent(models.Model):
         'website.published.multi.mixin',
         'website.cover_properties.mixin',
         'website.searchable.mixin',
+        'website.page_visibility_options.mixin',
     ]
 
     def _default_cover_properties(self):


### PR DESCRIPTION
*: website_blog, website_event, website_slides

This commit introduces the `WebsitePageOptionsMixin` for blog posts, events, and courses. It enables the specification of the "Header Position" for specific records.

As a bonus, the footer's "Page Visibility" also becomes configurable for those records.

task-3430319
