### PR TITLE
[FIX] point_of_sale: limit category display to two rows

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.scss
@@ -41,6 +41,7 @@
         min-height: 60px;
         max-height: 80px;
     }
+    max-height: 175px;
 }
 
 

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -19,7 +19,7 @@
             </div>
             <div class="rightpane d-flex flex-grow-1 flex-column bg-view w-60 bg-100" t-if="!ui.isSmall || pos.mobile_pane === 'right'">
                 <div t-if="!ui.isSmall" t-ref="category-box" t-att-class="{'d-none': state.scrollDown and ui.isSmall}" class="d-flex flex-column shadow-sm control-top-bar">
-                    <div class="category-box flex-grow-1">
+                    <div class="category-box flex-grow-1 overflow-auto">
                         <CategorySelector class="'category-selector d-grid p-1 gap-1'" categories="getCategoriesAndSub()" onClick="(id) => this.pos.setSelectedCategory(id)"/>
                     </div>
                 </div>


### PR DESCRIPTION
Before this commit, the PoS interface could become cluttered when hundreds of categories were loaded, covering the entire screen in desktop browsing.

This commit addresses the issue by limiting the category display to two rows and adding a scrollbar for overflow, improving the user experience when there are many categories.

Before:
![image](https://github.com/odoo/odoo/assets/36274868/274366e1-16a1-49bd-8099-aec8ad565b10)

After:
![image](https://github.com/odoo/odoo/assets/36274868/9b8dfb1a-45da-46d7-901e-bf421b39a5c9)


opw-3865072

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
