### PR TITLE
[IMP] repair: repair improvements

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -94,12 +94,7 @@
                     </div>
                     <group>
                         <group>
-                            <field name="picking_product_ids" invisible="1"/>
-                            <field name="picking_product_id" invisible="1"/>
-                            <field name="tracking" invisible="1" readonly="True"/>
-                            <field name="company_id" invisible="1"/>
-                            <field name="sale_order_id" invisible="1"/>
-                            <field name="sale_order_line_id" invisible="1"/>
+                            <field name="allowed_lot_ids" invisible="1"/>
                             <field name="repair_request" invisible="not sale_order_line_id"/>
                             <field name="partner_id" widget="res_partner_many2one" context="{'res_partner_search_mode': 'customer', 'show_vat': True}" readonly="sale_order_id"/>
                             <field name="product_id" readonly="state in ['cancel', 'done']"/>


### PR DESCRIPTION
When a picking is selected as the return order of a repair order, pre-fill `partner_id` and `product_qty` fields from the picking.

ENT PR: odoo/enterprise#60801

Task-3848611

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
