### PR TITLE
[IMP] website_slides: display comments of correct answers in submitted quiz

### DIFF
--- a/addons/website_slides/static/src/xml/slide_quiz.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz.xml
@@ -27,10 +27,13 @@
                                 </label>
                                 <span t-esc="answer.text_value"/>
                             </a>
+                            <t t-if="widget.slide.completed and answer.is_correct" t-set="correct_answer_comment" t-value="answer.comment"/>
                         </t>
-                        <div class="o_wslides_quiz_answer_info list-group-item list-group-item-info d-none">
+                        <div t-attf-class="o_wslides_quiz_answer_info list-group-item list-group-item-info #{correct_answer_comment ? '' : 'd-none'}">
                             <i class="fa fa-info-circle"/>
-                            <span class="o_wslides_quiz_answer_comment ms-2"/>
+                            <span class="o_wslides_quiz_answer_comment ms-2">
+                                <t t-if="correct_answer_comment" t-out="correct_answer_comment"/>
+                            </span>
                         </div>
                     </div>
                 </div>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -527,10 +527,13 @@
                     </label>
                     <span t-esc="answer['text_value']"/>
                 </a>
+                <t t-if="slide_completed and answer['is_correct']" t-set="correct_answer_comment" t-value="answer['comment']"/>
             </t>
-            <div class="o_wslides_quiz_answer_info list-group-item list-group-item-info d-none">
+            <div t-attf-class="o_wslides_quiz_answer_info list-group-item list-group-item-info #{'' if correct_answer_comment else 'd-none'}">
                 <i class="fa fa-info-circle"/>
-                <span class="o_wslides_quiz_answer_comment ms-1"/>
+                <span class="o_wslides_quiz_answer_comment ms-1">
+                    <t t-if="correct_answer_comment" t-out="correct_answer_comment"/>
+                </span>
             </div>
         </div>
     </div>


### PR DESCRIPTION
This PR enhances the user experience by making comments or explanations for correct answers of a quiz 
always accessible even after the quiz has been completed. 

This change is made in order to facilitate the users to review the comments later at anytime.

Task-[3847997](https://www.odoo.com/web#id=3847997&menu_id=4722&cids=2&action=333&active_id=965&model=project.task&view_type=form)