### PR TITLE
[FIX] mass_mailing: fix links in test mailings

### DIFF
--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -65,7 +65,7 @@ class MailMail(models.Model):
     def _prepare_outgoing_list(self, recipients_follower_status=None):
         """ Update mailing specific links to add tracking based on res_id """
         email_list = super()._prepare_outgoing_list(recipients_follower_status)
-        if not self.res_id or not self.mailing_id:
+        if not self.mailing_id:
             return email_list
 
         base_url = self.mailing_id.get_base_url()

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -61,8 +61,6 @@ class TestMassMailing(models.TransientModel):
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
                 'auto_delete': False,  # they are manually deleted after notifying the document
                 'mail_server_id': mailing.mail_server_id.id,
-                'res_id': self.env.user.id,
-                'model': 'res.users'
             }
             mail = self.env['mail.mail'].sudo().create(mail_values)
             mails_sudo |= mail

--- a/addons/mass_mailing/wizard/mailing_mailing_test.py
+++ b/addons/mass_mailing/wizard/mailing_mailing_test.py
@@ -61,6 +61,8 @@ class TestMassMailing(models.TransientModel):
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
                 'auto_delete': False,  # they are manually deleted after notifying the document
                 'mail_server_id': mailing.mail_server_id.id,
+                'res_id': self.env.user.id,
+                'model': 'res.users'
             }
             mail = self.env['mail.mail'].sudo().create(mail_values)
             mails_sudo |= mail

--- a/addons/test_mass_mailing/tests/test_mailing_test.py
+++ b/addons/test_mass_mailing/tests/test_mailing_test.py
@@ -62,6 +62,31 @@ class TestMailingTest(TestMassMailCommon):
         with self.mock_mail_gateway(), self.assertRaises(Exception):
             mailing_test.send_mail_test()
 
+        # Test if link snippets are correctly converted
+        mailing.write({
+            'subject': 'Subject {{ object.name }}',
+            'preview': 'Preview {{ object.name }}',
+            'body_html':
+                '''<p>
+                Hello
+                    <div class="o_snippet_view_in_browser o_mail_snippet_general pt16 pb16" style="text-align: center; padding-left: 15px; padding-right: 15px;">
+                        <a href="/view">
+                            View Online
+                        </a>
+                    </div>
+                    <div class="o_mail_footer_links">
+                        <a role="button" href="/unsubscribe_from_list" class="btn btn-link">Unsubscribe</a>
+                    </div>
+                </p>'''
+        })
+
+        with self.mock_mail_gateway():
+            mailing_test.send_mail_test()
+
+        body_html = self._mails.pop()['body']
+        self.assertIn(f'/mailing/{mailing.id}/view', body_html)
+        self.assertNotIn('/unsubscribe_from_list', body_html)
+
     def test_mailing_test_equals_reality(self):
         """
         Check that both test and real emails will format the qweb and inline placeholders correctly in body and subject.


### PR DESCRIPTION
This commit fixes an issue with the mailing_mailing_test wizard in mass_mailing. When sending a test email the snippets `s_mail_block_header_view` and `s_mail_block_footer_social_left` contains placeholder links that are replaced by correct ones when rendered.
When the user sends a test mailing the mail sent will still contain the placeholder links without being replaced.
This means that when clicking on them the user is redirected to 404 error as those are mere placeholders.

Those links are not replaced because the mail created inside testing wizard did not give a res_id, linked to a mailing.contact, to the mail.mail created. This led the function `_prepare_outgoing_list` to be exited prematurely without replacing the placeholders.

Now we are adding a res_id linked to the current user to the mail.mail created in order for the method to finish its execution.

task-3869575

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
