### PR TITLE
[IMP] google_calendar, hr_holidays: remove video call URL for time off event

### DIFF
--- a/addons/calendar/views/calendar_views.xml
+++ b/addons/calendar/views/calendar_views.xml
@@ -186,7 +186,7 @@
 
                             <field name="location" placeholder="Online Meeting" readonly="not user_can_edit"/>
                             <label for="videocall_location" class="opacity-100"/>
-                            <div col="2">
+                            <div name="videocall_location_div" col="2">
                                 <field name="videocall_location" string="Videocall URL" widget="CopyClipboardChar" force_save="1" readonly="videocall_source == 'discuss' or not user_can_edit"/>
                                 <button name="clear_videocall_location" type="object" class="btn btn-link ps-0"
                                     invisible="not videocall_location or not user_can_edit" context="{'recurrence_update': recurrence_update}">

--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -273,6 +273,13 @@ class GoogleSync(models.AbstractModel):
         }
         return writeable_values
 
+    def _need_video_call(self):
+        """ Implement this method to return True if the event needs a video call
+        :return: bool
+        """
+        self.ensure_one()
+        return True
+
     @after_commit
     def _google_insert(self, google_service: GoogleCalendarService, values, timeout=TIMEOUT):
         if not values:
@@ -282,7 +289,7 @@ class GoogleSync(models.AbstractModel):
                 try:
                     send_updates = self._context.get('send_updates', True)
                     google_service.google_service = google_service.google_service.with_context(send_updates=send_updates)
-                    google_values = google_service.insert(values, token=token, timeout=timeout)
+                    google_values = google_service.insert(values, token=token, timeout=timeout, need_video_call=self._need_video_call())
                     self.with_context(dont_notify=True).write(self._get_post_sync_values(values, google_values))
                 except HTTPError as e:
                     if e.response.status_code in (400, 403):

--- a/addons/google_calendar/utils/google_calendar.py
+++ b/addons/google_calendar/utils/google_calendar.py
@@ -72,9 +72,9 @@ class GoogleCalendarService():
         return GoogleEvent(events), next_sync_token, default_reminders
 
     @requires_auth_token
-    def insert(self, values, token=None, timeout=TIMEOUT):
+    def insert(self, values, token=None, timeout=TIMEOUT, need_video_call=True):
         send_updates = self.google_service._context.get('send_updates', True)
-        url = "/calendar/v3/calendars/primary/events?conferenceDataVersion=1&sendUpdates=%s" % ("all" if send_updates else "none")
+        url = "/calendar/v3/calendars/primary/events?conferenceDataVersion=%d&sendUpdates=%s" % (1 if need_video_call else 0, "all" if send_updates else "none")
         headers = {'Content-type': 'application/json', 'Authorization': 'Bearer %s' % token}
         if not values.get('id'):
             values['id'] = uuid4().hex

--- a/addons/hr_holidays/__manifest__.py
+++ b/addons/hr_holidays/__manifest__.py
@@ -42,6 +42,7 @@ A synchronization with an internal agenda (Meetings of the CRM module) is also p
         'views/hr_leave_accrual_views.xml',
         'views/hr_leave_mandatory_day_views.xml',
         'views/mail_activity_views.xml',
+        'views/calendar_views.xml',
 
         'wizard/hr_holidays_cancel_leave_views.xml',
         'wizard/hr_holidays_summary_employees_views.xml',

--- a/addons/hr_holidays/models/__init__.py
+++ b/addons/hr_holidays/models/__init__.py
@@ -14,3 +14,4 @@ from . import hr_leave_mandatory_day
 from . import mail_message_subtype
 from . import res_partner
 from . import res_users
+from . import calendar_event

--- a/addons/hr_holidays/models/calendar_event.py
+++ b/addons/hr_holidays/models/calendar_event.py
@@ -1,0 +1,17 @@
+from odoo import models
+
+
+class CalendarEvent(models.Model):
+    _inherit = 'calendar.event'
+
+    def _need_video_call(self):
+        """ Determine if the event needs a video call or not depending
+        on the model of the event.
+
+        This method, implemented and invoked in google_calendar, is necessary
+        due to the absence of a bridge module between google_calendar and hr_holidays.
+        """
+        self.ensure_one()
+        if self.res_model == 'hr.leave':
+            return False
+        return super()._need_video_call()

--- a/addons/hr_holidays/tests/__init__.py
+++ b/addons/hr_holidays/tests/__init__.py
@@ -22,3 +22,4 @@ from . import test_negative
 from . import test_past_accruals
 from . import test_allocations
 from . import test_multicompany
+from . import test_timeoff_event

--- a/addons/hr_holidays/tests/test_timeoff_event.py
+++ b/addons/hr_holidays/tests/test_timeoff_event.py
@@ -1,0 +1,35 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from datetime import datetime
+from dateutil.relativedelta import relativedelta
+
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+
+
+class TestTimeoffEvent(TestHrHolidaysCommon):
+
+    def test_no_videocall_url_in_timeoff_event(self):
+        """ Test that the timeoff event does not need a video call """
+
+        self.hr_leave_type = self.env['hr.leave.type'].with_user(self.user_hrmanager).create({
+            'name': 'Time Off Type',
+            'requires_allocation': 'no',
+        })
+        self.holiday = self.env['hr.leave'].with_context(mail_create_nolog=True, mail_notrack=True).with_user(self.user_employee).create({
+            'name': 'Time Off 1 sura',
+            'employee_id': self.employee_emp.id,
+            'holiday_status_id': self.hr_leave_type.id,
+            'request_date_from': datetime(2020, 1, 15),
+            'request_date_to': datetime(2020, 1, 15) + relativedelta(days=1),
+        })
+        self.holiday.with_user(self.user_hrmanager).action_validate()
+
+        # Finding the event corresponding to the leave
+        search_criteria = [
+            ('name', 'like', self.holiday.employee_id.name),
+            ('start_date', '>=', self.holiday.request_date_from),
+            ('stop_date', '<=', self.holiday.request_date_to),
+        ]
+        timeoff_event = self.env['calendar.event'].search(search_criteria)
+        self.assertTrue(timeoff_event, "The timeoff event should exist")
+        self.assertFalse(timeoff_event._need_video_call(), "The timeoff event does not need a video call")

--- a/addons/hr_holidays/views/calendar_views.xml
+++ b/addons/hr_holidays/views/calendar_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_calendar_event_form_inherit" model="ir.ui.view">
+        <field name="name">view.calendar.event.form.inherit</field>
+        <field name="model">calendar.event</field>
+        <field name="inherit_id" ref="calendar.view_calendar_event_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//label[@for='videocall_location']" position="attributes">
+                <attribute name="invisible">res_model == 'hr.leave'</attribute>
+            </xpath>
+            <xpath expr="//div[@name='videocall_location_div']" position="attributes">
+                <attribute name="invisible">res_model == 'hr.leave'</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before Commit:
---------------------
When Google Sync is enabled and if you create a time-off request and it gets validated, Odoo will automatically create a corresponding event in the Odoo calendar and when its gets synced with the google calendar a video call URL for that time-off event is generated.

Steps to reproduce:
---------------------------
- Make sure Google Sync is enabled
- Open the Time off module
- Create a new time off request
- Go to your time offs, approve and validate the time off request
- Go to the calendar module and open the respective event made for the time off
- You can see a video call URL is generated for this event

After Commit:
-------------------
When you create a time off request and validate it, the corresponding event is made but no video call URL is generated.

task-3853586

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
