### PR TITLE
[FIX] account_peppol: fix traceback when peppol endpoint is empty

### DIFF
--- a/addons/account_peppol/models/res_company.py
+++ b/addons/account_peppol/models/res_company.py
@@ -109,7 +109,7 @@ class ResCompany(models.Model):
             return True
 
         if endpoint_rule[0] == 'regex':
-            return bool(re.match(endpoint_rule[1], self.peppol_endpoint))
+            return bool(re.match(endpoint_rule[1], self.peppol_endpoint or ''))
 
         if endpoint_rule[0] == 'ean':
             check_module = ean


### PR DESCRIPTION
This traceback arises when the user doesn't give the Peppol endpoint and tries to save it.

To reproduce this issue:

1) Install `account_peppol`
2) create a `Belgium` company and switch to that company. 
3) Activate `Use PEPPOL Invoicing` in invoice settings 
4) Change the Peppol EAS as `0201 - Codice Univoco Unità Organizzativa iPA` 
5) Remove the `Endpoint` and try to save it.

Error:- 

```
TypeError: expected string or bytes-like object
```

When the user makes the `endpoint` as empty its value is `False`. 
which leads to the above traceback, as the `endpoint` is used to match the `endpoint_rule`.

https://github.com/odoo/odoo/blob/c6c0f6ea677f5cb5935d6a3766bca5990539d17a/addons/account_peppol/models/res_company.py#L113-L114

After applying this commit will resolve this issue by giving a `fallback value` 
and make code more robust. when thepeppol_endpoint is not given by the user.

sentry-5121223884
