### PR TITLE
[FIX] web: convert inline templates with text to regular templates.

### DIFF
--- a/addons/web/i18n/web.pot
+++ b/addons/web/i18n/web.pot
@@ -6819,6 +6819,7 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
+#: code:addons/web/static/src/core/commands/command_items.xml:0
 #: code:addons/web/static/src/webclient/user_menu/user_menu_items.xml:0
 #, python-format
 msgid "TIP"
@@ -8491,6 +8492,7 @@ msgstr ""
 
 #. module: web
 #. odoo-javascript
+#: code:addons/web/static/src/core/commands/command_items.xml:0
 #: code:addons/web/static/src/core/domain_selector/utils.js:0
 #: code:addons/web/static/src/core/domain_selector/utils.js:0
 #, python-format
@@ -14602,6 +14604,13 @@ msgstr ""
 #: code:addons/web/static/src/core/emoji_picker/emoji_data.js:0
 #, python-format
 msgid "empanada"
+msgstr ""
+
+#. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/webclient/actions/action_service.xml:0
+#, python-format
+msgid "empty"
 msgstr ""
 
 #. module: web
@@ -33641,6 +33650,13 @@ msgstr ""
 #: code:addons/web/static/src/webclient/user_menu/user_menu_items.xml:0
 #, python-format
 msgid "— press"
+msgstr ""
+
+#. module: web
+#. odoo-javascript
+#: code:addons/web/static/src/core/commands/command_items.xml:0
+#, python-format
+msgid "— search for"
 msgstr ""
 
 #. module: web

--- a/addons/web/static/src/webclient/actions/action_service.js
+++ b/addons/web/static/src/webclient/actions/action_service.js
@@ -30,12 +30,7 @@ import { downloadReport, getReportUrl } from "./reports/utils";
 
 class BlankComponent extends Component {
     static props = ["onMounted", "withControlPanel", "*"];
-    static template = xml`
-        <ControlPanel display="{disableDropdown: true}" t-if="props.withControlPanel and !env.isSmall">
-            <t t-set-slot="layout-buttons">
-                <button class="btn btn-primary invisible"> empty </button>
-            </t>
-        </ControlPanel>`;
+    static template = "web.BlankComponent";
     static components = { ControlPanel };
 
     setup() {

--- a/addons/web/static/src/webclient/actions/action_service.xml
+++ b/addons/web/static/src/webclient/actions/action_service.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<templates>
+
+    <t t-name="web.BlankComponent" owl="1">
+        <ControlPanel display="{disableDropdown: true}" t-if="props.withControlPanel and !env.isSmall">
+            <t t-set-slot="layout-buttons">
+                <button class="btn btn-primary invisible">empty</button>
+            </t>
+        </ControlPanel>
+    </t>
+  
+</templates>


### PR DESCRIPTION
Strings within inline templates are not translatable, so we convert these templates into standard templates so that they can be.

Task-3761551

