### PR TITLE
[IMP] point_of_sale: product description in product info popup in pos terminal

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -6,8 +6,9 @@
                 <div class="d-flex flex-column flex-grow-1 text-start w-100 w-sm-25">
                     <span t-esc="props.product.display_name" class="global-info-title fs-2 fw-bolder text-truncate"/>
                     <span class="fs-3"><t t-if="props.product.default_code" t-esc="props.product.default_code"/> <t t-if="props.product.default_code and props.product.barcode"> - </t> <t t-if="props.product.barcode" t-esc="props.product.barcode"/></span>
+                    <pre t-if="props.product.description_sale" t-esc="props.product.description_sale" class="text-break" style="white-space: break-spaces; font-family: var(--body-font-family); color: #000000; font-size: 14px;"/>
                 </div>
-                <div class="d-flex flex-column justify-content-center text-start text-sm-end w-100 w-sm-25">
+                <div class="d-flex flex-column justify-content-start text-start text-sm-end w-100 w-sm-25">
                     <span t-esc="env.utils.formatCurrency(props.info.productInfo.all_prices.price_with_tax)" class="global-info-title fs-2 fw-bolder" />
                     <span class="fs-3">
                         <t t-foreach="props.info.productInfo.all_prices.tax_details" t-as="tax" t-key="tax.name">


### PR DESCRIPTION
Before this commit:
==========
- The Product Info Popup in the POS terminal did not include the product description.

After this commit:
==========
- The Product Info Popup now contains the product description in the POS terminal.

task-3647813