### PR TITLE
[FIX] stock_*: user should not be able to set global route companies

### DIFF
--- a/addons/mrp/models/__init__.py
+++ b/addons/mrp/models/__init__.py
@@ -20,3 +20,4 @@ from . import stock_rule
 from . import stock_scrap
 from . import stock_warehouse
 from . import stock_quant
+from . import stock_route

--- a/addons/mrp/models/stock_route.py
+++ b/addons/mrp/models/stock_route.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+class StockRoute(models.Model):
+    _inherit = 'stock.route'
+
+    def _get_global_routes(self):
+        return super()._get_global_routes() + [self.env.ref('mrp.route_warehouse0_manufacture', raise_if_not_found=False)]
+

--- a/addons/mrp/models/stock_warehouse.py
+++ b/addons/mrp/models/stock_warehouse.py
@@ -5,7 +5,6 @@ from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.tools import split_every
 
-
 class StockWarehouse(models.Model):
     _inherit = 'stock.warehouse'
 

--- a/addons/mrp_subcontracting/models/__init__.py
+++ b/addons/mrp_subcontracting/models/__init__.py
@@ -12,3 +12,4 @@ from . import stock_quant
 from . import stock_rule
 from . import stock_warehouse
 from . import mrp_production
+from . import stock_route

--- a/addons/mrp_subcontracting/models/stock_route.py
+++ b/addons/mrp_subcontracting/models/stock_route.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+class StockRoute(models.Model):
+    _inherit = 'stock.route'
+
+    def _get_global_routes(self):
+        return super()._get_global_routes() + [self.env.ref('mrp_subcontracting.route_resupply_subcontractor_mto', raise_if_not_found=False)]
+

--- a/addons/mrp_subcontracting_dropshipping/models/__init__.py
+++ b/addons/mrp_subcontracting_dropshipping/models/__init__.py
@@ -8,3 +8,4 @@ from . import stock_warehouse
 from . import purchase
 from . import stock_rule
 from . import stock_orderpoint
+from . import stock_route

--- a/addons/mrp_subcontracting_dropshipping/models/stock_route.py
+++ b/addons/mrp_subcontracting_dropshipping/models/stock_route.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+class StockRoute(models.Model):
+    _inherit = 'stock.route'
+
+    def _get_global_routes(self):
+        return super()._get_global_routes() + [self.env.ref('mrp_subcontracting_dropshipping.route_subcontracting_dropshipping', raise_if_not_found=False)]
+

--- a/addons/purchase_stock/models/__init__.py
+++ b/addons/purchase_stock/models/__init__.py
@@ -11,3 +11,4 @@ from . import res_company
 from . import stock
 from . import stock_move
 from . import stock_rule
+from . import stock_route

--- a/addons/purchase_stock/models/stock_route.py
+++ b/addons/purchase_stock/models/stock_route.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+class StockRoute(models.Model):
+    _inherit = 'stock.route'
+
+    def _get_global_routes(self):
+        return super()._get_global_routes() + [self.env.ref('purchase_stock.route_warehouse0_buy', raise_if_not_found=False)]
+

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -192,7 +192,8 @@
                             <field name="sequence" string="Sequence" groups="base.group_no_one"/>
                             <field name="supplied_wh_id" groups="base.group_no_one"/>
                             <field name="active" invisible="1"/>
-                            <field name="company_id" groups="base.group_multi_company" options="{'no_create': True}"/>
+                            <field name="is_global_route" invisible="1"/>
+							<field name="company_id" groups="base.group_multi_company" options="{'no_create': True}" attrs="{'invisible': [('is_global_route', '=', True)]}"/>
                         </group>
                     </group>
                     <group string="Applicable On" name="route_selector">

--- a/addons/stock_dropshipping/models/__init__.py
+++ b/addons/stock_dropshipping/models/__init__.py
@@ -5,3 +5,4 @@ from . import purchase
 from . import res_company
 from . import sale
 from . import stock
+from . import stock_route

--- a/addons/stock_dropshipping/models/stock_route.py
+++ b/addons/stock_dropshipping/models/stock_route.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import models
+
+class StockRoute(models.Model):
+    _inherit = 'stock.route'
+
+    def _get_global_routes(self):
+        return super()._get_global_routes() + [self.env.ref('stock_dropshipping.route_drop_shipping', raise_if_not_found=False)]
+


### PR DESCRIPTION
Problem:
It is possible for the user to set the company of one
of the default stock routes (eg `Buy` from purchasing) from the form view
of the route.
After saving this change, it is then impossible to create new companies
due to a `ValidationError` for inconsistent companies.

Desired behavior and rationale:
The global routes are meant to be global, therefore,
it should not be possible to set their company at all.

Note:
We need a way to know if a route is global, so we to add the Boolean
field `is_global_route`. Ideally it would be a stored field set in the
`data/_.xml` of every submodule that needs a new default route,
but to prevent breaking changes, we make it a compute_field and
implement the `_get_global_routes` method. with child classes
for every submodule declaring a new default routes
which hardcodes its new route into its child `_get_global_routes` method.

opw-3790512
