### PR TITLE
[FIX] pos_self_order: prevent upload corrupt image in Customize Header

### DIFF
--- a/addons/pos_self_order/i18n/pos_self_order.pot
+++ b/addons/pos_self_order/i18n/pos_self_order.pot
@@ -1205,6 +1205,13 @@ msgid "The user must be a POS user"
 msgstr ""
 
 #. module: pos_self_order
+#. odoo-python
+#: code:addons/pos_self_order/models/pos_config.py:0
+#, python-format
+msgid "This file could not be decoded as an image file."
+msgstr ""
+
+#. module: pos_self_order
 #: model:ir.model.fields,help:pos_self_order.field_pos_config__self_ordering_alternative_fp_id
 #: model:ir.model.fields,help:pos_self_order.field_res_config_settings__pos_self_ordering_alternative_fp_id
 msgid ""

--- a/addons/pos_self_order/models/pos_config.py
+++ b/addons/pos_self_order/models/pos_config.py
@@ -5,7 +5,7 @@ import io
 import uuid
 import base64
 from os.path import join as opj
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from typing import Optional, List, Dict
 from werkzeug.urls import url_quote
 from odoo.exceptions import UserError
@@ -165,6 +165,12 @@ class PosConfig(models.Model):
 
             if vals.get('self_ordering_mode') == 'mobile' and vals.get('self_ordering_pay_after') == 'meal':
                 vals['self_ordering_service_mode'] = 'table'
+
+            if vals.get('self_ordering_image_brand'):
+                try:
+                    Image.open(io.BytesIO(base64.b64decode(vals['self_ordering_image_brand'])))
+                except UnidentifiedImageError:
+                    raise UserError(_('This file could not be decoded as an image file.'))
         return super().write(vals)
 
     @api.depends("module_pos_restaurant")


### PR DESCRIPTION
Currently, an exception is generated when the user tries to open self ordering with a corrupt customised header image.

Steps to produce an exception:
1. Install "Restaurant"
2. Open "Point of Sale" > Configuration > Setting
3. Select "Restaurant" in Point of Sale
4. Upload a corrupt image in (E.x. ![corrupt_logo](https://github.com/odoo/odoo/assets/98319223/66c9bf62-fa9d-4e57-8004-daa5b62ce32e)) `Customize Header` > Click Save
5. Now click "Preview Web interface" of the Restaurant >>> error occur

Stack Trace:
```
UnidentifiedImageError: cannot identify image file <_io.BytesIO object at 0x7f14b96d2f20>
  File "odoo/http.py", line 2251, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1827, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1847, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1825, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1832, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 1970, in dispatch
    return self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 739, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/pos_self_order/controllers/self_entry.py", line 60, in start_self_ordering
    **pos_config._get_self_ordering_data(),
  File "addons/pos_self_order_epson_printer/models/pos_config.py", line 11, in _get_self_ordering_data
    data = super()._get_self_ordering_data()
  File "addons/pos_online_payment_self_order/models/pos_config.py", line 20, in _get_self_ordering_data
    res = super()._get_self_ordering_data()
  File "addons/pos_self_order/models/pos_config.py", line 359, in _get_self_ordering_data
    "self_ordering_image_brand": self._get_self_ordering_image(self.self_ordering_image_brand),
  File "addons/pos_self_order/models/pos_config.py", line 379, in _get_self_ordering_image
    image = Image.open(io.BytesIO(base64.b64decode(image))) if image else False
  File "PIL/Image.py", line 3008, in open
    raise UnidentifiedImageError(
```


This commit resolves the above issue by preventing the upload corrupt images by the user.

sentry-5042331835


