### PR TITLE
[IMP] web: hide seconds in datetime widgets

### DIFF
--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -22,6 +22,7 @@ import { DateTimePickerPopover } from "./datetime_picker_popover";
  * @property {string | ReturnType<typeof import("@odoo/owl").useRef>} [target]
  * @property {(component, options) => import("../popover/popover_hook").PopoverHookReturnType} [createPopover]
  * @property {() => boolean} [ensureVisibility=() => env.isSmall]
+ * @property {boolean} [showSeconds]
  *
  * @typedef {import("./datetime_picker").DateTimePickerProps} DateTimePickerProps
  */
@@ -272,7 +273,11 @@ export const datetimePickerService = {
                     const convertFn = (operation === "format" ? formatters : parsers)[type];
                     try {
                         return [
-                            convertFn(value, { format: hookParams.format, tz: pickerProps.tz }),
+                            convertFn(value, {
+                                format: hookParams.format,
+                                tz: pickerProps.tz,
+                                showSeconds: hookParams.showSeconds ?? true,
+                            }),
                             null,
                         ];
                     } catch (error) {

--- a/addons/web/static/src/core/l10n/dates.js
+++ b/addons/web/static/src/core/l10n/dates.js
@@ -349,7 +349,10 @@ export function formatDateTime(value, options = {}) {
     if (!value) {
         return "";
     }
-    const format = options.format || localization.dateTimeFormat;
+    var format = options.format || localization.dateTimeFormat;
+    if (options.showSeconds === false) {
+        format = `${localization.dateFormat} ${localization.shortTimeFormat}`;
+    }
     return value.setZone(options.tz || "default").toFormat(format);
 }
 

--- a/addons/web/static/src/views/fields/datetime/datetime_field.js
+++ b/addons/web/static/src/views/fields/datetime/datetime_field.js
@@ -27,6 +27,7 @@ import { standardFieldProps } from "../standard_field_props";
  *  rounding?: number;
  *  startDateField?: string;
  *  warnFuture?: boolean;
+ *  showSeconds?: boolean;
  * }} DateTimeFieldProps
  *
  * @typedef {import("@web/core/datetime/datetime_picker").DateTimePickerProps} DateTimePickerProps
@@ -45,7 +46,9 @@ export class DateTimeField extends Component {
         rounding: { type: Number, optional: true },
         startDateField: { type: String, optional: true },
         warnFuture: { type: Boolean, optional: true },
+        showSeconds: { type: Boolean, optional: true },
     };
+    static defaultProps = { showSeconds: true };
 
     static template = "web.DateTimeField";
 
@@ -94,12 +97,15 @@ export class DateTimeField extends Component {
             }
             if (!isNaN(this.props.rounding)) {
                 pickerProps.rounding = this.props.rounding;
+            } else if (!this.props.showSeconds) {
+                pickerProps.rounding = 0;
             }
             return pickerProps;
         };
 
         const dateTimePicker = useDateTimePicker({
             target: "root",
+            showSeconds: this.props.showSeconds,
             get pickerProps() {
                 return getPickerProps();
             },
@@ -162,7 +168,7 @@ export class DateTimeField extends Component {
         return value
             ? this.field.type === "date"
                 ? formatDate(value)
-                : formatDateTime(value)
+                : formatDateTime(value, { showSeconds: this.props.showSeconds })
             : "";
     }
 
@@ -334,7 +340,18 @@ export const dateTimeField = {
                 `Control the number of minutes in the time selection. E.g. set it to 15 to work in quarters.`
             ),
         },
+        {
+            label: _t("Show seconds"),
+            name: "show_seconds",
+            type: "boolean",
+            default: true,
+            help: _t(`Displays or hides the seconds in the datetime value.`),
+        },
     ],
+    extractProps: ({ attrs, options }, dynamicInfo) => ({
+        ...dateField.extractProps({ attrs, options }, dynamicInfo),
+        showSeconds: exprToBoolean(options.show_seconds ?? true),
+    }),
     supportedTypes: ["datetime"],
 };
 


### PR DESCRIPTION
Before this commit:
- The datetime widget had no option to hide the seconds from the datetime widget.

After this commit:
- A 'showSeconds' option is added to the datetime widget. When set to false, it hides the seconds from the displayed time.

Enterprise PR: https://github.com/odoo/enterprise/pull/61553

Task-2517675

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
