### PR TITLE
[IMP] Stock: quant update qty fix quant selection

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -161,6 +161,9 @@ class StockQuant(models.Model):
             package_id = self.env['stock.quant.package'].browse(vals.get('package_id'))
             owner_id = self.env['res.partner'].browse(vals.get('owner_id'))
             quant = self._gather(product, location, lot_id=lot_id, package_id=package_id, owner_id=owner_id, strict=True)
+            if lot_id:
+                quant = quant.filtered(lambda q: q.lot_id)
+
             if quant:
                 quant = quant[0]
             else:
@@ -423,7 +426,7 @@ class StockQuant(models.Model):
         quant = None
         if quants:
             # see _acquire_one_job for explanations
-            self._cr.execute("SELECT id FROM stock_quant WHERE id IN %s LIMIT 1 FOR NO KEY UPDATE SKIP LOCKED", [tuple(quants.ids)])
+            self._cr.execute("SELECT id FROM stock_quant WHERE id IN %s ORDER BY lot_id LIMIT 1 FOR NO KEY UPDATE SKIP LOCKED", [tuple(quants.ids)])
             stock_quant_result = self._cr.fetchone()
             if stock_quant_result:
                 quant = self.browse(stock_quant_result[0])

--- a/addons/stock/tests/test_stock_flow.py
+++ b/addons/stock/tests/test_stock_flow.py
@@ -1193,7 +1193,7 @@ class TestStockFlow(TestStockCommon):
         self.assertEqual(lotproduct.qty_available, 10, "Wrong qty available for lotproduct")
         quants = self.StockQuantObj.search([('product_id', '=', lotproduct.id), ('location_id', '=', self.stock_location), ('lot_id', '=', lot1.id)])
         total_qty = sum([quant.quantity for quant in quants])
-        self.assertEqual(total_qty, 10, 'Expecting 0 units lot of lotproduct, but we got %.4f on location stock!' % (total_qty))
+        self.assertEqual(total_qty, 10, 'Expecting 10 units lot of lotproduct, but we got %.4f on location stock!' % (total_qty))
         quants = self.StockQuantObj.search([('product_id', '=', lotproduct.id), ('location_id', '=', self.stock_location), ('lot_id', '=', False)])
         total_qty = sum([quant.quantity for quant in quants])
         self.assertEqual(total_qty, 0, 'Expecting 0 units lot of lotproduct, but we got %.4f on location stock!' % (total_qty))


### PR DESCRIPTION
This is a backport of https://github.com/odoo/odoo/commit/b5d16141dc48d4379452ea40e167f3b00f956c20
And it is based on this opened PR https://github.com/odoo/odoo/pull/113834

Description of the issue/feature this PR addresses:

if there's with multiple lines for the same product, and there's multiple quants to pick the quantities from, it might happen that the same quant is used twice.
When this happens, our customer isn't able to confirm a picking.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
