### PR TITLE
[IMP] website_crm_partner_assign: revamp portal filterby menu

### DIFF
--- a/addons/website_crm_partner_assign/controllers/main.py
+++ b/addons/website_crm_partner_assign/controllers/main.py
@@ -1,10 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import datetime
 import werkzeug.urls
 
-from collections import OrderedDict
 from werkzeug.exceptions import NotFound
 
 from odoo import fields
@@ -100,14 +98,16 @@ class WebsiteAccount(CustomerPortal):
         domain = self.get_domain_my_opp(request.env.user)
 
         today = fields.Date.today()
-        this_week_end_date = fields.Date.to_string(fields.Date.from_string(today) + datetime.timedelta(days=7))
 
         searchbar_filters = {
             'all': {'label': _('Active'), 'domain': []},
+            'no_activities': {
+                'label': _('No Activities'),
+                'domain': [('activity_ids', 'not any', [('user_id', '=', request.env.user.id)]), ('stage_id.is_won', '=', False)]
+            },
+            'overdue': {'label': _('Late Activities'), 'domain': [('activity_date_deadline', '<', today)]},
             'today': {'label': _('Today Activities'), 'domain': [('activity_date_deadline', '=', today)]},
-            'week': {'label': _('This Week Activities'),
-                     'domain': [('activity_date_deadline', '>=', today), ('activity_date_deadline', '<=', this_week_end_date)]},
-            'overdue': {'label': _('Overdue Activities'), 'domain': [('activity_date_deadline', '<', today)]},
+            'future': {'label': _('Future Activities'), 'domain': [('activity_date_deadline', '>', today)]},
             'won': {'label': _('Won'), 'domain': [('stage_id.is_won', '=', True)]},
             'lost': {'label': _('Lost'), 'domain': [('active', '=', False), ('probability', '=', 0)]},
         }
@@ -155,7 +155,7 @@ class WebsiteAccount(CustomerPortal):
             'pager': pager,
             'searchbar_sortings': searchbar_sortings,
             'sortby': sortby,
-            'searchbar_filters': OrderedDict(sorted(searchbar_filters.items())),
+            'searchbar_filters': searchbar_filters,
             'filterby': filterby,
         })
         return request.render("website_crm_partner_assign.portal_my_opportunities", values)


### PR DESCRIPTION
**Specifications:**
Allow partners to easily filter opportunities by reordering the menu and
add a new 'no activities' filter.

**After this PR:**
- Partners will be able to filter opportunities where the activity is not
  scheduled or opportunities where the activity is not assigned to them.
- The ordering of the filter by menu will be changed for easy navigation.
- This Week Activities will be changed to Future Activities, and the partners 
will be able to see all the future activities.

Task-3872145
