### PR TITLE
[IMP] hr_timesheet, _*: make the timesheets report more uniform acros…

### DIFF
--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -9,13 +9,12 @@
                         <tr>
                             <t t-set="timesheet_record_label" t-value="False"/>
                             <t t-if="show_task">
-                                <t t-set="timesheet_record_label">Task</t>
+                                <t t-set="timesheet_record_label">Project &amp; Task</t>
                             </t>
                             <t t-elif="show_project">
                                 <t t-set="timesheet_record_label">Project</t>
                             </t>
-                            <th class="text-start align-middle"><span>Date</span></th>
-                            <th class="text-start align-middle"><span>Employee</span></th>
+                            <th class="text-start align-middle" style="white-space: nowrap;"><span>Date &amp; Employee</span></th>
                             <th class="text-start align-middle" t-if="timesheet_record_label"><span t-out="timesheet_record_label"/></th>
                             <th class="text-start align-middle"><span>Description</span></th>
                             <th class="text-end">
@@ -26,21 +25,21 @@
                    <tbody>
                         <tr t-foreach="lines" t-as="line" t-att-style="'background-color: #F1F1F1;' if line_index % 2 == 0 else ''">
                             <td class="align-middle">
-                               <span t-field="line.date">2021-09-01</span>
+                                <span t-field="line.date">2021-09-01</span><br/>
+                                <span t-if="line.user_id.partner_id.name" t-field="line.user_id.partner_id.name">Audrey Peterson</span>
+                                <span t-else="" t-field="line.employee_id">Audrey Peterson</span>
                             </td>
-                            <td class="align-middle">
-                               <span t-if="line.user_id.partner_id.name" t-field="line.user_id.partner_id.name">Audrey Peterson</span>
-                               <span t-else="" t-field="line.employee_id">Audrey Peterson</span>
-                            </td>
-                            <t t-set="timesheet_record_info" t-value="False"/>
-                            <t t-if="show_project">
-                                <t t-set="timesheet_record_info" t-value="line.project_id.sudo().name"/>
-                                <t t-if="show_task and line.task_id" t-set="timesheet_record_info" t-value="'%s / %s' % (timesheet_record_info, line.task_id.sudo().name)"/>
+                            <t class="align-middle">
+                                <td t-if="show_project">
+                                    <span t-out="line.project_id.sudo().name"/>
+                                    <t t-if="show_task and line.task_id">
+                                        <br/><span t-out="line.task_id.sudo().name"/>
+                                    </t>
+                                </td>
+                                <td t-elif="show_task">
+                                    <span t-out="line.task_id.sudo().name"/>
+                                </td>
                             </t>
-                            <t t-elif="show_task" t-set="timesheet_record_info" t-value="line.task_id.sudo().name"/>
-                            <td t-if="show_task or show_project" class="align-middle">
-                                <span t-if="timesheet_record_info" t-out="timesheet_record_info">Research and Development/New Portal System</span>
-                            </td>
                             <td class="align-middle">
                                 <span t-field="line.name" t-options="{'widget': 'text'}">Call client and discuss project</span>
                             </td>
@@ -52,7 +51,7 @@
                         <tr>
                             <td class="text-end" colspan="100">
                                 <strong t-if="not is_uom_day">
-                                    <span style="margin-right: 15px;">Total (Hours)</span>
+                                    <span style="margin-right: 15px;">Total</span>
                                     <t t-esc="sum(lines.mapped('unit_amount'))" t-options="{'widget': 'duration', 'digital': True, 'unit': 'hour', 'round': 'minute'}">2 hours</t>
                                 </strong>
                                 <strong t-else="">

--- a/addons/sale_timesheet/report/report_timesheet_templates.xml
+++ b/addons/sale_timesheet/report/report_timesheet_templates.xml
@@ -1,5 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+    <template id="report_timesheet_sale_timesheet" inherit_id="hr_timesheet.timesheet_table">
+        <xpath expr="//th/span[text()='Description']" position="after">
+            <th class="text-start align-middle" t-if="not hide_sale_line">Sale Order Item</th>
+        </xpath>
+        <xpath expr="//td[span[@t-field='line.name']]" position="after">
+            <td class="align-middle" t-if="not hide_sale_line">
+                <span t-field="line.so_line">S00023 - Furniture Delivery (Manual) (Deco Addict)</span>
+            </td>
+        </xpath>
+    </template>
     <template id="timesheet_sale_page">
         <t t-set="show_project" t-value="true"/>
         <t t-set="show_task" t-value="true"/>
@@ -16,10 +26,11 @@
                                 <t t-if="doc.timesheet_ids">
                                     <h2>
                                         <br/>
-                                        <span>Timesheets for the <t t-out="doc_name">S0001</t> <t t-out="record_name">- Timesheet product</t>
-                                        </span>
+                                        <span t-if="not doc_name.startswith('INV/')">Order <t t-out="doc_name"/></span>
+                                        <span t-else="">Timesheets for the Invoice <t t-out="doc_name"/></span>
                                     </h2>
                                     <t t-set='lines' t-value='doc.timesheet_ids'/>
+                                    <t t-set="hide_sale_line" t-value="true"/>
                                     <t t-call="hr_timesheet.timesheet_table"/>
                                 </t>
                             </div>


### PR DESCRIPTION
_*= sale_timesheet
In this PR:
- formatting the table
- displaying 'project & task' or 'project & ticket' for the second column if we are in the context of a specific task/ticket
- changed 'total (hours)' into 'total'
- Displayed a main 'Timesheets' title at the top of the report then secondary 'ticket: drawer's...' titles above each table
- change 'timesheets for the S00080 - Customer Care (Prepaid Hours) Sales Order item' -> 'Order S00080 - Customer Care (Prepaid Hours)'
- also for invoices -> changed the title to 'Invoice INV/2024/00021'

task-3704612
