### PR TITLE
[FIX] web: cumulated graph single fix

### DIFF
--- a/addons/web/static/src/views/graph/graph_renderer.js
+++ b/addons/web/static/src/views/graph/graph_renderer.js
@@ -376,6 +376,13 @@ export class GraphRenderer extends Component {
             } else {
                 dataset.borderColor = getColor(index, cookie.get("color_scheme"));
             }
+            if (cumulated) {
+                let accumulator = dataset.cumulatedStart;
+                dataset.data = dataset.data.map((value) => {
+                    accumulator += value;
+                    return accumulator;
+                });
+            }
             if (data.labels.length === 1) {
                 // shift of the real value to right. This is done to
                 // center the points in the chart. See data.labels below in
@@ -388,13 +395,6 @@ export class GraphRenderer extends Component {
             dataset.pointBorderColor = "rgba(0,0,0,0.2)";
             if (stacked) {
                 dataset.backgroundColor = hexToRGBA(dataset.borderColor, LINE_FILL_TRANSPARENCY);
-            }
-            if (cumulated) {
-                let accumulator = dataset.cumulatedStart;
-                dataset.data = dataset.data.map((value) => {
-                    accumulator += value;
-                    return accumulator;
-                });
             }
         }
         if (data.datasets.length === 1 && data.datasets[0].originIndex === 0) {


### PR DESCRIPTION
Single value graph were not shown in cumulated graph.

This is due to unshift happening before the accumulator, leading to `undefined + X = NaN` for the value.

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
