### PR TITLE
[FIX] sale_project: project._fetch_sale_order_item_ids fails intermittently

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -287,6 +287,8 @@ class Project(models.Model):
         query.limit = limit
         query.offset = offset
         query_str, params = query.select('DISTINCT sale_line_id')
+        # Prior to executing the query, flush the ORM cache to make sure everything is in the database
+        self.env.flush_all()
         self._cr.execute(query_str, params)
         return [row[0] for row in self._cr.fetchall()]
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Tests dependent on project.task's _get_sale_order_items method fail intermittently. This was noted while migrating a custom module from 15.0 to 17.0 and ensuring it passed all tests. In debugging, it was noted that the project.task and sale.order.line records expected to be found by the query in project.project's _get_sale_order_items_query were in fact not present in the database despite the objects being accessible in the memory. This was confirmed by observing records in memory at a break point during test debugging as well as running SQL queries using the same debug environment.

Current behavior before PR:

Intermittent test failures at:

- sale_project/tests/test_sale_project.py:143
- sale_project/tests/test_project_profitability:175

Desired behavior after PR is merged:

Sale order items are correctly fetched by project._get_sale_order_items() regardless of whether there are pending computations and updates to the database. Tests mentioned above now pass as expected more consistently.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
