### PR TITLE
[FIX] website_sale, website_sale_stock: no add to cart button when not allowed out of stock order

### DIFF
--- a/addons/website_sale_stock/static/src/js/variant_mixin.js
+++ b/addons/website_sale_stock/static/src/js/variant_mixin.js
@@ -48,6 +48,8 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
     const $addQtyInput = $parent.find('input[name="add_qty"]');
     let qty = $addQtyInput.val();
 
+    $parent.find('#add_to_cart_wrap').prev('.css_quantity')[0].classList.replace('d-none', 'd-inline-flex');
+    $parent.find('#add_to_cart_wrap')[0].classList.replace('d-none', 'd-inline');
     $parent.find('#add_to_cart').removeClass('out_of_stock');
     $parent.find('.o_we_buy_now').removeClass('out_of_stock');
     if (combination.product_type === 'product' && !combination.allow_out_of_stock_order) {
@@ -61,7 +63,9 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
             $addQtyInput.val(qty);
         }
         if (combination.free_qty < 1) {
-            $parent.find('#add_to_cart').addClass('disabled out_of_stock');
+            $parent.find('#add_to_cart').addClass('out_of_stock');
+            $parent.find('#add_to_cart_wrap').prev('.css_quantity')[0].classList.replace('d-inline-flex', 'd-none');
+            $parent.find('#add_to_cart_wrap')[0].classList.replace('d-inline', 'd-none');
             $parent.find('.o_we_buy_now').addClass('disabled out_of_stock');
         }
     }


### PR DESCRIPTION
## **Issue:** 

When having a storable product with 0 amount on hand or even a negative amount but we have unselected the 'allow_out_of_stock_order' we are going to still see the 'Add to cart' button and the input for the quantities which will behave badly when working with negative amounts.

## **Steps to reproduce:**

1. Install website_sale_stock.
2. Create a new storable product and update the on-hand quantity to -1.
3. Disable the "Continue Selling" option under the sales tab of the product.
4. Publish this product on the website.
5. Go to the website and try to click the "+" button to increase the quantity.

## **Solution:** 

Following the behavior of newer versions, we could just remove this button and input for when we are not able to order because of 'out of stock', for this we should have both the quantity input and the button under the same div, and then apply the styles needed for it.

opw-3850592
