### PR TITLE
[FIX] base, website_mass_mailing: remove website style from mailing

### DIFF
--- a/addons/website_mass_mailing/views/snippets_templates.xml
+++ b/addons/website_mass_mailing/views/snippets_templates.xml
@@ -7,6 +7,12 @@
     <t t-call-assets="website.assets_editor" t-js="false"/>
 </template>
 
+<template id="iframe_css_assets_edit_no_website" inherit_id="mass_mailing.iframe_css_assets_edit" name="Remove website style from mailing">
+    <xpath expr="//t[@t-call-assets='web.assets_frontend']" position="attributes">
+        <attribute name="t-exclude">/website</attribute>
+    </xpath>
+</template>
+
 <template id="remove_external_snippets" inherit_id="website.external_snippets">
     <xpath expr="//t[@id='newsletter_snippet']" position="replace"/>
     <xpath expr="//t[@id='newsletter_popup_snippet']" position="replace"/>


### PR DESCRIPTION
The `web.assets_frontend` asset's CSS from `website` are included in the mailing's HTML assets. Because of this the styles of the last visited website apply to the mail template.

This commit fixes this by introducing a `t-exclude` tag on the `t-call-assets` QWeb tag. When defined, any file of the assets that starts with the specified value is excluded from the asset's rendering. This new tag is then used from `website_mass_mailing` to exclude `/website` from the `web.assets_frontend` asset call.

Steps to reproduce:
- Install `website_mass_mailing`.
- Create a mailing with HTML content.
- Setup domains on two websites.
- On each website configure a different font size.
- Go to the mailing form.

=> The font size is the one from the last visited website.

opw-3836519
