### PR TITLE
[15.0][FIX] crm: Access rules exchanged between salesman and sale manager

### DIFF
--- a/addons/crm/security/ir.model.access.csv
+++ b/addons/crm/security/ir.model.access.csv
@@ -3,10 +3,10 @@ access_crm_lead_manager,crm.lead.manager,model_crm_lead,sales_team.group_sale_ma
 access_crm_lead,crm.lead,model_crm_lead,sales_team.group_sale_salesman,1,1,1,0
 access_crm_stage,crm.stage,model_crm_stage,,1,0,0,0
 access_crm_stage_manager,crm.stage,model_crm_stage,sales_team.group_sale_manager,1,1,1,1
-access_res_partner_manager,res.partner.crm.manager,base.model_res_partner,sales_team.group_sale_manager,1,0,0,0
-access_res_partner_category_manager,res.partner.category.crm.manager,base.model_res_partner_category,sales_team.group_sale_manager,1,0,0,0
-access_res_partner,res.partner.crm.user,base.model_res_partner,sales_team.group_sale_salesman,1,1,1,0
-access_res_partner_category,res.partner.category.crm.user,base.model_res_partner_category,sales_team.group_sale_salesman,1,1,1,0
+access_res_partner_manager,res.partner.crm.manager,base.model_res_partner,sales_team.group_sale_manager,1,1,1,0
+access_res_partner_category_manager,res.partner.category.crm.manager,base.model_res_partner_category,sales_team.group_sale_manager,1,1,1,0
+access_res_partner,res.partner.crm.user,base.model_res_partner,sales_team.group_sale_salesman,1,0,0,0
+access_res_partner_category,res.partner.category.crm.user,base.model_res_partner_category,sales_team.group_sale_salesman,1,0,0,0
 access_crm_lost_reason_manager,crm.lost.reason.manager,model_crm_lost_reason,sales_team.group_sale_manager,1,1,1,1
 access_crm_lost_reason_salesman,crm.lost.reason.salesman,model_crm_lost_reason,sales_team.group_sale_salesman,1,0,0,0
 access_crm_lost_reason_user,crm.lost.reason.user,model_crm_lost_reason,base.group_user,1,0,0,0


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Access rules exchanged between salesman and sale manager

Current behavior before PR:
Salesman can create partner and sales manager cannot and the same with partner categories.

Desired behavior after PR is merged:
Sale manager can create partner and salesman cannot and the same with partner categories.

https://github.com/Tecnativa

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
