### PR TITLE
[FIX] hr_holidays: fix title of leave allocation in dashboard

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -160,24 +160,27 @@ class HolidaysAllocation(models.Model):
     def _compute_description(self):
         self.check_access_rights('read')
         self.check_access_rule('read')
-
-        is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user')
-
         for allocation in self:
-            if is_officer or allocation.employee_id.user_id == self.env.user or allocation.employee_id.leave_manager_id == self.env.user:
-                title = allocation.sudo().private_name
-                if allocation.env.context.get('is_employee_allocation'):
-                    if allocation.holiday_status_id:
-                        allocation_duration = allocation.number_of_days_display if allocation.type_request_unit != 'hour' else allocation.number_of_hours_display
-                        title = _("%s allocation request (%s %s)",
-                            allocation.holiday_status_id.name,
-                            allocation_duration,
-                            allocation.type_request_unit)
-                    else:
-                        title = _("Allocation Request")
-                allocation.name = title
+            if not allocation.env.context.get('is_employee_allocation'):
+                allocation.name = allocation.sudo().private_name
+            elif not allocation.holiday_status_id:
+                allocation.name = _("Allocation Request")
+            elif allocation.type_request_unit == 'hour':
+                allocation.name = _(
+                    '%(name)s (%(duration)s hour(s))',
+                    name=allocation.holiday_status_id.name,
+                    duration=allocation.number_of_days * (
+                        allocation.employee_id.sudo().resource_calendar_id.hours_per_day
+                        or allocation.holiday_status_id.company_id.resource_calendar_id.hours_per_day
+                        or HOURS_PER_DAY
+                    ),
+                )
             else:
-                allocation.name = '*****'
+                allocation.name = _(
+                    '%(name)s (%(duration)s day(s))',
+                    name=allocation.holiday_status_id.name,
+                    duration=allocation.number_of_days,
+                )
 
     def _inverse_description(self):
         is_officer = self.env.user.has_group('hr_holidays.group_hr_holidays_user')

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -99,7 +99,7 @@ class TestAllocations(TestHrHolidaysCommon):
         num_of_allocations = self.env['hr.leave.allocation'].search_count([('employee_id', '=', self.employee.id), ('multi_employee', '=', False)])
         self.assertEqual(num_of_allocations, 1)
 
-    def test_allocation_request(self):
+    def test_allocation_request_day(self):
         self.leave_type.write({
             'name': 'Custom Time Off Test',
             'allocation_validation_type': 'officer'
@@ -116,7 +116,68 @@ class TestAllocations(TestHrHolidaysCommon):
             allocation.number_of_days_display = 10
             employee_allocation = allocation.save()
 
-        self.assertEqual(employee_allocation.private_name, "Custom Time Off Test allocation request (10.0 day)")
+        self.assertEqual(employee_allocation.private_name, "Custom Time Off Test (10.0 day(s))")
+
+    def test_allocation_request_half_days(self):
+        self.leave_type.write({
+            'name': 'Custom Time Off Test',
+            'allocation_validation_type': 'officer'
+        })
+
+        employee_allocation = self.env['hr.leave.allocation'].create({
+            'holiday_type': 'employee',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'allocation_type': 'regular',
+            'type_request_unit': 'half_day',
+        })
+
+        with Form(employee_allocation.with_context(is_employee_allocation=True), 'hr_holidays.hr_leave_allocation_view_form_dashboard') as allocation:
+            allocation.number_of_days_display = 10
+            employee_allocation = allocation.save()
+
+        self.assertEqual(employee_allocation.private_name, "Custom Time Off Test (10.0 day(s))")
+
+    def change_allocation_type_day(self):
+        self.leave_type.write({
+            'name': 'Custom Time Off Test',
+            'allocation_validation_type': 'officer'
+        })
+
+        employee_allocation = self.env['hr.leave.allocation'].create({
+            'holiday_type': 'employee',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'allocation_type': 'regular',
+        })
+
+        with Form(employee_allocation.with_context(is_employee_allocation=True), 'hr_holidays.hr_leave_allocation_view_form_dashboard') as allocation:
+            allocation.allocation_type = 'extra'
+            allocation.allocation_type = 'regular'
+            employee_allocation = allocation.save()
+
+        self.assertEqual(employee_allocation.number_of_days, 1.0)
+
+    def change_allocation_type_hours(self):
+        self.leave_type.write({
+            'name': 'Custom Time Off Test',
+            'allocation_validation_type': 'officer'
+        })
+
+        employee_allocation = self.env['hr.leave.allocation'].create({
+            'holiday_type': 'employee',
+            'employee_id': self.employee.id,
+            'holiday_status_id': self.leave_type.id,
+            'allocation_type': 'regular',
+            'type_request_unit': 'hour',
+        })
+
+        with Form(employee_allocation.with_context(is_employee_allocation=True), 'hr_holidays.hr_leave_allocation_view_form_dashboard') as allocation:
+            allocation.allocation_type = 'extra'
+            allocation.allocation_type = 'regular'
+            employee_allocation = allocation.save()
+
+        self.assertEqual(employee_allocation.number_of_days, 1.0)
 
     def test_allowed_change_allocation(self):
         allocation = self.env['hr.leave.allocation'].create({


### PR DESCRIPTION
### To merge in 17.0 to master  -.1

Bugs:
-----
1.
both: -go to time off and click on "New Allocation Request"
      -change the allocation type to any other

2.a
-> the number of days or hours is set to 0 where it should be 1 day
   or 8 hours/ressource callendar of the employee

2.b
-> if you have selected an allocation where the unit is "half_day" or
   the number of days and the title doesn't corresponds to each other

First introduction:
-------------------
    task: 3084232
    PR: https://github.com/odoo/odoo/pull/116472

Reasons:
--------
a. We where using the fields where were made for the front-end only
   and where not computed properly and thus resetting the value to 0
   when changing the allocation type

b. The title was using the unit of the allocation type in db and not
    Labels or the unit of the allocation duration

Fixes:
------
Not use the display fields for the computation of the title and make labels corresponding to the actual unit of the allocation duration

task-3852940

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
