### PR TITLE
[IMP] {google, microsoft}_calendar: event synchronization action

### DIFF
--- a/addons/google_calendar/views/google_calendar_views.xml
+++ b/addons/google_calendar/views/google_calendar_views.xml
@@ -10,4 +10,12 @@
             </field>
         </field>
     </record>
+    <record id="action_synchronize_google_events" model="ir.actions.server">
+        <field name="name">Sync with Google</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="google_calendar.model_calendar_event"/>
+        <field name="binding_model_id" ref="google_calendar.model_calendar_event" />
+        <field name="state">code</field>
+        <field name="code">action = records.action_synchronize_google_events()</field>
+    </record>
 </odoo>

--- a/addons/microsoft_calendar/views/microsoft_calendar_views.xml
+++ b/addons/microsoft_calendar/views/microsoft_calendar_views.xml
@@ -10,4 +10,12 @@
             </field>
         </field>
     </record>
+    <record id="action_synchronize_microsoft_events" model="ir.actions.server">
+        <field name="name">Sync with Outlook</field>
+        <field name="type">ir.actions.server</field>
+        <field name="model_id" ref="microsoft_calendar.model_calendar_event"/>
+        <field name="binding_model_id" ref="microsoft_calendar.model_calendar_event" />
+        <field name="state">code</field>
+        <field name="code">action = records.action_synchronize_microsoft_events()</field>
+    </record>
 </odoo>


### PR DESCRIPTION
This Pull Request adds the menu options of synchronizing `calendar.event` records with Google Calendar and Outlook Calendar, making it easier for users to synchronize events in case their synchronization got stuck at some point or if it is being blocked by other code snippets (e.g. old events are skipped in Outlook Calendar for avoiding spam in Microsoft side). 

This is a good addition because sometimes when an error happens, the users usually restart their current synchronization for re-syncing events which takes a lot of time and can cause bugs. Considering this, this addition will help them a lot in problem solving by making it possible re-syncing a single event.

task-3292562