### PR TITLE
[FIX] web_editor: wrong position of checkbox

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/shiftTab.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/shiftTab.js
@@ -62,7 +62,7 @@ HTMLLIElement.prototype.oShiftTab = function () {
                 p = p || document.createElement('P');
                 if (dir) {
                     p.setAttribute('dir', dir);
-                    p.style.setProperty('text-align', ul.style.getPropertyValue('text-align'));
+                    p.style.setProperty('text-align', getComputedStyle(ul).textAlign);
                 }
                 p.append(li.firstChild);
             }

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -161,11 +161,24 @@ ul.o_checklist {
         }
     }
 }
-ul.o_checklist[dir="rtl"] > li:not(.oe-nested)::before {
-    left: auto;
-    right: - $o-checklist-margin-left;
+/*rtl:begin:ignore*/
+ul.o_checklist[dir="rtl"] {
     text-align: right;
+    li:not(.oe-nested)::before {
+        left: auto;
+        right: - $o-checklist-margin-left;
+        text-align: right;
+    }
 }
+ul.o_checklist[dir="ltr"] {
+    text-align: left;
+    li:not(.oe-nested)::before {
+        right: auto;
+        left: - $o-checklist-margin-left;
+        text-align: left;
+    }
+}
+/*rtl:end:ignore*/
 ol > li.o_indent, ul > li.o_indent {
     margin-left: 0;
     list-style: none;


### PR DESCRIPTION
Current behavior before PR:

When switching the checkbox direction from left to right and pressing tab, 
the checkbox would shift to the left while the text appeared on the right, 
and vice versa for RTL languages.

Desired behavior after PR is merged:

Commit [1] added the positioning of checklists in Right-to-Left (RTL) languages. 
Previously, only the direct child `li` elements of `ul` were styled because of 
the use of the child combinator selector (>), as the `dir` attribute was only
applied to the outermost `ul` element. This commit  ensures uniform styling 
across various languages, including RTL languages.

[1]: https://github.com/odoo/odoo/commit/bb9c4b3892353901a2cf33bccf0d6324466fd1fa

task-3828737