### PR TITLE
[IMP] base_import: add field type in dropdown

### DIFF
--- a/addons/base_import/static/src/import_data_content/import_data_content.js
+++ b/addons/base_import/static/src/import_data_content/import_data_content.js
@@ -47,6 +47,7 @@ export class ImportDataContent extends Component {
         return fields.map((field) => ({
             label: field.label,
             value: field.fieldPath,
+            iconClass: `o_import_field_icon_${field.type}`,
         }));
     }
 

--- a/addons/base_import/static/src/import_data_content/import_data_content.scss
+++ b/addons/base_import/static/src/import_data_content/import_data_content.scss
@@ -1,12 +1,4 @@
 .o_import_data_content {
-    .o_import_field_icon {
-        filter: invert(0.5); // make the icons visible in dark theme
-        background-image: url('/base_import/static/src/import_data_content/img/studio_icons.png');
-        background-repeat: no-repeat;
-        width: 25px;
-        height: 20px;
-    }
-
     .o_import_file_column_cell {
         max-width: 300px;
     }
@@ -18,6 +10,28 @@
     td {
         vertical-align: top;
     }
+}
+
+.o_import_field_icon {
+    filter: invert(0.5); // make the icons visible in dark theme
+    background-image: url('/base_import/static/src/import_data_content/img/studio_icons.png');
+    background-repeat: no-repeat;
+    width: 25px;
+    height: 20px;
+
+    &.o_import_field_choice {
+        z-index: -1; // prevent icon dropdown overflow
+    }
+}
+
+.o_select_active:has(.o_import_field_icon) {
+    // Keep icon visible when selected
+    position: relative;
+    z-index: -1;
+}
+
+.o_select_active .o_import_field_icon {
+    filter: brightness(6);
 }
 
 @mixin o-import-sprite-icon($x: 0, $y: 0) {

--- a/addons/base_import/static/src/import_data_content/import_data_content.xml
+++ b/addons/base_import/static/src/import_data_content/import_data_content.xml
@@ -81,6 +81,8 @@
 
                                     <t t-set-slot="choice" t-slot-scope="choice">
                                         <div t-att-class="`${choice.data.value and choice.data.value.required ? 'fw-bolder text-decoration-underline' : ''}`">
+                                            <i class="o_import_field_choice o_import_field_icon position-relative d-inline-block align-middle border-end me-2"
+                                                t-att-class="choice.data.iconClass"/>
                                             <t t-esc="choice.data.label" />
                                         </div>
                                     </t>

--- a/addons/web/static/src/core/select_menu/select_menu.js
+++ b/addons/web/static/src/core/select_menu/select_menu.js
@@ -38,6 +38,7 @@ export class SelectMenu extends Component {
                 shape: {
                     value: true,
                     label: { type: String },
+                    "*": true,
                 },
             },
         },
@@ -55,6 +56,7 @@ export class SelectMenu extends Component {
                             shape: {
                                 value: true,
                                 label: { type: String },
+                                "*": true,
                             },
                         },
                     },

--- a/addons/web/static/tests/legacy/core/select_menu_tests.js
+++ b/addons/web/static/tests/legacy/core/select_menu_tests.js
@@ -521,6 +521,28 @@ QUnit.module("Web Components", (hooks) => {
         assert.strictEqual(target.querySelector(".coolClass").textContent, "Hello");
     });
 
+    QUnit.test("Can add custom data to choices", async (assert) => {
+        class Parent extends Component {
+            static props = ["*"];
+            static components = { SelectMenu };
+            static template = xml`
+                <SelectMenu choices="choices">
+                    <t t-set-slot="choice" t-slot-scope="choice">
+                        <span class="coolClass" t-esc="choice.data.custom" />
+                    </t>
+                </SelectMenu>
+            `;
+            setup() {
+                this.choices = [
+                    { label: "Hello", value: "hello", custom: "hi" },
+                ];
+            }
+        }
+        await mountInFixture(Parent, target, { env });
+        await open();
+        assert.strictEqual(target.querySelector(".coolClass").textContent, "hi");
+    });
+
     QUnit.test(
         "Custom template for the bottom area of the dropdown using a slot",
         async (assert) => {

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -7213,7 +7213,7 @@ def itemgetter_tuple(items):
 
 def convert_pgerror_not_null(model, fields, info, e):
     if e.diag.table_name != model._table:
-        return {'message': _(u"Missing required value for the field '%s'", e.diag.column_name)}
+        return {'message': _("Missing required value for the field '%(name)s' on a linked model [%(linked_model)s]", name=e.diag.column_name, linked_model=e.diag.table_name)}
 
     field_name = e.diag.column_name
     field = fields[field_name]


### PR DESCRIPTION
Enhancing the select menu by giving the possibility to pass
additional data to the choices.

----------------------------------------------------------------------------

Display the field type icon in the Odoo field dropdown so that it's easier
and faster to retrieve a certain type of field.

For example, if the users are searching for an integer field they can
quickly scan for the integer icon while scrolling in the dropdown.

Also updating the error message displayed when the current model and the
model where the error occurs are different to be more explicit.


Task-3859340

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
