### PR TITLE
[FIX] mail: fix customer's message `author_id`

### DIFF
--- a/addons/mail/models/mail_thread.py
+++ b/addons/mail/models/mail_thread.py
@@ -2309,7 +2309,7 @@ class MailThread(models.AbstractModel):
 
         :return tuple: res.partner ID (may be False or None), email_from
         """
-        if author_id is None:
+        if not author_id:
             if email_from:
                 author = self._mail_find_partner_from_emails([email_from])[0]
             else:


### PR DESCRIPTION
To reproduce:
=============
- configure helpdesk team with email address
- contact this email address with a contact who doesn't exist in the database -> the created ticket won't have a description

Problem:
========
the method `_message_compute_author` is called with `author_id=False` which is falsy value for the condition `if author_id is None` so the message's `author_id` is never set

Solution:
=========
check if `author_id` is falsy instead of `None`

opw-3850228
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
