### PR TITLE
[FIX] purchase_mrp: handle multiple linked MOs

### DIFF
--- a/addons/purchase_mrp/report/mrp_report_mo_overview.py
+++ b/addons/purchase_mrp/report/mrp_report_mo_overview.py
@@ -17,7 +17,8 @@ class ReportMoOverview(models.AbstractModel):
         for po_line in po_lines:
             line_qty = po_line.product_qty
             for move in po_line.move_dest_ids:
-                linked_production = self.env['stock.move'].browse(move._rollup_move_dests()).raw_material_production_id
+                # Get the newest associated MO
+                linked_production = self.env['stock.move'].browse(move._rollup_move_dests()).raw_material_production_id[-1:]
                 # Only create specific lines for moves directly linked to a manufacturing order
                 if not linked_production:
                     continue


### PR DESCRIPTION
Under certain edge conditions, when creating backorders after partially producing an MO with MTO components, the replenishment logic will fail to conclusively determine which production is responsible for a particular replenishment. This commit fixes that by specifying it's always the newest.

[OPW-3849252](https://www.odoo.com/web#id=3849252&cids=1&menu_id=6478&action=4043&model=project.task&view_type=form)