### PR TITLE
[REF] mail: cleanup mail.message fields

### DIFF
--- a/addons/account_audit_trail/models/mail_message.py
+++ b/addons/account_audit_trail/models/mail_message.py
@@ -28,7 +28,7 @@ class Message(models.Model):
         (self - move_messages).account_audit_log_preview = False
         for message in move_messages:
             title = message.subject or message.preview
-            tracking_value_ids = message.sudo().tracking_value_ids._filter_tracked_field_access(self.env)
+            tracking_value_ids = message.sudo().tracking_value_ids._filter_has_field_access(self.env)
             if not title and tracking_value_ids:
                 title = _("Updated")
             if not title and message.subtype_id and not message.subtype_id.internal:

--- a/addons/account_audit_trail/models/mail_message.py
+++ b/addons/account_audit_trail/models/mail_message.py
@@ -3,7 +3,7 @@
 
 from markupsafe import Markup
 
-from odoo import fields, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 
 
@@ -17,58 +17,63 @@ class Message(models.Model):
         compute="_compute_account_audit_log_move_id",
         search="_search_account_audit_log_move_id",
     )
-    show_audit_log = fields.Boolean(compute="_compute_account_audit_log_move_id", search="_search_show_audit_log")
+    account_audit_log_activated = fields.Boolean(
+        string="Audit Log Activated",
+        compute="_compute_account_audit_log_activated",
+        search="_search_account_audit_log_activated")
 
+    @api.depends('tracking_value_ids')
     def _compute_account_audit_log_preview(self):
-        for message in self:
+        move_messages = self.filtered(lambda m: m.model == 'account.move' and m.res_id)
+        (self - move_messages).account_audit_log_preview = False
+        for message in move_messages:
             title = message.subject or message.preview
             tracking_value_ids = message.sudo().tracking_value_ids._filter_tracked_field_access(self.env)
             if not title and tracking_value_ids:
                 title = _("Updated")
-            elif not title and message.subtype_id and not message.subtype_id.internal:
+            if not title and message.subtype_id and not message.subtype_id.internal:
                 title = message.subtype_id.display_name
-            audit_log_preview = Markup("<div>%s</div>") % title
-            for fmt_vals in tracking_value_ids._tracking_value_format():
-                field_desc = fmt_vals['changedField']
-                old_value = fmt_vals['oldValue']['value']
-                new_value = fmt_vals['newValue']['value']
-                audit_log_preview += Markup(
-                    "<li>%(old_value)s <i class='o_TrackingValue_separator fa fa-long-arrow-right mx-1 text-600' title='%(title)s' role='img' aria-label='%(title)s'></i>%(new_value)s (%(field)s)</li>"
+            audit_log_preview = Markup("<div>%s</div>") % (title or '')
+            audit_log_preview += Markup("<br>").join(
+                Markup(
+                    "%(old_value)s <i class='o_TrackingValue_separator fa fa-long-arrow-right mx-1 text-600' title='%(title)s' role='img' aria-label='%(title)s'></i>%(new_value)s (%(field)s)"
                 ) % {
-                    'old_value': old_value,
-                    'new_value': new_value,
+                    'old_value': fmt_vals['oldValue']['value'],
+                    'new_value': fmt_vals['newValue']['value'],
                     'title': _("Changed"),
-                    'field': field_desc,
+                    'field': fmt_vals['changedField'],
                 }
+                for fmt_vals in tracking_value_ids._tracking_value_format()
+            )
             message.account_audit_log_preview = audit_log_preview
 
+    @api.depends('model', 'res_id')
     def _compute_account_audit_log_move_id(self):
-        messages_of_account_move = self.filtered(lambda m: m.model == 'account.move' and m.res_id)
-        recordset_difference = (self - messages_of_account_move)
-        recordset_difference.update({
-            'account_audit_log_move_id': False,
-            'show_audit_log': False,
+        move_messages = self.filtered(lambda m: m.model == 'account.move' and m.res_id)
+        (self - move_messages).update({
+            "account_audit_log_activated": False,
+            "account_audit_log_move_id": False,
         })
-        moves = self.env['account.move'].sudo().search([
-            ('id', 'in', messages_of_account_move.mapped('res_id')),
-            ('company_id.check_account_audit_trail', '=', True),
-        ])
-        moves_by_id = {m.id: m for m in moves}
-        for message in messages_of_account_move:
-            message.account_audit_log_move_id = moves_by_id.get(message.res_id, False)
-            message.show_audit_log = bool(moves_by_id.get(message.res_id))
+        if move_messages:
+            moves = self.env['account.move'].sudo().search([
+                ('id', 'in', list(set(move_messages.mapped('res_id')))),
+                ('company_id.check_account_audit_trail', '=', True),
+            ])
+            for message in move_messages:
+                message.account_audit_log_activated = message.res_id in moves.ids
+                message.account_audit_log_move_id = message.res_id in moves.ids and message.res_id
 
     def _search_account_audit_log_move_id(self, operator, value):
         if operator in ['=', 'like', 'ilike', '!=', 'not ilike', 'not like'] and isinstance(value, str):
             res_id_domain = [('res_id', 'in', self.env['account.move']._name_search(value, operator=operator))]
-        elif operator in ['=', 'in', '!=', 'not in']:
+        elif operator in ['in', '!=', 'not in']:
             res_id_domain = [('res_id', operator, value)]
         else:
             raise UserError(_('Operation not supported'))
         return [('model', '=', 'account.move')] + res_id_domain
 
-    def _search_show_audit_log(self, operator, value):
+    def _search_account_audit_log_activated(self, operator, value):
         if operator not in ['=', '!='] or not isinstance(value, bool):
             raise UserError(_('Operation not supported'))
         move_query = self.env['account.move']._search([('company_id.check_account_audit_trail', operator, value)])
-        return [('model', '=', 'account.move'), ('res_id', 'in', move_query)]
+        return ['&', ('model', '=', 'account.move'), ('res_id', 'in', move_query)]

--- a/addons/account_audit_trail/report/audit_trail_report_views.xml
+++ b/addons/account_audit_trail/report/audit_trail_report_views.xml
@@ -8,7 +8,6 @@
         <field name="mode">primary</field>
         <field name="arch" type="xml">
             <tree edit="0" delete="0" create="0" action="action_open_document" type="object">
-                <field name="res_id" column_invisible="True"/>
                 <field name="date"/>
                 <field name="author_id" widget="many2one_avatar"/>
                 <field name="account_audit_log_move_id"/>
@@ -27,10 +26,11 @@
                 <field name="account_audit_log_move_id"/>
                 <field name="author_id"/>
                 <field name="date" string="Date"/>
-                <filter string="Update Only" name="update_only" domain="[('tracking_value_ids', '!=', False)]" groups="base.group_system"/>
+                <filter string="Update Only" name="filter_tracking_value_ids"
+                        domain="[('tracking_value_ids', '!=', False)]" groups="base.group_system"/>
                 <group expand="0" string="Group By">
                     <filter string="date" name="group_by_date" domain="[]" context="{'group_by': 'date'}"/>
-                    <filter string="Journal Entry" name="group_by_log_move_id" domain="[]" context="{'group_by': 'res_id'}"/>
+                    <filter string="Journal Entry" name="group_by_res_id" domain="[]" context="{'group_by': 'res_id'}"/>
                 </group>
             </search>
         </field>
@@ -48,9 +48,9 @@
         </field>
         <field name="domain">[
             ('model', '=', 'account.move'),
+            ('res_id', '!=', False),
             ('message_type', '=', 'notification'),
-            ('account_audit_log_move_id', '!=', False),
-            ('show_audit_log', '=', True),
+            ('account_audit_log_activated', '=', True),
         ]</field>
         <field name="search_view_id" ref="view_message_tree_audit_log_search"/>
     </record>

--- a/addons/mail/__manifest__.py
+++ b/addons/mail/__manifest__.py
@@ -2,7 +2,7 @@
 
 {
     'name': 'Discuss',
-    'version': '1.17',
+    'version': '1.18',
     'category': 'Productivity/Discuss',
     'sequence': 145,
     'summary': 'Chat, mail gateway and private channels',

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1015,7 +1015,7 @@ class Message(models.Model):
                     thread["module_icon"] = modules.module.get_module_icon(self.env[message_sudo.model]._original_module)
                 vals["thread"] = thread
             if for_current_user:
-                allowed_tracking_ids = message_sudo.tracking_value_ids._filter_tracked_field_access(self.env)
+                allowed_tracking_ids = message_sudo.tracking_value_ids._filter_has_field_access(self.env)
                 displayed_tracking_ids = allowed_tracking_ids
                 if record and hasattr(record, '_track_filter_for_display'):
                     displayed_tracking_ids = record._track_filter_for_display(displayed_tracking_ids)

--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -3470,7 +3470,7 @@ class MailThread(models.AbstractModel):
         if check_tracking:
             tracking_values = self.env['mail.tracking.value'].sudo().search(
                 [('mail_message_id', '=', message.id)]
-            )._filter_tracked_field_access(self.env)
+            )._filter_has_field_access(self.env)
             if tracking_values and hasattr(record_wlang, '_track_filter_for_display'):
                 tracking_values = record_wlang._track_filter_for_display(tracking_values)
             tracking = [
@@ -4093,20 +4093,15 @@ class MailThread(models.AbstractModel):
         if message.subtype_id and message.subtype_id.description:
             tracking_message = return_line + message.subtype_id.description + return_line
 
-        def _free_access(tracking):
-            model = self.env[tracking.mail_message_id.model]
-            field = model._fields.get(tracking.field_id.name)
-            return field and not field.groups
-
-        for value in message.sudo().tracking_value_ids.filtered(_free_access):
-            if value.field_id.ttype == 'boolean':
-                old_value = str(bool(value.old_value_integer))
-                new_value = str(bool(value.new_value_integer))
+        for tracking in message.sudo().tracking_value_ids._filter_free_field_access():
+            if tracking.field_id.ttype == 'boolean':
+                old_value = str(bool(tracking.old_value_integer))
+                new_value = str(bool(tracking.new_value_integer))
             else:
-                old_value = value.old_value_char if value.old_value_char else str(value.old_value_integer)
-                new_value = value.new_value_char if value.new_value_char else str(value.new_value_integer)
+                old_value = tracking.old_value_char or str(tracking.old_value_integer)
+                new_value = tracking.new_value_char or str(tracking.new_value_integer)
 
-            tracking_message += value.field_id.field_description + ': ' + old_value
+            tracking_message += tracking.field_id.field_description + ': ' + old_value
             if old_value != new_value:
                 tracking_message += ' → ' + new_value
             tracking_message += return_line


### PR DESCRIPTION
Remove useless MailMessage 'description' field.This does not seems used
anymore. Anyway does not seems really interesting as it is either the subject,
either a truncated preview. It was used some time ago with mailing lists
using discuss.channel messages but now that mailing lists use their own
message, no need of a description field anymore.

Cleanup a bit account audit trail code at mail.message level, notably try to make
code smaller and trying to avoid some searches when possible. Use "res_id"
when possible to ease index usage.

Task-3864657