### PR TITLE
[FIX] account: Remove `invoice_pdf_report_id` on reset to draft

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -4121,7 +4121,7 @@ class AccountMove(models.Model):
             move.mapped('line_ids.analytic_line_ids').unlink()
 
         self.mapped('line_ids').remove_move_reconcile()
-        self.write({'state': 'draft', 'is_move_sent': False})
+        self.state = 'draft'
 
     def button_cancel(self):
         self.write({'auto_post': 'no', 'state': 'cancel'})

--- a/addons/account/tests/test_account_move_send.py
+++ b/addons/account/tests/test_account_move_send.py
@@ -880,3 +880,17 @@ class TestAccountMoveSend(TestAccountMoveSendCommon):
             self.create_send_and_print(invoice_draft)
         with self.assertRaises(UserError):
             self.create_send_and_print(invoice_posted + invoice_draft)
+
+    def test_out_invoice_is_move_sent(self):
+        invoice = self.init_invoice(move_type='out_invoice', amounts=[1000.0], post=True)
+        wizard = self.create_send_and_print(invoice)
+
+        self.assertEqual(invoice.state, 'posted')
+        self.assertFalse(invoice.is_move_sent)
+
+        wizard.action_send_and_print()
+        self.assertTrue(invoice.is_move_sent)
+
+        invoice.button_draft()
+        self.assertEqual(invoice.state, 'draft')
+        self.assertTrue(invoice.is_move_sent)


### PR DESCRIPTION
Current Behavior:
`is_move_sent` is not updated if there is an existing `invoice_pdf_report_id`.

Purpose of this PR:
Remove the `invoice_pdf_report_id` when resetting invoice to draft so that when the invoice is sent again (using the Send and Print wizard), `is_move_sent` is updated.

Steps to Reproduce on Runbot:
1) Create and Send and Print invoice. (`is_move_sent` is set to True) 
2) Reset invoice to draft. (`is_move_sent` is set to False) 
3) Confirm and resend invoice using Send and Print wizard. (`is_move_sent` remains False, expected to be changed to True)

Notes:
This PR #116698 added a _compute in Odoo 16, however it was removed in saas-16.3 with this PR #125392. `is_move_sent` is not updated on the second Send and Print because of the existing `invoice_pdf_report_id` (generated and linked during the first Send and Print).

opw-3849109