### PR TITLE
[FIX] {google, microsoft}_calendar: fix traceback for rapid clicks calendar view

### DIFF
--- a/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
+++ b/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js
@@ -11,6 +11,7 @@ patch(AttendeeCalendarModel.prototype, "google_calendar_google_calendar_model_fu
     setup(params, { rpc }) {
         this._super(...arguments);
         this.rpc = rpc;
+        this.isAlive = params.isAlive;
         this.googleIsSync = true;
         this.googlePendingSync = false;
     },
@@ -35,7 +36,9 @@ patch(AttendeeCalendarModel.prototype, "google_calendar_google_calendar_model_fu
             console.error("Could not synchronize Google events now.", error);
             this.googlePendingSync = false;
         }
-        return _super(...arguments);
+        if (this.isAlive()) {
+            return _super(...arguments);
+        }
     },
 
     async syncGoogleCalendar(silent = false) {

--- a/addons/microsoft_calendar/__manifest__.py
+++ b/addons/microsoft_calendar/__manifest__.py
@@ -23,6 +23,7 @@
         ],
         'web.qunit_suite_tests': [
             'microsoft_calendar/static/tests/microsoft_calendar_mock_server.js',
+            'microsoft_calendar/static/tests/microsoft_calendar_tests.js',
         ],
         'web.qunit_mobile_suite_tests': [
             'microsoft_calendar/static/tests/microsoft_calendar_mock_server.js',

--- a/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
+++ b/addons/microsoft_calendar/static/src/views/microsoft_calendar/microsoft_calendar_model.js
@@ -11,6 +11,7 @@ patch(AttendeeCalendarModel.prototype, "microsoft_calendar_microsoft_calendar_mo
     setup(params, { rpc }) {
         this._super(...arguments);
         this.rpc = rpc;
+        this.isAlive = params.isAlive;
         this.microsoftIsSync = true;
         this.microsoftPendingSync = false;
     },
@@ -35,7 +36,9 @@ patch(AttendeeCalendarModel.prototype, "microsoft_calendar_microsoft_calendar_mo
             console.error("Could not synchronize microsoft events now.", error);
             this.microsoftPendingSync = false;
         }
-        return _super(...arguments);
+        if (this.isAlive()) {
+            return _super(...arguments);
+        }
     },
 
     async syncMicrosoftCalendar(silent = false) {

--- a/addons/microsoft_calendar/static/tests/microsoft_calendar_tests.js
+++ b/addons/microsoft_calendar/static/tests/microsoft_calendar_tests.js
@@ -1,7 +1,7 @@
 /** @odoo-module **/
 
 import { click, getFixture, patchDate, makeDeferred, nextTick} from "@web/../tests/helpers/utils";
-import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
+import { setupViewRegistries } from "@web/../tests/views/helpers";
 import { registry } from "@web/core/registry";
 import { userService } from "@web/core/user_service";
 import { createWebClient, doAction } from "@web/../tests/webclient/helpers";
@@ -12,7 +12,7 @@ let target;
 let serverData;
 const uid = -1;
 
-QUnit.module('Google Calendar', {
+QUnit.module('Microsoft Calendar', {
     beforeEach: function () {
         patchDate(2016, 11, 12, 8, 0, 0);
         serverData = {
@@ -23,21 +23,10 @@ QUnit.module('Google Calendar', {
                         user_id: {string: "user", type: "many2one", relation: 'user'},
                         partner_id: {string: "user", type: "many2one", relation: 'partner', related: 'user_id.partner_id'},
                         name: {string: "name", type: "char"},
-                        start_date: {string: "start date", type: "date"},
-                        stop_date: {string: "stop date", type: "date"},
                         start: {string: "start datetime", type: "datetime"},
                         stop: {string: "stop datetime", type: "datetime"},
-                        allday: {string: "allday", type: "boolean"},
                         partner_ids: {string: "attendees", type: "one2many", relation: 'partner'},
-                        type: {string: "type", type: "integer"},
                     },
-                    records: [
-                        {id: 5, user_id: uid, partner_id: 4, name: "event 1", start: "2016-12-13 15:55:05", stop: "2016-12-15 18:55:05", allday: false, partner_ids: [4], type: 2},
-                        {id: 6, user_id: uid, partner_id: 5, name: "event 2", start: "2016-12-18 08:00:00", stop: "2016-12-18 09:00:00", allday: false, partner_ids: [4], type: 3}
-                    ],
-                    check_access_rights: function () {
-                        return Promise.resolve(true);
-                    }
                 },
                 'appointment.type': {
                     fields: {},
@@ -98,63 +87,7 @@ QUnit.module('Google Calendar', {
     }
 }, function () {
 
-    QUnit.test('sync google calendar', async function (assert) {
-        assert.expect(11);
-
-        let id = 7;
-        await makeView({
-            type: "calendar",
-            resModel: 'calendar.event',
-            serverData,
-            arch:
-            '<calendar class="o_calendar_test" '+
-                'js_class="attendee_calendar" '+
-                'date_start="start" '+
-                'date_stop="stop" '+
-                'attendee="partner_ids" '+
-                'mode="month">'+
-                    '<field name="name"/>'+
-                    '<field name="partner_ids" write_model="filter_partner" write_field="partner_id"/>'+
-            '</calendar>',
-            mockRPC: async function (route, args) {
-                if (route === '/google_calendar/sync_data') {
-                    assert.step(route);
-                    serverData.models['calendar.event'].records.push(
-                        {id: id++, user_id: uid, partner_id: 4, name: "event from google calendar", start: "2016-12-28 15:55:05", stop: "2016-12-29 18:55:05", allday: false, partner_ids: [4], type: 4}
-                    );
-                    return Promise.resolve({status: 'need_refresh'});
-                } else if (route === '/web/dataset/call_kw/calendar.event/search_read') {
-                    assert.step(route);
-                } else if (route === '/web/dataset/call_kw/res.partner/get_attendee_detail') {
-                    return Promise.resolve([]);
-                } else if (route === '/web/dataset/call_kw/res.users/has_group') {
-                    return Promise.resolve(true);
-                }
-            },
-        });
-        // select the partner filter
-        await click(target.querySelector('.o_calendar_filter_item[data-value=all] input'));
-        // sync_data was called a first time without filter, event from google calendar was created twice
-        assert.containsN(target, '.fc-event-container', 4, "should display 4 events on the month");
-
-        await click(target.querySelector('.o_calendar_button_next'));
-        await click(target.querySelector('.o_calendar_button_prev'));
-
-        assert.verifySteps([
-            '/google_calendar/sync_data',
-            '/web/dataset/call_kw/calendar.event/search_read',
-            '/google_calendar/sync_data',
-            '/web/dataset/call_kw/calendar.event/search_read',
-            '/google_calendar/sync_data',
-            '/web/dataset/call_kw/calendar.event/search_read',
-            '/google_calendar/sync_data',
-            '/web/dataset/call_kw/calendar.event/search_read',
-        ], 'should do a search_read before and after the call to sync_data');
-
-        assert.containsN(target, '.fc-event-container', 6, "should now display 6 events on the month");
-    });
-
-    QUnit.test("component is destroyed while sync google calendar", async function (assert) {
+    QUnit.test("component is destroyed while sync microsoft calendar", async function (assert) {
         assert.expect(4);
         const def = makeDeferred();
         serverData.actions = {
@@ -176,14 +109,14 @@ QUnit.module('Google Calendar', {
                     <field name="name"/>
                     <field name="partner_ids" write_model="filter_partner" write_field="partner_id"/>
                 </calendar>`,
-            "calendar.event,false,list": `<tree sample="1"/>`,
+            "calendar.event,false,list": `<tree sample="1" />`,
             "calendar.event,false,search": `<search />`,
         };
 
         const webClient = await createWebClient({
             serverData,
             async mockRPC(route, args) {
-                if (route === '/google_calendar/sync_data') {
+                if (route === '/microsoft_calendar/sync_data') {
                     assert.step(route);
                     return def;
                 } else if (route === '/web/dataset/call_kw/calendar.event/search_read') {
@@ -208,8 +141,8 @@ QUnit.module('Google Calendar', {
         await nextTick();
 
         assert.verifySteps([
-            "/google_calendar/sync_data",
-            "/google_calendar/sync_data",
+            "/microsoft_calendar/sync_data",
+            "/microsoft_calendar/sync_data",
             "/web/dataset/call_kw/calendar.event/search_read"
         ], "Correct RPC calls were made");
     });

--- a/addons/web/static/src/views/model.js
+++ b/addons/web/static/src/views/model.js
@@ -5,7 +5,7 @@ import { SEARCH_KEYS } from "@web/search/with_search/with_search";
 import { buildSampleORM } from "@web/views/sample_server";
 import { useSetupView } from "@web/views/view_hook";
 
-import { EventBus, onWillStart, onWillUpdateProps, useComponent } from "@odoo/owl";
+import { EventBus, onWillStart, onWillUpdateProps, status, useComponent } from "@odoo/owl";
 
 /**
  * @typedef {import("@web/search/search_model").SearchParams} SearchParams
@@ -94,6 +94,10 @@ export function useModel(ModelClass, params, options = {}) {
         services[key] = useService(key);
     }
     services.orm = services.orm || useService("orm");
+
+    if (!("isAlive" in params)) {
+        params.isAlive = () => status(component) !== "destroyed";
+    }
 
     const model = new ModelClass(component.env, params, services);
     useBus(


### PR DESCRIPTION
This issue arises when multiple clicks are made on the calendar view button.

Steps to reproduce:
- Install either the `google_calendar` or `microsoft_calendar` module.
- Go to calendar > Click multiple times on the calendar view button.
- Error will be generated

This issue specifically occurs if either the `google_calendar` or `microsoft_calendar` module has been installed.
this issue occurs because here
https://github.com/odoo/odoo/blob/79666cbab0ab0947b3d853ab58a929635c309bab/addons/google_calendar/static/src/views/google_calendar/google_calendar_model.js#L28 google or microsoft sync will taking longer then 1s, this promise will resolve after 1s and the component is destroyed.

so to address this issue, we need to eliminate the race condition and await the completion of the google/microsoft sync.

Task-3768492

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
