### PR TITLE
[FIX] portal: prevent error while country is not selected

### DIFF
--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -491,7 +491,7 @@
             <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" t-att-disabled="None if partner_can_edit_vat else '1'">
                 <option value="">Country...</option>
                 <t t-foreach="countries or []" t-as="country">
-                    <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">
+                    <option t-att-value="country.id" t-att-selected="country.id == (int(country_id) if country_id and country_id != 'False' else partner.country_id.id)">
                         <t t-esc="country.name" />
                     </option>
                 </t>


### PR DESCRIPTION
Currently, the error arises when saving details in the portal view without selecting a country

Steps to reproduce:

- Install the 'account' module.
- Navigate to invoicing / Customers / Invoices and create a new invoice.
- Add a current user as a customer (Make sure that the customer has no country) and add a product, then confirm it.
- Go to portal view and click on 'Edit information'.
- Click on the 'Save' button (Make sure that some fields are empty like Phone, City, Street).

```
ValueError: invalid literal for int() with base 10: 'False'
  File "<453>", line 531, in template_453
  File "<453>", line 416, in template_453_content
QWebException: Error while render the template
ValueError: invalid literal for int() with base 10: 'False'
Template: ir.ui.view(453,)
Path: /t/div[13]/select/t/option
Node: <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id"/>
  File "odoo/http.py", line 2252, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1828, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1848, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1826, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1833, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1971, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 224, in _dispatch
    result.flatten()
  File "odoo/http.py", line 1321, in flatten
    self.response.append(self.render())
  File "odoo/http.py", line 1313, in render
    return request.env["ir.ui.view"]._render_template(self.template, self.qcontext)
  File "addons/website/models/ir_ui_view.py", line 442, in _render_template
    return super()._render_template(template, values=values)
  File "odoo/addons/base/models/ir_ui_view.py", line 2023, in _render_template
    return self.env['ir.qweb']._render(template, values)
  File "odoo/tools/profiler.py", line 302, in _tracked_method_render
    return method_render(self, template, values, **options)
  File "odoo/addons/base/models/ir_qweb.py", line 594, in _render
    result = ''.join(rendering)
  File "<454>", line 86, in template_454
  File "<454>", line 68, in template_454_content
  File "<454>", line 41, in template_454_t_call_0
  File "<453>", line 539, in template_453

```

The issue occurs when attempting to save details in the portal view without selecting a country. At this point [1], a string 'False' is passed as the 'country_id', and the system attempts to convert it into an integer using typecasting (int()).

A 'False' string is passed as the 'country_id' when a partner has no country [2], Added in the code from this PR.

link[1] : https://github.com/odoo/odoo/blob/fc55cd0ecb9e79ee4491537cc77baa0d57f1f3c7/addons/portal/views/portal_templates.xml#L500

link[2]: https://github.com/odoo/odoo/commit/d6d6bee087fe2d3dc17974054353430c2662aecf

To resolve the issue, Ensure that 'False' string should not pass to the 'country_id', When a partner has no country.

sentry-4959817278

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
