### PR TITLE
[FIX] mail: cleanup broadcast channel after test

### DIFF
--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -246,6 +246,7 @@ async function addSwitchTabDropdownItem(rootTarget, tabTarget) {
 let NEXT_ENV_ID = 1;
 
 export async function start({ asTab = false, authenticateAs, env: pEnv } = {}) {
+    mockBroadcastChannel();
     if (!MockServer.current) {
         await startServer();
     }
@@ -457,6 +458,16 @@ export function mockGetMedia() {
             stream.getTracks().forEach((track) => track.stop());
         });
     });
+}
+
+function mockBroadcastChannel() {
+    class SelfClosingBroadcastChannel extends BroadcastChannel {
+        constructor() {
+            super(...arguments);
+            after(() => this.close());
+        }
+    }
+    patchWithCleanup(browser, { BroadcastChannel: SelfClosingBroadcastChannel });
 }
 
 /**


### PR DESCRIPTION
The discuss core common service uses a `BroadcastChannel` that is never closed during tests. This can lead to memory leaks and to messages being received more than once (since listeners are never cleared and channel is never closed). This PR mocks the `BroadcastChannel` API to automatically close the channel after each test.
