### PR TITLE
[FIX] stock: generate return for less than half of the UOM

### DIFF
--- a/addons/stock/wizard/stock_picking_return.py
+++ b/addons/stock/wizard/stock_picking_return.py
@@ -142,7 +142,7 @@ class ReturnPicking(models.TransientModel):
         for return_line in self.product_return_moves:
             if not return_line.move_id:
                 raise UserError(_("You have manually created product lines, please delete them to proceed."))
-            if not float_is_zero(return_line.quantity, return_line.uom_id.rounding):
+            if not float_is_zero(return_line.quantity, precision_rounding=return_line.uom_id.rounding):
                 returned_lines += 1
                 vals = self._prepare_move_default_values(return_line, new_picking)
                 r = return_line.move_id.copy(vals)


### PR DESCRIPTION
### Steps to reproduce:
- Go to the settings and activate "Units of Measure"
- Create a storable product measured in kg
- Create and confirm a sale order for 0.2 kg of your product
- Go to the associate delivery set 0.2 kg and validate it
- Click on return and try to generate a return

#### > Invalid operation please specify at least one non-zero quantity.

### Cause of the issue:

The precision rounding is incorrectly used as precision digit during the call of the `_create_returns` method`:
https://github.com/odoo/odoo/blob/6788f43d6b487ce07f8678cadcd06f90e417dffa/addons/stock/wizard/stock_picking_return.py#L145 https://github.com/odoo/odoo/blob/6788f43d6b487ce07f8678cadcd06f90e417dffa/odoo/tools/float_utils.py#L116 As a result line setting a quantity smaller than ~ 0.48 will be considered as set to zero and will raise the error.

opw-3862923
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
