### PR TITLE
[FIX] web: update statusbar data without reloading page 

### DIFF
--- a/addons/web/static/tests/views/fields/statusbar_field_tests.js
+++ b/addons/web/static/tests/views/fields/statusbar_field_tests.js
@@ -622,7 +622,7 @@ QUnit.module("Fields", (hooks) => {
     });
 
     QUnit.test(
-        "For the same record, a single rpc is done to recover the specialData",
+        "For the same record, multiple RPCs are made to retrieve the specialData",
         async function (assert) {
             serverData.views = {
                 "partner,3,list": '<tree><field name="display_name"/></tree>',
@@ -661,7 +661,7 @@ QUnit.module("Fields", (hooks) => {
 
             await click(target, ".o_back_button");
             await click(target.querySelector(".o_data_row .o_data_cell"));
-            assert.verifySteps([]);
+            assert.verifySteps(["search_read"]);
         }
     );
 
@@ -891,6 +891,6 @@ QUnit.module("Fields", (hooks) => {
             getNodesTextContent(target.querySelectorAll(".o_statusbar_status button:not(.d-none)")),
             ["Stage Project 2"]
         );
-        assert.verifySteps([]);
+        assert.verifySteps(["[\"|\",[\"id\",\"=\",2],[\"project_ids\",\"in\",2]]"]);
     });
 });


### PR DESCRIPTION
Steps to reproduce:
-------------
 - Install the project module.
 - Go to the project and create a new one.
 - Create a new task stage and a task for the project.
 - Once you add a stage in the Kanban view, go to the task,
   and you will see the stage added.
 - Add another stage and return to the task; the stage you added
   will not appear.

Issue:
-----------
  The status bar is currently using special data caching. Once the data
  is stored, if there are changes in the stage, the special dataset does
  not get updated, so the old stage is shown.

Fix:
---------
  The old data is stored in specialDataCaches, so we have to fetch updated
  data from ORM.

Limitation:
---------
 Every time the ORM method is called when a user opens a record.

task-3753697