### PR TITLE
[IMP] website_slides: enhance UX for adding questions to quiz

### DIFF
--- a/addons/website_slides/static/src/js/slides_course_quiz_question_form.js
+++ b/addons/website_slides/static/src/js/slides_course_quiz_question_form.js
@@ -14,6 +14,7 @@ var QuestionFormWidget = publicWidget.Widget.extend({
     template: 'slide.quiz.question.input',
     events: {
         'click .o_wslides_js_quiz_validate_question': '_validateQuestion',
+        'click .o_wslides_js_quiz_validate_question_and_new': '_validateQuestionAndNew',
         'click .o_wslides_js_quiz_cancel_question': '_cancelValidation',
         'click .o_wslides_js_quiz_comment_answer': '_toggleAnswerLineComment',
         'click .o_wslides_js_quiz_add_answer': '_addAnswerLine',
@@ -28,6 +29,7 @@ var QuestionFormWidget = publicWidget.Widget.extend({
      * @param options
      */
     init: function (parent, options) {
+        this.parent = parent;
         this.$editedQuestion = options.editedQuestion;
         this.question = options.question || {};
         this.update = options.update;
@@ -113,7 +115,7 @@ var QuestionFormWidget = publicWidget.Widget.extend({
     },
 
     /**
-     * Handler when user click on 'Save' or 'Update' buttons.
+     * Handler when user click on 'Save & Close' or 'Update' buttons.
      * @param ev
      * @private
      */
@@ -124,7 +126,18 @@ var QuestionFormWidget = publicWidget.Widget.extend({
     },
 
     /**
-     * Handler when user click on the 'Cancel' button.
+     * Handler when a user clicks on the 'Save & New' button.
+     * @private
+     */
+    async _validateQuestionAndNew() {
+        await this._createOrUpdateQuestion();
+        if (!document.querySelector(".o_wslides_js_quiz_validation_error")) {
+            this.parent._onCreateQuizClick();
+        }
+    },
+
+    /**
+     * Handler when user click on the 'Discard' button.
      * Calls a method from slides_course_quiz.js widget
      * which will handle the reset of the question display.
      * @private
@@ -146,7 +159,7 @@ var QuestionFormWidget = publicWidget.Widget.extend({
      * @param options
      * @private
      */
-    _createOrUpdateQuestion: async function (options) {
+    _createOrUpdateQuestion: async function (options = {}) {
         var $form = this.$('form');
 
         if (this._isValidForm($form)) {

--- a/addons/website_slides/static/src/xml/slide_quiz_create.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz_create.xml
@@ -71,10 +71,13 @@
 
     <t t-name="slide.quiz.create.buttons">
         <a class="o_wslides_js_quiz_validate_question btn btn-primary text-white border me-1" role="button">
-            <span>Save</span>
+            <span>Save &amp; Close</span>
+        </a>
+        <a class="o_wslides_js_quiz_validate_question_and_new btn btn-primary text-white border me-1" role="button">
+            <span>Save &amp; New</span>
         </a>
         <a class="o_wslides_js_quiz_cancel_question btn btn-light border" role="button">
-            <span>Cancel</span>
+            <span>Discard</span>
         </a>
     </t>
 

--- a/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
+++ b/addons/website_slides/static/tests/tours/slide_course_publisher_standard.js
@@ -99,6 +99,29 @@ wTourUtils.registerWebsitePreviewTour('course_publisher_standard', {
 }],
     slidesTourTools.addImageToSection('Introduction', 'Overview', true),
     slidesTourTools.addPdfToSection('Introduction', 'Exercise', true),
+    slidesTourTools.addQuizToSection(
+        'Introduction',
+        {
+            name: 'quiz',
+            questions: [
+                {
+                    title: 'In which year was this course created?',
+                    options: [{ title: '2024', isCorrect: true }, { title: '2023' }],
+                },
+                {
+                    title: 'Which one would you prefer more in your leisure time?',
+                    options: [{ title: 'Coding' }, { title: 'Sleeping', isCorrect: true }],
+                },
+            ],
+        },
+        true
+    ),
+    [
+        {
+            content: "eLearning: wait for the page to no longer be in questions creation mode.",
+            trigger: ':iframe a.o_wslides_js_quiz_add_question:not(.d-none)',
+        },
+    ]
 //     [
 // {
 //     content: 'eLearning: move new course inside introduction',

--- a/addons/website_slides/static/tests/tours/slides_tour_tools.js
+++ b/addons/website_slides/static/tests/tours/slides_tour_tools.js
@@ -10,6 +10,16 @@ const testPngImage = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAACXBIWXMAAC
 const testPdf = 'JVBERi0xLjEKJWPDtsO2bW1lbnQKMSAwIG9iago8PC9UeXBlIC9DYXRhbG9nCi9QYWdlcyAyIDAgUgo+PgplbmRvYmoKMiAwIG9iago8PC9UeXBlIC9QYWdlcwovS2lkcyBbMyAwIFJdCi9Db3VudCAxCi9NZWRpYUJveCBbMCAwIDIxMCAyOTddCj4+CmVuZG9iagozIDAgb2JqCjw8L1R5cGUgL1BhZ2UKL1BhcmVudCAyIDAgUgovUmVzb3VyY2VzCjw8L0ZvbnQKPDwvRjEKPDwvVHlwZSAvRm9udAovU3VidHlwZSAvVHlwZTEKL0Jhc2VGb250IC9UaW1lcy1Sb21hbgo+Pgo+Pgo+PgovQ29udGVudHMgNCAwIFIKPj4KZW5kb2JqCjQgMCBvYmoKPDwvTGVuZ3RoIDQ4Pj4Kc3RyZWFtCkJUCi9GMSA0OCBUZgo1MCAxMzAgVGQKKFRFU1QpIFRqCkVUCmVuZHN0cmVhbQplbmRvYmoKeHJlZgowIDUKMDAwMDAwMDAwMCA2NTUzNSBmCjAwMDAwMDAwMjEgMDAwMDAgbgowMDAwMDAwMDY5IDAwMDAwIG4KMDAwMDAwMDE0OSAwMDAwMCBuCjAwMDAwMDAyOTggMDAwMDAgbgp0cmFpbGVyCjw8L1Jvb3QgMSAwIFIKL1NpemUgNQo+PgpzdGFydHhyZWYKMzgxCiUlRU9G';
 
 /*
+ * Helpers
+ */
+
+const addSectionContent = (prefix, sectionName) => [{
+    content: 'eLearning: add content to section',
+    trigger: `${prefix}div.o_wslides_slide_list_category_header:contains("${sectionName}") a:contains("Add Content")`,
+    run: "click",
+}]
+
+/*
  * PUBLISHER / CONTENT CREATION
  */
 
@@ -28,21 +38,15 @@ var addSection = function (sectionName, backend = false) {
     content: 'eLearning: create section',
     trigger: prefix + 'footer.modal-footer button:contains("Save")',
     run: "click",
-}, {
-	content: 'eLearning: section created empty',
-	trigger: prefix + 'div.o_wslides_slide_list_category_header:contains("' + sectionName + '")',
-    run: "click",
-}];
+},
+...addSectionContent(prefix, sectionName)];
 };
 
 var addVideoToSection = function (sectionName, saveAsDraft, backend = false) {
     const prefix = backend ? ':iframe ' : '';
 	var base_steps = [
+	...addSectionContent(prefix, sectionName),
 {
-	content: 'eLearning: add content to section',
-	trigger: prefix + 'div.o_wslides_slide_list_category_header:contains("' + sectionName + '") a:contains("Add Content")',
-    run: "click",
-}, {
 	content: 'eLearning: click on video',
 	trigger: prefix + 'a[data-slide-category=video]',
     run: "click",
@@ -77,11 +81,8 @@ var addVideoToSection = function (sectionName, saveAsDraft, backend = false) {
 var addArticleToSection = function (sectionName, pageName, backend) {
     const prefix = backend ? ':iframe ' : '';
 	return [
+    ...addSectionContent(prefix, sectionName),
 {
-	content: 'eLearning: add content to section',
-	trigger: prefix + 'div.o_wslides_slide_list_category_header:contains("' + sectionName + '") a:contains("Add Content")',
-    run: "click",
-}, {
 	content: 'eLearning: click on article',
 	trigger: prefix + 'a[data-slide-category=article]',
     run: "click",
@@ -131,11 +132,8 @@ const compareBase64Content = async (url, name, type, expectedContent) => {
 const addImageToSection = (sectionName, pageName, backend) => {
     const prefix = backend ? ':iframe ' : '';
     return [
+    ...addSectionContent(prefix, sectionName),
 {
-    content: 'eLearning: add content to section',
-    trigger: `${prefix}div.o_wslides_slide_list_category_header:contains("${sectionName}") a:contains("Add Content")`,
-    run: "click",
-}, {
     content: 'eLearning: click on image',
     trigger: `${prefix}a[data-slide-category=infographic]`,
     run: "click",
@@ -196,11 +194,8 @@ const addImageToSection = (sectionName, pageName, backend) => {
 const addPdfToSection = function (sectionName, pageName, backend) {
     const prefix = backend ? ':iframe ' : '';
     return [
+    ...addSectionContent(prefix, sectionName),
 {
-    content: 'eLearning: add content to section',
-    trigger: `${prefix}div.o_wslides_slide_list_category_header:contains("${sectionName}") a:contains("Add Content")`,
-    run: "click",
-}, {
     content: 'eLearning: click on document',
     trigger: `${prefix}a[data-slide-category=document]`,
     run: "click",
@@ -322,12 +317,100 @@ var addNewCourseTag = function (courseTagName, backend) {
 }];
 };
 
+/**
+ * Adds a new quiz to the given section name.
+ *
+ * @param {string} sectionName
+ * @param {{name: string, questions: {title: string, options: {title: string, isCorrect: boolean}[]}[]}} quizConfig
+ * @param {boolean} backend
+ */
+const addQuizToSection = (sectionName, quizConfig, backend) => {
+    const prefix = backend ? ':iframe ' : '';
+    return [
+    ...addSectionContent(prefix, sectionName),
+{
+    content: 'eLearning: click on quiz',
+    trigger: prefix + 'a[data-slide-category=quiz]',
+    run: "click",
+}, {
+    content: 'eLearning: fill quiz title',
+    trigger: prefix + 'input[name=name]',
+    run: `edit ${quizConfig.name}`,
+}, {
+    content: 'eLearning: fill quiz completion time',
+    trigger: prefix + 'input[name=duration]',
+    run: "edit 10",
+}, {
+    content: 'eLearning: create and publish slide',
+    trigger: prefix + 'footer.modal-footer button:contains("Publish")',
+    run: "click",
+},
+    ...addQuizQuestionsSteps(quizConfig.questions, prefix),
+];
+};
+
+/**
+ * Helper function to add options to a quiz question.
+ *
+ * @param {string} prefix
+ * @param {{title: string, isCorrect: boolean}} option
+ * @param {Number} index
+ */
+const addQuizQuestionsOptionSteps = (prefix, option, index) => [
+    {
+        content: `eLearning: enter option ${index + 1}`,
+        trigger: `${prefix}div.list-group .o_wslides_js_quiz_answer:nth-of-type(${index + 1}) input`,
+        run: `edit ${option.title}`,
+    },
+    ...(option.isCorrect ? [{
+            content: 'eLearning: select the correct option',
+            trigger: `${prefix}div.list-group .o_wslides_js_quiz_answer:nth-of-type(${index + 1}) i`,
+            run: "click",
+    },] : []),
+];
+
+/**
+ * When invoked from inside a QUIZ this function adds questions to it.
+ *
+ * @param {{title: string, options: {title: string, isCorrect: boolean}[]}[]} questions
+ * @param {string} prefix
+ */
+const addQuizQuestionsSteps = (questions, prefix) => {
+    return questions.flatMap(({ title, options }, questionIdx, questions) => {
+        return [
+            {
+                content: 'eLearning: add a question',
+                trigger: `${prefix}input[name="question-name"]`,
+                run: `edit ${title}`,
+            },
+            // filling options, and selecting the one having isCorrect: true.
+            ...options.flatMap((option, index) => addQuizQuestionsOptionSteps(prefix, option, index)),
+
+            // On the last iteration when we are adding the last question,
+            // we no longer wish to click SAVE & NEW, rather just SAVE.
+            ...(questionIdx === questions.length - 1 ? [{
+                content: 'eLearning: save the question',
+                trigger: `${prefix}a.o_wslides_js_quiz_validate_question`,
+                run: "click",
+            }] : [{
+                content: 'eLearning: click SAVE & NEW button',
+                trigger: `${prefix}.o_wslides_js_quiz_validate_question_and_new`,
+                run: "click",
+            }, {
+                content: 'eLearning: wait before adding the next question',
+                trigger: `${prefix}.o_wslides_quiz_question_sequence:contains(${questionIdx + 2})`,
+            }]),
+        ];
+    });
+};
+
 export default {
 	addSection: addSection,
 	addImageToSection: addImageToSection,
 	addPdfToSection: addPdfToSection,
 	addVideoToSection: addVideoToSection,
 	addArticleToSection: addArticleToSection,
+	addQuizToSection: addQuizToSection,
 	addExistingCourseTag: addExistingCourseTag,
 	addNewCourseTag: addNewCourseTag,
 };


### PR DESCRIPTION
Before this commit:
- From the front end, open any course.
- Click on `Add Content` and then select `Quiz`.
- Give the quiz an appropriate title, then click `Save & Publish`.
- You will see only 2 buttons. `Save` and `Cancel`.

After this commit:
- The `Save` button has been renamed `Save & Close`, while the `Cancel`
  button has been renamed to `Discard`.
- A new button `Save & New` has been added. It will save the current quiz
  question and simultaneously prompt the user to add a new question.

Task-3850910