### PR TITLE
[FIX] web_editor: unwrap when pasting in same block only

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -51,6 +51,7 @@ import {
     getCursorDirection,
     padLinkWithZws,
     isLinkEligibleForZwnbsp,
+    lastLeaf,
 } from '../utils/utils.js';
 
 const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/;
@@ -295,6 +296,14 @@ export const editorCommands = {
         }
 
         currentNode = lastChildNode || currentNode;
+        if (
+            currentNode.nodeName !== 'BR' &&
+            currentNode.nextSibling &&
+            currentNode.nextSibling.nodeName === 'BR' &&
+            lastLeaf(currentNode.parentNode) === currentNode.nextSibling
+        ) {
+            currentNode.nextSibling.remove();
+        }
         selection.removeAllRanges();
         const newRange = new Range();
         let lastPosition;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -188,7 +188,7 @@ export const editorCommands = {
         startNode = startNode || editor.document.getSelection().anchorNode;
         const shouldUnwrap = (node) => (
             [...paragraphRelatedElements, 'LI'].includes(node.nodeName) &&
-            block.textContent !== "" &&
+            block.textContent !== "" && node.textContent !== "" &&
             (
                 block.nodeName === node.nodeName ||
                 ['BLOCKQUOTE', 'PRE', 'DIV'].includes(block.nodeName)

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -195,6 +195,15 @@ export const editorCommands = {
             )
         );
 
+        // Empty block must contain a br element to allow cursor placement.
+        if (
+            container.lastElementChild &&
+            isBlock(container.lastElementChild) &&
+            !container.lastElementChild.hasChildNodes()
+        ) {
+            fillEmpty(container.lastElementChild);
+        }
+
         // In case the html inserted is all contained in a single root <p> or <li>
         // tag, we take the all content of the <p> or <li> and avoid inserting the
         // <p> or <li>. The same is true for a <pre> inside a <pre>.

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -305,7 +305,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, `<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-ddad60c5-7fff-0a8f-fdd5-c1107201fe26"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">test1</span></p><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">test2</span></p></b>`);
                     },
-                    contentAfter: '<p>test1</p><p>test2[]<br></p>',
+                    contentAfter: '<p>test1</p><p>test2[]</p>',
                 });
             });
             it('should remove unwanted b tag and p tag with unwanted styles when pasting list from gdocs', async () => {
@@ -382,7 +382,7 @@ describe('Paste', () => {
                     contentAfter: '<p style="margin-bottom: 0px;">a</p>' +
                                   '<p style="margin-bottom: 0px;">b</p>' +
                                   '<p style="margin-bottom: 0px;">c</p>' +
-                                  '<p>d[]<br></p>',
+                                  '<p>d[]</p>',
                 });
             });
             it('should paste text and understand \\r\\n newlines', async () => {
@@ -394,7 +394,7 @@ describe('Paste', () => {
                     contentAfter: '<p style="margin-bottom: 0px;">a</p>' +
                                   '<p style="margin-bottom: 0px;">b</p>' +
                                   '<p style="margin-bottom: 0px;">c</p>' +
-                                  '<p>d[]<br></p>',
+                                  '<p>d[]</p>',
                 });
             });
             it('should paste text and understand \\n newlines within UNBREAKABLE node', async () => {
@@ -403,7 +403,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteText(editor, 'a\nb\nc\nd');
                     },
-                    contentAfter: '<div>a<br>b<br>c<br>d[]<br></div>',
+                    contentAfter: '<div>a<br>b<br>c<br>d[]</div>',
                 });
             });
             it('should paste text and understand \\n newlines within UNBREAKABLE node(2)', async () => {
@@ -412,7 +412,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteText(editor, 'b\nc\nd');
                     },
-                    contentAfter: '<div><span style="font-size: 9px;">ab<br>c<br>d[]<br></span></div>',
+                    contentAfter: '<div><span style="font-size: 9px;">ab<br>c<br>d[]</span></div>',
                 });
             });
         });
@@ -769,7 +769,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc<br>def<br>ghi<br>jkl</h1>');
                     },
-                    contentAfter: '<p>abc</p><h1>def</h1><h1>ghi</h1><p>jkl[]<br></p>',
+                    contentAfter: '<p>abc</p><h1>def</h1><h1>ghi</h1><p>jkl[]</p>',
                 });
             });
             it('should split h2 with <br> into seperate h2 elements', async () => {
@@ -778,7 +778,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h2>abc<br>def<br>ghi<br>jkl</h2>');
                     },
-                    contentAfter: '<p>abc</p><h2>def</h2><h2>ghi</h2><p>jkl[]<br></p>',
+                    contentAfter: '<p>abc</p><h2>def</h2><h2>ghi</h2><p>jkl[]</p>',
                 });
             });
             it('should split h3 with <br> into seperate h3 elements', async () => {
@@ -787,7 +787,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h3>abc<br>def<br>ghi<br>jkl</h3>');
                     },
-                    contentAfter: '<p>abc</p><h3>def</h3><h3>ghi</h3><p>jkl[]<br></p>',
+                    contentAfter: '<p>abc</p><h3>def</h3><h3>ghi</h3><p>jkl[]</p>',
                 });
             });
             it('should split h4 with <br> into seperate h4 elements', async () => {
@@ -796,7 +796,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h4>abc<br>def<br>ghi<br>jkl</h4>');
                     },
-                    contentAfter: '<p>abc</p><h4>def</h4><h4>ghi</h4><p>jkl[]<br></p>',
+                    contentAfter: '<p>abc</p><h4>def</h4><h4>ghi</h4><p>jkl[]</p>',
                 });
             });
             it('should split h5 with <br> into seperate h5 elements', async () => {
@@ -805,7 +805,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h5>abc<br>def<br>ghi<br>jkl</h5>');
                     },
-                    contentAfter: '<p>abc</p><h5>def</h5><h5>ghi</h5><p>jkl[]<br></p>',
+                    contentAfter: '<p>abc</p><h5>def</h5><h5>ghi</h5><p>jkl[]</p>',
                 });
             });
             it('should split h6 with <br> into seperate h6 elements', async () => {
@@ -814,7 +814,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h6>abc<br>def<br>ghi<br>jkl</h6>');
                     },
-                    contentAfter: '<p>abc</p><h6>def</h6><h6>ghi</h6><p>jkl[]<br></p>',
+                    contentAfter: '<p>abc</p><h6>def</h6><h6>ghi</h6><p>jkl[]</p>',
                 });
             });
             it('should split p with <br> into seperate p elements', async () => {
@@ -823,28 +823,28 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<p>abc<br>def<br>ghi<br>jkl</p>');
                     },
-                    contentAfter: '<p>abc</p><p>def</p><p>ghi</p><p>jkl[]<br></p>',
+                    contentAfter: '<p>abc</p><p>def</p><p>ghi</p><p>jkl[]</p>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[]<br></p>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<p>abc<br>def<br>ghi<br>jkl</p><p>mno</p>');
                     },
-                    contentAfter: '<p>abc</p><p>def</p><p>ghi</p><p>jkl</p><p>mno[]<br></p>',
+                    contentAfter: '<p>abc</p><p>def</p><p>ghi</p><p>jkl</p><p>mno[]</p>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[]<br></p>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<p>abc<br>def<br>ghi<br>jkl</p><p><br></p><p>mno</p>');
                     },
-                    contentAfter: '<p>abc</p><p>def</p><p>ghi</p><p>jkl</p><p><br></p><p>mno[]<br></p>',
+                    contentAfter: '<p>abc</p><p>def</p><p>ghi</p><p>jkl</p><p><br></p><p>mno[]</p>',
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[]<br></p>',
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<p>abc<br>def<br><br><br>ghi</p>');
                     },
-                    contentAfter: '<p>abc</p><p>def</p><p><br></p><p><br></p><p>ghi[]<br></p>',
+                    contentAfter: '<p>abc</p><p>def</p><p><br></p><p><br></p><p>ghi[]</p>',
                 });
             });
             it('should split multiple elements with <br>', async () => {
@@ -853,7 +853,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<p>abc<br>def</p><h1>ghi<br>jkl</h1><h2><br></h2><h3>mno<br>pqr</h3>');
                     },
-                    contentAfter: '<p>abc</p><p>def</p><h1>ghi</h1><h1>jkl</h1><h2><br></h2><h3>mno</h3><p>pqr[]<br></p>',
+                    contentAfter: '<p>abc</p><p>def</p><h1>ghi</h1><h1>jkl</h1><h2><br></h2><h3>mno</h3><p>pqr[]</p>',
                 });
             });
             it('should split div with <br>', async () => {
@@ -862,7 +862,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<div>abc<br>def</div>');
                     },
-                    contentAfter: '<p>abc</p><p>def[]<br></p>',
+                    contentAfter: '<p>abc</p><p>def[]</p>',
                 });
             });
         });
@@ -1719,7 +1719,7 @@ describe('Paste', () => {
                         await pasteText(editor, 'odoo.com\ngoogle.com');
                     },
                     contentAfter: '<p style="margin-bottom: 0px;"><a href="https://odoo.com">odoo.com</a></p>' +
-                                  '<p><a href="https://google.com">google.com</a>[]<br></p>'
+                                  '<p><a href="https://google.com">google.com</a>[]</p>'
                 });
             });
             it('should paste html content over an empty link', async () => {
@@ -1871,7 +1871,7 @@ describe('Paste', () => {
                         // Powerbox should not open
                         window.chai.expect(editor.powerbox.isOpen).to.be.false;
                     },
-                    contentAfter: `<p>abc <a href="${url}">${url}</a> def[]<br></p>`,
+                    contentAfter: `<p>abc <a href="${url}">${url}</a> def[]</p>`,
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[xyz]<br></p>',
@@ -1880,7 +1880,7 @@ describe('Paste', () => {
                         // Powerbox should not open
                         window.chai.expect(editor.powerbox.isOpen).to.be.false;
                     },
-                    contentAfter: `<p>abc <a href="${imgUrl}">${imgUrl}</a> def[]<br></p>`,
+                    contentAfter: `<p>abc <a href="${imgUrl}">${imgUrl}</a> def[]</p>`,
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[xyz]<br></p>',
@@ -1889,7 +1889,7 @@ describe('Paste', () => {
                         // Powerbox should not open
                         window.chai.expect(editor.powerbox.isOpen).to.be.false;
                     },
-                    contentAfter: `<p>abc <a href="${videoUrl}">${videoUrl}</a> def[]<br></p>`,
+                    contentAfter: `<p>abc <a href="${videoUrl}">${videoUrl}</a> def[]</p>`,
                 });
                 await testEditor(BasicEditor, {
                     contentBefore: '<p>[xyz]<br></p>',
@@ -1898,7 +1898,7 @@ describe('Paste', () => {
                         // Powerbox should not open
                         window.chai.expect(editor.powerbox.isOpen).to.be.false;
                     },
-                    contentAfter: `<p><a href="${url}">${url}</a> <a href="${videoUrl}">${videoUrl}</a> <a href="${imgUrl}">${imgUrl}</a>[]<br></p>`,
+                    contentAfter: `<p><a href="${url}">${url}</a> <a href="${videoUrl}">${videoUrl}</a> <a href="${imgUrl}">${imgUrl}</a>[]</p>`,
                 });
             });
             it('should paste and transform URL over the existing url', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -314,7 +314,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-5d8bcf85-7fff-ebec-8604-eedd96f2d601"><ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;"><li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Google</span></p></li><li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Test</span></p></li><li dir="ltr" style="list-style-type:disc;font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><p dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:0pt;" role="presentation"><span style="font-size:11pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">test2</span></p></li></ul></b>');
                     },
-                    contentAfter: '<ul><li>Google</li><li>Test</li><li>test2</li></ul><p>[]<br></p>',
+                    contentAfter: '<ul><li>Google</li><li>Test</li><li>test2[]</li></ul>',
                 });
             });
             it('should remove unwanted styles and keep tags when pasting list from gdoc', async () => {
@@ -323,7 +323,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-477946a8-7fff-f959-18a4-05014997e161"><ul style="margin-top:0;margin-bottom:0;padding-inline-start:48px;"><li dir="ltr" style="list-style-type:disc;font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:0pt;" role="presentation"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Google</span></h1></li><li dir="ltr" style="list-style-type:disc;font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><h1 dir="ltr" style="line-height:1.38;margin-top:0pt;margin-bottom:6pt;" role="presentation"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">Test</span></h1></li><li dir="ltr" style="list-style-type:disc;font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;" aria-level="1"><h1 dir="ltr" style="line-height:1.38;margin-top:20pt;margin-bottom:0pt;" role="presentation"><span style="font-size:20pt;font-family:Arial,sans-serif;color:#000000;background-color:transparent;font-weight:400;font-style:normal;font-variant:normal;text-decoration:none;vertical-align:baseline;white-space:pre;white-space:pre-wrap;">test2</span></h1></li></ul></b>');
                     },
-                    contentAfter: '<ul><li><h1>Google</h1></li><li><h1>Test</h1></li><li><h1>test2</h1></li></ul><p>[]<br></p>',
+                    contentAfter: '<ul><li><h1>Google</h1></li><li><h1>Test</h1></li><li><h1>test2[]</h1></li></ul>',
                 });
             });
         });
@@ -769,7 +769,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h1>abc<br>def<br>ghi<br>jkl</h1>');
                     },
-                    contentAfter: '<p>abc</p><h1>def</h1><h1>ghi</h1><p>jkl[]</p>',
+                    contentAfter: '<h1>abc</h1><h1>def</h1><h1>ghi</h1><h1>jkl[]</h1>',
                 });
             });
             it('should split h2 with <br> into seperate h2 elements', async () => {
@@ -778,7 +778,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h2>abc<br>def<br>ghi<br>jkl</h2>');
                     },
-                    contentAfter: '<p>abc</p><h2>def</h2><h2>ghi</h2><p>jkl[]</p>',
+                    contentAfter: '<h2>abc</h2><h2>def</h2><h2>ghi</h2><h2>jkl[]</h2>',
                 });
             });
             it('should split h3 with <br> into seperate h3 elements', async () => {
@@ -787,7 +787,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h3>abc<br>def<br>ghi<br>jkl</h3>');
                     },
-                    contentAfter: '<p>abc</p><h3>def</h3><h3>ghi</h3><p>jkl[]</p>',
+                    contentAfter: '<h3>abc</h3><h3>def</h3><h3>ghi</h3><h3>jkl[]</h3>',
                 });
             });
             it('should split h4 with <br> into seperate h4 elements', async () => {
@@ -796,7 +796,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h4>abc<br>def<br>ghi<br>jkl</h4>');
                     },
-                    contentAfter: '<p>abc</p><h4>def</h4><h4>ghi</h4><p>jkl[]</p>',
+                    contentAfter: '<h4>abc</h4><h4>def</h4><h4>ghi</h4><h4>jkl[]</h4>',
                 });
             });
             it('should split h5 with <br> into seperate h5 elements', async () => {
@@ -805,7 +805,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h5>abc<br>def<br>ghi<br>jkl</h5>');
                     },
-                    contentAfter: '<p>abc</p><h5>def</h5><h5>ghi</h5><p>jkl[]</p>',
+                    contentAfter: '<h5>abc</h5><h5>def</h5><h5>ghi</h5><h5>jkl[]</h5>',
                 });
             });
             it('should split h6 with <br> into seperate h6 elements', async () => {
@@ -814,7 +814,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<h6>abc<br>def<br>ghi<br>jkl</h6>');
                     },
-                    contentAfter: '<p>abc</p><h6>def</h6><h6>ghi</h6><p>jkl[]</p>',
+                    contentAfter: '<h6>abc</h6><h6>def</h6><h6>ghi</h6><h6>jkl[]</h6>',
                 });
             });
             it('should split p with <br> into seperate p elements', async () => {
@@ -853,7 +853,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<p>abc<br>def</p><h1>ghi<br>jkl</h1><h2><br></h2><h3>mno<br>pqr</h3>');
                     },
-                    contentAfter: '<p>abc</p><p>def</p><h1>ghi</h1><h1>jkl</h1><h2><br></h2><h3>mno</h3><p>pqr[]</p>',
+                    contentAfter: '<p>abc</p><p>def</p><h1>ghi</h1><h1>jkl</h1><h2><br></h2><h3>mno</h3><h3>pqr[]</h3>',
                 });
             });
             it('should split div with <br>', async () => {
@@ -873,7 +873,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<ul><li>abc<br>def</li></ul>');
                     },
-                    contentAfter: '<ul><li>abc<br>def</li></ul><p>[]<br></p>',
+                    contentAfter: '<ul><li>abc<br>def[]</li></ul>',
                 });
             });
             it('should not split blockquote with <br>', async () => {
@@ -882,7 +882,7 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<blockquote>abc<br>def</blockquote>');
                     },
-                    contentAfter: '<blockquote>abc<br>def</blockquote><p>[]<br></p>',
+                    contentAfter: '<blockquote>abc<br>def[]</blockquote>',
                 });
             });
             it('should not split pre with <br>', async () => {
@@ -891,11 +891,264 @@ describe('Paste', () => {
                     stepFunction: async editor => {
                         await pasteHtml(editor, '<pre>abc<br>def</pre>');
                     },
-                    contentAfter: '<pre>abc<br>def</pre><p>[]<br></p>',
+                    contentAfter: '<pre>abc<br>def[]</pre>',
                 });
             });
         });
     });
+    describe('Unwrapping html element', () => {
+        describe('range collapsed', async () => {
+            it('should not unwrap a node when pasting on empty node', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1>');
+                    },
+                    contentAfter: '<h1>abc[]</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h2>abc</h2>');
+                    },
+                    contentAfter: '<h2>abc[]</h2>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h3>abc</h3>');
+                    },
+                    contentAfter: '<h3>abc[]</h3>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2>');
+                    },
+                    contentAfter: '<h1>abc</h1><h2>def[]</h2>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<h1>abc</h1><h2>def</h2><h3>ghi[]</h3>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p><p><br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h3>abc</h3>');
+                    },
+                    contentAfter: '<h3>abc[]</h3><p><br></p>',
+                });
+            });
+            it('should not unwrap a node when pasting in between different node', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>mn[]op</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1>');
+                    },
+                    contentAfter: '<p>mn</p><h1>abc[]</h1><p>op</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>mn[]op</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2>');
+                    },
+                    contentAfter: '<p>mn</p><h1>abc</h1><h2>def[]</h2><p>op</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>mn[]op</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<p>mn</p><h1>abc</h1><h2>def</h2><h3>ghi[]</h3><p>op</p>',
+                });
+            });
+            it('should unwrap a node when pasting in between same node', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>mn[]op</h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1>');
+                    },
+                    contentAfter: '<h1>mnabc[]op</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>mn[]op</h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2>');
+                    },
+                    contentAfter: '<h1>mnabc</h1><h2>def[]</h2><h1>op</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h2>mn[]op</h2>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2>');
+                    },
+                    contentAfter: '<h2>mn</h2><h1>abc</h1><h2>def[]op</h2>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>mn[]op</h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h1>def</h1><h1>ghi</h1>');
+                    },
+                    contentAfter: '<h1>mnabc</h1><h1>def</h1><h1>ghi[]op</h1>',
+                });
+            });
+            it('should not unwrap a node when pasting at start of different node', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]mn</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1>');
+                    },
+                    contentAfter: '<h1>abc[]</h1><p>mn</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]mn</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2>');
+                    },
+                    contentAfter: '<h1>abc</h1><h2>def[]</h2><p>mn</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]mn</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<h1>abc</h1><h2>def</h2><h3>ghi[]</h3><p>mn</p>',
+                });
+            });
+            it('should unwrap a node when pasting at start of same node', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>[]mn</h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1>');
+                    },
+                    contentAfter: '<h1>abc[]mn</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>[]mn</h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h2>abc</h2><h1>def</h1>');
+                    },
+                    contentAfter: '<h2>abc</h2><h1>def[]mn</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1><font style="background-color: rgb(255, 0, 0);">[]mn</font></h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h1>def</h1><h1>ghi</h1>');
+                    },
+                    contentAfter: '<h1>abc</h1><h1>def</h1><h1><font style="background-color: rgb(255, 0, 0);">ghi[]mn</font></h1>',
+                });
+            });
+            it('should not unwrap a node when pasting at end of different node', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>mn[]</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1>');
+                    },
+                    contentAfter: '<p>mn</p><h1>abc[]</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>mn[]</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2>');
+                    },
+                    contentAfter: '<p>mn</p><h1>abc</h1><h2>def[]</h2>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>mn[]</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<p>mn</p><h1>abc</h1><h2>def</h2><h3>ghi[]</h3>',
+                });
+            });
+            it('should unwrap a node when pasting at end of same node', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>mn[]</h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1>');
+                    },
+                    contentAfter: '<h1>mnabc[]</h1>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1>mn[]</h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2>');
+                    },
+                    contentAfter: '<h1>mnabc</h1><h2>def[]</h2>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<h1><font style="background-color: rgb(255, 0, 0);">mn[]</font></h1>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h1>def</h1><h1>ghi</h1>');
+                    },
+                    contentAfter: '<h1><font style="background-color: rgb(255, 0, 0);">mnabc</font></h1><h1>def</h1><h1>ghi[]</h1>',
+                });
+            });
+            it('should paste all nodes as blockquote when pasting in blockquote', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<blockquote>[]<br></blockquote>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<blockquote>abc</blockquote><blockquote>def</blockquote><blockquote>ghi[]</blockquote>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<blockquote>x[]</blockquote>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<blockquote>xabc</blockquote><blockquote>def</blockquote><blockquote>ghi[]</blockquote>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<blockquote>[]x</blockquote>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<blockquote>abc</blockquote><blockquote>def</blockquote><blockquote>ghi[]x</blockquote>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<blockquote>x[]y</blockquote>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<blockquote>xabc</blockquote><blockquote>def</blockquote><blockquote>ghi[]y</blockquote>',
+                });
+            });
+            it('should paste all nodes as pre when pasting in pre', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<pre>[]<br></pre>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<pre>abc</pre><pre>def</pre><pre>ghi[]</pre>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<pre>x[]</pre>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<pre>xabc</pre><pre>def</pre><pre>ghi[]</pre>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<pre>[]x</pre>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<pre>abc</pre><pre>def</pre><pre>ghi[]x</pre>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<pre>x[]y</pre>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
+                    },
+                    contentAfter: '<pre>xabc</pre><pre>def</pre><pre>ghi[]y</pre>',
+                });
+            });
+        });
+    })
     describe('Complex html span', () => {
         const complexHtmlData = '<span style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;">1</span><b style="box-sizing: border-box; font-weight: bolder; font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;">23</b><span style="font-family: -apple-system, BlinkMacSystemFont, &quot;Segoe UI&quot;, Roboto, &quot;Helvetica Neue&quot;, Arial, &quot;Noto Sans&quot;, sans-serif, &quot;Apple Color Emoji&quot;, &quot;Segoe UI Emoji&quot;, &quot;Segoe UI Symbol&quot;, &quot;Noto Color Emoji&quot;; font-variant-ligatures: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: left; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; display: inline !important; float: none;"><span> </span>4</span>';
         describe('range collapsed', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/copyPaste.test.js
@@ -941,6 +941,13 @@ describe('Paste', () => {
                     },
                     contentAfter: '<h3>abc[]</h3><p><br></p>',
                 });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>[]<br></p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<p>abc</p><p><br></p><p><br></p>');
+                    },
+                    contentAfter: '<p>abc</p><p><br></p><p><br>[]</p>',
+                });
             });
             it('should not unwrap a node when pasting in between different node', async () => {
                 await testEditor(BasicEditor, {
@@ -1145,6 +1152,15 @@ describe('Paste', () => {
                         await pasteHtml(editor, '<h1>abc</h1><h2>def</h2><h3>ghi</h3>');
                     },
                     contentAfter: '<pre>xabc</pre><pre>def</pre><pre>ghi[]y</pre>',
+                });
+            });
+            it('should not unwrap empty block nodes even when pasting on same node', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a[]</p>',
+                    stepFunction: async editor => {
+                        await pasteHtml(editor, '<p><br></p><p><br></p><p><br></p>');
+                    },
+                    contentAfter: '<p>a</p><p><br></p><p><br></p><p><br>[]</p>',
                 });
             });
         });

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
@@ -102,6 +102,15 @@ describe('insert HTML', () => {
                 contentAfter: '<p><br><br><br>[]<br></p>',
             });
         });
+        it('should paste an "empty" block', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>abcd[]</p>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<p>efgh</p><p></p>'));
+                },
+                contentAfter: '<p>abcdefgh</p><p><br>[]</p>',
+            });
+        });
     });
     describe('not collapsed selection', () => {
         it('should delete selection and insert html in its place', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insertHTML.test.js
@@ -17,8 +17,8 @@ describe('insert HTML', () => {
                     await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
                 contentAfterEdit:
-                    '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br></p>',
-                contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]<br></p>',
+                    '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]</p>',
+                contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]</p>',
             });
         });
         it('should insert html between two letters', async () => {
@@ -79,6 +79,29 @@ describe('insert HTML', () => {
                 contentAfter: '<p>contentunwrapped</p><div><i class="fa fa-circle-o-notch"></i></div><p>culprit</p><p>after[]</p>',
             });
         });
+        it('should not remove the trailing <br> when pasting content ending with a <br>', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>[]<br></p>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<p>abc<br></p>'));
+                },
+                contentAfter: '<p>abc<br>[]<br></p>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab[]cd</p>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<p>efg<br></p>'));
+                },
+                contentAfter: '<p>abefg<br>[]cd</p>',
+            });
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>[]<br></p>',
+                stepFunction: async editor => {
+                    await editor.execCommand('insert', parseHTML('<p><br><br><br></p>'));
+                },
+                contentAfter: '<p><br><br><br>[]<br></p>',
+            });
+        });
     });
     describe('not collapsed selection', () => {
         it('should delete selection and insert html in its place', async () => {
@@ -87,8 +110,8 @@ describe('insert HTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insert', parseHTML('<i class="fa fa-pastafarianism"></i>'));
                 },
-                contentAfterEdit: '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]<br></p>',
-                contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]<br></p>',
+                contentAfterEdit: '<p><i class="fa fa-pastafarianism" contenteditable="false">\u200b</i>[]</p>',
+                contentAfter: '<p><i class="fa fa-pastafarianism"></i>[]</p>',
             });
         });
         it('should delete selection and insert html in its place (2)', async () => {
@@ -128,7 +151,7 @@ describe('insert HTML', () => {
                 stepFunction: editor => editor.execCommand('insert', span('TEST')),
                 contentAfter: unformat(
                     `<table><tbody>
-                        <tr><td>cd</td><td><span class="a">TEST</span>[]<br></td><td>gh</td></tr>
+                        <tr><td>cd</td><td><span class="a">TEST</span>[]</td><td>gh</td></tr>
                         <tr><td>ij</td><td><br></td><td>mn</td></tr>
                         <tr><td>op</td><td>qr</td><td>st</td></tr>
                     </tbody></table>`,
@@ -200,7 +223,7 @@ describe('insert HTML', () => {
                     </tbody></table>`,
                 ),
                 stepFunction: editor => editor.execCommand('insert', span('TEST')),
-                contentAfter: `<p><span class="a">TEST</span>[]<br></p>`,
+                contentAfter: `<p><span class="a">TEST</span>[]</p>`,
             });
         });
         it('should remove a selection including several tables', async () => {
@@ -248,7 +271,7 @@ describe('insert HTML', () => {
                     <p>67]</p>`,
                 ),
                 stepFunction: editor => editor.execCommand('insert', span('TEST')),
-                contentAfter: `<p><span class="a">TEST</span>[]<br></p>`,
+                contentAfter: `<p><span class="a">TEST</span>[]</p>`,
             });
         });
     });

--- a/addons/web_editor/static/tests/field_html_tests.js
+++ b/addons/web_editor/static/tests/field_html_tests.js
@@ -986,7 +986,7 @@ QUnit.module('web_editor', {}, function () {
             const clipboardData = new DataTransfer();
             clipboardData.setData('text/plain', 'https://www.youtube.com/watch?v=qxb74CMR748');
             p.dispatchEvent(new ClipboardEvent('paste', { clipboardData, bubbles: true }));
-            assert.strictEqual(p.outerHTML, '<p>https://www.youtube.com/watch?v=qxb74CMR748<br></p>',
+            assert.strictEqual(p.outerHTML, '<p>https://www.youtube.com/watch?v=qxb74CMR748</p>',
                 "The URL should be inserted as text");
             assert.isVisible($('.oe-powerbox-wrapper:contains("Embed Youtube Video")'),
                 "The powerbox should be opened");


### PR DESCRIPTION
Current behavior before PR:

I. Inserting text into an empty paragraph tag with a `br` does not remove the `br`.
II. When pasting single or multiple block elements the start and end block would
unwrap causing inconsistency while pasting.
III. Unwrapping the firstChild and the lastChild when pasting empty blocks resulted
in the addition of br's to the block.

Desired behavior after PR is merged:

I. Inserting text into an empty node with a `br` should result in the removal of
that `br`.
II. Make sure if the node to start or end with is the same node we want to paste
into; unwrap it, otherwise split the node.
III. Empty blocks are no longer unwrapped when pasting.
IV. This PR also addresses issues with testcases that includes `p` tag
without a `br`.

task-3630662