### PR TITLE
[IMP] account: Deferred options reload

### DIFF
--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -142,6 +142,10 @@ class AccountReport(models.Model):
         string="Favorite Filters", help="If activated, user-defined filters on journal items can be selected on this report",
         compute=lambda x: x._compute_report_option_filter('filter_aml_ir_filters'), readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
     )
+    deferred_options_reload = fields.Boolean(
+        string='Deferred options reload', help="Enables the selection of multiple filters before applying them and reloading the report (recommended for large databases)",
+        readonly=False, store=True, depends=['root_report_id', 'section_main_report_ids'],
+    )
 
     def _compute_report_option_filter(self, field_name, default_value=False):
         # We don't depend on the different filter fields on the root report, as we don't want a manual change on it to be reflected on all the reports


### PR DESCRIPTION
Add a feature that enables companies to select multiple filters in an accounting report before reloading the data of the report. This feature can be activated by selecting the boolean field 'Deferred options reload' in the form view of the accounting report.

On any report, as it is now, the whole report gets refreshed when giving a value to a single option filter. It is very nice on small databases, but on bigger ones might sometimes make the flow more painful for the user if she needs to change the value of multiple filters (e.g. select a journal => wait 10 seconds for the reload => select a partner => wait 10 more seconds). For those big databases, we'd like to have the possibility to have a button under the filters triggering the recompute of the report; hence not doing it immediately when an option is checked. However, we don't want that for all the dbs, as it would then add one click for all the users of small databases, who don't have any issue. Therefore, the chosen solution is rather to support both cases, and add a boolean option on the account.report (in the form view) allowing to switch to this "deferred computation mode". By default, it won't be enabled, and the historical behavior will apply.

See enterprise-PR:

task-3263762

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
