### PR TITLE
[FIX] pos_hr: fix read method in HrEmployeePublic model

### DIFF
--- a/addons/pos_hr/models/hr_employee_public.py
+++ b/addons/pos_hr/models/hr_employee_public.py
@@ -7,7 +7,7 @@ from odoo import models
 class HrEmployeePublic(models.Model):
     _inherit = "hr.employee.public"
 
-    def read(self, fields):
+    def read(self, fields=None, load='_classic_read'):
         # as `pos_blackbox_be` is a certified module, it's hard to make fixes in it
         # so this is a workaround to remove `insz_or_bis_number` field from the fields list
         # as the parent hr.employee model will attempt to read it from hr.employee.public
@@ -18,4 +18,4 @@ class HrEmployeePublic(models.Model):
             if pos_blackbox_be_installed and not has_hr_user_group:
                 fields.remove('insz_or_bis_number')
 
-        return super().read(fields)
+        return super(HrEmployeePublic, self).read(fields=fields, load=load)


### PR DESCRIPTION
This commit fixes an issue where users without HR access rights were unable to read the HrEmployeePublic model due to a missing 'load' argument. This issue was introduced in the following PR: https://github.com/odoo/odoo/commit/d9fd1f2066b1423cb0090ef46011c3504901695c

opw-3844755

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
