### PR TITLE
[FIX] stock: Preserve package levels when reserving stock moves

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -490,7 +490,7 @@ class StockMoveLine(models.Model):
         package_levels = self.package_level_id
         res = super(StockMoveLine, self).unlink()
         package_levels = package_levels.filtered(lambda pl: not (pl.move_line_ids or pl.move_ids))
-        if package_levels:
+        if package_levels and not self.env.context.get('preserve_package_level'):
             package_levels.unlink()
         if moves:
             # Add with_prefetch() to set the _prefecht_ids = _ids

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -814,7 +814,7 @@ class Picking(models.Model):
         # If a package level is done when confirmed its location can be different than where it will be reserved.
         # So we remove the move lines created when confirmed to set quantity done to the new reserved ones.
         package_level_done = self.mapped('package_level_ids').filtered(lambda pl: pl.is_done and pl.state == 'confirmed')
-        package_level_done.write({'is_done': False})
+        package_level_done.with_context(preserve_package_level=True).write({'is_done': False})
         moves._action_assign()
         package_level_done.write({'is_done': True})
 
@@ -948,7 +948,7 @@ class Picking(models.Model):
                         for ml in move_lines_in_package_level:
                             ml.package_level_id = ml.move_id.package_level_id.id
 
-                        move_lines_without_package_level.package_level_id: package_level_ids[0]
+                        move_lines_without_package_level.package_level_id = package_level_ids[0]
                         for pl in package_level_ids:
                             pl.location_dest_id = self._get_entire_pack_location_dest(pl.move_line_ids) or picking.location_dest_id.id
 


### PR DESCRIPTION
Previously, when reserving stock moves (using the 'check availabilities' button), "done" package levels were implicitly unlinked and recreated. If a user made their own package level (picked another pack from the UI), this package level would get unlinked and the first available quant, with no consideration of the user's selected package, would get picked.

This commit selectively preserves package levels after all of their move lines have been unlinked, and introduces new behaviour to the stock move reservation logic: when reserving quants, it first attempts to use quants in packages belonging to a picking's "done" package levels.

opw-3770754
