### PR TITLE
[IMP] purchase: prevent to recompute price on pol

### DIFF
--- a/addons/purchase/tests/test_purchase_invoice.py
+++ b/addons/purchase/tests/test_purchase_invoice.py
@@ -90,7 +90,6 @@ class TestPurchaseToInvoiceCommon(AccountTestInvoicingCommon):
         for product in (products or []):
             with po_form.order_line.new() as line_form:
                 line_form.product_id = product
-                line_form.price_unit = product.list_price
                 line_form.product_qty = 1
                 line_form.product_uom_id = product.uom_id
                 line_form.date_planned = date_planned

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -258,6 +258,7 @@
                                     <field name="state" column_invisible="True"/>
                                     <field name="product_type" column_invisible="True"/>
                                     <field name="invoice_lines" column_invisible="True"/>
+                                    <field name="technical_price_unit" column_invisible="True"/>
                                     <field name="sequence" widget="handle"/>
                                     <!-- optional="show" allows name (description) to be editable -->
                                     <field


### PR DESCRIPTION
In this commit, we ensure that once a user manually sets a custom unit price on a Purchase Order Line, it is no longer overwritten by automatic price recomputation when the quantity, unit of measure, or vendor is changed.

This was necessary because previously, any modification to those fields would reset the unit price to the product’s default value, even if the user had intentionally set a different price. This led to incorrect order totals and required users to manually re-correct the price, causing frustration and inefficiency.

Task: [3794760](https://www.odoo.com/odoo/project/966/tasks/3794760)