### PR TITLE
[FIX] bus: fixed import error

### DIFF
--- a/addons/bus/tests/test_notify.py
+++ b/addons/bus/tests/test_notify.py
@@ -2,7 +2,7 @@
 
 from odoo.tests import BaseCase
 
-from ..models.bus import json_dump, get_notify_payloads, NOTIFY_PAYLOAD_MAX_LENGTH
+from odoo.addons.bus.models.bus import json_dump, get_notify_payloads, NOTIFY_PAYLOAD_MAX_LENGTH
 
 
 class NotifyTests(BaseCase):


### PR DESCRIPTION
by mistaked there was wrong path in import

`from ..models.bus import json_dump, get_notify_payloads, NOTIFY_PAYLOAD_MAX_LENGTH` so we need to correct it by giving correct path

```
 File "/home/odoo/src/odoo/17.0/addons/l10n_gcc_invoice/tests/test_gcc_invoice.py", line 5, in <module>
    from odoo.addons.account.tests.common import AccountTestInvoicingCommon
  File "/home/odoo/src/odoo/17.0/addons/account/tests/__init__.py", line 11, in <module>
    from . import test_account_journal
  File "/home/odoo/src/odoo/17.0/addons/account/tests/test_account_journal.py", line 8, in <module>
    from odoo.addons.mail.tests.common import MailCommon
  File "/home/odoo/src/odoo/17.0/addons/mail/tests/__init__.py", line 19, in <module>
    from .discuss import *
  File "/home/odoo/src/odoo/17.0/addons/mail/tests/discuss/__init__.py", line 7, in <module>
    from . import test_guest_feature
  File "/home/odoo/src/odoo/17.0/addons/mail/tests/discuss/test_guest_feature.py", line 5, in <module>
    from odoo.addons.bus.tests.common import WebsocketCase
  File "/home/odoo/src/odoo/17.0/addons/bus/tests/__init__.py", line 6, in <module>
    from . import test_notify
  File "/home/odoo/src/odoo/17.0/addons/bus/tests/test_notify.py", line 5, in <module>
    from ..models.bus import json_dump, get_notify_payloads, NOTIFY_PAYLOAD_MAX_LENGTH
ImportError: cannot import name 'get_notify_payloads' from 'odoo.addons.bus.models.bus' (/home/odoo/src/odoo/17.0/addons/bus/models/bus.py)
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
