### PR TITLE
[FIX] pos_restaurant: merge tables into a single bill

### DIFF
--- a/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
+++ b/addons/pos_restaurant/static/src/app/floor_screen/floor_screen.xml
@@ -4,10 +4,8 @@
         <div class="floor-screen screen h-100 position-relative d-flex flex-column flex-nowrap m-0 bg-100 text-start overflow-hidden">
             <t t-set="editButtonClass" t-value="'text-center d-flex flex-column align-items-center btn btn-light text-uppercase'" />
             <div t-if="pos.orderToTransfer" class="d-flex align-items-center justify-content-between px-3 border-bottom bg-view overflow-x-auto w-100">
-                <button t-attf-class="ms-auto {{editButtonClass}}" t-att-class="{active: !pos.isTableToMerge}" t-on-click="() => this.pos.isTableToMerge = false">
-                    <i class="fa fa-arrow-right" role="img" aria-label="Transfer" title="Transfer" />Transfer</button>
-                <button t-attf-class="{{editButtonClass}}" t-att-class="{active: pos.isTableToMerge}" t-on-click="() => this.pos.isTableToMerge = true">
-                    <i class="fa fa-link" role="img" aria-label="Merge" title="Merge" />Merge</button>
+                <button t-attf-class="ms-auto active {{editButtonClass}}">
+                    <i class="fa fa-link" role="img" aria-label="Transfer/Merge" title="Transfer/Merge" />Transfer/Merge</button>
                 <button t-attf-class="ms-auto {{editButtonClass}}" t-on-click.stop="stopOrderTransfer">
                     <i class="fa fa-times" role="img" aria-label="Close" title="Close" />Discard</button>
             </div>

--- a/addons/pos_restaurant/static/src/overrides/components/dialog/transfer_merge_dialog.js
+++ b/addons/pos_restaurant/static/src/overrides/components/dialog/transfer_merge_dialog.js
@@ -1,0 +1,26 @@
+/** @odoo-module */
+
+import { Component } from "@odoo/owl";
+import { Dialog } from "@web/core/dialog/dialog";
+
+export class TransferMergeDialog extends Component {
+    static template = "pos_restaurant.TransferMergeDialog";
+    static components = { Dialog };
+    static props = {
+        isTableToMerge: false,
+        title: String,
+        close: Function,
+        getPayload: Function,
+    };
+    closeDialog() {
+        this.props.close();
+    }
+    confirm(merge) {
+        if (merge) {
+            this.props.getPayload(true);
+        } else {
+            this.props.getPayload(false);
+        }
+        this.props.close();
+    }
+}

--- a/addons/pos_restaurant/static/src/overrides/components/dialog/transfer_merge_dialog.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/dialog/transfer_merge_dialog.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+
+    <t t-name="pos_restaurant.TransferMergeDialog">
+        <Dialog title="this.props.title" size="'md'" body="this.props.body">
+            <span>
+                Transferring to an occupied table will add a new, separate order found in the order menu. Perhaps you would prefer to merge them into a single instead?
+            </span>
+            <t t-set-slot="footer">
+                <button class="btn btn-primary o-default-button" t-on-click="() => this.confirm(false)">Transfer</button>
+                <button class="btn btn-secondary o-default-button" t-on-click="() => this.confirm(true)">Merge into single bill</button>
+                <button class="btn btn-secondary o-default-button" t-on-click="closeDialog">Discard</button>
+            </t>
+        </Dialog>
+    </t>
+
+</templates>


### PR DESCRIPTION
Before this commit:
=============================================================
- If table 1 is merge with table 2 then order of table 1 was transfer to table 2 but order of table 2 got vanished
- Transfer and Merge were two different buttons in the UI

After this commit:
==============================================================
- now order of table 2 does not get vanished and order of table 1 is updated on table 2 and both tables get merged.
- Transfer and Merge button are combined to enhance the user experience.
- Dialog box is been updated with 3 buttons i.e.
  - Transfer
  - Merge into this bill
  - Discard

task-3845696
