### PR TITLE
[FIX] point_of_sale: fix customer display

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1098,9 +1098,9 @@ export class PosStore extends Reactive {
         const orderLines = order.get_orderlines();
         const productImages = Object.fromEntries(
             await Promise.all(
-                orderLines.map(async ({ product }) => [
-                    product.id,
-                    await getProductImage(product.id, product.writeDate),
+                orderLines.map(async ({ product_id }) => [
+                    product_id.id,
+                    await getProductImage(product_id.id, product_id.writeDate),
                 ])
             )
         );


### PR DESCRIPTION
Currently, if you setup a customer display through iot and link it to your point of sale, when you try to add products to your order, you will get an error.

![image](https://github.com/odoo/odoo/assets/36443074/3a389323-43e5-4b32-9960-01789e988940)

This is due to a wrongly named variable "product" which was renamed to "product_id"

After renaming it to "product_id" the customer display works as usual.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
