### PR TITLE
[FIX] base: Make user lookup by email case insensitive.

### DIFF
--- a/odoo/addons/base/models/res_users.py
+++ b/odoo/addons/base/models/res_users.py
@@ -30,6 +30,7 @@ from odoo.exceptions import AccessDenied, AccessError, UserError, ValidationErro
 from odoo.http import request, DEFAULT_LANG
 from odoo.osv import expression
 from odoo.tools import is_html_empty, partition, collections, frozendict, lazy_property, SetDefinitions
+from odoo.tools.mail import email_escape_char
 
 _logger = logging.getLogger(__name__)
 
@@ -862,7 +863,7 @@ class Users(models.Model):
 
     @api.model
     def _get_email_domain(self, email):
-        return [('email', '=', email)]
+        return [('email', '=ilike', email_escape_char(email))]
 
     @api.model
     def _get_login_order(self):

--- a/odoo/addons/base/tests/test_res_users.py
+++ b/odoo/addons/base/tests/test_res_users.py
@@ -334,6 +334,13 @@ class TestUsers2(TransactionCase):
         with self.assertRaises(ValueError):
             User.read_group([], fnames + [reified_fname], [reified_fname])
 
+    def test_get_email_domain(self):
+        """ Check that _get_email_domain escapes wildcards """
+        User = self.env['res.users']
+        self.assertIn(('email', '=ilike', '\\\\bobs@example.com'), User._get_email_domain('\\bobs@example.com'), "backslashes should be escaped")
+        self.assertIn(('email', '=ilike', '\\%your@example.com'), User._get_email_domain('%your@example.com'), "percents should be escaped")
+        self.assertIn(('email', '=ilike', '\\_uncle@example.com'), User._get_email_domain('_uncle@example.com'), "underscores should be escaped")
+
     def test_reified_groups_on_change(self):
         """Test that a change on a reified fields trigger the onchange of groups_id."""
         group_public = self.env.ref('base.group_public')


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

This avoids user frustration when attempting to reset password via email address.

Related: #25532, #131607.

### Current behavior before PR:

Error: "Reset password: invalid username or email"

### Desired behavior after PR is merged:

User resets password successfully.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
