### PR TITLE
[FIX] account: contruct string tax depending on company

### DIFF
--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -80,8 +80,10 @@ class ProductTemplate(models.Model):
             record.tax_string = record._construct_tax_string(record.list_price)
 
     def _construct_tax_string(self, price):
+        company_id = self._context.get('company_id', self.env.company.id)
         currency = self.currency_id
-        res = self.taxes_id.compute_all(price, product=self, partner=self.env['res.partner'])
+        res = self.taxes_id.filtered(lambda x: x.company_id.id == company_id).\
+            compute_all(price, product=self, partner=self.env['res.partner'])
         joined = []
         included = res['total_included']
         if currency.compare_amounts(included, price):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When product has set two taxes (one for MyCompany San Fransisco and the other one for BE Company - thats an example) the field tax_string doesn´t discriminate each ones

Current behavior before PR:
Configure a product with Sales Price = $100
Add a 21% tax for the first company
Add a 21% tax for the second company
The tax_string is (= $ 142.00 Incl. Taxes)

Desired behavior after PR is merged:
The tax_string depend on company where i stay. So, tax_string must be (= $ 121.00 Incl. Taxes)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
