### PR TITLE
[FIX] mail, project: adapt the task duration tracking during stage change

### DIFF
--- a/addons/mail/models/mail_tracking_duration_mixin.py
+++ b/addons/mail/models/mail_tracking_duration_mixin.py
@@ -80,6 +80,20 @@ class MailTrackingDurationMixin(models.AbstractModel):
         json = defaultdict(lambda: 0)
         previous_date = self.create_date
 
+        # If there is a tracking value to be created, but still in the
+        # precommit values, create a fake one to take it into account.
+        # Otherwise, the duration_tracking value will add time spent on
+        # previous tracked field value to the time spent in the new value
+        # (after writing the stage on the record)
+        if f'mail.tracking.{self._name}' in self.env.cr.precommit.data:
+            if data := self.env.cr.precommit.data.get(f'mail.tracking.{self._name}', {}).get(self.id):
+                new_id = data.get(self._track_duration_field, self.env[self._name]).id
+                if new_id and new_id != self[self._track_duration_field].id:
+                    trackings.append({
+                        'create_date': self.env.cr.now(),
+                        'old_value_integer': data[self._track_duration_field].id,
+                    })
+
         # add "fake" tracking for time spent in the current value
         trackings.append({
             'create_date': self.env.cr.now(),

--- a/addons/project/tests/test_project_task_mail_tracking_duration.py
+++ b/addons/project/tests/test_project_task_mail_tracking_duration.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.mail.tests.mail_tracking_duration_mixin_case import MailTrackingDurationMixinCase
+from odoo.tests import Form
 
 
 class TestProjectTaskMailTrackingDuration(MailTrackingDurationMixinCase):
@@ -18,3 +19,16 @@ class TestProjectTaskMailTrackingDuration(MailTrackingDurationMixinCase):
 
     def test_project_task_queries_batch_mail_tracking_duration(self):
         self._test_queries_batch_duration_tracking()
+
+    def test_task_mail_tracking_duration_during_onchange_stage(self):
+        """
+        Checks that the status bar duration is correctly set during an onchange of its stage_id.
+        """
+        task = self.rec_1
+        task.stage_id = self.stage_1
+        initial_tracking = task.duration_tracking
+        with Form(task) as task_form:
+            task_form.stage_id = self.stage_2
+        final_tracking = task.duration_tracking
+        self.assertEqual(initial_tracking[str(self.stage_1.id)], final_tracking[str(self.stage_1.id)])
+        self.assertEqual(final_tracking[str(self.stage_2.id)], 0)


### PR DESCRIPTION
### Current Behavior:

- Go in the project app, click on a project and click on a task
- Change the stage of the task

The duration spent in the previous stage is displayed in the new stage.

Note: if you refresh the page the bug will disappear.

### Cause of the issue:

The `duration_tracking` of the `project.task` model is a non stored computed json field. During the computation of this field, the previous trackings of the object are retrieved from `mail.tracking.value` model: https://github.com/odoo/odoo/blob/bb0cb2896236ead6b474cd1b3a685ff447716b95/addons/mail/models/mail_tracking_duration_mixin.py#L45-L60 To be sure that these trackings will be correctly retrieved, the model used by the query are even flushed. However, these mail tracking values are only created at the end of the sql transaction because the `_track_finalize` method is part of the precommit hooks of the transaction and is hence only run during the general sql flush: https://github.com/odoo/odoo/blob/784f90d25614e4816ac3ed26f0643b562071edbd/odoo/sql_db.py#L134-L138 https://github.com/odoo/odoo/blob/784f90d25614e4816ac3ed26f0643b562071edbd/odoo/tools/misc.py#L1215-L1221 As such, the mail tracking values generated by the old value of the stage will only be accessible at the end of the transaction and will not be available during the computation duration_tracking run for the project task in its final stage. Leading to an incorrect computation of the field during onchanges:
https://github.com/odoo/odoo/blob/bb0cb2896236ead6b474cd1b3a685ff447716b95/addons/mail/models/mail_tracking_duration_mixin.py#L62-L64

### Fix:

In order for the the mail tracking values generated by the old stage to be present during the final computation of our duration_tracking we trigger the `_track_finalize` precommit hook on the records for which it should be run at the end of the transaction before the execution of our query.

opw-3837359
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
