### PR TITLE
[IMP] mail: silent mail during tests

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -14,7 +14,7 @@ import pytz
 from collections import defaultdict
 from dateutil.parser import parse
 
-from odoo import _, api, fields, models, registry, SUPERUSER_ID
+from odoo import _, api, fields, models, modules, registry, SUPERUSER_ID
 from odoo import tools
 from odoo.addons.base.models.ir_mail_server import MailDeliveryException
 
@@ -639,9 +639,10 @@ class MailMail(models.Model):
                     mail_server=mail_server,
                     post_send_callback=post_send_callback,
                 )
-                _logger.info(
-                    'Sent batch %s emails via mail server ID #%s',
-                    len(batch_ids), mail_server_id)
+                if not modules.module.current_test:
+                    _logger.info(
+                        'Sent batch %s emails via mail server ID #%s',
+                        len(batch_ids), mail_server_id)
             finally:
                 if smtp_session:
                     smtp_session.quit()
@@ -756,7 +757,8 @@ class MailMail(models.Model):
                             raise
                 if res:  # mail has been sent at least once, no major exception occurred
                     mail.write({'state': 'sent', 'message_id': res, 'failure_reason': False})
-                    _logger.info('Mail with ID %r and Message-Id %r successfully sent', mail.id, mail.message_id)
+                    if not modules.module.current_test:
+                        _logger.info('Mail with ID %r and Message-Id %r successfully sent', mail.id, mail.message_id)
                     # /!\ can't use mail.state here, as mail.refresh() will cause an error
                     # see revid:odo@openerp.com-20120622152536-42b2s28lvdv3odyr in 6.1
                 mail._postprocess_sent_message(success_pids=success_pids, failure_type=failure_type)

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -20,7 +20,7 @@ from OpenSSL.crypto import Error as SSLCryptoError, FILETYPE_PEM
 from OpenSSL.SSL import Error as SSLError
 from urllib3.contrib.pyopenssl import PyOpenSSLContext
 
-from odoo import api, fields, models, tools, _
+from odoo import api, fields, models, tools, _, modules
 from odoo.exceptions import UserError
 from odoo.tools import ustr, pycompat, formataddr, email_normalize, encapsulate_email, email_domain_extract, email_domain_normalize, human_size
 
@@ -374,9 +374,8 @@ class IrMailServer(models.Model):
            longer raised.
         """
         # Do not actually connect while running in test mode
-        if self._is_test_mode():
+        if modules.module.current_test:
             return
-
         mail_server = smtp_encryption = None
         if mail_server_id:
             mail_server = self.sudo().browse(mail_server_id)
@@ -730,8 +729,8 @@ class IrMailServer(models.Model):
         smtp_from, smtp_to_list, message = self._prepare_email_message(message, smtp)
 
         # Do not actually send emails in testing mode!
-        if self._is_test_mode():
-            _test_logger.info("skip sending email in test mode")
+        if modules.module.current_test:
+            _test_logger.debug("skip sending email in test mode")
             return message['Message-Id']
 
         try:
@@ -858,11 +857,3 @@ class IrMailServer(models.Model):
         else:
             self.smtp_port = 25
         return result
-
-    def _is_test_mode(self):
-        """Return True if we are running the tests, so we do not send real emails.
-
-        Can be overridden in tests after mocking the SMTP lib to test in depth the
-        outgoing mail server.
-        """
-        return getattr(threading.current_thread(), 'testing', False) or self.env.registry.in_test_mode()

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -7,7 +7,7 @@ from contextlib import contextmanager
 from unittest.mock import patch, Mock
 
 from odoo.tests.common import new_test_user, TransactionCase, HttpCase
-from odoo import Command
+from odoo import Command, modules
 
 DISABLED_MAIL_CONTEXT = {
     'tracking_disable': True,
@@ -445,7 +445,7 @@ class MockSmtplibCase:
 
         with patch('smtplib.SMTP_SSL', side_effect=lambda *args, **kwargs: self.testing_smtp_session), \
              patch('smtplib.SMTP', side_effect=lambda *args, **kwargs: self.testing_smtp_session), \
-             patch.object(type(IrMailServer), '_is_test_mode', lambda self: False), \
+             patch.object(modules.module, 'current_test', False), \
              patch.object(type(IrMailServer), 'connect', mock_function(connect_origin)) as connect_mocked, \
              patch.object(type(IrMailServer), '_find_mail_server', mock_function(find_mail_server_origin)) as find_mail_server_mocked:
             self.connect_mocked = connect_mocked.mock
@@ -463,7 +463,7 @@ class MockSmtplibCase:
         )
 
     def _send_email(self, msg, smtp_session):
-        with patch.object(threading.current_thread(), 'testing', False):
+        with patch.object(modules.module, 'current_test', False):
             self.env['ir.mail_server'].send_email(msg, smtp_session=smtp_session)
         return smtp_session.messages.pop()
 

--- a/odoo/addons/base/tests/test_ir_mail_server_smtpd.py
+++ b/odoo/addons/base/tests/test_ir_mail_server_smtpd.py
@@ -11,6 +11,7 @@ from pathlib import Path
 from unittest.mock import patch
 from socket import getaddrinfo  # keep a reference on the non-patched function
 
+from odoo import modules
 from odoo.exceptions import UserError
 from odoo.tools import file_path, mute_logger
 from .common import TransactionCaseWithUserDemo
@@ -137,9 +138,8 @@ class TestIrMailServerSMTPD(TransactionCaseWithUserDemo):
         # reactivate sending emails during this test suite, make sure
         # NOT TO send emails using another ir.mail_server than the one
         # created in setUp!
-        patcher = patch.object(cls.registry['ir.mail_server'], '_is_test_mode')
-        mock = patcher.start()
-        mock.return_value = False
+        patcher = patch.object(modules.module, 'current_test', False)
+        patcher.start()
         cls.addClassCleanup(patcher.stop)
 
         # fix runbot, docker uses a single ipv4 stack but it gives ::1


### PR DESCRIPTION
The mail loggers can be noisy during tests, lets mute them in this scope
While on it, also adapt in_test_mode by a more robust current_test check
