### PR TITLE
[FIX] point_of_sale : differentiate between self-order and normal order numbers

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -1474,10 +1474,7 @@ export class Order extends PosModel {
             this.sequence_number = this.pos.pos_session.sequence_number++;
         } else {
             this.sequence_number = json.sequence_number;
-            this.pos.pos_session.sequence_number = Math.max(
-                this.sequence_number + 1,
-                this.pos.pos_session.sequence_number
-            );
+            this.updateSequenceNumber(json);
         }
         this.session_id = this.pos.pos_session.id;
         this.uid = json.uid;
@@ -1565,6 +1562,12 @@ export class Order extends PosModel {
         this.ticketCode = json.ticket_code || "";
         this.lastOrderPrepaChange =
             json.last_order_preparation_change && JSON.parse(json.last_order_preparation_change);
+    }
+    updateSequenceNumber(json) {
+        this.pos.pos_session.sequence_number = Math.max(
+            this.sequence_number + 1,
+            this.pos.pos_session.sequence_number
+        );
     }
     export_as_JSON() {
         var orderLines, paymentLines;

--- a/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/TicketScreenTourMethods.js
@@ -222,3 +222,12 @@ export function receiptTotalIs(amount) {
         },
     ];
 }
+
+export function nthColumnContains(nRow, nCol, string){
+    return [
+        {
+            trigger: `.ticket-screen .order-row:nth-child(${nRow}) > .col:nth-child(${nCol}):contains("${string}")`,
+            run: () => {},
+        },
+    ];
+}

--- a/addons/pos_restaurant/static/tests/tours/TicketScreen.tour.js
+++ b/addons/pos_restaurant/static/tests/tours/TicketScreen.tour.js
@@ -65,3 +65,21 @@ registry.category("web_tour.tours").add("PosResTicketScreenTour", {
             ProductScreen.orderIsEmpty(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("OrderNumberConflictTour", {
+    test: true,
+    steps: () =>
+        [
+            FloorScreen.clickTable("3"),
+            ProductScreen.isShown(),
+            ProductScreen.addOrderline("Coca-Cola", "1", "3"),
+            FloorScreen.backToFloor(),
+            Chrome.clickMenuButton(),
+            Chrome.clickTicketButton(),
+            TicketScreen.nthColumnContains(6, 2, "Order"),
+            TicketScreen.nthColumnContains(6, 3, "01"),
+            TicketScreen.nthColumnContains(7, 2, "Self-Order"),
+            TicketScreen.nthColumnContains(7, 3, "S"),
+            TicketScreen.nthColumnContains(7, 3, "01")
+        ].flat(),
+});

--- a/addons/pos_self_order/static/src/app/models/order.js
+++ b/addons/pos_self_order/static/src/app/models/order.js
@@ -61,7 +61,7 @@ export class Order extends Reactive {
             const arrRef = reference.split(" ")[1].split("-");
             const sessionID = arrRef[0][4];
             const sequence = arrRef[2].substr(2, 2);
-            const trackingNumber = sessionID + sequence;
+            const trackingNumber = "S" + sessionID + sequence;
             return trackingNumber;
         }
         return null;

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -13,6 +13,13 @@ patch(PosStore.prototype, {
 });
 
 patch(Order.prototype, {
+    setup() {
+        super.setup(...arguments);
+        if (this.name.startsWith('Self-Order')) {
+            this.trackingNumber = "S" + this.trackingNumber
+        }
+    },
+
     defaultTableNeeded(options) {
         return (
             super.defaultTableNeeded(...arguments) &&
@@ -20,4 +27,10 @@ patch(Order.prototype, {
             !this.name.includes("Self-Order")
         );
     },
+
+    updateSequenceNumber(json){
+        if(!json.name.startsWith('Self-Order')) {
+            super.updateSequenceNumber(json);
+        }
+    }
 });

--- a/addons/pos_self_order/static/tests/helpers/utils.js
+++ b/addons/pos_self_order/static/tests/helpers/utils.js
@@ -3,7 +3,7 @@
 export function clickBtn(buttonName) {
     return {
         content: `Click on button '${buttonName}'`,
-        trigger: `.btn.btn-lg:contains('${buttonName}')`,
+        trigger: `.btn:contains('${buttonName}')`,
     };
 }
 

--- a/addons/pos_self_order/static/tests/tours/test_self_order_mobile.js
+++ b/addons/pos_self_order/static/tests/tours/test_self_order_mobile.js
@@ -234,3 +234,17 @@ registry.category("web_tour.tours").add("self_order_mobile_each_cancel", {
         Utils.checkBtn("Pay"),
     ],
 });
+
+registry.category("web_tour.tours").add("SelfOrderOrderNumberTour", {
+    test: true,
+    steps: () => [
+        Utils.checkIsNoBtn("My Order"),
+        Utils.clickBtn("Order Now"),
+        ProductPage.clickProduct("Coca-Cola"),
+        Utils.clickBtn("Order"),
+        Utils.clickBtn("Pay"),
+        Utils.clickBtn("Confirm"),
+        Utils.clickBtn("Ok"),
+        Utils.checkIsNoBtn("Ok"),
+    ],
+});

--- a/addons/pos_self_order/tests/__init__.py
+++ b/addons/pos_self_order/tests/__init__.py
@@ -8,3 +8,4 @@ from . import test_self_order_kiosk
 from . import test_self_order_attribute
 from . import test_self_order_combo
 from . import test_self_order_common
+from . import test_self_order_sequence

--- a/addons/pos_self_order/tests/test_self_order_sequence.py
+++ b/addons/pos_self_order/tests/test_self_order_sequence.py
@@ -1,0 +1,20 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import odoo.tests
+from odoo.addons.pos_self_order.tests.self_order_common_test import SelfOrderCommonTest
+
+
+@odoo.tests.tagged("post_install", "-at_install")
+class TestSelfOrderSequence(SelfOrderCommonTest):
+    browser_size = "1920,1080"
+
+    def test_self_order_order_number_conflict_with_normal_orders(self):
+        self.pos_config.write({
+            'self_ordering_mode': 'mobile',
+            'self_ordering_service_mode': 'table',
+        })
+
+        self.pos_config.open_ui()
+        self_route = self.pos_config._get_self_order_route()
+        self.start_tour(self_route, 'SelfOrderOrderNumberTour', login="pos_admin")
+        self.start_tour("/pos/ui?config_id=%d" % self.pos_config.id, 'OrderNumberConflictTour', login="pos_admin")


### PR DESCRIPTION
**Steps to reproduce:**
	1- Install POS and POS restaurant
	2- Activate self ordering
	3- Create a self order from the mobile menu
	4- Create another order from the Shop POS

**Current behavior before PR:**
There is a conflict happening in order numbers between Self order and other orders where at some point we might have two orders with the same number. This is happening because when adding the order from Shop we get the sequence number from the JS side in Order class
https://github.com/odoo/odoo/blob/d82ffde0b316c52f726c247bf6f3d38e2e73e405/addons/point_of_sale/static/src/app/store/models.js#L1383 but in case of self order. We get it from ir_sequence https://github.com/odoo/odoo/blob/d82ffde0b316c52f726c247bf6f3d38e2e73e405/addons/pos_self_order/controllers/orders.py#L19 So we don't have a shared sequence between them.

**Desired behavior after PR is merged:**
We are now creating another sequence for self-order and as agreed with the PO we will have
'S' before the order number if the order is self-order

opw-3809595