### PR TITLE
Add filterby in account portal pagination

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -101,7 +101,7 @@ class PortalAccount(CustomerPortal):
             'page_name': 'invoice',
             'pager': {  # vals to define the pager.
                 "url": url,
-                "url_args": {'date_begin': date_begin, 'date_end': date_end, 'sortby': sortby},
+                "url_args": {'date_begin': date_begin, 'date_end': date_end, 'sortby': sortby, 'filterby': filterby},
                 "total": AccountInvoice.search_count(domain) if AccountInvoice.check_access_rights('read', raise_exception=False) else 0,
                 "page": page,
                 "step": self._items_per_page,

--- a/doc/cla/corporate/nexterpromania.md
+++ b/doc/cla/corporate/nexterpromania.md
@@ -13,6 +13,5 @@ Fekete Mihai-Adrian feketemihai@nexterp.ro https://github.com/feketemihai
 List of contributors:
 
 Fekete Mihai-Adrian feketemihai@nexterp.ro https://github.com/feketemihai
-Horja Robert horjarobert@nexterp.ro https://github.com/horjarobert
-Cojocaru Marcel cojocarumarcel@nexterp.ro https://github.com/mcojocaru
-Teodor Alexandru teodoralexandru@nexterp.ro https://github.com/alexteodor
+Sima Elisabeta elisabeta.sima@nexterp.ro https://github.com/SimaElisabeta
+Musat Natanaela musatnatanaela@nexterp.ro https://github.com/stananatanaela


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

When navigation to the invoices portal, the filterby resets when changing the page.

Current behavior before PR:

The filterby is reset to None and showing all invoices.

Desired behavior after PR is merged:

The invoices remains filtered by the filterby option.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
