### PR TITLE
[FIX] base: edit any reports in the studio mode

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -99,7 +99,7 @@ def _hasclass(context, *cls):
 
 
 def get_view_arch_from_file(filepath, xmlid):
-    module, view_id = xmlid.split('.')
+    module, view_id = xmlid.split('.', 1)
 
     xpath = f"//*[@id='{xmlid}' or @id='{view_id}']"
     # when view is created from model with inheritS of ir_ui_view, the


### PR DESCRIPTION
Currently, raise an error message in the report editor when trying to edit any reports in the studio mode.

error message: too many values to unpack (expected 2))

When we modify a report, the system tries to make a copy of it. To make this copy, the system needs to provide certain details like the name, mode key etc . At that time system tries to assign multiple values instead of two at this point [1] because the 'key' passed to do a copy of the report is [2] split by '.' as we see in [1] which leads to multiple values instead of two.

link [1]:  https://github.com/odoo/odoo/blob/1648ee1abff1ae12b3933baa85a2e048fa2eb557/odoo/addons/base/models/ir_ui_view.py#L102

link [2]:
https://github.com/odoo/enterprise/blob/34a042bb196273c34cd163f4c43bbd858664b7dc/web_studio/controllers/report.py#L337

To resolve the issue, Add limiting into split, To ensure that there are only two elements in the resulting list, which can unpacked into two (first is module, second is view_id) variables to prevent error.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
