### PR TITLE
[FIX] resource: remove daterange widget from resources leaves views

### DIFF
--- a/addons/resource/views/resource_calendar_leaves_views.xml
+++ b/addons/resource/views/resource_calendar_leaves_views.xml
@@ -46,8 +46,8 @@
                         <field name="resource_id"/>
                     </group>
                     <group name="leave_dates">
-                       <field name="date_from" string="Dates" widget="daterange" options="{'end_date_field': 'date_to'}"/>
-                       <field name="date_to" invisible="1"/>
+                       <field name="date_from"/>
+                       <field name="date_to"/>
                     </group>
                 </group>
             </sheet>


### PR DESCRIPTION
Issue:

At some point we added the daterange widget to select the dates for the resource leaves without taking into account certain cases, the most relevant is that we have a compute_date_to which depends on the date_from, the duty of this compute is that whenever we select a date_from, we will get the date_to to allocate exactly 1 day, which is the most common use, the problem is that with this widget we will always modify both date_from and date_to at the same time, making the compute to be called everytime which will not allow us to select a further date for date_to.

Steps to reproduce:

1. Install Appointments.
2. Go to Configuration > Resource Leaves > New
3. Try to allocate more than 1 day for the Resource Time Off

Solution:

We should, at least for the moment, keep it as it was before, where we can select both dates separetely, this way whenever we select our date_from we will get the date_to updated automatically to make things easier for the most common case, but we will still be able to change the date_to without triggering the compute.

opw-3861325