### PR TITLE
[FIX] website_slides_survey: stop showing not finished attempts

### DIFF
--- a/addons/website_slides_survey/controllers/website_profile.py
+++ b/addons/website_slides_survey/controllers/website_profile.py
@@ -20,6 +20,7 @@ class WebsiteSlidesSurvey(WebsiteProfile):
 
         domain = expression.AND([
             [('survey_id.certification', '=', True)],
+            [('state', '=', 'done')],
             expression.OR([
                 [('email', '=', values['user'].email)],
                 [('partner_id', '=', values['user'].partner_id.id)]


### PR DESCRIPTION
## Issue:

Right now we will be showing as Attemtps (under the website profile in attempts tab) any attempt, even whe we didn't even started the certification yet.

## Steps to reproduce:

1. Install website_slide_survey.
2. Create or go to an existing course logged in.
3. Create or use an exsiting certigication and press the 'Begin certification' and don't start the certification after the redirect.
4. Go to your profile and check for the attemtps.

## Solution:

It will make more sense that we only show the actual attempts, which means that we shouldn't show here the attempts that are not finished, since how user_inputs works and are always created at the time of the link creation, we could just filter out the user_inputs that are not actually valid to show here and show only the proper ones.

opw-3781323
