### PR TITLE
[IMP] website: make menu url required and default value to #

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -278,7 +278,7 @@ class Website(models.Model):
         :return: True if the menu contains a record like url
         """
         return any(self.env['website.menu'].browse(self._get_menu_ids()).filtered(
-            lambda menu: (menu.url and re.search(r"[/](([^/=?&]+-)?[0-9]+)([/]|$)", menu.url)) or menu.group_ids
+            lambda menu: re.search(r"[/](([^/=?&]+-)?[0-9]+)([/]|$)", menu.url) or menu.group_ids
         ))
 
     @api.model_create_multi

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -70,12 +70,10 @@ class WebsiteMenu(models.Model):
     @api.depends("page_id", "is_mega_menu", "child_id")
     def _compute_url(self):
         for menu in self:
-            if menu.page_id:
-                menu.url = menu.page_id.url
             if menu.is_mega_menu or menu.child_id:
                 menu.url = "#"
             else:
-                menu.url = menu.url or "#"
+                menu.url = (menu.page_id.url if menu.page_id else menu.url) or "#"
 
     @api.model_create_multi
     def create(self, vals_list):
@@ -159,16 +157,13 @@ class WebsiteMenu(models.Model):
 
     def _clean_url(self):
         # clean the url with heuristic
-        if self.page_id:
-            url = self.page_id.sudo().url
-        else:
-            url = self.url
-            if url and not self.url.startswith('/'):
-                if '@' in self.url:
-                    if not self.url.startswith('mailto'):
-                        url = 'mailto:%s' % self.url
-                elif not self.url.startswith('http'):
-                    url = '/%s' % self.url
+        url = self.url
+        if url and not self.url.startswith("/"):
+            if "@" in self.url:
+                if not self.url.startswith("mailto"):
+                    url = "mailto:%s" % self.url
+            elif not self.url.startswith("http"):
+                url = "/%s" % self.url
         return url
 
     def _is_active(self):
@@ -200,13 +195,7 @@ class WebsiteMenu(models.Model):
         request_url = url_parse(request.httprequest.url)
 
         if not self.child_id:
-            # Don't compare to `url` as it could be shadowed by the linked
-            # website page's URL
-            menu_url = self._clean_url()
-            if not menu_url:
-                return False
-
-            menu_url = url_parse(menu_url)
+            menu_url = url_parse(self._clean_url())
             unslug_url = self.env['ir.http']._unslug_url
             if unslug_url(menu_url.path) == unslug_url(request_url.path):
                 if not (
@@ -233,19 +222,18 @@ class WebsiteMenu(models.Model):
         website = self.env['website'].browse(website_id)
 
         def make_tree(node):
-            menu_url = node.page_id.url if node.page_id else node.url
             menu_node = {
                 'fields': {
                     'id': node.id,
                     'name': node.name,
-                    'url': menu_url,
+                    'url': node.url,
                     'new_window': node.new_window,
                     'is_mega_menu': node.is_mega_menu,
                     'sequence': node.sequence,
                     'parent_id': node.parent_id.id,
                 },
                 'children': [],
-                'is_homepage': menu_url == (website.homepage_url or '/'),
+                'is_homepage': node.url == (website.homepage_url or '/'),
             }
             for child in node.child_id:
                 menu_node['children'].append(make_tree(child))
@@ -275,7 +263,7 @@ class WebsiteMenu(models.Model):
             menu_id = self.browse(menu['id'])
             # Check if the url match a website.page (to set the m2o relation),
             # except if the menu url contains '#', we then unset the page_id
-            if not menu['url'] or '#' in menu['url']:
+            if '#' in menu['url']:
                 # Multiple case possible
                 # 1. `#` => menu container (dropdown, ..)
                 # 2. `#anchor` => anchor on current page
@@ -283,7 +271,7 @@ class WebsiteMenu(models.Model):
                 # 4. https://google.com#smth => valid external URL
                 if menu_id.page_id:
                     menu_id.page_id = None
-                if request and menu['url'] and menu['url'].startswith('#') and len(menu['url']) > 1:
+                if request and menu['url'].startswith('#') and len(menu['url']) > 1:
                     # Working on case 2.: prefix anchor with referer URL
                     referer_url = werkzeug.urls.url_parse(request.httprequest.headers.get('Referer', '')).path
                     menu['url'] = referer_url + menu['url']

--- a/addons/website/models/website_menu.py
+++ b/addons/website/models/website_menu.py
@@ -39,7 +39,7 @@ class WebsiteMenu(models.Model):
                 menu.mega_menu_classes = False
 
     name = fields.Char('Menu', required=True, translate=True)
-    url = fields.Char('Url', default='')
+    url = fields.Char("Url", compute="_compute_url", store=True, required=True, default="#", copy=True)
     page_id = fields.Many2one('website.page', 'Related Page', ondelete='cascade')
     controller_page_id = fields.Many2one('website.controller.page', 'Related Model Page', ondelete='cascade')
     new_window = fields.Boolean('New Window')
@@ -66,6 +66,16 @@ class WebsiteMenu(models.Model):
             if menu.website_id:
                 menu_name += f' [{menu.website_id.name}]'
             menu.display_name = menu_name
+
+    @api.depends("page_id", "is_mega_menu", "child_id")
+    def _compute_url(self):
+        for menu in self:
+            if menu.page_id:
+                menu.url = menu.page_id.url
+            if menu.is_mega_menu or menu.child_id:
+                menu.url = "#"
+            else:
+                menu.url = menu.url or "#"
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/website/static/src/components/dialog/edit_menu.js
+++ b/addons/website/static/src/components/dialog/edit_menu.js
@@ -186,12 +186,13 @@ export class EditMenuDialog extends Component {
     addMenu(isMegaMenu) {
         this.dialogs.add(MenuDialog, {
             isMegaMenu,
+            url: "#",
             save: (name, url, isNewWindow) => {
                 const newMenu = {
                     fields: {
                         id: `menu_${(new Date).toISOString()}`,
                         name,
-                        url: isMegaMenu ? '#' : url,
+                        url,
                         new_window: isNewWindow,
                         'is_mega_menu': isMegaMenu,
                         sequence: 0,

--- a/addons/website/static/tests/tours/edit_menus.js
+++ b/addons/website/static/tests/tours/edit_menus.js
@@ -95,20 +95,22 @@ registerWebsitePreviewTour('edit_menus', {
         run: "edit Random!",
     },
     {
+        content: "Remove the URL input value",
+        trigger: ".modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input#url_input",
+        run: "edit ",
+    },
+    {
         content: "Confirm the new menu entry without a url",
         trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
         run: "click",
     },
     {
-        trigger: ".modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input.is-invalid",
-    },
-    {
-        content: "It didn't save without a url. Fill url input.",
-        trigger: '.modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input:eq(1)',
+        content: "It didn't save without URL input value. Fill url input.",
+        trigger: ".modal:not(.o_inactive_modal) .modal-dialog .o_website_dialog input#url_input",
         run: "edit #",
     },
     {
-        content: "Confirm the new menu entry",
+        content: "Confirm the new menu entry with # url",
         trigger: ".modal:not(.o_inactive_modal) .modal-footer .btn-primary:contains(ok)",
         run: "click",
     },

--- a/addons/website/tests/test_menu.py
+++ b/addons/website/tests/test_menu.py
@@ -340,14 +340,3 @@ class TestMenuHttp(common.HttpCase):
         self.assertIn(b"french_mega_menu_content", page.content)
         page = self.url_open('/%s?edit_translations=1' % fr.url_code)
         self.assertIn(b"french_mega_menu_content", page.content)
-
-    def test_menu_empty_url(self):
-        website = self.env['website'].browse(1)
-        menu = self.env['website.menu'].create({
-            'name': 'Test Empty URL menu',
-            'parent_id': website.menu_id.id,
-            'website_id': website.id,
-        })
-        self.assertFalse(menu.url, "Menu URL should be empty")
-        # this should not crash
-        website.is_menu_cache_disabled()

--- a/addons/website/views/website_views.xml
+++ b/addons/website/views/website_views.xml
@@ -99,13 +99,13 @@
                         <group>
                             <group>
                                 <field name="name"/>
-                                <field name="url"/>
+                                <field name="url" readonly="page_id or is_mega_menu or child_id"/>
                                 <field name="page_id"/>
                                 <field name="controller_page_id"/>
                                 <field name="is_mega_menu"/>
                             </group>
                             <group>
-                                <field name="new_window"/>
+                                <field name="new_window" readonly="is_mega_menu or child_id"/>
                                 <field name="sequence"/>
                                 <field name="website_id" options="{'no_create': True}" groups="website.group_multi_website"/>
                             </group>

--- a/addons/website_sale/models/website_menu.py
+++ b/addons/website_sale/models/website_menu.py
@@ -8,7 +8,7 @@ class WebsiteMenu(models.Model):
 
     def _compute_visible(self):
         """ Hide '/shop' menus to the public user if only logged-in users can access it. """
-        shop_menus = self.filtered(lambda m: m.url and m.url[:5] == '/shop')
+        shop_menus = self.filtered(lambda m: m.url[:5] == '/shop')
         for menu in shop_menus:
             menu.is_visible = menu.website_id.has_ecommerce_access()
 


### PR DESCRIPTION
This PR makes the url field required and set it's default value to "#".
This change was prompted by [1] and [2], as both introduced bugs causing page crashes when the url was empty. Although [3] fixed this in version 16.0, in master we have removed that fix and made the url field required.

Additionally, when changing the related page in the menu form, the url field now updates to reflect the url of the newly selected page. Previously, if a related page was selected and a custom url was entered,users would be redirected to the related page's menu instead of the custom url. Furthermore, if the menu is a mega menu or has child menus, the url is irrelevant. To address these issues, the url field is set to readonly under certain conditions, automatically updating it to the related page's url and '#' if it's a mega menu or has child menus.

[1]: https://github.com/odoo/odoo/commit/948235079f002794f9837d3cf91e2d20e3254e20
[2]: https://github.com/odoo/odoo/commit/5bde2e42c8ec5e943a779ad4b3e1b7142f2d2fcf
[3]: https://github.com/odoo/odoo/commit/f4211b14025508b7b3b1522a73cc019f7a315125

task-3851453

Co-authored-by: Pratik Raval <prra@odoo.com>