### PR TITLE
[FIX] account: ensure non empty VALUES in query

### DIFF
--- a/addons/account/report/account_invoice_report.py
+++ b/addons/account/report/account_invoice_report.py
@@ -135,7 +135,7 @@ class AccountInvoiceReport(models.Model):
                     AND product_standard_price.company_id = line.company_id
                 JOIN {currency_table} ON currency_table.company_id = line.company_id
         '''.format(
-            currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
+            currency_table=self.env['res.currency']._get_query_currency_table((self.env.companies | self.env.company).ids, fields.Date.today())
         )
 
     @api.model

--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -117,7 +117,7 @@ class SaleReport(models.Model):
             LEFT JOIN stock_picking_type picking ON picking.id = config.picking_type_id
             JOIN {currency_table} ON currency_table.company_id = pos.company_id
             """.format(
-            currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
+            currency_table=self.env['res.currency']._get_query_currency_table((self.env.companies | self.env.company).ids, fields.Date.today())
             )
 
     def _where_pos(self):

--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -106,7 +106,7 @@ class PurchaseReport(models.Model):
                 left join uom_uom product_uom on (product_uom.id=t.uom_id)
                 left join {currency_table} ON currency_table.company_id = po.company_id
         """.format(
-            currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
+            currency_table=self.env['res.currency']._get_query_currency_table((self.env.companies | self.env.company).ids, fields.Date.today())
         )
         return from_str
 

--- a/addons/sale/report/sale_report.py
+++ b/addons/sale/report/sale_report.py
@@ -177,7 +177,7 @@ class SaleReport(models.Model):
             LEFT JOIN uom_uom u2 ON u2.id=t.uom_id
             JOIN {currency_table} ON currency_table.company_id = s.company_id
             """.format(
-            currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
+            currency_table=self.env['res.currency']._get_query_currency_table((self.env.companies | self.env.company).ids, fields.Date.today())
             )
 
     def _where_sale(self):


### PR DESCRIPTION
When the companies of system user are all archived we get an invalid SQL syntax on the output of `_from`. For normal users having their company_id archived is not a standard flow, but system user (Odoo Bot) is an archived user, thus it can be associated to an archived company (usually the id=1 one).

The invalid query is necessary during the installation of some modules. This operation runs as system user.

Steps reproduce:
1. On a clean DB with just account installed, add an extra company.
2. Archive company 1 (after switching admin/demo/portal to comp2)
3. Set allowed companies of system user to just company 1
4. Try to install gamification_sale_crm

The validation of the domain in for gamification records fail due to the invalid query.

Compare:
```
>>> self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today())
'(VALUES ) AS currency_table(company_id, rate, precision)'
>>> self.env['res.currency']._get_query_currency_table((self.env.companies | self.env.company).ids, fields.Date.today())
'(VALUES (1, 1.0, 2)) AS currency_table(company_id, rate, precision)'
```

Setting:
```
>>> self.env.user
res.users(1,)
>>> self.env.company
res.company(1,)
>>> self.env.company.active
False
>>> self.env.user.with_context(active_test=False).company_ids
res.company(1,)
>>> self.env.companies
res.company()
```

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
