### PR TITLE
[FIX] purchase: make purchase catalog view work

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -846,7 +846,7 @@ class PurchaseOrder(models.Model):
     def _get_product_catalog_order_data(self, products, **kwargs):
         res = super()._get_product_catalog_order_data(products, **kwargs)
         for product in products:
-            res[product.id] += self._get_product_price_and_data(product)
+            res[product.id].update(self._get_product_price_and_data(product))
         return res
 
     def _get_product_catalog_record_lines(self, product_ids):

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -474,7 +474,7 @@ class PurchaseOrderLine(models.Model):
         else:
             self.product_qty = 1.0
 
-    def _get_product_catalog_lines_data(self):
+    def _get_product_catalog_lines_data(self, **kwargs):
         """ Return information about purchase order lines in `self`.
 
         If `self` is empty, this method returns only the default value(s) needed for the product


### PR DESCRIPTION
Problem:
An error is thrown when trying to access the catalog from any purchase order.

Fix:
make it work

opw-3865182
+duplicates:
 opw-3864210
 opw-3862341

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
