### PR TITLE
[IMP] core: add session deletion mechanism

### DIFF
--- a/addons/bus/models/ir_websocket.py
+++ b/addons/bus/models/ir_websocket.py
@@ -56,7 +56,7 @@ class IrWebsocket(models.AbstractModel):
     @classmethod
     def _authenticate(cls):
         if wsrequest.session.uid is not None:
-            if not security.check_session(wsrequest.session, wsrequest.env):
+            if not security.check_session(wsrequest.session, wsrequest.env, wsrequest):
                 wsrequest.session.logout(keep_db=True)
                 raise SessionExpiredException()
         else:

--- a/addons/web/controllers/home.py
+++ b/addons/web/controllers/home.py
@@ -44,7 +44,7 @@ class Home(http.Controller):
             return request.redirect_query('/web/login', query={'redirect': request.httprequest.full_path}, code=303)
         if kw.get('redirect'):
             return request.redirect(kw.get('redirect'), 303)
-        if not security.check_session(request.session, request.env):
+        if not security.check_session(request.session, request.env, request):
             raise http.SessionExpiredException("Session expired")
         if not is_user_internal(request.session.uid):
             return request.redirect('/web/login_successful', 303)

--- a/odoo/addons/base/__manifest__.py
+++ b/odoo/addons/base/__manifest__.py
@@ -68,6 +68,7 @@ The kernel of Odoo, needed for all installation.
         'views/res_country_views.xml',
         'views/res_currency_views.xml',
         'views/res_users_views.xml',
+        'views/res_device_views.xml',
         'views/res_users_identitycheck_views.xml',
         'views/ir_property_views.xml',
         'views/res_config_settings_views.xml',

--- a/odoo/addons/base/models/__init__.py
+++ b/odoo/addons/base/models/__init__.py
@@ -46,5 +46,6 @@ from . import res_company
 from . import res_users
 from . import res_users_settings
 from . import res_users_deletion
+from . import res_device
 
 from . import decimal_precision

--- a/odoo/addons/base/models/ir_http.py
+++ b/odoo/addons/base/models/ir_http.py
@@ -159,7 +159,7 @@ class IrHttp(models.AbstractModel):
     def _authenticate_explicit(cls, auth):
         try:
             if request.session.uid is not None:
-                if not security.check_session(request.session, request.env):
+                if not security.check_session(request.session, request.env, request):
                     request.session.logout(keep_db=True)
                     request.env = api.Environment(request.env.cr, None, request.session.context)
             getattr(cls, f'_auth_method_{auth}')()

--- a/odoo/addons/base/models/res_device.py
+++ b/odoo/addons/base/models/res_device.py
@@ -1,0 +1,175 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from contextlib import nullcontext
+from datetime import datetime
+import logging
+
+from odoo import api, fields, models, tools
+from odoo.http import GeoIP, request, root
+from odoo.tools import SQL, OrderedSet, unique
+from odoo.tools.translate import _
+from .res_users import check_identity
+
+_logger = logging.getLogger(__name__)
+
+
+class ResDeviceLog(models.Model):
+    _name = 'res.device.log'
+    _description = 'Device Log'
+    _rec_names_search = ['platform', 'browser']
+
+    session_identifier = fields.Char("Session Identifier", required=True, index='btree')
+    platform = fields.Char("Platform")
+    browser = fields.Char("Browser")
+    ip_address = fields.Char("IP Address")
+    country = fields.Char("Country")
+    city = fields.Char("City")
+    device_type = fields.Selection([('computer', 'Computer'), ('mobile', 'Mobile')], "Device Type")
+    user_id = fields.Many2one("res.users", index='btree')
+    first_activity = fields.Datetime("First Activity")
+    last_activity = fields.Datetime("Last Activity", index='btree')
+    revoked = fields.Boolean("Revoked",
+                            help="""If True, the session file corresponding to this device
+                                    no longer exists on the filesystem.""")
+    is_current = fields.Boolean("Current Device", compute="_compute_is_current")
+    linked_ip_addresses = fields.Text("Linked IP address", compute="_compute_linked_ip_addresses")
+
+    def _compute_display_name(self):
+        for device in self:
+            platform = device.platform or _("Unknown")
+            browser = device.browser or _("Unknown")
+            device.display_name = f"{platform.capitalize()} {browser.capitalize()}"
+
+    def _compute_is_current(self):
+        for device in self:
+            device.is_current = request and request.session.sid.startswith(device.session_identifier)
+
+    def _compute_linked_ip_addresses(self):
+        device_group_map = dict(self._read_group(
+            domain=[('session_identifier', 'in', self.mapped('session_identifier'))],
+            groupby=['session_identifier'],
+            aggregates=['ip_address:array_agg']
+        ))
+        for device in self:
+            device.linked_ip_addresses = '\n'.join(OrderedSet(device_group_map.get(device.session_identifier, [])))
+
+    def _order_field_to_sql(self, alias, field_name, direction, nulls, query):
+        if field_name == 'is_current' and request:
+            return SQL("session_identifier = %s DESC", request.session.sid[:42])
+        return super()._order_field_to_sql(alias, field_name, direction, nulls, query)
+
+    def _is_mobile(self, platform):
+        if not platform:
+            return False
+        mobile_platform = ['android', 'iphone', 'ipad', 'ipod', 'blackberry', 'windows phone', 'webos']
+        return platform.lower() in mobile_platform
+
+    @api.model
+    def _update_device(self, request):
+        """
+            Must be called when we want to update the device for the current request.
+            Passage through this method must leave a "trace" in the session.
+
+            :param request: Request or WebsocketRequest object
+        """
+        trace = request.session.update_trace(request)
+        if not trace:
+            return
+
+        geoip = GeoIP(trace['ip_address'])
+        user_id = request.session.uid
+        session_identifier = request.session.sid[:42]
+
+        if self.env.cr.readonly:
+            self.env.cr.rollback()
+            cursor = self.env.registry.cursor(readonly=False)
+        else:
+            cursor = nullcontext(self.env.cr)
+        with cursor as cr:
+            cr.execute(SQL("""
+                INSERT INTO res_device_log (session_identifier, platform, browser, ip_address, country, city, device_type, user_id, first_activity, last_activity, revoked)
+                VALUES (%(session_identifier)s, %(platform)s, %(browser)s, %(ip_address)s, %(country)s, %(city)s, %(device_type)s, %(user_id)s, %(first_activity)s, %(last_activity)s, %(revoked)s)
+            """,
+                session_identifier=session_identifier,
+                platform=trace['platform'],
+                browser=trace['browser'],
+                ip_address=trace['ip_address'],
+                country=geoip.get('country_name'),
+                city=geoip.get('city'),
+                device_type='mobile' if self._is_mobile(trace['platform']) else 'computer',
+                user_id=user_id,
+                first_activity=datetime.fromtimestamp(trace['first_activity']),
+                last_activity=datetime.fromtimestamp(trace['last_activity']),
+                revoked=False,
+            ))
+        _logger.info("User %d inserts device log (%s)", user_id, session_identifier)
+
+    @api.autovacuum
+    def _gc_device_log(self):
+        # Keep the last device log
+        # (even if the session file no longer exists on the filesystem)
+        self.env.cr.execute("""
+            DELETE FROM res_device_log log1
+            WHERE EXISTS (
+                SELECT 1 FROM res_device_log log2
+                WHERE
+                    log1.session_identifier = log2.session_identifier
+                    AND log1.platform = log2.platform
+                    AND log1.browser = log2.browser
+                    AND log1.ip_address = log2.ip_address
+                    AND log1.last_activity < log2.last_activity
+            )
+        """)
+        _logger.info("GC device logs delete %d entries", self.env.cr.rowcount)
+
+
+class ResDevice(models.Model):
+    _name = "res.device"
+    _inherit = ["res.device.log"]
+    _description = "Devices"
+    _auto = False
+
+    @check_identity
+    def revoke(self):
+        return self._revoke()
+
+    def _revoke(self):
+        ResDeviceLog = self.env['res.device.log']
+        session_identifiers = list(unique(device.session_identifier for device in self))
+        root.session_store.delete_from_identifiers(session_identifiers)
+        revoked_devices = ResDeviceLog.sudo().search([('session_identifier', 'in', session_identifiers)])
+        revoked_devices.write({'revoked': True})
+        _logger.info("User %d revokes devices (%s)", self.env.uid, ', '.join(session_identifiers))
+
+        must_logout = bool(self.filtered('is_current'))
+        if must_logout:
+            request.session.logout()
+
+    @api.model
+    def _select(self):
+        return "SELECT DISTINCT ON (D.session_identifier, D.platform, D.browser) D.*"
+
+    @api.model
+    def _from(self):
+        return "FROM res_device_log D"
+
+    @api.model
+    def _where(self):
+        return "WHERE D.revoked = False"
+
+    @api.model
+    def _order_by(self):
+        return "ORDER BY D.session_identifier, D.platform, D.browser, D.last_activity DESC"
+
+    @property
+    def _query(self):
+        return "%s %s %s %s" % (self._select(), self._from(), self._where(), self._order_by())
+
+    def init(self):
+        tools.drop_view_if_exists(self.env.cr, self._table)
+        self.env.cr.execute(SQL("""
+            CREATE or REPLACE VIEW %s as (%s)
+        """,
+            SQL.identifier(self._table),
+            SQL(self._query)
+        ))

--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -335,7 +335,7 @@ class Users(models.Model):
             'image_1024', 'image_512', 'image_256', 'image_128', 'lang', 'tz',
             'tz_offset', 'groups_id', 'partner_id', 'write_date', 'action_id',
             'avatar_1920', 'avatar_1024', 'avatar_512', 'avatar_256', 'avatar_128',
-            'share',
+            'share', 'device_ids',
         ]
 
     @property
@@ -371,6 +371,7 @@ class Users(models.Model):
         help="If specified, this action will be opened at log on for this user, in addition to the standard menu.")
     groups_id = fields.Many2many('res.groups', 'res_groups_users_rel', 'uid', 'gid', string='Groups', default=lambda s: s._default_groups())
     log_ids = fields.One2many('res.users.log', 'create_uid', string='User log entries')
+    device_ids = fields.One2many('res.device', 'user_id', string='User devices')
     login_date = fields.Datetime(related='log_ids.create_date', string='Latest authentication', readonly=False)
     share = fields.Boolean(compute='_compute_share', compute_sudo=True, string='Share User', store=True,
          help="External user with limited access, created only for the purpose of sharing data.")

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -225,5 +225,33 @@
             <field name="perm_create" eval="False"/>
             <field name="perm_unlink" eval="True"/>
         </record>
+
+        <!-- Record Rules For User Devices -->
+        <record id="user_device" model="ir.rule">
+            <field name="name">Users can read only their own devices</field>
+            <field name="model_id" ref="model_res_device"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
+        </record>
+        <record id="user_device_admin" model="ir.rule">
+            <field name="name">Administrators can read all devices</field>
+            <field name="model_id" ref="model_res_device"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
+        </record>
+
+        <record id="user_device_logs" model="ir.rule">
+            <field name="name">Users can read only their own device logs</field>
+            <field name="model_id" ref="model_res_device_log"/>
+            <field name="domain_force">[('user_id', '=', user.id)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_user'))]"/>
+        </record>
+        <record id="user_device_logs_admin" model="ir.rule">
+            <field name="name">Administrators can read all device logs</field>
+            <field name="model_id" ref="model_res_device_log"/>
+            <field name="domain_force">[(1, '=', 1)]</field>
+            <field name="groups" eval="[Command.link(ref('base.group_system'))]"/>
+        </record>
+
     </data>
 </odoo>

--- a/odoo/addons/base/security/ir.model.access.csv
+++ b/odoo/addons/base/security/ir.model.access.csv
@@ -142,3 +142,5 @@ access_res_users_settings_user,res.users.settings,model_res_users_settings,group
 "access_base_partner_merge_automatic_wizard","access.base.partner.merge.automatic.wizard","model_base_partner_merge_automatic_wizard","base.group_partner_manager",1,1,1,0
 "access_ir_profile","ir_profile","model_ir_profile","group_system",1,1,1,1
 "access_base_enable_profiling_wizard","access.base.enable.profiling.wizard","model_base_enable_profiling_wizard","group_system",1,1,1,0
+"access_res_device",access_res_device,base.model_res_device,base.group_user,1,0,0,0
+"access_res_device_log",access_res_device_log,base.model_res_device_log,base.group_user,1,0,0,0

--- a/odoo/addons/base/views/res_device_views.xml
+++ b/odoo/addons/base/views/res_device_views.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record model="ir.ui.view" id="res_device_view_form">
+            <field name="name">res.device.form</field>
+            <field name="model">res.device</field>
+            <field name="arch" type="xml">
+                <form>
+                    <group>
+                        <group>
+                            <field name="user_id"/>
+                            <field name="display_name" string="Name"/>
+                            <field name="ip_address" string="Last IP Address"/>
+                        </group>
+                        <group>
+                            <field name="first_activity"/>
+                            <field name="last_activity"/>
+                        </group>
+                        <group>
+                            <field name="linked_ip_addresses"/>
+                        </group>
+                    </group>
+                </form>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="res_device_view_tree">
+            <field name="name">res.device.tree</field>
+            <field name="model">res.device</field>
+            <field name="arch" type="xml">
+                <tree default_order="last_activity desc">
+                    <field name="user_id"/>
+                    <field name="display_name" string="Name"/>
+                    <field name="ip_address"/>
+                    <field name="first_activity"/>
+                    <field name="last_activity"/>
+                    <field name="country" optional="hidden"/>
+                    <field name="city" optional="hidden"/>
+                    <button type="object" name="revoke" string="Revoke" class="btn btn-secondary"/>
+                </tree>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="res_device_view_kanban">
+            <field name="name">res.device.kanban</field>
+            <field name="model">res.device</field>
+            <field name="arch" type="xml">
+                <kanban create="false" default_order="is_current desc, last_activity desc">
+                    <field name="id"/>
+                    <field name="display_name" string="Name"/>
+                    <field name="device_type"/>
+                    <field name="country"/>
+                    <field name="city"/>
+                    <field name="last_activity"/>
+                    <field name="is_current"/>
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div class="oe_kanban_card oe_kanban_global_click">
+                                <div class="o_kanban_card_content d-flex">
+                                    <div>
+                                        <t t-if="record.device_type.raw_value === 'computer'">
+                                            <span class="fa fa-laptop fs-1" title="Computer" role="img" aria-label="Computer"/>
+                                        </t>
+                                        <t t-else="">
+                                            <span class="fa fa-mobile fs-1" title="Mobile" role="img" aria-label="Mobile"/>
+                                        </t>
+                                    </div>
+                                    <div class="oe_kanban_details d-flex flex-column ms-3">
+                                        <div class="d-flex align-items-center">
+                                            <strong class="o_kanban_title">
+                                                <field name="display_name" string="Name"/>
+                                            </strong>
+                                            <t t-if="record.is_current.raw_value">
+                                                <span class="ms-2 text-success o_status o_status_green"></span>
+                                            </t>
+                                        </div>
+                                        <field name="ip_address"/>
+                                        <field name="country"/>
+                                        <field name="city"/>
+                                        <t t-out="luxon.DateTime.fromISO(record.last_activity.raw_value).toRelative()"/>
+                                    </div>
+                                    <div class="o_kanban_button">
+                                        <button name="revoke" type="object" string="Revoke" class="btn btn-secondary"/>
+                                    </div>
+                                </div>
+                            </div>
+                        </t>
+                    </templates>
+                </kanban>
+            </field>
+        </record>
+
+        <record id="action_user_device" model="ir.actions.act_window">
+            <field name="name">User Devices</field>
+            <field name="res_model">res.device</field>
+            <field name="path">user-device</field>
+            <field name="view_id" ref="res_device_view_tree"/>
+        </record>
+        <menuitem action="action_user_device" id="menu_action_user_device" parent="base.menu_security" sequence="10"/>
+
+    </data>
+</odoo>

--- a/odoo/addons/base/views/res_users_views.xml
+++ b/odoo/addons/base/views/res_users_views.xml
@@ -485,6 +485,9 @@
                                 </div>
                             </group>
                         </page>
+                        <page string="Devices" name="page_devices">
+                            <field name="device_ids" mode="kanban"/>
+                        </page>
                     </notebook>
                     <footer>
                         <button name="preference_save" type="object" string="Save" class="btn-primary" data-hotkey="q"/>

--- a/odoo/addons/test_http/controllers.py
+++ b/odoo/addons/test_http/controllers.py
@@ -47,6 +47,16 @@ class TestHttp(http.Controller):
         assert request.env.user, "ORM should be initialized"
         return "Tek'ma'te"
 
+    @http.route('/test_http/greeting-public-rw', type='http', auth='public')
+    def greeting_public_rw(self):
+        assert request.env.user, "ORM should be initialized"
+        return "Tek'ma'te"
+
+    @http.route('/test_http/greeting-user-rw', type='http', auth='user')
+    def greeting_user_rw(self):
+        assert request.env.user, "ORM should be initialized"
+        return "Tek'ma'te"
+
     @http.route('/test_http/wsgi_environ', type='http', auth='none')
     def wsgi_environ(self):
         environ = {

--- a/odoo/addons/test_http/tests/__init__.py
+++ b/odoo/addons/test_http/tests/__init__.py
@@ -1,4 +1,5 @@
 from . import test_common
+from . import test_device
 from . import test_echo_reply
 from . import test_error
 from . import test_greeting

--- a/odoo/addons/test_http/tests/test_device.py
+++ b/odoo/addons/test_http/tests/test_device.py
@@ -1,0 +1,316 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from freezegun import freeze_time
+from unittest.mock import patch
+
+from odoo import Command
+from odoo.addons.test_http.utils import (
+    TEST_IP,
+    USER_AGENT_android_chrome,
+    USER_AGENT_linux_chrome,
+    USER_AGENT_linux_firefox
+)
+from .test_common import TestHttpBase
+
+
+class TestDevice(TestHttpBase):
+
+    def setUp(self):
+        super().setUp()
+
+        self.Device = self.env['res.device']
+        self.DeviceLog = self.env['res.device.log']
+        self.DeviceLog.search([]).unlink()
+
+        self.user_admin = self.env.ref('base.user_admin')
+        self.user_internal = self.env['res.users'].create({
+            'login': 'internal',
+            'password': 'internal',
+            'name': 'Internal',
+            'email': 'internal@example.com',
+            'groups_id': [Command.set([self.env.ref('base.group_user').id])],
+        })
+
+    def hit(self, time, endpoint, headers=None, ip=None):
+        if ip:
+            headers = headers or {}
+            headers = {
+                **headers,
+                'Host': '',
+                'X-Forwarded-For': ip,
+                'X-Forwarded-Host': 'odoo.com',
+                'X-Forwarded-Proto': 'https'
+            }
+        with freeze_time(time), \
+            patch.dict('odoo.tools.config.options', {'proxy_mode': bool(ip)}):
+            res = self.url_open(url=endpoint, headers=headers)
+        return res
+
+    def info_trace(self, trace):
+        return {
+            'elapsed_time': trace['last_activity'] - trace['first_activity'],
+            'platform': trace['platform'],
+            'browser': trace['browser'],
+            'ip_address': trace['ip_address'],
+        }
+
+    def get_devices_logs(self, user=None):
+        domain = [('user_id', '=', user.id)] if user else []
+        devices = self.Device.search(domain)
+        logs = self.DeviceLog.search([
+            ('session_identifier', 'in', devices.mapped('session_identifier')),
+            ('platform', 'in', devices.mapped('platform')),
+            ('browser', 'in', devices.mapped('browser'))
+        ])
+        return devices, logs
+
+    # --------------------
+    # DETECTION
+    # --------------------
+
+    def test_detection_device_readonly(self):
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(len(session._trace), 1)
+
+    def test_detection_device_no_readonly(self):
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(len(session._trace), 1)
+
+    def test_detection_user_public(self):
+        self.authenticate(None, None)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs()
+        self.assertEqual(len(devices), 0)
+        self.assertEqual(len(logs), 0)
+
+    def test_detection_device_readonly_then_no_readonly(self):
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(len(session._trace), 1)
+
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(len(session._trace), 1)
+
+    def test_detection_device_according_to_time(self):
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(len(session._trace), 1)
+        self.assertEqual(self.info_trace(session._trace[0])['elapsed_time'], 0)
+
+        self.hit('2024-01-01 08:30:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(len(session._trace), 1)
+        self.assertEqual(self.info_trace(session._trace[0])['elapsed_time'], 0)  # No trace update (< 3600 sec)
+
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 2)
+        self.assertEqual(len(session._trace), 1)
+        self.assertEqual(self.info_trace(session._trace[0])['elapsed_time'], 3600)
+
+        self.hit('2024-01-01 10:00:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 3)
+        self.assertEqual(len(session._trace), 1)
+        self.assertEqual(self.info_trace(session._trace[0])['elapsed_time'], 7200)
+
+    def test_detection_device_according_to_useragent(self):
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(len(session._trace), 1)
+        self.assertEqual(self.info_trace(session._trace[0])['platform'], 'linux')
+        self.assertEqual(self.info_trace(session._trace[0])['browser'], 'chrome')
+
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 2)
+        self.assertEqual(len(logs), 2)
+        self.assertEqual(len(session._trace), 2)
+        self.assertEqual(self.info_trace(session._trace[1])['platform'], 'linux')
+        self.assertEqual(self.info_trace(session._trace[1])['browser'], 'firefox')
+
+    def test_detection_device_according_to_ipaddress(self):
+        session = self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 1)
+        self.assertEqual(len(session._trace), 1)
+
+        self.hit('2024-01-01 08:00:01', '/test_http/greeting-public-rw', ip=TEST_IP)
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 2)
+        self.assertEqual(len(session._trace), 2)
+        self.assertNotEqual(self.info_trace(session._trace[0])['ip_address'], TEST_IP)
+        self.assertEqual(self.info_trace(session._trace[1])['ip_address'], TEST_IP)
+
+        localized_device = devices.filtered(lambda device: device.ip_address == TEST_IP)
+        self.assertEqual(localized_device.country, 'France')
+
+    def test_detection_usurpation_sid(self):
+        session = self.authenticate(self.user_internal.login, self.user_internal.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw')
+
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'session_id': session.sid}, ip=TEST_IP)
+        devices, logs = self.get_devices_logs(self.user_internal)
+        self.assertEqual(len(devices), 1)
+        self.assertEqual(len(logs), 2)
+        self.assertEqual(len(self.user_internal.device_ids), 1)
+
+    def test_detection_devices_according_to_time_useragent(self):
+        self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.assertEqual(len(self.user_admin.device_ids), 1)
+
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.assertEqual(len(self.user_admin.device_ids), 1)
+
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        self.assertEqual(len(self.user_admin.device_ids), 2)
+
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        self.assertEqual(len(self.user_admin.device_ids), 2)
+
+    def test_detection_devices_according_to_user_or_admin(self):
+        self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw')
+        self.authenticate(self.user_internal.login, self.user_internal.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-public-rw')
+
+        devices, logs = self.get_devices_logs()
+        self.assertEqual(len(devices), 2)
+        self.assertEqual(len(logs), 4)
+        self.assertEqual(len(self.user_admin.device_ids), 1)
+        self.assertEqual(len(self.user_internal.device_ids), 1)
+
+        devices_from_admin = self.Device.with_user(self.user_admin).search([])
+        devices_from_internal = self.Device.with_user(self.user_internal).search([])
+        self.assertEqual(len(devices_from_admin), 2)
+        self.assertEqual(len(devices_from_internal), 1)
+
+    def test_differentiate_computer_and_mobile(self):
+        self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw', headers={'User-Agent': USER_AGENT_android_chrome})
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 2)
+        self.assertEqual(len(logs), 2)
+
+        laptop_device = devices.filtered(lambda device: device.device_type == 'computer')
+        mobile_device = devices.filtered(lambda device: device.device_type == 'mobile')
+        self.assertEqual(len(laptop_device), 1)
+        self.assertEqual(len(mobile_device), 1)
+
+    # --------------------
+    # DELETION
+    # --------------------
+
+    def test_deletion_device(self):
+        """
+            A user is authenticated and the administrator
+            wants to block his device (and therefore its session).
+        """
+        self.authenticate(self.user_internal.login, self.user_internal.login)
+        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw')
+        self.assertNotIn('/web/login', res.url)
+
+        user_internal_device = self.user_internal.device_ids
+        self.assertEqual(len(user_internal_device), 1)
+        self.assertEqual(user_internal_device.revoked, False)
+
+        user_internal_device._revoke()
+
+        res = self.hit('2024-01-01 08:00:01', '/test_http/greeting-user-rw')
+        self.assertIn('/web/login', res.url)
+
+    def test_deletion_invalidate_sid(self):
+        session = self.authenticate(self.user_internal.login, self.user_internal.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw')
+
+        self.user_internal.device_ids._revoke()
+
+        res = self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'session_id': session.sid})
+        self.assertIn('/web/login', res.url)
+
+    def test_deletion_specific_device(self):
+        self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.authenticate(self.user_admin.login, self.user_admin.login)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 09:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_chrome})
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+
+        devices, logs = self.get_devices_logs(self.user_admin)
+        self.assertEqual(len(devices), 3)
+        self.assertEqual(len(logs), 5)
+        self.assertEqual(len(self.user_admin.device_ids), 3)
+
+        self.user_admin.device_ids.filtered(lambda device: 'firefox' in device.browser)._revoke()
+
+        res = self.hit('2024-01-01 08:00:30', '/test_http/greeting-user-rw', headers={'User-Agent': USER_AGENT_linux_firefox})
+        self.assertIn('/web/login', res.url)
+
+    # --------------------
+    # SPECIFIC USE CASE
+    # --------------------
+
+    def test_specific_public_user_write(self):
+        """
+            A public user who hits a non-readonly route
+            does not have to create a session file if there
+            are no changes in the session itself.
+        """
+        session = self.authenticate(None, None)
+        self.hit('2024-01-01 08:00:00', '/test_http/greeting-public-rw')
+
+        # As we don't have a uid in the session, we shouldn't go through
+        # the session check and therefore we won't go through the device update.
+        # `authenticate` method in the test is not the real method.
+        # To check that we are not creating a session (by making it dirty),
+        # we can check that there is no `_trace`.
+        # This means that the device logic will not create a session file
+        # (because we are not passing in the `_update_device` logic).
+        self.assertFalse(session._trace)

--- a/odoo/addons/test_http/utils.py
+++ b/odoo/addons/test_http/utils.py
@@ -24,6 +24,9 @@ TEST_IP_GEOIP_COUNTRY = geoip2.models.Country(
      'traits': {'ip_address': TEST_IP, 'prefix_len': 21},
     }, ['en']
 )
+USER_AGENT_linux_chrome = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36'
+USER_AGENT_linux_firefox = 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:126.0) Gecko/20100101 Firefox/126.0'
+USER_AGENT_android_chrome = 'Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Mobile Safari/537.36'
 
 
 class MemoryGeoipResolver:
@@ -59,6 +62,14 @@ class MemorySessionStore(SessionStore):
 
     def delete(self, session):
         self.store.pop(session.sid, None)
+
+    def delete_from_identifiers(self, identifiers):
+        sid_to_remove = []
+        for sid in self.store:
+            if any(sid.startswith(identifier) for identifier in identifiers):
+                sid_to_remove.append(sid)
+        for sid in sid_to_remove:
+            self.store.pop(sid)
 
     def rotate(self, session, env):
         FilesystemSessionStore.rotate(self, session, env)

--- a/odoo/service/security.py
+++ b/odoo/service/security.py
@@ -12,9 +12,12 @@ def compute_session_token(session, env):
     self = env['res.users'].browse(session.uid)
     return self._compute_session_token(session.sid)
 
-def check_session(session, env):
+
+def check_session(session, env, request=None):
     self = env['res.users'].browse(session.uid)
     expected = self._compute_session_token(session.sid)
     if expected and odoo.tools.misc.consteq(expected, session.session_token):
+        if request:
+            env['res.device.log']._update_device(request)
         return True
     return False


### PR DESCRIPTION
Objective:
----------
A user must be able to see which of his sessions/devices are active.
Make it easy to block devices and analyse current sessions.
If a user notices unusual operations concerning him on another device,
he must be able to stop these operations by blocking the session used by this device.

General:
--------
A device is uniquely identified by its name, IP address and the session to which it is linked.
Consequently, a device is always linked to a session, and a session is always linked to at least one device.

A device is tracked with its last activity.
The same device is updated every X seconds in order to track its use in terms of duration of activity.

Tracking data is collected within the session itself.
This data is updated in the database when necessary (according to elapsed time).

Within the database, data are inserted as logs (model `res.device.log`).
The `res.device` model is responsible for filtering the logs so that the user can obtain usable data.
Logs are cleaned during garbage collection.

Each user sees data from their own devices.
Administrators can view all devices.

Blocking sessions:
------------------
Blocking a session by selecting a device must block the session directly.
From an administrator's point of view, if we want to block a session,
we expect the session file to be deleted directly on the filesystem.

If the session file is no longer present on the filesystem, we can be sure
that there is no longer any risk of session usurpation.

Note:
There are several ways of blocking the session, but this is the safest.
Blocking a session based on DB values does not cover scenarios in which we perform a backup, for example.

Find the session file:
----------------------
To find a session file on the filesystem, we need to know the sid of the session (as this is its filename).
We don't want to store the sid in the database.
However, we can store a part of it with:
- a large enough part to be certain of the uniqueness of the session;
- a small enough part that we cannot brute force the end of the sid.

Browsing the filesystem has a certain performance cost (and can therefore have defects if abused).

The proposed solution is to change the granularity of the way we store the session on the filesystem.
This means finding a compromise between sub-folders and files per sub-folder to browse for a session file.

The sid will be Base64 encoded in order to increase the number of sub-folders (64^2 instead of 16^2).

Task:3627898