### PR TITLE
[IMP] hr_holidays: computed name

### DIFF
--- a/addons/hr_holidays/report/hr_leave_report.py
+++ b/addons/hr_holidays/report/hr_leave_report.py
@@ -59,7 +59,7 @@ class LeaveReport(models.Model):
                     allocation.id as allocation_id,
                     null as leave_id,
                     allocation.employee_id as employee_id,
-                    allocation.private_name as name,
+                    allocation.name as name,
                     allocation.number_of_days as number_of_days,
                     allocation.number_of_hours_display as number_of_hours,
                     allocation.category_id as category_id,

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -99,7 +99,7 @@ class TestAllocations(TestHrHolidaysCommon):
         num_of_allocations = self.env['hr.leave.allocation'].search_count([('employee_id', '=', self.employee.id), ('multi_employee', '=', False)])
         self.assertEqual(num_of_allocations, 1)
 
-    def test_allocation_request(self):
+    def test_allocation_request_day(self):
         self.leave_type.write({
             'name': 'Custom Time Off Test',
             'allocation_validation_type': 'officer'
@@ -116,7 +116,68 @@ class TestAllocations(TestHrHolidaysCommon):
             allocation.number_of_days_display = 10
             employee_allocation = allocation.save()
 
-        self.assertEqual(employee_allocation.private_name, "Custom Time Off Test allocation request (10.0 day)")
+        self.assertEqual(employee_allocation.name, "Custom Time Off Test (10.0 day(s))")
+
+    def test_allocation_request_half_days(self):
+        self.leave_type.write({
+            'name': 'Custom Time Off Test',
+            'allocation_validation_type': 'officer'
+        })
+
+        employee_allocation = self.env['hr.leave.allocation'].create({
+            'holiday_type': 'employee',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'allocation_type': 'regular',
+            'type_request_unit': 'half_day',
+        })
+
+        with Form(employee_allocation.with_context(is_employee_allocation=True), 'hr_holidays.hr_leave_allocation_view_form_dashboard') as allocation:
+            allocation.number_of_days_display = 10
+            employee_allocation = allocation.save()
+
+        self.assertEqual(employee_allocation.name, "Custom Time Off Test (10.0 day(s))")
+
+    def change_allocation_type_day(self):
+        self.leave_type.write({
+            'name': 'Custom Time Off Test',
+            'allocation_validation_type': 'officer'
+        })
+
+        employee_allocation = self.env['hr.leave.allocation'].create({
+            'holiday_type': 'employee',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'allocation_type': 'regular',
+        })
+
+        with Form(employee_allocation.with_context(is_employee_allocation=True), 'hr_holidays.hr_leave_allocation_view_form_dashboard') as allocation:
+            allocation.allocation_type = 'extra'
+            allocation.allocation_type = 'regular'
+            employee_allocation = allocation.save()
+
+        self.assertEqual(employee_allocation.number_of_days, 1.0)
+
+    def change_allocation_type_hours(self):
+        self.leave_type.write({
+            'name': 'Custom Time Off Test',
+            'allocation_validation_type': 'officer'
+        })
+
+        employee_allocation = self.env['hr.leave.allocation'].create({
+            'holiday_type': 'employee',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'allocation_type': 'regular',
+            'type_request_unit': 'hour',
+        })
+
+        with Form(employee_allocation.with_context(is_employee_allocation=True), 'hr_holidays.hr_leave_allocation_view_form_dashboard') as allocation:
+            allocation.allocation_type = 'extra'
+            allocation.allocation_type = 'regular'
+            employee_allocation = allocation.save()
+
+        self.assertEqual(employee_allocation.number_of_days, 1.0)
 
     def test_allowed_change_allocation(self):
         allocation = self.env['hr.leave.allocation'].create({

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -79,6 +79,7 @@
                     </div>
                     <group>
                         <group>
+                            <field name="is_name_custom" invisible="1"/> <!-- needed for triggering reasons -->
                             <field name="type_request_unit" invisible="1"/>
                             <field name="has_accrual_plan" invisible="1"/>
                             <!-- Save already_accrued when creating record to avoid double allocation when cron runs -->


### PR DESCRIPTION
[IMP] [FIX] hr_holidays: computed name
Improvement
-----------
This commit adds the autogeneration of the name
field.
Previously this behavior was only available in the
dashboard.
The name will not be computed if modified by the
user.

The reason of this change is to avoid the user
to manually put the name of the allocation
every time or update it on changes.

Fixes
-----
In addition to that this commit corrects

fix 1.
======
The name is now computed when the allocation
The problematic reset of the name when the
allocation is updated. (follows task 3713656)

Steps to reproduce the bug:

- Go to Time Off -> Allocation -> Create
- put a name
- change the allocation type
-> the name is reset

Expected result:
The name should not be reset to the old value

Reason:
The displayed name is relies on the private_name
field to get its value. And thus every time
an onchange is triggered the name is reset.

New Fix:
Revert most of the change of the commit https://github.com/extraprofitro/odoo/commit/c2eef0cacea0100b1bfa7c39140d267e94a16de6
(no task-id found) that was made for odoo 13.1
(except the compute of the title that was
readapted for the behavior expected for this
new task)
The commit was originally made in response
to this change https://github.com/extraprofitro/odoo/commit/eb02e9b3e00243bcf8a41b0f42273e59875ab968
(task-2088559) for fix in odoo 11.3 and imp in 13.1

NOTE:
=====
The two next bug where discovered while
making the Improvement. Those will be also covered
in a separate commit for previous version in
task 3852940

The two bugs are both introduce by the same PR
https://github.com/odoo/odoo/pull/116472
(task-3084232)

fix 2.
======
Wrong units in the form views display (dashboard)
No task
Steps to reproduce the bug:

- Go to Time Off
- On the dashboard, click on "New Allocation Request"
- Select an Time Off Type that is in Half Days
-> The units are displayed in "half_days" and
are not corresponding to the days unit

Reason
The units where retrived from the type_request_unit
field while the duration was just readen from the
number_of_days_display or the number_of_hours_display
fields.

Fix
The units are now computed selected between hours
and days not derived from the type_request_unit.

fix 3.
======
Reset of number of days/hours when changing the
allocation type
No task

Steps to reproduce the bug:
- Go to Time Off
- On the dashboard, click on "New Allocation Request"
- Select an other Time Off Type in days
- the number of days is reset to 0 while it should
be kept at one

Reason
When computing the title:
The two fields number_of_days_display and
number_of_hours are computed from the number_of_days
field. But when you change the allocation type
the recomputation is still not done at the title
computation time and thus the number_of_days_display
and number_of_hours_display are 0 and since the
number_of_days is also based on the number_of_days_display
the number_of_days is also reset to 0 after title
computation.

Fix
use the number_of_days field instead of the
number_of_days_display field to compute the
title.

task-3552639
task-3598745
task-3713656
task-3852940
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
