### PR TITLE
[FIX] web_editor: click enter in a banner inside a list in chrome

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3546,7 +3546,7 @@ export class OdooEditor extends EventTarget {
         // and trigger manually the input event to simulate the correct flow.
         if (ev.inputType ==="insertParagraph") {
             const banner = closestElement(ev.target, ".o_editor_banner");
-            if (banner && closestElement(banner, "ul")) {
+            if (banner && closestElement(banner, "ul, ol")) {
                 ev.preventDefault();
                 this._onInput(ev);
                 return;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3529,6 +3529,29 @@ export class OdooEditor extends EventTarget {
 
     _onBeforeInput(ev) {
         this._lastBeforeInputType = ev.inputType;
+        // For chrome when we have this structure
+        // <div contenteditable="true">
+        //     <ul>
+        //         <div contenteditable="false">
+        //             <div contenteditable="true">
+        //                 <p>
+        //                     text[]
+        //                 </p>
+        //             </div>
+        //         </div>
+        //     </ul>
+        // </div>
+        // clicking on `enter` doesn't works as expected and the `input` event is never
+        // triggered, to solve the problem we can use this hack where we stop the propagation
+        // and trigger manually the input event to simulate the correct flow.
+        if (ev.inputType ==="insertParagraph") {
+            const banner = closestElement(ev.target, ".o_editor_banner");
+            if (banner && closestElement(banner, "ul")) {
+                ev.preventDefault();
+                this._onInput(ev);
+                return;
+            }
+        }
     }
 
     /**

--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -1059,7 +1059,13 @@ section, .oe_img_bg, [data-oe-shape-data] {
 
 .o_editor_banner {
     // force margin to ensure vertical center alignment in correlation with icon
-    p, h1, h2, h3 {
+    p, h1, h2, h3, ul, ol {
         margin-bottom: 1rem;
+    }
+    ol ol, ul ul, ol ul, ul ol {
+        margin-bottom: 0;
+    }
+    ul.o_checklist>li:not(.oe-nested)::before {
+        top: 0px!important;
     }
 }


### PR DESCRIPTION
Issue:
======
Clicking enter in a banner inside a list breaks the layout in chrome browser.

Steps to reproduce the issue:
=============================
- Open chrome browser
- Go to to-do
- Create a list  and add 1 item
- Click enter (Second element of the list) and add a banner in the item
- Click enter
- Doesn't work as expected

Origin of the issue:
====================
This is a browser issue, chrome in this specific case doesn't work properly, all the events until `textInput` are called when clicking `enter` but the last event is never triggerged which is the `input` event. The specific case can be reproduced with this:
```
<div contenteditable="true">
     <ul>
         <div contenteditable="false">
             <div contenteditable="true">
                 <p>
                     text[]
                 </p>
             </div>
         </div>
     </ul
</div>
```

Solution:
==========
We manually trigger the `input` event in this specific case.

Issue:
======
List inside a banner under a list doesn't align correctly

steps to reproduce the issue:
=============================
- Go to do
- Add a list and first item
- Add a banner
- Add a list inside the banner
- It's not correctly centered

Origin of the issue:
====================
Since the list inside the banner is considered nested list under the top
list, the `margin-bottom` is removed.

Solution:
=========
Reassign the style again when we are inside the banner.

task-3857296