### PR TITLE
[FIX] delivery: error while loading sale orders in pos terminal

### DIFF
--- a/addons/delivery/models/sale_order_line.py
+++ b/addons/delivery/models/sale_order_line.py
@@ -21,8 +21,9 @@ class SaleOrderLine(models.Model):
             if not line.product_id or not line.product_uom or not line.product_uom_qty:
                 line.product_qty = 0.0
                 continue
+            # Temporary Fix: Added raise_if_failure=False for FIXING Error occurring while importing Sale Orders to PoS terminal
             line.product_qty = line.product_uom._compute_quantity(
-                line.product_uom_qty, line.product_id.uom_id
+                line.product_uom_qty, line.product_id.uom_id, raise_if_failure=False
             )
 
     def unlink(self):


### PR DESCRIPTION
Steps:
- Install point_of_sale and sale module with demo data.
- Enable Units of Measure and Delivery Methods in the sale app configuration.
- Open PoS Register.
- Click on Quotation / Order.

Issue:
- Error Occurs while loading Sale Orders.

Cause:
- In some sales orders the order line's Units of Measure category is not matched to the order line's product's Units of Measure category. Ex. Order lines Units of Measure  Category = Unit
and Order lines Product's Unit of Measure category = Working Time

FIX:
- Added raise_if_failure=False in order line model's _compute_product_qty method in the delivery module.

task-3847421