### PR TITLE
[FIX] web: inconsistent daterange validation

### DIFF
--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -10,6 +10,7 @@ import {
     formatDateTime,
     today,
 } from "@web/core/l10n/dates";
+import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "@web/core/registry";
 import { ensureArray } from "@web/core/utils/arrays";
@@ -376,6 +377,31 @@ export const dateRangeField = {
         },
     ],
     supportedTypes: ["date", "datetime"],
+    isValid: (record, fieldname, fieldInfo) => {
+        if (fieldInfo.widget === "daterange") {
+            if (
+                !record.data[fieldInfo.options[END_DATE_FIELD_OPTION]] !==
+                    !record.data[fieldname] &&
+                evaluateBooleanExpr(
+                    record.activeFields[fieldInfo.options[END_DATE_FIELD_OPTION]]?.required,
+                    record.evalContextWithVirtualIds
+                )
+            ) {
+                return false;
+            }
+            if (
+                !record.data[fieldInfo.options[START_DATE_FIELD_OPTION]] !==
+                    !record.data[fieldname] &&
+                evaluateBooleanExpr(
+                    record.activeFields[fieldInfo.options[START_DATE_FIELD_OPTION]]?.required,
+                    record.evalContextWithVirtualIds
+                )
+            ) {
+                return false;
+            }
+        }
+        return !record.isFieldInvalid(fieldname);
+    }
 };
 
 registry

--- a/addons/web/static/src/views/fields/field.js
+++ b/addons/web/static/src/views/fields/field.js
@@ -53,7 +53,9 @@ export function fieldVisualFeedback(field, record, fieldName, fieldInfo) {
     return {
         readonly,
         required,
-        invalid: record.isFieldInvalid(fieldName),
+        invalid: field.isValid
+            ? !field.isValid(record, fieldName, fieldInfo)
+            : record.isFieldInvalid(fieldName),
         empty,
     };
 }

--- a/addons/web/static/tests/views/fields/daterange_field_tests.js
+++ b/addons/web/static/tests/views/fields/daterange_field_tests.js
@@ -1240,4 +1240,52 @@ QUnit.module("Fields", (hooks) => {
             assert.containsOnce(target, ".fa-long-arrow-right");
         }
     );
+
+    QUnit.test("invalid empty date with optional end date", async (assert) => {
+        serverData.models.partner.fields.date_end = { string: "Date End", type: "date" };
+        serverData.models.partner.records[0].date_end = "2017-02-08";
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                    <form>
+                        <label for="date" string="Daterange" />
+                        <field name="date" widget="daterange" options="{'end_date_field': 'date_end','always_range': '1'}"  string="Planned Date" required="date_end"/>
+                        <field name="date_end" invisible="1" required="date"/>
+                    </form>`,
+            resId: 1,
+        });
+        await editInput(target, "input[data-field=date_end]", "");
+        await click(target);
+        assert.hasClass(
+            target.querySelector(".o_field_daterange"),
+            "o_field_invalid",
+            "date field should be displayed as invalid"
+        );
+    });
+
+    QUnit.test("invalid empty date with optional start date", async (assert) => {
+        serverData.models.partner.fields.date_end = { string: "Date End", type: "date" };
+        serverData.models.partner.records[0].date_end = "2017-02-08";
+        await makeView({
+            type: "form",
+            resModel: "partner",
+            serverData,
+            arch: `
+                    <form>
+                        <label for="date_end" string="Daterange" />
+                        <field name="date" invisible="1" required="date_end"/>
+                        <field name="date_end" widget="daterange" options="{'start_date_field': 'date','always_range': '1'}" string="Planned Date" required="date"/>
+                    </form>`,
+            resId: 1,
+        });
+        await editInput(target, "input[data-field=date]", "");
+        await click(target);
+        assert.hasClass(
+            target.querySelector(".o_field_daterange"),
+            "o_field_invalid",
+            "date field should be displayed as invalid"
+        );
+    });
 });


### PR DESCRIPTION
Specification:
In the daterange widget, if the second date field is required and left empty, the field should be marked as invalid and be colored red.

Expected behavior:
if the second field is empty so that fields should be highlighted in red.

Task-3786540