### PR TITLE
[FIX] pos_loyalty: multiple reward quantity

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -1056,6 +1056,10 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                 if (points < reward.required_points) {
                     continue;
                 }
+                // Skip if the reward program is of type 'coupons' and there is already an reward orderline linked to the current reward to avoid multiple reward apply
+                if ((reward.program_id.program_type === 'coupons' && this.orderlines.find(((rewardline) => rewardline.reward_id === reward.id)))) {
+                    continue;
+                }
                 if (auto && this.disabledRewards.has(reward.id)) {
                     continue;
                 }


### PR DESCRIPTION
Before this commit:
===================
- when creating a discount and loyalty program type coupon with rules for
 minimum quantity and purchase equals 1, along with a specific product reward,
 `multiple reward order lines` were erroneously generated if the coupon balance
 exceeded 1.
- upon refreshing the page, the reward line quantity would increment incorrectly.

After this commit:
==================
- with this commit, only one reward order line is created per coupon application, and the coupon now correctly applies only once, resolving the previous inconsistencies.

task - 3869549
