### PR TITLE
[FIX] mail: Error on creating user from kanban view

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -595,6 +595,10 @@ class Users(models.Model):
             user.partner_id.active = user.active
         return users
 
+    @api.model
+    def name_create(self, name):
+        raise ValidationError(_("You cannot create a new User from here."))
+
     def _apply_groups_to_existing_employees(self):
         """ Should new groups be added to existing employees?
 


### PR DESCRIPTION
[FIX] mail: Error on creating user from kanban view
When attempting to create a user from the kanban view, it's necessary to specify
an email. However, when adding a new user via a column in the kanban view
(especially when grouped by user), the email field may be missing, preventing
user creation.

To address this issue, a an Error popup has been added. Now, when users try to
create a new user in this manner, they will be prompted with an Error.

[Reproduce A]
- Install crm
- Open pipeline (have to have some opportunities)
- Group by -> Salesperson
- Click on add column button, try to add new Salesperson
- BUG: traceback

[Reproduce B]
- Install sale_management
- Open Quotations (have to have some records there)
- Group by -> Salesperson
- Switch to Kanban view, Click on add column button, try to add new Salesperson
- BUG: traceback

opw-[3855217](https://www.odoo.com/web#id=3855217&view_type=form&model=project.task)