### PR TITLE
[FIX] hr_holidays: display warning on wrong accrual balance

### DIFF
--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -39,6 +39,7 @@ TimeOffCardPopover.props = [
     "max_allowed_negative",
     "onClickNewAllocationRequest?",
     "errorLeaves",
+    "accrualExcess",
 ];
 
 export class TimeOffCard extends Component {
@@ -63,17 +64,14 @@ export class TimeOffCard extends Component {
 
     updateWarning() {
         const { data } = this.props;
-        const excess = Math.max(data.exceeding_duration, -data.virtual_remaining_leaves);
-        const exceeding_duration = data.allows_negative
-            ? excess > data.max_allowed_negative
-            : excess > 0;
         const errorLeavesSignificant = data.allows_negative
             ? this.errorLeavesDuration > data.max_allowed_negative
             : this.errorLeavesDuration > 0;
+        const accrualExcess = this.getAccrualExcess(data);
         const closeExpire =
             data.closest_allocation_duration &&
             data.closest_allocation_duration < data.virtual_remaining_leaves;
-        this.warning = errorLeavesSignificant || exceeding_duration || closeExpire;
+        this.warning = errorLeavesSignificant || accrualExcess || closeExpire;
     }
 
     onClickInfo(ev) {
@@ -92,7 +90,14 @@ export class TimeOffCard extends Component {
             max_allowed_negative: data.max_allowed_negative,
             onClickNewAllocationRequest: this.newAllocationRequestFrom.bind(this),
             errorLeaves: this.errorLeaves,
+            accrualExcess: this.getAccrualExcess(data),
         });
+    }
+
+    getAccrualExcess(data) {
+        return data.allows_negative
+            ? -data.exceeding_duration > data.max_allowed_negative
+            : -data.exceeding_duration > 0;
     }
 
     async newAllocationRequestFrom() {

--- a/addons/hr_holidays/static/src/dashboard/time_off_card.xml
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.xml
@@ -68,21 +68,21 @@
             <li class="d-flex justify-content-between border-bottom">Planned: <span class="ps-1" t-esc="props.planned"/></li>
             <li class="d-flex justify-content-between">Available: <span class="ps-1" t-esc="props.left"/></li>
         </ul>
-        <div t-if="props.warning" class="alert alert-warning mb-0 o_time_off_card_popover_warning">
-            <span class="m-0 mt-3"
+        <div t-if="props.warning" class="alert alert-warning mb-0 pb-0 o_time_off_card_popover_warning">
+            <span class="d-inline-block m-0 mb-3"
                 t-if="props.errorLeaves.length">
                 Some leaves cannot be linked to any allocation. To see those leaves, 
                 <a t-on-click="() => this.openLeaves()" class="cursor-pointer">click here</a>.
             </span>
-            <span class="m-0 mt-3"
-                t-elif="props.closest &amp;&amp; props.closest &lt; props.left">
+            <span class="d-inline-block m-0 mb-3"
+                t-if="props.closest &amp;&amp; props.closest &lt; props.left">
                 <i class="fa fa-warning"/> Only <t t-esc="props.closest"/>
                 <t t-if="props.request_unit == 'hour'"> hours</t>
                 <t t-else=""> days</t>
                 can be used before the allocation expires.
             </span>
-            <span class="m-0 mt-3"
-                t-else="">
+            <span class="d-inline-block m-0 mb-3"
+                t-if="props.accrualExcess">
                 The leaves planned in the future are exceeding the maximum value of the allocation.
                 It will not be possible to take all of them.
             </span>


### PR DESCRIPTION
__Description of the issue:__
The way that accrual works now is that future leaves are not taken into account for the balance both for the dashboard display and upon taking leaves.
It is then possible to create situation that would lead to issues by taking leaves in a certain order; those issue are avoided with a cron that automatically cancels those issuing leaves. However, if leaves are causing issues and might be cancelled by the cron, a warning should appear on the dashboard of the employee to indicate that issue.

To reproduce the issue:
- Have any kind of accrual plan; the demo seniority for example
- Have a time off type that requires allocation
- Create an allocation for any employee for that accrual plan starting now and manually grant 1 day
- Go on that employee's dashboard
- Create a leave in a few days: it should be possible because one day is available for the employee
- Create another one the day before: the system allows it but it  is a discrepancy in the balance
- Look on the balance for the time off type: no warning is displayed

__Expected behaviour:__
There should be a warning after the creation of the second

__Description of the bugfix:__
This commit fixes the way the excess is detected to make it accurate. Additionally, the different warning messages were previously made incompatible with one another though they're not linked; this commit allows multiple warning messages if multiple are to be displayed.

task-3859558