### PR TITLE
[FIX] survey: sharing right link when public survey

### DIFF
--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -230,6 +230,8 @@ class SurveyUserInput(models.Model):
 
     def get_start_url(self):
         self.ensure_one()
+        if self.survey_id.access_mode == 'public' and not self.survey_id.users_login_required:
+            return self.survey_id.get_start_url()
         return '%s?answer_token=%s' % (self.survey_id.get_start_url(), self.access_token)
 
     def get_print_url(self):


### PR DESCRIPTION
Issue: when we have our survey set to 'anyone with the link', which is esentially, public survey, when sharing through mail we will always share an invitation link specific for this user, and if we are not logged in we won't be able to try the survey, or if we are not the same user.

Steps to reproduce:

- Install survey and create a new one
- Make sure the settings are set to be accessible by anyone with the link
- Now send the invitation through mail
- Try to click on the button without the right account signed in, we are being redirected.

Solution: The solution to this might be very simple, just share the same link that we got if we just copy it when sending the mail, but only when our survey is set to public, otherwise, we still keep the same behavior.

opw-3792297
