### PR TITLE
[FIX] crm: restore groups on measures

### DIFF
--- a/addons/crm/report/crm_opportunity_report_views.xml
+++ b/addons/crm/report/crm_opportunity_report_views.xml
@@ -11,6 +11,13 @@
                     <field name="create_date" interval="month" type="col"/>
                     <field name="stage_id" type="row"/>
                     <field name="prorated_revenue" type="measure"/>
+                    <field name="color" invisible="1"/>
+                    <field name="message_bounce" invisible="1"/>
+                    <field name="probability" invisible="1"/>
+                    <field name="automated_probability" invisible="1"/>
+                    <field name="recurring_revenue_monthly" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                 </pivot>
             </field>
         </record>
@@ -27,9 +34,9 @@
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
                     <field name="automated_probability" invisible="1"/>
-                    <field name="recurring_revenue_monthly" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                 </pivot>
             </field>
         </record>
@@ -44,6 +51,12 @@
                     <field name="date_deadline" interval="month"/>
                     <field name="prorated_revenue" type="measure"/>
                     <field name="color" invisible="1"/>
+                    <field name="message_bounce" invisible="1"/>
+                    <field name="probability" invisible="1"/>
+                    <field name="automated_probability" invisible="1"/>
+                    <field name="recurring_revenue_monthly" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -60,9 +73,9 @@
                     <field name="automated_probability" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
-                    <field name="recurring_revenue_monthly" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                 </graph>
             </field>
         </record>

--- a/addons/crm/views/crm_lead_views.xml
+++ b/addons/crm/views/crm_lead_views.xml
@@ -892,6 +892,11 @@
                     <field name="stage_id"/>
                     <field name="user_id"/>
                     <field name="color" invisible="1"/>
+                    <field name="automated_probability" invisible="1"/>
+                    <field name="message_bounce" invisible="1"/>
+                    <field name="recurring_revenue_monthly" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -910,9 +915,9 @@
                     <field name="day_close" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
-                    <field name="recurring_revenue_monthly" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                 </graph>
             </field>
         </record>
@@ -929,9 +934,9 @@
                     <field name="automated_probability" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
-                    <field name="recurring_revenue_monthly" type="measure" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly" type="measure" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                 </pivot>
             </field>
         </record>
@@ -951,9 +956,9 @@
                     <field name="day_close" invisible="1"/>
                     <field name="message_bounce" invisible="1"/>
                     <field name="probability" invisible="1"/>
-                    <field name="recurring_revenue_monthly" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue_monthly_prorated" groups="crm.group_use_recurring_revenues"/>
-                    <field name="recurring_revenue" groups="crm.group_use_recurring_revenues"/>
+                    <field name="recurring_revenue_monthly" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue_monthly_prorated" groups="!crm.group_use_recurring_revenues" invisible="1"/>
+                    <field name="recurring_revenue" groups="!crm.group_use_recurring_revenues" invisible="1"/>
                 </pivot>
             </field>
         </record>


### PR DESCRIPTION
**Before this PR:**
- Some fields are associated with groups in XML files, but they are visible 
  even though the groups are disabled. (Recurring Revenue is not ticked in 
  settings, i.e., the feature is not activated).
- automated_probability and message_bounce fields are visible in the measure 
  in the pipeline graph view.

**After this PR:**
- recurring_revenue fields in the measure will only be visible when it is ticked
  in settings, i.e., only when the feature is activated.
- automated_probability and message_bounce fields will be hidden from the 
  measure in the pipeline graph view.

Task-3810415