### PR TITLE
[FIX] website_event: add to calendar button follows secondary button style

### DIFF
--- a/addons/website_event/views/event_templates_page_registration.xml
+++ b/addons/website_event/views/event_templates_page_registration.xml
@@ -74,7 +74,7 @@
                                 <span t-else="" t-field="event.date_end" t-options="{'tz_name': event.date_tz, 'time_only': 'true', 'format': 'short'}" t-att-datetime="event.date_end"/>
                                 (<span t-out="event.date_tz"/>)
 
-                                <a href="#" role="button" data-bs-toggle="dropdown" class="btn btn-secondary text-bg-secondary dropdown w-100 mt-3">
+                                <a href="#" role="button" data-bs-toggle="dropdown" class="btn btn-secondary dropdown w-100 mt-3">
                                     <p class="mb-0"><i class="fa fa-calendar me-2"/>Add to Calendar</p>
                                 </a>
                                 <div class="dropdown-menu">
@@ -98,7 +98,7 @@
                                     "widget": "contact",
                                     "fields": ["phone", "mobile", "email"]
                                 }'/>
-                                <a t-att-href="event._google_map_link()" target="_blank" class="btn btn-secondary text-bg-secondary w-100">
+                                <a t-att-href="event._google_map_link()" target="_blank" class="btn btn-secondary w-100">
                                     <p class="mb-0"><i class="fa fa-map-marker fa-fw" role="img"/>Get the direction</p>
                                 </a>
                             </div>


### PR DESCRIPTION

## Issue:
Due to having 'text-bg-secondary' in our Add to Calendar button, if we modify the secondary button style for the website theme, the new style for the secondary button will not be applied properly even though it's a secondary button.

## Steps to reproduce:
1. Install website_event.
2. Modify the secondary button style for the theme (i.e set it to outline)
3. Check the button inside events > register an event.

## Solution:
We could get rid of the class 'text-bg-secondary' for this button which will make the button to keep same style and still be "responsive" to theme changes.

opw-3869252
