### PR TITLE
[16.0][FIX] base: no traceback when Attachment file not found

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -120,6 +120,8 @@ class IrAttachment(models.Model):
         try:
             with open(full_path, 'rb') as f:
                 return f.read()
+        except (FileNotFoundError):
+            _logger.warning("File not found %s", full_path)
         except (IOError, OSError):
             _logger.info("_read_file reading %s", full_path, exc_info=True)
         return b''


### PR DESCRIPTION
When an attachment file is not found, an error is logged along with a
Python traceback.

This is inconvenient when working with a copy of a database where only
the PosgreSQL dump was restored, and the data files are missing.

With this change, the file not found exception is specifically handled
to print a warning to the log, without opriting a full stack trace.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
