### PR TITLE
[IMP] mail, web: emoji picker position in chatter

### DIFF
--- a/addons/html_editor/static/src/main/emoji_plugin.js
+++ b/addons/html_editor/static/src/main/emoji_plugin.js
@@ -48,6 +48,7 @@ export class EmojiPlugin extends Plugin {
                     this.shared.domInsert(str);
                     this.dispatch("ADD_STEP");
                 },
+                state: { isOpen: true },
             },
             target,
         });

--- a/addons/mail/static/src/core/common/composer.js
+++ b/addons/mail/static/src/core/common/composer.js
@@ -12,7 +12,7 @@ import { rpc } from "@web/core/network/rpc";
 import { isEventHandled, markEventHandled } from "@web/core/utils/misc";
 import { browser } from "@web/core/browser/browser";
 import { useDebounced } from "@web/core/utils/timing";
-
+import { useEmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import {
     Component,
     markup,
@@ -146,7 +146,13 @@ export class Composer extends Component {
         useChildSubEnv({
             inComposer: true,
         });
-        this.picker = usePicker(this.pickerSettings);
+        if (!this.ui.isSmall || !this.env.inChatter) {
+            this.picker = usePicker(this.pickerSettings);
+        } else {
+            this.emojiPicker = useEmojiPicker(this.emojiButton, {
+                onSelect: (emoji) => this.addEmoji(emoji),
+            });
+        }
         useEffect(
             (focus) => {
                 if (focus && this.ref.el) {
@@ -209,6 +215,14 @@ export class Composer extends Component {
                     : "top-end",
             fixed: !this.props.composer.message,
         };
+    }
+
+    get isEmojiPickerActive() {
+        if (this.picker) {
+            return this.picker.state.picker === this.picker.PICKERS.EMOJI;
+        } else {
+            return this.emojiPicker.isOpen;
+        }
     }
 
     get placeholder() {

--- a/addons/mail/static/src/core/common/composer.xml
+++ b/addons/mail/static/src/core/common/composer.xml
@@ -84,7 +84,7 @@
                     attachments="props.composer.attachments"
                     unlinkAttachment.bind="(...args) => attachmentUploader.unlink(...args)"
                     imagesHeight="75"/>
-                <Picker t-props="picker"/>
+                <Picker t-if="picker" t-props="picker"/>
             </div>
         </div>
         <div t-if="props.composer.message" class="d-flex align-items-center gap-1 w-100">

--- a/addons/mail/static/src/core/common/message_actions.js
+++ b/addons/mail/static/src/core/common/message_actions.js
@@ -4,12 +4,11 @@ import { _t } from "@web/core/l10n/translation";
 import { download } from "@web/core/network/download";
 import { registry } from "@web/core/registry";
 import { MessageReactionButton } from "./message_reaction_button";
-import { useService } from "@web/core/utils/hooks";
+import { onExternalClick, useService } from "@web/core/utils/hooks";
 import { discussComponentRegistry } from "./discuss_component_registry";
 import { Deferred } from "@web/core/utils/concurrency";
 import { EMOJI_PICKER_PROPS, EmojiPicker } from "@web/core/emoji_picker/emoji_picker";
 import { Dialog } from "@web/core/dialog/dialog";
-import { onExternalClick } from "@mail/utils/common/hooks";
 import { convertBrToLineBreak } from "@mail/utils/common/format";
 
 const { DateTime } = luxon;
@@ -33,6 +32,9 @@ class EmojiPickerMobile extends Component {
             onSelect: (...args) => {
                 this.props.onSelect(...args);
                 this.props.close?.();
+            },
+            state: {
+                isOpen: true,
             },
         };
     }
@@ -70,7 +72,12 @@ messageActionsRegistry
                         def.resolve(true);
                     },
                 },
-                { context: component, onClose: () => def.resolve(false) }
+                {
+                    context: component,
+                    onClose: () => {
+                        def.resolve(false);
+                    },
+                }
             );
             return def;
         },

--- a/addons/mail/static/src/core/common/message_reaction_button.js
+++ b/addons/mail/static/src/core/common/message_reaction_button.js
@@ -25,6 +25,9 @@ export class MessageReactionButton extends Component {
                     this.props.message.react(emoji);
                 }
             },
+            state: {
+                isOpen: true,
+            },
         });
     }
 }

--- a/addons/mail/static/src/core/common/message_reaction_menu.js
+++ b/addons/mail/static/src/core/common/message_reaction_menu.js
@@ -1,5 +1,4 @@
 import { loadEmoji, loader } from "@web/core/emoji_picker/emoji_picker";
-import { onExternalClick } from "@mail/utils/common/hooks";
 
 import {
     Component,
@@ -12,7 +11,7 @@ import {
 } from "@odoo/owl";
 
 import { Dialog } from "@web/core/dialog/dialog";
-import { useService } from "@web/core/utils/hooks";
+import { useService, onExternalClick } from "@web/core/utils/hooks";
 
 export class MessageReactionMenu extends Component {
     static props = ["close", "message", "initialReaction?"];

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -24,6 +24,9 @@ export class MessageReactions extends Component {
                     this.props.message.react(emoji);
                 }
             },
+            state: {
+                isOpen: true,
+            },
         });
     }
 }

--- a/addons/mail/static/src/core/common/navigable_list.js
+++ b/addons/mail/static/src/core/common/navigable_list.js
@@ -1,12 +1,11 @@
 import { ImStatus } from "@mail/core/common/im_status";
-import { onExternalClick } from "@mail/utils/common/hooks";
 import { markEventHandled, isEventHandled } from "@web/core/utils/misc";
 
 import { Component, useEffect, useExternalListener, useRef, useState } from "@odoo/owl";
 
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 import { usePosition } from "@web/core/position/position_hook";
-import { useService } from "@web/core/utils/hooks";
+import { useService, onExternalClick } from "@web/core/utils/hooks";
 
 export class NavigableList extends Component {
     static components = { ImStatus };

--- a/addons/mail/static/src/core/common/picker_content.js
+++ b/addons/mail/static/src/core/common/picker_content.js
@@ -10,7 +10,9 @@ export class PickerContent extends Component {
     static components = { EmojiPicker };
     static props = ["PICKERS", "close", "pickers", "state", "storeScroll"];
     static template = "mail.PickerContent";
-
+    setup() {
+        this.props.state.isOpen = true;
+    }
     onClick(ev) {
         markEventHandled(ev, "PickerContent.onClick");
     }

--- a/addons/mail/static/src/core/web/messaging_menu_patch.js
+++ b/addons/mail/static/src/core/web/messaging_menu_patch.js
@@ -1,9 +1,8 @@
 import { MessagingMenu } from "@mail/core/public_web/messaging_menu";
-import { onExternalClick } from "@mail/utils/common/hooks";
 import { useEffect, useState } from "@odoo/owl";
 
 import { _t } from "@web/core/l10n/translation";
-import { useService } from "@web/core/utils/hooks";
+import { useService, onExternalClick } from "@web/core/utils/hooks";
 import { patch } from "@web/core/utils/patch";
 import { MessagingMenuQuickSearch } from "@mail/core/web/messaging_menu_quick_search";
 import { isIOS } from "@web/core/browser/feature_detection";

--- a/addons/mail/static/src/core/web/messaging_menu_quick_search.js
+++ b/addons/mail/static/src/core/web/messaging_menu_quick_search.js
@@ -1,8 +1,7 @@
-import { onExternalClick } from "@mail/utils/common/hooks";
 import { Component, useState } from "@odoo/owl";
 import { getActiveHotkey } from "@web/core/hotkeys/hotkey_service";
 
-import { useAutofocus, useService } from "@web/core/utils/hooks";
+import { useAutofocus, useService, onExternalClick } from "@web/core/utils/hooks";
 
 export class MessagingMenuQuickSearch extends Component {
     static components = {};

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.js
@@ -23,6 +23,11 @@ const composerPatch = {
         }
         return setting;
     },
+    get isGifPickerActive() {
+        return this.picker
+            ? this.picker.state.picker === this.picker.PICKERS.GIF && this.ui.isSmall
+            : false;
+    },
     get hasGifPicker() {
         return (
             (this.store.hasGifPickerFeature || this.store.self.isAdmin) &&

--- a/addons/mail/static/src/discuss/gif_picker/common/composer_patch.xml
+++ b/addons/mail/static/src/discuss/gif_picker/common/composer_patch.xml
@@ -3,11 +3,11 @@
     <t t-inherit="mail.Composer.emojiPicker" t-inherit-mode="extension">
         <xpath expr="//*[@t-ref='emoji-button']" position="attributes">
             <attribute name="t-att-class">
-                {'bg-300': this.picker.state.picker === this.picker.PICKERS.EMOJI or (this.picker.state.picker === this.picker.PICKERS.GIF and this.ui.isSmall)}
+                {'bg-300': isEmojiPickerActive or isGifPickerActive}
             </attribute>
         </xpath>
         <xpath expr="//*[@t-ref='emoji-button']" position="after">
-            <button t-if="hasGifPickerButton" class="btn border-0 rounded-pill p-1" t-att-class="{'bg-300': this.picker.state.picker === this.picker.PICKERS.GIF}" aria-label="GIFs" t-on-click="onClickAddGif" t-ref="gif-button"><i class="oi oi-fw oi-gif-picker"/></button>
+            <button t-if="hasGifPickerButton" class="btn border-0 rounded-pill p-1" t-att-class="{'bg-300': isGifPickerActive}" aria-label="GIFs" t-on-click="onClickAddGif" t-ref="gif-button"><i class="oi oi-fw oi-gif-picker"/></button>
         </xpath>
     </t>
 </templates>

--- a/addons/mail/static/src/utils/common/hooks.js
+++ b/addons/mail/static/src/utils/common/hooks.js
@@ -11,8 +11,8 @@ import {
 import { browser } from "@web/core/browser/browser";
 import { Deferred } from "@web/core/utils/concurrency";
 import { makeDraggableHook } from "@web/core/utils/draggable_hook_builder_owl";
-import { useService } from "@web/core/utils/hooks";
-import { monitorAudio } from "@mail/utils/common/media_monitoring";
+import { onExternalClick, useService } from "@web/core/utils/hooks";
+import { monitorAudio } from "./media_monitoring";
 
 export function useLazyExternalListener(target, eventName, handler, eventParams) {
     const boundHandler = handler.bind(useComponent());
@@ -41,33 +41,6 @@ export function useLazyExternalListener(target, eventName, handler, eventParams)
             return;
         }
         t.removeEventListener(eventName, boundHandler, eventParams);
-    });
-}
-
-export function onExternalClick(refName, cb) {
-    let downTarget, upTarget;
-    const ref = useRef(refName);
-    function onClick(ev) {
-        if (ref.el && !ref.el.contains(ev.composedPath()[0])) {
-            cb(ev, { downTarget, upTarget });
-            upTarget = downTarget = null;
-        }
-    }
-    function onMousedown(ev) {
-        downTarget = ev.target;
-    }
-    function onMouseup(ev) {
-        upTarget = ev.target;
-    }
-    onMounted(() => {
-        document.body.addEventListener("mousedown", onMousedown, true);
-        document.body.addEventListener("mouseup", onMouseup, true);
-        document.body.addEventListener("click", onClick, true);
-    });
-    onWillUnmount(() => {
-        document.body.removeEventListener("mousedown", onMousedown, true);
-        document.body.removeEventListener("mouseup", onMouseup, true);
-        document.body.removeEventListener("click", onClick, true);
     });
 }
 

--- a/addons/mail/static/src/views/web/fields/emojis_field_common/emojis_field_common.js
+++ b/addons/mail/static/src/views/web/fields/emojis_field_common/emojis_field_common.js
@@ -32,6 +32,9 @@ export const EmojisFieldCommon = (T) =>
                             this._emojiAdded();
                         }
                     },
+                    state: {
+                        isOpen: true,
+                    },
                 },
                 {
                     position: "bottom",

--- a/addons/mail/static/tests/legacy/qunit_suite_tests/widgets/emojis_char_field_tests.js
+++ b/addons/mail/static/tests/legacy/qunit_suite_tests/widgets/emojis_char_field_tests.js
@@ -40,6 +40,7 @@ QUnit.module("mail", {}, () => {
 
             click(document, ".o_field_char_emojis button");
             await nextTick();
+            await nextTick();
             click(document, '.o-Emoji[data-codepoints="😀"]');
             assert.strictEqual(inputName.value, "Hello😀");
         });
@@ -54,6 +55,7 @@ QUnit.module("mail", {}, () => {
             assert.strictEqual(inputName.value, "Hello ");
 
             click(document, ".o_field_char_emojis button");
+            await nextTick();
             await nextTick();
             click(document, '.o-Emoji[data-codepoints="😀"]');
             assert.strictEqual(inputName.value, "Hello 😀");

--- a/addons/mail/static/tests/legacy/web/fields/emojis_fields_tests.js
+++ b/addons/mail/static/tests/legacy/web/fields/emojis_fields_tests.js
@@ -6,7 +6,7 @@ import { startServer } from "@bus/../tests/helpers/mock_python_environment";
 
 import { start } from "@mail/../tests/helpers/test_utils";
 
-import { click } from "@web/../tests/helpers/utils";
+import { click, nextTick } from "@web/../tests/helpers/utils";
 import { contains } from "@web/../tests/utils";
 
 /**
@@ -34,6 +34,7 @@ export async function testEmojiButton(assert, input, button) {
     await click(button);
     await contains(".o-EmojiPicker");
     // clicking an emoji adds it to the input field
+    await nextTick();
     const emoji_1 = $(".o-EmojiPicker-content .o-Emoji")[0];
     const emojiChar_1 = emoji_1.textContent;
     await click(emoji_1);
@@ -43,6 +44,7 @@ export async function testEmojiButton(assert, input, button) {
     input.setSelectionRange(2, input.value.length - emojiChar_1.length);
     // pick an emoji while the text is selected
     await click(button);
+    await nextTick();
     const emoji_2 = $(".o-EmojiPicker-content .o-Emoji")[0];
     const emojiChar_2 = emoji_2.textContent;
     await click(emoji_2);

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.js
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.js
@@ -248,9 +248,6 @@ export class EmojiPicker extends Component {
                 return;
             }
             this.highlightActiveCategory();
-            if (this.props.storeScroll && this.gridRef.el) {
-                this.gridRef.el.scrollTop = this.props.storeScroll.get();
-            }
         });
         onPatched(() => {
             if (this.emojis.length === 0) {
@@ -273,7 +270,9 @@ export class EmojiPicker extends Component {
         useEffect(
             () => {
                 if (this.searchTerm) {
-                    this.gridRef.el.scrollTop = 0;
+                    if (this.gridRef.el) {
+                        this.gridRef.el.scrollTop = 0;
+                    }
                     this.state.categoryId = null;
                 } else {
                     if (this.lastSearchTerm) {
@@ -285,6 +284,18 @@ export class EmojiPicker extends Component {
             },
             () => [this.searchTerm]
         );
+        useEffect(() => {
+            if (this.ui.isSmall) {
+                if (
+                    this.emojiPickerRef?.el?.offsetTop >= this.props.emojiButtonRef?.el?.offsetTop
+                ) {
+                    this.props.emojiButtonRef.el.scrollIntoView({ behaviour: "smooth" });
+                }
+            }
+            if (this.props.storeScroll && this.gridRef.el) {
+                this.gridRef.el.scrollTop = this.props.storeScroll.get();
+            }
+        });
         useEffect(
             () => {
                 this.state.isOpen = this.props.state?.isOpen;

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.scss
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.scss
@@ -5,6 +5,18 @@
 
 .o-EmojiPicker {
     --o-emoji-picker-active: #{$gray-200};
+
+    &.o-mobile {
+        height: 55vh;
+        width: 100%;
+        --o-emoji-picker-active: #{$gray-200};
+
+        .o-Emoji {
+            width: 40px;
+            font-size: 1.5rem !important;
+        }
+    }
+
     .o-active {
         background-color: var(--o-emoji-picker-active) !important;
     }
@@ -48,3 +60,4 @@
         }
     }
 }
+

--- a/addons/web/static/src/core/emoji_picker/emoji_picker.xml
+++ b/addons/web/static/src/core/emoji_picker/emoji_picker.xml
@@ -2,7 +2,16 @@
 <templates xml:space="preserve">
 
 <t t-name="web.EmojiPicker">
-    <div class="o-EmojiPicker bg-view d-flex flex-column justify-content-center" t-att-class="{ 'align-items-center': emojis.length === 0 }" t-on-click="onClick" t-on-keydown="onKeydown">
+    <div
+    t-if="state.isOpen"
+    class="o-EmojiPicker bg-view d-flex flex-column justify-content-center"
+    t-att-class="{
+        'align-items-center': emojis.length === 0,
+        'o-mobile': ui.isSmall,
+        }"
+    t-ref="emojiPicker"
+    t-on-click="onClick"
+    t-on-keydown="onKeydown">
         <t t-if="emojis.length === 0">
             <span class="o-EmojiPicker-empty">😵‍💫</span>
             <span class="fs-5 text-muted">Failed to load emojis...</span>


### PR DESCRIPTION
**Current behavior before PR:**

In mobile view, when using the emoji picker in the chatter, it replaces the native keyboard but it does not take its position. It's possible to scroll outside the emoji picker.

**Desired behavior after PR is merged:**

In mobile view, chatter emoji picker works just like discuss's emoji picker and replaces native keyboard and takes the right position.

task-id:3757047

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
