### PR TITLE
[FIX] point_of_sale: prevent duplicate attribute values in product configurator

### DIFF
--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -5,8 +5,8 @@ import { Component, onMounted, useRef, useState, useSubEnv } from "@odoo/owl";
 export class BaseProductAttribute extends Component {
     setup() {
         this.env.attribute_components.push(this);
-        this.attribute = this.props.attribute;
-        this.values = this.attribute.template_value_ids;
+        this.attribute = this.props.attribute.attribute_id;
+        this.values = this.props.attribute.product_template_value_ids;
         this.state = useState({
             attribute_value_ids: parseFloat(this.values[0].id),
             custom_value: "",
@@ -89,7 +89,7 @@ export class MultiProductAttribute extends BaseProductAttribute {
     initAttribute() {
         const attribute = this.props.attribute;
 
-        for (const value of attribute.template_value_ids) {
+        for (const value of attribute.product_template_value_ids) {
             this.state.attribute_value_ids[value.id] = false;
         }
     }
@@ -108,10 +108,6 @@ export class ProductConfiguratorPopup extends Component {
 
     setup() {
         useSubEnv({ attribute_components: [] });
-    }
-
-    get attributes() {
-        return this.props.product.attribute_line_ids.map((attrLine) => attrLine.attribute_id);
     }
 
     computePayload() {

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -121,13 +121,13 @@
 
     <t t-name="point_of_sale.ProductConfiguratorPopup">
         <Dialog title="props.product.display_name">
-            <div t-foreach="attributes" t-as="attribute" t-key="attribute.id" class="attribute mb-3">
-                <div class="attribute_name mb-2 fw-bolder" t-esc="attribute.name"/>
-                <RadioProductAttribute t-if="attribute.display_type === 'radio'" attribute="attribute"/>
-                <PillsProductAttribute t-elif="attribute.display_type === 'pills'" attribute="attribute"/>
-                <SelectProductAttribute t-elif="attribute.display_type === 'select'" attribute="attribute"/>
-                <ColorProductAttribute t-elif="attribute.display_type === 'color'" attribute="attribute"/>
-                <MultiProductAttribute t-elif="attribute.display_type === 'multi'" attribute="attribute"/>
+            <div t-foreach="props.attributes" t-as="attribute" t-key="attribute.id" class="attribute mb-3">
+                <div class="attribute_name mb-2 fw-bolder" t-esc="attribute.attribute_id.name"/>
+                <RadioProductAttribute t-if="attribute.attribute_id.display_type === 'radio'" attribute="attribute"/>
+                <PillsProductAttribute t-elif="attribute.attribute_id.display_type === 'pills'" attribute="attribute"/>
+                <SelectProductAttribute t-elif="attribute.attribute_id.display_type === 'select'" attribute="attribute"/>
+                <ColorProductAttribute t-elif="attribute.attribute_id.display_type === 'color'" attribute="attribute"/>
+                <MultiProductAttribute t-elif="attribute.attribute_id.display_type === 'multi'" attribute="attribute"/>
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>


### PR DESCRIPTION
Before this commit:
===================
product configurator in the point of sale displays duplicate attribute values.

After this commit:
===================
with this commit, POS product configurator no longer displays duplicate attribute values.

task - 3851020
