### PR TITLE
[FIX] account: handle missing journals when loading chart template

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -12712,6 +12712,15 @@ msgid "The country to use the tax reports from for this company"
 msgstr ""
 
 #. module: account
+#. odoo-python
+#: code:addons/account/models/chart_template.py:0
+#, python-format
+msgid ""
+"The currency exchange difference journal is missing. Please configure it in "
+"the '%s' company settings to proceed with the operation."
+msgstr ""
+
+#. module: account
 #: model:ir.model.fields,help:account.field_account_journal__currency_id
 msgid "The currency used to enter statement"
 msgstr ""
@@ -13309,6 +13318,15 @@ msgstr ""
 #: model:ir.model.fields,help:account.field_account_fiscal_position__foreign_vat
 msgid ""
 "The tax ID of your company in the region mapped by this fiscal position."
+msgstr ""
+
+#. module: account
+#. odoo-python
+#: code:addons/account/models/chart_template.py:0
+#, python-format
+msgid ""
+"The tax cash basis journal is missing. Please configure it in the '%s' "
+"company settings to proceed with the operation."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -557,10 +557,24 @@ class AccountChartTemplate(models.AbstractModel):
                 journal.loss_account_id = journal.loss_account_id or company.default_cash_difference_expense_account_id
 
         # Set newly created journals as defaults for the company
-        if not company.tax_cash_basis_journal_id:
-            company.tax_cash_basis_journal_id = self.ref('caba')
+        if not company.tax_cash_basis_journal_id and company.tax_exigibility:
+            caba_journal = self.ref("caba", raise_if_not_found=False)
+            if not caba_journal:
+                raise UserError(_(
+                    "The tax cash basis journal is missing. "
+                    "Please configure it in the '%s' company settings to proceed with the operation.",
+                    company.display_name,
+                ))
+            company.tax_cash_basis_journal_id = caba_journal
         if not company.currency_exchange_journal_id:
-            company.currency_exchange_journal_id = self.ref('exch')
+            exchange_journal = self.ref("exch", raise_if_not_found=False)
+            if not exchange_journal:
+                raise UserError(_(
+                    "The currency exchange difference journal is missing. "
+                    "Please configure it in the '%s' company settings to proceed with the operation.",
+                    company.display_name,
+                ))
+            company.currency_exchange_journal_id = exchange_journal
 
         # Setup default Income/Expense Accounts on Sale/Purchase journals
         sale_journal = self.ref("sale", raise_if_not_found=False)


### PR DESCRIPTION
### Steps to reproduce

* install `account`
* delete the 'Exchange Difference' and/or 'Cash Basis Taxes' journals.
* attempt to install `stock`

You should be met with a traceback:
`ValueError: External ID not found in the system: account.1_caba`

opw-3483524