### PR TITLE
[FIX] web_editor: backport fixes to link zwnbsp mechanism

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2822,7 +2822,7 @@ export class OdooEditor extends EventTarget {
         const selection = this.document.getSelection();
         const [anchorLink, focusLink] = [selection.anchorNode, selection.focusNode]
             .map(node => closestElement(node, 'a:not(.btn)'));
-        const singleLinkInSelection = anchorLink === focusLink && anchorLink && isLinkEligibleForZwnbsp(anchorLink) && anchorLink;
+        const singleLinkInSelection = anchorLink === focusLink && anchorLink && isLinkEligibleForZwnbsp(this.editable, anchorLink) && anchorLink;
         if (singleLinkInSelection) {
             singleLinkInSelection.classList.add('o_link_in_selection');
         }

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -442,6 +442,7 @@ export class OdooEditor extends EventTarget {
 
         // sanitize and mark current position as sanitized
         sanitize(commonAncestor);
+        this._resetLinkInSelection();
         this._pluginCall('sanitizeElement', [commonAncestor]);
         this.options.onPostSanitize(commonAncestor);
     }
@@ -2795,19 +2796,7 @@ export class OdooEditor extends EventTarget {
             // re-trigger the _onSelectionChange.
             return;
         }
-        // Apply the o_link_in_selection class if the selection is in a single
-        // link, remove it otherwise.
-        const [anchorLink, focusLink] = [selection.anchorNode, selection.focusNode]
-            .map(node => closestElement(node, 'a:not(.btn)'));
-        const singleLinkInSelection = anchorLink === focusLink && anchorLink;
-        if (singleLinkInSelection && isLinkEligibleForZwnbsp(singleLinkInSelection)) {
-            singleLinkInSelection.classList.add('o_link_in_selection');
-        }
-        for (const link of this.editable.querySelectorAll('.o_link_in_selection')) {
-            if (link !== singleLinkInSelection) {
-                link.classList.remove('o_link_in_selection');
-            }
-        };
+        this._resetLinkInSelection();
         // Compute the current selection on selectionchange but do not record it. Leave
         // that to the command execution or the 'input' event handler.
         this._computeHistorySelection();
@@ -2825,7 +2814,24 @@ export class OdooEditor extends EventTarget {
             this.options.onCollaborativeSelectionChange(this.getCurrentCollaborativeSelection());
         }
     }
-
+    /**
+     * Apply the o_link_in_selection class if the selection is in a single link,
+     * remove it otherwise.
+     */
+    _resetLinkInSelection() {
+        const selection = this.document.getSelection();
+        const [anchorLink, focusLink] = [selection.anchorNode, selection.focusNode]
+            .map(node => closestElement(node, 'a:not(.btn)'));
+        const singleLinkInSelection = anchorLink === focusLink && anchorLink && isLinkEligibleForZwnbsp(anchorLink) && anchorLink;
+        if (singleLinkInSelection) {
+            singleLinkInSelection.classList.add('o_link_in_selection');
+        }
+        for (const link of this.editable.querySelectorAll('.o_link_in_selection')) {
+            if (link !== singleLinkInSelection) {
+                link.classList.remove('o_link_in_selection');
+            }
+        };
+    }
     /**
      * Returns true if the current selection is inside the editable.
      *

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -2822,7 +2822,8 @@ export class OdooEditor extends EventTarget {
         const selection = this.document.getSelection();
         const [anchorLink, focusLink] = [selection.anchorNode, selection.focusNode]
             .map(node => closestElement(node, 'a:not(.btn)'));
-        const singleLinkInSelection = anchorLink === focusLink && anchorLink && isLinkEligibleForZwnbsp(this.editable, anchorLink) && anchorLink;
+        const singleLinkInSelection = anchorLink === focusLink && anchorLink &&
+            this.editable.contains(anchorLink) && isLinkEligibleForZwnbsp(anchorLink) && anchorLink;
         if (singleLinkInSelection) {
             singleLinkInSelection.classList.add('o_link_in_selection');
         }

--- a/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/OdooEditor.js
@@ -1425,7 +1425,7 @@ export class OdooEditor extends EventTarget {
         let range = getDeepRange(this.editable, { sel, correctTripleClick: true });
         if (!range) return;
         for (const node of descendants(closestBlock(range.commonAncestorContainer))) {
-            if (node.nodeType === Node.TEXT_NODE && node.textContent === '\uFEFF') {
+            if (node.nodeType === Node.TEXT_NODE && [...node.textContent].every(char => char === '\uFEFF')) {
                 const restore = prepareUpdate(...leftPos(node));
                 node.remove();
                 restore(); // Make sure to make <br>s visible if needed.

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -208,7 +208,7 @@ function insert(editor, data, isText = true) {
     } else {
         lastPosition = rightPos(currentNode);
     }
-    if (lastPosition[0] === editor.editable) {
+    if (!editor.options.allowInlineAtRoot && lastPosition[0] === editor.editable) {
         // Correct the position if it happens to be in the editable root.
         lastPosition = getDeepestPosition(...lastPosition);
     }

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -201,7 +201,7 @@ function insert(editor, data, isText = true) {
     selection.removeAllRanges();
     const newRange = new Range();
     let lastPosition;
-    if (currentNode.nodeName === 'A' && isLinkEligibleForZwnbsp(currentNode)) {
+    if (currentNode.nodeName === 'A' && isLinkEligibleForZwnbsp(editor.editable, currentNode)) {
         padLinkWithZws(editor.editable, currentNode);
         currentNode = currentNode.nextSibling;
         lastPosition = getDeepestPosition(...rightPos(currentNode));

--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -201,8 +201,8 @@ function insert(editor, data, isText = true) {
     selection.removeAllRanges();
     const newRange = new Range();
     let lastPosition;
-    if (currentNode.nodeName === 'A' && isLinkEligibleForZwnbsp(editor.editable, currentNode)) {
-        padLinkWithZws(editor.editable, currentNode);
+    if (currentNode.nodeName === 'A' && editor.editable.contains(currentNode) && isLinkEligibleForZwnbsp(currentNode)) {
+        padLinkWithZws(currentNode);
         currentNode = currentNode.nextSibling;
         lastPosition = getDeepestPosition(...rightPos(currentNode));
     } else {

--- a/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/powerbox/Powerbox.js
@@ -208,7 +208,7 @@ export class Powerbox {
                 initialTarget.textContent.split(''),
                 true,
             );
-            this._lastText = diff.bMove.join('');
+            this._lastText = diff.bMove.join('').replaceAll('\ufeff', '');
             const selection = this.options.document.getSelection();
             if (
                 (this._lastText.match(/\s/) && this._currentOpenOptions.closeOnSpace !== false) ||

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -280,7 +280,7 @@ class Sanitize {
                         node.setAttribute('href', urlInfo[0].url);
                     }
                 }
-                padLinkWithZws(this.root, node);
+                padLinkWithZws(node);
             }
             node = node.nextSibling;
         }

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -60,7 +60,8 @@ export function areSimilarElements(node, node2) {
         isNotNoneValue(getComputedStyle(node, ':before').getPropertyValue('content')) ||
         isNotNoneValue(getComputedStyle(node, ':after').getPropertyValue('content')) ||
         isNotNoneValue(getComputedStyle(node2, ':before').getPropertyValue('content')) ||
-        isNotNoneValue(getComputedStyle(node2, ':after').getPropertyValue('content'))
+        isNotNoneValue(getComputedStyle(node2, ':after').getPropertyValue('content')) ||
+        isFontAwesome(node) || isFontAwesome(node2)
     ) {
         return false;
     }

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/sanitize.js
@@ -264,10 +264,15 @@ class Sanitize {
                     // the node because these two methods create different
                     // mutations and at least the tour system breaks if all we
                     // send here is a text content change.
-                    const newTextNode = document.createTextNode(newText);
-                    node.before(newTextNode);
+                    let replacement;
+                    if (newText.length) {
+                        replacement = document.createTextNode(newText);
+                        node.before(replacement);
+                    } else {
+                        replacement = node.parentElement;
+                    }
                     node.remove();
-                    node = newTextNode;
+                    node = replacement; // The node has been removed, update the reference.
                 }
             }
 

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1123,26 +1123,25 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
         }
     }
 }
-export const isLinkEligibleForZwnbsp = (editable, link) => {
-    return link.isContentEditable && editable.contains(link) && !(
+export const isLinkEligibleForZwnbsp = link => {
+    return link.isContentEditable && !(
         [link, ...link.querySelectorAll('*')].some(el => el.nodeName === 'IMG' || isBlock(el)) ||
         link.matches('nav a, a.nav-link')
-    )
+    );
 }
 /**
  * Take a link and pad it with non-break zero-width spaces to ensure that it is
  * always possible to place the cursor at its inner and outer edges.
  *
- * @param {HTMLElement} editable
  * @param {HTMLAnchorElement} link
  */
-export const padLinkWithZws = (editable, link) => {
-    if (!isLinkEligibleForZwnbsp(editable, link)) {
+export const padLinkWithZws = link => {
+    if (!isLinkEligibleForZwnbsp(link)) {
         // Only add the ZWNBSP for simple (possibly styled) text links, and
         // never in a nav.
         return;
     }
-    const selection = editable.ownerDocument.getSelection() || {};
+    const selection = link.ownerDocument.getSelection() || {};
     const { anchorOffset, focusOffset } = selection;
     let extraAnchorOffset = 0;
     let extraFocusOffset = 0;

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -510,11 +510,13 @@ export function insertSelectionChars(anchorNode, anchorOffset, focusNode, focusO
  * the selection.
  *
  * @param {Element} root
- * @param {Selection} [sel] if undefined, the current selection is used.
- * @param {boolean} [doFormat=false] if true, the HTML is formatted.
+ * @param {Object} [options={}]
+ * @param {Selection} [options.selection] if undefined, the current selection is used.
+ * @param {boolean} [options.doFormat] if true, the HTML is formatted.
+ * @param {boolean} [options.includeOids] if true, the HTML is formatted.
  */
-export function logSelection(root, sel, doFormat = false) {
-    sel = sel || root.ownerDocument.getSelection();
+export function logSelection(root, options = {}) {
+    const sel = options.selection || root.ownerDocument.getSelection();
     if (!root.contains(sel.anchorNode) || !root.contains(sel.focusNode)) {
         console.warn('The selection is not contained in the root.');
         return;
@@ -524,6 +526,9 @@ export function logSelection(root, sel, doFormat = false) {
     let anchorClone, focusClone;
     const cloneTree = node => {
         const clone = node.cloneNode();
+        if (options.includeOids) {
+            clone.oid = node.oid;
+        }
         anchorClone = anchorClone || (node === sel.anchorNode && clone);
         focusClone = focusClone || (node === sel.focusNode && clone);
         for (const child of node.childNodes || []) {
@@ -540,7 +545,7 @@ export function logSelection(root, sel, doFormat = false) {
     rootClone.removeAttribute('data-last-history-steps');
 
     // Format the HTML by splitting and indenting to highlight the structure.
-    if (doFormat) {
+    if (options.doFormat) {
         const formatHtml = (node, spaces = 0) => {
             node.before(document.createTextNode('\n' + ' '.repeat(spaces)));
             for (const child of [...node.childNodes]) {
@@ -548,6 +553,13 @@ export function logSelection(root, sel, doFormat = false) {
             }
             if (node.nodeType !== Node.TEXT_NODE) {
                 node.appendChild(document.createTextNode('\n' + ' '.repeat(spaces)));
+            }
+            if (options.includeOids) {
+                if (node.nodeType === Node.TEXT_NODE) {
+                    node.textContent += ` (${node.oid})`;
+                } else {
+                    node.setAttribute('oid', node.oid);
+                }
             }
         }
         formatHtml(rootClone);

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1142,7 +1142,7 @@ export const padLinkWithZws = (editable, link) => {
         // never in a nav.
         return;
     }
-    const selection = editable.ownerDocument.getSelection();
+    const selection = editable.ownerDocument.getSelection() || {};
     const { anchorOffset, focusOffset } = selection;
     let extraAnchorOffset = 0;
     let extraFocusOffset = 0;

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1123,8 +1123,8 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
         }
     }
 }
-export const isLinkEligibleForZwnbsp = link => {
-    return link.isContentEditable && !(
+export const isLinkEligibleForZwnbsp = (editable, link) => {
+    return link.isContentEditable && editable.contains(link) && !(
         [link, ...link.querySelectorAll('*')].some(el => el.nodeName === 'IMG' || isBlock(el)) ||
         link.matches('nav a, a.nav-link')
     )
@@ -1137,7 +1137,7 @@ export const isLinkEligibleForZwnbsp = link => {
  * @param {HTMLAnchorElement} link
  */
 export const padLinkWithZws = (editable, link) => {
-    if (!isLinkEligibleForZwnbsp(link)) {
+    if (!isLinkEligibleForZwnbsp(editable, link)) {
         // Only add the ZWNBSP for simple (possibly styled) text links, and
         // never in a nav.
         return;

--- a/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/utils/utils.js
@@ -1112,9 +1112,8 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
     }
 }
 export const isLinkEligibleForZwnbsp = link => {
-    return !(
-        link.textContent.trim() === '' ||
-        [link, ...link.querySelectorAll('*')].some(isBlock) ||
+    return link.isContentEditable && !(
+        [link, ...link.querySelectorAll('*')].some(el => el.nodeName === 'IMG' || isBlock(el)) ||
         link.matches('nav a, a.nav-link')
     )
 }

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/editor.test.js
@@ -2973,13 +2973,13 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><a>[]ab</a></p>',
                         stepFunction: editor => editor.document.execCommand('insertParagraph'),
-                        contentAfterEdit: '<p><br></p><p>\ufeff<a>[]\ufeffab\ufeff</a>\ufeff</p>',
+                        contentAfterEdit: '<p><br></p><p>\ufeff<a class="o_link_in_selection">[]\ufeffab\ufeff</a>\ufeff</p>',
                         contentAfter: '<p><br></p><p><a>[]ab</a></p>',
                     });
                     await testEditor(BasicEditor, {
                         contentBefore: '<p>ab<a>[]cd</a></p>',
                         stepFunction: editor => editor.document.execCommand('insertParagraph'),
-                        contentAfterEdit: '<p>ab</p><p>\ufeff<a>[]\ufeffcd\ufeff</a>\ufeff</p>',
+                        contentAfterEdit: '<p>ab</p><p>\ufeff<a class="o_link_in_selection">[]\ufeffcd\ufeff</a>\ufeff</p>',
                         contentAfter: '<p>ab</p><p><a>[]cd</a></p>',
                     });
                 });
@@ -2987,7 +2987,7 @@ X[]
                     await testEditor(BasicEditor, {
                         contentBefore: '<p><a>a[]b</a></p>',
                         stepFunction: editor => editor.document.execCommand('insertParagraph'),
-                        contentAfterEdit: '<p>\ufeff<a>\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a>\ufeff[]b\ufeff</a>\ufeff</p>',
+                        contentAfterEdit: '<p>\ufeff<a>\ufeffa\ufeff</a>\ufeff</p><p>\ufeff<a class="o_link_in_selection">\ufeff[]b\ufeff</a>\ufeff</p>',
                         contentAfter: '<p><a>a</a></p><p><a>[]b</a></p>',
                     });
                 });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
@@ -290,6 +290,30 @@ describe('Link', () => {
                     contentAfter: '<p>a<a href="https://google.com">google.vvv[]</a>b</p>',
                 });
             });
+            it('should replace all the contents of a link', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="#">[bcd]</a>e</p>',
+                    contentBeforeEdit: '<p>a\ufeff<a href="#" class="o_link_in_selection">\ufeff[bcd]\ufeff</a>\ufeffe</p>',
+                    stepFunction: async editor => {
+                        await insertText(editor, 'fg');
+                    },
+                    contentAfterEdit: '<p>a\ufeff<a href="#" class="o_link_in_selection">\ufefffg[]\ufeff</a>\ufeffe</p>',
+                    contentAfter: '<p>a<a href="#">fg[]</a>e</p>',
+                });
+                await testEditor(BasicEditor, {
+                    contentBefore: '<p>a<a href="#">bcd</a>e</p>',
+                    contentBeforeEdit: '<p>a\ufeff<a href="#">\ufeffbcd\ufeff</a>\ufeffe</p>',
+                    stepFunction: async editor => {
+                        const link = editor.editable.querySelector('a');
+                        // Select the whole link, including the ZWNBSP.
+                        setSelection(link.firstChild, 0, link.lastChild, 3);
+                        await new Promise(resolve => setTimeout(resolve, 0)); // Wait for selectionchange
+                        await insertText(editor, 'fg');
+                    },
+                    contentAfterEdit: '<p>a\ufeff<a href="#" class="o_link_in_selection">\ufefffg[]\ufeff</a>\ufeffe</p>',
+                    contentAfter: '<p>a<a href="#">fg[]</a>e</p>',
+                });
+            });
         });
     });
     describe('remove link', () => {

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/link.test.js
@@ -790,8 +790,8 @@ describe('Link', () => {
             });
             await testEditor(BasicEditor, {
                 contentBefore: '<p>a<a href="exist"></a>b</p>',
-                contentBeforeEdit: '<p>a<a href="exist"></a>b</p>',
-                contentAfterEdit: '<p>a<a href="exist"></a>b</p>',
+                contentBeforeEdit: '<p>a\ufeff<a href="exist">\ufeff</a>\ufeffb</p>',
+                contentAfterEdit: '<p>a\ufeff<a href="exist">\ufeff</a>\ufeffb</p>',
                 contentAfter: '<p>ab</p>',
             });
         });

--- a/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/list.test.js
@@ -6064,7 +6064,7 @@ describe('List', () => {
                         </ol>`),
                 });
             });
-            it('should empty list items, starting and ending with links', async () => {
+            describe('empty list items, starting and ending with links', () => {
                 // Since we introduce \ufeff characters in and around links, we
                 // can enter situations where the links aren't technically fully
                 // selected but should be treated as if they were. These tests
@@ -6097,13 +6097,17 @@ describe('List', () => {
                     '<ul><li>ab</li><li>[\ufeff<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
                     '<ul><li>ab</li><li>\ufeff[<a href="#">cd</a></li><li>ef</li><li><a href="#a">gh</a>]\ufeff</li><li>ij</li></ul>',
                 ];
+                let testIndex = 1;
                 for (const contentBefore of tests) {
-                    await testEditor(BasicEditor, {
-                        contentBefore,
-                        stepFunction: deleteBackward,
-                        contentAfterEdit: '<ul><li>ab</li><li placeholder="List" class="oe-hint">[]<br></li><li>ij</li></ul>',
-                        contentAfter: '<ul><li>ab</li><li>[]<br></li><li>ij</li></ul>',
+                    it(`should empty list items, starting and ending with links (${testIndex})`, async () => {
+                        await testEditor(BasicEditor, {
+                            contentBefore,
+                            stepFunction: deleteBackward,
+                            contentAfterEdit: '<ul><li>ab</li><li placeholder="List" class="oe-hint">[]<br></li><li>ij</li></ul>',
+                            contentAfter: '<ul><li>ab</li><li>[]<br></li><li>ij</li></ul>',
+                        });
                     });
+                    testIndex += 1;
                 }
             });
         });

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/link.js
@@ -87,7 +87,7 @@ const Link = Widget.extend({
                 $node = $node.parent();
             }
             const linkNode = this.linkEl || this.data.range.cloneContents();
-            const linkText = linkNode.innerText.replaceAll("\u200B", "");
+            const linkText = linkNode.innerText.replaceAll("\u200B", "").replaceAll("\uFEFF", "");
             this.data.content = linkText.replace(/[ \t\r\n]+/g, ' ');
             this.data.originalText = this.data.content;
             if (linkNode instanceof DocumentFragment) {


### PR DESCRIPTION
Some fixes that were revealed to be needed during the 16.0, saas-16.3 and saas-16.4 forward port of PR [1] (157200) and PR [2] (160718), are needed in 15.0 as well. This backports them from said forward port PR [3] (159995), PR [4] (162575) and PR [5] (163548).

[1]: https://github.com/odoo/odoo/pull/157200
[2]: https://github.com/odoo/odoo/pull/160718
[3]: https://github.com/odoo/odoo/pull/159995
[4]: https://github.com/odoo/odoo/pull/162575
[5]: https://github.com/odoo/odoo/pull/163548

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
