### PR TITLE
[FIX] web: Prevent date_to onchange without date_from modification

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -115,22 +115,11 @@ export class DateTimeField extends Component {
                 } else {
                     toUpdate[this.props.name] = this.state.value;
                 }
-                // when startDateField and endDateField are set, and one of them has changed, we keep
-                // the unchanged one to make sure ORM protects both fields from being recomputed by the
-                // server, ORM team will handle this properly on master, then we can remove unchanged values
-                if (!this.startDateField || !this.endDateField) {
-                    // If startDateField or endDateField are not set, delete unchanged fields
-                    for (const fieldName in toUpdate) {
-                        if (areDatesEqual(toUpdate[fieldName], this.props.record.data[fieldName])) {
-                            delete toUpdate[fieldName];
-                        }
-                    }
-                } else {
-                    // If both startDateField and endDateField are set, check if they haven't changed
-                    if (areDatesEqual(toUpdate[this.startDateField], this.props.record.data[this.startDateField]) &&
-                        areDatesEqual(toUpdate[this.endDateField], this.props.record.data[this.endDateField])) {
-                        delete toUpdate[this.startDateField];
-                        delete toUpdate[this.endDateField];
+
+                // If startDateField or endDateField are not set, delete unchanged fields
+                for (const fieldName in toUpdate) {
+                    if (areDatesEqual(toUpdate[fieldName], this.props.record.data[fieldName])) {
+                        delete toUpdate[fieldName];
                     }
                 }
 

--- a/addons/web/static/tests/views/fields/daterange_field_tests.js
+++ b/addons/web/static/tests/views/fields/daterange_field_tests.js
@@ -377,8 +377,7 @@ QUnit.module("Fields", (hooks) => {
                 mockRPC(route, args) {
                     if (args.method === "web_save") {
                         assert.deepEqual(args.args[1], {
-                            datetime: "2017-02-08 06:00:00",
-                            datetime_end: "2017-03-13 00:00:00",
+                            datetime: "2017-02-08 06:00:00"
                         });
                     }
                 },

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -11659,7 +11659,7 @@ QUnit.module("Views", (hooks) => {
                     if (args.method === "write") {
                         assert.deepEqual(args.args, [
                             [1, 2],
-                            { date_start: "2021-04-01", date_end: "2017-01-26" },
+                            { date_start: "2021-04-01" },
                         ]);
                     }
                 },
@@ -11686,7 +11686,7 @@ QUnit.module("Views", (hooks) => {
             const changesTable = target.querySelector(".modal-body .o_modal_changes");
             assert.strictEqual(
                 changesTable.innerText.replaceAll("\n", "").replaceAll("\t", ""),
-                "Field:Date StartUpdate to:04/01/202101/26/2017Field:Date EndUpdate to:01/26/2017"
+                "Field:Date StartUpdate to:04/01/202101/26/2017"
             );
 
             // Valid the confirm dialog


### PR DESCRIPTION
Previously, the end-time of 'date_to' for leave requests was consistently
set to the end of the day (i.e., 23:59), which was only desirable for
public holidays (ref.1). However, this caused undesired behavior in other
modules, such as the appointment module. The behavior was tracked down
to an onchnge method (ref.2) supposed to be triggered only if date_from
has changed. What happend instead that both updates:
updating date_from as well as date_to, triggered the onchange.

With this commit we modify the datetime_field, so it only triggers the
date_from update when the date_from has changed. So it would behave in the
following way:

1) date_from field has changed -> will trigger the onchange (setting date_to)
date_from: Monday 10:00 -> Monday 12:00
date_to:   Monday 18:00 -> Monday 20:00 (results in Monday **23:59**)
                                                           

2) date_from field hasn't changed (and date_to has changed)-> won't trigger the onchange
date_from: Monday 10:00 -> Monday 10:00
date_to:   Monday 18:00 -> Monday 20:00 (results in Monday **20:00**)

(ref.1)
[IMP] resource: compute date_to for better ux
https://github.com/odoo-dev/odoo/commit/e0f3dd9e01d91896f1c00fb5cb3ce5c821912d03
https://github.com/odoo/odoo/pull/115688

(ref.2)
ResourceCalendarLeaves._compute_date_to
https://github.com/odoo/odoo/blob/6ae13a697bfd685366d10aa763de1bd6f2bd3e43/addons/resource/models/resource_calendar_leaves.py#L53-L61

[Reproduce]
- Install appointment
- Create New Resource Time Off (Appointments/ Configuration/ Resource Leaves)
- change time of "End Date"
- BUG: time sets itself to 23:59

opw-3841275