### PR TITLE
[FIX] web_editor: select small icons in website editor

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -2137,6 +2137,7 @@ body.editor_enable.editor_has_snippets {
 
                 &.readonly {
                     cursor: auto !important;
+                    pointer-events: none;
 
                     &:after {
                         display: none !important;


### PR DESCRIPTION
This is a backport of: https://github.com/odoo/odoo/commit/8f729148e5531249e5ab5f8c60905cb1c7867f0b

Issue:
======
small icons can't be removed in website editor

Steps to reproduce the issue:
=============================
- Go to website editor
- Change the  navbar template to the sidebar on the left
- Click on the email icon on the side bar
- Click on the blue border of the icon
- Click again on the icon and try to remove it, nothing happens.

Origin of the issue:
====================
The handles are too wide for the small icon so they cover it completely
and we can't put the selection on the icon and the pointer event is
intercepted by the handles.

Solution:
=========
Remove pointer-events for readonly handles.

task-3522397