### PR TITLE
[IMP] stock:  Field UI improvements and UoM as text headers

### DIFF
--- a/addons/delivery/views/delivery_price_rule_views.xml
+++ b/addons/delivery/views/delivery_price_rule_views.xml
@@ -21,9 +21,9 @@
                     <div>
                         <field name="list_base_price" widget="monetary" class="oe_inline"/>
                         +
-                        <field name="list_price" widget="monetary" class="oe_inline"/>
+                        <field name="list_price" widget="monetary" class="oe_inline ms-3"/>
                         *
-                        <field name="variable_factor" class="oe_inline"/>
+                        <field name="variable_factor" class="oe_inline ms-2"/>
                     </div>
                 </group>
             </form>

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -44,7 +44,7 @@ class MrpBom(models.Model):
         digits='Product Unit of Measure', required=True,
         help="This should be the smallest quantity that this product can be produced in. If the BOM contains operations, make sure the work center capacity is accurate.")
     product_uom_id = fields.Many2one(
-        'uom.uom', 'Unit of Measure',
+        'uom.uom', 'Unit',
         default=_get_default_product_uom_id, required=True,
         help="Unit of Measure (Unit of Measure) is the unit of measurement for the inventory control", domain="[('category_id', '=', product_uom_category_id)]")
     product_uom_category_id = fields.Many2one(related='product_tmpl_id.uom_id.category_id')

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -28,7 +28,7 @@ class MrpUnbuild(models.Model):
         compute='_compute_product_qty', store=True, precompute=True, readonly=False,
         required=True)
     product_uom_id = fields.Many2one(
-        'uom.uom', 'Unit of Measure',
+        'uom.uom', 'Unit',
         compute='_compute_product_uom_id', store=True, readonly=False, precompute=True,
         required=True)
     bom_id = fields.Many2one(

--- a/addons/product/models/product_packaging.py
+++ b/addons/product/models/product_packaging.py
@@ -19,7 +19,7 @@ class ProductPackaging(models.Model):
     product_id = fields.Many2one('product.product', string='Product', check_company=True, required=True, ondelete="cascade")
     qty = fields.Float('Contained Quantity', default=1, digits='Product Unit of Measure', help="Quantity of products contained in the packaging.")
     barcode = fields.Char('Barcode', copy=False, help="Barcode used for packaging identification. Scan this packaging barcode from a transfer in the Barcode app to move all the contained units")
-    product_uom_id = fields.Many2one('uom.uom', related='product_id.uom_id', readonly=True)
+    product_uom_id = fields.Many2one('uom.uom', related='product_id.uom_id', string='Unit', readonly=True)
     company_id = fields.Many2one('res.company', 'Company', index=True)
 
     _sql_constraints = [

--- a/addons/product/models/product_supplierinfo.py
+++ b/addons/product/models/product_supplierinfo.py
@@ -30,7 +30,7 @@ class ProductSupplierinfo(models.Model):
     sequence = fields.Integer(
         'Sequence', default=1, help="Assigns the priority to the list of product vendor.")
     product_uom = fields.Many2one(
-        'uom.uom', 'Unit of Measure',
+        'uom.uom', 'Unit',
         related='product_tmpl_id.uom_po_id')
     min_qty = fields.Float(
         'Quantity', default=0.0, required=True, digits="Product Unit of Measure",

--- a/addons/product/views/product_views.xml
+++ b/addons/product/views/product_views.xml
@@ -194,14 +194,14 @@
                             <group name="inventory">
                                 <group name="group_lots_and_weight" string="Logistics" invisible="type != 'consu'">
                                     <label for="weight" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
-                                    <div class="o_row" name="weight" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                                        <field name="weight" class="oe_inline"/>
-                                        <field name="weight_uom_name"/>
+                                    <div class="row" name="weight" invisible="product_variant_count &gt; 1 and not is_product_variant">
+                                        <div class="col-4"><field name="weight" /></div>
+                                        <div class="col-4"><field name="weight_uom_name"/></div>
                                     </div>
                                     <label for="volume" invisible="product_variant_count &gt; 1 and not is_product_variant"/>
-                                    <div class="o_row" name="volume" invisible="product_variant_count &gt; 1 and not is_product_variant">
-                                        <field name="volume" string="Volume" class="oe_inline"/>
-                                        <field name="volume_uom_name"/>
+                                    <div class="row" name="volume" invisible="product_variant_count &gt; 1 and not is_product_variant">
+                                        <div class="col-4"><field name="volume" string="Volume" /></div>
+                                        <div class="col-4"><field name="volume_uom_name"/></div>
                                     </div>
                                 </group>
                             </group>

--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -25,7 +25,7 @@ class StockMoveLine(models.Model):
     company_id = fields.Many2one('res.company', string='Company', readonly=True, required=True, index=True)
     product_id = fields.Many2one('product.product', 'Product', ondelete="cascade", check_company=True, domain="[('type', '!=', 'service')]", index=True)
     product_uom_id = fields.Many2one(
-        'uom.uom', 'Unit of Measure', required=True, domain="[('category_id', '=', product_uom_category_id)]",
+        'uom.uom', 'Unit', required=True, domain="[('category_id', '=', product_uom_category_id)]",
         compute="_compute_product_uom_id", store=True, readonly=False, precompute=True,
     )
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -49,7 +49,7 @@ class StockQuant(models.Model):
         'product.template', string='Product Template',
         related='product_id.product_tmpl_id')
     product_uom_id = fields.Many2one(
-        'uom.uom', 'Unit of Measure',
+        'uom.uom', 'Unit',
         readonly=True, related='product_id.uom_id')
     is_favorite = fields.Boolean(related='product_tmpl_id.is_favorite')
     company_id = fields.Many2one(related='location_id.company_id', string='Company', store=True, readonly=True)

--- a/addons/stock/models/stock_scrap.py
+++ b/addons/stock/models/stock_scrap.py
@@ -21,7 +21,7 @@ class StockScrap(models.Model):
         'product.product', 'Product', domain="[('type', '=', 'consu')]",
         required=True, check_company=True)
     product_uom_id = fields.Many2one(
-        'uom.uom', 'Unit of Measure',
+        'uom.uom', 'Unit',
         compute="_compute_product_uom_id", store=True, readonly=False, precompute=True,
         required=True, domain="[('category_id', '=', product_uom_category_id)]")
     product_uom_category_id = fields.Many2one(related='product_id.uom_id.category_id')

--- a/addons/stock/models/stock_storage_category.py
+++ b/addons/stock/models/stock_storage_category.py
@@ -55,7 +55,7 @@ class StockStorageCategoryCapacity(models.Model):
             " [('is_storable', '=', True)]"))
     package_type_id = fields.Many2one('stock.package.type', 'Package Type', ondelete='cascade', check_company=True)
     quantity = fields.Float('Quantity', required=True)
-    product_uom_id = fields.Many2one(related='product_id.uom_id')
+    product_uom_id = fields.Many2one(related='product_id.uom_id', string='Unit')
     company_id = fields.Many2one('res.company', 'Company', related="storage_category_id.company_id")
 
     _sql_constraints = [

--- a/addons/stock/views/stock_lot_views.xml
+++ b/addons/stock/views/stock_lot_views.xml
@@ -37,9 +37,9 @@
                     <group>
                         <field name="product_id" context="{'default_is_storable': True, 'default_tracking': 'lot'}" readonly="context.get('set_product_readonly', False)" force_save="1" help="Product this lot/serial number contains. You cannot change it anymore if it has already been moved."/>
                         <label for="product_qty" invisible="not display_complete"/>
-                        <div class="o_row" invisible="not display_complete">
-                            <field name="product_qty"/>
-                            <field name="product_uom_id" groups="uom.group_uom"/>
+                        <div class="row" invisible="not display_complete">
+                            <div class="col-2"><field name="product_qty"/></div>
+                            <div class="col-2"><field name="product_uom_id" groups="uom.group_uom"/></div>
                         </div>
                         <field name="ref"/>
                         <field name="company_id" groups="base.group_multi_company"/>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -86,9 +86,9 @@
                         </group>
                         <group>
                             <label for="quantity" string="Quantity"/>
-                            <div class="o_row">
-                                <field name="quantity"/>
-                                <field name="product_uom_id" options="{'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/>
+                            <div class="row">
+                                <div class="col col-md-3"><field name="quantity"/></div>
+                                <div class="col"><field name="product_uom_id" options="{'no_create': True}" string="Unit of Measure" groups="uom.group_uom"/></div>
                             </div>
                             <field name="lot_id" groups="stock.group_production_lot" context="{'default_product_id': product_id, 'active_picking_id': picking_id}"
                                    invisible="tracking == 'none' or not lot_id and lot_name"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -213,7 +213,7 @@
                     <field name="is_locked" column_invisible="True"/>
                     <field name="picking_code" column_invisible="True"/>
                     <field name="quantity" string="Quantity" readonly="(state == 'done' and is_locked) or (package_level_id and parent.picking_type_entire_packs)" sum="Quantity"/>
-                    <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" string="Unit of Measure" groups="uom.group_uom"
+                    <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"
                         readonly="(package_level_id and parent.picking_type_entire_packs) or (state == 'done' and id)"/>
                 </list>
             </field>

--- a/addons/stock/views/stock_package_type_view.xml
+++ b/addons/stock/views/stock_package_type_view.xml
@@ -24,14 +24,14 @@
                             <span><field name="length_uom_name" help="Size: Length &#215; Width &#215; Height"/></span>
                         </div>
                         <label for="base_weight"/>
-                        <div class="o_row" name="base_weight">
-                            <field name="base_weight"/>
-                            <span><field name="weight_uom_name"/></span>
+                        <div class="row" name="base_weight">
+                            <div class="col-2"><field name="base_weight"/></div>
+                            <div class="col-1"><field name="weight_uom_name"/></div>
                         </div>
                         <label for="max_weight"/>
-                        <div class="o_row" name="max_weight">
-                            <field name="max_weight"/>
-                            <span><field name="weight_uom_name"/></span>
+                        <div class="row" name="max_weight">
+                            <div class="col-2"><field name="max_weight"/></div>
+                            <div class="col-1"><field name="weight_uom_name"/></div>
                         </div>
                         <field name="barcode"/>
                         <field name="company_id" groups="base.group_multi_company"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -282,7 +282,7 @@
                             <field name="package_type_id"/>
                             <field name='company_id' groups="base.group_multi_company"/>
                             <field name='owner_id' groups="stock.group_tracking_owner"/>
-                            <field name="location_id" options="{'no_create': True}"/>
+                            <field name="location_id" options="{'no_create': True}" class="w-auto"/>
                         </group>
                         <group>
                             <field name="pack_date"/>
@@ -448,7 +448,7 @@ in this location. That leads to a negative stock.
                 <field name="last_count_date" optional='hidden' readonly='1'/>
                 <field name="available_quantity" string="Available Quantity" decoration-danger="available_quantity &lt; 0" optional="hidden"/>
                 <field name="quantity" optional="show" decoration-warning="quantity &lt; 0" string="On Hand Quantity"/>
-                <field name="product_uom_id" groups="uom.group_uom" string="UoM"/>
+                <field name="product_uom_id" groups="uom.group_uom"/>
                 <field name="inventory_quantity" widget="counted_quantity_widget"/>
                 <field name="inventory_diff_quantity" string="Difference"  invisible="not inventory_quantity_set" decoration-muted="inventory_diff_quantity == 0" decoration-danger="inventory_diff_quantity &lt; 0" decoration-success="inventory_diff_quantity &gt; 0" decoration-bf="inventory_diff_quantity != 0"/>
                 <field name="inventory_date" optional="show"/>

--- a/addons/stock_delivery/views/delivery_view.xml
+++ b/addons/stock_delivery/views/delivery_view.xml
@@ -89,10 +89,15 @@
             <field name="arch" type="xml">
                 <field name="company_id" position="before">
                     <label for="shipping_weight"/>
-                    <div class="o_row" name="Shipping Weight">
-                        <field name="shipping_weight" class="oe_inline"/>
-                        <span><field name="weight_uom_name"/></span>
-                        <span class="text-muted">(computed: <field name="weight" class="oe_inline" nolabel="1"/></span><span class="text-muted"><field name="weight_uom_name" nolabel="1" class="oe_inline"/>)</span>
+                    <div class="row" name="Shipping Weight">
+                        <div class="col-3"><field name="shipping_weight"/></div>
+                        <div class="col-6">
+                            <field name="weight_uom_name" class="oe_inline"/>
+                            <span class="text-muted">
+                                (computed: <field name="weight" class="oe_inline"/>
+                                <field name="weight_uom_name" class="ms-1 oe_inline"/>)
+                            </span>
+                        </div>
                     </div>
                 </field>
             </field>

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -13,7 +13,7 @@ class UomCategory(models.Model):
 
     name = fields.Char('Unit of Measure Category', required=True, translate=True)
 
-    uom_ids = fields.One2many('uom.uom', 'category_id')
+    uom_ids = fields.One2many('uom.uom', 'category_id', string='Units')
     reference_uom_id = fields.Many2one('uom.uom', "Reference UoM", store=False) # Dummy field to keep track of reference uom change
 
     @api.onchange('uom_ids')


### PR DESCRIPTION
Before this commit some fields were taking extra space and ruining the UI by breaking uniformity as well as Unit of Measure is used in UI at different views.
After this commit uniformity was restored in UI and Unit of Measures was replaced by UoM in the several views of inventory.

task - 3770694
