### PR TITLE
[FIX] hr_expense: Properly re-close expense sheets on small reconciles

### DIFF
--- a/addons/hr_expense/models/account_move_line.py
+++ b/addons/hr_expense/models/account_move_line.py
@@ -24,7 +24,7 @@ class AccountMoveLine(models.Model):
         res = super().reconcile()
         # Do not consider expense sheet states if account_move_id is False, it means it has been just canceled
         not_paid_expense_sheets = not_paid_expenses.sheet_id.filtered(lambda sheet: sheet.account_move_id)
-        paid_expenses = not_paid_expenses.filtered(lambda expense: expense.currency_id.is_zero(expense.amount_residual))
+        paid_expenses = not_paid_expense_sheets.expense_line_ids.filtered(lambda expense: expense.currency_id.is_zero(expense.amount_residual))
         paid_expenses.write({'state': 'done'})
         not_paid_expense_sheets.filtered(lambda sheet: all(expense.state == 'done' for expense in sheet.expense_line_ids)).set_to_paid()
         return res

--- a/doc/cla/corporate/manatec.md
+++ b/doc/cla/corporate/manatec.md
@@ -21,3 +21,5 @@ Philipp Köhler bandsache@gmx.net https://github.com/fploetzlich
 Alexander Heyber alexander.heyber@manatec.de https://github.com/alexander-heyber-manatec
 
 Walter Salzmann walter.salzmann@manatec.de https://github.com/ws-manatec
+
+Gerald Malsch gerald.malsch@manatec.de https://github.com/AlienAtSystem


### PR DESCRIPTION
To reproduce:

- Create an Expense Report with multiple expenses
- approve and post it
- pay it via multiple payments. 
- Choose any payment that doesn't have an amount so large it has to affect all expense lines (e.g. if the payments are 3€, 4€, 5€, any amount smaller or equal to 9€ triggers the bug). 
- Set this payment to draft
- Re-post it
- reconcile it again (or reconcile the missing amount with another payment). 

The Expense Report is not set to "Done" even though all lines are fully paid, even if the reconciliation does not affect all expense lines, no matter the amount that needed to be reconciled again.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
