### PR TITLE
[FIX] l10n_ke_edi_tremol: discount sign

### DIFF
--- a/addons/l10n_ke_edi_tremol/models/account_move.py
+++ b/addons/l10n_ke_edi_tremol/models/account_move.py
@@ -207,8 +207,8 @@ class AccountMove(models.Model):
             line_data += b'*' + str(abs(line.quantity)).encode('cp1251')[:10]
             if discount_dict.get(line.id):
                 # 1 to 7 symbols for percentage of discount/addition
-                discount_sign = b'-' if discount_dict[line.id] > 0 else b'+'
-                discount = discount_sign + str(abs(discount_dict[line.id])).encode('cp1251')[:6]
+                discount_sign = b'-' if discount_dict[line.id] > 0 else b''
+                discount = discount_sign + (str(abs(discount_dict[line.id]))).rstrip('0').rstrip('.').encode('cp1251')[:6]
                 line_data += b',' + discount + b'%'
 
             # Command: Sale of article (0x31)

--- a/addons/l10n_ke_edi_tremol/tests/test_move_export.py
+++ b/addons/l10n_ke_edi_tremol/tests/test_move_export.py
@@ -77,7 +77,7 @@ class TestKeMoveExport(AccountTestInvoicingCommon):
             'name': b'Infinite Improbability Drive        ',
             'price': b'1432.09', # This is the unit price, tax included
             'quantity': b'10.0',
-            'discount': b'-25.0%',
+            'discount': b'-25%',
         })
         expected_messages = [
             # open invoice
@@ -147,7 +147,7 @@ class TestKeMoveExport(AccountTestInvoicingCommon):
             'quantity': b'10.0',
             # The discount is -20%, because there is an existing discount on the line of 10%, and
             # another negative line with the amount -10 would be another -10% discount.
-            'discount': b'-20.0%',
+            'discount': b'-20%',
         })
         expected_messages = [
             b'01;     0;0;1;Sirius Cybernetics Corporation;A000123456F   ;Test StreetFurther Test Street;Test StreetFurther Test Street;00500Nairobi                  ;                              ;INV202300001   ',
@@ -220,6 +220,6 @@ class TestKeMoveExport(AccountTestInvoicingCommon):
             'name': b'Infinite Improbability Drive        ',
             'price': b'1160',  # This is the unit price, tax included, but only the 16% VAT
             'quantity': b'10.0',
-            'discount': b'-25.0%',
+            'discount': b'-25%',
         })
         self.assertEqual(generated_messages, [expected_sale_line])


### PR DESCRIPTION
When sending an invoice with negative discount, the code responsible for serialising this discount applies a '+' plus sign to the discount. This is because the DiscAddP (Discount Addition Percentage) field on the device expects a negative amount for discounts (with a minus sign).

However, due to errors with our own device, we have detected that surcharges (or negative discounts), serialised with a '+' plus sign actually trigger an error on the fiscal device (5 Input registers overflow).

This commit adapts the serialisation to specify no sign in the case of negative discounts (surcharges), since a non-negative number in this field serves as a representation of a surcharge. Trailing zeros are stripped from the value and tests are updated to coincide with this change.
