### PR TITLE
[FIX] account: add journal to mobile view

### DIFF
--- a/addons/account/views/account_payment_method.xml
+++ b/addons/account/views/account_payment_method.xml
@@ -12,4 +12,18 @@
         </field>
     </record>
 
+    <record id="view_account_payment_method_line_kanban_mobile" model="ir.ui.view">
+        <field name="name">account.payment.method.line.kanban</field>
+        <field name="model">account.payment.method.line</field>
+        <field name="arch" type="xml">
+            <kanban class="o_kanban_mobile">
+                <t t-name="kanban-box">
+                    <div t-attf-class="oe_kanban_card">
+                        <field name="display_name"/>
+                    </div>
+                </t>
+            </kanban>
+        </field>
+    </record>
+
 </odoo>


### PR DESCRIPTION
Only the payment method is shown on mobile view and some method payments have the same name so we don't know which one we are choosing

Steps to reproduce:
- Install the "hr_expense" app
- Make an expense and set "Paid By" to "Company"
- Create a report and go to mobile view
- Click on "search more" on "payment method" field and we have the payment method names displayed with some names many times

Solution:
Add a record to manage mobile view and which shows the journal with the payment method so we can know what we are selecting

opw-3774769

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
