### PR TITLE
[FIX] base: prevent duplication of "website_id" during duplicating view

### DIFF
--- a/addons/website/models/ir_ui_view.py
+++ b/addons/website/models/ir_ui_view.py
@@ -20,7 +20,7 @@ class View(models.Model):
     _name = "ir.ui.view"
     _inherit = ["ir.ui.view", "website.seo.metadata"]
 
-    website_id = fields.Many2one('website', ondelete='cascade', string="Website")
+    website_id = fields.Many2one('website', ondelete='cascade', string="Website", copy=False)
     page_ids = fields.One2many('website.page', 'view_id')
     first_page_id = fields.Many2one('website.page', string='Website Page', help='First page linked to this view', compute='_compute_first_page_id')
     track = fields.Boolean(string='Track', default=False, help="Allow to specify for one page of the website to be trackable or not")


### PR DESCRIPTION
When a user duplicates a view of the website menu and subsequently navigates to the website and click on edit the traceback will appear.

Steps to reproduce:
- Install the ``website`` Module
- Open Setting -> Technical -> User Interface -> Views
- Open one view of the website Menu(Home Menu)
- Create a duplicate view of that Menu
- Open the website -> Click on Edit Button.

Traceback: -
```ValueError: too many values to unpack (expected 1)
  File "odoo/models.py", line 5848, in ensure_one
    _id, = self._ids
ValueError: Expected singleton: ir.ui.view(1647, 1648, 1649, 1650, 1654, 1651, 1653, 1652)
  File "odoo/http.py", line 2251, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1827, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1847, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1825, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1832, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2057, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 739, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website/controllers/main.py", line 711, in get_switchable_related_views
    views = request.env["ir.ui.view"].get_related_views(key, bundles=False).filtered(lambda v: v.customize_show)
  File "addons/website/models/ir_ui_view.py", line 277, in get_related_views
    return super(View, self).get_related_views(key, bundles=bundles)
  File "addons/web_editor/models/ir_ui_view.py", line 390, in get_related_views
    views = View._views_get(key, bundles=bundles)
  File "addons/web_editor/models/ir_ui_view.py", line 351, in _views_get
    node = etree.fromstring(view.arch)
  File "odoo/fields.py", line 1202, in __get__
    record.ensure_one()
  File "odoo/models.py", line 5851, in ensure_one
    raise ValueError("Expected singleton: %s" % self)
   ```

This commit will resolve the error by preventing the duplication of the website during duplicating view.

sentry - 4991676595

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
