### PR TITLE
[FIX] web_editor: aligning checklist  items and text

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -143,7 +143,8 @@ ul.o_checklist {
             display: block;
             height: $o-checklist-before-size;
             width: $o-checklist-before-size;
-            top: 4px;
+            top: 50%;
+            transform: translateY(-50%);
             border: 1px solid;
             text-align: center;
             cursor: pointer;


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

The checklist items were misaligned, with checklist positioned at the top of the text on increasing font-size.

Current behavior before PR:

Aligned checklist items and text to ensure they remain properly positioned when increasing the font size.

task-3829735


