### PR TITLE
[IMP] website: enable the "Banner" snippet column count option

### DIFF
--- a/addons/website/views/snippets/s_banner.xml
+++ b/addons/website/views/snippets/s_banner.xml
@@ -4,7 +4,7 @@
 <template id="s_banner" name="Banner">
     <section class="s_banner pt96 pb96">
         <div class="container">
-            <div class="row s_nb_column_fixed o_grid_mode" data-row-count="11">
+            <div class="row o_grid_mode" data-row-count="11">
                 <div class="justify-content-center o_grid_item g-height-8 g-col-lg-5 col-lg-5" data-name="Box" style="z-index: 1; grid-area: 2 / 1 / 10 / 6;">
                     <h1 class="display-3">Sell Online. <strong>Easily.</strong></h1>
                     <p class="lead">This is a simple hero unit, a simple jumbotron-style component for calling extra attention to featured content or information.</p>


### PR DESCRIPTION
This PR aims to remove the s_nb_column_fixed class that is present on the "Banner" snippet row, as it prevents from choosing its number of columns with the "Column Count" option.

task-3839820