### PR TITLE
[FIX] account_edi_ubl_cii: allow to confirm partners' invoices withou…

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_bis3.py
@@ -117,7 +117,7 @@ class AccountEdiXmlUBLBIS3(models.AbstractModel):
         if partner.country_code == 'NO':
             if 'l10n_no_bronnoysund_number' in partner._fields:
                 vals['endpoint_id'] = partner.l10n_no_bronnoysund_number
-            else:
+            elif partner.vat:
                 vals['endpoint_id'] = partner.vat.replace("NO", "").replace("MVA", "")
         # [BR-NL-1] Dutch supplier registration number ( AccountingSupplierParty/Party/PartyLegalEntity/CompanyID );
         # With a Dutch supplier (NL), SchemeID may only contain 106 (Chamber of Commerce number) or 190 (OIN number).

--- a/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
+++ b/addons/account_edi_ubl_cii/tests/test_ubl_cii.py
@@ -120,3 +120,15 @@ class TestAccountEdiUblCii(AccountTestInvoicingCommon):
                 .with_context(default_journal_id=self.company_data["default_journal_purchase"].id)\
                 ._create_document_from_attachment(xml_attachment.id)
         self.assertEqual(bill.invoice_line_ids.tax_ids, new_tax_2)
+
+    def test_get_norway_partner_party_vals_with_no_tax(self):
+        norway = self.env["res.country"].search([("code", "=", "NO")])
+        partner = self.env["res.partner"].create({
+            "name": "Test partner",
+            "country_id": norway.id,
+            "country_code": norway.code,
+            "vat": False,
+        })
+
+        partner_party_vals = self.env["account.edi.xml.ubl_bis3"]._get_partner_party_vals(partner, role='customer')
+        self.assertEqual(partner_party_vals['endpoint_id'], partner.vat)


### PR DESCRIPTION
…t vat number

Current behavior:
An invoice with Norwegian partner without VAT number cannot be confirmed.

This behaviour does not happen when l10n_no module is installed

After this commit:
If the partner does not have a VAT number, the invoice will be confirmed

opw-3844723