### PR TITLE
[FIX] web: fix qweb profiler after the update of ace library

### DIFF
--- a/addons/web/static/src/core/debug/profiling/profiling_qweb.scss
+++ b/addons/web/static/src/core/debug/profiling/profiling_qweb.scss
@@ -29,6 +29,12 @@
             }
         }
     }
+    .ace_hidpi .ace_text-layer,
+    .ace_hidpi .ace_gutter-layer,
+    .ace_hidpi .ace_content,
+    .ace_hidpi .ace_gutter {
+        contain: layout !important;
+    }
     .ace_editor {
         overflow: visible;
         .ace_qweb, .ace_tag-name {
@@ -54,6 +60,7 @@
             }
         }
         .ace_gutter {
+            width: 134px !important;
             overflow: visible;
         }
         .ace_gutter-layer {


### PR DESCRIPTION
Before this commit the qweb profiler was broken.

Steps to reproduce:

- enable profiling and record qweb and it's directive for 5 minutes.
- then go to Settings > Configure Document Layout > click on save.
- then go to Settings > Techincal > Profiling and open profile - /web/dataset/call_kw/base.document.layout/onchange?

Observed behavior:
qweb profiler css is not appropriate.

Expected behavior:
qweb profiler should be visible with proper css.

Task-3700415

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
