### PR TITLE
[FIX] hr_timesheet: fixed total time not showing in portal

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -193,7 +193,7 @@
                             </div>
                         </tr>
                         <tr>
-                            <div t-if="task.total_hours_spent > 0 and timesheets_by_subtask" name="total_time">
+                            <div t-if="task.total_hours_spent and task.subtask_effective_hours" name="total_time">
                                 <t t-if="is_uom_day">
                                     <td><strong>Total Days: </strong></td>
                                     <td class="text-end">


### PR DESCRIPTION
Steps to reproduce:

- Open project and create a task with  some allocated time
- Create a sub task and log some time sheets in both main task and sub-task
- Share the main task to portal user
- Open show the portal view and open the task

Issue:

- You can see that total time is missing.

Cause:

- Non existent constraint in the condition

Solution:

- Removing the constraint and changing with the correct constraint
- The constraint is changed in the PR
- https://github.com/odoo/odoo/pull/128407
- from timesheets_by_subtask to task.subtask_effective_hours

task-3862095

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
