### PR TITLE
[FIX] mrp_subcontracting: validate picking with registered components

### DIFF
--- a/addons/mrp_subcontracting/models/mrp_production.py
+++ b/addons/mrp_subcontracting/models/mrp_production.py
@@ -70,6 +70,7 @@ class MrpProduction(models.Model):
         if consumption_issues:
             return self._action_generate_consumption_wizard(consumption_issues)
         self.sudo()._update_finished_move()  # Portal user may need sudo rights to update pickings
+        self._get_subcontract_move().picked = False
         self.subcontracting_has_been_recorded = True
 
         quantity_issues = self._get_quantity_produced_issues()


### PR DESCRIPTION
### Steps to reproduce:

- Go to the settings and activate subcontracting
- Create a storable product with Manufacture route and a BOM of type subcontracting
- Create and confirm a PO for your subcontractor with two lines:
  - a line with your subcontracted product
  - a line with any other storable product
- Go on the associated receipt and set only one of the 2 lines as picked
- Record components > add the desired quantity and record Production
- Try to validate the transfer

### Expected behavior:

Since the quantity is set on both lines, the transfer should be validated and both lines should be picked.

### Current behavior:

A backorder wizzard appears and notifies you that you have processed less products than the initial demand.

### Cause of the issue:

The picked field of the `stock.move` model is computed depending on the the picked state of its stock.move.line's:
https://github.com/odoo/odoo/blob/1648ee1abff1ae12b3933baa85a2e048fa2eb557/addons/stock/models/stock_move.py#L206-L210 As such, recording the components for your subcontracted product will set the picked field of the associated stock move to True during the call of the `_update_finished_move` method:
https://github.com/odoo/odoo/blob/1648ee1abff1ae12b3933baa85a2e048fa2eb557/addons/mrp_subcontracting/models/mrp_production.py#L72 https://github.com/odoo/odoo/blob/1648ee1abff1ae12b3933baa85a2e048fa2eb557/addons/mrp_subcontracting/models/mrp_production.py#L119-L121 Hence, since at least one of the stock move linked to our picking is picked, the other stock moves will not be set to picked = True here: https://github.com/odoo/odoo/blob/1648ee1abff1ae12b3933baa85a2e048fa2eb557/addons/stock/models/stock_picking.py#L1181-L1189 and the backorder process will be launched.

### Fix:

Since the picked field of the stock move line is used in the call of the `_update_finished_move`:
https://github.com/odoo/odoo/blob/1648ee1abff1ae12b3933baa85a2e048fa2eb557/addons/mrp_subcontracting/models/mrp_production.py#L144
we need to reset the picked status of the stock move after this call. However, since the `subcontracting_record_component` method is used in other flows for wich it is desirable to create a back order for the other stock moves, we can not reset the picked status of these moves in this method. As such, we decided to introduce a new method that will be called only in our flow. Note that the picked status of the related stock move lines will automatically be updated via the inverse compute method:
https://github.com/odoo/odoo/blob/1648ee1abff1ae12b3933baa85a2e048fa2eb557/addons/stock/models/stock_move.py#L212-L214

#### Note:

The picked field did not exist prior to 17.0.

opw-3847825
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
