### PR TITLE
[FIX] survey: put shadow if no background image

### DIFF
--- a/addons/survey/static/src/scss/survey_templates_form.scss
+++ b/addons/survey/static/src/scss/survey_templates_form.scss
@@ -11,6 +11,9 @@ div.o_frontend_to_backend_nav {
 /**********************************************************
                         Common Style
  **********************************************************/
+// dynamic color is used to ensure enough contrast between the text and the background color
+$dynamic-text-color: if(lightness($body-bg) > 50%, $gray-900, $gray-100);
+
 // the survey background image takes all the page background, with a translucent white overlay (box-shadow)
 // When changing the background from one section to another, the overlay will become opaque to simulate a fade out of
 // the background image. This ensure a smooth transition from one background to another, likewise the question
@@ -19,9 +22,20 @@ div.o_frontend_to_backend_nav {
     height: 100%;
     overflow: auto;
     transition: box-shadow 0.3s ease-in-out;
-    box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7);
     background: no-repeat fixed center;
     background-size: cover;
+    color: $dynamic-text-color !important;
+    .text-muted {
+        opacity: 0.7;
+        color: $dynamic-text-color !important;
+    }
+    &.o_survey_background_shadow {
+        box-shadow: inset 0 0 0 10000px rgba(255,255,255,.7);
+        color: $gray-900 !important;
+        .text-muted {
+            color: $gray-900 !important;
+        }
+    }
     &.o_survey_background_transition {
         box-shadow: inset 0 0 0 10000px rgba(255,255,255,1);
     }
@@ -98,6 +112,9 @@ _::-webkit-full-page-media, _:future, :root .o_survey_wrap {
         }
         &:focus {
             box-shadow: none;
+        }
+        .o_survey_background_shadow & {
+            color: $gray-900 !important;
         }
     }
 

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -16,7 +16,13 @@
                              else ('background-image: url(' + survey.background_image_url + ');')
                              if survey and survey.background_image_url
                              else '')"/>
-            <attribute name="t-attf-class" add="o_survey_background" separator=" "/>
+            <attribute name="t-att-class"
+                       add="(('o_survey_background o_survey_background_shadow')
+                             if (question and question.background_image_url)
+                             or (page and page.background_image_url)
+                             or (survey and survey.background_image_url)
+                             else 'o_survey_background')"
+                       separator=" "/>
         </xpath>
         <xpath expr="//head/t[@t-call-assets][last()]" position="after">
             <t t-call-assets="survey.survey_assets" lazy_load="True"/>
@@ -353,7 +359,7 @@
 
     <template id="question_text_box" name="Question: free text box">
         <div class="o_survey_comment_container p-0">
-            <textarea class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0" rows="3"
+            <textarea class="form-control o_survey_question_text_box bg-transparent rounded-0 p-0" rows="3"
                       t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                       t-att-data-question-type="question.question_type"><t t-if="answer_lines" t-esc="answer_lines[0].value_text_box or None"/></textarea>
         </div>
@@ -362,7 +368,7 @@
     <template id="question_char_box" name="Question: text box">
         <div class="o_survey_comment_container p-0">
             <input t-att-type="'email' if question.validation_email else 'text'"
-               class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0"
+               class="form-control o_survey_question_text_box bg-transparent rounded-0 p-0"
                t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                t-att-value="answer_lines[0].value_char_box if answer_lines else None"
                t-att-data-question-type="question.question_type"
@@ -372,7 +378,7 @@
     </template>
 
     <template id="question_numerical_box" name="Question: numerical box">
-        <input type="number" step="any" class="form-control o_survey_question_numerical_box bg-transparent text-dark rounded-0 p-0"
+        <input type="number" step="any" class="form-control o_survey_question_numerical_box bg-transparent rounded-0 p-0"
                t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                t-att-value="answer_lines[0].value_numerical_box if answer_lines else None"
                t-att-data-question-type="question.question_type"
@@ -384,7 +390,7 @@
         <div class="input-group o_survey_form_date" t-attf-id="datetimepicker_#{question.id}" data-target-input="nearest"
                 t-att-data-mindate="question.validation_min_date"
                 t-att-data-maxdate="question.validation_max_date">
-            <input type="text" class="form-control datetimepicker-input o_survey_question_date bg-transparent text-dark rounded-0 p-0"
+            <input type="text" class="form-control datetimepicker-input o_survey_question_date bg-transparent rounded-0 p-0"
                    t-attf-data-target="#datetimepicker_#{question.id}"
                    t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                    t-att-value="format_date(answer_lines[0].value_date) if answer_lines else None"
@@ -397,7 +403,7 @@
         <div class="input-group o_survey_form_date" t-attf-id="datetimepicker_#{question.id}" data-target-input="nearest"
                 t-att-data-mindate="question.validation_min_datetime"
                 t-att-data-maxdate="question.validation_max_datetime">
-            <input type="text" class="form-control datetimepicker-input o_survey_question_datetime bg-transparent text-dark rounded-0 p-0"
+            <input type="text" class="form-control datetimepicker-input o_survey_question_datetime bg-transparent rounded-0 p-0"
                    t-attf-data-target="#datetimepicker_#{question.id}"
                    t-att-name="question.id" t-att-placeholder="question.question_placeholder"
                    t-att-value="format_datetime(answer_lines[0].value_datetime) if answer_lines else None"
@@ -479,12 +485,12 @@
                     </label>
                 </div>
                 <div t-attf-class="o_survey_comment_container mt-3 py-0 px-1  #{'d-none' if not comment_line else ''}">
-                    <textarea type="text" class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0"
+                    <textarea type="text" class="form-control o_survey_question_text_box bg-transparent rounded-0 p-0"
                               t-att-disabled="None if comment_line else 'disabled'"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
                 </div>
             </div>
             <div t-if='question.comments_allowed and not question.comment_count_as_answer' class="col-lg-12 o_survey_comment_container mx-1 mt-3 ps-3 pe-4">
-                <textarea type="text" class="form-control o_survey_comment o_survey_question_text_box bg-transparent text-dark rounded-0 p-0"
+                <textarea type="text" class="form-control o_survey_comment o_survey_question_text_box bg-transparent rounded-0 p-0"
                           t-att-placeholder="question.comments_message or default_comments_message if not survey_form_readonly else ''"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
             </div>
         </div>
@@ -548,12 +554,12 @@
                     </label>
                 </div>
                 <div t-attf-class="o_survey_comment_container mt-3 py-0 px-1 #{'d-none' if not comment_line else ''}">
-                    <textarea type="text" class="form-control o_survey_question_text_box bg-transparent text-dark rounded-0 p-0"
+                    <textarea type="text" class="form-control o_survey_question_text_box bg-transparent rounded-0 p-0"
                               t-att-disabled="None if comment_line else 'disabled'"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
                 </div>
             </div>
             <div t-if='question.comments_allowed and not question.comment_count_as_answer' class="col-lg-12 o_survey_comment_container mx-1 mt-3 py-0 ps-3 pe-4">
-                <textarea type="text" class="form-control o_survey_comment o_survey_question_text_box bg-transparent text-dark rounded-0 p-0"
+                <textarea type="text" class="form-control o_survey_comment o_survey_question_text_box bg-transparent rounded-0 p-0"
                           t-att-placeholder="question.comments_message or default_comments_message if not survey_form_readonly else ''"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
             </div>
         </div>
@@ -602,7 +608,7 @@
             </tbody>
         </table>
         <div t-if='question.comments_allowed'>
-            <textarea type="text" class="form-control o_survey_question_text_box o_survey_comment bg-transparent text-dark rounded-0 p-0 mt-3"
+            <textarea type="text" class="form-control o_survey_question_text_box o_survey_comment bg-transparent rounded-0 p-0 mt-3"
                       t-att-placeholder="question.comments_message or default_comments_message if not survey_form_readonly else ''"
                       t-att-name="'%s_%s' % (question.id, 'comment')"><t t-esc="comment_line.value_char_box if comment_line else ''"/></textarea>
         </div>


### PR DESCRIPTION
Current behavior:
---
On the website, when changing the background color to 
a darker color (ie: black) then starting a survey, 
the background color for the survey is lighter (ie: gray)

Expected behavior:
---
The survey colors should be the same as the website theme.

Steps to reproduce:
---
1. Go to the website
2. Click on Edit > Theme
3. Change the background color to black
4. Save then go to Survey
5. Select a survey
6. Remove the background image if there is one
7. Click on Test
8. Survey's background color is grey

Cause of the issue:
---
Introduced by https://github.com/odoo/odoo/blob/90c6e52f15277d44cbecdd5f6a70391551fb72bd/addons/survey/static/src/scss/survey_templates_form.scss#L22 
A box-shadow is used to make a "translucent white overlay" 
Which lighten the background color if there is no image

Fix:
---
Only lighten the background if there is a background image

opw-3834397

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
