### PR TITLE
[FIX] web: hide time in datetime widgets

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -29,6 +29,7 @@ import { standardFieldProps } from "../standard_field_props";
  *  rounding?: number;
  *  startDateField?: string;
  *  warnFuture?: boolean;
+ *  showTime?: boolean;
  * }} DateTimeFieldProps
  *
  * @typedef {import("@web/core/datetime/datetime_picker").DateTimePickerProps} DateTimePickerProps
@@ -47,7 +48,9 @@ export class DateTimeField extends Component {
         rounding: { type: Number, optional: true },
         startDateField: { type: String, optional: true },
         warnFuture: { type: Boolean, optional: true },
+        showTime: { type: Boolean, optional: true },
     };
+    static defaultProps = { showTime: true };
 
     static template = "web.DateTimeField";
 
@@ -171,7 +174,7 @@ export class DateTimeField extends Component {
     getFormattedValue(valueIndex) {
         const value = this.values[valueIndex];
         return value
-            ? this.field.type === "date"
+            ? this.field.type === "date" || !this.props.showTime
                 ? formatDate(value)
                 : formatDateTime(value)
             : "";
@@ -345,7 +348,18 @@ export const dateTimeField = {
                 `Control the number of minutes in the time selection. E.g. set it to 15 to work in quarters.`
             ),
         },
+        {
+            label: _t("Show time"),
+            name: "show_time",
+            type: "boolean",
+            default: true,
+            help: _t(`Displays or hides the time in the datetime value.`),
+        },
     ],
+    extractProps: ({ attrs, options }, dynamicInfo) => ({
+        ...dateField.extractProps({ attrs, options }, dynamicInfo),
+        showTime: archParseBoolean(options.show_time ?? true),
+    }),
     supportedTypes: ["datetime"],
 };
 

--- a/addons/web/static/tests/views/fields/datetime_field_tests.js
+++ b/addons/web/static/tests/views/fields/datetime_field_tests.js
@@ -573,4 +573,36 @@ QUnit.module("Fields", (hooks) => {
 
         assert.strictEqual(getInput().value, "٠٢/٠٨/٢٠١٧ ١١:٤٥:٠٠");
     });
+
+    QUnit.test("list datetime with date widget test", async (assert) => {
+        await makeView({
+            type: "list",
+            resModel: "partner",
+            arch: /* xml */ `
+                <tree editable="bottom">
+                    <field name="datetime" widget="datetime" options="{'show_time': false}"/>
+                    <field name="datetime" widget="datetime"/>
+                </tree>`,
+            serverData,
+        });
+
+        const dates = target.querySelectorAll(".o_field_cell");
+
+        assert.strictEqual(
+            dates[0].textContent,
+            "02/08/2017",
+            "for datetime field only date should be visible with show_time as false and readonly"
+        );
+        assert.strictEqual(
+            dates[1].textContent,
+            "02/08/2017 11:00:00",
+            "for datetime field both date and time should be visible with show_time by default true"
+        );
+        await click(dates[0]);
+        assert.strictEqual(
+            target.querySelector(".o_field_datetime input").value,
+            "02/08/2017 11:00:00",
+            "for datetime field both date and time should be visible with show_time as false and edit"
+        );
+    });
 });


### PR DESCRIPTION
Before this commit:
- There was no option to hide the time part from the datetime widget.

After this commit:
- A 'show_time' option is added to the datetime widget. When set to false, it
hides the time part from the datetime.

Enterprise PR:  ﻿﻿https://github.com/odoo/enterprise/pull/67258

Task-3698841

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
