### PR TITLE
[IMP] [website_]event_*: improve UI of event form view

### DIFF
--- a/addons/event/models/event_event.py
+++ b/addons/event/models/event_event.py
@@ -130,7 +130,9 @@ class EventEvent(models.Model):
         'res.partner', string='Organizer', tracking=True,
         default=lambda self: self.env.company.partner_id,
         check_company=True)
-    event_type_id = fields.Many2one('event.type', string='Template', ondelete='set null')
+    event_type_id = fields.Many2one(
+        'event.type', string='Template', ondelete='set null',
+        help="Choose a template to auto-fill tickets, communications, descriptions and other fields.")
     event_mail_ids = fields.One2many(
         'event.mail', 'event_id', string='Mail Schedule', copy=True,
         compute='_compute_event_mail_ids', readonly=False, store=True)

--- a/addons/event/views/event_event_views.xml
+++ b/addons/event/views/event_event_views.xml
@@ -15,6 +15,8 @@
                 <header>
                     <button name="%(event_barcode_action_main_view)d"
                         type="action"
+                        class="btn btn-primary"
+                        invisible="not seats_taken"
                         context="{'default_event_id': id}">
                         Registration Desk
                     </button>
@@ -38,17 +40,6 @@
                                 help="Total Registrations for this Event">
                             <field name="seats_taken" widget="statinfo" string="Attendees"/>
                         </button>
-
-                        <button name="%(event_barcode_action_main_view)d"
-                            type="action"
-                            class="oe_stat_button"
-                            icon="fa-mobile"
-                            context="{'default_event_id': id}">
-                            <div class="o_stat_info">
-                                <span class="o_stat_text">Registration Desk</span>
-                            </div>
-                        </button>
-
                     </div>
                     <field name="active" invisible="1"/>
                     <field name="company_id" invisible="1"/>

--- a/addons/event/views/event_ticket_views.xml
+++ b/addons/event/views/event_ticket_views.xml
@@ -77,8 +77,8 @@
                 <field name="start_sale_datetime" optional="show"/>
                 <field name="end_sale_datetime" optional="show"/>
                 <field name="seats_max" sum="Total" width="105px" string="Maximum"/>
-                <field name="seats_taken" sum="Total" width="105px" string="Taken"/>
-                <field name="color" widget="color" optional="show"/>
+                <field name="seats_taken" sum="Total" width="105px" string="Registration"/>
+                <field name="color" widget="color" optional="hidden"/>
             </tree>
         </field>
     </record>

--- a/addons/event_sale/views/event_ticket_views.xml
+++ b/addons/event_sale/views/event_ticket_views.xml
@@ -7,7 +7,7 @@
         <field name="model">event.type.ticket</field>
         <field name="inherit_id" ref="event.event_type_ticket_view_tree_from_type"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
+            <field name="name" position="before">
                 <field name="product_id"
                     context="{
                         'default_type': 'service',
@@ -26,7 +26,7 @@
         <field name="model">event.type.ticket</field>
         <field name="inherit_id" ref="event.event_type_ticket_view_form_from_type"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
+            <field name="name" position="before">
                 <field name="product_id"
                     context="{
                         'default_type': 'service',
@@ -52,7 +52,7 @@
             <field name="end_sale_datetime" position="attributes">
                 <attribute name="string">Sales End</attribute>
             </field>
-            <field name="name" position="after">
+            <field name="name" position="before">
                 <field name="product_id"
                     context="{
                         'default_type': 'service',
@@ -72,7 +72,7 @@
         <field name="model">event.event.ticket</field>
         <field name="inherit_id" ref="event.event_event_ticket_view_form_from_event"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
+            <field name="name" position="before">
                 <field name="product_id"
                     context="{
                         'default_type': 'service',
@@ -91,7 +91,7 @@
         <field name="model">event.event.ticket</field>
         <field name="inherit_id" ref="event.event_event_ticket_view_kanban_from_event"/>
         <field name="arch" type="xml">
-            <field name="name" position="after">
+            <field name="name" position="before">
                 <field name="product_id"/>
                 <field name="price"/>
             </field>

--- a/addons/mass_mailing_event/views/event_views.xml
+++ b/addons/mass_mailing_event/views/event_views.xml
@@ -11,11 +11,11 @@
                 <button name="action_invite_contacts" type="object" string="Invite"
                     class="btn btn-primary"
                     groups="mass_mailing.group_mass_mailing_user"
-                    invisible="not event_registrations_open"/>
+                    invisible="is_finished or not event_registrations_open"/>
                 <button name="action_invite_contacts" type="object" string="Invite"
                     class="btn btn-secondary"
                     groups="mass_mailing.group_mass_mailing_user"
-                    invisible="event_registrations_open"/>
+                    invisible="is_finished or event_registrations_open"/>
                 <button name="action_mass_mailing_attendees" type="object" string="Contact Attendees"
                     groups="mass_mailing.group_mass_mailing_user"
                     invisible="seats_taken == 0"/>

--- a/addons/website_event/views/event_event_views.xml
+++ b/addons/website_event/views/event_event_views.xml
@@ -29,9 +29,11 @@
                 <attribute name="context">{'default_website_id': website_id}</attribute>
                 <attribute name="groups">website.group_multi_website</attribute>
             </xpath>
+            <xpath expr="//button[@name='%(event.event_registration_action_stats_from_event)d']" position="before">
+                <field name="is_published" widget="website_redirect_button"/>
+            </xpath>
             <div name="button_box" position="inside">
                 <field name="website_url" invisible="1"/>
-                <field name="is_published" widget="website_redirect_button"/>
             </div>
             <xpath expr="//div[hasclass('oe_title')]" position="after">
                 <div name="event_menu_configuration" groups="base.group_no_one">

--- a/addons/website_event_exhibitor/views/event_event_views.xml
+++ b/addons/website_event_exhibitor/views/event_event_views.xml
@@ -7,7 +7,7 @@
         <field name="priority" eval="5"/>
         <field name="inherit_id" ref="website_event.event_event_view_form"/>
         <field name="arch" type="xml">
-            <field name="is_published" position="before">
+            <field name="website_url" position="before">
                 <button name="%(event_sponsor_action_from_event)d"
                         type="action"
                         class="oe_stat_button"

--- a/addons/website_event_meet/views/event_event_views.xml
+++ b/addons/website_event_meet/views/event_event_views.xml
@@ -7,7 +7,7 @@
         <field name="inherit_id" ref="website_event.event_event_view_form"/>
         <field name="priority" eval="10"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='is_published']" position="before">
+            <xpath expr="//field[@name='website_url']" position="before">
                 <button class="oe_stat_button" context="{'default_event_id': id, 'search_default_event_id': id}" icon="fa-comments-o" name="%(event_meeting_room_action)d" type="action">
                     <field name="meeting_room_count" string="Rooms" widget="statinfo"/>
                 </button>

--- a/addons/website_event_track/views/event_event_views.xml
+++ b/addons/website_event_track/views/event_event_views.xml
@@ -7,7 +7,7 @@
         <field name="model">event.event</field>
         <field name="priority" eval="3"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='is_published']" position="before">
+            <xpath expr="//field[@name='website_url']" position="before">
                 <button name="%(action_event_track_from_event)d"
                         type="action"
                         class="oe_stat_button"


### PR DESCRIPTION
This PR applies the following general improvements to the event form:

- Removes redundant `Registration Desk` stat button and alters the position
  of a few others to improve accessibility.

- Conditionally changes the look and visibility of some form buttons.

- Adds a tooltip to the `event_type_id` field to familiarize the user about the purpose of that field.

- Swaps the `Name` and `Product` fields to position them better.

- Renames the `seats_taken` field for better readability and makes the `color` field hidden by default.

Task-[3777482](https://www.odoo.com/web#id=3777482&menu_id=4722&cids=2&action=333&active_id=965&model=project.task&view_type=form)