### PR TITLE
[FIX] analytic: update analytic distribution on deleted analytic account

### DIFF
--- a/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
+++ b/addons/analytic/static/src/components/analytic_distribution/analytic_distribution.js
@@ -25,6 +25,7 @@ import {
     useExternalListener,
     onWillStart,
     onPatched,
+    onMounted,
 } from "@odoo/owl";
 
 export class AnalyticDistribution extends Component {
@@ -68,6 +69,9 @@ export class AnalyticDistribution extends Component {
         onWillStart(this.willStart);
         useRecordObserver(this.willUpdateRecord.bind(this));
         onPatched(this.patched);
+        onMounted(async () => {
+            if (this.pendingSave) this.save(true)
+        })
 
         useExternalListener(window, "click", this.onWindowClick, true);
         useExternalListener(window, "resize", this.onWindowResized);
@@ -254,7 +258,7 @@ export class AnalyticDistribution extends Component {
         this.state.formattedData = distribution;
         if (accountNotFound) {
             // Analytic accounts in the json were not found, save the json without them
-            await this.save();
+            this.pendingSave = true
         }
     }
 
@@ -452,8 +456,8 @@ export class AnalyticDistribution extends Component {
         return result;
     }
 
-    async save() {
-        await this.props.record.update({ [this.props.name]: this.dataToJson() });
+    async save(actualSave=false) {
+        await this.props.record.update({ [this.props.name]: this.dataToJson() }, { save: actualSave });
     }
 
     onSaveNew() {


### PR DESCRIPTION
This commit addresses an issue where opening the analytic distribution models list view triggers excessive network requests due to mishandling of analytic accounts deletion.

### Steps to Reproduce

1. Install `account_accountant`.
2. Enable 'Analytic Accounting' in the accounting settings.
3. Create 45 analytic distribution models.
4. Configure 5 of them to use analytic distributions that reference deleted analytic accounts.
5. With the network inspector open, navigate to the analytic distribution models list view.

More than 700 requests are made, potentially reaching the rate limit and blocking access to the page.

### Cause

Analytic distributions are represented by a JSON mapping of analytic account IDs to integers. When an analytic account is deleted, the JSON references to it are not immediately updated in the database. Instead, this task is deferred to the analytic distribution widget on the frontend. Specifically, when the widget attempts to fetch an analytic account for display and fails to find it, it infers that the account has been deleted. Consequently, the widget updates its JSON representation to exclude the deleted account. It's important to note that this update occurs only on the frontend; the database remains unchanged until the user saves the record they are editing. However, in scenarios where we're merely displaying data — as in a list view — no edits are made, and hence no save operation occurs to update the database.

This process of updating occurs within the `onWillStart` lifecycle method of the analytic distribution widget. A critical aspect of this implementation is that the record object is passed as a prop to the widget component. Modifying a component's `props` during its lifecycle triggers its destruction and re-creation. As a result, displaying an analytic distribution that references deleted accounts necessitates two requests — one for the initial display and another post-recreation.

Moreover, this mechanism extends to the entire list view. If a list view element is modified during its loading phase, it triggers a reconstruction of the entire list view. This reconstruction, in turn, prompts new requests for each analytic distribution model, potentially restarting the process if additional discrepancies in the distribution models exist.

This recursive behavior can lead to an exponential increase in the number of requests proportional to the number of faulty analytic distribution models.

### Fix

To address these issues, this commit implements the following changes:

1. Moves the actual updating of the JSON from `onWillStart` to `onMounted`. This change prevents the unnecessary destruction and recreation of components, reducing the number of requests significantly.
2. Automatically saves the record when modifications involve removing analytic distributions that reference deleted analytic accounts, ensuring the changes are persisted, further reducing the number of Unnecessary requests

opw-3813783