### PR TITLE
[IMP] account: Make unreconcile button in paid info popover accessible for long payment memos

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -91,6 +91,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'web.assets_backend': [
             'account/static/src/css/account_bank_and_cash.css',
             'account/static/src/css/account.css',
+            'account/static/src/css/account_payment.scss',
             'account/static/src/scss/account_journal_dashboard.scss',
             'account/static/src/scss/account_searchpanel.scss',
             'account/static/src/scss/account_payment_term.scss',

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -78,9 +78,9 @@
                             </td>
                         </tr>
                         <tr>
-                            <td><strong>Memo: </strong></td>
-                            <td>
-                                <div style="width: 200px; word-wrap: break-word">
+                            <td class="fw-bolder align-top">Memo:</td>
+                            <td class="ps-1">
+                                <div class="o_memo_content" t-att-data-tooltip="props.ref" data-tooltip-position="left">
                                     <t t-out="props.ref"/>
                                 </div>
                             </td>

--- a/addons/account/static/src/components/account_payment_field/account_payment.xml
+++ b/addons/account/static/src/components/account_payment_field/account_payment.xml
@@ -69,8 +69,8 @@
                 <div>
                     <table>
                         <tr>
-                            <td><strong>Amount: </strong></td>
-                            <td>
+                            <td class="fw-bolder">Amount:</td>
+                            <td class="ps-1">
                                 <t t-out="props.amount_company_currency"></t>
                                 <t t-if="props.amount_foreign_currency">
                                     (<span class="fa fa-money"/> <t t-out="props.amount_foreign_currency"/>)
@@ -86,16 +86,21 @@
                             </td>
                         </tr>
                         <tr>
-                            <td><strong>Date: </strong></td>
-                            <td><t t-out="props.date"/></td>
+                            <td class="fw-bolder">Date:</td>
+                            <td class="ps-1"><t t-out="props.date"/></td>
                         </tr>
                         <tr>
-                            <td><strong>Journal: </strong></td>
-                            <td><t t-out="props.journal_name"/><span t-if="props.payment_method_name"> (<t t-out="props.payment_method_name"/>)</span></td>
+                            <td class="fw-bolder">Journal:</td>
+                            <td class="ps-1">
+                                <t t-out="props.journal_name"/>
+                                <span t-if="props.payment_method_name">
+                                    (<t t-out="props.payment_method_name"/>)
+                                </span>
+                            </td>
                         </tr>
                         <tr t-if="props.company_name">
-                            <td><strong>Branch: </strong></td>
-                            <td><t t-out="props.company_name"/></td>
+                            <td class="fw-bolder">Branch:</td>
+                            <td class="ps-1"><t t-out="props.company_name"/></td>
                         </tr>
                     </table>
                 </div>

--- a/addons/account/static/src/css/account_payment.scss
+++ b/addons/account/static/src/css/account_payment.scss
@@ -2,3 +2,12 @@
     padding: 5px 0 5px 8px;
     border-bottom: 1px solid #ccc;
 }
+
+.o_memo_content {
+    max-width: 200px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+}

--- a/addons/account/static/src/css/account_payment.scss
+++ b/addons/account/static/src/css/account_payment.scss
@@ -1,0 +1,4 @@
+.o_popover_header {
+    padding: 5px 0 5px 8px;
+    border-bottom: 1px solid #ccc;
+}


### PR DESCRIPTION
The unreconcile button in the paid info popover is often inaccessible when several invoices are paid via a group payment. To make it accessible when the memo is more than 3 lines, replace the end of the memo with `...` and only show the full text when hovering over it in a tooltip.

Prettify the Payment info popover as described in the task.

task id: 3865801

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
