### PR TITLE
[IMP] account: Allow email aliases on MISC journals

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5041,7 +5041,7 @@ class AccountMove(models.Model):
     def message_new(self, msg_dict, custom_values=None):
         # EXTENDS mail mail.thread
         # Add custom behavior when receiving a new invoice through the mail's gateway.
-        if (custom_values or {}).get('move_type', 'entry') not in ('out_invoice', 'in_invoice'):
+        if (custom_values or {}).get('move_type', 'entry') not in ('out_invoice', 'in_invoice', 'entry'):
             return super().message_new(msg_dict, custom_values=custom_values)
 
         company = self.env['res.company'].browse(custom_values['company_id']) if custom_values.get('company_id') else self.env.company
@@ -5101,7 +5101,7 @@ class AccountMove(models.Model):
         res = super()._message_post_after_hook(new_message, message_values)
 
         attachments = new_message.attachment_ids
-        if not attachments or self.env.context.get('no_new_invoice') or not self.is_invoice(include_receipts=True):
+        if not attachments or self.env.context.get('no_new_invoice'):
             return res
 
         odoobot = self.env.ref('base.partner_root')

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -5105,13 +5105,13 @@ class AccountMove(models.Model):
             return res
 
         odoobot = self.env.ref('base.partner_root')
-        if attachments and self.state != 'draft':
+        if self.state != 'draft':
             self.message_post(body=_('The invoice is not a draft, it was not updated from the attachment.'),
                               message_type='comment',
                               subtype_xmlid='mail.mt_note',
                               author_id=odoobot.id)
             return res
-        if attachments and self.invoice_line_ids:
+        if self.invoice_line_ids:
             self.message_post(body=_('The invoice already contains lines, it was not updated from the attachment.'),
                               message_type='comment',
                               subtype_xmlid='mail.mt_note',

--- a/addons/account/views/account_journal_views.xml
+++ b/addons/account/views/account_journal_views.xml
@@ -148,19 +148,20 @@
                                     </group>
                                     <!-- email alias -->
                                     <group class="oe_read_only" name="group_alias_ro"
-                                           string="Create Invoices upon Emails" invisible="type not in ('sale', 'purchase')">
+                                           string="Create Invoices upon Emails" invisible="type not in ('sale', 'purchase', 'general')">
                                        <field name="alias_id"/>
                                     </group>
+                                    <field name="display_alias_fields" invisible="1"/>
                                     <group name="group_alias_no_domain" string="Create Invoices upon Emails"
-                                           invisible="type not in ('sale', 'purchase') or alias_domain_id">
+                                           invisible="type not in ('sale', 'purchase', 'general') or display_alias_fields">
                                         <div class="content-group" colspan="2">
                                             <a type='action' name='%(action_open_settings)d' class="btn btn-link" role="button">
-                                                <i class="oi oi-fw o_button_icon oi-arrow-right"/> Choose or Configure Email Servers
+                                                <i class="oi oi-fw o_button_icon oi-arrow-right"/> Configure Alias Domain
                                             </a>
                                         </div>
                                     </group>
                                     <group class="oe_edit_only" name="group_alias_edit" string="Create Invoices upon Emails"
-                                           invisible="type not in ('sale', 'purchase') or not alias_domain_id">
+                                           invisible="type not in ('sale', 'purchase', 'general') or not display_alias_fields">
                                         <label string="Email Alias" for="alias_name"/>
                                         <div class="oe_inline" name="edit_alias" style="display: inline;" dir="ltr" >
                                             <field name="alias_name" placeholder="alias" class="oe_inline"/>@


### PR DESCRIPTION
Allow to define email aliases on Misc journals (same as is already the case on Sale & Purchase journals).
It also changes the conditions on which to display the email alias name and domain fields to allow the creation of an alias on said view. (Previously fields were only displayed if an alias domain was already set)

Task: 3829571

Enterprise PR: https://github.com/odoo/enterprise/pull/61015