### PR TITLE
[IMP] portal: Add skip to content link button

### DIFF
--- a/addons/portal/static/src/scss/portal.scss
+++ b/addons/portal/static/src/scss/portal.scss
@@ -25,6 +25,12 @@ body {
     direction: ltr;
 }
 
+.o_skip_to_content {
+    // We require the z-index property to ensure that the "Skip to Content"
+    // button appears above the header.
+    z-index: $zindex-fixed + 1;
+}
+
 header {
     .navbar-brand {
         flex: 0 0 auto;

--- a/addons/portal/static/tests/tours/skip_to_content.js
+++ b/addons/portal/static/tests/tours/skip_to_content.js
@@ -1,0 +1,22 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("skip_to_content", {
+    test: true,
+    url: "/",
+    steps: () => [
+        {
+            content: "Make sure that Skip to Content button is on top of all the links present in header",
+            trigger: "a:first-child[class~='o_skip_to_content']",
+            run: "click"
+        },
+        {
+            content: "Check if we have been redirected to #wrap",
+            trigger: "body",
+            run: () => {
+                if (!window.location.href.endsWith("/#wrap")) {
+                    console.error("We should be on #wrap.");
+                }
+            }
+        }
+    ]
+});

--- a/addons/portal/tests/test_tours.py
+++ b/addons/portal/tests/test_tours.py
@@ -29,3 +29,6 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
         willis.parent_id = self.user_demo.partner_id.id
         self.start_tour("/", 'portal_load_homepage', login="portal")
         self.assertEqual(willis.phone, "+1 555 666 7788")
+
+    def test_03_skip_to_content(self):
+        self.start_tour("/", "skip_to_content", login="portal")

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -5,6 +5,9 @@
             <attribute name="t-attf-class" add="#{request.env['res.lang']._get_data(code=request.env.lang).direction == 'rtl' and 'o_rtl' or ''}" separator=" "/>
             <attribute name="t-attf-class" add="#{'o_portal' if is_portal else ''}" separator=" "/>
         </xpath>
+        <xpath expr="//div[@id='wrapwrap']/header" position="before">
+            <a class="o_skip_to_content btn btn-primary rounded-0 visually-hidden-focusable position-absolute start-0" href="#wrap" tabindex="2" groups="!base.group_user">Skip to Content</a>
+        </xpath>
         <xpath expr="//div[@id='wrapwrap']/header/img" position="replace">
             <t t-cache="res_company">
                 <nav class="navbar navbar-expand navbar-light bg-light">

--- a/addons/website/static/src/scss/website.ui.scss
+++ b/addons/website/static/src/scss/website.ui.scss
@@ -61,7 +61,7 @@ $-mini-nav-size: 40px;
         border-radius: 0.25rem;
     }
 
-    &:hover {
+    &:hover, &:focus-within {
         &:before, .o_frontend_to_backend_icon {
             transform: scale(.3);
             transition-delay: 0ms;


### PR DESCRIPTION
This PR aims to implement a "Skip to Content" button to enhance keyboard navigation for users.This link allows users to bypass all header links and immediately access the main content. When a user presses the TAB key on a fresh page, this link will be displayed. Upon clicking it, the user will be redirected to the topmost snippet of content.

Additionally, for admin users, we've introduced a navigation animation for the frontend-to-backend button. Using TAB key, users can open the back-end mode or edit mode(+1 TAB).

![skip_to_content](https://github.com/odoo/odoo/assets/157009134/3dbb5f5a-1015-4c6d-89fe-433c9d6ae400)

task-3782983