### PR TITLE
[FIX] mail: splicing schedule method

### DIFF
--- a/addons/mail/static/src/web/activity/activity.js
+++ b/addons/mail/static/src/web/activity/activity.js
@@ -72,6 +72,10 @@ export class Activity extends Component {
         return computeDelay(this.props.data.date_deadline);
     }
 
+    get onUpdate() {
+        return this.props.onUpdate?.();
+    }
+
     toggleDetails() {
         this.state.showDetails = !this.state.showDetails;
     }
@@ -84,7 +88,7 @@ export class Activity extends Component {
         this.popover.open(ev.currentTarget, {
             activity: this.props.data,
             hasHeader: true,
-            reload: this.props.onUpdate,
+            reload: this.onUpdate,
         });
     }
 
@@ -94,20 +98,20 @@ export class Activity extends Component {
             this.props.data
         );
         await this.activityService.markAsDone(this.props.data, [attachmentId]);
-        this.props.onUpdate();
+        this.onUpdate();
         await this.threadService.fetchNewMessages(this.thread);
     }
 
     async edit() {
         const { id, res_model, res_id } = this.props.data;
         await this.env.services["mail.activity"].schedule(res_model, res_id, id);
-        this.props.onUpdate();
+        this.onUpdate();
     }
 
     async unlink() {
         this.activityService.delete(this.props.data);
         await this.env.services.orm.unlink("mail.activity", [this.props.data.id]);
-        this.props.onUpdate();
+        this.onUpdate();
     }
 
     get thread() {

--- a/addons/mail/static/src/web/chatter.js
+++ b/addons/mail/static/src/web/chatter.js
@@ -111,7 +111,10 @@ export class Chatter extends Component {
         this.scrollPosition = useScrollPosition("root", undefined, "top");
         this.rootRef = useRef("root");
         this.onScrollDebounced = useThrottleForAnimation(this.onScroll);
-        useChildSubEnv({ inChatter: true });
+        useChildSubEnv({
+            inChatter: true,
+            reloadParentView: () => this.reloadParentView(),
+        });
         useDropzone(
             this.rootRef,
             async (ev) => {
@@ -395,17 +398,18 @@ export class Chatter extends Component {
         this.state.showActivities = !this.state.showActivities;
     }
 
+    async schedule(threadId) {
+        await this.activityService.schedule(this.props.threadModel, threadId);
+        this.load(this.props.threadId, ["activities", "messages"]);
+    }
+
     async scheduleActivity() {
-        const schedule = async (threadId) => {
-            await this.activityService.schedule(this.props.threadModel, threadId);
-            this.load(this.props.threadId, ["activities", "messages"]);
-        };
         if (this.props.threadId) {
-            schedule(this.props.threadId);
+            this.schedule(this.props.threadId);
         } else {
             this.onNextUpdate = (nextProps) => {
                 if (nextProps.threadId) {
-                    schedule(nextProps.threadId);
+                    this.schedule(nextProps.threadId);
                 } else {
                     return true;
                 }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:
This PR separates the schedule method from scheduleActivity method, so that it can be overridden.
Needed to be done to trigger reloadParentView method for documents.document.

See here: odoo-dev/enterprise@14c7a95

Task - 3786861



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
