### PR TITLE
[IMP] mail: sharpen UX of activity flows

### DIFF
--- a/addons/mail/static/src/core/web/activity_list_popover_item.js
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.js
@@ -60,11 +60,14 @@ export class ActivityListPopoverItem extends Component {
         }
     }
 
+    get hasCancelButton() {
+        const activity = this.props.activity;
+        return activity.state !== "done" && activity.can_write;
+    }
+
     get hasEditButton() {
         const activity = this.props.activity;
-        return (
-            activity.state !== "done" && activity.chaining_type === "suggest" && activity.can_write
-        );
+        return activity.state !== "done" && activity.can_write;
     }
 
     get hasFileUploader() {
@@ -91,6 +94,13 @@ export class ActivityListPopoverItem extends Component {
         });
         await this.props.activity.markAsDone([attachmentId]);
         this.props.onActivityChanged?.();
+    }
+
+    unlink() {
+        this.props.activity.remove();
+        this.env.services.orm
+            .unlink("mail.activity", [this.props.activity.id])
+            .then(() => this.props.onActivityChanged?.());
     }
 
     get activityAssigneeAvatar() {

--- a/addons/mail/static/src/core/web/activity_list_popover_item.xml
+++ b/addons/mail/static/src/core/web/activity_list_popover_item.xml
@@ -3,16 +3,12 @@
     <t t-name="mail.ActivityListPopoverItem">
         <div class="o-mail-ActivityListPopoverItem d-flex flex-column border-bottom py-2">
             <div class="overflow-auto d-flex align-items-baseline ms-3 me-1">
-                <i t-if="props.activity.icon" class="fa small me-2" t-attf-class="{{ props.activity.icon }}" role="img"/>
                 <t t-if="props.activity.summary">
                     <b class="text-900 me-2 text-truncate flex-grow-1 flex-basis-0" t-esc="props.activity.summary"/>
                 </t>
                 <t t-if="!props.activity.summary and props.activity.activity_type_id">
                     <b class="text-900 me-2 text-truncate flex-grow-1" t-esc="props.activity.activity_type_id[1]"/>
                 </t>
-                <button t-if="hasEditButton" class="o-mail-ActivityListPopoverItem-editbtn btn btn-sm btn-success btn-link" t-on-click="onClickEditActivityButton">
-                    <i class="fa fa-pencil"/>
-                </button>
                 <t t-if="props.activity.can_write">
                     <FileUploader t-if="hasFileUploader" onUploaded.bind="onFileUploaded">
                         <t t-set-slot="toggler">
@@ -22,9 +18,15 @@
                         </t>
                     </FileUploader>
                     <button t-if="hasMarkDoneButton" class="o-mail-ActivityListPopoverItem-markAsDone btn btn-sm btn-success btn-link" title="Mark as done" aria-label="Mark as done" t-on-click="onClickMarkAsDone">
-                        <i class="fa fa-check-circle"/>
+                        <i class="fa fa-check"/>
                     </button>
                 </t>
+                <button t-if="hasEditButton" class="o-mail-ActivityListPopoverItem-editbtn btn btn-sm btn-success btn-link" title="Edit" aria-label="Edit" t-on-click="onClickEditActivityButton">
+                    <i class="fa fa-pencil"/>
+                </button>
+                <button t-if="hasCancelButton" class="o-mail-ActivityListPopoverItem-cancel btn btn-sm btn-danger btn-link" title="Cancel" aria-label="Cancel" t-on-click="unlink">
+                    <i class="fa fa-times"/>
+                </button>
             </div>
             <div class="d-flex align-items-center flex-wrap mx-3">
                 <img t-if="props.activity.user_id[0]" class="me-2 rounded" t-att-src="activityAssigneeAvatar" style="max-width: 1.5rem; max-height: 1.5rem;"/>


### PR DESCRIPTION
This PR improves the UX of activity popover in the following ways:

- Changes the icons and positions of the activity popover buttons (Mark Done, Edit) 
such that they match the ones for an activity in the chatter.
- Introduces a `Cancel` button in the activity popover, which also works just the way it does in the chatter.
  Also a test case is added to test the functionality of the `Cancel` button in popover. 
- It also tweaks the condition to display `Edit` and `Cancel` buttons.
  Earlier, the edit button was not visible when the chaining type for an activity was `trigger`. 
  Instead, both the buttons will now be visible irrespective of the activity chaining type, just like in case of Chatter.
- With the change of icons of activity popover buttons, it now removes the icons that are displayed alongside 
  the 'activity type' titles in the popover, and aligns the title text to the left, in order to avoid duplicate icons.
  (For eg. in case of `to-do` and `upload document` activities).

Task-[3861855](https://www.odoo.com/web#id=3861855&menu_id=4722&cids=2&action=333&active_id=965&model=project.task&view_type=form)