### PR TITLE
[FIX] stock: apply routes for inter-company transactions

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -681,6 +681,7 @@ class ProductTemplate(models.Model):
         default=lambda self: self.env['stock.route'].search_count([('product_selectable', '=', True)]))
     route_ids = fields.Many2many(
         'stock.route', 'stock_route_product', 'product_id', 'route_id', 'Routes',
+        depends_context=('company',),
         domain=[('product_selectable', '=', True)],
         help="Depending on the modules installed, this will allow you to define the route of the product: whether it will be bought, manufactured, replenished on order, etc.")
     nbr_moves_in = fields.Integer(compute='_compute_nbr_moves', compute_sudo=False, help="Number of incoming stock moves in the past 12 months")


### PR DESCRIPTION
### Steps to reproduce:

- Go to Settings > Users & companies > companies
- Create two branches for your company: Branch 1 and Branch 2
- Activate "Multi-Step Routes" As branch 2:
- Go to the General Settings and activate: Inter-Company Transactions:
            > "Synchronize Sales and Purchase Order" and "Automatic Validation"
- Go to Inventory > Configuration > Warehouse Management > Routes
- Create a new route applicable on products with a Push to action From "Branch 2/stock" to the location of your choice. 
#### As your main company:
- Create a product and select the route you have created 
#### As Branch 1:
- Create a new SO with your product and Branch 2 as a customer. 
#### As Branch 2:
- Go to to the purchase app.

#### > A purchase order was created but the push rule was not applied to generate a stock move

### Cause of the issue:

Confirming the SO with Branch 1 will first generate an outgoing stock move for your product in that branch. During this process, the value of the related field `route_ids` of your product will be accessed and hence stored in the cache. Later in the flow, a purchase order will be created and auto-confirmed for the other branch (Branch 2): https://github.com/odoo/enterprise/blob/45fea18a57c94e08bc41074cc882ad8d48b89fca/sale_purchase_inter_company_rules/models/sale_order.py#L60-L61 This confirmation will first trigger the creation of an incoming stock move for Branch 2 and during its confirmation, other applicable rules will be searched for:
https://github.com/odoo/odoo/blob/1154556a0e681df25e327136a33618b39fd0e090/addons/purchase_stock/models/purchase_order.py#L250 https://github.com/odoo/odoo/blob/1154556a0e681df25e327136a33618b39fd0e090/addons/stock/models/stock_rule.py#L514-L516 However, since `product_id.route_ids` is stored in the cache (with the value related to Branch 1), this value will be used instead of recomputing the value with respect to the current context (related to Branch 2). The rule created in the Branch 2 route will therefore not be found.

opw-3748877
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
