### PR TITLE
[IMP] web: show Archive, Unarchive & Delete actions when grouped by M2M field

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -248,7 +248,7 @@ export class DynamicList extends DataPoint {
             );
             this.model.notification.add(msg, { title: _t("Warning") });
         }
-        await this._removeRecords(records.map((r) => r.id));
+        await this.model.load();
         return unlinked;
     }
 

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -328,11 +328,6 @@ export class ListController extends Component {
     }
 
     getStaticActionMenuItems() {
-        const list = this.model.root;
-        const isM2MGrouped = list.groupBy.some((groupBy) => {
-            const fieldName = groupBy.split(":")[0];
-            return list.fields[fieldName].type === "many2many";
-        });
         return {
             export: {
                 isAvailable: () => this.isExportEnable,
@@ -342,7 +337,7 @@ export class ListController extends Component {
                 callback: () => this.onExportData(),
             },
             archive: {
-                isAvailable: () => this.archiveEnabled && !isM2MGrouped,
+                isAvailable: () => this.archiveEnabled,
                 sequence: 20,
                 icon: "oi oi-archive",
                 description: _t("Archive"),
@@ -351,21 +346,21 @@ export class ListController extends Component {
                 },
             },
             unarchive: {
-                isAvailable: () => this.archiveEnabled && !isM2MGrouped,
+                isAvailable: () => this.archiveEnabled,
                 sequence: 30,
                 icon: "oi oi-unarchive",
                 description: _t("Unarchive"),
                 callback: () => this.toggleArchiveState(false),
             },
             duplicate: {
-                isAvailable: () => this.activeActions.duplicate && !isM2MGrouped,
+                isAvailable: () => this.activeActions.duplicate,
                 sequence: 35,
                 icon: "fa fa-clone",
                 description: _t("Duplicate"),
                 callback: () => this.duplicateRecords(),
             },
             delete: {
-                isAvailable: () => this.activeActions.delete && !isM2MGrouped,
+                isAvailable: () => this.activeActions.delete,
                 sequence: 40,
                 icon: "fa fa-trash-o",
                 description: _t("Delete"),


### PR DESCRIPTION
Before this commit, users were unable to see the archive, unarchive, and delete options in the Actions dropdown in the list view of M2M groupby.

Steps to reproduce:

- Navigate to Project > Tasks > All Tasks.
- Add an "Assignees" groupby filter.
- Click on the checkbox of any task and then click on the "Actions" button.

Observed behavior:
Users were unable to see the archive, unarchive, and delete options in the dropdown of Actions.

Expected behavior:
Users should be able to see the archive, unarchive, and delete options in the dropdown of Actions.

After this commit, users will be able to see the archive, unarchive, and delete options in the Actions dropdown in the list view of M2M groupby.

Task-3358034

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
