### PR TITLE
[FIX] mail: mail tracking for field desc should respect language

### DIFF
--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -850,7 +850,7 @@ class Message(models.Model):
                 if not groups or self.env.is_superuser() or self.user_has_groups(groups):
                     tracking_value_ids.append({
                         'id': tracking.id,
-                        'changed_field': tracking.field_desc,
+                        'changed_field': tracking.field.field_description,
                         'old_value': tracking.get_old_display_value()[0],
                         'new_value': tracking.get_new_display_value()[0],
                         'field_type': tracking.field_type,


### PR DESCRIPTION
-Before this commit whenever we have tracking values on the chatter for example the 'status' of sale order then the field description (the status field string) never respect user's language at all

-Purpose of this commit is When in English it should be: 'Status:SalesOrder -> Cancelled' and switch to vietnamese language it need to be 'Tình trạng: Sales -> Cancelled'. Of course if it is 'Tình trạng: Đơn bán -> Hủy' will be the best. But will do that in master

-Note: this commit only to fwd up to <17.0 because in v17 it already correct

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
