### PR TITLE
[IMP] web: make the metrics of graph visible in dark mode

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -317,6 +317,9 @@ export class GraphRenderer extends Component {
                 },
             };
         }
+        if (this.cookies.current.color_scheme === "dark") {
+            legendOptions.labels.fontColor = getColor(15, this.cookies.current.color_scheme);
+        }
         return legendOptions;
     }
 
@@ -444,16 +447,34 @@ export class GraphRenderer extends Component {
             scaleLabel: {
                 display: Boolean(groupBy.length),
                 labelString: groupBy.length ? fields[groupBy[0].fieldName].string : "",
+                fontColor:
+                    this.cookies.current.color_scheme === "dark"
+                        ? getColor(15, this.cookies.current.color_scheme)
+                        : null,
             },
-            ticks: { callback: (value) => shortenLabel(value) },
+            ticks: {
+                callback: (value) => shortenLabel(value),
+                fontColor:
+                    this.cookies.current.color_scheme === "dark"
+                        ? getColor(15, this.cookies.current.color_scheme)
+                        : null,
+            },
         };
         const yAxe = {
             type: "linear",
             scaleLabel: {
                 labelString: measures[measure].string,
+                fontColor:
+                    this.cookies.current.color_scheme === "dark"
+                        ? getColor(15, this.cookies.current.color_scheme)
+                        : null,
             },
             ticks: {
                 callback: (value) => this.formatValue(value, allIntegers),
+                fontColor:
+                    this.cookies.current.color_scheme === "dark"
+                        ? getColor(15, this.cookies.current.color_scheme)
+                        : null,
                 suggestedMax: 0,
                 suggestedMin: 0,
             },


### PR DESCRIPTION
Before this commit:
- Graph chart metrics not properly visible in dark mode.

After this commit:
- White color is added to the text of the metrics, label and legends to make them properly visible in the dark mode.

Task-3770589

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
