### PR TITLE
[IMP] web: update action state from controllers components

### DIFF
--- a/addons/board/static/src/board_controller.js
+++ b/addons/board/static/src/board_controller.js
@@ -19,7 +19,6 @@ export class BoardController extends Component {
     static props = {
         ...standardViewProps,
         board: Object,
-        updateResId: { type: Function, optional: true },
     };
 
     setup() {

--- a/addons/im_livechat/static/src/views/discuss_channel_list/discuss_channel_list_view_controller.js
+++ b/addons/im_livechat/static/src/views/discuss_channel_list/discuss_channel_list_view_controller.js
@@ -15,7 +15,9 @@ export class DiscussChannelListController extends ListController {
         if (!this.ui.isSmall) {
             return this.actionService.doAction("mail.action_discuss", {
                 name: _t("Discuss"),
-                additionalContext: { active_id: record.resId },
+                props: {
+                    resId: record.resId,
+                },
             });
         }
         const thread = await this.store.Thread.getOrFetch({

--- a/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_history_back_and_forth.js
@@ -5,7 +5,7 @@ registry.category("web_tour.tours").add("im_livechat_history_back_and_forth_tour
     steps: () => [
         {
             trigger: "body",
-            run: "press ctrl+k"
+            run: "press ctrl+k",
         },
         {
             trigger: ".o_command_palette_search input",

--- a/addons/mail/static/src/discuss/core/web/discuss_client_action_patch.js
+++ b/addons/mail/static/src/discuss/core/web/discuss_client_action_patch.js
@@ -7,15 +7,4 @@ patch(DiscussClientAction.prototype, {
         await this.store.channels.fetch();
         return super.restoreDiscussThread(...arguments);
     },
-    parseActiveId(rawActiveId) {
-        if (typeof rawActiveId === "number") {
-            return ["discuss.channel", rawActiveId];
-        }
-        const [model, id] = super.parseActiveId(rawActiveId);
-        if (model === "mail.channel") {
-            // legacy format (sent in old emails, shared links, ...)
-            return ["discuss.channel", id];
-        }
-        return [model, id];
-    },
 });

--- a/addons/mail/static/tests/legacy/helpers/test_utils.js
+++ b/addons/mail/static/tests/legacy/helpers/test_utils.js
@@ -34,14 +34,20 @@ registryNamesToCloneWithCleanup.push("mock_server_callbacks", "discuss.model");
 
 let currentEnv = null;
 
-export async function openDiscuss(activeId, { target } = {}) {
+export async function openDiscuss(channelId, { target } = {}) {
     const env = target ?? currentEnv;
-    await env.services.action.doAction({
-        context: { active_id: activeId },
+    const action = {
         id: DISCUSS_ACTION_ID,
         tag: "mail.action_discuss",
         type: "ir.actions.client",
-    });
+    };
+    const options = {};
+    if (typeof channelId === "number") {
+        options.props = { resId: channelId };
+    } else if (typeof channelId === "string") {
+        action.context = { active_id: channelId.split("_")[1] };
+    }
+    await env.services.action.doAction(action, options);
 }
 
 export async function openFormView(resModel, resId, { props = {}, target } = {}) {

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -133,14 +133,20 @@ export function registerArchs(newArchs) {
     after(() => (archs = {}));
 }
 
-export async function openDiscuss(activeId, { target } = {}) {
+export async function openDiscuss(channelId, { target } = {}) {
     const actionService = target?.services.action ?? getService("action");
-    await actionService.doAction({
-        context: { active_id: activeId },
+    const action = {
         id: DISCUSS_ACTION_ID,
         tag: "mail.action_discuss",
         type: "ir.actions.client",
-    });
+    };
+    const options = {};
+    if (typeof channelId === "number") {
+        options.props = { resId: channelId };
+    } else if (typeof channelId === "string") {
+        action.context = { active_id: channelId.split("_")[1] };
+    }
+    await actionService.doAction(action, options);
 }
 
 export async function openFormView(resModel, resId, params) {

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -141,12 +141,11 @@ export class FormController extends Component {
         preventEdit: { type: Boolean, optional: true },
         onDiscard: { type: Function, optional: true },
         onSave: { type: Function, optional: true },
-        updateResId: { type: Function, optional: true },
     };
     static defaultProps = {
         preventCreate: false,
         preventEdit: false,
-        updateResId: () => {},
+        updateActionState: () => {},
     };
 
     setup() {
@@ -198,7 +197,7 @@ export class FormController extends Component {
             effect(
                 (model) => {
                     if (status(this) === "mounted") {
-                        this.props.updateResId(model.root.resId);
+                        this.props.updateActionState({ resId: model.root.resId });
                     }
                 },
                 [this.model]

--- a/addons/web/static/src/views/standard_view_props.js
+++ b/addons/web/static/src/views/standard_view_props.js
@@ -36,4 +36,5 @@ export const standardViewProps = {
     selectRecord: { type: Function, optional: true },
     state: { type: Object, optional: true },
     useSampleModel: { type: Boolean },
+    updateActionState: { type: Function, optional: true },
 };

--- a/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
+++ b/addons/web/static/tests/legacy/webclient/actions/load_state_tests.js
@@ -204,8 +204,7 @@ QUnit.module("ActionManager", (hooks) => {
     });
 
     QUnit.test("correctly sends additional context", async (assert) => {
-        // %2C is a URL-encoded comma
-        redirect("/odoo/4/action-1001?active_ids=4%2C8");
+        redirect("/odoo/4/action-1001");
         logHistoryInteractions(assert);
         function mockRPC(route, params) {
             if (route === "/web/action/load") {
@@ -213,7 +212,7 @@ QUnit.module("ActionManager", (hooks) => {
                     action_id: 1001,
                     context: {
                         active_id: 4, // aditional context
-                        active_ids: [4, 8], // aditional context
+                        active_ids: [4], // aditional context
                         lang: "en", // user context
                         tz: "taht", // user context
                         uid: 7, // user context
@@ -224,10 +223,10 @@ QUnit.module("ActionManager", (hooks) => {
         await createWebClient({ serverData, mockRPC });
         assert.strictEqual(
             browser.location.href,
-            "http://example.com/odoo/4/action-1001?active_ids=4%2C8",
+            "http://example.com/odoo/4/action-1001",
             "url did not change"
         );
-        assert.verifySteps(["replaceState http://example.com/odoo/4/action-1001?active_ids=4%2C8"]);
+        assert.verifySteps(["replaceState http://example.com/odoo/4/action-1001"]);
     });
 
     QUnit.test("supports action as xmlId", async (assert) => {
@@ -385,7 +384,7 @@ QUnit.module("ActionManager", (hooks) => {
         );
     });
 
-    QUnit.test("properly load client actions with updateResId", async function (assert) {
+    QUnit.test("properly load client actions with updateActionState", async function (assert) {
         class ClientAction extends Component {
             static template = xml`<ControlPanel/><div class="o_client_action_test">Hello World</div>`;
             static props = ["*"];
@@ -394,7 +393,7 @@ QUnit.module("ActionManager", (hooks) => {
 
             setup() {
                 onMounted(() => {
-                    this.props.updateResId(12);
+                    this.props.updateActionState({ resId: 12 });
                 });
             }
         }


### PR DESCRIPTION
Since [1] a new prop (a function called updateResId) was give to the
controllers components of the window actions to update the resId on the
action state and url, when needed. For instance, the form view after
saving a new record, will update the state and the url with the newly
created id.

Since [2], the prop was also given to the controllers components of the
client actions to update the resId.

There is a need to update more than the resId. This PR will introduce a
new prop with the aim to update the action state (updateActionState).
This props will allow the controller components to update the state and
push the new state to the router (updating the url).

In practical, this allows to push a new state in the url, keeping the
action service in sync. This synchronization between the router and the
action service allows the browser back/forward/reload to work as
expected.

[1]: https://github.com/odoo/odoo/commit/c63d14a0485a553b74a8457aee158384e9ae6d3f
[2]: https://github.com/odoo/odoo/commit/3ad4fd65387f60b524e5f786556963ead8ae9dfe
