### PR TITLE
[FIX] account_peppol: installation crash

### DIFF
--- a/addons/account_edi_ubl_cii/__manifest__.py
+++ b/addons/account_edi_ubl_cii/__manifest__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 {
     'name': "Import/Export electronic invoices with UBL/CII",
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Accounting/Accounting',
     'description': """
 Electronic invoicing module

--- a/addons/account_peppol/wizard/account_move_send_views.xml
+++ b/addons/account_peppol/wizard/account_move_send_views.xml
@@ -7,6 +7,8 @@
             <field name="inherit_id" ref="account.account_move_send_form"/>
             <field name="arch" type="xml">
                 <xpath expr="//div[@name='warnings']" position="inside">
+                    <!-- the ubl_partner_warning field is there to prevent a traceback in case ubl_cii isn't up to date -->
+                    <div invisible="1"><field name="ubl_partner_warning"/></div>
                     <field name="enable_peppol" invisible="1"/>
                     <div class="alert alert-warning" role="alert" attrs="{
                                 'invisible': ['|', '|',


### PR DESCRIPTION
The aim of this commit is to allow user to tick the peppol checkbox without facing a traceback

Context:
The commit cffd0e9dd91376dd7fe4613f4fd94e659daaeef0 introduced a check based on a field introduced in the view by another module it depends on.

The problem is that ticking the peppol checkbox install the `account_peppol` module but doesn't trigger an update of the `account_edi_ubl_cii` module.

Before the commit:
Traceback when ticking peppol in settings

After the commit:
No Traceback when ticking peppol in settings

opw-3874304
