### PR TITLE
[IMP] pos_loyalty: sell physical giftcard from terminal

### DIFF
--- a/addons/pos_loyalty/models/__init__.py
+++ b/addons/pos_loyalty/models/__init__.py
@@ -11,6 +11,5 @@ from . import pos_config
 from . import pos_order_line
 from . import pos_order
 from . import pos_session
-from . import res_config_settings
 from . import product_product
 from . import res_partner

--- a/addons/pos_loyalty/models/pos_config.py
+++ b/addons/pos_loyalty/models/pos_config.py
@@ -7,15 +7,6 @@ from odoo.exceptions import UserError
 class PosConfig(models.Model):
     _inherit = 'pos.config'
 
-    gift_card_settings = fields.Selection(
-        [
-            ("create_set", "Generate PDF cards"),
-            ("scan_use", "Scan existing cards"),
-        ],
-        string="Gift Cards settings",
-        default="create_set",
-        help="Defines the way you want to set your gift cards.",
-    )
     # NOTE: this funtions acts as a m2m field with loyalty.program model. We do this to handle an excpetional use case:
     # When no PoS is specified at a loyalty program form, this program is applied to every PoS (instead of none)
     def _get_program_ids(self):
@@ -63,11 +54,10 @@ class PosConfig(models.Model):
                 reward = gc_program.reward_ids
                 if reward.reward_type != 'discount' or reward.discount_mode != 'per_point' or reward.discount != 1:
                     raise UserError(_('Invalid gift card program reward. Use 1 currency per point discount.'))
-                if self.gift_card_settings == "create_set":
-                    if not gc_program.mail_template_id:
-                        raise UserError(_('There is no email template on the gift card program and your pos is set to print them.'))
-                    if not gc_program.pos_report_print_id:
-                        raise UserError(_('There is no print report on the gift card program and your pos is set to print them.'))
+                if not gc_program.mail_template_id:
+                    raise UserError(_('There is no email template on the gift card program and your pos is set to print them.'))
+                if not gc_program.pos_report_print_id:
+                    raise UserError(_('There is no print report on the gift card program and your pos is set to print them.'))
 
         return super()._check_before_creating_new_session()
 

--- a/addons/pos_loyalty/models/pos_order.py
+++ b/addons/pos_loyalty/models/pos_order.py
@@ -73,7 +73,7 @@ class PosOrder(models.Model):
         coupon_create_vals = [{
             'program_id': p['program_id'],
             'partner_id': get_partner_id(p.get('partner_id', False)),
-            'code': p.get('barcode') or self.env['loyalty.card']._generate_code(),
+            'code': p.get('code') or p.get('barcode') or self.env['loyalty.card']._generate_code(),
             'points': 0,
             'source_pos_order_id': self.id,
         } for p in coupons_to_create.values()]

--- a/addons/pos_loyalty/models/res_config_settings.py
+++ b/addons/pos_loyalty/models/res_config_settings.py
@@ -1,9 +1,0 @@
-# -*- coding: utf-8 -*-
-
-from odoo import fields, models, api
-
-
-class ResConfigSettings(models.TransientModel):
-    _inherit = 'res.config.settings'
-
-    pos_gift_card_settings = fields.Selection(related='pos_config_id.gift_card_settings', readonly=False)

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
@@ -3,6 +3,8 @@ import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_su
 import { patch } from "@web/core/utils/patch";
 import { ask } from "@point_of_sale/app/store/make_awaitable_dialog";
 import { useService } from "@web/core/utils/hooks";
+import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
+import { ManageGiftCardPopup } from "@pos_loyalty/utils/manage_giftcard_popup/manage_giftcard_popup";
 
 patch(OrderSummary.prototype, {
     setup() {
@@ -90,6 +92,94 @@ patch(OrderSummary.prototype, {
         const result = await super._showDecreaseQuantityPopup();
         if (result) {
             this.pos.updateRewards();
+        }
+    },
+
+    /**
+     * Updates the order line with the gift card information:
+     * 1. Reduce the quantity if greater than one, otherwise remove the order line.
+     * 2. Add a new order line with updated gift card code and points, removing any existing related couponPointChanges.
+     */
+    async _updateGiftCardOrderline(code, points) {
+        let selectedLine = this.currentOrder.get_selected_orderline();
+        const product = selectedLine.product_id;
+
+        if (selectedLine.get_quantity() > 1) {
+            selectedLine.set_quantity(selectedLine.get_quantity() - 1);
+        } else {
+            this.currentOrder.removeOrderline(selectedLine);
+        }
+
+        const program = this.pos.models["loyalty.program"].find(
+            (p) => p.program_type === "gift_card"
+        );
+        const existingCouponIds = Object.keys(this.currentOrder.uiState.couponPointChanges).filter(
+            (key) => {
+                const change = this.currentOrder.uiState.couponPointChanges[key];
+                return (
+                    change.points === product.lst_price &&
+                    change.program_id === program.id &&
+                    change.product_id === product.id &&
+                    !change.manual
+                );
+            }
+        );
+        if (existingCouponIds.length) {
+            const couponId = existingCouponIds.shift();
+            delete this.currentOrder.uiState.couponPointChanges[couponId];
+        }
+
+        await this.pos.addLineToCurrentOrder({ product_id: product }, { price_unit: points });
+        selectedLine = this.currentOrder.get_selected_orderline();
+        selectedLine.gift_code = code;
+    },
+
+    manageGiftCard() {
+        this.dialog.add(ManageGiftCardPopup, {
+            title: _t("Sell/Manage physical gift card"),
+            placeholder: _t("Enter Gift Card Number"),
+            getPayload: async (code, points) => {
+                points = parseFloat(points);
+                if (isNaN(points)) {
+                    console.error("Invalid amount value:", points);
+                    return;
+                }
+                code = code.trim();
+                const res = await this.pos.data.searchRead(
+                    "loyalty.card",
+                    ["&", ["program_type", "=", "gift_card"], ["code", "=", code]],
+                    []
+                );
+                if (res.length > 0) {
+                    this.notification.add(_t("This Gift card is already been sold."), {
+                        type: "danger",
+                    });
+                    return;
+                }
+
+                // check for duplicate code
+                if (this.currentOrder.duplicateCouponChanges(code)) {
+                    this.dialog.add(ConfirmationDialog, {
+                        title: _t("Validation Error"),
+                        body: _t("A coupon/loyalty card must have a unique code."),
+                    });
+                    return;
+                }
+
+                await this._updateGiftCardOrderline(code, points);
+                this.currentOrder.processGiftCard(code, points);
+
+                // update indexedDB
+                this.pos.data.syncDataWithIndexedDB(this.pos.data.records);
+            },
+        });
+    },
+
+    clickLine(ev, orderline) {
+        if (orderline.isSelected() && orderline.getEWalletGiftCardProgramType() === "gift_card") {
+            return;
+        } else {
+            super.clickLine(ev, orderline);
         }
     },
 });

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.xml
@@ -5,6 +5,10 @@
             <li t-if="line.isGiftCardOrEWalletReward()">
                 Current Balance: <t t-esc="line.getGiftCardOrEWalletBalance()"/>
             </li>
+            <t t-if="!line.isGiftCardOrEWalletReward() and line.getEWalletGiftCardProgramType() === 'gift_card'">
+                <a t-if="!line.gift_code" class="text-wrap text-primary" t-on-click="manageGiftCard">Sell physical gift card?</a>
+                <div t-if="line.gift_code" class="text-wrap" t-esc="line.gift_code"/>
+            </t>
         </xpath>
         <xpath expr="//OrderWidget/t[@t-set-slot='details']" position="inside">
             <t t-foreach="pos.get_order()?.getLoyaltyPoints() or []" t-as="_loyaltyStat" t-key="_loyaltyStat.couponId">

--- a/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_loyalty/static/src/overrides/models/pos_order_line.js
@@ -12,6 +12,12 @@ patch(PosOrderline, {
             type: "many2one",
             local: true,
         },
+        gift_code: {
+            model: "pos.order.line",
+            name: "gift_code",
+            type: "char",
+            local: true,
+        },
         _gift_barcode: {
             model: "pos.order.line",
             name: "_gift_barcode",

--- a/addons/pos_loyalty/static/src/utils/manage_giftcard_popup/manage_giftcard_popup.js
+++ b/addons/pos_loyalty/static/src/utils/manage_giftcard_popup/manage_giftcard_popup.js
@@ -1,0 +1,60 @@
+import { Component, onMounted, useRef, useState } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+
+export class ManageGiftCardPopup extends Component {
+    static template = "pos_loyalty.ManageGiftCardPopup";
+    static components = { Dialog };
+    static props = {
+        title: String,
+        placeholder: { type: String, optional: true },
+        rows: { type: Number, optional: true },
+        getPayload: Function,
+        close: Function,
+    };
+    static defaultProps = {
+        startingValue: "",
+        placeholder: "",
+        rows: 1,
+    };
+
+    setup() {
+        this.state = useState({
+            inputValue: this.props.startingValue,
+            amountValue: "",
+            error: false,
+            amountError: false,
+        });
+        this.inputRef = useRef("input");
+        this.amountInputRef = useRef("amountInput");
+        onMounted(this.onMounted);
+    }
+
+    onMounted() {
+        this.inputRef.el.focus();
+    }
+
+    addBalance() {
+        if (!this.validateCode()) {
+            return;
+        }
+        this.props.getPayload(this.state.inputValue, parseFloat(this.state.amountValue));
+        this.props.close();
+    }
+
+    close() {
+        this.props.close();
+    }
+
+    validateCode() {
+        const { inputValue, amountValue } = this.state;
+        if (inputValue.trim() === "") {
+            this.state.error = true;
+            return false;
+        }
+        if (amountValue.trim() === "") {
+            this.state.amountError = true;
+            return false;
+        }
+        return true;
+    }
+}

--- a/addons/pos_loyalty/static/src/utils/manage_giftcard_popup/manage_giftcard_popup.xml
+++ b/addons/pos_loyalty/static/src/utils/manage_giftcard_popup/manage_giftcard_popup.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="pos_loyalty.ManageGiftCardPopup">
+        <Dialog title="props.title" size="'md'">
+            <input id="code" t-att-rows="props.rows" class="form-control form-control-lg mx-auto" type="text" t-model="state.inputValue" t-ref="input" t-att-placeholder="props.placeholder" t-att-style="state.error ? 'border-color: red;' : ''" />
+            <div class="mt-3">
+                <div class="col align-items-center d-flex">
+                    <div class="col-form-label text-center pe-0 me-3 fs-5">Amount</div>
+                    <div class="flex-grow-1">
+                        <input id="amount" class="form-control form-control-lg" type="number" t-model="state.amountValue" t-ref="amountInput" placeholder="Enter amount" t-att-style="state.amountError ? 'border-color: red;' : ''"/>
+                    </div>
+                </div>
+            </div>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary o-default-button" t-on-click="addBalance">Add Balance</button>
+            </t>
+        </Dialog>
+    </t>
+</templates>

--- a/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
+++ b/addons/pos_loyalty/static/tests/tours/gift_card_program_tour.js
@@ -1,12 +1,11 @@
 import * as PosLoyalty from "@pos_loyalty/../tests/tours/utils/pos_loyalty_util";
 import * as ProductScreen from "@point_of_sale/../tests/tours/utils/product_screen_util";
-import * as TextInputPopup from "@point_of_sale/../tests/tours/utils/text_input_popup_util";
 import * as Dialog from "@point_of_sale/../tests/tours/utils/dialog_util";
 import { registry } from "@web/core/registry";
 import * as TicketScreen from "@point_of_sale/../tests/tours/utils/ticket_screen_util";
 import * as Order from "@point_of_sale/../tests/tours/utils/generic_components/order_widget_util";
 
-registry.category("web_tour.tours").add("GiftCardProgramCreateSetTour1", {
+registry.category("web_tour.tours").add("GiftCardProgramTour1", {
     test: true,
     steps: () =>
         [
@@ -17,7 +16,7 @@ registry.category("web_tour.tours").add("GiftCardProgramCreateSetTour1", {
         ].flat(),
 });
 
-registry.category("web_tour.tours").add("GiftCardProgramCreateSetTour2", {
+registry.category("web_tour.tours").add("GiftCardProgramTour2", {
     test: true,
     steps: () =>
         [
@@ -25,30 +24,6 @@ registry.category("web_tour.tours").add("GiftCardProgramCreateSetTour2", {
             PosLoyalty.enterCode("044123456"),
             PosLoyalty.orderTotalIs("0.00"),
             PosLoyalty.finalizeOrder("Cash", "0"),
-        ].flat(),
-});
-
-registry.category("web_tour.tours").add("GiftCardProgramScanUseTour", {
-    test: true,
-    steps: () =>
-        [
-            Dialog.confirm("Open session"),
-            // Pay the 5$ gift card.
-            ProductScreen.clickDisplayedProduct("Gift Card"),
-            TextInputPopup.inputText("043123456"),
-            Dialog.confirm(),
-            PosLoyalty.orderTotalIs("5.00"),
-            PosLoyalty.finalizeOrder("Cash", "5"),
-            // Partially use the gift card. (4$)
-            ProductScreen.addOrderline("Desk Pad", "2", "2", "4.0"),
-            PosLoyalty.enterCode("043123456"),
-            PosLoyalty.orderTotalIs("0.00"),
-            PosLoyalty.finalizeOrder("Cash", "0"),
-            // Use the remaining of the gift card. (5$ - 4$ = 1$)
-            ProductScreen.addOrderline("Whiteboard Pen", "6", "6", "36.0"),
-            PosLoyalty.enterCode("043123456"),
-            PosLoyalty.orderTotalIs("35.00"),
-            PosLoyalty.finalizeOrder("Cash", "35"),
         ].flat(),
 });
 
@@ -98,13 +73,8 @@ registry.category("web_tour.tours").add("PosLoyaltyPointsGiftcard", {
     steps: () =>
         [
             Dialog.confirm("Open session"),
-            ProductScreen.clickDisplayedProduct("Gift Card"),
-            TextInputPopup.inputText("044123456"),
-            // pressing enter should confirm the text input popup
-            {
-                trigger: ".modal textarea",
-                run: "press Enter",
-            },
+            ProductScreen.addOrderline("Gift Card", "1", "50", "50"),
+            PosLoyalty.createManualGiftCard("044123456", 50),
             PosLoyalty.orderTotalIs("50.00"),
             PosLoyalty.finalizeOrder("Cash", "50"),
             ProductScreen.clickPartnerButton(),
@@ -122,14 +92,37 @@ registry.category("web_tour.tours").add("PosLoyaltyGiftCardTaxes", {
     steps: () =>
         [
             Dialog.confirm("Open session"),
-            ProductScreen.clickDisplayedProduct("Gift Card"),
-            TextInputPopup.inputText("044123456"),
-            Dialog.confirm(),
+            ProductScreen.addOrderline("Gift Card", "1", "50", "50"),
+            PosLoyalty.createManualGiftCard("044123456", 50),
             PosLoyalty.orderTotalIs("50.00"),
             PosLoyalty.finalizeOrder("Cash", "50"),
             ProductScreen.clickDisplayedProduct("Test Product A"),
             PosLoyalty.enterCode("044123456"),
             PosLoyalty.orderTotalIs("50.00"),
             ProductScreen.checkTaxAmount("-6.52"),
+        ].flat(),
+});
+
+registry.category("web_tour.tours").add("PhysicalGiftCardProgramSaleTour", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.addOrderline("Gift Card", "1", "50", "50"),
+            PosLoyalty.createManualGiftCard("test-card-0000", 125),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "125"),
+            PosLoyalty.orderTotalIs("125"),
+            PosLoyalty.finalizeOrder("Cash", "125"),
+            ProductScreen.addOrderline("Gift Card", "1", "50", "50"),
+            PosLoyalty.createManualGiftCard("test-card-0001", 100),
+            PosLoyalty.clickPhysicalGiftCard("test-card-0001"),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "100"),
+            ProductScreen.addOrderline("Gift Card", "1", "50", "50"),
+            PosLoyalty.createManualGiftCard("new-card-0001", 250),
+            PosLoyalty.clickPhysicalGiftCard("new-card-0001"),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "250"),
+            PosLoyalty.orderTotalIs("350"),
+            PosLoyalty.finalizeOrder("Cash", "350"),
         ].flat(),
 });

--- a/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
+++ b/addons/pos_loyalty/static/tests/tours/utils/pos_loyalty_util.js
@@ -123,3 +123,35 @@ export function checkAddedLoyaltyPoints(points) {
         },
     ];
 }
+
+export function createManualGiftCard(code, amount) {
+    return [
+        {
+            trigger: `a:contains("Sell physical gift card?")`,
+            run: "click",
+        },
+        {
+            content: `Input code '${code}'`,
+            trigger: `input[id="code"]`,
+            run: `edit ${code}`,
+        },
+        {
+            content: `Input amount '${amount}'`,
+            trigger: `input[id="amount"]`,
+            run: `edit ${amount}`,
+        },
+        {
+            trigger: `.btn-primary:contains("Add Balance")`,
+            run: "click",
+        },
+    ];
+}
+
+export function clickPhysicalGiftCard(code = "Sell physical gift card?") {
+    return [
+        {
+            trigger: `ul.info-list .text-wrap:contains("${code}")`,
+            run: "click",
+        },
+    ];
+}

--- a/addons/pos_loyalty/views/res_config_settings_view.xml
+++ b/addons/pos_loyalty/views/res_config_settings_view.xml
@@ -7,9 +7,6 @@
         <field name="arch" type="xml">
             <xpath expr="//setting[@id='pos-loyalty']" position="inside">
                 <div class="content-group" invisible="not module_loyalty">
-                    <div class="mt16 o_light_label" id="pos_gift_card_settings" invisible="is_kiosk_mode">
-                        <field name="pos_gift_card_settings" colspan="4" nolabel="1" widget="radio"/>
-                    </div>
                     <div class="mt8">
                         <button name="%(loyalty.loyalty_program_discount_loyalty_action)d" icon="oi-arrow-right" type="action" string="Discount &amp; Loyalty" class="btn-link"/>
                     </div>


### PR DESCRIPTION
Before the commit:
---
Gift card codes were generated automatically, without any option for manual input or selling physical gift cards.

After the commit:
---
- Added the "Sell Physical Gift Card" option under the "Gift Card" product in POS.
- Allows for the manual input of gift card numbers.
- Orders generate gift cards with entered numbers.
- Existing gift cards can have amounts added.

Related PR:
- Upgrade: https://github.com/odoo/upgrade/pull/6363

task-3647760