### PR TITLE
[FIX] website_sale: free product confirmation fix

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1693,7 +1693,8 @@ class WebsiteSale(http.Controller):
             return request.redirect('/shop')
 
         if order and not order.amount_total and not tx_sudo:
-            order.with_context(send_email=True).with_user(SUPERUSER_ID).action_confirm()
+            if order.state != 'sale':
+                order.with_context(send_email=True).with_user(SUPERUSER_ID).action_confirm()
             return request.redirect(order.get_portal_url())
 
         # clean context and session, then redirect to the confirmation page


### PR DESCRIPTION
If customer returned to confirmation step,by clicking back arrow from
already confirmed sale order in portal view, if they would not refresh
they would get an error that this Sale Order is not able to be confirmed.
Now, in this case, double confirmation is skipped.

opw-3819450

