### PR TITLE
[FIX] pos_restaurant: Grant loyalty points for products only

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -913,7 +913,6 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                             }
                         }
                         const lineQty = (line.reward_product_id ? -line.get_quantity() : line.get_quantity());
-                        totalProductQty += lineQty;
                         if (qtyPerProduct[line.reward_product_id || line.get_product().id]) {
                             qtyPerProduct[line.reward_product_id || line.get_product().id] += lineQty;
                         } else {
@@ -921,6 +920,7 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                         }
                         if(!line.is_reward_line){
                             orderedProductPaid += line.get_price_with_tax();
+                            totalProductQty += lineQty;
                         }
                     }
                 }

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -185,3 +185,21 @@ ProductScreen.exec.addOrderline('Desk Organizer', '3');
 PosLoyalty.exec.finalizeOrder('Cash', '15.3');
 
 Tour.register('PosLoyaltyNextOrderCouponExpirationDate', { test: true, url: '/pos/web' }, getSteps());
+
+startSteps();
+
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer('Test Partner');
+
+ProductScreen.exec.addOrderline('Desk Organizer', '1');
+ProductScreen.exec.addOrderline('Whiteboard Pen', '1');
+
+PosLoyalty.do.clickRewardButton();
+
+PosLoyalty.check.orderTotalIs('5.10');
+PosLoyalty.exec.finalizeOrder('Cash', '5.10');
+
+Tour.register('PosLoyaltyDontGrantPointsForRewardOrderLines', { test: true, url: '/pos/web' }, getSteps());

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1603,3 +1603,43 @@ class TestUi(TestPointOfSaleHttpCommon):
             'PosLoyaltyMinAmountAndSpecificProductTour',
             login='accountman',
         )
+
+    def test_dont_grant_points_reward_order_lines(self):
+        """
+        Make sure that points granted per unit are only given
+        for the product -non reward- lines!
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+
+        loyalty_program = self.env['loyalty.program'].create({
+            'name': 'Loyalty Program',
+            'program_type': 'loyalty',
+            'applies_on': 'both',
+            'trigger': 'auto',
+            'rule_ids': [(0, 0, {
+                'reward_point_amount': 1,
+                'reward_point_mode': 'unit',
+                'minimum_qty': 2,
+            })],
+            'reward_ids': [(0, 0, {
+                'reward_type': 'discount',
+                'discount': 100,
+                'discount_mode': 'percent',
+                'discount_applicability': 'cheapest',
+                'required_points': 2,
+            })],
+        })
+
+        partner = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyDontGrantPointsForRewardOrderLines",
+            login="accountman",
+        )
+
+        loyalty_card = loyalty_program.coupon_ids.filtered(lambda coupon: coupon.partner_id.id == partner.id)
+
+        self.assertTrue(loyalty_card)
+        self.assertFalse(loyalty_card.points)


### PR DESCRIPTION
### Steps to reproduce:
- Install **POS** app.
- Go to **POS** > **Products** > **Discount & Loyalty**
- Create a New program with: 
    - **Program Type:** Loyalty Cards 
    - Conditional rules: 
        - **Minimum Quantity:** 2 
        - **Grant:** 1 Loyalty Points per unit paid
    - Rewards: 
        - **Reward Type:** Discount 
        - **Discount:** 100 % one Cheapest Product 
        - **In exchange of:** 2 Loyalty Points
- Start a new POS session
- Select a Customer
- Add two different products.
- Notice the Loyalty Points of **+2** shown. This is _Correct_
- Click on the **Reward** button
- Notice how the Loyalty Points are now **+3** which is obviously _wrong_ given we only have two products. Basically it's as if the reward line (100% discount) is taken into consideration as the cheapest product.

### Investigation:
- Inside `_updatePrograms`, `pointsForPrograms()` are calculated.
- we sum the lines quantities regardless of whether it's a reward line or not https://github.com/odoo/odoo/blob/e5c3ba58964f47cfd41d337e39e1bf25eaa25379/addons/pos_loyalty/static/src/js/Loyalty.js#L906
- By doing so, the reward lines are taken into consideration and the rule is triggerd by skipping this if clause https://github.com/odoo/odoo/blob/e5c3ba58964f47cfd41d337e39e1bf25eaa25379/addons/pos_loyalty/static/src/js/Loyalty.js#L917-L921

opw-3855323