### PR TITLE
[IMP] core: new api - `search_exists`

### DIFF
--- a/odoo/models.py
+++ b/odoo/models.py
@@ -1580,6 +1580,28 @@ class BaseModel(metaclass=MetaModel):
 
     @api.model
     @api.readonly
+    def search_exists(self, domain):
+        """ search_exists(domain) -> bool
+
+        Returns `True` if there is a record in the current model matching :ref:`the
+        provided domain <reference/orm/domains>` else False.
+
+        :param domain: :ref:`A search domain <reference/orm/domains>`. Use an empty
+                     list to match all records.
+
+        This is a high-level method, which should not be overridden. Its actual
+        implementation is done by method :meth:`_search`.
+        """
+        query = self._search(domain, limit=1)
+
+        if query.is_empty():
+            # optimization: don't execute the query at all
+            return False
+
+        return query.exists()
+
+    @api.model
+    @api.readonly
     @api.returns('self')
     def search(self, domain, offset=0, limit=None, order=None):
         """ search(domain[, offset=0][, limit=None][, order=None])

--- a/odoo/tools/query.py
+++ b/odoo/tools/query.py
@@ -248,6 +248,17 @@ class Query:
             self.add_where(SQL("%s IN %s", SQL.identifier(self.table, 'id'), ids))
         self._ids = ids
 
+    def exists(self):
+        """ Returns True if there are records satisfying the query, else False """
+        assert not self.offset, "Method exists() can only be called on a Query with no offset"
+        if self._ids is None:
+            if self.limit is None or self.limit:
+                return self._env.execute_query(SQL("SELECT EXISTS(%s)", self.select("")))[0][0]
+            else:
+                # optimization: limit == 0 -> no results, don't execute the query at all
+                return False
+        return bool(self)
+
     def __str__(self):
         sql = self.select()
         return f"<Query: {sql.code!r} with params: {sql.params!r}>"


### PR DESCRIPTION
## Purpose
It's often the case that it is necessary to check for the existence of records of a specific model that matches a domain predicate, usually done during python validation for enforcing constraints. What is done currently is either a `search` with a `limit=1`, which is not optimal, as the `_order` is applied, in better case `search_count` is used instead.
The issue is mostly a question of expressiveness, as `search_count(.. ., limit=1)` is not really obvious for what we are checking: existence.

## Feature
Create a new model API endpoint `search_exists`, that takes a `domain` and check if there are records in the model that satisfy the domain.

## Implementation
Check the existence with `SELECT EXISTS(...)` as it's the most trivial plan possible for what we are trying to do (InitPlan -> Results). Note that the presence of a limit, if it's not 0, will usually be optimized out by [postgres][1], so the presence of it on the query object is irrelevant.

[1]:https://github.com/postgres/postgres/blob/0de5274f59c9d84d803d7f3dc75577d8aa6e56b8/src/backend/optimizer/plan/subselect.c#L1523-L1611

## Reference
task-3844634

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
