### PR TITLE
[FIX] base: prevent user from selecting an invalid home action

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -31,6 +31,7 @@ from odoo.modules.module import get_module_resource
 from odoo.osv import expression
 from odoo.service.db import check_super
 from odoo.tools import partition, collections, frozendict, lazy_property, image_process
+from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
 
@@ -489,11 +490,20 @@ class Users(models.Model):
         # Prevent using reload actions.
         # We use sudo() because  "Access rights" admins can't read action models
         for user in self.sudo():
-            if user.action_id.type == "ir.actions.client":
-                action = self.env["ir.actions.client"].browse(user.action_id.id)  # magic
+            action_type = user.action_id.type
+            if not user.action_id.type:
+                continue
+            action = self.env[action_type].browse(user.action_id.id)  # magic
+            if action_type == "ir.actions.client":
                 if action.tag == "reload":
                     raise ValidationError(_('The "%s" action cannot be selected as home action.', action.name))
 
+            if action_type in ('ir.actions.client', 'ir.actions.act_window'):
+                user_context = self.with_user(user).context_get()
+                try:
+                    safe_eval(action.context, dict(user_context))
+                except Exception as e:
+                    raise ValidationError(_('The "%s" action cannot be selected as home action.\n%s', action.name, e)) from None
 
     @api.constrains('groups_id')
     def _check_one_user_type(self):

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -3,6 +3,7 @@
 
 from odoo.addons.base.models.res_users import is_selection_groups, get_selection_groups
 from odoo.tests.common import TransactionCase, Form, tagged
+from odoo.exceptions import ValidationError
 
 
 class TestUsers(TransactionCase):
@@ -115,6 +116,25 @@ class TestUsers(TransactionCase):
             "On user company change, if its partner_id has already a company_id,"
             "the company_id of the partner_id shall be updated"
         )
+
+    def test_user_incorrect_home_action(self):
+        """ Check that user can not select an home action that can not be rendered
+        because of its limited context.
+        """
+        valid_home_action, invalid_home_action = self.env['ir.actions.act_window'].create([{
+            'name': 'valid home action',
+            'res_model': 'res.partner',
+            'context': "{'key': tz}"
+        }, {
+            'name': 'invalid home action',
+            'res_model': 'res.partner',
+            'context': "{'active_id': active_id}"
+        }])
+
+        self.env.user.action_id = self.env['ir.actions.actions'].browse(valid_home_action.id)
+        with self.assertRaises(ValidationError):
+            self.env.user.action_id = self.env['ir.actions.actions'].browse(invalid_home_action.id)
+
 
 @tagged('post_install', '-at_install')
 class TestUsers2(TransactionCase):


### PR DESCRIPTION
The home action have a limited context available (ex: no active_id). If a clueless user selects a wrong action, he can't log back to change its mistake.

steps to reproduce:
- go to Settings/Users
- click on your user (ex: admin)
- Tab Preferences
- set Home action to RFQs and Purchases
- go back to the dashboard home menu

before this commit:
Uncaught Promise > Can not evaluate python expression: ({'search_default_partner_id': active_id, 'default_partner_id': active_id})

after this commit:
user can't select this action anymore

opw-3834888

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
