### PR TITLE
[FIX] account: reset payment term on draft

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4139,6 +4139,7 @@ class AccountMove(models.Model):
                 raise UserError(_('You cannot modify a posted entry of this journal because it is in strict mode.'))
             # We remove all the analytics entries for this journal
             move.mapped('line_ids.analytic_line_ids').unlink()
+            move.invoice_payment_term_id = False
 
         self.mapped('line_ids').remove_move_reconcile()
         self.write({'state': 'draft', 'is_move_sent': False})


### PR DESCRIPTION
Steps to reproduce:
1. create a payment term "A" with discount 10%
2. make a vendor bill with payment term "A" (post it)
3. change discount on payment term "A" to 20%
4. go to vendor bill - reset to draft - put back the payment term - post it.
4. Check vendor > Amount to settle. (the discount amount is not updated).

Issue:
Still 10% instead of 20%

opw-3768356
