### PR TITLE
[FIX] web: werkeug 3.0+

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -137,7 +137,7 @@ def ensure_db(redirect='/web/database/selector'):
         url_redirect = werkzeug.urls.url_parse(r.base_url)
         if r.query_string:
             # in P3, request.query_string is bytes, the rest is text, can't mix them
-            query_string = iri_to_uri(r.query_string)
+            query_string = iri_to_uri(str(r.query_string))
             url_redirect = url_redirect.replace(query=query_string)
         request.session.db = db
         abort_and_redirect(url_redirect.to_url())


### PR DESCRIPTION
Werkzeug.urls is vendored in Odoo but some methods like iri_to_uri are not since they are still present in the latest version.

However, it looks like the implementation changed enough so that the iri cannot be bytes, because _to_str is not called anymore.

Since the comment assumes that it should be bytes all the time, casting it to str before calling iri_to_uri should solve the issue.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
