### PR TITLE
[FIX] project: allow portal user to add image in task description

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -1,11 +1,13 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+import json
+
 from collections import OrderedDict
 from operator import itemgetter
 from markupsafe import Markup
 
 from odoo import conf, http, _
-from odoo.exceptions import AccessError, MissingError
+from odoo.exceptions import AccessError, MissingError, UserError
 from odoo.http import request
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
 from odoo.tools import groupby as groupbyelem
@@ -541,3 +543,43 @@ class ProjectCustomerPortal(CustomerPortal):
             request.session['my_tasks_history'] = task_sudo.ids
         values = self._task_get_page_view_values(task_sudo, access_token, **kw)
         return request.render("project.portal_my_task", values)
+
+    @http.route('/project_sharing/attachment/add_image', type='http', auth='user', methods=['POST'], website=True)
+    def add_image(self, name, data, res_id, access_token=None, **kwargs):
+        res_model = 'project.task'
+        try:
+            task_sudo = self._document_check_access(res_model, int(res_id), access_token=access_token)
+            if not task_sudo.with_user(request.env.uid).project_id._check_project_sharing_access():
+                return request.not_found()
+        except (AccessError, MissingError):
+            raise UserError(_("The document does not exist or you do not have the rights to access it."))
+
+        IrAttachment = request.env['ir.attachment']
+
+        # Avoid using sudo when not necessary: internal users can create attachments,
+        # as opposed to public and portal users.
+        if not request.env.user._is_internal():
+            IrAttachment = IrAttachment.sudo().with_context(binary_field_real_user=IrAttachment.env.user)
+
+        values = IrAttachment._check_contents({
+            'name': name,
+            'datas': data,
+            'res_model': res_model,
+            'res_id': res_id,
+            'access_token': IrAttachment._generate_access_token(),
+        })
+
+        valid_image_mime_types = ['image/jpeg', 'image/png', 'image/bmp', 'image/tiff']
+
+        if values.get('mimetype', False) not in valid_image_mime_types:
+            return request.make_response(
+                data=json.dumps({'error': _('Only images are allowed as attachments')}),
+                headers=[('Content-Type', 'application/json')],
+                status=400
+            )
+
+        attachment = IrAttachment.create(values)
+        return request.make_response(
+            data=json.dumps(attachment.read(['id', 'name', 'mimetype', 'file_size', 'access_token'])[0]),
+            headers=[('Content-Type', 'application/json')]
+        )

--- a/addons/project/i18n/project.pot
+++ b/addons/project/i18n/project.pot
@@ -2983,6 +2983,13 @@ msgid "Once a Month"
 msgstr ""
 
 #. module: project
+#. odoo-python
+#: code:addons/project/controllers/portal.py:0
+#, python-format
+msgid "Only images are allowed as attachments"
+msgstr ""
+
+#. module: project
 #. odoo-javascript
 #: code:addons/project/static/src/project_sharing/components/chatter/chatter_composer.xml:0
 #, python-format
@@ -3767,6 +3774,20 @@ msgstr ""
 #: code:addons/project/models/project_project.py:0
 #, python-format
 msgid "Satisfaction"
+msgstr ""
+
+#. module: project
+#. odoo-javascript
+#: code:addons/project/static/src/project_sharing/views/form/project_sharing_form_controller.js:0
+#, python-format
+msgid "Save the task to be able to paste images in description"
+msgstr ""
+
+#. module: project
+#. odoo-javascript
+#: code:addons/project/static/src/project_sharing/views/form/project_sharing_form_controller.js:0
+#, python-format
+msgid "Save the task to be able to drag images in Description"
 msgstr ""
 
 #. module: project

--- a/addons/project/static/src/project_sharing/editor/odoo_editor.js
+++ b/addons/project/static/src/project_sharing/editor/odoo_editor.js
@@ -1,0 +1,23 @@
+/** @odoo-module **/
+
+import { OdooEditor } from "@web_editor/js/editor/odoo-editor/src/OdooEditor";
+import { patch } from "@web/core/utils/patch";
+
+/**
+ * The goal of this patch is to remove the crop and replace buttons
+ * from the image editor toolbar as the portal user doesn't have
+ * access to save modified attachments.
+ */
+patch(OdooEditor.prototype, "project_sharing_portal_toolbar_media_update", {
+    /**
+     * @override
+     */
+    _updateToolbar(show) {
+        this._super(show);
+        const isInMedia = this.toolbar.classList.contains('oe-media');
+        const cropButton = this.toolbar.querySelector('#image-crop');
+        const replaceButton = this.toolbar.querySelector('#media-replace');
+        cropButton?.classList.toggle('d-none', isInMedia);
+        replaceButton?.classList.toggle('d-none', isInMedia);
+    },
+});

--- a/addons/project/static/src/project_sharing/editor/wysiwyg.js
+++ b/addons/project/static/src/project_sharing/editor/wysiwyg.js
@@ -1,0 +1,48 @@
+/** @odoo-module **/
+
+import { Wysiwyg } from "@web_editor/js/wysiwyg/wysiwyg";
+import { useService } from '@web/core/utils/hooks';
+import { patch } from "@web/core/utils/patch";
+
+/**
+ * The goal of this patch is to allow portal user to add images in html fields
+ */
+patch(Wysiwyg.prototype, "project_sharing_portal_image_save", {
+    /**
+     * @override
+     */
+    setup() {
+        this._super();
+        this.http = useService('http');
+    },
+    /**
+     * @overwrite
+     */
+    async _saveB64Image(el, resModel, resId) {
+        if (resId) {
+            el.classList.remove('o_b64_image_to_save');
+            const params = {
+                name: el.dataset.fileName || '',
+                data: el.getAttribute('src').split('base64,')[1],
+                res_id: resId,
+                access_token: '',
+                csrf_token: odoo.csrf_token,
+            };
+
+            const response = JSON.parse(await this.http.post('/project_sharing/attachment/add_image', params, "text"));
+            if (response.error) {
+                this.notification.add(response.error, { type: 'danger' });
+                el.remove();
+            }
+            else {
+                const attachment = response;
+                let src = "/web/image/" + attachment.id + "-" + attachment.name;
+                if (!attachment.public) {
+                    let accessToken = attachment.access_token;
+                    src += `?access_token=${encodeURIComponent(accessToken)}`;
+                }
+                el.setAttribute('src', src);
+            }
+        }
+    },
+});

--- a/addons/project/static/src/project_sharing/views/form/project_sharing_form_controller.js
+++ b/addons/project/static/src/project_sharing/views/form/project_sharing_form_controller.js
@@ -7,10 +7,13 @@ import { useViewCompiler } from '@web/views/view_compiler';
 import { ProjectSharingChatterCompiler } from './project_sharing_form_compiler';
 import { ChatterContainer } from '../../components/chatter/chatter_container';
 
+const { useExternalListener } = owl;
+
 export class ProjectSharingFormController extends FormController {
     setup() {
         super.setup();
         this.uiService = useService('ui');
+        this.notification = useService('notification');
         const { arch, xmlDoc } = this.archInfo;
         const template = createElement('t');
         const xmlDocChatter = xmlDoc.querySelector("div.oe_chatter");
@@ -19,6 +22,8 @@ export class ProjectSharingFormController extends FormController {
         }
         const mailTemplates = useViewCompiler(ProjectSharingChatterCompiler, arch, { Mail: template }, {});
         this.mailTemplate = mailTemplates.Mail;
+        useExternalListener(window, "paste", this.onGlobalPaste, { capture: true });
+        useExternalListener(window, "drop", this.onGlobalDrop, { capture: true });
     }
 
     get actionMenuItems() {
@@ -27,6 +32,36 @@ export class ProjectSharingFormController extends FormController {
 
     get translateAlert() {
         return null;
+    }
+
+    onGlobalPaste(ev) {
+        ev.preventDefault();
+        if (ev.target.closest('.o_field_widget[name="description"]')) {
+            const items = ev.clipboardData.items;
+            for (let i = 0; i < items.length; i++) {
+                if (items[i].type.indexOf('image') !== -1 && !this.model.root.resId) {
+                    this.notification.add(
+                        this.env._t("Save the task to be able to paste images in description"),
+                        { type: 'warning' },
+                    )
+                    ev.stopImmediatePropagation();
+                    return;
+                }
+            }
+        }
+    }
+
+    onGlobalDrop(ev) {
+        ev.preventDefault();
+        if (ev.target.closest('.o_field_widget[name="description"]')) {
+            if(ev.dataTransfer.files.length > 0 && !this.model.root.resId){
+                this.notification.add(
+                    this.env._t("Save the task to be able to drag images in description"),
+                    { type: 'warning' },
+                )
+                ev.stopImmediatePropagation();
+            }
+        }
     }
 }
 

--- a/addons/project/views/project_sharing_project_task_views.xml
+++ b/addons/project/views/project_sharing_project_task_views.xml
@@ -182,7 +182,9 @@
                     </group>
                     <notebook>
                         <page name="description_page" string="Description">
-                            <field name="description" type="html" options="{'collaborative': true}"/>
+                            <!-- Portal users get some commands disabled, notably /image, as they don't have access to ir.attachment -->
+                            <!-- workaround : They may copy/paste or drag/drop the image into description field -->
+                            <field name="description" type="html" options="{'collaborative': true, 'allowCommandImage': false}"/>
                         </page>
                         <page name="sub_tasks_page" string="Sub-tasks">
                             <field name="child_ids" context="{


### PR DESCRIPTION
To reproduce:
=============
- share a project with a portal user
- connect as the portal user
- on a task paste an image in the description
- save -> AccessError

Problem:
========
Portal user doesn't have the right to create attachments

Solution:
=========
- when saving the record, editor tries to save the image as an attachment by `POST` request on the route `/web_editor/attachment/add_image`

- `/web_editor/attachment/add_image` is not dedicated to portal user, so the save method is patched to modify the route to `/portal/attachment/add`

opw-3774447
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
