### PR TITLE
15.0 fix stock warehouse orderpoint unlink domain

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -476,7 +476,7 @@ class StockWarehouseOrderpoint(models.Model):
             ('qty_to_order', '<=', 0)
         ]
         if self.ids:
-            expression.AND([domain, [('ids', 'in', self.ids)]])
+            domain = expression.AND([domain, [('id', 'in', self.ids)]])
         orderpoints_to_remove = self.env['stock.warehouse.orderpoint'].with_context(active_test=False).search(domain)
         # Remove previous automatically created orderpoint that has been refilled.
         orderpoints_to_remove.unlink()

--- a/doc/cla/corporate/camptocamp.md
+++ b/doc/cla/corporate/camptocamp.md
@@ -54,3 +54,4 @@ Victor Vermot-Petit-Outhenin victor.vermot@camptocamp.com https://github.com/vic
 Sarah Jallon sarah.jallon@camptocamp.com https://github.com/sarsurgithub
 Ricardo Almeida Soares ricardo.almeidasoares@camptocamp.com https://github.com/ricardoalso
 Italo Lopes italo.lopes@camptocamp.com https://github.com/imlopes
+Paolo Yammouni paolo.yammouni@camptocamp.com https://github.com/paoloyam


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fulfilling the if condition doesn't change anything as the the result of the concatenation isn't attributed. Also the domain contains an error as it should be id and not ids.  

Current behavior before PR:

If record(s) are passed through the super,  it doesn't change anything to the method's behavior as the domain stays the same. 

Desired behavior after PR is merged:

If self.ids is true, the new value of domain would be: domain + [('id', 'in', self.ids]]). 

@pgu-odoo

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
