### PR TITLE
[ADD] l10n_us_account: Auto load the localization pack and related reports automatically

### DIFF
--- a/addons/l10n_us_account/__init__.py
+++ b/addons/l10n_us_account/__init__.py
@@ -1,0 +1,5 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+# The purpose of l10n_us_account is to automatically trigger the installation of l10n_us for the new US databases
+# Also, l10n_us_account should contains all the accounting-related dependencies of US localization package
+# Currently, It's empty module but it should be filled going forward!

--- a/addons/l10n_us_account/__manifest__.py
+++ b/addons/l10n_us_account/__manifest__.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': 'United States - Accounting',
+    'website': 'https://www.odoo.com/documentation/saas-17.2/applications/finance/fiscal_localizations.html',
+    'icon': '/account/static/description/l10n.png',
+    'countries': ['us'],
+    'version': '1.0',
+    'category': 'Accounting/Localizations/Account Charts',
+    'description': """
+    """,
+    'depends': ['l10n_us', 'account'],
+    'installable': True,
+    'auto_install': ['account'],
+    'license': 'LGPL-3',
+}


### PR DESCRIPTION
[ADD] l10n_us_account: Auto load the localization pack and related reports automatically

Problem: Users, especially newer ones, don't have the experience; or don't know how to install modules manually to their database.
This will create the incorrect idea that Odoo doesn't fulfill the minimum requirements to operate in the US.  
- Examples of those uninstalled requirements are ABA routing for payments, correct layout for checks, 1099 reports, and Avatax for tax calculation.

Desired behavior:-
Auto load the following when creating odoo US database
- US Accounting: l10n_us_account
- United States Localization: l10n_us
- US Accounting Reports: l10n_us_reports
- 1099 Reporting: l10n_us_1099
- US Checks Layout: l10n_us_check_printing
- NACHA Payments: l10n_us_payment_nacha
- Avatax: account_avatax

Solution: Create new module l10n_us_account to separate the accounting dependent stuff and auto load it and l10n_us which is going to load the mentioned packages above for US-db.

Task-3865230

Enterprise PR: https://github.com/odoo/enterprise/pull/60644

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
