### PR TITLE
[FIX] web, *: autocomplete cancels search on click out

### DIFF
--- a/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
+++ b/addons/partner_autocomplete/static/src/js/partner_autocomplete_fieldchar.js
@@ -73,6 +73,9 @@ export class PartnerAutoCompleteCharField extends CharField {
             }
         });
         this.props.record.update(data.company);
+        if (this.props.setDirty) {
+            this.props.setDirty(false);
+        }
     }
 }
 

--- a/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
+++ b/addons/partner_autocomplete/static/tests/partner_autocomplete_tests.js
@@ -4,11 +4,11 @@ import { browser } from "@web/core/browser/browser";
 import { registry } from "@web/core/registry";
 import {
     click,
+    editInput,
     editSelect,
     getFixture,
     patchWithCleanup,
     triggerEvent,
-    editInput,
 } from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { loadJS } from "@web/core/assets";
@@ -348,18 +348,20 @@ QUnit.module('partner_autocomplete', {
         }
     });
 
-    QUnit.test("Show confirmation dialog on input blur", async function (assert) {
-        assert.expect(1);
+    QUnit.test("Click out after edition", async function (assert) {
+        assert.expect(2);
         await makeView(makeViewParams);
         const input = target.querySelector("[name=parent_id] input.o-autocomplete--input.o_input");
         await triggerEvent(input, null, "focus");
         await click(input);
         await editInput(input, null, "go");
+        assert.strictEqual(input.value, "go");
+        await triggerEvent(target, null, "pointerdown");
         await triggerEvent(input, null, "blur");
-        assert.containsOnce(target, ".modal-open");
+        assert.strictEqual(input.value, "");
     });
 
-    QUnit.test("Hide auto complate suggestion for no create", async function (assert) {
+    QUnit.test("Hide auto complete suggestion for no create", async function (assert) {
         const partnerMakeViewParams = {
             ...makeViewParams,
             arch:

--- a/addons/purchase_product_matrix/static/src/js/purchase_product_field.js
+++ b/addons/purchase_product_matrix/static/src/js/purchase_product_field.js
@@ -22,10 +22,7 @@ export class PurchaseOrderLineProductField extends Many2OneField {
             super_update(recordlist);
         };
         if (this.props.canQuickCreate) {
-            this.quickCreate = (name, params = {}) => {
-                if (params.triggeredOnBlur) {
-                    return this.openConfirmationDialog(name);
-                }
+            this.quickCreate = (name) => {
                 isInternalUpdate = true;
                 return this.props.update([false, name]);
             };

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -16,10 +16,7 @@ export class SaleOrderLineProductField extends Many2OneField {
             super_update(recordlist);
         };
         if (this.props.canQuickCreate) {
-            this.quickCreate = (name, params = {}) => {
-                if (params.triggeredOnBlur) {
-                    return this.openConfirmationDialog(name);
-                }
+            this.quickCreate = (name) => {
                 isInternalUpdate = true;
                 return this.props.update([false, name]);
             };

--- a/addons/sale/static/tests/sale_product_field_tests.js
+++ b/addons/sale/static/tests/sale_product_field_tests.js
@@ -1,7 +1,13 @@
 /** @odoo-module **/
 
 import {
-    getFixture, patchWithCleanup, addRow, editInput, triggerEvent, click } from "@web/../tests/helpers/utils";
+    getFixture,
+    patchWithCleanup,
+    addRow,
+    editInput,
+    triggerHotkey,
+    nextTick
+} from "@web/../tests/helpers/utils";
 import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 import { browser } from "@web/core/browser/browser";
 
@@ -34,7 +40,7 @@ QUnit.module("Fields", (hooks) => {
                 },
                 'sale.order.line': {
                     fields: {
-                        product_template_id: { 
+                        product_template_id: {
                             string: "Product",
                             type: "many2one",
                             relation: "product.template",
@@ -82,7 +88,7 @@ QUnit.module("Fields", (hooks) => {
 
     QUnit.module("Sale product field");
 
-    QUnit.test("blurring input with incomplete text will propose to create product", async function (assert) {
+    QUnit.test("pressing tab with incomplete text will create a product", async function (assert) {
 
         await makeView({
             type: "form",
@@ -106,23 +112,16 @@ QUnit.module("Fields", (hooks) => {
         // add a line and enter new product name
         await addRow(target, ".o_field_x2many_list");
         await editInput(target, "[name='product_template_id'] input", "new product");
-
-        // blur input => should ask for confirmation if we want to create product
-        await triggerEvent(target, "[name='product_template_id'] input", "blur");
-        assert.containsOnce(target, ".modal:contains(Create new product as a new Product)")
+        await triggerHotkey("tab");
+        await nextTick();
         assert.verifySteps([
             "get_views",
             "onchange",
             "onchange",
             "name_search",
-        ]);
-
-        await click(target, ".modal button.btn-primary");
-        assert.verifySteps([
             "name_create",
             "get_single_product_variant",
         ]);
-
     });
 
 });

--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -88,6 +88,16 @@ export class AutoComplete extends Component {
         this.state.activeSourceOption = null;
     }
 
+    cancel() {
+        if (this.inputRef.el.value.length) {
+            if (this.props.autoSelect) {
+                this.inputRef.el.value = this.props.value;
+                this.props.onCancel();
+            }
+        }
+        this.close();
+    }
+
     async loadSources(useInput) {
         this.sources = [];
         this.state.activeSourceOption = null;
@@ -219,20 +229,9 @@ export class AutoComplete extends Component {
             this.ignoreBlur = false;
             return;
         }
-        const value = this.inputRef.el.value;
-        if (
-            this.props.autoSelect &&
-            this.state.activeSourceOption &&
-            value.length > 0 &&
-            value !== this.props.value
-        ) {
-            this.selectOption(this.state.activeSourceOption, { triggeredOnBlur: true });
-        } else {
-            this.props.onBlur({
-                inputValue: value,
-            });
-            this.close();
-        }
+        this.props.onBlur({
+            inputValue: this.inputRef.el.value,
+        });
     }
     onInputClick() {
         if (!this.isOpened) {
@@ -279,7 +278,7 @@ export class AutoComplete extends Component {
                 if (!this.isOpened) {
                     return;
                 }
-                this.close();
+                this.cancel();
                 break;
             case "tab":
                 if (!this.isOpened) {
@@ -327,7 +326,7 @@ export class AutoComplete extends Component {
 
     externalClose(ev) {
         if (this.isOpened && !this.root.el.contains(ev.target)) {
-            this.close();
+            this.cancel();
         }
     }
 }
@@ -351,6 +350,7 @@ Object.assign(AutoComplete, {
         placeholder: { type: String, optional: true },
         autoSelect: { type: Boolean, optional: true },
         resetOnSelect: { type: Boolean, optional: true },
+        onCancel: { type: Function, optional: true },
         onInput: { type: Function, optional: true },
         onChange: { type: Function, optional: true },
         onBlur: { type: Function, optional: true },
@@ -359,6 +359,7 @@ Object.assign(AutoComplete, {
     defaultProps: {
         placeholder: "",
         autoSelect: false,
+        onCancel: () => {},
         onInput: () => {},
         onChange: () => {},
         onBlur: () => {},

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -90,10 +90,7 @@ export class Many2OneField extends Component {
         };
 
         if (this.props.canQuickCreate) {
-            this.quickCreate = (name, params = {}) => {
-                if (params.triggeredOnBlur) {
-                    return this.openConfirmationDialog(name);
-                }
+            this.quickCreate = (name) => {
                 return this.props.update([false, name]);
             };
         }

--- a/addons/web/static/src/views/fields/properties/property_value.js
+++ b/addons/web/static/src/views/fields/properties/property_value.js
@@ -104,16 +104,20 @@ export class PropertyValue extends Component {
                 const hasAccess = many2manyValue[1] !== null;
                 return {
                     id: many2manyValue[0],
-                    text: hasAccess ? many2manyValue[1] : _lt('No Access'),
-                    onClick: hasAccess && this.clickableRelational
-                        && (async () => await this._openRecord(this.props.comodel, many2manyValue[0])),
+                    text: hasAccess ? many2manyValue[1] : _lt("No Access"),
+                    onClick:
+                        hasAccess &&
+                        this.clickableRelational &&
+                        (async () => await this._openRecord(this.props.comodel, many2manyValue[0])),
                     onDelete:
-                        !this.props.readonly && hasAccess
-                        && (() => this.onMany2manyDelete(many2manyValue[0])),
+                        !this.props.readonly &&
+                        hasAccess &&
+                        (() => this.onMany2manyDelete(many2manyValue[0])),
                     colorIndex: 0,
-                    img: this.showAvatar && hasAccess
-                        ? `/web/image/${this.props.comodel}/${many2manyValue[0]}/avatar_128`
-                        : null,
+                    img:
+                        this.showAvatar && hasAccess
+                            ? `/web/image/${this.props.comodel}/${many2manyValue[0]}/avatar_128`
+                            : null,
                 };
             });
         } else if (this.props.type === "tags") {
@@ -134,7 +138,10 @@ export class PropertyValue extends Component {
         }
         let domain = new Domain(this.props.domain);
         if (this.props.type === "many2many" && this.props.value) {
-            domain = Domain.and([domain, [['id', 'not in', this.props.value.map(rec => rec[0])]]])
+            domain = Domain.and([
+                domain,
+                [["id", "not in", this.props.value.map((rec) => rec[0])]],
+            ]);
         }
         return domain.toList();
     }
@@ -180,8 +187,10 @@ export class PropertyValue extends Component {
      * @returns {boolean}
      */
     get showAvatar() {
-        return ["many2one", "many2many"].includes(this.props.type)
-            && ["res.users", "res.partner"].includes(this.props.comodel);
+        return (
+            ["many2one", "many2many"].includes(this.props.type) &&
+            ["res.users", "res.partner"].includes(this.props.comodel)
+        );
     }
 
     /* --------------------------------------------------------
@@ -283,10 +292,6 @@ export class PropertyValue extends Component {
      * @param {object} params
      */
     async onQuickCreate(name, params = {}) {
-        if (params.triggeredOnBlur) {
-            this.onValueChange(false);
-            return;
-        }
         const result = await this.orm.call(this.props.comodel, "name_create", [name], {
             context: this.props.context,
         });

--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -215,6 +215,9 @@ export class Many2XAutocomplete extends Component {
             this.props.setInputFloats(true);
         }
     }
+    onCancel() {
+        this.props.setInputFloats(false);
+    }
 
     onSelect(option, params = {}) {
         if (option.action) {

--- a/addons/web/static/src/views/fields/relational_utils.xml
+++ b/addons/web/static/src/views/fields/relational_utils.xml
@@ -56,6 +56,7 @@
             onSelect.bind="onSelect"
             onInput.bind="onInput"
             onChange.bind="onChange"
+            onCancel.bind="onCancel"
         />
         <a role="button" class="o_dropdown_button" draggable="false" />
     </div>

--- a/addons/web/static/tests/core/autocomplete_tests.js
+++ b/addons/web/static/tests/core/autocomplete_tests.js
@@ -121,7 +121,7 @@ QUnit.module("Components", (hooks) => {
         assert.containsOnce(target, ".o-autocomplete--dropdown-menu");
     });
 
-    QUnit.test("close dropdown on escape keydown", async (assert) => {
+    QUnit.test("cancel result on escape keydown", async (assert) => {
         class Parent extends Component {}
         Parent.components = { AutoComplete };
         Parent.template = xml`
@@ -129,20 +129,24 @@ QUnit.module("Components", (hooks) => {
                 value="'Hello'"
                 sources="[{ options: [{ label: 'World' }, { label: 'Hello' }] }]"
                 onSelect="() => {}"
+                autoSelect="true"
             />
         `;
 
         await mount(Parent, target, { env });
         assert.containsNone(target, ".o-autocomplete--dropdown-menu");
+        assert.strictEqual(target.querySelector(".o-autocomplete--input").value, "Hello");
 
         await triggerEvents(target, ".o-autocomplete--input", ["focus", "click"]);
         assert.containsOnce(target, ".o-autocomplete--dropdown-menu");
+        await editInput(target, ".o-autocomplete--input", "H");
 
         await triggerEvent(target, ".o-autocomplete--input", "keydown", { key: "Escape" });
         assert.containsNone(target, ".o-autocomplete--dropdown-menu");
+        assert.strictEqual(target.querySelector(".o-autocomplete--input").value, "Hello");
     });
 
-    QUnit.test("scroll outside should close dropdown", async (assert) => {
+    QUnit.test("scroll outside should cancel result", async (assert) => {
         class Parent extends Component {}
         Parent.components = { AutoComplete };
         Parent.template = xml`
@@ -150,17 +154,21 @@ QUnit.module("Components", (hooks) => {
                 value="'Hello'"
                 sources="[{ options: [{ label: 'World' }, { label: 'Hello' }] }]"
                 onSelect="() => {}"
+                autoSelect="true"
             />
         `;
 
         await mount(Parent, target, { env });
         assert.containsNone(target, ".o-autocomplete--dropdown-menu");
+        assert.strictEqual(target.querySelector(".o-autocomplete--input").value, "Hello");
 
         await click(target, ".o-autocomplete--input");
         assert.containsOnce(target, ".o-autocomplete--dropdown-menu");
+        await editInput(target, ".o-autocomplete--input", "H");
 
         await triggerEvent(target, null, "scroll");
         assert.containsNone(target, ".o-autocomplete--dropdown-menu");
+        assert.strictEqual(target.querySelector(".o-autocomplete--input").value, "Hello");
     });
 
     QUnit.test("scroll inside should keep dropdown open", async (assert) => {
@@ -184,7 +192,33 @@ QUnit.module("Components", (hooks) => {
         assert.containsOnce(target, ".o-autocomplete--dropdown-menu");
     });
 
-    QUnit.test("losing focus should close dropdown", async (assert) => {
+    QUnit.test("losing focus should cancel result", async (assert) => {
+        class Parent extends Component {}
+        Parent.components = { AutoComplete };
+        Parent.template = xml`
+            <AutoComplete
+                value="'Hello'"
+                sources="[{ options: [{ label: 'World' }, { label: 'Hello' }] }]"
+                onSelect="() => {}"
+                autoSelect="true"
+            />
+        `;
+
+        await mount(Parent, target, { env });
+        assert.containsNone(target, ".o-autocomplete--dropdown-menu");
+        assert.strictEqual(target.querySelector(".o-autocomplete--input").value, "Hello");
+
+        await triggerEvents(target, ".o-autocomplete--input", ["focus", "click"]);
+        assert.containsOnce(target, ".o-autocomplete--dropdown-menu");
+        await editInput(target, ".o-autocomplete--input", "H");
+
+        await triggerEvent(target, "", "pointerdown");
+        await triggerEvent(target, ".o-autocomplete--input", "blur");
+        assert.containsNone(target, ".o-autocomplete--dropdown-menu");
+        assert.strictEqual(target.querySelector(".o-autocomplete--input").value, "Hello");
+    });
+
+    QUnit.test("click out after clearing input", async (assert) => {
         class Parent extends Component {}
         Parent.components = { AutoComplete };
         Parent.template = xml`
@@ -197,12 +231,16 @@ QUnit.module("Components", (hooks) => {
 
         await mount(Parent, target, { env });
         assert.containsNone(target, ".o-autocomplete--dropdown-menu");
+        assert.strictEqual(target.querySelector(".o-autocomplete--input").value, "Hello");
 
         await triggerEvents(target, ".o-autocomplete--input", ["focus", "click"]);
         assert.containsOnce(target, ".o-autocomplete--dropdown-menu");
+        await editInput(target, ".o-autocomplete--input", "");
 
+        await triggerEvent(target, "", "pointerdown");
         await triggerEvent(target, ".o-autocomplete--input", "blur");
         assert.containsNone(target, ".o-autocomplete--dropdown-menu");
+        assert.strictEqual(target.querySelector(".o-autocomplete--input").value, "");
     });
 
     QUnit.test("open twice should not display previous results", async (assert) => {
@@ -343,10 +381,9 @@ QUnit.module("Components", (hooks) => {
             onChange() {
                 assert.step("change");
             }
-            onSelect(option, params) {
+            onSelect(option) {
                 target.querySelector(".o-autocomplete--input").value = option.label;
                 assert.step("select " + option.label);
-                assert.notOk(params.triggeredOnBlur);
             }
             onBlur() {
                 assert.step("blur");

--- a/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2many_tags_field_tests.js
@@ -939,7 +939,8 @@ QUnit.module("Fields", (hooks) => {
         await triggerEvent(input, null, "focus");
         await click(input);
         await editInput(input, null, "go");
-        await triggerEvent(input, null, "blur");
+        await triggerHotkey("tab");
+        await nextTick();
 
         assert.containsNone(document.body, ".modal");
         assert.containsOnce(target, ".o_field_many2many_tags .badge");
@@ -953,7 +954,8 @@ QUnit.module("Fields", (hooks) => {
         await click(input);
         await editInput(input, null, "r");
         await triggerEvent(input, null, "keydown", { key: "ArrowDown" });
-        await triggerEvent(input, null, "blur");
+        await triggerHotkey("tab");
+        await nextTick();
         assert.strictEqual(
             target.querySelectorAll(".o_field_many2many_tags .badge")[1].textContent,
             "red",

--- a/addons/web/static/tests/views/fields/many2one_field_tests.js
+++ b/addons/web/static/tests/views/fields/many2one_field_tests.js
@@ -2937,7 +2937,7 @@ QUnit.module("Fields", (hooks) => {
     );
 
     QUnit.test("quick create on a many2one", async function (assert) {
-        assert.expect(2);
+        assert.expect(1);
 
         await makeView({
             type: "form",
@@ -2958,13 +2958,7 @@ QUnit.module("Fields", (hooks) => {
 
         await triggerEvent(target, ".o_field_many2one input", "focus");
         await editInput(target, ".o_field_many2one input", "new partner");
-        await triggerEvent(target, ".o_field_many2one input", "blur");
-
-        assert.strictEqual(
-            target.querySelector(".modal .modal-body").textContent.trim(),
-            "Create new partner as a new Product?"
-        );
-        await click(target, ".modal .modal-footer .btn-primary");
+        await triggerHotkey("tab");
     });
 
     QUnit.test(
@@ -3116,7 +3110,8 @@ QUnit.module("Fields", (hooks) => {
 
         // cancel the many2one creation with Discard button
         await editInput(target, ".o_field_many2one input", "new product");
-        await triggerEvent(target, ".o_field_many2one input", "blur");
+        await triggerHotkey("tab");
+        await nextTick();
 
         assert.containsOnce(target, ".modal", "there should be one opened modal");
 
@@ -3130,7 +3125,8 @@ QUnit.module("Fields", (hooks) => {
 
         // cancel the many2one creation with Close button
         await editInput(target, ".o_field_many2one input", "new product");
-        await triggerEvent(target, ".o_field_many2one input", "blur");
+        await triggerHotkey("tab");
+        await nextTick();
 
         assert.containsOnce(target, ".modal", "there should be one opened modal");
         await click(target, ".modal .modal-header button");
@@ -3151,7 +3147,8 @@ QUnit.module("Fields", (hooks) => {
         );
 
         await editInput(target, ".o_field_many2one input", "new product");
-        await triggerEvent(target, ".o_field_many2one input", "blur");
+        await triggerHotkey("tab");
+        await nextTick();
         assert.containsOnce(target, ".modal", "there should be one opened modal");
 
         await click(target, ".modal .modal-footer .btn:not(.btn-primary)");
@@ -3163,7 +3160,8 @@ QUnit.module("Fields", (hooks) => {
 
         // confirm the many2one creation
         await editInput(target, ".o_field_many2one input", "new product");
-        await triggerEvent(target, ".o_field_many2one input", "blur");
+        await triggerHotkey("tab");
+        await nextTick();
 
         assert.containsOnce(
             target,
@@ -3183,7 +3181,8 @@ QUnit.module("Fields", (hooks) => {
         });
 
         await editInput(target, ".o_field_many2one input", "xph");
-        await triggerEvent(target, ".o_field_many2one input", "blur");
+        await triggerHotkey("tab");
+        await nextTick();
 
         assert.containsNone(target, ".modal");
         assert.strictEqual(target.querySelector(".o_field_many2one input").value, "xphone");
@@ -3204,7 +3203,8 @@ QUnit.module("Fields", (hooks) => {
         });
 
         await editInput(target, ".o_field_many2one input", "new partner");
-        await triggerEvent(target, ".o_field_many2one input", "blur");
+        await triggerHotkey("tab");
+        await nextTick();
 
         assert.containsNone(target, ".modal", "should not display the create modal");
         assert.strictEqual(
@@ -3228,7 +3228,8 @@ QUnit.module("Fields", (hooks) => {
                 </form>`,
         });
         await editInput(target, ".o_field_many2one input", "new partner");
-        await triggerEvent(target, ".o_field_many2one input", "blur");
+        await triggerHotkey("tab");
+        await nextTick();
 
         assert.containsNone(target, ".modal", "should not display the create modal");
         assert.strictEqual(
@@ -3238,30 +3239,33 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
-    QUnit.test("no_quick_create option on a many2one when can_create is absent", async function (assert) {
-        serverData.models.partner.fields.product_id.readonly = true;
-        await makeView({
-            type: "form",
-            resModel: "partner",
-            serverData,
-            arch: `
+    QUnit.test(
+        "no_quick_create option on a many2one when can_create is absent",
+        async function (assert) {
+            serverData.models.partner.fields.product_id.readonly = true;
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
                 <form>
                     <sheet>
                         <field name="product_id" options="{'no_quick_create': 1}" readonly="0" />
                     </sheet>
                 </form>`,
-        });
-        await editInput(target, ".o_field_many2one input", "new partner");
-        assert.containsOnce(
-            target,
-            ".ui-autocomplete .o_m2o_dropdown_option",
-            "Dropdown should be opened and have only one item"
-        );
-        assert.hasClass(
-            target.querySelector(".ui-autocomplete .o_m2o_dropdown_option"),
-            "o_m2o_dropdown_option_create_edit"
-        );
-    });
+            });
+            await editInput(target, ".o_field_many2one input", "new partner");
+            assert.containsOnce(
+                target,
+                ".ui-autocomplete .o_m2o_dropdown_option",
+                "Dropdown should be opened and have only one item"
+            );
+            assert.hasClass(
+                target.querySelector(".ui-autocomplete .o_m2o_dropdown_option"),
+                "o_m2o_dropdown_option_create_edit"
+            );
+        }
+    );
 
     QUnit.test("can_create and can_write option on a many2one", async function (assert) {
         serverData.models.product.options = {
@@ -3446,12 +3450,8 @@ QUnit.module("Fields", (hooks) => {
                 "there should be option for 'No records'"
             );
 
-            await triggerEvent(target, ".o_field_many2one[name=product_id] input", "blur");
-            assert.containsNone(
-                target,
-                ".o_field_many2one[name=product_id] .o_m2o_no_result",
-                "there should be option for 'No records'"
-            );
+            await triggerEvent(target, "", "pointerdown");
+            assert.containsNone(target, ".o_field_many2one[name=product_id] .o_m2o_no_result");
         }
     );
 

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -3218,6 +3218,7 @@ QUnit.module("Views", (hooks) => {
 
     QUnit.test("quick create record: cancel when modal is opened", async (assert) => {
         serverData.views["partner,some_view_ref,form"] = '<form><field name="product_id"/></form>';
+        serverData.views["product,false,form"] = '<form><field name="name"/></form>';
 
         // patch setTimeout s.t. the autocomplete dropdown opens directly
         patchWithCleanup(browser, {
@@ -3243,7 +3244,7 @@ QUnit.module("Views", (hooks) => {
 
         await editInput(target, ".o_kanban_quick_create input", "test");
         await triggerEvent(target, ".o_kanban_quick_create input", "input");
-        await triggerEvent(target, ".o_kanban_quick_create input", "blur");
+        await click(target, ".o_m2o_dropdown_option_create_edit");
 
         // When focusing out of the many2one, a modal to add a 'product' will appear.
         // The following assertions ensures that a click on the body element that has 'modal-open'
@@ -10397,8 +10398,7 @@ QUnit.module("Views", (hooks) => {
             type: "kanban",
             resModel: "partner",
             serverData,
-            arch:
-                `<kanban>
+            arch: `<kanban>
                     <templates>
                         <t t-name="kanban-box">
                             <div class="oe_kanban_global_click">
@@ -13610,13 +13610,14 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".my_kanban_compiler");
     });
 
-    QUnit.test("can quick create a column when pressing enter when input is focused", async (assert) => {
-        await makeView({
-            type: "kanban",
-            resModel: "partner",
-            serverData,
-            arch:
-                `<kanban>
+    QUnit.test(
+        "can quick create a column when pressing enter when input is focused",
+        async (assert) => {
+            await makeView({
+                type: "kanban",
+                resModel: "partner",
+                serverData,
+                arch: `<kanban>
                     <field name="product_id"/>
                     <templates>
                         <t t-name="kanban-box">
@@ -13624,23 +13625,24 @@ QUnit.module("Views", (hooks) => {
                         </t>
                     </templates>
                 </kanban>`,
-            groupBy: ["product_id"],
-        });
+                groupBy: ["product_id"],
+            });
 
-        assert.containsN(target, ".o_kanban_group", 2);
+            assert.containsN(target, ".o_kanban_group", 2);
 
-        await createColumn();
-        
-        // We don't use the editInput helper as it would trigger a change event automatically.
-        // We need to wait for the enter key to trigger the event.
-        const input = target.querySelector(".o_column_quick_create input");
-        input.value = "New Column";
-        await triggerEvent(input, null, "input");
+            await createColumn();
 
-        await triggerEvent(target, ".o_quick_create_unfolded input", "keydown", {
-            key: "Enter",
-        });
+            // We don't use the editInput helper as it would trigger a change event automatically.
+            // We need to wait for the enter key to trigger the event.
+            const input = target.querySelector(".o_column_quick_create input");
+            input.value = "New Column";
+            await triggerEvent(input, null, "input");
 
-        assert.containsN(target, ".o_kanban_group", 3);
-    });
+            await triggerEvent(target, ".o_quick_create_unfolded input", "keydown", {
+                key: "Enter",
+            });
+
+            assert.containsN(target, ".o_kanban_group", 3);
+        }
+    );
 });

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -11899,10 +11899,9 @@ QUnit.module("Views", (hooks) => {
             await editInput(target, ".o_field_many2one input", "abcdef");
             await nextTick();
 
-            // simulate focus out
-            await triggerEvent(target, ".o_field_many2one input", "blur");
+            await click(target, ".o_m2o_dropdown_option_create_edit");
 
-            assert.containsOnce(target, ".modal", "should ask confirmation to create a record");
+            assert.containsOnce(target, ".modal", "should show dialog to create the record");
             assert.containsOnce(target, ".o_data_row", "the row should still be there");
         }
     );
@@ -15355,13 +15354,9 @@ QUnit.module("Views", (hooks) => {
 
         const input = target.querySelector(".o_data_row .o_data_cell input");
         await editInput(input, null, "aaa");
-        await triggerEvents(input, null, ["keyup", "blur"]);
-        document.body.click();
+        await triggerEvents(input, null, ["keyup"]);
+        await triggerHotkey("tab");
         await nextTick();
-        assert.containsOnce(target, ".modal", "the quick_create modal should appear");
-
-        await click(target.querySelector(".modal .btn-primary"));
-        await click(target.querySelector(".o_list_view"));
         assert.strictEqual(
             target.getElementsByClassName("o_data_cell")[0].innerHTML,
             "aaa",


### PR DESCRIPTION
This commit fixes a bug where the value of an autocomplete with autoselect could go into an undefined state where the model value doesn't match the input value but no change is detected. This would happen on escape press, scroll and more recently due to https://github.com/odoo/odoo/pull/159333 on click out. To fix this issue, the commit introduces some change in the autocomplete behavior so that it will no longer select the active option on click out (blur) when autoselect is active and instead it will revert the input value to the one stored into the model. Also applies this behavior on escape key press and scroll for the before mentioned reasons.

Steps to reproduce:
- Go to CRM form view
- Edit the salesperson name to some non existant one and click out (or
scroll or press escape)

Before the fix, the name was stuck to the invalid one but no change was detected so we couldnt save it. Before https://github.com/odoo/odoo/pull/159333, click out would select the active option of the dropdown instead (and launch a dialog for quick create). This is removed because the behavior is neither intuitive nor practical. After the fix, the name is reset to its previous valid value instead. This applies to all autocomplete components with autoselect prop set to true.