### PR TITLE
[FIX] website: fix dynamic snippet js method 

### DIFF
--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.js
@@ -211,7 +211,9 @@ const DynamicSnippet = publicWidget.Widget.extend({
         if (enable === true) {
             this.removeSizeListener = listenSizeChange(this._onSizeChanged.bind(this));
         } else {
-            this.removeSizeListener();
+            if (typeof this.removeSizeListener === 'function') {
+                this.removeSizeListener();
+            }
             delete this.removeSizeListener;
         }
     },


### PR DESCRIPTION
DynamicSnippet._setupSizeChangedManagement()

the problem occurs if removeSizeListener() is not defined and you are trying to call it. This would result in an Odoo Client Error

Description of the issue/feature this PR addresses:
BUG

Current behavior before PR:
Odoo Client Error

Desired behavior after PR is merged:
No Error on WEbsite Snippet Load



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
