### PR TITLE
[FIX] hr_skills: Add skill from "My Profile"

### DIFF
--- a/addons/hr_skills/static/src/fields/skills_one2many.js
+++ b/addons/hr_skills/static/src/fields/skills_one2many.js
@@ -26,7 +26,7 @@ SkillsListRenderer.template = 'hr_skills.SkillsListRenderer';
 
 export class SkillsX2ManyField extends X2ManyField {
     async onAdd({ context, editable } = {}) {
-        const employeeId = this.props.record.resId;
+        const employeeId = this.props.record.resModel === "res.users" ? this.props.record.data.employee_id[0] : this.props.record.resId;
         return super.onAdd({
             editable,
             context: {

--- a/addons/hr_skills/views/hr_views.xml
+++ b/addons/hr_skills/views/hr_views.xml
@@ -148,6 +148,7 @@
             <xpath expr="//page[@name='public']" position="before">
                 <page name="skills_resume" string="Resume">
                     <div class="row">
+                        <field name="employee_id" invisible="1" />
                         <div class="o_hr_skills_group o_group_resume col-lg-7 d-flex">
                             <!-- This field uses a custom tree view rendered by the 'resume_one2many' widget.
                                 Adding fields in the tree arch below makes them accessible to the widget


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Default employee ID send in request context is not the good one, not show in 16, but from 17 with hr_skills_survey it's show so it's easy to detect.

Steps in 17 ut code logic exist since 16:
- Install hr_skills, hr_skills_survey
- Delete all employee except "Mitchel Admin"
- Open "My profile"
- Open "Resume"
- Add a skill

Actual result:
- Error due to missing employee
- default_employee_id is using the current record id so a user id
- default_employee_id is not the correct ID
- Can lead to record not existing error or access error

Expected result:
- No error
- default_employee_id is the correct employee of the user

opw-3852542

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
