### PR TITLE
[FIX] calendar: irrelevant map link and resources section in email

### DIFF
--- a/addons/calendar/data/mail_template_data.xml
+++ b/addons/calendar/data/mail_template_data.xml
@@ -75,7 +75,7 @@
             <ul>
                 <t t-if="object.event_id.location">
                     <li>Location: <t t-out="object.event_id.location or ''">Bruxelles</t>
-                        (<a target="_blank" t-attf-href="http://maps.google.com/maps?oi=map&amp;q={{object.event_id.location}}">View Map</a>)
+                        <a target="_blank" t-if="not is_online or is_online and object.event_id.location != object.event_id.appointment_type_id.location_id.name" t-attf-href="http://maps.google.com/maps?oi=map&amp;q={{object.event_id.location}}">(View Map)</a>
                     </li>
                 </t>
                 <t t-if="recurrent">
@@ -206,7 +206,7 @@
             <ul>
                 <t t-if="object.event_id.location">
                     <li>Location: <t t-out="object.event_id.location or ''">Bruxelles</t>
-                        (<a target="_blank" t-attf-href="http://maps.google.com/maps?oi=map&amp;q={{ object.event_id.location }}">View Map</a>)
+                        <a target="_blank" t-if="not is_online or is_online and object.event_id.location != object.event_id.appointment_type_id.location_id.name" t-attf-href="http://maps.google.com/maps?oi=map&amp;q={{object.event_id.location}}">(View Map)</a>
                     </li>
                 </t>
                 <t t-if="recurrent">
@@ -313,7 +313,7 @@
             <ul>
                 <t t-if="object.event_id.location">
                     <li>Location: <t t-out="object.event_id.location or ''">Bruxelles</t>
-                        (<a target="_blank" t-attf-href="http://maps.google.com/maps?oi=map&amp;q={{ object.event_id.location }}">View Map</a>)
+                        <a target="_blank" t-if="not is_online or is_online and object.event_id.location != object.event_id.appointment_type_id.location_id.name" t-attf-href="http://maps.google.com/maps?oi=map&amp;q={{object.event_id.location}}">(View Map)</a>
                     </li>
                 </t>
                 <t t-if="recurrent">
@@ -423,8 +423,9 @@
                         </t>
                         <t t-if="object.location">
                             <li>Location: <t t-out="object.location or ''">Bruxelles</t>
-                                (<a target="_blank"
-                                    t-attf-href="http://maps.google.com/maps?oi=map&amp;q={{object.location}}">View Map</a>)
+                                <a target="_blank"
+                                    t-if="not is_online or is_online and object.location != object.appointment_type_id.location_id.name"
+                                    t-attf-href="http://maps.google.com/maps?oi=map&amp;q={{object.location}}">(View Map)</a>
                             </li>
                         </t>
                         <t t-if="recurrent">


### PR DESCRIPTION
**Before this PR:**

While booking an appointment, the outgoing emails contain an irrelevant 'View Map' hyperlink, 
displayed after location name even when 'res.partner' has no contact address set.

This PR resolves the issue by tweaking the conditions to display the 'hyperlink' 
to search location address correctly.

**After this PR:**

The 'View Map' hyperlink is displayed only when res.partner not only has the location name, 
but a set location address for the appointment.

Task - [3829148](https://www.odoo.com/web#id=3829148&menu_id=4722&cids=2&action=333&active_id=10888&model=project.task&view_type=form)