### PR TITLE
[FIX] spreadsheet: correctly get pivot id from position

### DIFF
--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -79,7 +79,10 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
                 const { col, row } = event.anchor.cell;
                 const cell = this.getters.getCell({ sheetId, col, row });
                 if (cell !== undefined && cell.content.startsWith("=ODOO.PIVOT.HEADER(")) {
-                    const filters = this._getFiltersMatchingPivot(cell.compiledFormula.tokens);
+                    const filters = this._getFiltersMatchingPivot(
+                        sheetId,
+                        cell.compiledFormula.tokens
+                    );
                     this.dispatch("SET_MANY_GLOBAL_FILTER_VALUE", { filters });
                 }
                 break;
@@ -198,7 +201,7 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
     getPivotIdFromPosition(position) {
         const cell = this.getters.getCorrespondingFormulaCell(position);
         if (cell && cell.isFormula) {
-            const pivotFunction = this.getters.getFirstPivotFunction(cell.compiledFormula.tokens);
+            const pivotFunction = this.getters.getFirstPivotFunction(position.sheetId, cell.compiledFormula.tokens);
             if (pivotFunction && pivotFunction.args[0]) {
                 return pivotFunction.args[0].toString();
             }
@@ -206,7 +209,11 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
         return undefined;
     }
 
-    getFirstPivotFunction(tokens) {
+    /**
+     * @param {string} sheetId sheet id on which the formula tokens are
+     * @param {import("@odoo/o-spreadsheet").Token[]} tokens
+     */
+    getFirstPivotFunction(sheetId, tokens) {
         const pivotFunction = getFirstPivotFunction(tokens);
         if (!pivotFunction) {
             return undefined;
@@ -223,7 +230,7 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
                 return argAst.value;
             }
             const argsString = astToFormula(argAst);
-            return this.getters.evaluateFormula(this.getters.getActiveSheetId(), argsString);
+            return this.getters.evaluateFormula(sheetId, argsString);
         });
         return { functionName, args: evaluatedArgs };
     }
@@ -255,6 +262,7 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
         }
         const mainPosition = this.getters.getCellPosition(cell.id);
         const { args, functionName } = this.getters.getFirstPivotFunction(
+            position.sheetId,
             cell.compiledFormula.tokens
         );
         if (functionName === "ODOO.PIVOT.TABLE") {
@@ -364,12 +372,13 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
 
     /**
      * Get the filter impacted by a pivot formula's argument
-     * @param {Token[]} tokens Formula of the pivot cell
+     * @param {string} sheetId sheet id on which the formula tokens are
+     * @param {import("@odoo/o-spreadsheet").Token[]} tokens Formula of the pivot cell
      *
      * @returns {Array<Object>}
      */
-    _getFiltersMatchingPivot(tokens) {
-        const functionDescription = this.getters.getFirstPivotFunction(tokens);
+    _getFiltersMatchingPivot(sheetId, tokens) {
+        const functionDescription = this.getters.getFirstPivotFunction(sheetId, tokens);
         if (!functionDescription) {
             return [];
         }

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
@@ -71,8 +71,9 @@ const DEFAULT_FIELD_MATCHINGS = {
 };
 
 function getFiltersMatchingPivot(model, formula) {
+    const sheetId = model.getters.getActiveSheetId();
     const pivotUIPlugin = model["handlers"].find((handler) => handler instanceof PivotUIPlugin);
-    return pivotUIPlugin._getFiltersMatchingPivot(tokenize(formula));
+    return pivotUIPlugin._getFiltersMatchingPivot(sheetId, tokenize(formula));
 }
 
 QUnit.module("spreadsheet > Global filters model", {}, () => {

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
@@ -125,6 +125,21 @@ QUnit.module("spreadsheet > pivot plugin", {}, () => {
     );
 
     QUnit.test(
+        "can get a Pivot from cell formula where the id is a reference in an inactive sheet",
+        async function (assert) {
+            const { model } = await createSpreadsheetWithPivot();
+            const firstSheetId = model.getters.getActiveSheetId();
+            model.dispatch("CREATE_SHEET", { sheetId: "2" });
+            model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: firstSheetId, sheetIdTo: "2" });
+            setCellContent(model, "A1", "1");
+            setCellContent(model, "A2", '=ODOO.PIVOT(A1,"probability")');
+            model.dispatch("ACTIVATE_SHEET", { sheetIdFrom: "2", sheetIdTo: firstSheetId });
+            const pivotId = model.getters.getPivotIdFromPosition({ sheetId: "2", col: 0, row: 1 });
+            assert.strictEqual(pivotId, "1");
+        }
+    );
+
+    QUnit.test(
         "can select a Pivot from cell formula (Mix of test scenarios above)",
         async function (assert) {
             const { model } = await createSpreadsheetWithPivot({


### PR DESCRIPTION
Steps to reproduce in 17.0:

There's no way to reproduce the issue in 17.0 because the faulty getter in only called on positions in the active sheet (pivot autofill, global filter auto-matching)

Steps to reproduce in saas-17.1:

- insert a pivot in a blank spreadsheet
- delete all pivot formulas
- insert a new sheet
- in the new sheet:
	- in A1: type "1"
	- in A2: =ODOO.PIVOT(A1)
- activate the first sheet again
- Open the Data menu => the pivot 1 is marked as being unused, even though it's used in the second
   sheet

Task: 3859472

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
