### PR TITLE
[FIX] l10n_de/de_reports: fix updating balance sheets

### DIFF
--- a/addons/l10n_de/migrations/2.0/pre-migrate.py
+++ b/addons/l10n_de/migrations/2.0/pre-migrate.py
@@ -21,6 +21,27 @@ def migrate(cr, version):
         """
     )
 
+    # As some people already upgraded, they will have renamed the C_1 tag to B_1. This doesn't come from the script but from the
+    # account_account_tags_data.xml. If they try to run this script now in the fix they get the error that B_1 already exists.
+    # To fix this we can check if it exists or not, and if it does then we don't run the script. This means that the ones
+    # that upgraded won't have the old tags data transferred to the new tags but they will still be able to have the updated sheet.
+    cr.execute(
+        """SELECT 1 FROM ir_model_data
+            WHERE module='l10n_de' AND name='tag_de_liabilities_bs_B_1'
+        """)
+    if cr.rowcount:
+        # If the script didn't run, we should remove the tags that have been replaced from ir_model_data too so they're
+        # not deleted by the ORM if they were already used.
+        cr.execute(
+            """DELETE FROM ir_model_data
+                WHERE module='l10n_de'
+                  AND name IN ('tag_de_liabilities_bs_F', 'tag_de_liabilities_bs_D_1', 'tag_de_liabilities_bs_D_2',
+                               'tag_de_liabilities_bs_D_3', 'tag_de_liabilities_bs_D_4', 'tag_de_liabilities_bs_D_5',
+                               'tag_de_liabilities_bs_D_6', 'tag_de_liabilities_bs_D_7', 'tag_de_liabilities_bs_D_8')
+            """
+        )
+        return
+
     rename_tag(cr, "tag_de_liabilities_bs_C_1", "tag_de_liabilities_bs_B_1")
     rename_tag(cr, "tag_de_liabilities_bs_C_2", "tag_de_liabilities_bs_B_2")
     rename_tag(cr, "tag_de_liabilities_bs_C_3", "tag_de_liabilities_bs_B_3")


### PR DESCRIPTION
Forward port this pull request because the [request](https://upgrade.odoo.com/web#id=1454059&cids=1&menu_id=107&action=150&model=upgrade.request&view_type=form) is failing when we try to rename [ref](https://github.com/odoo/odoo/blob/17.0/addons/l10n_de/migrations/2.0/pre-migrate.py#L24)  the tag due to the duplicate name constraint. To prevent duplication, we have implemented a check before renaming the tag. If the tag 'B1' already exists, we skip the execution of the script.
Upgrade request traceback group: 813
```
File "/home/odoo/src/odoo/17.0/addons/l10n_de/migrations/2.0/pre-migrate.py", line 45, in migrate
    rename_tag(cr, "tag_de_liabilities_bs_C_1", "tag_de_liabilities_bs_B_1")
  File "/home/odoo/src/odoo/17.0/addons/l10n_de/migrations/2.0/pre-migrate.py", line 5, in rename_tag
    cr.execute(
  File "/home/odoo/src/odoo/17.0/odoo/sql_db.py", line 332, in execute
    res = self._obj.execute(query, params)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "ir_model_data_module_name_uniq_index"
DETAIL:  Key (module, name)=(l10n_de, tag_de_liabilities_bs_B_1) already exists.
```


In #126249 the german balance sheet report was updated and
 during the 15.2 FW port, some issues needed fixing. The
issues and their fixes are:

- Double version: in the original PR and 15.2 a version was added to the manifest in l10n_de and was not merged correctly leading to double versions. The upgrade script in 2.0 doesn't run as Odoo sets the module version to 1.1 and this is fixed by removing the 1.1 line.
- Deleted tags: As the script didn't run, some tags (like F and all D tags) would be deleted and not renamed. As the tag might already be used as a FK in another table, we remove it from ir_model_data so it's not deleted by the ORM. Also, this means that the tags xml adds the B1 as a new tag which means renaming C1 to B1 will not work in the script due to the unique name constraint, this is handled by checking if B1 exists and if it does we do not run the script.

Enterprise PR: odoo/enterprise/pull/45899

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
