### PR TITLE
[FIX] web_editor: apply color on header link

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -632,7 +632,13 @@ export const editorCommands = {
 
         function getFonts(selectedNodes) {
             return selectedNodes.flatMap(node => {
-                let font = closestElement(node, "font") || closestElement(node, "span");
+                let font = closestElement(node, "font, a");
+                if (!font || font.nodeName === "A") {
+                    font = closestElement(node, "span, a");
+                    if (font && font.nodeName === "A") {
+                        font = null;
+                    }
+                }
                 const children = font && descendants(font);
                 if (font && (font.nodeName === 'FONT' || (font.nodeName === 'SPAN' && font.style[mode]))) {
                     // Partially selected <font>: split it.

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/color.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/color.test.js
@@ -113,4 +113,12 @@ describe('applyColor', () => {
             contentAfter: '<p>[abcabc]</p>',
         });
     });
+
+    it('should apply color on header link', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p><font style="font-size: 62px;"><a href="http://test.com">[Your Site Title]</a></font></p>',
+            stepFunction: setColor('rgb(255, 0, 0)', 'color'),
+            contentAfter: '<p><font style="font-size: 62px;"><a href="http://test.com"><font style="color: rgb(255, 0, 0);">[Your Site Title]</font></a></font></p>',
+        });
+    });
 });


### PR DESCRIPTION
Issue:
======
Color doesn't get applied on a header link

Steps to reproduce the issue:
=============================
- Go to email marketing
- Create a new one and drop the header block
- Select the header and add url to it to make it a link
- Try to change the font color of the header
- Nothing happens

Origin of the issue:
====================
The snippet have this format `<font>text</font>` , changing it to link will make it `<font><a>text</a></font>`, so now when we apply color , we will find that `font` element as the closest one and change the style on it, but the `a` element overrides the font color that's why we don't see any visible change.

Solution:
=========
We force the `font` element to be inside the `A` element if exists.

opw-3843327