### PR TITLE
[FIX] base_import: prevent UnicodeDecodeError when invalid encoding is selected

### DIFF
--- a/addons/base_import/i18n/base_import.pot
+++ b/addons/base_import/i18n/base_import.pot
@@ -545,6 +545,12 @@ msgstr ""
 #. module: base_import
 #: code:addons/base_import/models/base_import.py:0
 #, python-format
+msgid "Invalid Encoding option: %s"
+msgstr ""
+
+#. module: base_import
+#: code:addons/base_import/models/base_import.py:0
+#, python-format
 msgid "Invalid cell value at row %(row)s, column %(col)s: %(cell_value)s"
 msgstr ""
 

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -473,7 +473,10 @@ class Import(models.TransientModel):
                 encoding = options['encoding'] = encoding[:-2]
 
         if encoding != 'utf-8':
-            csv_data = csv_data.decode(encoding).encode('utf-8')
+            try:
+                csv_data = csv_data.decode(encoding).encode('utf-8')
+            except UnicodeDecodeError as e:
+                raise ImportValidationError(_("Invalid Encoding option: %s", encoding))
 
         separator = options.get('separator')
         if not separator:


### PR DESCRIPTION
When user selects the invalid encoding option and tries to import csv file in bank statements,
a traceback will appear.

Steps to reproduce the error:
- Go to Accounting > Bank > Upload csv file
- Change Encoding to utf-16 > Import

Traceback:
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0x9c in position 0: invalid start byte
  File "odoo/http.py", line 2251, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1827, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1847, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1825, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1832, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2057, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 739, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "home/odoo/src/enterprise/saas-17.2/account_bank_statement_import_csv/wizard/account_bank_statement_import_csv.py", line 141, in execute_import
    return super(AccountBankStmtImportCSV, self).execute_import(fields, columns, options, dryrun=dryrun)
  File "addons/base_import/models/base_import.py", line 1314, in execute_import
    input_file_data, import_fields = self._convert_import_data(fields, options)
  File "addons/base_import/models/base_import.py", line 1052, in _convert_import_data
    _file_length, rows_to_import = self._read_file(options)
  File "addons/base_import/models/base_import.py", line 377, in _read_file
    raise e
  File "addons/base_import/models/base_import.py", line 375, in _read_file
    return getattr(self, '_read_' + ext[1:])(options)
  File "addons/base_import/models/base_import.py", line 500, in _read_csv
    content = [
  File "addons/base_import/models/base_import.py", line 500, in <listcomp>
    content = [
  File "codecs.py", line 645, in __next__
    line = self.readline()
  File "codecs.py", line 558, in readline
    data = self.read(readsize, firstline=True)
  File "codecs.py", line 504, in read
    newchars, decodedbytes = self.decode(data, self.errors)
```

Solution: ImportValidationError will be raised when csv file is unable
to encode.

sentry-5175087486

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
