### PR TITLE
[IMP] core: docstring of odoo.tools.date_util.end_of. Docstring was probably copied from start_of and not fixed up, so described the wrong semantics.

### DIFF
--- a/odoo/tools/date_utils.py
+++ b/odoo/tools/date_utils.py
@@ -147,7 +147,7 @@ def end_of(value, granularity):
 
     :param value: initial date or datetime.
     :param granularity: Type of period in string, can be year, quarter, month, week, day or hour.
-    :return: A date/datetime object corresponding to the start of the specified period.
+    :return: A date/datetime object corresponding to the end of the specified period.
     """
     is_datetime = isinstance(value, datetime)
     if granularity == "year":


### PR DESCRIPTION
Docstring was probably copied from `start_of` and not fixed up, so described the wrong semantics.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
