### PR TITLE
[FIX] l10n_br_sales: show price_total on lines

### DIFF
--- a/addons/l10n_br_sales/models/sale_order.py
+++ b/addons/l10n_br_sales/models/sale_order.py
@@ -5,10 +5,6 @@ from odoo import models
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
 
-    def _get_name_portal_content_view(self):
-        self.ensure_one()
-        return 'l10n_br_sales.sale_order_portal_content_brazil' if self.company_id.country_code == 'BR' else super()._get_name_portal_content_view()
-
     def _get_name_tax_totals_view(self):
         self.ensure_one()
         return 'l10n_br_sales.document_tax_totals_brazil' if self.company_id.country_code == 'BR' else super()._get_name_tax_totals_view()

--- a/addons/l10n_br_sales/report/sale_order_templates.xml
+++ b/addons/l10n_br_sales/report/sale_order_templates.xml
@@ -13,12 +13,14 @@
     <template id="report_saleorder_document_brazil" inherit_id="sale.report_saleorder_document" primary="True">
         <th name="th_taxes" position="replace"/>
         <td name="td_taxes" position="replace"/>
-        <th name="th_subtotal" position="replace"/>
-        <td name="td_subtotal" position="replace"/>
+        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
+            <attribute name="t-value">current_subtotal + line.price_total</attribute>
+        </t>
+        <span t-field="line.price_subtotal" position="attributes">
+            <attribute name="t-field">line.price_total</attribute>
+        </span>
         <xpath expr="//t[@t-call='sale.document_tax_totals']" position="replace">
             <t t-call="l10n_br_sales.document_tax_totals_brazil"/>
         </xpath>
-        <!-- hide subsection subtotals, because they don't include tax -->
-        <td name="td_section_subtotal" position="replace"/>
     </template>
 </odoo>

--- a/addons/l10n_br_sales/views/sale_portal_templates.xml
+++ b/addons/l10n_br_sales/views/sale_portal_templates.xml
@@ -1,21 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <template id="sale_order_portal_content_brazil" inherit_id="sale.sale_order_portal_content" primary="True">
+    <template id="sale_order_portal_content_brazil" inherit_id="sale.sale_order_portal_content">
         <!-- hide the taxes th -->
-        <th id="taxes_header" position="replace"/>
+        <th id="taxes_header" position="attributes">
+            <attribute name="t-if">sale_order.country_code != 'BR'</attribute>
+        </th>
+
         <!-- hide the taxes td -->
-        <td id="taxes" position="replace"/>
-        <!-- hide the "Amount" th -->
-        <th id="subtotal_header" position="replace"/>
-        <!-- hide the "Amount" td -->
-        <td id='subtotal' position="replace"/>
-        <xpath expr="//t[@t-call='sale.sale_order_portal_content_totals_table']" position="replace">
-            <table class="table table-sm">
-                <t t-set="tax_totals" t-value="sale_order.tax_totals"/>
-                <t t-call="l10n_br_sales.document_tax_totals_brazil"/>
-            </table>
-        </xpath>
-        <!-- hide subsection subtotals, because they don't include tax -->
-        <xpath expr="//span[@t-out='current_subtotal']/.." position="replace"/>
+        <td id="taxes" position="attributes">
+            <attribute name="t-if">sale_order.country_code != 'BR'</attribute>
+        </td>
+
+        <t t-set="current_subtotal" t-value="current_subtotal + line.price_subtotal" position="attributes">
+            <attribute name="t-value">(current_subtotal + line.price_total) if sale_order.country_code == 'BR' else (current_subtotal + line.price_subtotal)</attribute>
+        </t>
+
+        <span t-field="line.price_subtotal" position="attributes">
+            <attribute name="t-if">sale_order.country_code != 'BR'</attribute>
+        </span>
+        <span t-field="line.price_subtotal" position="after">
+            <span t-if="sale_order.country_code == 'BR'" class="oe_order_line_price_subtotal" t-field="line.price_total"/>
+        </span>
     </template>
+
+    <record id="sale_order_portal_content_brazil" model="ir.ui.view">
+        <field name="mode">extension</field>
+    </record>
 </odoo>


### PR DESCRIPTION
This module was introduced in saas-16.4. In that version the sale order report and portal template displayed both price_subtotal and price_total for each sale order
line. 655d375af83dd49bbbd5f5818e319c3b0e9778c1 removed price_total.

Because this module removes price_subtotal we end up with no line total at all on the default Brazilian quotation PDF and portal view (just 3 columns: description, quantity and unit price).

Loosely inspired by l10n_cl [1], this commit changes our approach to turn the two places where we use price_subtotal into price_total. The aforementioned commit also changed the heading of this column from "Subtotal" to a more generic "Amount", so there's no inconsistency there.

For the portal view, we change our previous approach of using a primary view because of changes to sale_subscription [2]. It now also overrides _get_name_portal_content_view() and as a result would require a new Brazil-specific module to get our primary view selected again. We switch to a t-if based approach, which has its own downsides but was considered preferable to needing the additional module. Finally, the tax totals override was removed, because there seems to be no need. It's already handled by the
_get_name_tax_totals_view() override.

We explicitly turn the view into an extension view (not possible with a <template> attribute [3]). We don't remove this view and create a new one in case somebody inherited it.

[1] https://github.com/odoo/odoo/blob/655d375af83dd49bbbd5f5818e319c3b0e9778c1/addons/l10n_cl/views/report_invoice.xml#L173-L175
[2] odoo/enterprise@4755b82fa40df50362e72ccc3e08f6ce5383dde3
[3] https://github.com/odoo/odoo/blob/22ab49e3432b9342b657b9f8f4cf2d06b083ddad/odoo/tools/convert.py#L465

Alternative approach to https://github.com/odoo/enterprise/pull/59703.