### PR TITLE
[FIX] web_editor: include descendants of end containter traversed nodes

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/test/spec/utils.test.js
+++ b/addons/web_editor/static/lib/odoo-editor/test/spec/utils.test.js
@@ -1060,6 +1060,165 @@ describe('Utils', () => {
                 },
             });
         });
+        it('selection does not have an edge with a br element', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '[<p>ab</p><p>cd<br></p>]',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const p2 = editable.lastChild;
+                    const cd = p2.firstChild;
+                    const br = p2.lastChild;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([ab, p2, cd, br]);
+                },
+            });
+        });
+        it('selection ends before br element at start of p element', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '[<p>ab</p><p>]<br>cd<br></p>',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const p2 = editable.firstChild.nextSibling;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([ab, p2]);
+                },
+            });
+        });
+        it('selection ends before a br in middle of p element', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '[<p>ab</p><p><br>cd]<br>ef<br></p>',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const p2 = editable.lastChild;
+                    const firstBr = p2.firstChild;
+                    const cd = firstBr.nextSibling;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([ab, p2, firstBr, cd]);
+                },
+            });
+        });
+        it('selection end after a br in middle of p elemnt', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '[<p>ab</p><p><br>cd<br>]ef<br></p>',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const p2 = editable.lastChild;
+                    const br1 = p2.firstChild;
+                    const cd = br1.nextSibling;
+                    const br2 = cd.nextSibling;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([ab, p2, br1, cd, br2]);
+                },
+            });
+        });
+        it('selection ends after a br at end of p elemnt', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '[<p>ab</p><p><br>cd<br>]</p>',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const p2 = editable.lastChild;
+                    const br1 = p2.firstChild;
+                    const cd = br1.nextSibling;
+                    const br2 = cd.nextSibling;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([ab, p2, br1, cd, br2]);
+                },
+            });
+        });
+        it('selection ends between 2 br elements', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '[<p>ab</p><p>cd<br>]<br>ef</p>',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const p2 =  editable.firstChild.nextSibling;
+                    const cd = p2.firstChild;
+                    const br1 = cd.nextSibling;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([ab, p2, cd, br1]);
+                },
+            });
+        });
+        it('selection starts before a br in middle of p element', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab[<br>cd</p><p>ef</p>]',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const br = ab.nextSibling;
+                    const cd = br.nextSibling;
+                    const p2 = editable.lastChild;
+                    const ef = p2.firstChild;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([br, cd, p2, ef]);
+                },
+            });
+        });
+        it('selection starts before a br in start of p element', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>[ab<br>cd</p><p>ef</p>]',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const br = ab.nextSibling;
+                    const cd = br.nextSibling;
+                    const p2 = editable.lastChild;
+                    const ef = p2.firstChild;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([ab, br, cd, p2, ef]);
+                },
+            });
+        });
+        it('selection starts after a br at end of p element', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab<br>[</p><p>cd</p>]',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const br = ab.nextSibling;
+                    const p2 = editable.lastChild;
+                    const cd = p2.firstChild;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([p2, cd]);
+                },
+            });
+        });
+        it('selection starts after a br in middle of p element', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab<br>[cd</p><p>ef</p>]',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const br = ab.nextSibling;
+                    const cd = br.nextSibling;
+                    const p2 = editable.lastChild;
+                    const ef = p2.firstChild;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([cd, p2, ef]);
+                },
+            });
+        });
+        it('selection starts between 2 br elements', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: '<p>ab<br>[<br>cd</p><p>ef</p>]',
+                stepFunction: editor => {
+                    const editable = editor.editable;
+                    const ab = editable.firstChild.firstChild;
+                    const br1 = ab.nextSibling;
+                    const br2 = br1.nextSibling;
+                    const cd = br2.nextSibling;
+                    const p2 =  editable.firstChild.nextSibling;
+                    const ef = p2.firstChild;
+                    const result = getTraversedNodes(editable);
+                    window.chai.expect(result).to.eql([br2, cd, p2, ef]);
+                },
+            });
+        });
     });
     describe('getSelectedNodes', () => {
         it('should return nothing if the range is collapsed', async () => {


### PR DESCRIPTION
Issue:
======
Applying bold after copy paste doesn't cover all the selection.

Steps to reproduce the issue:
=============================
- Go to notes
- Add 3 lines
- Press `CTRL+A` to select all the lines.
- `CTRL+X` then `CTRL+V` of all the lines
- Press `CTRL+A` to select all the lines again.
- Press `CTRL+B` to make all the lines bold
- The last line doesn't get formatted.

Origin of the issue:
====================
The issue is originating from the fact that paste add `br` in the last `p`
element so actually the issue can be reproduced by just adding couple of
lines and at the end of the last line press `SHIFT+enter` (to add br
element). In the function `getTraversedNodes` we stop as soon as we
reach the `endContainer` which is the last `p` elemnt because we can't
have the `br` as endContainer so we don't include its desendants.
In the case when we don't do copy paste (without the extra br) the
`endContainer` is the node element so it will be included and it works
correctly.

Solution:
========
- `<p>ab<br>[</p>...]`, `<p>ab<br>[<br>cd</p>..`: startContainer is p
  element, we need to go to the node at the startOffset.
- `<p>ab[<br></p>...`: start container is ab we need to skip it and
  start from the br element
- `[...<p>ab<br>]cd</p>`: endContainer is cd we shouldn't include it
- `[...<p>ab><br>]</p>`, `[...<p>ab<br>]<br>cd</p>`: encContainer is p
  element, we loop over descendants and include only the ones before
  endOffset.

task-3874926