### PR TITLE
[FIX] purchase: change tax column placement in purchase order pdf

### DIFF
--- a/addons/purchase/report/purchase_order_templates.xml
+++ b/addons/purchase/report/purchase_order_templates.xml
@@ -49,10 +49,10 @@
                 <thead style="display: table-row-group">
                     <tr>
                         <th name="th_description"><strong>Description</strong></th>
-                        <th name="th_taxes"><strong>Taxes</strong></th>
                         <th name="th_date_req" class="text-center"><strong>Date Req.</strong></th>
                         <th name="th_quantity" class="text-end"><strong>Qty</strong></th>
                         <th name="th_price_unit" class="text-end"><strong>Unit Price</strong></th>
+                        <th name="th_taxes"><strong>Taxes</strong></th>
                         <th name="th_subtotal" class="text-end">
                             <strong>Tax excl.</strong>
                         </th>
@@ -73,9 +73,6 @@
                                     <span t-field="line.name"/>
                                 </td>
                                 <t t-set="taxes" t-value="', '.join([(tax.invoice_label or tax.name) for tax in line.taxes_id])"/>
-                                <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
-                                    <span t-out="taxes">Tax 15%</span>
-                                </td>
                                 <td class="text-center">
                                     <span t-field="line.date_planned"/>
                                 </td>
@@ -85,6 +82,9 @@
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_unit"/>
+                                </td>
+                                <td name="td_taxes" t-attf-class="text-end {{ 'text-nowrap' if len(taxes) &lt; 10 else '' }}">
+                                    <span t-out="taxes">Tax 15%</span>
                                 </td>
                                 <td class="text-end">
                                     <span t-field="line.price_subtotal"


### PR DESCRIPTION
Issue:
In purchase order pdfs, the per product tax column placement is right after the product description.
This is inconsistent with the purchase order form view, and is not the "most natural" place to put it.

After fix:
place tax just after unit price

opw-3859721

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
