### PR TITLE
[FIX] point_of_sale: WIP

### DIFF
--- a/addons/point_of_sale/models/res_partner.py
+++ b/addons/point_of_sale/models/res_partner.py
@@ -14,6 +14,10 @@ class ResPartner(models.Model):
     )
     pos_order_ids = fields.One2many('pos.order', 'partner_id', readonly=True)
 
+    def get_payment_term_discount(self):
+        # return the sum of all % discounts included in this partner's payment term record
+        return sum(self.property_payment_term_id.line_ids.mapped('discount_percentage'))
+
     def _compute_pos_order(self):
         # retrieve all children partners and prefetch 'parent_id' on them
         all_partners = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])

--- a/addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderSummary.js
+++ b/addons/point_of_sale/static/src/js/Screens/ProductScreen/OrderSummary.js
@@ -18,6 +18,9 @@ odoo.define('point_of_sale.OrderSummary', function(require) {
                 displayAmount: this.env.pos.format_currency(taxAmount),
             };
         }
+        getTermDiscount() {
+            return this.props.order.payment_term_discount;
+        }
     }
     OrderSummary.template = 'OrderSummary';
 

--- a/addons/point_of_sale/static/src/xml/Screens/ProductScreen/OrderSummary.xml
+++ b/addons/point_of_sale/static/src/xml/Screens/ProductScreen/OrderSummary.xml
@@ -5,6 +5,12 @@
         <div class="summary clearfix">
             <t t-set="_total" t-value="getTotal()" />
             <t t-set="_tax" t-value="getTax()" />
+            <t t-set="_term_discount" t-value="getTermDiscount()"/>
+            <div class="font-small">
+                <t t-if="_term_discount !== 0">
+                    <t t-esc="_term_discount"/>% immediate payment discount
+                </t>
+            </div>
             <div class="line">
                 <div class="entry total">
                     <span class="badge">Total: </span>


### PR DESCRIPTION
Account module is not accurately calculating a discount originating in a payment term (in this case, an early payment -> discount on order). However, since POS has to do sale orders without using the Account module, we can do a fix that only addresses the issue for POS orders (the ticket is specifically about POS opw-3763076).

Currently when an order is paid for such that an early payment term discount is applicable, you will have 3 different invoices/journal entry sequences in: the Accounting, POS, and Sales applications. <-- (seems like a problem)

 The only problem here is that if/when the real problem in Account is fixed, components of this fix will have to be modified (assuming this fix gets fw-ported to master). Although, even if this PR is never merged, you would still have to do a lot of fixes in POS because, again, they are doing some redundant/parallel order creation.