### PR TITLE
[FIX] mrp: workorder state not updated on parent MO validation

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -571,12 +571,9 @@ class MrpProduction(models.Model):
             else:
                 production.workorder_ids = [Command.delete(wo.id) for wo in production.workorder_ids.filtered(lambda wo: wo.operation_id)]
 
-    @api.depends('state', 'move_raw_ids.state')
+    @api.depends('move_raw_ids.state')
     def _compute_reservation_state(self):
         for production in self:
-            if production.state in ('draft', 'done', 'cancel'):
-                production.reservation_state = False
-                continue
             relevant_move_state = production.move_raw_ids._get_relevant_state_among_moves()
             # Compute reservation state according to its component's moves.
             if relevant_move_state == 'partially_available':

--- a/addons/mrp/tests/test_order.py
+++ b/addons/mrp/tests/test_order.py
@@ -2318,7 +2318,7 @@ class TestMrpOrder(TestMrpCommon):
         mo.do_unreserve()
 
         self.assertEqual(list(mo.workorder_ids.mapped("state")), ["waiting", "pending"])
-
+        import pudb; pudb.set_trace()
         mo.workorder_ids[0].unlink()
 
         self.assertEqual(list(mo.workorder_ids.mapped("state")), ["waiting"])


### PR DESCRIPTION
It happens due to a loop
`production reservation_state` -> `production state` -> `workorder state` -> `production reservation_state`

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
