### PR TITLE
[FIX] portal {website_form_,}project: handle parent rec. sharing

### DIFF
--- a/addons/portal/models/mail_thread.py
+++ b/addons/portal/models/mail_thread.py
@@ -76,3 +76,11 @@ class MailThread(models.AbstractModel):
         secret = self.env["ir.config_parameter"].sudo().get_param("database.secret")
         token = (self.env.cr.dbname, self[self._mail_post_token_field], pid)
         return hmac.new(secret.encode('utf-8'), repr(token).encode('utf-8'), hashlib.sha256).hexdigest()
+
+    def _portal_get_parent_hash_token(self, pid):
+        """ Overridden in models which have M2o 'parent' field and can be shared on
+        either an individual basis or indirectly in a group via the M2o record.
+
+        :return: False or logical parent's _sign_token() result
+        """
+        return False

--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1789,6 +1789,9 @@ class Task(models.Model):
         fields = {name for name, field in self._fields.items() if getattr(field, 'task_dependency_tracking', None)}
         return fields and set(self.fields_get(fields))
 
+    def _portal_get_parent_hash_token(self, pid):
+        return self.project_id._sign_token(pid)
+
     # ----------------------------------------
     # Case management
     # ----------------------------------------

--- a/addons/website_form_project/tests/__init__.py
+++ b/addons/website_form_project/tests/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import test_project_portal_access

--- a/addons/website_form_project/tests/test_project_portal_access.py
+++ b/addons/website_form_project/tests/test_project_portal_access.py
@@ -1,0 +1,45 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from re import search
+
+from odoo import Command
+from odoo.tests import HttpCase
+
+from odoo.addons.portal.controllers.mail import PortalChatter
+from odoo.addons.project.tests.test_project_sharing import TestProjectSharingCommon
+from odoo.addons.website.tools import MockRequest
+
+
+class TestProjectPortalAccess(TestProjectSharingCommon, HttpCase):
+    def test_post_chatter_as_portal_user(self):
+        self.env['project.share.wizard'].create({
+            'res_model': 'project.project',
+            'res_id': self.project_no_collabo.id,
+            'access_mode': 'edit',
+            'partner_ids': [Command.set([self.user_portal.partner_id.id])],
+        }).action_send_mail()
+        message = self.env['mail.message'].search([
+            ('partner_ids', 'in', self.user_portal.partner_id.id),
+        ])
+
+        share_link = str(message.body.split('href="')[1].split('">')[0])
+        match = search(r"access_token=([^&]+)&amp;pid=([^&]+)&amp;hash=([^&]*)", share_link)
+        access_token, pid, _hash = match.groups()
+
+        with self.with_user('chell'), MockRequest(self.env, path=share_link):
+            PortalChatter().portal_chatter_post(
+                res_model='project.task',
+                res_id=self.task_no_collabo.id,
+                message='(-b ±√[b²-4ac]) / 2a',
+                attachment_ids=None,
+                attachment_tokens=None,
+                token=access_token,
+                pid=pid,
+                hash=_hash,
+            )
+
+        self.assertTrue(
+            self.env['mail.message'].sudo().search([
+                ('author_id', '=', self.user_portal.partner_id.id),
+            ])
+        )


### PR DESCRIPTION
**Current behavior:**
Sharing an editable link to a project with a portal user creates
an undesirable scenario where they can read a project record and
associated tasks but trying to use the chatter on a task's page
results in a vague access error.

**Expected behavior:**
An editable share link should require the invitee to login prior
to accessing records and the chatter.

**Steps to reproduce:**
1. Make a project shareable with external users, share an
     editable link with a portal user

2. Open the generated link in an incognito window, go to a task
     that has the chatter text area input available

3. Try to leave a comment, observe the vague error
     (access error behind the scenes)

**Cause of the issue:**
The hash which is generated with the share link for the invitee
uses the project record's `_mail_post_token_field` to permit
access on that record. The system which should recognize this
case and also permit access to that project's task records is
not working properly. Eventually, we fail a consteq() check on
the hash in the URL and the token generated by the ORM to
determine accessibility of the record (because it uses the
task's `_mail_post_token_field` value while ours was generated
using the project's).

**Fix:**
Create a method on the `mail.thread` extension in `portal` which
can be overridden in inheriting classes to return a logical
parent's `_sign_token()` result.

When checking for chatter post access, check both values against
the provided hash.

opw-3777597