### PR TITLE
[IMP] test_lint: add lint tests for translations

### DIFF
--- a/odoo/addons/test_lint/tests/__init__.py
+++ b/odoo/addons/test_lint/tests/__init__.py
@@ -12,3 +12,4 @@ from . import test_override_signatures
 from . import test_pofile
 from . import test_pylint
 from . import test_routes
+from . import test_i18n

--- a/odoo/addons/test_lint/tests/_odoo_checker_gettext.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_gettext.py
@@ -49,9 +49,14 @@ class OdooBaseChecker(BaseChecker):
             'gettext-repr',
             'Don\'t use %r to automatically insert quotes in translation strings. Quotes can be different depending on the language: they must be part of the translated string.',
         ),
+        'E8507': (
+            'Concatenation of translated text',
+            'gettext-concat',
+            'Do not concatenate translated text',
+        ),
     }
 
-    @only_required_for_messages('gettext-variable', 'gettext-placeholders', 'gettext-repr')
+    @only_required_for_messages('gettext-concat', 'gettext-variable', 'gettext-placeholders', 'gettext-repr')
     def visit_call(self, node):
         if isinstance(node.func, astroid.Name) and node.func.name in ('_', '_lt'):
             first_arg = node.args[0]
@@ -62,7 +67,8 @@ class OdooBaseChecker(BaseChecker):
                     self.add_message('gettext-placeholders', node=node)
                 elif re.search(REPR_REGEXP, first_arg.value):
                     self.add_message('gettext-repr', node=node)
-
+            if isinstance(node.parent, astroid.BinOp) and node.parent.op == '+':
+                self.add_message('gettext-concat', node=node.parent)
 
 def register(linter):
     linter.register_checker(OdooBaseChecker(linter))

--- a/odoo/addons/test_lint/tests/eslintrc
+++ b/odoo/addons/test_lint/tests/eslintrc
@@ -33,6 +33,10 @@
             {
                 "selector": "CallExpression[callee.name='_t'] > :first-child[value=/(.*%s){2,}/]",
                 "message": "Usage of _t function with multiple unnamed placeholders"
+            },
+            {
+                "selector": "BinaryExpression[operator='+'] > CallExpression[callee.name='_t']",
+                "message": "Concatenation of translated text"
             }
         ],
         "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all" }]

--- a/odoo/addons/test_lint/tests/test_i18n.py
+++ b/odoo/addons/test_lint/tests/test_i18n.py
@@ -1,0 +1,74 @@
+import logging
+import re
+
+from . import lint_case
+
+from odoo import tools
+from odoo.tools import TRANSLATED_ATTRS
+
+_logger = logging.getLogger(__name__)
+
+
+class TestI18n(lint_case.LintCase):
+    # Assumption: Text starting with an uppercase letter is likely supposed to be translated.
+    DIRECTIVES_RE = re.compile(r"t-(value|out|esc)=\"'[A-Z][a-z]")
+    ATTRS_AS_PROPS_RE = re.compile(r"\b(%s)=\"'[A-Z][a-z]" % "|".join(TRANSLATED_ATTRS))
+    JS_GETTEXT_RE = re.compile(r"\b_t\(")
+    BACKSLASH_NEWLINE_RE = re.compile(r"""
+        _t\(\s*
+            (
+                '(\\'|[^'])+\\$
+                |
+                "(\\"|[^"])+\\$
+            )
+    """, re.MULTILINE | re.VERBOSE)
+
+    def test_js_translatability(self):
+        """
+        Checks for:
+        - Backslash-newline inside JS translated strings:
+            https://github.com/python-babel/babel/issues/1056
+        """
+        error_count = 0
+        for file_path in self.iter_module_files("*.js"):
+            with tools.file_open(file_path, "r") as f:
+                file_content = f.read()
+                for m in self.BACKSLASH_NEWLINE_RE.finditer(file_content):
+                    lineno = file_content[: m.start()].count("\n") + 1
+                    _logger.error(f"Backslash-newline in translated string in file {file_path} at line {lineno}")
+                    error_count += 1
+        self.assertEqual(error_count, 0)
+
+    def test_xml_translatability(self):
+        """
+        Checks for:
+        - Translated attributes as props:
+            <MyComponent title="'Shrek The Musical'"/>
+            The title is not exported or translated because it is a prop, not an attribute.
+        - Human-readable text in Qweb directives:
+            <t t-set="page_title" t-value="'Payment Confirmation'"/>
+            Content of Qweb directives is not exported or translated.
+        - Calls to _t in Owl templates:
+            <t t-esc="something ? something : _t('Nothing')"/>
+            Calls to gettext inside templates aren't exported.
+        """
+        error_count = 0
+        for file_path in self.iter_module_files("*.xml"):
+            with tools.file_open(file_path, "r") as f:
+                file_content = f.read()
+                for m in self.DIRECTIVES_RE.finditer(file_content):
+                    lineno = file_content[: m.start()].count("\n") + 1
+                    _logger.error(f"Human-readable text in Qweb directives in file {file_path} at line {lineno}")
+                    error_count += 1
+        for file_path in self.iter_module_files("*/static/src/**/*.xml"):
+            with tools.file_open(file_path, "r") as f:
+                file_content = f.read()
+                for m in self.JS_GETTEXT_RE.finditer(file_content):
+                    lineno = file_content[: m.start()].count("\n") + 1
+                    _logger.error(f"Call to “_t” in Owl template in file {file_path} at line {lineno}")
+                    error_count += 1
+                for m in self.ATTRS_AS_PROPS_RE.finditer(file_content):
+                    lineno = file_content[: m.start()].count("\n") + 1
+                    _logger.error(f"Translated attribute as a prop in file {file_path} at line {lineno}")
+                    error_count += 1
+        self.assertEqual(error_count, 0)

--- a/odoo/addons/test_lint/tests/test_pylint.py
+++ b/odoo/addons/test_lint/tests/test_pylint.py
@@ -31,6 +31,7 @@ class TestPyLint(TransactionCase):
 
         # custom checkers
         'sql-injection',
+        'gettext-concat',
         'gettext-variable',
         'gettext-placeholders',
         'gettext-repr',


### PR DESCRIPTION
Adds the following checks for translation antipatterns:
## Pylint
+ Usage of `_, `_lt` function with multiple unnamed placeholders
+ Concatenation of translated text
## ESLint
+ Usage of `_t` function with multiple unnamed placeholders
+ Concatenation of translated text
## Python tests
+ .js files:
  + Backslash-newline in translated strings
+ .xml files:
  + Translated attributes as props
  + Human-readable text in Qweb directives
  + Call to `_`t in Owl templates

Task-3869533