### PR TITLE
[FIX] project: Prevent portal user from adding image to description

### DIFF
--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_controller.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_controller.js
@@ -7,6 +7,8 @@ import { useViewCompiler } from '@web/views/view_compiler';
 import { ProjectSharingChatterCompiler } from './project_sharing_form_compiler';
 import { ChatterContainer } from '../../components/chatter/chatter_container';
 
+const { useExternalListener } = owl;
+
 export class ProjectSharingFormController extends FormController {
     setup() {
         super.setup();
@@ -19,6 +21,8 @@ export class ProjectSharingFormController extends FormController {
         }
         const mailTemplates = useViewCompiler(ProjectSharingChatterCompiler, arch, { Mail: template }, {});
         this.mailTemplate = mailTemplates.Mail;
+        useExternalListener(window, "paste", this.onGlobalPaste, { capture: true });
+        useExternalListener(window, "drop", this.onGlobalDrop, { capture: true });
     }
 
     get actionMenuItems() {
@@ -27,6 +31,30 @@ export class ProjectSharingFormController extends FormController {
 
     get translateAlert() {
         return null;
+    }
+
+    onGlobalPaste(ev) {
+        // prevent pasting an image on Description field as Portal users don't have access to ir.attachment
+        ev.preventDefault();
+        if (ev.target.closest('.o_field_widget[name="description"]')) {
+            const items = ev.clipboardData.items;
+            for (let i = 0; i < items.length; i++) {
+                if (items[i].type.indexOf('image') !== -1) {
+                    ev.stopImmediatePropagation();
+                    return;
+                }
+            }
+        }
+    }
+
+    onGlobalDrop(ev) {
+        // prevent dropping an image on Description field as Portal users don't have access to ir.attachment
+        ev.preventDefault();
+        if (ev.target.closest('.o_field_widget[name="description"]')) {
+            if(ev.dataTransfer.files.length > 0){
+                ev.stopImmediatePropagation();
+            }
+        }
     }
 }
 

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -183,7 +183,8 @@
                     </group>
                     <notebook>
                         <page name="description_page" string="Description">
-                            <field name="description" type="html" options="{'collaborative': true}"/>
+                            <!-- Portal users get some commands disabled, notably /image, as they don't have access to ir.attachment -->
+                            <field name="description" type="html" options="{'collaborative': true, 'allowCommandImage': false}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks">
                             <field name="child_ids" context="{'default_project_id': project_id, 'default_parent_id': id, 'default_partner_id': partner_id, 'form_view_ref' : 'project.project_sharing_project_task_view_form'}">


### PR DESCRIPTION
To reproduce:
=============
- share a project with a portal user
- connect as the portal user
- on a task paste an image in the description
- save -> AccessError

Problem:
========
Portal user doesn't have the right to create attachments

Solution:
=========
- prevent protal user from using /image command in the description
- prevent protal user from pasting an image in the description
- prevent protal user from dropping an image in the description

opw-3774447

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
