### PR TITLE
[FIX] stock: Improve handling of zero-qty moves

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -385,10 +385,10 @@
                                     <field name="is_quantity_done_editable" invisible="1"/>
                                     <field name="product_packaging_id" groups="product.group_stock_packaging"/>
                                     <field name="product_uom_qty" string="Demand" attrs="{'column_invisible': [('parent.immediate_transfer', '=', True)], 'readonly': ['|', ('is_initial_demand_editable', '=', False), '&amp;', '&amp;', ('show_operations', '=', True), ('is_locked', '=', True), ('is_initial_demand_editable', '=', False)]}"/>
-                                    <button type="object" name="action_product_forecast_report" icon="fa-area-chart" 
-                                        attrs="{'invisible': ['|', '&amp;', ('reserved_availability', '=', 0), ('forecast_availability', '&lt;=', 0), '|', ('parent.immediate_transfer', '=', True), '&amp;', ('parent.picking_type_code', '=', 'outgoing'), ('state', '!=', 'draft')]}"/>
-                                    <button type="object" name="action_product_forecast_report" icon="fa-area-chart text-danger" 
-                                        attrs="{'invisible': ['|', '|', ('reserved_availability', '!=', 0), ('forecast_availability', '&gt;', 0), '|', ('parent.immediate_transfer', '=', True), '&amp;', ('parent.picking_type_code', '=', 'outgoing'), ('state', '!=', 'draft')]}"/>
+                                    <button type="object" name="action_product_forecast_report" icon="fa-area-chart"
+                                        attrs="{'invisible': ['&amp;', ('product_uom_qty', '!=', 0), '|', '&amp;', ('reserved_availability', '=', 0), ('forecast_availability', '&lt;=', 0), '|', ('parent.immediate_transfer', '=', True), '&amp;', ('parent.picking_type_code', '=', 'outgoing'), ('state', '!=', 'draft')]}"/>
+                                    <button type="object" name="action_product_forecast_report" icon="fa-area-chart text-danger"
+                                        attrs="{'invisible': ['|', ('product_uom_qty', '=', 0), '|', '|', ('reserved_availability', '!=', 0), ('forecast_availability', '&gt;', 0), '|', ('parent.immediate_transfer', '=', True), '&amp;', ('parent.picking_type_code', '=', 'outgoing'), ('state', '!=', 'draft')]}"/>
                                     <field name="forecast_expected_date" invisible="1"/>
                                     <field name="forecast_availability" string="Reserved"
                                         attrs="{'column_invisible': ['|', '|', ('parent.state', 'in', ['draft', 'done']), ('parent.picking_type_code', '!=', 'outgoing'), ('parent.immediate_transfer', '=', True)]}" widget="forecast_widget"/>


### PR DESCRIPTION
Bug:
- Enable 2-step manufacturing in warehouse
- Create a BoM with 4 components, using 9 qty of every component
- Update quantities to 99 for every component EXCEPT THE SECOND
- Create an MO with the BoM, confirm it
- Open the associated picking (transfer)
- Under Additional Info, set Shipping Policy to 'When all products are ready'
- Picking state should change from 'ready' to 'waiting', because component 2 isn't assigned yet
- Unlock the picking
- Change the demand for component 3 to zero units
- Picking state erroneously changes to 'ready'

Fix:
This is caused by `move.state` being updated out of sync with
`move.product_uom_qty` when changing a move's qty to zero. This
inconsistent combination of fields then triggers an unintended path when
determining the picking state. Fixed by making the picking state logic
more robust, and ensuring that `move.state` and `move.product_uom_qty`
don't get out of sync for zero-qty moves.

Additionally ensures that the forecast widget doesn't show a red icon
for zero-qty moves.

opw-3850635