### PR TITLE
[FIX] calendar: public user no attachment

### DIFF
--- a/addons/calendar/models/calendar_attendee.py
+++ b/addons/calendar/models/calendar_attendee.py
@@ -9,6 +9,7 @@ from odoo import api, fields, models, _
 from odoo.addons.base.models.res_partner import _tz_get
 from odoo.exceptions import UserError
 from odoo.tools.misc import clean_context
+from odoo.tools import split_every
 
 _logger = logging.getLogger(__name__)
 
@@ -116,12 +117,26 @@ class Attendee(models.Model):
         # get ics file for all meetings
         ics_files = self.mapped('event_id')._get_ics_file()
 
+        # If the mail template has attachments, prepare copies for each attendee (to be added to each attendee's mail)
+        if mail_template.attachment_ids:
+
+            # Setting res_model to ensure attachments are linked to the msg (otherwise only internal users are allowed link attachments)
+            attachments_values = [a.copy_data({'res_id': 0, 'res_model': 'mail.compose.message'})[0] for a in mail_template.attachment_ids]
+            attachments_values *= len(self)
+            attendee_attachment_ids = self.env['ir.attachment'].create(attachments_values).ids
+
+            # Map attendees to their respective attachments
+            template_attachment_count = len(mail_template.attachment_ids)
+            attendee_id_attachment_id_map = dict(zip(self.ids, split_every(template_attachment_count, attendee_attachment_ids, list)))
+
         for attendee in self:
             if attendee.email and attendee._should_notify_attendee():
                 event_id = attendee.event_id.id
                 ics_file = ics_files.get(event_id)
 
-                attachment_ids = mail_template.attachment_ids.ids
+                # Add template attachments copies to the attendee's email, if available
+                attachment_ids = attendee_id_attachment_id_map[attendee.id] if mail_template.attachment_ids else []
+
                 if ics_file:
                     context = {
                         **clean_context(self.env.context),
@@ -131,8 +146,8 @@ class Attendee(models.Model):
                         'datas': base64.b64encode(ics_file),
                         'description': 'invitation.ics',
                         'mimetype': 'text/calendar',
-                        'res_id': event_id,
-                        'res_model': 'calendar.event',
+                        'res_id': 0,
+                        'res_model': 'mail.compose.message',
                         'name': 'invitation.ics',
                     }).ids
 


### PR DESCRIPTION
### [FIX] calendar: public user no attachment
When public user will create an appointment, the attachments
attached to the related mail template will filtered out by
a `_process_attachments_for_post` method (ref.1)
I happens because attachment's `res_model` is not set to `mail.compose.message`.
Instead it's set to `mail.template` also `create_uid` isn't set to public user,
but to the user creating the template). With this commit attachments will
get copied on send with corrected `res_model`.

### [Reproduce]
- Install modules: appointment,website
- Add an attachment A to email templates: (in Settings/Email_Templates):
	- "Appointment Booked"
- On Website/Appointment: book an appointment (from an incognito window)
- BUG: no attachments are added to the emails (Settings/ Technical/ Email/ Emails)
	- no .ics attachment
	- no A attachment

(ref.1)
https://github.com/odoo/odoo/blob/312b0365e26e1578c5995d55f357b8aec14e5a5b/addons/mail/models/mail_thread.py#L2207C1-L2210

opw-[3685871](https://www.odoo.com/web#id=3685871&view_type=form&model=project.task)