### PR TITLE
[FIX] account_payment: use the right company for the payment creation

### DIFF
--- a/addons/account_payment/models/payment_transaction.py
+++ b/addons/account_payment/models/payment_transaction.py
@@ -125,7 +125,7 @@ class PaymentTransaction(models.Model):
         # Create and post missing payments for transactions requiring reconciliation
         for tx in self.filtered(lambda t: t.operation != 'validation' and not t.payment_id):
             if not any(child.state in ['done', 'cancel'] for child in tx.child_transaction_ids):
-                tx._create_payment()
+                tx.with_company(tx.company_id)._create_payment()
 
     def _create_payment(self, **extra_create_values):
         """Create an `account.payment` record for the current transaction.


### PR DESCRIPTION
Steps to reproduce:
- Install eCommerce and `l10n_be` (to get a second company)
- Enable online payment in the settings
- Go to the payment provider and duplicate it for belgium company
- Publish the payment provider
- Make an invoice for a customer
- Send or generate the link
- Open the link in incognito
- Pay the invoice

Issues:
When we create the `temp_move` we don't provide the `company_id` as such we will go in the compute which will fail.

https://github.com/odoo/odoo/blob/f1d6ad2645fcc206b43454400e2c70d1d23a4ee3/addons/account/models/account_journal.py#L363

https://github.com/odoo/odoo/blob/17d85347f92d813704d3f8faef366166bbbaa730/addons/account/models/account_move.py#L693

In this line we call the `_accessible_branches` method on the belgium company as expected, in this method we use `self.env.companies` (default company) and we do an intersection with the current company (belgium).
This results in an empty recordset for the company.

Later in the stock we face this instruction which ends up in an empty recordset error as we have an ensure one at the beggining of `_get_violated_lock_dates`.

https://github.com/odoo/odoo/blob/f1d6ad2645fcc206b43454400e2c70d1d23a4ee3/addons/account/models/account_move.py#L4394

https://github.com/odoo/odoo/blob/f1d6ad2645fcc206b43454400e2c70d1d23a4ee3/addons/account/models/company.py#L370

Website solve it by copying the `public_user` and affecting it to the desired company.

https://github.com/odoo/odoo/blob/9079b7038754ca4fe547086d3fe8947a4bb6ddce/addons/website/models/res_company.py#L43-L57

A potential approach to solve this problem could be to allow `public_user` to access all of the companies (possibly problematic w.r.t. security).

The solution chosen for this PR is a local solution as it makes more sense for stable.

opw-3859791