### PR TITLE
[FIX] sale_timesheet: prevent editing so line if validated timesheet

### DIFF
--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -67,7 +67,7 @@ class AccountAnalyticLine(models.Model):
 
     @api.depends('task_id.sale_line_id', 'project_id.sale_line_id', 'employee_id', 'project_id.allow_billable')
     def _compute_so_line(self):
-        for timesheet in self.filtered(lambda t: not t.is_so_line_edited and t._is_not_billed()):  # Get only the timesheets are not yet invoiced
+        for timesheet in self.filtered(lambda t: not t.validated and not t.is_so_line_edited and t._is_not_billed()):  # Get only the timesheets are not yet invoiced
             timesheet.so_line = timesheet.project_id.allow_billable and timesheet._timesheet_determine_sale_line()
 
     @api.depends('timesheet_invoice_id.state')

--- a/addons/sale_timesheet/models/project.py
+++ b/addons/sale_timesheet/models/project.py
@@ -213,7 +213,7 @@ class Project(models.Model):
 
     def _update_timesheets_sale_line_id(self):
         for project in self.filtered(lambda p: p.allow_billable and p.allow_timesheets):
-            timesheet_ids = project.sudo(False).mapped('timesheet_ids').filtered(lambda t: not t.is_so_line_edited and t._is_not_billed())
+            timesheet_ids = project.sudo(False).mapped('timesheet_ids').filtered(lambda t: not t.validated and not t.is_so_line_edited and t._is_not_billed())
             if not timesheet_ids:
                 continue
             for employee_id in project.sale_line_employee_ids.filtered(lambda l: l.project_id == project).employee_id:


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create a product: - service - based on timesheet - create on order: project & task

- create a sale order with this product
- confirm the sale order
- go on the created task
- add timesheets with an employee

- go to timesheet
- validate created timesheets

- go to the project settings
- in invoicing tab, change de sale order item for the employee

Issue:
------
The sale order item linked to the validated timesheets are modified.

This behaviour causes negative side effects.
A validated timesheet should no longer be modified, but the backend logic does, which is not consistent.

Solution:
---------
Make the condition that filters timesheets to update take account of whether the timesheet is validated or not.

opw-3791062