### PR TITLE
[FIX] mrp,stock,stock_picking_batch: quantity update issue in detailed operation

### DIFF
--- a/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
+++ b/addons/mrp/static/tests/tours/mrp_sm_sml_synchronization.js
@@ -1,0 +1,65 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { stepUtils } from '@web_tour/tour_service/tour_utils';
+
+registry.category("web_tour.tours").add('test_manufacturing_and_byproduct_sm_to_sml_synchronization', {
+    test: true,
+    steps: () => [
+        { trigger: ".btn-primary[name=action_confirm]" },
+        { trigger: ".o_data_row > td:contains('product2')" },
+        { trigger: ".fa-list" },
+        { trigger: "h4:contains('Components')" },
+        { trigger: ".o_list_number:contains('5')" },
+        { trigger: ".o_form_button_save" },
+        { trigger: ".o_data_row > td:contains('product2')" },
+        {
+            trigger: ".o_field_widget[name=quantity] input",
+            run: 'text 21',
+        },
+        { trigger: ".fa-list" },
+        { trigger: "h4:contains('Components')" },
+        { trigger: ".o_data_row > td:contains('WH/Stock')" },
+        {
+            trigger: ".o_field_widget[name=quantity] input",
+            run: 'text 27',
+        },
+        { trigger: ".o_form_button_save" },
+        { trigger: ".o_data_row > td:contains('43')" },
+        {
+            trigger: ".o_field_widget[name=quantity] input",
+            run: 'text 7',
+        },
+        { trigger: ".fa-list" },
+        { trigger: ".o_data_row > td:contains('7')" },
+        { trigger: ".o_form_button_save" },
+        { trigger: ".nav-link[name=finished_products]" },
+        { trigger: ".o_data_row > td:contains('product2')" },
+        { trigger: ".fa-list" },
+        { trigger: "h4:contains('Move Byproduct')" },
+        { trigger: ".o_list_number:contains('2')" },
+        { trigger: ".o_form_button_save" },
+        { trigger: ".o_data_row > td:contains('product2')" },
+        {
+            trigger: ".o_field_widget[name=quantity] input",
+            run: 'text 5',
+        },
+        { trigger: ".fa-list" },
+        { trigger: "h4:contains('Move Byproduct')" },
+        { trigger: ".o_data_row > td:contains('WH/Stock')" },
+        {
+            trigger: ".o_field_widget[name=quantity] input",
+            run: 'text 7',
+        },
+        { trigger: ".o_form_button_save" },
+        { trigger: ".o_data_row > td:contains('10')" },
+        {
+            trigger: ".o_field_widget[name=quantity] input",
+            run: 'text 7',
+        },
+        { trigger: ".fa-list" },
+        { trigger: ".o_list_footer .o_list_number > span:contains('7')" },
+        { trigger: ".o_form_button_save" },
+        ...stepUtils.saveForm(),
+    ]
+});

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -6,7 +6,7 @@ from freezegun import freeze_time
 
 from odoo import Command, fields
 from odoo.exceptions import UserError
-from odoo.tests import Form
+from odoo.tests import Form, HttpCase, tagged
 from odoo.tools.misc import format_date
 
 from odoo.addons.mrp.tests.common import TestMrpCommon
@@ -4090,3 +4090,62 @@ class TestMrpOrder(TestMrpCommon):
         self.assertEqual(wo.duration_expected, 30.0)
         self.assertEqual(wo.date_start, dt)
         self.assertEqual(wo.date_finished, dt + timedelta(hours=0, minutes=30))
+
+
+@tagged('post_install', '-at_install')
+class TestMrpSynchronization(HttpCase):
+
+    def test_manufacturing_and_byproduct_sm_to_sml_synchronization(self):
+        """ Test the synchronization between stock moves and stock move lines within
+            the detailed operation modal for manufacturings and by-products.
+        """
+
+        self.env['res.config.settings'].create({'group_stock_multi_locations': True}).execute()
+        self.env['res.config.settings'].create({'group_mrp_byproducts': True}).execute()
+
+        location = self.env.ref('stock.stock_location_stock')
+        product = self.env['product.product']
+        product_finish = product.create({
+            'name': 'product1',
+            'type': 'product',
+            'tracking': 'none',
+        })
+        component = product.create({
+            'name': 'product2',
+            'type': 'product',
+            'tracking': 'none',
+        })
+        by_product = product.create({
+            'name': 'product2',
+            'type': 'product',
+            'tracking': 'none',
+        })
+
+        self.env['stock.quant']._update_available_quantity(component, location, 50)
+
+        bom = self.env['mrp.bom'].create({
+            'product_id': product_finish.id,
+            'product_tmpl_id': product_finish.product_tmpl_id.id,
+            'product_qty': 1,
+            'type': 'normal',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component.id, 'product_qty': 5}),
+            ],
+            'byproduct_ids': [
+                (0, 0, {'product_id': by_product.id, 'product_qty': 2, 'product_uom_id': by_product.uom_id.id})
+            ],
+        })
+
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = product_finish
+        mo_form.product_qty = 1
+        mo_form.bom_id = bom
+        mo = mo_form.save()
+
+        action_id = self.env.ref('mrp.menu_mrp_production_action').action
+        url = f'/web#model=mrp.production&view_type=form&action={action_id.id}&id={mo.id}'
+        self.start_tour(url, "test_manufacturing_and_byproduct_sm_to_sml_synchronization", login="admin", timeout=100)
+        self.assertEqual(mo.move_raw_ids.quantity, 7)
+        self.assertEqual(mo.move_raw_ids.move_line_ids.quantity, 7)
+        self.assertEqual(mo.move_byproduct_ids.quantity, 7)
+        self.assertEqual(len(mo.move_byproduct_ids.move_line_ids), 2)

--- a/addons/stock/static/src/views/picking_form/stock_move_one2many.js
+++ b/addons/stock/static/src/views/picking_form/stock_move_one2many.js
@@ -49,8 +49,8 @@ export class StockMoveX2ManyField extends X2ManyField {
         if (this.canOpenRecord && !record.isNew) {
             const dirty = await record.isDirty();
             if (dirty && 'quantity' in record._changes) {
-                await record.model.root.save({ reload: true });
-                record = record.model.root.data[this.props.name].records.find(e => e.resId === record.resId);
+                await record._parentRecord.save({ reload: true });
+                record = record._parentRecord.data[this.props.name].records.find(e => e.resId === record.resId);
                 if (!record) {
                     return;
                 }

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -162,6 +162,7 @@
                     <field name="show_quant" invisible="1"/>
                     <field name="show_lots_text" invisible="1"/>
                     <field name="show_lots_m2o" invisible="1"/>
+                    <field name="quantity" invisible="1"/>
                     <group>
                         <group>
                             <field name="product_id" readonly="id or move_line_ids"/>

--- a/addons/stock_picking_batch/__manifest__.py
+++ b/addons/stock_picking_batch/__manifest__.py
@@ -29,4 +29,9 @@ This module adds the batch transfer option in warehouse management
     ],
     'installable': True,
     'license': 'LGPL-3',
+    'assets': {
+        'web.assets_tests': [
+            'stock_picking_batch/static/tests/tours/**/*',
+        ],
+    },
 }

--- a/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
+++ b/addons/stock_picking_batch/static/tests/tours/stock_picking_batch_tour.js
@@ -1,0 +1,49 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { stepUtils } from '@web_tour/tour_service/tour_utils';
+
+registry.category("web_tour.tours").add('test_stock_picking_batch_sm_to_sml_synchronization', {
+    test: true,
+    steps: () => [
+        { trigger: ".btn-primary[name=action_confirm]" },
+        {
+            trigger: ".o_data_cell[name=name]" ,
+            run: 'click',
+        },
+        { trigger: "h4:contains('Transfers')" },
+        { trigger: ".o_data_row > td:contains('Product A')" },
+        {
+            trigger: ".o_list_number[name=quantity] input",
+            run: 'text 7',
+        },
+        { trigger: ".fa-list" },
+        { trigger: "h4:contains('Stock move')" },
+        { trigger: ".o_field_pick_from > span:contains('WH/Stock/Shelf A')" },
+        { trigger: ".o_list_footer .o_list_number > span:contains('7')" },
+        { trigger: ".o_form_button_save" },
+        { trigger: ".o_data_row > td:contains('Product A')" },
+        {
+            trigger: ".o_list_number[name=quantity] input",
+            run: 'text 21',
+        },
+        { trigger: ".fa-list" },
+        { trigger: "h4:contains('Stock move')" },
+        { trigger: ".o_field_pick_from > span:contains('WH/Stock/Shelf A')" },
+        {
+            trigger: ".o_list_number[name=quantity] input",
+            run: 'text 27',
+        },
+        { trigger: ".o_form_button_save" },
+        { trigger: ".o_data_row > td:contains('47')" },
+        {
+            trigger: ".o_field_widget[name=quantity] input",
+            run: 'text 7',
+        },
+        { trigger: ".fa-list" },
+        { trigger: ".o_data_row > td:contains('7')" },
+        { trigger: ".o_form_button_save" },
+        { trigger: ".o_form_button_save" },
+        ...stepUtils.saveForm(),
+    ]
+});


### PR DESCRIPTION
Issue:
============================
There is a missing synchronization between the stock move line and stock move
for manufacturing orders, by-products, and batch transfers. When clicking on
the list icon and making changes in quantity in the detailed operation modal,
the updates are not properly reflected.

Resolution:
============================
For manufacturing and by-products, add a "quantity" field in the 'detailed 
operation' view so that whenever the save button is clicked, all fields are 
updated properly. For batch transfers, save '_parentRecord' instead of
'model.root' when the save button is clicked.

Steps to Reproduce:
============================
1. Install the mrp and stock modules.
2. Navigate to the stock module.
3. For manufacturing, go to the manufacturing menu inside operations.
   For by-products, go to the by-products tab inside the manufacturing order
   form view.
   For batch transfers, go to the batch transfer menu inside operations.
4. In the form view of each, open the modal (Detailed Operations) and modify
   the quantity.
5. Notice the lack of synchronization between the stock move line and the
   stock move.

Expected Result:
=============================
After implementing the solution, changes in quantities should be synchronized
between the stock move line and the stock move in manufacturing orders,
by-products, and batch transfers. When clicking on the list icon, the
quantities should be updated accurately, reflecting any changes made.

Task: 3815521