### PR TITLE
[FIX] delivery: allow parent company's taxes on shipping line

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -96,7 +96,7 @@ class SaleOrder(models.Model):
             carrier = carrier.with_context(lang=self.partner_id.lang)
 
         # Apply fiscal position
-        taxes = carrier.product_id.taxes_id.filtered(lambda t: t.company_id.id == self.company_id.id)
+        taxes = carrier.product_id.taxes_id.filtered(lambda t: t.company_id in self.company_id.parent_ids)
         taxes_ids = taxes.ids
         if self.partner_id and self.fiscal_position_id:
             taxes_ids = self.fiscal_position_id.map_tax(taxes).ids


### PR DESCRIPTION
Currently, in a branch company, a shipping line will not contain taxes from the parent company.

### Steps to reproduce

* install `delivery` and `sale_management`
* have a company `C` and its branch `B`
* switch to company `B`
* create a shipping product with a tax from company `C`
* create a shipping method using the product you just created
* on a sales order, add the shipping method you just created.

You should see that the tax is missing from the shipping line.

opw-3775579