### PR TITLE
[FIX] web_editor: print style html_field

### DIFF
--- a/addons/mass_mailing/static/src/js/tours/mass_mailing_editor_tour.js
+++ b/addons/mass_mailing/static/src/js/tours/mass_mailing_editor_tour.js
@@ -164,7 +164,7 @@ odoo.define('mass_mailing.mass_mailing_editor_tour', function (require) {
         },
         {
             content: "Check that color was applied",
-            trigger: 'iframe p font.text-o-color-1',
+            trigger: 'iframe p span.text-o-color-1',
             run: () => null,
         },
         {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1069,7 +1069,7 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
         // with a class (in case the formating comes from the class).
         while (
             parentNode && !isBlock(parentNode) &&
-            !(parentNode.classList && parentNode.classList.length) &&
+            !(parentNode.classList && parentNode.classList.length && !parentNode.classList.contains('text-gradient')) &&
             !isUnbreakable(parentNode) && !isUnbreakable(currentNode)
         ) {
             const isUselessZws = parentNode.tagName === 'SPAN' &&

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/color.test.js
@@ -30,23 +30,23 @@ describe('applyColor', () => {
         await testEditor(BasicEditor, {
             contentBefore: '<p>ab[]cd</p>',
             stepFunction: setColor('rgb(255, 0, 0)', 'color'),
-            contentAfter: '<p>ab<font style="color: rgb(255, 0, 0);">[]\u200B</font>cd</p>',
+            contentAfter: '<p>ab<span style="color: rgb(255, 0, 0);">[]\u200B</span>cd</p>',
         });
     });
     it('should get ready to type with a different background color', async () => {
         await testEditor(BasicEditor, {
             contentBefore: '<p>ab[]cd</p>',
             stepFunction: setColor('rgb(255, 0, 0)', 'backgroundColor'),
-            contentAfter: '<p>ab<font style="background-color: rgb(255, 0, 0);">[]\u200B</font>cd</p>',
+            contentAfter: '<p>ab<span style="background-color: rgb(255, 0, 0);">[]\u200B</span>cd</p>',
         });
     });
     it('should apply a color on empty selection', async () => {
         await testEditor(BasicEditor, {
             contentBefore: '<p>[<br></p><p><br></p><p>]<br></p>',
             stepFunction: setColor('rgb(255, 0, 0)', 'color'),
-            contentAfterEdit: '<p>[<font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
-                              '<p><font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>' +
-                              '<p>]<font data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</font></p>',
+            contentAfterEdit: '<p>[<span data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</span></p>' +
+                              '<p><span data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</span></p>' +
+                              '<p>]<span data-oe-zws-empty-inline="" style="color: rgb(255, 0, 0);">\u200B</span></p>',
             contentAfter: '<p>[</p><p></p><p>]</p>',
         });
     });
@@ -54,9 +54,9 @@ describe('applyColor', () => {
         await testEditor(BasicEditor, {
             contentBefore: '<p>[<br></p><p><br></p><p>]<br></p>',
             stepFunction: setColor('rgb(255, 0, 0)', 'backgroundColor'),
-            contentAfterEdit: '<p>[<font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
-                              '<p><font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>' +
-                              '<p>]<font data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</font></p>',
+            contentAfterEdit: '<p>[<span data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</span></p>' +
+                              '<p><span data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</span></p>' +
+                              '<p>]<span data-oe-zws-empty-inline="" style="background-color: rgb(255, 0, 0);">\u200B</span></p>',
             contentAfter: '<p>[</p><p></p><p>]</p>',
         });
     });
@@ -64,16 +64,16 @@ describe('applyColor', () => {
         await testEditor(BasicEditor, {
             contentBefore: '<p><strong>[abcd</strong><br><strong>efghi]</strong></p>',
             stepFunction: setColor('rgb(255, 0, 0)', 'backgroundColor'),
-            contentAfter: '<p><strong><font style="background-color: rgb(255, 0, 0);">[abcd</font></strong><br>' +
-                          '<strong><font style="background-color: rgb(255, 0, 0);">efghi]</font></strong></p>',
+            contentAfter: '<p><strong><span style="background-color: rgb(255, 0, 0);">[abcd</span></strong><br>' +
+                          '<strong><span style="background-color: rgb(255, 0, 0);">efghi]</span></strong></p>',
         });
     });
     it('should not merge line on color change', async () => {
         await testEditor(BasicEditor, {
             contentBefore: '<p><strong>[abcd</strong><br><strong>efghi]</strong></p>',
             stepFunction: setColor('rgb(255, 0, 0)', 'color'),
-            contentAfter: '<p><strong><font style="color: rgb(255, 0, 0);">[abcd</font></strong><br>' +
-                          '<strong><font style="color: rgb(255, 0, 0);">efghi]</font></strong></p>',
+            contentAfter: '<p><strong><span style="color: rgb(255, 0, 0);">[abcd</span></strong><br>' +
+                          '<strong><span style="color: rgb(255, 0, 0);">efghi]</span></strong></p>',
         });
     });
     it('should not apply color on an uneditable element', async () => {
@@ -81,9 +81,9 @@ describe('applyColor', () => {
             contentBefore: '<p>[a</p><p contenteditable="false">b</p><p>c]</p>',
             stepFunction: setColor('rgb(255, 0, 0)', 'color'),
             contentAfter: unformat(`
-                <p><font style="color: rgb(255, 0, 0);">[a</font></p>
+                <p><span style="color: rgb(255, 0, 0);">[a</span></p>
                 <p contenteditable="false">b</p>
-                <p><font style="color: rgb(255, 0, 0);">c]</font></p>
+                <p><span style="color: rgb(255, 0, 0);">c]</span></p>
             `),
         });
     });

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -5396,19 +5396,19 @@ X[]
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
                             contentAfterEdit: unformat(`
                                 <p>
-                                    a<font style="color: aquamarine;">[bc</font>
+                                    a<span style="color: aquamarine;">[bc</span>
                                 </p>
                                 <table class="o_selected_table">
                                     <tbody>
                                         <tr>
                                             <td class="o_selected_td">
-                                                <font style="color: aquamarine;">a]b</font>
+                                                <span style="color: aquamarine;">a]b</span>
                                             </td>
                                             <td class="o_selected_td">
-                                                <font style="color: aquamarine;">cd</font>
+                                                <span style="color: aquamarine;">cd</span>
                                             </td>
                                             <td class="o_selected_td">
-                                                <font style="color: aquamarine;">ef</font>
+                                                <span style="color: aquamarine;">ef</span>
                                             </td>
                                         </tr>
                                     </tbody>
@@ -5427,18 +5427,18 @@ X[]
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
+                                            <span style="color: aquamarine;">ab</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">e[f</font>
+                                            <span style="color: aquamarine;">e[f</span>
                                         </td>
                                     </tr></tbody>
                                 </table>
                                 <p>
-                                    <font style="color: aquamarine;">a]</font>bc
+                                    <span style="color: aquamarine;">a]</span>bc
                                 </p>`),
                         });
                     });
@@ -5454,23 +5454,23 @@ X[]
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
                             contentAfterEdit: unformat(`
                                 <p>
-                                    a<font style="color: aquamarine;">[bc</font>
+                                    a<span style="color: aquamarine;">[bc</span>
                                 </p>
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
+                                            <span style="color: aquamarine;">ab</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ef</font>
+                                            <span style="color: aquamarine;">ef</span>
                                         </td>
                                     </tr></tbody>
                                 </table>
                                 <p>
-                                    <font style="color: aquamarine;">a]</font>bc
+                                    <span style="color: aquamarine;">a]</span>bc
                                 </p>`),
                         });
                     });
@@ -5491,34 +5491,34 @@ X[]
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
                             contentAfterEdit: unformat(`
                                 <p>
-                                    a<font style="color: aquamarine;">[bc</font>
+                                    a<span style="color: aquamarine;">[bc</span>
                                 </p>
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
+                                            <span style="color: aquamarine;">ab</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ef</font>
+                                            <span style="color: aquamarine;">ef</span>
                                         </td>
                                     </tr></tbody>
                                 </table>
                                 <p>
-                                    <font style="color: aquamarine;">abc</font>
+                                    <span style="color: aquamarine;">abc</span>
                                 </p>
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">a]b</font>
+                                            <span style="color: aquamarine;">a]b</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ef</font>
+                                            <span style="color: aquamarine;">ef</span>
                                         </td>
                                     </tr></tbody>
                                 </table>`),
@@ -5542,36 +5542,36 @@ X[]
                             stepFunction: async editor => editor.execCommand('applyColor', 'aquamarine', 'color'),
                             contentAfterEdit: unformat(`
                                 <p>
-                                    a<font style="color: aquamarine;">[bc</font>
+                                    a<span style="color: aquamarine;">[bc</span>
                                 </p>
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
+                                            <span style="color: aquamarine;">ab</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ef</font>
+                                            <span style="color: aquamarine;">ef</span>
                                         </td>
                                     </tr></tbody>
                                 </table>
-                                <p><font style="color: aquamarine;">abc</font></p>
+                                <p><span style="color: aquamarine;">abc</span></p>
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
+                                            <span style="color: aquamarine;">ab</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ef</font>
+                                            <span style="color: aquamarine;">ef</span>
                                         </td>
                                     </tr></tbody>
                                 </table>
-                                <p><font style="color: aquamarine;">a]</font>bc</p>`),
+                                <p><span style="color: aquamarine;">a]</span>bc</p>`),
                         });
                     });
                 });
@@ -5990,10 +5990,10 @@ X[]
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">a[b</font>
+                                            <span style="color: aquamarine;">a[b</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">c]d</font>
+                                            <span style="color: aquamarine;">c]d</span>
                                         </td>
                                         <td>ef</td>
                                     </tr></tbody>
@@ -6012,13 +6012,13 @@ X[]
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">a[b</font>
+                                            <span style="color: aquamarine;">a[b</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">e]f</font>
+                                            <span style="color: aquamarine;">e]f</span>
                                         </td>
                                     </tr>
                                     <tr>
@@ -6053,21 +6053,21 @@ X[]
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">a[b</font>
+                                            <span style="color: aquamarine;">a[b</span>
                                         </td>
                                         <td>cd</td>
                                         <td>ef</td>
                                     </tr>
                                     <tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
+                                            <span style="color: aquamarine;">ab</span>
                                         </td>
                                         <td>cd</td>
                                         <td>ef</td>
                                     </tr>
                                     <tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">a]b</font>
+                                            <span style="color: aquamarine;">a]b</span>
                                         </td>
                                         <td>cd</td>
                                         <td>ef</td>
@@ -6099,19 +6099,19 @@ X[]
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">a[b</font>
+                                            <span style="color: aquamarine;">a[b</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td>ef</td>
                                     </tr>
                                     <tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
+                                            <span style="color: aquamarine;">ab</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">c]d</font>
+                                            <span style="color: aquamarine;">c]d</span>
                                         </td>
                                         <td>ef</td>
                                     </tr>
@@ -6147,35 +6147,35 @@ X[]
                                 <table class="o_selected_table">
                                     <tbody><tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">a[b</font>
+                                            <span style="color: aquamarine;">a[b</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ef</font>
-                                        </td>
-                                    </tr>
-                                    <tr>
-                                        <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
-                                        </td>
-                                        <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
-                                        </td>
-                                        <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ef</font>
+                                            <span style="color: aquamarine;">ef</span>
                                         </td>
                                     </tr>
                                     <tr>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">ab</font>
+                                            <span style="color: aquamarine;">ab</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">cd</font>
+                                            <span style="color: aquamarine;">cd</span>
                                         </td>
                                         <td class="o_selected_td">
-                                            <font style="color: aquamarine;">e]f</font>
+                                            <span style="color: aquamarine;">ef</span>
+                                        </td>
+                                    </tr>
+                                    <tr>
+                                        <td class="o_selected_td">
+                                            <span style="color: aquamarine;">ab</span>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <span style="color: aquamarine;">cd</span>
+                                        </td>
+                                        <td class="o_selected_td">
+                                            <span style="color: aquamarine;">e]f</span>
                                         </td>
                                     </tr></tbody>
                                 </table>`),
@@ -6726,7 +6726,7 @@ X[]
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[b<span class="a">c</span>d]e</p>',
                 stepFunction: editor => editor.execCommand('applyColor', 'rgb(255, 0, 0)', 'color'),
-                contentAfter: '<p>a<font style="color: rgb(255, 0, 0);">[b<span class="a">c</span>d]</font>e</p>',
+                contentAfter: '<p>a<span style="color: rgb(255, 0, 0);">[b<span class="a">c</span>d]</span>e</p>',
             });
         });
         it('should apply background color to a list of 3 items with font size', async () => {
@@ -6751,24 +6751,18 @@ X[]
                 stepFunction: editor => editor.execCommand('applyColor', 'rgb(255, 0, 0)', 'backgroundColor'),
                 contentAfter: '<ul>' +
                                     '<li>' +
-                                        '<span style="font-size: 36px;">' +
-                                            '<font style="background-color: rgb(255, 0, 0);">' +
+                                        '<span style="font-size: 36px; background-color: rgb(255, 0, 0);">' +
                                                 '[abc' +
-                                            '</font>' +
                                         '</span>' +
                                     '</li>' +
                                     '<li>' +
-                                        '<span style="font-size: 36px;">' +
-                                            '<font style="background-color: rgb(255, 0, 0);">' +
+                                        '<span style="font-size: 36px; background-color: rgb(255, 0, 0);">' +
                                                 'bcd' +
-                                            '</font>' +
-                                        '</span>' +
+                                            '</span>' +
                                     '</li>' +
                                     '<li>' +
-                                        '<span style="font-size: 36px;">' +
-                                            '<font style="background-color: rgb(255, 0, 0);">' +
+                                        '<span style="font-size: 36px; background-color: rgb(255, 0, 0);">' +
                                                 'cde]' +
-                                            '</font>' +
                                         '</span>' +
                                     '</li>' +
                                 '</ul>',
@@ -6797,23 +6791,23 @@ X[]
                 contentAfter: '<ul>' +
                                     '<li>' +
                                         '<a href="#">' +
-                                            '<font style="background-color: rgb(255, 0, 0);">' +
+                                            '<span style="background-color: rgb(255, 0, 0);">' +
                                                 '[abc' +
-                                            '</font>' +
+                                            '</span>' +
                                         '</a>' +
                                     '</li>' +
                                     '<li>' +
                                         '<a href="#">' +
-                                            '<font style="background-color: rgb(255, 0, 0);">' +
+                                            '<span style="background-color: rgb(255, 0, 0);">' +
                                                 'bcd' +
-                                            '</font>' +
+                                            '</span>' +
                                         '</a>' +
                                     '</li>' +
                                     '<li>' +
                                         '<a href="#">' +
-                                            '<font style="background-color: rgb(255, 0, 0);">' +
+                                            '<span style="background-color: rgb(255, 0, 0);">' +
                                                 'cde]' +
-                                            '</font>' +
+                                            '</span>' +
                                         '</a>' +
                                     '</li>' +
                                 '</ul>',
@@ -6823,9 +6817,9 @@ X[]
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a[b<a class="btn">c</a>d]e</p>',
                 stepFunction: editor => editor.execCommand('applyColor', 'rgb(255, 0, 0)', 'color'),
-                contentAfter: '<p>a<font style="color: rgb(255, 0, 0);">[b</font>' +
-                    '<a class="btn"><font style="color: rgb(255, 0, 0);">c</font></a>' +
-                    '<font style="color: rgb(255, 0, 0);">d]</font>e</p>',
+                contentAfter: '<p>a<span style="color: rgb(255, 0, 0);">[b</span>' +
+                    '<a class="btn"><span style="color: rgb(255, 0, 0);">c</span></a>' +
+                    '<span style="color: rgb(255, 0, 0);">d]</span>e</p>',
             });
         });
     });

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/color_palette.js
@@ -444,8 +444,14 @@ const ColorPaletteWidget = Widget.extend({
      * @returns {Object}
      */
     _getButtonInfo: function (buttonEl) {
-        const bgColor = buttonEl.style.backgroundColor;
-        const value = buttonEl.dataset.color || (bgColor && bgColor !== 'initial' ? ColorpickerWidget.normalizeCSSColor(bgColor) : '') || '';
+        let bgColor = buttonEl.style.backgroundColor;
+        // if (weUtils.isColorGradient(bgColor) && !bgColor.startsWith('-webkit-')) {
+        //     bgColor = '-webkit-' + bgColor;
+        // }
+        let value = buttonEl.dataset.color || (bgColor && bgColor !== 'initial' ? ColorpickerWidget.normalizeCSSColor(bgColor) : '') || '';
+        // if (weUtils.isColorGradient(value) && !value.startsWith('-webkit-')) {
+        //     value = '-webkit-' + value;
+        // }
         const info = {
             target: buttonEl,
         };

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -292,10 +292,10 @@ QUnit.module('web_editor', {}, function () {
                 "should close the color picker");
 
             assert.strictEqual($field.find('.note-editable').html(),
-                '<p>t<font style="background-color: rgb(0, 255, 255);">oto toto </font>toto</p><p>tata</p>',
+                '<p>t<span style="background-color: rgb(0, 255, 255);">oto toto </span>toto</p><p>tata</p>',
                 "should have rendered the field correctly in edit");
 
-            var fontElement = $field.find('.note-editable font')[0];
+            var fontElement = $field.find('.note-editable span')[0];
             var rangeControl = {
                 sc: fontElement.firstChild,
                 so: 0,
@@ -315,7 +315,7 @@ QUnit.module('web_editor', {}, function () {
             await testUtils.dom.click($('#toolbar .note-back-color-preview [style="background-color: var(--we-cp-o-color-3);"]'));
 
             assert.strictEqual($field.find('.note-editable').html(),
-                '<p>t<font style="background-color: rgb(0, 255, 255);">oto t</font><font class="bg-o-color-3">oto to</font>to</p><p>tata</p>',
+                '<p>t<span style="background-color: rgb(0, 255, 255);">oto t</span><span class="bg-o-color-3">oto to</span>to</p><p>tata</p>',
                 "should have rendered the field correctly in edit");
 
             // Make sure the reset button works too
@@ -325,7 +325,7 @@ QUnit.module('web_editor', {}, function () {
             // TODO right now the behavior is to force "inherit" as background
             // but it should remove the useless font element when possible.
             assert.strictEqual($field.find('.note-editable').html(),
-                '<p>t<font style="background-color: rgb(0, 255, 255);">oto t</font>oto toto</p><p>tata</p>',
+                '<p>t<span style="background-color: rgb(0, 255, 255);">oto t</span>oto toto</p><p>tata</p>',
                 "should have properly reset the background color");
 
             // Select the whole paragraph.
@@ -810,7 +810,7 @@ QUnit.module('web_editor', {}, function () {
                 mockRPC: function (route, args) {
                     if (args.method === "write") {
                         assert.strictEqual(args.args[1].body,
-                            '<p>t<font class="bg-o-color-3">oto toto&nbsp;</font>toto</p><p>tata</p>',
+                            '<p>t<span class="bg-o-color-3">oto toto&nbsp;</span>toto</p><p>tata</p>',
                             "should save the content");
 
                     }


### PR DESCRIPTION
Issue:
======
text style with gradient disappears when printing.

Steps to reproduce the issue:
=============================
- Go to any sale order
- Add any text to terms and conditions
- Add style using gradient
- Print it

Origin of the issue:
====================
- the `font` tag is not recognized by `wkhtmltopdf`.
- `linear-gradient` is not supported byt `wkhtmltopdf`

Solution:
=========
- use of `span` instead of `font`
- use of  `-webkit-linear-gradient` instead of `linear-gradient`

task-3756431