### PR TITLE
[15.0][FIX] project: Allow access share action from project tasks to project users

### DIFF
--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -17,6 +17,7 @@ of this module is to allow the display of a customer portal without having
 a dependency towards website editing and customization capabilities.""",
     'depends': ['web', 'web_editor', 'http_routing', 'mail', 'auth_signup'],
     'data': [
+        'security/portal_security.xml',
         'security/ir.model.access.csv',
         'data/mail_template_data.xml',
         'data/mail_templates.xml',

--- a/addons/portal/security/portal_security.xml
+++ b/addons/portal/security/portal_security.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="partner_manager_all_portal_share_rule" model="ir.rule">
+        <field name="name">Portal Share: partner manager: see all</field>
+        <field name="model_id" ref="portal.model_portal_share"/>
+        <field name="domain_force">[(1,'=',1)]</field>
+        <field name="groups" eval="[(4, ref('base.group_partner_manager'))]"/>
+    </record>
+</odoo>

--- a/addons/project/security/ir.model.access.csv
+++ b/addons/project/security/ir.model.access.csv
@@ -41,3 +41,4 @@ access_project_collaborator_user,project.collaborator.user,model_project_collabo
 access_project_collaborator_portal,project.collaborator.portal,model_project_collaborator,base.group_portal,1,0,0,0
 access_project_share_manager,project.share.wizard.manager,model_project_share_wizard,project.group_project_manager,1,1,1,0
 access_project_personal_stage,project.personal.stage.user,model_project_task_stage_personal,base.group_user,1,1,1,1
+access_project_portal_share,access.project.portal.share,portal.model_portal_share,project.group_project_user,1,1,1,0

--- a/addons/project/security/project_security.xml
+++ b/addons/project/security/project_security.xml
@@ -262,5 +262,12 @@
         <field name="domain_force">[(1, '=', 1)]</field>
         <field name="groups" eval="[(4, ref('project.group_project_manager'))]"/>
     </record>
+
+    <record id="access_project_portal_share_rule" model="ir.rule">
+        <field name="name">Project/Task: Allow to share tasks</field>
+        <field name="model_id" ref="portal.model_portal_share"/>
+        <field name="domain_force">[('res_model', '=', 'project.task')]</field>
+        <field name="groups" eval="[(4, ref('group_project_user'))]"/>
+    </record>
 </data>
 </odoo>


### PR DESCRIPTION
Resume of https://github.com/odoo/odoo/pull/105220 in v15

**Description of the issue/feature this PR addresses**:
Allow access share action from project tasks to project users.

**Steps to reproduce the error**:
- Go to Settings > Users & Companies > Users and create a user only with Project > User permission. (User must not have the Extra Rights > Contact Creation permission).
- Go to Project and go into a task and click on "action".
- Share action is not shown.

**Impacted versions**:
- 15.0
- 16.0
- 17.0
 - master

Ping  @pedrobaeza 

cc @Tecnativa

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr