### PR TITLE
[IMP] website: improve the website form layout

### DIFF
--- a/addons/auth_signup/views/auth_signup_login_templates.xml
+++ b/addons/auth_signup/views/auth_signup_login_templates.xml
@@ -9,6 +9,9 @@
             <xpath expr="//label[@for='password']" position="inside">
                 <a t-if="reset_password_enabled" class="btn btn-link btn-sm" tabindex="1" t-attf-href="/web/reset_password?{{ keep_query() }}">Reset Password</a>
             </xpath>
+            <xpath expr="//form" position="attributes">
+                <attribute name="t-attf-class" add="o_custom_label_position" separator=" "/>
+            </xpath>
         </template>
 
         <template id="auth_signup.fields" name="Auth Signup/ResetPassword form fields">

--- a/addons/test_website/views/templates.xml
+++ b/addons/test_website/views/templates.xml
@@ -42,13 +42,12 @@
         <span class="hidden" data-for="test_form" t-att-data-values="{'tag_id': tag and tag.id or ''}" />
         <section class="s_website_form pt16 pb16 o_colored_level" data-vcss="001" data-snippet="s_website_form" data-name="Form">
             <div class="container">
-                <form id="test_form" action="#fake" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-success-mode="redirect" data-success-page="/success" data-model_name="test.model" hide-change-model="true">
+                <form id="test_form" action="#fake" method="post" enctype="multipart/form-data" data-pre-fill="true" data-success-mode="redirect" data-success-page="/success" data-model_name="test.model" hide-change-model="true">
                     <div class="s_website_form_rows row s_col_no_bgcolor">
                         <div class="mb-0 py-2 s_website_form_field col-12 s_website_form_required" data-type="char" data-name="Field">
                             <div class="row s_col_no_resize s_col_no_bgcolor">
                                 <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="testform1">
                                     <span class="s_website_form_label_content">Name</span>
-                                    <span class="s_website_form_mark"> *</span>
                                 </label>
                                 <div class="col-sm">
                                     <input type="text" class="form-control s_website_form_input" name="name" required="1" data-fill-with="name" id="testform1"/>

--- a/addons/web_editor/static/src/js/editor/snippets.editor.js
+++ b/addons/web_editor/static/src/js/editor/snippets.editor.js
@@ -3169,6 +3169,7 @@ class SnippetsMenu extends Component {
     _computeSnippetTemplates(html) {
         var self = this;
         var $html = $(html);
+        this._adaptSnippetTemplates($html);
 
         this.templateOptions = [];
         var selectors = [];
@@ -4070,6 +4071,14 @@ class SnippetsMenu extends Component {
             delete $target[0].dataset.name;
         }
     }
+    /**
+     * Used to customize the snippets content before being dropped.
+     *
+     * @private
+     * @abstract
+     * @param {jQuery} $html
+     */
+    _adaptSnippetTemplates($html) {}
 
     //--------------------------------------------------------------------------
     // Handlers

--- a/addons/website/__manifest__.py
+++ b/addons/website/__manifest__.py
@@ -222,6 +222,7 @@
             'website/static/src/js/content/auto_hide_menu.js',
             'website/static/src/js/content/redirect.js',
             'website/static/src/js/content/adapt_content.js',
+            'website/static/src/js/content/form_processing.js',
         ],
         'web.assets_frontend_lazy': [
             # Remove assets_frontend_minimal
@@ -229,6 +230,7 @@
             ('remove', 'website/static/src/js/content/auto_hide_menu.js'),
             ('remove', 'website/static/src/js/content/redirect.js'),
             ('remove', 'website/static/src/js/content/adapt_content.js'),
+            ('remove', 'website/static/src/js/content/form_processing.js'),
         ],
         'web._assets_primary_variables': [
             'website/static/src/scss/primary_variables.scss',
@@ -269,6 +271,7 @@
             'website/static/src/components/autocomplete_with_pages/*',
             'website/static/src/xml/website.xml',
             'website/static/src/scss/website_controller_page_kanban.scss',
+            'website/static/src/js/content/form_processing.js',
 
             # Don't include dark mode files in light mode
             ('remove', 'website/static/src/client_actions/*/*.dark.scss'),

--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -51,12 +51,11 @@
                                 </p>
                                 <section class="s_website_form" data-vcss="001" data-snippet="s_website_form">
                                     <div class="container">
-                                        <form id="contactus_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you" data-pre-fill="true">
+                                        <form id="contactus_form" action="/website/form/" method="post" enctype="multipart/form-data" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you" data-pre-fill="true">
                                             <div class="s_website_form_rows row s_col_no_bgcolor">
                                                 <div class="mb-3 col-lg-6 s_website_form_field s_website_form_custom s_website_form_required" data-type="char" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact1">
                                                         <span class="s_website_form_label_content">Name</span>
-                                                        <span class="s_website_form_mark"> *</span>
                                                     </label>
                                                     <input id="contact1" type="text" class="form-control s_website_form_input" name="name" required="" data-fill-with="name"/>
                                                 </div>
@@ -69,7 +68,6 @@
                                                 <div class="mb-3 col-lg-6 s_website_form_field s_website_form_required s_website_form_model_required" data-type="email" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact3">
                                                         <span class="s_website_form_label_content">Email</span>
-                                                        <span class="s_website_form_mark"> *</span>
                                                     </label>
                                                     <input id="contact3" type="email" class="form-control s_website_form_input" name="email_from" required="" data-fill-with="email"/>
                                                 </div>
@@ -82,14 +80,12 @@
                                                 <div class="mb-3 col-12 s_website_form_field s_website_form_required s_website_form_model_required" data-type="char" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact5">
                                                         <span class="s_website_form_label_content">Subject</span>
-                                                        <span class="s_website_form_mark"> *</span>
                                                     </label>
                                                     <input id="contact5" type="text" class="form-control s_website_form_input" name="subject" required=""/>
                                                 </div>
                                                 <div class="mb-3 col-12 s_website_form_field s_website_form_custom s_website_form_required" data-type="text" data-name="Field">
                                                     <label class="s_website_form_label" style="width: 200px" for="contact6">
                                                         <span class="s_website_form_label_content">Question</span>
-                                                        <span class="s_website_form_mark"> *</span>
                                                     </label>
                                                     <textarea id="contact6" class="form-control s_website_form_input" name="description" required="" rows="8"></textarea>
                                                 </div>

--- a/addons/website/static/src/js/content/form_processing.js
+++ b/addons/website/static/src/js/content/form_processing.js
@@ -1,0 +1,248 @@
+/** @odoo-module */
+
+// Contains the modifiers used to adapt the input label position.
+const _formLabelPositionConfig = {
+    hide: (options) => {
+        resetWebsiteLabel(options);
+        options.labelEl.classList.add("d-none");
+        cleanWebsiteLabel(options);
+    },
+    top: (options) => {
+        resetWebsiteLabel(options);
+        cleanWebsiteLabel(options);
+    },
+    left: (options) => {
+        resetWebsiteLabel(options);
+        inlineWebsiteLabel(options);
+        cleanWebsiteLabel(options);
+    },
+    right: (options) => {
+        resetWebsiteLabel(options);
+        inlineWebsiteLabel(options);
+        options.labelEl.classList.add("text-end");
+        cleanWebsiteLabel(options);
+    },
+    floating: (options) => {
+        const setFloatingLabel = options.websiteFormField
+            ? canSetFloatingLabel(options.websiteFormField.dataset.type)
+            : options.contentEls[0].matches("input, select, textarea");
+        if (!setFloatingLabel) {
+            return;
+        }
+        resetWebsiteLabel(options);
+        if (!options.contentEls[0].hasAttribute("placeholder")) {
+            options.contentEls[0].setAttribute("placeholder", "");
+        }
+        const containerEl = document.createElement("div");
+        containerEl.className = "form-floating";
+        options.labelEl.before(containerEl);
+        containerEl.append(
+            ...[
+                options.contentEls[0],
+                options.labelEl,
+                ...(options.descriptionEl ? [options.descriptionEl] : []),
+            ]
+        );
+        cleanWebsiteLabel(options);
+    },
+};
+
+/**
+ * Check if a "floating label" design can be applied on a website form field.
+ *
+ * @param {String} type
+ * @returns {Boolean}
+ */
+export function canSetFloatingLabel(type) {
+    return !["boolean", "one2many", "selection", "date", "datetime", "binary"].includes(type);
+}
+
+/**
+ * Check if a label can be added after the input in a form field.
+ *
+ * @param {String} type
+ * @returns {Boolean}
+ */
+export function canSetLabelAfterCheckbox(type) {
+    return type === "boolean";
+}
+
+/**
+ * Check if we can set a default label width.
+ *
+ * @param {String} position The current label position.
+ * @returns {Boolean}
+ */
+function canSetLabelWidth(position) {
+    return ["left", "right"].includes(position);
+}
+
+/**
+ * Returns a field content except label & description (single input, input
+ * group, radio, etc.)
+ *
+ * @param {Object} options
+ * @returns {HTMLElement[]}
+ */
+export function getInputContent(options) {
+    switch (options.oldPosition) {
+        case "left":
+        case "right":
+            return [
+                ...options.websiteFormField.querySelectorAll(
+                    ".col-sm > :not(.s_website_form_field_description)"
+                ),
+            ];
+        default:
+            return [
+                ...options.websiteFormField.querySelectorAll(
+                    ":scope > :not(label, .s_website_form_field_description)"
+                ),
+            ];
+    }
+}
+
+/**
+ * Returns the current position of an input label element.
+ *
+ * @param {HTMLElement} labelEl
+ * @returns {String}
+ */
+export function getWebsiteLabelPosition(labelEl) {
+    if (!labelEl) {
+        return "";
+    }
+    const labelClassList = labelEl.classList;
+    if (labelClassList.contains("col-sm-auto")) {
+        return labelClassList.contains("text-end") ? "right" : "left";
+    } else if (labelEl.previousElementSibling?.matches(".form-check > input[type='checkbox']")) {
+        return "after-checkbox";
+    } else if (labelEl.closest(".form-floating")) {
+        return "floating";
+    } else {
+        return labelClassList.contains("d-none") ? "none" : "top";
+    }
+}
+
+/**
+ * Removes elements wrapping a form input / label (mainly used for "inline" &
+ * "floating" positions) to be able to apply the new position correctly.
+ *
+ * @param {Object} options
+ */
+function resetWebsiteLabel(options) {
+    if (options.websiteFormField) {
+        for (const wrapEl of options.websiteFormField.querySelectorAll(
+            ":scope > .row:not(.s_website_form_multiple), .col-sm, :scope > .form-floating, :scope > .form-check"
+        )) {
+            wrapEl.after(...wrapEl.childNodes);
+            wrapEl.remove();
+        }
+        // Ensure that the label is before the input content.
+        options.labelEl.parentElement.insertBefore(options.labelEl, ...options.contentEls);
+    }
+}
+
+/**
+ * Cleans the DOM and removes unwanted CSS from the old design.
+ *
+ * @param {Object} options
+ */
+function cleanWebsiteLabel(options) {
+    const classesToRemove = [
+        ...(!["right", "left"].includes(options.newPosition) ? ["col-sm-auto"] : []),
+        ...(options.oldPosition === "right" ? ["text-end"] : []),
+        ...(options.oldPosition === "hide" ? ["d-none"] : []),
+    ];
+    options.labelEl.classList.remove(...classesToRemove);
+}
+
+/**
+ * Used to apply an inline label position (left or right).
+ *
+ * @param {Object} options
+ */
+function inlineWebsiteLabel(options) {
+    const rowEl = document.createElement("div");
+    rowEl.className = "row s_col_no_resize s_col_no_bgcolor";
+    const colEl = document.createElement("div");
+    colEl.className = "col-sm";
+    options.labelEl.classList.add("col-sm-auto");
+    colEl.append(
+        ...[...options.contentEls, ...(options.descriptionEl ? [options.descriptionEl] : [])]
+    );
+    options.labelEl.before(rowEl);
+    rowEl.append(options.labelEl, colEl);
+}
+
+/**
+ * Applies the default label width.
+ *
+ * @param {Object} options
+ */
+function adaptLabelWidth(options) {
+    if (options.width && options.labelEl) {
+        options.labelEl.style.width = canSetLabelWidth(options.position) ? options.width : "";
+    }
+}
+
+/**
+ * Applies the provided label width and position design to a form (for every
+ * field that supports it).
+ *
+ * @param {HTMLElement} formEl
+ * @param {String} newPosition
+ * @param {String} width
+ */
+export function adaptFormLabel(formEl, newPosition, width) {
+    for (const inputEl of formEl.querySelectorAll(
+        ".form-control:not([type=hidden]), .form-select:not([type=hidden]), .form-check-input"
+    )) {
+        const websiteFormField = inputEl.closest(".s_website_form_field");
+        const labelEl = (websiteFormField || inputEl.parentElement).querySelector("label");
+        const descriptionEl = websiteFormField?.querySelector(".s_website_form_field_description");
+        const oldPosition = getWebsiteLabelPosition(labelEl);
+        if (websiteFormField?.classList.contains("o_custom_label_position")) {
+            adaptLabelWidth({ position: oldPosition, labelEl, width });
+            continue;
+        }
+        if (oldPosition && oldPosition !== newPosition) {
+            _formLabelPositionConfig[newPosition]({
+                websiteFormField,
+                oldPosition,
+                newPosition,
+                descriptionEl,
+                contentEls: websiteFormField
+                    ? getInputContent({ websiteFormField, oldPosition, inputEl })
+                    : [inputEl],
+                labelEl,
+            });
+        }
+        adaptLabelWidth({ position: newPosition, labelEl, width });
+    }
+}
+
+/**
+ * Set the default label position and width on all forms on a page (website and
+ * bootstrap forms):
+ * The label position can always be customized in the website editor (for every
+ * label element).
+ * The label width can also be edited (on a form level) since it's a form option
+ */
+document.addEventListener("DOMContentLoaded", () => {
+    const style = window.getComputedStyle(document.documentElement);
+    const defaultLabelPosition = style.getPropertyValue("--input-label-position").replace(/'/g, "");
+    const defaultLabelWidth = style.getPropertyValue("--input-label-width");
+
+    if (defaultLabelPosition) {
+        for (const formEl of document.querySelectorAll(
+            `main form:not(.o_custom_label_position, .o_custom_label_position_${defaultLabelPosition})`
+        )) {
+            adaptFormLabel(
+                formEl,
+                defaultLabelPosition,
+                !formEl.closest(".o_custom_label_width") && defaultLabelWidth
+            );
+        }
+    }
+});

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -11,6 +11,8 @@ import { Component, onMounted, onWillStart, useEffect, useRef, useState } from "
 import { throttleForAnimation } from "@web/core/utils/timing";
 import { applyTextHighlight, switchTextHighlight } from "@website/js/text_processing";
 import { registry } from "@web/core/registry";
+import weUtils from "@web_editor/js/common/utils";
+import { adaptFormLabel } from "@website/js/content/form_processing";
 
 const snippetsEditorRegistry = registry.category("snippets_editor");
 snippetsEditorRegistry.add("no_parent_editor_snippets", ["s_popup", "o_mega_menu"]);
@@ -554,6 +556,19 @@ export class WebsiteSnippetsMenu extends weSnippetEditor.SnippetsMenu {
             applyTextHighlight(textEl);
         }
         return super._updateDroppedSnippet(...arguments);
+    }
+    /**
+     * @override
+     */
+    _adaptSnippetTemplates($html) {
+        // Apply the default form label style.
+        for (const snippetFormEl of $html[0].querySelectorAll('[data-snippet="s_website_form"] form')) {
+            adaptFormLabel(
+                snippetFormEl,
+                weUtils.getCSSVariableValue("input-label-position").replaceAll("'", ""),
+                weUtils.getCSSVariableValue("input-label-width")
+            );
+        }
     }
 
     //--------------------------------------------------------------------------

--- a/addons/website/static/src/scss/primary_variables.scss
+++ b/addons/website/static/src/scss/primary_variables.scss
@@ -2155,6 +2155,8 @@ $o-base-website-values-palette: (
     'input-border-radius': null, // Default to BS
     'input-border-radius-sm': null, // Default to BS
     'input-border-radius-lg': null, // Default to BS
+    'input-label-position': 'floating',
+    'input-label-width': 200px,
 
     // A key from the $o-theme-font-configs map (null = default to the first key
     // for the base 'font' value, the others just fallback to 'font').

--- a/addons/website/static/src/snippets/s_website_form/001.scss
+++ b/addons/website/static/src/snippets/s_website_form/001.scss
@@ -27,11 +27,6 @@
         display: none;
     }
 
-    span.s_website_form_mark {
-        @include font-size(0.85em);
-        font-weight: 400;
-    }
-
     .s_website_form_dnone {
         display: none;
     }

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -357,7 +357,7 @@
                 t-att="field.maxFilesNumber > 1 and {'multiple': ''} or {}"
                 t-att-id="field.id"
                 t-att-data-max-files-number="field.maxFilesNumber or '1'"
-                t-att-data-max-file-size="field.maxFileSize or '1'"
+                t-att-data-max-file-size="field.maxFileSize or '10'"
             />
         </t>
     </t>

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -51,12 +51,6 @@
 
     <t t-name="website.form_label_content">
         <span class="s_website_form_label_content" t-esc="field.string"/>
-        <t t-if="field.required or field.modelRequired">
-            <span class="s_website_form_mark" t-if="field.formatInfo.requiredMark" t-esc="' ' + field.formatInfo.mark"/>
-        </t>
-        <t t-else="">
-            <span class="s_website_form_mark" t-if="field.formatInfo.optionalMark" t-esc="' ' + field.formatInfo.mark"/>
-        </t>
     </t>
 
     <t t-name="website.form_field_description">

--- a/addons/website/static/src/xml/website_form_editor.xml
+++ b/addons/website/static/src/xml/website_form_editor.xml
@@ -27,20 +27,36 @@
     <!-- Generic Field Layout -->
     <!-- Changes made here needs to be reflected in the different Form view (Contact Us, Jobs, ...) -->
     <t t-name="website.form_field">
-        <div t-attf-class="s_website_form_field mb-3 #{field.formatInfo.col or 'col-12'} #{field.custom and 's_website_form_custom' or ''} #{(field.required and 's_website_form_required' or '') or (field.modelRequired and 's_website_form_model_required' or '')} #{field.hidden and 's_website_form_field_hidden' or ''} #{field.dnone and 's_website_form_dnone' or ''}"
+        <div t-attf-class="s_website_form_field mb-3 #{field.formatInfo.col or 'col-12'} #{field.custom and 's_website_form_custom' or ''} #{(field.required and 's_website_form_required' or '') or (field.modelRequired and 's_website_form_model_required' or '')} #{field.hidden and 's_website_form_field_hidden' or ''} #{field.dnone and 's_website_form_dnone' or ''} #{field.formatInfo.customLabelPosition and 'o_custom_label_position' or ''}"
             t-att-data-type="field.type"
             data-name="Field">
-            <div t-if="field.formatInfo.labelPosition != 'none' and field.formatInfo.labelPosition != 'top'" class="row s_col_no_resize s_col_no_bgcolor">
-                <label t-attf-class="#{!field.isCheck and 'col-form-label' or ''} col-sm-auto s_website_form_label #{field.formatInfo.labelPosition == 'right' and 'text-end' or ''}" t-attf-style="width: #{field.formatInfo.labelWidth or '200px'}" t-att-for="field.id">
-                     <t t-call="website.form_label_content"/>
-                </label>
-                <div class="col-sm">
+            <div t-if="field.formatInfo.labelPosition != 'none' and field.formatInfo.labelPosition != 'top' and field.formatInfo.labelPosition != 'after-checkbox'"
+                t-attf-class="#{field.formatInfo.labelPosition == 'floating' and 'form-floating' or 'row s_col_no_resize s_col_no_bgcolor'}">
+                <t t-if="field.formatInfo.labelPosition == 'floating'">
                     <t t-out="0"/>
+                    <label t-attf-class="s_website_form_label"
+                        t-attf-style="width: #{field.formatInfo.labelWidth or '200px'}"
+                        t-att-for="field.id">
+                        <t t-call="website.form_label_content"/>
+                    </label>
                     <t t-call="website.form_field_description"/>
-                </div>
+                </t>
+                <t t-else="">
+                    <label t-attf-class="#{!field.isCheck and 'col-form-label' or ''} col-sm-auto s_website_form_label #{field.formatInfo.labelPosition == 'right' and 'text-end' or ''}"
+                        t-attf-style="width: #{field.formatInfo.labelWidth or '200px'}"
+                        t-att-for="field.id">
+                        <t t-call="website.form_label_content"/>
+                    </label>
+                    <div class="col-sm">
+                        <t t-out="0"/>
+                        <t t-call="website.form_field_description"/>
+                    </div>
+                </t>
             </div>
             <t t-else="">
-                <label t-attf-class="s_website_form_label #{field.formatInfo.labelPosition == 'none' and 'd-none' or ''}" t-attf-style="width: #{field.formatInfo.labelWidth or '200px'}" t-att-for="field.id">
+                <label t-attf-class="s_website_form_label #{field.formatInfo.labelPosition == 'none' and 'd-none' or ''}"
+                    t-attf-style="width: #{field.formatInfo.labelWidth or '200px'}"
+                    t-att-for="field.id">
                      <t t-call="website.form_label_content"/>
                 </label>
                 <t t-out="0"/>
@@ -94,7 +110,7 @@
                 t-att-required="field.required || field.modelRequired || None"
                 t-att-value="field.value"
                 t-att-data-fill-with="field.fillWith"
-                t-att-placeholder="field.placeholder"
+                t-att-placeholder="field.placeholder || ''"
                 t-att-id="field.id"
             />
         </t>

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -743,8 +743,8 @@ registerWebsitePreviewTour('website_form_contactus_edition_no_email', {
 }, () => editContactUs([
     {
         content: "Change a random option",
-        trigger: '[data-set-mark] input',
-        run: "edit ** && click body",
+        trigger: '[data-css-property="width"][data-apply-to=".s_website_form_label"] input',
+        run: "edit 210 && click body",
     }, {
         content: "Check that the recipient email is correct",
         trigger: 'we-input[data-field-name="email_to"] input:value("website_form_contactus_edition_no_email@mail.com")',
@@ -895,9 +895,8 @@ registerWebsitePreviewTour('website_form_contactus_change_random_option', {
 }, () => editContactUs([
     {
         content: "Change a random option",
-        trigger: '[data-set-mark] input',
-        // TODO: remove && click body
-        run: "edit ** && click body",
+        trigger: '[data-css-property="width"][data-apply-to=".s_website_form_label"] input',
+        run: "edit 210 && click body",
     },
 ]));
 

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -8,6 +8,7 @@ import {
     insertSnippet,
     goBackToBlocks,
     registerWebsitePreviewTour,
+    selectElementInWeSelectWidget,
 } from '@website/js/tours/tour_utils';
 
 // Visibility possible values:
@@ -199,11 +200,13 @@ registerWebsitePreviewTour("website_form_editor_tour", {
         content: 'Edit the Phone Number field',
         trigger: ':iframe input[name="phone"]',
         run: "click",
-    }, {
-        content: 'Change the label position of the phone field',
-        trigger: 'we-button[data-select-label-position="right"]',
+    },
+    {
+        content: "Open the collapse to edit the label position of the phone field",
+        trigger: "we-collapse:has(we-input[data-set-label-text]) we-toggler",
         run: "click",
     },
+    ...selectElementInWeSelectWidget("input_label_position_opt", "Right"),
     ...addCustomField("char", "text", "Conditional Visibility Check 1", false),
     ...addCustomField("char", "text", "Conditional Visibility Check 2", false),
     ...selectButtonByData("data-set-visibility='conditional'"),

--- a/addons/website/tests/test_disable_unused_snippets_assets.py
+++ b/addons/website/tests/test_disable_unused_snippets_assets.py
@@ -114,7 +114,7 @@ HOMEPAGE_UP_TO_DATE = """
     <div id="wrap" class="oe_structure oe_empty">
       <section class="s_website_form pt16 pb16 o_colored_level" data-vcss="001" data-snippet="s_website_form" data-name="Form">
         <div class="container">
-          <form action="/website_form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-success-mode="redirect" data-success-page="/contactus-thank-you" data-model_name="mail.mail">
+          <form action="/website_form/" method="post" enctype="multipart/form-data" data-success-mode="redirect" data-success-page="/contactus-thank-you" data-model_name="mail.mail">
           </form>
         </div>
       </section>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -234,7 +234,7 @@
             <we-input string="Max File Size"
                 title="The maximum size (in MB) an uploaded file can have."
                 data-attribute-name="maxFileSize"
-                data-select-data-attribute="1MB"
+                data-select-data-attribute="10MB"
                 data-apply-to="input[type='file']"
                 data-unit="MB"/>
 

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -95,7 +95,7 @@
         <!-- Form -->
         <div data-js="WebsiteFormEditor" data-selector=".s_website_form" data-target="form">
             <we-input string="Labels Width"
-                data-select-style="" data-css-property="width"
+                data-select-style="" data-set-label-width="" data-css-property="width"
                 data-unit="px" data-apply-to=".s_website_form_label"/>
             <we-row>
                 <we-select string="On Success" data-no-preview="true">
@@ -178,25 +178,20 @@
                 t-att-data-unit="unit_textarea_height" data-step="1"
                 t-attf-data-select-attribute="3#{unit_textarea_height}"
                 data-attribute-name="rows"/>
-            <we-input string="Label" class="o_we_large" data-set-label-text=""/>
-            <we-button-group string="Position" class="o_we_sublevel_1">
-                <we-button title="Hide"
-                           data-select-label-position="none">
-                    <i class="fa fa-eye-slash"/>
-                </we-button>
-                <we-button title="Top"
-                           data-select-label-position="top"
-                           data-img="/website/static/src/img/snippets_options/pos_top.svg"/>
-                <we-button title="Left"
-                           data-select-label-position="left"
-                           data-img="/website/static/src/img/snippets_options/pos_left.svg"/>
-                <we-button title="Right"
-                           data-select-label-position="right"
-                           data-img="/website/static/src/img/snippets_options/pos_right.svg"/>
-            </we-button-group>
+            <we-collapse>
+                <we-input string="Label" class="o_we_large" data-set-label-text=""/>
+                <we-select string="Position" class="o_we_sublevel_1" data-name="input_label_position_opt">
+                    <we-button data-select-label-position="none">Hide</we-button>
+                    <we-button data-select-label-position="top">Top</we-button>
+                    <we-button data-select-label-position="left">Left</we-button>
+                    <we-button data-select-label-position="right">Right</we-button>
+                    <we-button data-select-label-position="floating" data-name="input_label_position_floating_opt">Floating</we-button>
+                    <we-button data-select-label-position="after-checkbox" data-name="input_label_position_after_opt">After Checkbox</we-button>
+                </we-select>
+            </we-collapse>
             <we-checkbox string="Description" data-toggle-description="true" data-no-preview="true"/>
             <we-input string="Placeholder" class="o_we_large"
-                data-select-attribute="" data-attribute-name="placeholder"
+                data-select-attribute="" data-attribute-name="placeholder" data-name="input_placeholder_opt"
                 data-apply-to="input[type='text'], input[type='email'], input[type='number'], input[type='tel'], input[type='url'], textarea"/>
             <t t-set="default_value_label">Default Value</t>
             <we-input t-att-string="default_value_label" class="o_we_large" data-select-textarea-value="" data-apply-to="textarea"/>

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -4,7 +4,7 @@
 <template id="s_website_form" name="Form">
     <section class="s_website_form pt16 pb16" data-vcss="001" data-snippet="s_website_form">
         <div class="container-fluid">
-            <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required" data-mark="*" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
+            <form action="/website/form/" method="post" enctype="multipart/form-data" data-pre-fill="true" data-model_name="mail.mail" data-success-mode="redirect" data-success-page="/contactus-thank-you">
                 <div class="s_website_form_rows row s_col_no_bgcolor">
                     <div data-name="Field" class="s_website_form_field mb-3 col-12 s_website_form_dnone">
                         <div class="row s_col_no_resize s_col_no_bgcolor">
@@ -20,7 +20,6 @@
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="obij2aulqyau">
                                 <span class="s_website_form_label_content">Your Name</span>
-                                <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
                                 <input class="form-control s_website_form_input" type="text" name="name" required="1" data-fill-with="name" id="obij2aulqyau"/>
@@ -41,7 +40,6 @@
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="oub62hlfgjwf">
                                 <span class="s_website_form_label_content">Your Email</span>
-                                <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
                                 <input class="form-control s_website_form_input" type="email" name="email_from" required="" data-fill-with="email" id="oub62hlfgjwf"/>
@@ -62,7 +60,6 @@
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="oqsf4m51acj">
                                 <span class="s_website_form_label_content">Subject</span>
-                                <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
                                 <input class="form-control s_website_form_input" type="text" name="subject" required="" id="oqsf4m51acj"/>
@@ -73,7 +70,6 @@
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 200px" for="oyeqnysxh10b">
                                 <span class="s_website_form_label_content">Your Question</span>
-                                <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
                                 <textarea class="form-control s_website_form_input" name="description" required="1" id="oyeqnysxh10b" rows="3"></textarea>
@@ -98,12 +94,6 @@
     <xpath expr="//div" position="after">
         <!-- Form -->
         <div data-js="WebsiteFormEditor" data-selector=".s_website_form" data-target="form">
-            <we-select string="Marked Fields" data-name="field_mark_select">
-                <we-button data-select-class="">None</we-button>
-                <we-button data-select-class="o_mark_required" data-name="form_required_opt">Required</we-button>
-                <we-button data-select-class="o_mark_optional" data-name="form_optional_opt">Optional</we-button>
-            </we-select>
-            <we-input string="Mark Text" data-set-mark="" data-dependencies="form_required_opt, form_optional_opt"/>
             <we-input string="Labels Width"
                 data-select-style="" data-css-property="width"
                 data-unit="px" data-apply-to=".s_website_form_label"/>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -2219,6 +2219,21 @@
         </we-select>
     </div>
     <div data-js="OptionsTab" data-selector="theme-input" data-no-check="true">
+        <we-select string="Label Position" data-variable="input-label-position" data-reload="/">
+            <we-button data-customize-website-variable="'none'">Hide</we-button>
+            <we-button data-customize-website-variable="'top'">Top</we-button>
+            <we-button data-customize-website-variable="'left'" data-name="input_label_position_left_opt">Left</we-button>
+            <we-button data-customize-website-variable="'right'" data-name="input_label_position_right_opt">Right</we-button>
+            <we-button data-customize-website-variable="'floating'">Floating</we-button>
+        </we-select>
+        <we-row string="Width" class="o_we_sublevel_1">
+            <we-input data-dependencies="input_label_position_left_opt,input_label_position_right_opt"
+                data-customize-website-variable=""
+                data-variable="input-label-width"
+                title="Label Width"
+                data-reload="/"
+                data-unit="px"/>
+        </we-row>
         <we-collapse>
             <we-row string="Paddings">
                 <we-input title="Y" data-customize-website-variable="" data-variable="input-padding-y" data-unit="px" data-save-unit="rem"/>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -192,8 +192,7 @@
                     <section id="forms" class="col-12 col-md-9 s_website_form" data-vcss="001" data-snippet="s_website_form">
                         <div class="container">
                             <form id="hr_recruitment_form" action="/website/form/" method="post"
-                                enctype="multipart/form-data" class="o_mark_required row"
-                                data-mark="*" data-model_name="hr.applicant"
+                                enctype="multipart/form-data" class="row" data-model_name="hr.applicant"
                                 data-success-mode="redirect" data-success-page="/job-thank-you"
                                 hide-change-model="true">
                                 <div class="s_website_form_rows row s_col_no_bgcolor">
@@ -202,7 +201,6 @@
                                         <div class="row s_col_no_resize s_col_no_bgcolor">
                                             <label class="col-4 col-sm-auto s_website_form_label" style="width: 200px" for="recruitment1">
                                                 <span class="s_website_form_label_content">Your Name</span>
-                                                <span class="s_website_form_mark"> *</span>
                                             </label>
                                             <div class="col-sm">
                                                 <input id="recruitment1" type="text"
@@ -217,7 +215,6 @@
                                         <div class="row s_col_no_resize s_col_no_bgcolor">
                                             <label class="col-4 col-sm-auto s_website_form_label" style="width: 200px" for="recruitment2">
                                                 <span class="s_website_form_label_content">Your Email</span>
-                                                <span class="s_website_form_mark"> *</span>
                                             </label>
                                             <div class="col-sm">
                                                 <input id="recruitment2" type="email"
@@ -232,7 +229,6 @@
                                         <div class="row s_col_no_resize s_col_no_bgcolor">
                                             <label class="col-4 col-sm-auto s_website_form_label" style="width: 200px" for="recruitment3">
                                                 <span class="s_website_form_label_content">Your Phone Number</span>
-                                                <span class="s_website_form_mark"> *</span>
                                             </label>
                                             <div class="col-sm">
                                                 <input id="recruitment3" type="tel"

--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -63,14 +63,13 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
 <template id="s_newsletter_block_form_template" groups="base.group_user">
     <section class="s_website_form" data-vcss="001" data-snippet="s_website_form" data-name="Form">
         <div class="o_container_small">
-            <form id="newsletter_form" action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required"
-                  data-mark="*" data-model_name="mailing.contact" data-success-mode="message" hide-change-model="true">
+            <form id="newsletter_form" action="/website/form/" method="post" enctype="multipart/form-data"
+                  data-model_name="mailing.contact" data-success-mode="message" hide-change-model="true">
                 <div class="s_website_form_rows row s_col_no_bgcolor">
                     <div class="mb-0 py-2 col-12 s_website_form_field s_website_form_model_required" data-type="char" data-name="Field">
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub1">
                                 <span class="s_website_form_label_content">Name</span>
-                                <span class="s_website_form_mark"> *</span>
                             </label>
                             <div t-if="request.env['mailing.contact']._is_name_split_activated()" class="col-sm row">
                                 <div class="col-sm-6">
@@ -91,7 +90,6 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-form-label col-sm-auto s_website_form_label" style="width: 250px" for="mailing_sub2">
                                 <span class="s_website_form_label_content">Email</span>
-                                <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
                                 <input id="mailing_sub2" type='email' class='form-control s_website_form_input' name="email" placeholder="johnsmith@example.com"/>
@@ -102,7 +100,6 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-sm-auto s_website_form_label" style="width: 250px" for="mailing_list_">
                                 <span class="s_website_form_label_content">Subscribe to</span>
-                                <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
                                 <div class="row s_col_no_resize s_col_no_bgcolor s_website_form_multiple" data-name="list_ids" data-display="horizontal">
@@ -125,7 +122,6 @@ database, without the s_newsletter_list class. See fixNewsletterListClass.
                         <div class="row s_col_no_resize s_col_no_bgcolor">
                             <label class="col-sm-auto s_website_form_label" style="width: 250px;" for="mailing_sub3">
                                 <span class="s_website_form_label_content">I agree to receive updates</span>
-                                <span class="s_website_form_mark"> *</span>
                             </label>
                             <div class="col-sm">
                                 <div class="form-check">

--- a/addons/website_payment/views/payment_form_templates.xml
+++ b/addons/website_payment/views/payment_form_templates.xml
@@ -43,21 +43,18 @@
         <div class="row">
             <div t-attf-class="mb-3 #{error.get('name') and 'o_has_error' or ''} col-lg-12 div_name">
                 <label class="col-form-label fw-bold" for="name">Name
-                    <span class="s_website_form_mark"> *</span>
                 </label>
                 <input t-att-readonly="'1' if 'name' in partner_details and partner_id else None" type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="partner_details.get('name')" />
             </div>
             <div class="w-100"/>
             <div t-attf-class="mb-3 #{error.get('email') and 'o_has_error' or ''} col-lg-6" id="div_email">
                 <label class="col-form-label fw-bold" for="email">Email
-                    <span class="s_website_form_mark"> *</span>
                 </label>
                 <input t-att-readonly="'1' if 'email' in partner_details and partner_id else None" type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="partner_details.get('email')" />
             </div>
             <t t-set="country_id" t-value="partner_details.get('country_id')"/>
             <div t-attf-class="mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-lg-6 div_country">
                 <label class="col-form-label fw-bold" for="country_id">Country
-                    <span class="s_website_form_mark"> *</span>
                 </label>
                 <select t-att-disabled="'1' if country_id and partner_id else None" id="country_id" name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}">
                     <option value="">Country...</option>

--- a/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_customize.js
@@ -14,12 +14,12 @@ registerWebsitePreviewTour('shop_customize', {
         ...clickOnSave(),
         {
             content: "select product attribute Steel",
-            trigger: ':iframe form.js_attributes input:not(:checked) + label:contains(Steel - Test)',
+            trigger: ":iframe form.js_attributes div:has(input:not(:checked)) label:contains(Steel - Test)",
             run: "click",
         },
         {
             content: "check the selection",
-            trigger: ':iframe form.js_attributes input:checked + label:contains(Steel - Test)',
+            trigger: ":iframe form.js_attributes div:has(input:checked) label:contains(Steel - Test)",
         },
         {
             trigger: ":iframe body:not(:has(.oe_website_sale .oe_product_cart:eq(3)))",

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1801,7 +1801,7 @@
             <h3 class="mb-4">Extra info</h3>
             <section class="s_website_form" data-vcss="001" data-snippet="s_website_form">
                 <div class="container">
-                    <form action="/website/form/" method="post" enctype="multipart/form-data" class="o_mark_required s_website_form_no_recaptcha" data-mark="*" data-force_action="shop.sale.order" data-model_name="sale.order" data-success-mode="redirect" data-success-page="/shop/payment" hide-change-model="true">
+                    <form action="/website/form/" method="post" enctype="multipart/form-data" class="s_website_form_no_recaptcha" data-force_action="shop.sale.order" data-model_name="sale.order" data-success-mode="redirect" data-success-page="/shop/payment" hide-change-model="true">
                         <div class="s_website_form_rows s_col_no_bgcolor row">
                             <div class="s_website_form_field col-12 py-2 mb-0" data-type="char" data-name="Field">
                                 <div class="s_col_no_resize s_col_no_bgcolor row">


### PR DESCRIPTION
The goal of this PR is to allow the user to apply a default input
label design (width & position) by adapting the website editor options
in the following way:

"THEME" options:

1. Add a "Label Position" option (Hide, Top, Left, Right, Floating) to
the theme tab (the "Width" option is only displayed if the options are
"Left" or "Right").

2. Set the default label position and width on all forms on a page
(website & other bootstrap forms):

- The label position can always be customized in the website editor
(for every label element).

- The label width can also be edited (on a form level) since it's a
form option.

"CUSTOMIZE" options:

1. Add an option for the "Floating Label" position and change the label
position to a dropdown selection.

2. For boolean fields, add an option to display the label "After The
Checkbox".

ENT PR: https://github.com/odoo/odoo/pull/160479

task-3675302