### PR TITLE
[IMP] base: dynamic values in domains

### DIFF
--- a/addons/website_sale/views/sale_order_views.xml
+++ b/addons/website_sale/views/sale_order_views.xml
@@ -16,9 +16,9 @@
                 <filter string="From Website" name="from_website" domain="[('website_id', '!=', False)]"/>
                 <separator/>
                 <!-- Dashboard filter - used by context -->
-                <filter string="Last Week" invisible="1" name="week" domain="[('date_order','&gt;', (context_today() - datetime.timedelta(days=7)).strftime('%Y-%m-%d'))]"/>
-                <filter string="Last Month" invisible="1" name="month" domain="[('date_order','&gt;', (context_today() - datetime.timedelta(days=30)).strftime('%Y-%m-%d'))]"/>
-                <filter string="Last Year" invisible="1"  name="year" domain="[('date_order','&gt;', (context_today() - datetime.timedelta(days=365)).strftime('%Y-%m-%d'))]"/>
+                <filter string="Last Week" invisible="1" name="week" domain="[('date_order','&gt;', {'date': 'today', 'days': -7})]"/>
+                <filter string="Last Month" invisible="1" name="month" domain="[('date_order','&gt;', {'date': 'today', 'months': -1})]"/>
+                <filter string="Last Year" invisible="1"  name="year" domain="[('date_order','&gt;', {'date': 'today', 'years': -1})]"/>
             </filter>
         </field>
     </record>

--- a/odoo/addons/base/views/ir_filters_views.xml
+++ b/odoo/addons/base/views/ir_filters_views.xml
@@ -45,7 +45,7 @@
                     <field name="name" string="Filter Name"/>
                     <filter string="User" domain="[('user_id','!=',False)]" name="user" help="Filters visible only for one user"/>
                     <filter string="Shared" domain="[('user_id','=',False)]" name="shared" help="Filters shared with all users"/>
-                    <filter string="My filters" domain="[('user_id','=',uid)]" name="my_filters" help="Filters created by myself"/>
+                    <filter string="My filters" domain="[('user_id','=',{'env': 'uid'})]" name="my_filters" help="Filters created by myself"/>
                     <separator/>
                     <filter string="Archived" name="inactive" domain="[('active', '=', False)]"/>
                     <group expand="0" string="Group By">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

We quite often need to define domains with some dynamic values such as current user's id (uid) or a relative date to today. As an example, you can think of what are tasks assigned to me created more than a week ago. To implement this, the domains are evaluated in the python interpreter and are not fully serializable. This is a step forward to express such conditions using a dynamically computed value during the evaluation.

To define dynamic values, a dict is used with a specification of the needed value. `ast.literal_eval` is able to parse this and we can also easily serialize it as JSON.


Current behavior before PR:
[('user_id', '=', uid),
 ('create_date', '<', context_today() - datetime.timedelta(7))]
Cannot be fully serialized and must be evaluated, it's not supported by the domain editor.

Desired behavior after PR is merged:
[('user_id', '=', {'env': 'uid'}),
 ('create_date', '<', {'date': 'today', 'days': -7})]

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
