### PR TITLE
[IMP] hw_*: IoT technical details information file

### DIFF
--- a/addons/hw_drivers/__init__.py
+++ b/addons/hw_drivers/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import iot_object_info
 from . import server_logger
 from . import connection_manager
 from . import controllers

--- a/addons/hw_drivers/driver.py
+++ b/addons/hw_drivers/driver.py
@@ -4,6 +4,7 @@
 from threading import Thread, Event
 
 from odoo.addons.hw_drivers.main import drivers, iot_devices
+from odoo.addons.hw_drivers.iot_object_info import IoTObjectInfo
 from odoo.tools.lru import LRU
 
 
@@ -14,11 +15,12 @@ class DriverMetaClass(type):
             newclass.priority += 1
         else:
             newclass.priority = 0
-        drivers.append(newclass)
+        if clsname != 'Driver':  # Avoid registering the abstract Driver class itself
+            drivers.append(newclass)
         return newclass
 
 
-class Driver(Thread, metaclass=DriverMetaClass):
+class Driver(Thread, IoTObjectInfo, metaclass=DriverMetaClass):
     """
     Hook to register the driver into the drivers list
     """
@@ -73,3 +75,16 @@ class Driver(Thread, metaclass=DriverMetaClass):
             return cache[iot_idempotent_id]
         cache[iot_idempotent_id] = session_id
         return False
+
+    def _set_iot_info(self) -> dict:
+        return {
+            'thread': self._get_thread_info(),
+            'connection_type': self.connection_type,
+            'dev': self.dev,
+            'device_identifier': self.device_identifier,
+            'device_name': self.device_name,
+            'device_connection': self.device_connection,
+            'device_type': self.device_type,
+            'device_manufacturer': self.device_manufacturer,
+            'data': self.data,
+        }

--- a/addons/hw_drivers/iot_object_info.py
+++ b/addons/hw_drivers/iot_object_info.py
@@ -1,0 +1,41 @@
+
+import logging
+from threading import Thread
+
+_logger = logging.getLogger(__name__)
+
+
+class IoTObjectInfo:
+    """Abstract class for getting information about an arbitrary IoT object."""
+
+    def get_iot_info(self) -> dict:
+        """Get information about the object contained in a dictionary.
+        This method should NOT be overridden by subclasses."""
+        all_iot_info = self._set_iot_info()
+        # To avoid having to super().get_iot_info().update() in subclasses
+        # we use this for loop which will update a dict with the info of all child classes defined dict
+        for cls in self.__class__.__mro__:
+            if cls == IoTObjectInfo:
+                break
+            if hasattr(cls, '_set_iot_info'):
+                all_iot_info.update(cls._set_iot_info(self))
+        return all_iot_info
+
+    def _set_iot_info(self) -> dict:
+        """Define the dict info for the current object
+        This method should be overridden by subclasses."""
+        return {}
+
+    def _get_thread_info(self, thread: Thread = 'self') -> dict:
+        """Create a dictionary with information about a thread.
+        If no information is provided, assume the current object inherit from Thread."""
+        if not thread:
+            return '(unintialized thread)'
+        if thread == 'self':
+            thread = self
+        return {
+            'name': thread.name,
+            'ident': thread.ident,
+            'is_alive': thread.is_alive(),
+            'is_daemon': thread.daemon,
+        }

--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -29,10 +29,16 @@ except ImportError:
 
 drivers = []
 interfaces = {}
+interfaces_instance = set()
+"""Contain all instances of interfaces"""
 iot_devices = {}
 
 
 class Manager(Thread):
+    def __init__(self):
+        super().__init__()
+        self.previous_iot_devices = []
+
     def send_alldevices(self):
         """
         This method send IoT Box and devices informations to Odoo database
@@ -107,15 +113,15 @@ class Manager(Thread):
                 i = interface()
                 i.daemon = True
                 i.start()
-            except Exception as e:
-                _logger.error("Error in %s: %s", str(interface), e)
+                interfaces_instance.add(i)
+            except Exception:
+                _logger.exception("Error instanciating interface %s", str(interface))
 
         # Set scheduled actions
         schedule and schedule.every().day.at("00:00").do(helpers.get_certificate_status)
 
         # Check every 3 secondes if the list of connected devices has changed and send the updated
         # list to the connected DB.
-        self.previous_iot_devices = []
         while 1:
             try:
                 if iot_devices != self.previous_iot_devices:

--- a/addons/hw_drivers/tools/iot_object_info_controller.py
+++ b/addons/hw_drivers/tools/iot_object_info_controller.py
@@ -1,0 +1,135 @@
+
+from contextlib import suppress
+from datetime import datetime, timezone
+import logging
+import netifaces
+from pkg_resources import working_set
+from platform import system, uname
+from subprocess import check_output
+import sys
+
+from odoo import tools
+from odoo.addons.hw_drivers.main import drivers, interfaces_instance, iot_devices
+from odoo.addons.hw_drivers.tools import helpers
+from odoo.service.common import exp_version
+
+Vcgencmd = None
+GPIO = None
+with suppress(ImportError):
+    from vcgencmd import Vcgencmd
+    import RPi.GPIO as GPIO
+
+_logger = logging.getLogger(__name__)
+
+
+class IoTObjectInfoController:
+    """Handle the control of the dict info for the IoT objects."""
+    @classmethod
+    def _iot_info_system(cls) -> dict:
+        platform_system = system()
+        ssl_certificate = helpers._get_certificate()
+        if not isinstance(ssl_certificate, dict):
+            ssl_certificate = {
+                'get_notAfter': ssl_certificate.get_notAfter(),
+                'get_notBefore': ssl_certificate.get_notBefore(),
+                'get_subject': ssl_certificate.get_subject(),
+                'get_issuer': ssl_certificate.get_issuer(),
+            }
+
+        iot_info_system = {
+            'platform': {
+                'uname': uname(),
+            },
+            'netifaces': {
+                'AF_INET': netifaces.AF_INET,
+                'AF_INET6': netifaces.AF_INET6,
+                'AF_LINK': netifaces.AF_LINK,
+                'interfaces': {
+                    interface_name: netifaces.ifaddresses(interface_name)
+                    for interface_name in netifaces.interfaces()
+                }
+            },
+            'datetime': datetime.now(timezone.utc).isoformat(),
+            'helper checks/getters': {
+                'check_certificate': helpers.check_certificate(),
+                'get_certificate': ssl_certificate,
+                'get_ip': helpers.get_ip(),
+                'get_mac_address': helpers.get_mac_address(),
+                'get_path_nginx': helpers.get_path_nginx() if platform_system == 'Windows' else '(only for Windows IoT)',
+                'get_ssid': helpers.get_ssid() if platform_system == 'Linux' else '(only for Linux IoT-box)',
+                'get_odoo_server_url': helpers.get_odoo_server_url(),
+                'get_version': helpers.get_version(),
+            },
+            'python': {
+                'version': sys.version,
+                'argv': sys.argv,
+                'path': sys.path,
+                'pip': sorted([f"{i.key}=={i.version}" for i in working_set]),
+            },
+            'odoo (used by IoT)': {
+                'version': exp_version(),
+                'config': tools.config.options,
+            }
+        }
+        if platform_system == 'Linux':
+            iot_info_system.update({
+                'raspberry pi':
+                {
+                    'board model': GPIO.RPI_INFO.get('TYPE') if GPIO else 'GPIO python library not available',
+                    'vcgencmd': cls._iot_info_linux_vcgencmd(),
+                    'git': {
+                    'commit hash': check_output(
+                        ["git", "--work-tree=/home/pi/odoo/", "--git-dir=/home/pi/odoo/.git", "rev-parse", "HEAD"]
+                        ).decode('ascii').rstrip(),
+                    },
+                }
+            })
+        return iot_info_system
+
+    @staticmethod
+    def _iot_info_linux_vcgencmd() -> dict:
+        if not Vcgencmd:
+            return 'vcgencmd python library not available'
+        vcgm = Vcgencmd()
+        return {
+            'version': vcgm.version(),
+            'get_throttled': vcgm.get_throttled(),
+            'measure_temp': vcgm.measure_temp(),
+            'measure_volts': vcgm.measure_volts('core'),
+        }
+
+    @staticmethod
+    def _iot_info_interfaces() -> dict:
+        return {
+            interface_instance.__class__.__name__: interface_instance.get_iot_info()
+            for interface_instance in interfaces_instance
+        }
+
+    @staticmethod
+    def _iot_info_drivers_and_devices() -> dict:
+        # The concept of drivers and devices is very close as an IoT device is an instance of a driver
+        iot_info_drivers = {
+            driver_class.__name__: {
+                'connection_type': driver_class.connection_type,
+                'devices': []
+            }
+            for driver_class in drivers
+        }
+        iot_info_devices = {}
+        for iot_device_identifier, iot_device_instance in iot_devices.items():
+            iot_device_instance_info = iot_device_instance.get_iot_info()
+            iot_device_driver_name = iot_device_instance.__class__.__name__
+            iot_info_devices[f"{iot_device_identifier} ({iot_device_driver_name})"] = iot_device_instance_info
+            iot_info_drivers[iot_device_driver_name]['devices'].append(iot_device_identifier)
+        return iot_info_drivers, iot_info_devices
+
+    @classmethod
+    def get_all_iot_info(cls) -> dict:
+        """Get the IoT objects information in a dictionary format"""
+        driver_iot_info, device_iot_info = cls._iot_info_drivers_and_devices()
+        return {
+            'system': cls._iot_info_system(),
+            'interfaces': cls._iot_info_interfaces(),
+            'drivers': driver_iot_info,
+            'devices': device_iot_info,
+        }


### PR DESCRIPTION
Before this commit:
 IoT logs are useful for troubleshooting purpose events in time.
 However they are not very convenient to have:
 - global environment context variables. eg: os, python interpreter, network, current time, odoo version used, etc.
 - "states" of the different IoT elements at one given time. eg: drivers, interfaces, utilities class (helpers), etc.

After this commit:
 Proposition of concept of "IoT object Info".
 Any IoT related class can inherit from it and override the dict defined in `_set_iot_info` in order to make accessible some chosen instance attribute.

 To download this file, a button will be added on the IoT form view, see:
 https://github.com/odoo/enterprise/pull/64484

opw-3834690
