### PR TITLE
[FIX] calendar: allow internal users to download invitation.ics

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -125,6 +125,8 @@ class Attendee(models.Model):
                         'description': 'invitation.ics',
                         'mimetype': 'text/calendar',
                         'name': 'invitation.ics',
+                        'res_id': event_id,
+                        'res_model': 'calendar.event',
                     }).ids
 
                 body = mail_template._render_field(


### PR DESCRIPTION
Access rights on ir.attachment depend on the record it is linked to.

**steps to reproduce:**
- log as admin
- create a calendar event and invite marc demo
- log as marc demo
- check discuss notifications and try to download "invite.ics"

**before this commit:**
- file can not be downloaded from the webclient (access error appear in logs)

**after this commit:**
- file can be downloaded from the webclient

opw-3754798

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
