### PR TITLE
[FIX] payment_mercado_pago: fix checkout process

### DIFF
--- a/addons/payment_mercado_pago/models/payment_transaction.py
+++ b/addons/payment_mercado_pago/models/payment_transaction.py
@@ -40,7 +40,7 @@ class PaymentTransaction(models.Model):
         )
         api_url = self.provider_id._mercado_pago_make_request(
             '/checkout/preferences', payload=payload
-        )['init_point' if self.provider_id.state == 'enabled' else 'sandbox_init_point']
+        )['init_point']
 
         # Extract the payment link URL and embed it in the redirect form.
         rendering_values = {


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
'sandbox_init_point' is deprecated. Although it still exists in the payment preference creation, it is no longer functional in the result; 'init_point' should always be used instead. In the case of test credentials, 'init_point' will always behave as if in a test environment.

Steps to Reproduce:
 - Install the payment_mercado_pago module.
 - Configure the account with the following mercado_pago_access_token: TEST-4811719641145832-020115-c5caffc149634e3e9d72fde2b74544d8__LD_LA__-172837665
 - Initiate a payment process with a published mercado_pago payment provider link.
The following error occurs:

![m_p_error](https://github.com/odoo/odoo/assets/130502471/5f3d353f-69ce-4ae0-b745-c55a07951509)

Removing the 'sandbox' word from the URL generates the payment process correctly.
![image (1)](https://github.com/odoo/odoo/assets/130502471/c56a32fb-a1ec-47e2-ae87-0a1a0084ae6f)
![image (2)](https://github.com/odoo/odoo/assets/130502471/c6164128-7783-4033-bb5f-7cfb34ed01b6)

Current behavior before PR:
Payment cannot be made in sandbox mode using payment credentials with the mercado_pago provider.

Desired behavior after PR is merged:
The payment process should be completed successfully using test credentials for the mercado_pago provider.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
