### PR TITLE
[FIX] web: auto-adjust width for "Upload and Set" button

### DIFF
--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
@@ -27,7 +27,7 @@
                     onUpload.bind="onUpload"
                     resModel="props.record.resModel"
                     resId="props.record.resId">
-                        <button class="btn btn-primary" t-on-click="uploadImage">
+                        <button class="btn btn-primary w-auto" t-on-click="uploadImage">
                             Upload and Set
                         </button>
                 </FileInput>


### PR DESCRIPTION
Issue:
------------

  The width of the "Upload and Set" button did not adjust based on its text, resulting in the text being 
   clipped.

Fix:
-----------
 This commit enables automatic width adjustment for the "Upload and Set" button to ensure
 both the button and its text are fully visible on the same line.

Steps to Reproduce (mobile view):
------------------
   - Install the project module
   - Open the task Kanban view
  - Click on Set Cover Image

task-3761269
