### PR TITLE
[FIX] hr_expense: bill partner child contact

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -1289,16 +1289,21 @@ class HrExpenseSheet(models.Model):
 
     def _prepare_bill_vals(self):
         self.ensure_one()
-        return {
+        res = {
             **self._prepare_move_vals(),
             # force the name to the default value, to avoid an eventual 'default_name' in the context
             # to set it to '' which cause no number to be given to the account.move when posted.
             'journal_id': self.journal_id.id,
             'move_type': 'in_invoice',
-            'partner_id': self.employee_id.sudo().address_home_id.commercial_partner_id.id,
+            'partner_id': self.employee_id.sudo().address_home_id.id,
             'currency_id': self.currency_id.id,
             'line_ids':[Command.create(expense._prepare_move_line_vals()) for expense in self.expense_line_ids],
         }
+        if self.employee_id.sudo().bank_account_id:
+            res.update({
+                'partner_bank_id': self.employee_id.sudo().bank_account_id.id,
+            })
+        return res
 
     def _prepare_move_vals(self):
         self.ensure_one()


### PR DESCRIPTION
Open a [DEMO] employee record
Set the Bank Account Number under 'Private Information'
Open the contact (res.partner) of [DEMO]
Set the parent contact to be the current company
Add a bank account on the contact for current company
Go to Expenses and create a new expense for [DEMO], with Paid By "Employee (to reimburse)"
Create Report, Submit Report, Approve, then Post Journal Entries.

Issue: On the created bill, partner will be the parent company and also
the bank account will be the one of the parent company.
When registering payment from:
- bill: the user will see the bank account of the company
- expense: the user will see the bank account of the employee

opw-3800134