### PR TITLE
[FIX] payment_xendit: failure_reason

### DIFF
--- a/addons/payment_xendit/models/payment_transaction.py
+++ b/addons/payment_xendit/models/payment_transaction.py
@@ -144,7 +144,8 @@ class PaymentTransaction(models.Model):
         elif payment_status in const.PAYMENT_STATUS_MAPPING['cancel']:
             self._set_canceled()
         elif payment_status in const.PAYMENT_STATUS_MAPPING['error']:
+            failure_reason = notification_data.get('failure_reason')
             self._set_error(_(
                 "An error occurred during the processing of your payment (status %s). Please try "
-                "again."
+                "again.", failure_reason
             ))


### PR DESCRIPTION
This commit is to fix the built status message when an error occured during payment. The fix is to display the actual reason behind failed payment attempt



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
