### PR TITLE
[FIX] web: Make bold font works in Firefox

### DIFF
--- a/addons/web/static/src/scss/bootstrap_overridden.scss
+++ b/addons/web/static/src/scss/bootstrap_overridden.scss
@@ -115,7 +115,7 @@ $caret-width: 4px !default;
 // Font, line-height, and color for body text, headings, and more.
 
 $font-weight-normal: 400 !default;
-$font-weight-bold: 500 !default;
+$font-weight-bold: 600 !default;
 $font-weight-bolder: 700 !default;
 
 $font-family-sans-serif: $o-font-family-sans-serif !default;


### PR DESCRIPTION
font-weight: 500 doesn't work with Firefox

Steps:
 - Open Contact app for example
 - Internal notes
 - Add some text
 - Make it bold
 - Works in Chrome but not in Firefox

` font-weight: 600;` seems to works on both of them see https://stackoverflow.com/a/72234364

opw-3795512