### PR TITLE
[FIX] sale_pdf_quote_builder: Properly validates `attached_on` for product documents

### DIFF
--- a/addons/sale_pdf_quote_builder/models/product_document.py
+++ b/addons/sale_pdf_quote_builder/models/product_document.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import _, fields, models
+from odoo import _, fields, models, api
 from odoo.exceptions import ValidationError
 
 
@@ -20,11 +20,8 @@ class ProductDocument(models.Model):
              "header pages and the quote table. ",
     )
 
-    def write(self, vals):
-        res = super().write(vals)
-        if vals.keys() & {'attached_on', 'mimetype'}:
-            if any(
-                doc.attached_on == 'inside' and not doc.mimetype.endswith('pdf') for doc in self
-            ):
+    @api.constrains('attached_on', 'type', 'mimetype')
+    def _constrains_check_attached_on(self):
+        for doc in self:
+            if doc.attached_on == 'inside' and ((doc.mimetype and not doc.mimetype.endswith('pdf')) or doc.type == 'url'):
                 raise ValidationError(_("Only PDF documents can be attached inside a quote."))
-        return res


### PR DESCRIPTION
Issue:
Traceback error is raised when printing the PDF quote of a sales order with products that have documents that have `attached_on` = `inside` with `type` = `url`

Purpose:
This PR blocks the ability to create or change product documents that are `url` type with `attached_on` = `inside`.

Steps to Reproduce on Runbot:
1) Install sale_pdf_quote_builder
2) Go to a product > documents > create a new document with type `url` and set visibility to `Inside quote` 
3) Create Sale Order with product > Action > Print > PDF Quote 
4) Traceback is raised.

opw-3802795