### PR TITLE
[FIX] tools: ensure spliting xmlid 2 parts in translations

### DIFF
--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1318,7 +1318,7 @@ class TranslationImporter:
                     # [module_name, imd_name, module_name, imd_name, ...]
                     params = []
                     for xmlid in sub_xmlids:
-                        params.extend(xmlid.split('.'))
+                        params.extend(xmlid.split('.', maxsplit=1))
                     cr.execute(f'''
                         SELECT m.id, imd.module || '.' || imd.name, m."{field_name}", imd.noupdate
                         FROM "{model_table}" m, "ir_model_data" imd
@@ -1376,7 +1376,7 @@ class TranslationImporter:
                     # [xmlid, translations, xmlid, translations, ...]
                     params = []
                     for xmlid, translations in sub_field_dictionary:
-                        params.extend([*xmlid.split('.'), Json(translations)])
+                        params.extend([*xmlid.split('.', maxsplit=1), Json(translations)])
                     if not force_overwrite:
                         value_query = f"""CASE WHEN {overwrite} IS TRUE AND imd.noupdate IS FALSE
                         THEN m."{field_name}" || t.value


### PR DESCRIPTION
In `ir.model.data` model, there is no SQL constraint which is ensuring that the `name` field can not contain `.` (dot) So when loading the translations to database if the xmlid's `name` contains dot then `xmlid.split('.')` will split it more than 2 parts. Which will cause issue during saving it to database as it is expecting[^1]  2 parts `[<module>, <name>]`. I ensured the splitting to 2 parts with `maxsplit=1`

Description of the issue/feature this PR addresses:

Current behavior before PR:
It is splitting xmlids as many as possible parts.

Desired behavior after PR is merged:
It will split xmlid to the 2 parts `[module, name]`

[^1]: https://github.com/odoo/odoo/blob/16.0/odoo/tools/translate.py#L1326
        and
        https://github.com/odoo/odoo/blob/16.0/odoo/tools/translate.py#L1390



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
