### PR TITLE
[FIX] website_slides: raise UserError if slide not found

### DIFF
--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -90,6 +90,9 @@ class WebsiteSlides(WebsiteProfile):
             most_viewed_slides, related_slides = request.env['slide.slide'], request.env['slide.slide']
 
         channel_slides_ids = slide.channel_id.slide_content_ids.ids
+
+        if slide.id not in channel_slides_ids:
+            raise UserError(_("Slide you are trying to access is not found"))
         slide_index = channel_slides_ids.index(slide.id)
         previous_slide = slide.channel_id.slide_content_ids[slide_index-1] if slide_index > 0 else None
         next_slide = slide.channel_id.slide_content_ids[slide_index+1] if slide_index < len(channel_slides_ids) - 1 else None

--- a/addons/website_slides/i18n/website_slides.pot
+++ b/addons/website_slides/i18n/website_slides.pot
@@ -4547,6 +4547,12 @@ msgid ""
 msgstr ""
 
 #. module: website_slides
+#: code:addons/website_slides/controllers/main.py:0
+#, python-format
+msgid "Slide you are trying to access is not found"
+msgstr ""
+
+#. module: website_slides
 #: model:ir.model,name:website_slides.model_slide_slide
 #: model:ir.model.fields,field_description:website_slides.field_slide_channel__slide_content_ids
 #: model:ir.model.fields,field_description:website_slides.field_slide_slide__slide_ids


### PR DESCRIPTION
When users try to access the slide ID which is not in the ``channel_slides_ids`` the traceback occurs.

Steps to reproduce:
- Install ``website_slides`` module
- create website
- open this URL - http://localhost:8069/slides/embed/7

Traceback:
```ValueError: 73 is not in list
  File "odoo/http.py", line 2252, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1828, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1848, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1826, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1833, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1971, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 222, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 740, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_slides/controllers/main.py", line 1499, in slides_embed
    return self._slide_embed(slide_id, page=page, is_external_embed=False, **kw)
  File "addons/website_slides/controllers/main.py", line 1526, in _slide_embed
    values = self._get_slide_detail(slide)
  File "addons/website_slides/controllers/main.py", line 123, in _get_slide_detail
    slide_index = channel_slides_ids.index(slide.id)
   ```

This commit resolves the mentioned issue by verifying if the slide ID is present; otherwise, it will raise a UserError.

sentry - 5060355766

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
