### PR TITLE
[FIX] {purchase,sale}_mrp: kit order/moves qty update

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -370,9 +370,8 @@ class MrpBom(models.Model):
             # Set missing keys to default value
             for product in products:
                 product_boms.setdefault(product, self.env['mrp.bom'])
-        original_qty = quantity
         quantity = quantity / self.product_qty
-        boms_done = [(self, {'qty': quantity, 'product': product, 'original_qty': original_qty, 'parent_line': False})]
+        boms_done = [(self, {'qty': quantity, 'product': product, 'parent_line': False})]
         lines_done = []
 
         bom_lines = []
@@ -400,13 +399,13 @@ class MrpBom(models.Model):
                 for bom_line in bom.bom_line_ids:
                     if not bom_line.product_id in product_boms:
                         product_ids.add(bom_line.product_id.id)
-                boms_done.append((bom, {'qty': converted_line_quantity, 'product': current_product, 'original_qty': original_qty, 'parent_line': current_line}))
+                boms_done.append((bom, {'qty': converted_line_quantity, 'product': current_product, 'parent_line': current_line}))
             else:
                 # We round up here because the user expects that if he has to consume a little more, the whole UOM unit
                 # should be consumed.
                 rounding = current_line.product_uom_id.rounding
                 line_quantity = float_round(line_quantity, precision_rounding=rounding, rounding_method='UP')
-                lines_done.append((current_line, {'qty': line_quantity, 'product': current_product, 'original_qty': original_qty, 'parent_line': parent_line}))
+                lines_done.append((current_line, {'qty': line_quantity, 'product': current_product, 'parent_line': parent_line}))
 
         return boms_done, lines_done
 

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -582,7 +582,7 @@ class MrpProduction(models.Model):
                 # keep manual entries
                 workorders_values = []
                 product_qty = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
-                exploded_boms, dummy = production.bom_id.explode(production.product_id, product_qty / production.bom_id.product_qty, picking_type=production.bom_id.picking_type_id)
+                exploded_boms, dummy = production.bom_id.explode(production.product_id, product_qty, picking_type=production.bom_id.picking_type_id)
 
                 for bom, bom_data in exploded_boms:
                     # If the operations of the parent BoM and phantom BoM are the same, don't recreate work orders.
@@ -1154,8 +1154,8 @@ class MrpProduction(models.Model):
         for production in self:
             if not production.bom_id:
                 continue
-            factor = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id) / production.bom_id.product_qty
-            boms, lines = production.bom_id.explode(production.product_id, factor, picking_type=production.bom_id.picking_type_id)
+            product_qty = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
+            boms, lines = production.bom_id.explode(production.product_id, product_qty, picking_type=production.bom_id.picking_type_id)
             for bom_line, line_data in lines:
                 if bom_line.child_bom_id and bom_line.child_bom_id.type == 'phantom' or\
                         bom_line.product_id.type not in ['product', 'consu']:

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -246,8 +246,8 @@ class MrpUnbuild(models.Model):
                 for raw_move in raw_moves:
                     moves += unbuild._generate_move_from_existing_move(raw_move, factor, raw_move.location_dest_id, self.location_dest_id)
             else:
-                factor = unbuild.product_uom_id._compute_quantity(unbuild.product_qty, unbuild.bom_id.product_uom_id) / unbuild.bom_id.product_qty
-                boms, lines = unbuild.bom_id.explode(unbuild.product_id, factor, picking_type=unbuild.bom_id.picking_type_id)
+                product_qty = unbuild.product_uom_id._compute_quantity(unbuild.product_qty, unbuild.bom_id.product_uom_id)
+                boms, lines = unbuild.bom_id.explode(unbuild.product_id, product_qty, picking_type=unbuild.bom_id.picking_type_id)
                 for line, line_data in lines:
                     moves += unbuild._generate_move_from_bom_line(line.product_id, line.product_uom_id, line_data['qty'], bom_line_id=line.id)
         return moves

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -252,11 +252,11 @@ class ProductProduct(models.Model):
                 ratios_free_qty.append(component_res["free_qty"] / qty_per_kit)
             if bom_sub_lines and ratios_virtual_available:  # Guard against all cnsumable bom: at least one ratio should be present.
                 res[product.id] = {
-                    'virtual_available': min(ratios_virtual_available) * bom_kits[product].product_qty // 1,
-                    'qty_available': min(ratios_qty_available) * bom_kits[product].product_qty // 1,
-                    'incoming_qty': min(ratios_incoming_qty) * bom_kits[product].product_qty // 1,
-                    'outgoing_qty': min(ratios_outgoing_qty) * bom_kits[product].product_qty // 1,
-                    'free_qty': min(ratios_free_qty) * bom_kits[product].product_qty // 1,
+                    'virtual_available': min(ratios_virtual_available) // 1,
+                    'qty_available': min(ratios_qty_available) // 1,
+                    'incoming_qty': min(ratios_incoming_qty) // 1,
+                    'outgoing_qty': min(ratios_outgoing_qty) // 1,
+                    'free_qty': min(ratios_free_qty) // 1,
                 }
             else:
                 res[product.id] = {

--- a/addons/mrp/models/product.py
+++ b/addons/mrp/models/product.py
@@ -229,7 +229,7 @@ class ProductProduct(models.Model):
                         # to avoid a division by zero. The same logic is applied to non-storable products as those
                         # products have 0 qty available.
                         continue
-                    uom_qty_per_kit = bom_line_data['qty'] / bom_line_data['original_qty']
+                    uom_qty_per_kit = bom_line_data['qty']
                     qty_per_kit += bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, round=False, raise_if_failure=False)
                 if not qty_per_kit:
                     continue

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -400,10 +400,10 @@ class StockMove(models.Model):
                 moves_ids_to_return.add(move.id)
                 continue
             if float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding):
-                factor = move.product_uom._compute_quantity(move.quantity, bom.product_uom_id) / bom.product_qty
+                product_qty = move.product_uom._compute_quantity(move.quantity, bom.product_uom_id)
             else:
-                factor = move.product_uom._compute_quantity(move.product_uom_qty, bom.product_uom_id) / bom.product_qty
-            boms, lines = bom.sudo().explode(move.product_id, factor, picking_type=bom.picking_type_id)
+                product_qty = move.product_uom._compute_quantity(move.product_uom_qty, bom.product_uom_id)
+            boms, lines = bom.sudo().explode(move.product_id, product_qty, picking_type=bom.picking_type_id)
             for bom_line, line_data in lines:
                 if float_is_zero(move.product_uom_qty, precision_rounding=move.product_uom.rounding) or self.env.context.get('is_scrap'):
                     phantom_moves_vals_list += move._generate_move_phantom(bom_line, 0, line_data['qty'])
@@ -575,7 +575,7 @@ class StockMove(models.Model):
             # Now that we have every ratio by components, we keep the lowest one to know how many kits we can produce
             # with the quantities delivered of each component. We use the floor division here because a 'partial kit'
             # doesn't make sense.
-            return kit_bom.product_qty * min(qty_ratios) // 1
+            return min(qty_ratios) // 1
         else:
             return 0.0
 

--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -559,7 +559,7 @@ class StockMove(models.Model):
                 # We compute the quantities needed of each components to make one kit.
                 # Then, we collect every relevant moves related to a specific component
                 # to know how many are considered delivered.
-                uom_qty_per_kit = bom_line_data['qty'] / bom_line_data['original_qty']
+                uom_qty_per_kit = bom_line_data['qty'] / kit_qty
                 qty_per_kit = bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, round=False)
                 if not qty_per_kit:
                     continue

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -87,7 +87,7 @@ class StockWarehouseOrderpoint(models.Model):
                 component = bom_line.product_id
                 if component.type != 'product' or float_is_zero(bom_line_data['qty'], precision_rounding=bom_line.product_uom_id.rounding):
                     continue
-                uom_qty_per_kit = bom_line_data['qty'] / bom_line_data['original_qty']
+                uom_qty_per_kit = bom_line_data['qty']
                 qty_per_kit = bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, raise_if_failure=False)
                 if not qty_per_kit:
                     continue

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -258,8 +258,7 @@ class ProcurementGroup(models.Model):
             bom_kit = kits_by_company[procurement.company_id].get(procurement.product_id)
             if bom_kit:
                 order_qty = procurement.product_uom._compute_quantity(procurement.product_qty, bom_kit.product_uom_id, round=False)
-                qty_to_produce = (order_qty / bom_kit.product_qty)
-                boms, bom_sub_lines = bom_kit.explode(procurement.product_id, qty_to_produce)
+                boms, bom_sub_lines = bom_kit.explode(procurement.product_id, order_qty)
                 for bom_line, bom_line_data in bom_sub_lines:
                     bom_line_uom = bom_line.product_uom_id
                     quant_uom = bom_line.product_id.uom_id

--- a/addons/mrp_account/models/account_move.py
+++ b/addons/mrp_account/models/account_move.py
@@ -19,8 +19,7 @@ class AccountMoveLine(models.Model):
             bom_kit = bom_kits[product]
             if bom_kit:
                 invoiced_qty = product.uom_id._compute_quantity(qty, bom_kit.product_uom_id, round=False)
-                factor = invoiced_qty / bom_kit.product_qty
-                dummy, bom_sub_lines = bom_kit.explode(product, factor)
+                dummy, bom_sub_lines = bom_kit.explode(product, invoiced_qty)
                 for bom_line, bom_line_data in bom_sub_lines:
                     qties[bom_line.product_id] += bom_line.product_uom_id._compute_quantity(bom_line_data['qty'], bom_line.product_id.uom_id)
             else:

--- a/addons/mrp_repair/models/repair.py
+++ b/addons/mrp_repair/models/repair.py
@@ -24,8 +24,8 @@ class Repair(models.Model):
             bom = self.env['mrp.bom'].sudo()._bom_find(op.product_id, company_id=op.company_id.id, bom_type='phantom')[op.product_id]
             if not bom:
                 continue
-            factor = op.product_uom._compute_quantity(op.product_uom_qty, bom.product_uom_id) / bom.product_qty
-            _boms, lines = bom.sudo().explode(op.product_id, factor, picking_type=bom.picking_type_id)
+            product_qty = op.product_uom._compute_quantity(op.product_uom_qty, bom.product_uom_id)
+            _boms, lines = bom.sudo().explode(op.product_id, product_qty, picking_type=bom.picking_type_id)
             for bom_line, line_data in lines:
                 if bom_line.product_id.type != 'service':
                     line_vals_list.append(op._prepare_phantom_line_vals(bom_line, line_data['qty']))

--- a/addons/purchase_mrp/models/purchase.py
+++ b/addons/purchase_mrp/models/purchase.py
@@ -83,3 +83,10 @@ class PurchaseOrderLine(models.Model):
         if bom and 'previous_product_qty' in self.env.context:
             return self.env.context['previous_product_qty'].get(self.id, 0.0)
         return super()._get_qty_procurement()
+
+    def _get_move_dests_initial_demand(self, move_dests):
+        kit_bom = self.env['mrp.bom']._bom_find(self.product_id, bom_type='phantom')[self.product_id]
+        if kit_bom:
+            filters = {'incoming_moves': lambda m: True, 'outgoing_moves': lambda m: False}
+            return move_dests._compute_kit_quantities(self.product_id, self.product_qty, kit_bom, filters)
+        return super()._get_move_dests_initial_demand(move_dests)

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -932,6 +932,74 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
         line_values = report_values['lines']['components'][0]
         self.assertEqual(line_values['availability_state'], 'expected', 'The first component should be expected as there is an incoming PO.')
 
+    def test_purchase_multistep_kit_qty_change(self):
+        self.warehouse.write({"reception_steps": "two_steps"})
+        self.partner = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        kit_prod = self._create_product('kit_prod', self.uom_unit)
+        sub_kit = self._create_product('sub_kit', self.uom_unit)
+        component = self._create_product('component', self.uom_unit)
+
+        # 6 kit_prod == 5 component
+        self.env['mrp.bom'].create([{  # 2 kit_prod == 5 sub_kit
+            'product_tmpl_id': kit_prod.product_tmpl_id.id,
+            'product_qty': 2.0,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': sub_kit.id,
+                'product_qty': 5,
+            })],
+        }, {  # 3 sub_kit == 1 component
+            'product_tmpl_id': sub_kit.product_tmpl_id.id,
+            'product_qty': 3.0,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': component.id,
+                'product_qty': 1,
+            })],
+        }])
+
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [(0, 0, {
+                'name': kit_prod.name,
+                'product_id': kit_prod.id,
+                'product_qty': 30,
+            })],
+        })
+        # Validate the PO
+        po.button_confirm()
+        picking = po.picking_ids
+        # Check the component qty in the created picking should be 25
+        self.assertEqual(picking.move_line_ids.quantity_product_uom, 30 * 5 / 6)
+
+        # Update the kit quantity in the PO
+        po.order_line[0].product_qty = 60
+        # Check the component qty after the update should be 50
+        self.assertEqual(picking.move_line_ids.quantity_product_uom, 60 * 5 / 6)
+
+        # Recieve half the quantity 25 component == 30 kit_prod
+        picking.move_line_ids.qty_done = 25
+        picking.with_context(skip_backorder=True).button_validate()
+        self.assertEqual(po.order_line.qty_received, 25 / 5 * 6)
+
+        # Return 10 components
+        stock_return_picking_form = Form(self.env['stock.return.picking']
+            .with_context(active_ids=picking.ids, active_id=picking.id,
+            active_model='stock.picking'))
+        return_wiz = stock_return_picking_form.save()
+        for return_move in return_wiz.product_return_moves:
+            return_move.write({
+                'quantity': 10,
+                'to_refund': True
+            })
+        res = return_wiz.create_returns()
+        return_pick = self.env['stock.picking'].browse(res['res_id'])
+
+        # Process all components and validate the return
+        return_pick.button_validate()
+        self.assertEqual(po.order_line.qty_received, 15 / 5 * 6)
+
     def test_valuation_with_backorder(self):
         fifo_category = self.env['product.category'].create({
             'name': 'FIFO',

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -201,6 +201,11 @@ class PurchaseOrderLine(models.Model):
                 price_unit, order.company_id.currency_id, self.company_id, self.date_order or fields.Date.today(), round=False)
         return float_round(price_unit, precision_digits=price_unit_prec)
 
+    def _get_move_dests_initial_demand(self, move_dests):
+        return self.product_id.uom_id._compute_quantity(
+            sum(move_dests.filtered(lambda m: m.state != 'cancel' and m.location_dest_id.usage != 'supplier').mapped('product_qty')),
+            self.product_uom, rounding_method='HALF-UP')
+
     def _prepare_stock_moves(self, picking):
         """ Prepare the stock moves data for one order line. This function returns a list of
         dictionary ready to be used in stock.move's create()
@@ -220,9 +225,7 @@ class PurchaseOrderLine(models.Model):
             qty_to_attach = 0
             qty_to_push = self.product_qty - qty
         else:
-            move_dests_initial_demand = self.product_id.uom_id._compute_quantity(
-                sum(move_dests.filtered(lambda m: m.state != 'cancel' and m.location_dest_id.usage != 'supplier').mapped('product_qty')),
-                self.product_uom, rounding_method='HALF-UP')
+            move_dests_initial_demand = self._get_move_dests_initial_demand(move_dests)
             qty_to_attach = move_dests_initial_demand - qty
             qty_to_push = self.product_qty - move_dests_initial_demand
 

--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -36,6 +36,6 @@ class AccountMoveLine(models.Model):
                     prod_qty_to_invoice = factor * qty_to_invoice
                     product = product.with_company(self.company_id)
                     average_price_unit += factor * product._compute_average_price(prod_qty_invoiced, prod_qty_to_invoice, prod_moves, is_returned=is_line_reversing)
-                price_unit = average_price_unit / bom.product_qty or price_unit
+                price_unit = average_price_unit or price_unit
                 price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom_id)
         return price_unit

--- a/addons/sale_mrp/models/sale_order_line.py
+++ b/addons/sale_mrp/models/sale_order_line.py
@@ -36,14 +36,14 @@ class SaleOrderLine(models.Model):
             if order_line.qty_delivered_method == 'stock_move':
                 boms = order_line.move_ids.filtered(lambda m: m.state != 'cancel').mapped('bom_line_id.bom_id')
                 dropship = any(m._is_dropshipped() for m in order_line.move_ids)
-                if not boms and dropship:
-                    boms = boms._bom_find(order_line.product_id, company_id=order_line.company_id.id, bom_type='phantom')[order_line.product_id]
                 # We fetch the BoMs of type kits linked to the order_line,
                 # the we keep only the one related to the finished produst.
                 # This bom should be the only one since bom_line_id was written on the moves
                 relevant_bom = boms.filtered(lambda b: b.type == 'phantom' and
                         (b.product_id == order_line.product_id or
                         (b.product_tmpl_id == order_line.product_id.product_tmpl_id and not b.product_id)))
+                if not relevant_bom:
+                    relevant_bom = boms._bom_find(order_line.product_id, company_id=order_line.company_id.id, bom_type='phantom')[order_line.product_id]
                 if relevant_bom:
                     # not written on a move coming from a PO: all moves (to customer) must be done
                     # and the returns must be delivered back to the customer

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -107,9 +107,9 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
         self.assertEqual(len(amls), 4)
         stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertAlmostEqual(stock_out_aml.credit, 1.53, "Should not include the value of consumable component")
+        self.assertAlmostEqual(stock_out_aml.credit, 1.58, 2, "Should not include the value of consumable component")
         cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertAlmostEqual(cogs_aml.debit, 1.53, "Should not include the value of consumable component")
+        self.assertAlmostEqual(cogs_aml.debit, 1.58, 2, "Should not include the value of consumable component")
         self.assertEqual(cogs_aml.credit, 0)
 
     def test_sale_mrp_anglo_saxon_variant(self):

--- a/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_kit_bom.py
@@ -525,3 +525,77 @@ class TestSaleMrpKitBom(TransactionCase):
             if keys[0] in line:
                 keys = keys[1:]
         self.assertFalse(keys, "All keys should be in the report with the defined order")
+
+    def test_sale_multistep_kit_qty_change(self):
+        self.env['stock.warehouse'].search([], limit=1).write({'delivery_steps': 'pick_ship'})
+        self.partner = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        kit_prod = self._create_product('kit_prod', 'product', 0.00)
+        sub_kit = self._create_product('sub_kit', 'product', 0.00)
+        component = self._create_product('component', 'product', 0.00)
+
+        # 6 kit_prod == 5 component
+        self.env['mrp.bom'].create([{  # 2 kit_prod == 5 sub_kit
+            'product_tmpl_id': kit_prod.product_tmpl_id.id,
+            'product_qty': 2.0,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': sub_kit.id,
+                'product_qty': 5,
+            })],
+        }, {  # 3 sub_kit == 1 component
+            'product_tmpl_id': sub_kit.product_tmpl_id.id,
+            'product_qty': 3.0,
+            'type': 'phantom',
+            'bom_line_ids': [(0, 0, {
+                'product_id': component.id,
+                'product_qty': 1,
+            })],
+        }])
+
+        so = self.env['sale.order'].create({
+            'partner_id': self.partner.id,
+            'order_line': [(0, 0, {
+                'name': kit_prod.name,
+                'product_id': kit_prod.id,
+                'product_uom_qty': 30,
+            })],
+        })
+        # Validate the SO
+        so.action_confirm()
+        picking_pick = so.picking_ids[0]
+        picking_pick.picking_type_id.create_backorder = 'never'
+        picking_ship = so.picking_ids[1]
+        picking_ship.picking_type_id.create_backorder = 'never'
+
+        # Check the component qty in the created picking should be 25
+        self.assertEqual(picking_pick.move_ids.product_qty, 30 * 5 / 6)
+
+        # Update the kit quantity in the SO
+        so.order_line[0].product_uom_qty = 60
+        # Check the component qty after the update should be 50
+        self.assertEqual(picking_pick.move_ids.product_qty, 60 * 5 / 6)
+
+        # Recieve half the quantity 25 component == 30 kit_prod
+        picking_pick.move_ids.quantity = 25
+        picking_pick.button_validate()
+        picking_ship.move_ids.quantity = 25
+        picking_ship.button_validate()
+        self.assertEqual(so.order_line.qty_delivered, 25 / 5 * 6)
+
+        # Return 10 components
+        stock_return_picking_form = Form(self.env['stock.return.picking']
+            .with_context(active_ids=picking_ship.ids, active_id=picking_ship.id,
+            active_model='stock.picking'))
+        return_wiz = stock_return_picking_form.save()
+        for return_move in return_wiz.product_return_moves:
+            return_move.write({
+                'quantity': 10,
+                'to_refund': True
+            })
+        res = return_wiz.create_returns()
+        return_pick = self.env['stock.picking'].browse(res['res_id'])
+
+        # Process all components and validate the return
+        return_pick.button_validate()
+        self.assertEqual(so.order_line.qty_delivered, 15 / 5 * 6)


### PR DESCRIPTION
Steps to reproduce:
- Enable multistep delivery/reciept
- Create a kit and subkit with product quantity set on the bom (exemple values in the tests)
- Create and confirm a PO/SO (pickings created with correct values)
- Update the orders quantity 
BUG1: wrong quantity on the pickings
- Set an amount below the total quantity and validate the pickings 
BUG2: wrong Delivered/Recieved ammount on the SO/PO line

FIX:
- SALE: all boms should be taken into account not just the one on the move line to handle subkits
- PURCHASE: move_dest in the case of kits are the components moves not the order line product
- MRP: in "_compute_kit_quantities" done quantity of moves should be considered for done moves instead of their demand

also initial kit product quantity isn't taken into account because bom explode doesn't

I would rather make that change in bom explode and also remove original qty from it since it is uselessly taken from the input and duplicated on all the lines

opw-3827388

