### PR TITLE
[IMP] website, *: add user group option in conditional visibility

### DIFF
--- a/addons/website/models/ir_http.py
+++ b/addons/website/models/ir_http.py
@@ -429,11 +429,13 @@ class Http(models.AbstractModel):
         session_info = super(Http, self).get_frontend_session_info()
         geoip_country_code = request.geoip.country_code
         geoip_phone_code = request.env['res.country']._phone_code_for(geoip_country_code) if geoip_country_code else None
+        user_groups = request.env.user.groups_id.mapped("display_name")
         session_info.update({
             'is_website_user': request.env.user.id == request.website.user_id.id,
             'geoip_country_code': geoip_country_code,
             'geoip_phone_code': geoip_phone_code,
             'lang_url_code': request.lang.url_code,
+            'user_groups': user_groups,
         })
         if request.env.user.has_group('website.group_website_restricted_editor'):
             session_info.update({

--- a/addons/website/static/src/js/content/inject_dom.js
+++ b/addons/website/static/src/js/content/inject_dom.js
@@ -47,10 +47,12 @@ document.addEventListener('DOMContentLoaded', () => {
     setUtmsHtmlDataset();
     const htmlEl = document.documentElement;
     const country = session.geoip_country_code;
+    const user_groups = session.user_groups;
     if (country) {
         htmlEl.dataset.country = country;
     }
     htmlEl.dataset.logged = !session.is_website_user;
+    htmlEl.dataset.groups = user_groups;
 
     unhideConditionalElements();
 });

--- a/addons/website/static/src/js/editor/snippets.options.js
+++ b/addons/website/static/src/js/editor/snippets.options.js
@@ -3626,7 +3626,7 @@ options.registry.ConditionalVisibility = options.registry.DeviceVisibility.exten
             // e.g of selector:
             // html:not([data-attr-1="valueAttr1"]):not([data-attr-1="valueAttr2"]) [data-visibility-id="ruleId"]
             const selector = attribute.records.reduce((acc, record) => {
-                return acc += `:not([${attribute.name}="${record.value}"])`;
+                return acc += `:not([${attribute.name}*="${record.value}"])`;
             }, 'html') + ` body:not(.editor_enable) [data-visibility-id="${visibilityId}"]`;
             selectors += selector + ', ';
         }
@@ -3634,7 +3634,7 @@ options.registry.ConditionalVisibility = options.registry.DeviceVisibility.exten
             // html[data-attr-1="valueAttr1"] [data-visibility-id="ruleId"],
             // html[data-attr-1="valueAttr2"] [data-visibility-id="ruleId"]
             const selector = attribute.records.reduce((acc, record, i, a) => {
-                acc += `html[${attribute.name}="${record.value}"] body:not(.editor_enable) [data-visibility-id="${visibilityId}"]`;
+                acc += `html[${attribute.name}*="${record.value}"] body:not(.editor_enable) [data-visibility-id="${visibilityId}"]`;
                 return acc + (i !== a.length - 1 ? ',' : '');
             }, '');
             selectors += selector + ', ';

--- a/addons/website/static/tests/tours/conditional_visibility.js
+++ b/addons/website/static/tests/tours/conditional_visibility.js
@@ -26,6 +26,11 @@ const snippets = [
         name: "Popup",
         groupName: "Content",
     },
+    {
+        id: "s_title",
+        name: "Title",
+        groupName: "Text",
+    },
 ];
 function checkEyeIcon(snippetName, visible) {
     const eyeIcon = visible ? "fa-eye" : "fa-eye-slash";
@@ -268,3 +273,52 @@ registerWebsitePreviewTour("conditional_visibility_5", {
         trigger: ".o_we_invisible_el_panel .o_we_invisible_root_parent.o_we_invisible_entry:contains('Text - Image') + ul .o_we_invisible_entry.o_we_sublevel_1:contains('Column')",
     },
 ]);
+
+registerWebsitePreviewTour("conditional_visiblity_user_groups", {
+    edition: true,
+    url: "/?debug=1",
+    test: true,
+}, () => [
+    goBackToBlocks(),
+    {
+        trigger: ".o_website_preview.editor_enable.editor_has_snippets",
+    },
+    {
+        content: "Drag the Title building block and drop it at the bottom of the page.",
+        trigger: "#oe_snippets .oe_snippet[name='Text'].o_we_draggable .oe_snippet_thumbnail:not(.o_we_already_dragging)",
+        run: "drag_and_drop :iframe .oe_drop_zone:last",
+    },
+    {
+        content: "Click on the Title building block.",
+        trigger: ":iframe .o_snippet_preview_wrap[data-snippet-id='s_title']",
+        run: "click",
+    },
+    {
+        content: "Click on the Title Block",
+        trigger: ":iframe .s_title",
+        run: "click",
+    },
+    changeOption("ConditionalVisibility", "we-toggler"),
+    changeOption("ConditionalVisibility", '[data-name="visibility_conditional"]'),
+    {
+        content: "click on User Group toggler",
+        trigger: "[data-save-attribute='visibilityValueUserGroup'] we-toggler",
+        run: "click"
+    },
+    {
+        content: "Search for User types / Portal",
+        trigger: "[data-save-attribute='visibilityValueUserGroup'] we-selection-items .o_we_m2o_search input",
+        run: "edit User types / Portal",
+    },
+    {
+        content: "click on User types / Portal",
+        trigger: "[data-save-attribute='visibilityValueUserGroup'] we-selection-items [data-add-record='User types / Portal']",
+        run: "click"
+    },
+    ...clickOnSave(),
+    {
+        content: "check if the rule is applied",
+        trigger: ":iframe #wrap:has(.s_title.o_snippet_invisible)",
+    },
+]
+);

--- a/addons/website/tests/test_performance.py
+++ b/addons/website/tests/test_performance.py
@@ -204,16 +204,18 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # 1. `_serve_page` search page matching URL..
                     # 2. ..then reads it (`is_visible`)
                     'website': 1,
+                    'ir_module_category': 1,
+                    'res_groups': 2,
                 }
-                expected_query_count = 5
+                expected_query_count = 8
                 if not readonly_enabled:
                     select_tables_perf['ir_ui_view'] = 1 # Check if `view.track` to track visitor or not
                     expected_query_count += 1
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
-                self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
+                self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 13)
                 self.menu.unlink()  # page being or not in menu shouldn't add queries
                 self._check_url_hot_query(self.page.url, expected_query_count, select_tables_perf)
-                self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
+                self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 13)
                 savepoint.rollback()
 
     def test_15_perf_sql_queries_page(self):
@@ -229,9 +231,11 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # 1. `_serve_page` search page matching URL..
                     # 2. ..then reads it (`is_visible`)
                     'website': 1,
+                    'ir_module_category': 1,
+                    'res_groups': 2,
                 }
-                expected_query_count = 5
-                expected_query_count_no_cache = 10
+                expected_query_count = 8
+                expected_query_count_no_cache = 13
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     select_tables_perf['ir_ui_view'] = 1 # Check if `view.track` to track visitor or not
@@ -263,9 +267,11 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
                     # 1. the menu prefetching is also prefetching all menu's pages
                     # 2. find page matching the `/` url
                     'website': 1,
+                    'ir_module_category': 1,
+                    'res_groups': 2,
                 }
-                expected_query_count = 5
-                expected_query_count_no_cache = 8
+                expected_query_count = 8
+                expected_query_count_no_cache = 11
                 insert_tables_perf = {}
                 if not readonly_enabled:
                     select_tables_perf['ir_ui_view'] = 1 # Check if `view.track` to track visitor or not
@@ -322,10 +328,12 @@ class TestWebsitePerformance(TestWebsitePerformanceCommon):
             # 2. ..then reads it (`is_visible`)
             'website': 1,
             'ir_ui_view': 1,
+            'ir_module_category': 1,
+            'res_groups': 2,
             # Check if `view.track` to track visitor or not
         }
-        self._check_url_hot_query(self.page.url, 6, select_tables_perf)
-        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 10)
+        self._check_url_hot_query(self.page.url, 9, select_tables_perf)
+        self.assertEqual(self._get_url_hot_query(self.page.url, cache=False), 13)
 
 @tagged('-at_install', 'post_install')
 class TestWebsitePerformancePost(UtilPerf):

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -371,6 +371,7 @@ class TestUi(odoo.tests.HttpCase):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_3', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_4', login='admin')
         self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visibility_5', login='admin')
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'conditional_visiblity_user_groups', login='admin')
 
     def test_11_website_snippet_background_edition(self):
         self.env['ir.attachment'].create({

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -1668,6 +1668,14 @@
                 <we-button data-select-value="false">Visible for Logged Out</we-button>
                 <we-button data-select-value="">Visible for Everyone</we-button>
             </we-select>
+            <t t-if="debug" t-call="website.snippet_options_conditional_visibility">
+                <t t-set="option_name">User Group</t>
+                <t t-set="attribute_rule" t-valuef="visibilityValueUserGroupRule"/>
+                <t t-set="save_attribute" t-valuef="visibilityValueUserGroup"/>
+                <t t-set="attribute_name" t-valuef="data-groups"/>
+                <t t-set="model" t-valuef="res.groups"/>
+                <t t-set="call_with" t-valuef="display_name"/>
+            </t>
         </we-collapse>
     </div>
 

--- a/addons/website_blog/tests/test_performance.py
+++ b/addons/website_blog/tests/test_performance.py
@@ -35,7 +35,7 @@ class TestBlogPerformance(UtilPerf):
         } for blog in blogs])
 
     def test_10_perf_sql_blog_standard_data(self):
-        self.assertLessEqual(self._get_url_hot_query('/blog'), 11)
+        self.assertLessEqual(self._get_url_hot_query('/blog'), 14)
 
     def test_20_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -47,10 +47,10 @@ class TestBlogPerformance(UtilPerf):
         for blog_post in blog_posts:
             blog_post.tag_ids += blog_tags
             blog_tags = blog_tags[:-1]
-        self.assertEqual(self._get_url_hot_query('/blog'), 10)
-        self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 33)
-        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 16)
-        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 20)
+        self.assertEqual(self._get_url_hot_query('/blog'), 13)
+        self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 35)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 18)
+        self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 22)
 
     def test_30_perf_sql_blog_bigger_data_scaling(self):
         BlogPost = self.env['blog.post']
@@ -63,6 +63,6 @@ class TestBlogPerformance(UtilPerf):
             blog_post.write({'tag_ids': [[6, 0, random.choices(blog_tags.ids, k=random.randint(0, len(blog_tags)))]]})
 
         self.assertLessEqual(self._get_url_hot_query('/blog'), 29)
-        self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 71)
+        self.assertLessEqual(self._get_url_hot_query('/blog', cache=False), 73)
         self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url), 34)
         self.assertLessEqual(self._get_url_hot_query(blog_post[0].website_url, cache=False), 33)

--- a/addons/website_forum/tests/test_performance.py
+++ b/addons/website_forum/tests/test_performance.py
@@ -30,13 +30,13 @@ class TestForumPerformance(UtilPerf):
 
     def test_perf_sql_forum_standard_data(self):
         number_of_queries = self._get_url_hot_query(self.forum._compute_website_url())
-        self.assertEqual(number_of_queries, 24)
+        self.assertEqual(number_of_queries, 27)
         number_of_queries = self._get_url_hot_query(self.forum._compute_website_url(), cache=False)
-        self.assertLessEqual(number_of_queries, 28)
+        self.assertLessEqual(number_of_queries, 31)
         number_of_queries = self._get_url_hot_query(self.post.website_url)
-        self.assertEqual(number_of_queries, 21)
+        self.assertEqual(number_of_queries, 24)
         number_of_queries = self._get_url_hot_query(self.post.website_url, cache=False)
-        self.assertLessEqual(number_of_queries, 25)
+        self.assertLessEqual(number_of_queries, 28)
 
     def test_perf_sql_forum_scaling_answers(self):
         self.env['forum.tag'].create([
@@ -63,9 +63,9 @@ class TestForumPerformance(UtilPerf):
         ])
         self.env.flush_all()
         number_of_queries = self._get_url_hot_query(self.post.website_url)
-        self.assertEqual(number_of_queries, 24)
+        self.assertEqual(number_of_queries, 27)
         number_of_queries = self._get_url_hot_query(self.post.website_url, cache=False)
-        self.assertLessEqual(number_of_queries, 28)
+        self.assertLessEqual(number_of_queries, 31)
 
     def test_perf_sql_forum_scaling_posts(self):
         self.env['forum.post'].create([
@@ -83,6 +83,6 @@ class TestForumPerformance(UtilPerf):
         ])
         self.env.flush_all()
         number_of_queries = self._get_url_hot_query(self.forum._compute_website_url())
-        self.assertEqual(number_of_queries, 25)
+        self.assertEqual(number_of_queries, 28)
         number_of_queries = self._get_url_hot_query(self.forum._compute_website_url(), cache=False)
-        self.assertLessEqual(number_of_queries, 29)
+        self.assertLessEqual(number_of_queries, 32)


### PR DESCRIPTION
Specification:

To enhance content delivery customization, this commit introduces a user
group visibility feature within the website module. By incorporating
this functionality, user gain greater control over content
presentation, allowing them to provide specific content to designated
user groups.

Changes Introduced:
- Addition of a user-group suboption in conditional visibilty snippet
options.
- With the user group option, now user can have the functionality to
choose the snippet visibility based on user-groups.
- User group option will be visible only on debug mode.
- Added tour for the User Group Options.

Changes in Test Case:

Made change in the query count as due to improvement, 3 more queries
were introduced as below:
- 2 queries for getting groups display name as it is many2many.
- 1 for displaying user groups in snippet option selection.

task-3502447