### PR TITLE
[FIX] account: Fix mapping from xmlid to tax

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -278,7 +278,7 @@ class AccountChartTemplate(models.AbstractModel):
         unique_tax_name_keys = set(current_taxes.mapped(unique_tax_name_key))
         xmlid2tax = {
             xml_id.split('.')[1].split('_', maxsplit=1)[1]: self.env['account.tax'].browse(record)
-            for record, xml_id in current_taxes.get_external_id().items() if xml_id
+            for record, xml_id in current_taxes.get_external_id().items() if xml_id.startswith('account.')
         }
         def tax_template_changed(tax, template):
             return (

--- a/addons/l10n_es_edi_facturae/__init__.py
+++ b/addons/l10n_es_edi_facturae/__init__.py
@@ -21,7 +21,7 @@ def _edit_tax_types(env, template_data):
         return
     xmlid2tax = {
         xml_id.split('.')[1].split('_', maxsplit=1)[1]: env['account.tax'].browse(record)
-        for record, xml_id in current_taxes.get_external_id().items() if xml_id
+        for record, xml_id in current_taxes.get_external_id().items() if xml_id.startswith('account.')
     }
     for xmlid, values in template_data.items():
         # Only update the tax_type fields


### PR DESCRIPTION
Rewrite the mapping from xmlid to tax to only take into account standard taxes from the 'account' module

Related to blocking upgrade request [upg-1494099](https://upgrade.odoo.com/web#id=1494099&model=upgrade.request)

If there is a custom tax created by the user with a external id that doesn't contain '_', the mapping fails.

Traceback:
```
File "/home/odoo/src/odoo/17.0/addons/account/models/chart_template.py", line 280, in <dictcomp>
  xml_id.split('.')[1].split('_', maxsplit=1)[1]: self.env['account.tax'].browse(record)
IndexError: list index out of range
```

Only standard taxes (from `account` module) should be taken into account.

