### PR TITLE
[FIX] point_of_sale: remove custom properties 'nodestroy' to avoid warning

### DIFF
--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -899,7 +899,6 @@ class PosOrder(models.Model):
             'res_model': 'account.move',
             'context': "{'move_type':'out_invoice'}",
             'type': 'ir.actions.act_window',
-            'nodestroy': True,
             'target': 'current',
             'res_id': moves and moves.ids[0] or False,
         }


### PR DESCRIPTION
-This commit remove custom properties 'nodestroy' to avoid warning like this: `odoo.addons.web.controllers.utils: Action 'Customer Invoice' contains custom properties 'nodestroy'`. Passing them via the `params` or `context` properties is recommended instead

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
