### PR TITLE
[FIX] base_import_module: remove logger exception

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -282,7 +282,6 @@ class IrModule(models.Model):
                         path = opj(module_dir, mod_name)
                         self.sudo()._import_module(mod_name, path, force=force, with_demo=with_demo)
                     except Exception as e:
-                        _logger.exception('Error while importing module')
                         raise UserError(_(
                             "Error while importing module '%(module)s'.\n\n %(error_message)s \n\n",
                             module=mod_name, error_message=exception_to_unicode(e),


### PR DESCRIPTION
Currently, a log error is generated when the user tries to import a module that is not the same as the current Odoo version.


Stack Trace:
```
ValueError: Invalid version '17.0.1.0.0'. Modules should have a version in format `x.y`, `x.y.z`, `saas~17.2.x.y` or `saas~17.2.x.y.z`.
  File "addons/base_import_module/models/ir_module.py", line 253, in _import_zipfile
    self.sudo()._import_module(mod_name, path, force=force, with_demo=with_demo)
  File "addons/base_import_module/models/ir_module.py", line 81, in _import_module
    values['latest_version'] = adapt_version(terp['version'])
  File "odoo/modules/module.py", line 423, in adapt_version
    raise ValueError(f"Invalid version {base_version!r}. Modules should have a version in format `x.y`, `x.y.z`,"
```

The error was caught on log because at [1] `_logger.exception()` was used, and this log error was not
useful because after the printing, the log `UserError` was raised, which shows the user what's wrong with its custom module.

This commit removes the logger exception because the `UserError` shows
what is wrong with the custom modules.

[1]-https://github.com/odoo/odoo/blob/b95edd874ce904ef231c295790a003992db002e3/addons/base_import_module/models/ir_module.py#L255-L258

sentry-4931285432

