### PR TITLE
[FIX] Package Dependency: python3-phonenumbers

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -38,6 +38,7 @@ Depends:
  python3-num2words,
  python3-ofxparse,
  python3-passlib,
+ python3-phonenumbers,
  python3-polib,
  python3-psutil,
  python3-psycopg2,

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,7 @@ MarkupSafe==2.1.2 ; python_version > '3.10'
 num2words==0.5.10
 ofxparse==0.21
 passlib==1.7.4 # min version = 1.7.2 (Focal with security backports)
+phonenumbers==8.12.1 # Ubuntu Jammy 8.12.1, Debian Bookworm 8.12.57
 Pillow==9.0.1 ; python_version <= '3.10'  # min version = 7.0.0 (Focal with security backports)
 Pillow==9.4.0 ; python_version > '3.10'
 polib==1.1.1

--- a/setup/package.dfdebian
+++ b/setup/package.dfdebian
@@ -35,6 +35,7 @@ RUN apt-get update -qq &&  \
         python3-lxml \
         python3-ofxparse \
         python3-passlib \
+        python3-phonenumbers \
         python3-polib \
         python3-psutil \
         python3-psycopg2 \

--- a/setup/package.dffedora
+++ b/setup/package.dffedora
@@ -33,6 +33,7 @@ RUN dnf update -d 0 -e 0 -y && \
         python3-mock \
         python3-num2words \
         python3-ofxparse.noarch \
+        python3-phonenumbers \
         python3-passlib \
         python3-pillow \
         python3-polib \


### PR DESCRIPTION
website_crm mass_mailing_sms sms crm hr event_crm and other addons depend on phone_validation and the required Python package is not installed by default.

- PyPi: https://pypi.org/project/phonenumbers/
- Debian: https://packages.debian.org/bookworm/python3-phonenumbers
- Ubuntu: https://packages.ubuntu.com/jammy/python3-phonenumbers - (jammy specified at https://github.com/odoo/docker/blob/master/17.0/Dockerfile#L1)

### Description of the issue/feature this PR addresses:

Missing dependency

### Current behavior before PR:

phone_validation fails

### Desired behavior after PR is merged:

phone_validation works

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
