### PR TITLE
[FIX] {sale_loyalty_,}delivery: apply free shipping in checkout

### DIFF
--- a/addons/delivery/i18n/delivery.pot
+++ b/addons/delivery/i18n/delivery.pot
@@ -721,6 +721,14 @@ msgid "The shipping is free since the order amount exceeds %.2f."
 msgstr ""
 
 #. module: delivery
+#. odoo-python
+#: code:addons/delivery/models/delivery_carrier.py:0
+#, python-format
+msgid ""
+"The shipping is free since the order contains a coupon for free shipping."
+msgstr ""
+
+#. module: delivery
 #: model_terms:ir.actions.act_window,help:delivery.action_delivery_carrier_form
 msgid ""
 "These methods allow to automatically compute the delivery price\n"

--- a/addons/loyalty_delivery/models/__init__.py
+++ b/addons/loyalty_delivery/models/__init__.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from . import delivery_carrier
 from . import loyalty_program
 from . import loyalty_reward
 from . import sale_order

--- a/addons/loyalty_delivery/models/delivery_carrier.py
+++ b/addons/loyalty_delivery/models/delivery_carrier.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import _, models
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = 'delivery.carrier'
+
+    def rate_shipment(self, order):
+        self.ensure_one()
+        res = super().rate_shipment(order)
+        if res:
+            free_shipping = order.order_line.filtered(lambda line: line.reward_id.reward_type == 'shipping')
+            if res['success'] and free_shipping:
+                res['warning_message'] = _('The shipping is free since the order contains a coupon for free shipping.')
+                delivery_price = res['price']
+                discount = free_shipping.reward_id.discount_max_amount or delivery_price
+                res['price'] = max(0.0, delivery_price - discount)
+            return res


### PR DESCRIPTION
Steps to reproduce:
- Install eCommerce, Loyalty
- Create coupon for free shipping
- Apply coupon during checkout

Issues:
The amount displayed isn't right free shipping is not applied.

Solution:
Make sure to compute correctly the shipping cost in the event of a free shipping being in the orderlines.

opw-3830400