### PR TITLE
[FIX] account: fixed tax name unique constraints error

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -311,6 +311,19 @@ class AccountChartTemplate(models.AbstractModel):
                 elif model_name == 'account.tax':
                     # Only update the tags of existing taxes
                     if xmlid not in xmlid2tax or tax_template_changed(xmlid2tax[xmlid], values):
+                        account_tax = self.ref(xmlid, raise_if_not_found=False)
+                        if not account_tax:
+                            existing_account_tax = self.env['account.tax'].search([
+                                *self.env['account.tax']._check_company_domain(company),
+                                ('name', '=', values.get('name')),
+                                ('type_tax_use', '=', values.get('type_tax_use'))
+                            ])
+                            if existing_account_tax:
+                                self.env['ir.model.data']._update_xmlids([{
+                                    'xml_id': f"account.{company.id}_{xmlid}",
+                                    'record': existing_account_tax,
+                                    'noupdate': True,
+                                }])
                         if self._context.get('force_new_tax_active'):
                             values['active'] = True
                         if xmlid in xmlid2tax:


### PR DESCRIPTION
when account tax already exist but ir model data does not exist then it will try to create same account tax with ir model data entry which raise exception as we have unique constraints- `Tax names must be unique!`
see:
https://github.com/odoo/odoo/blob/740fb9ac8c8e121820feeac0e1f25a304e47da9d/addons/account/models/account_tax.py#L202 so because of this constraints we have to create ir model data entry for existing tax.

```
 File "/home/odoo/src/odoo/17.0/odoo/models.py", line 4864, in _create
    records._validate_fields(name for data in data_list for name in data['stored'])
  File "/home/odoo/src/odoo/17.0/odoo/models.py", line 1456, in _validate_fields
    check(self)
  File "/home/odoo/src/odoo/17.0/addons/account/models/account_tax.py", line 201, in _constrains_name
    raise ValidationError(
odoo.exceptions.ValidationError: Tax names must be unique!
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
