### PR TITLE
[FIX] analytic: make partial index

### DIFF
--- a/addons/analytic/models/analytic_mixin.py
+++ b/addons/analytic/models/analytic_mixin.py
@@ -32,7 +32,8 @@ class AnalyticMixin(models.AbstractModel):
         if self.env.cr.dictfetchone() and self._fields['analytic_distribution'].store:
             query = fr"""
                 CREATE INDEX IF NOT EXISTS {self._table}_analytic_distribution_accounts_gin_index
-                                        ON {self._table} USING gin(regexp_split_to_array(jsonb_path_query_array(analytic_distribution, '$.keyvalue()."key"')::text, '\D+'));
+                                        ON {self._table} USING gin(regexp_split_to_array(jsonb_path_query_array(analytic_distribution, '$.keyvalue()."key"')::text, '\D+'))
+                                    WHERE jsonb_typeof(analytic_distribution) = 'object'
             """
             self.env.cr.execute(query)
         super().init()


### PR DESCRIPTION
The index fails to apply when there are string values in the anlaytic_distribution column.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
