### PR TITLE
[IMP] web: Always show the name of the company on the app top right

### DIFF
--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.js
@@ -109,14 +109,14 @@ export class SwitchCompanyMenu extends Component {
         );
         useChildSubEnv({ companySelector: this.companySelector });
     }
+
+    get isSingleCompany() {
+        return Object.values(this.companyService.allowedCompaniesWithAncestors ?? {}).length === 1;
+    }
 }
 
 export const systrayItem = {
     Component: SwitchCompanyMenu,
-    isDisplayed(env) {
-        const { allowedCompanies } = env.services.company;
-        return Object.keys(allowedCompanies).length > 1;
-    },
 };
 
 registry.category("systray").add("SwitchCompanyMenu", systrayItem, { sequence: 1 });

--- a/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
+++ b/addons/web/static/src/webclient/switch_company_menu/switch_company_menu.xml
@@ -4,8 +4,8 @@
 <t t-name="web.SwitchCompanyMenu">
     <div class="o_switch_company_menu d-none d-md-block">
         <DropdownGroup group="'web-navbar-group'">
-            <Dropdown position="'bottom-end'">
-                <button>
+            <Dropdown disabled="isSingleCompany" position="'bottom-end'">
+                <button t-att-disabled="isSingleCompany">
                     <i class="fa fa-building d-lg-none"/>
                     <span class="oe_topbar_name d-none d-lg-block" t-esc="companyService.currentCompany.name"/>
                 </button>

--- a/addons/web/static/tests/webclient/switch_company_menu.test.js
+++ b/addons/web/static/tests/webclient/switch_company_menu.test.js
@@ -361,3 +361,28 @@ test("companies can be logged in even if some toggled within delay", async () =>
     expect(".dropdown-menu").toHaveCount(0, { message: "dropdown is directly closed" });
     expect(["2"]).toVerifySteps();
 });
+
+test("always show the name of the company on the top right of the app", async () => {
+    // initialize a single company
+    const companyName = "Single company";
+    patchWithCleanup(session.user_companies, {
+        allowed_companies: {
+            1: { id: 1, name: companyName, sequence: 1, parent_id: false, child_ids: [] },
+        },
+        disallowed_ancestor_companies: {},
+        current_company: 1,
+    });
+
+    function onSetCookie(key, values) {
+        if (key === "cids") {
+            expect.step(values);
+        }
+    }
+    await createSwitchCompanyMenu({ onSetCookie });
+    expect(["1"]).toVerifySteps();
+
+    // in case of a single company, drop down button should be displayed but disabled
+    expect(".dropdown-toggle").toBeDisplayed();
+    expect(".dropdown-toggle").not.toBeEnabled();
+    expect(".dropdown-toggle").toHaveText(companyName);
+});


### PR DESCRIPTION
Removed the isDisplayed condition of the SwitchCompanyMenu component.
With this, the name of the company on the top right of the app will always be shown even is there is only one company.
Also, if there is a single company, the company selector will be disabled.

The name of the company on the top right of the app was hidden when there was only one company.

task-3829645


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
