### PR TITLE
[FIX] point_of_sale: intermediary account aged receivable

### DIFF
--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -88,7 +88,7 @@ class PosPayment(models.Model):
                 'move_id': payment_move.id,
             }, amounts['amount'], amounts['amount_converted'])
             debit_line_vals = pos_session._debit_amounts({
-                'account_id': pos_session.company_id.account_default_pos_receivable_account_id.id,
+                'account_id': self.payment_method_id.receivable_account_id.id,
                 'move_id': payment_move.id,
             }, amounts['amount'], amounts['amount_converted'])
             self.env['account.move.line'].with_context(check_move_validity=False).create([credit_line_vals, debit_line_vals])


### PR DESCRIPTION
Steps:

- Create a payment method PM with an intermediary account A
- Activate it in the POS settings, and activate QR code on ticket
- Open a pos session and make an order for a product
- Select payment method PM and validate, print the receipt
- Close the session
- Scan the qr code on the receipt, and open the link in a private window
- Fill the form and get the invoice
- Go to Accounting/Reporting/Aged Receivable -> Two lines appears, one negative for account A, and one positive for
   the default receivable account set on the POS

This is due to the fact that we set the default pos receivable account on the payment move instead of the one set on the payment method, same goes for the account used to get the lines to reconcile.

opw-3801774

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
