### PR TITLE
[FIX] sale: onchange over product_packaging_id triggers a Warning for each sale.order.line

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -662,7 +662,8 @@ class SaleOrderLine(models.Model):
                 packaging_uom_qty = line.product_uom._compute_quantity(line.product_uom_qty, packaging_uom)
                 line.product_packaging_qty = float_round(
                     packaging_uom_qty / line.product_packaging_id.qty,
-                    precision_rounding=packaging_uom.rounding)
+                    precision_rounding=packaging_uom.rounding,
+                    rounding_method='UP') or 1.0
 
     # This computed default is necessary to have a clean computation inheritance
     # (cf sale_stock) instead of simply removing the default and specifying


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The actual state of the code (AS-IS) triggers a Warning for each product_packaging_id selected if the float_compare with precision_digits=self.product_uom.rounding returns a value different from 0 (0 meaning equal to)
```
float_compare(newqty, self.product_uom_qty, precision_rounding=self.product_uom.rounding) != 0
```
This means that the user can possibly face one Warning pop-up window for each line where he selects a product_packaging_id if the conditions are met.

Warning triggered by following onchange coming from sale addon 

```
@api.onchange('product_packaging_id')
def _onchange_product_packaging_id(self):
  if self.product_packaging_id and self.product_uom_qty:
      newqty = self.product_packaging_id._check_qty(self.product_uom_qty, self.product_uom, "UP")
      if float_compare(newqty, self.product_uom_qty, precision_rounding=self.product_uom.rounding) != 0:
          return {
              'warning': {
                  'title': _('Warning'),
                  'message': _(
                      "This product is packaged by %(pack_size).2f %(pack_name)s. You should sell %(quantity).2f %(unit)s.",
                      pack_size=self.product_packaging_id.qty,
                      pack_name=self.product_id.uom_id.name,
                      quantity=newqty,
                      unit=self.product_uom.name
                  ),
              },
          }
```

Current behavior before PR:


Products that are sold by packaging cannot be sold by partial packaging (for example : 0.5, 1.75 pack is not possible).

Therefore, the warning in the pop-up will always be displayed and its content becomes useless for the user. Users waste 1 click per sales order line to close systematically this pop-up. 

Desired behavior after PR is merged:

This PR (TO-BE) implements a ceil of product_packaging_qty whenever product_packaging_id changes in order to avoid the Warning pop-up when choosing a product_packaging_id

**Use case explanation and Reason for the change**

When we select a packaging, if the quantity of packaging is not a integer (float), round it up to an integer. Furthermore, If the quantity of packaging is 0, set it to 1.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
