### PR TITLE
[IMP] website: fallback on odoo social by default in all cases

### DIFF
--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -334,9 +334,21 @@ class Website(Home):
             action_url += '&step=' + str(step)
         return request.redirect(action_url)
 
+    def _get_social_default_urls(self):
+        """ Return the default URLs for social networks. """
+        return {
+            'facebook': 'https://www.facebook.com/Odoo',
+            'github': 'https://github.com/odoo',
+            'linkedin': 'https://www.linkedin.com/company/odoo',
+            'youtube': 'https://www.youtube.com/user/OpenERPonline',
+            'instagram': 'https://www.instagram.com/odoo.official',
+            'twitter': 'https://twitter.com/Odoo',
+            'tiktok': 'https://www.tiktok.com/@odoo',
+        }
+
     @http.route(['/website/social/<string:social>'], type='http', auth="public", website=True, sitemap=False)
     def social(self, social, **kwargs):
-        url = getattr(request.website, 'social_%s' % social, False)
+        url = getattr(request.website, 'social_%s' % social, False) or self._get_social_default_urls().get(social)
         if not url:
             raise werkzeug.exceptions.NotFound()
         return request.redirect(url, local=False)

--- a/addons/website/tests/test_website_favicon.py
+++ b/addons/website/tests/test_website_favicon.py
@@ -1,14 +1,17 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+# TODO in master: rename this file to `test_website` only
+
 from PIL import Image
 
 from odoo.tests import tagged
-from odoo.tests.common import TransactionCase
+from odoo.tests.common import HttpCase, TransactionCase
 from odoo.tools import base64_to_image, image_to_base64
 
 
 @tagged('post_install', '-at_install')
+# TODO: rename the class name, it's a bad copy paste
 class TestWebsiteResetPassword(TransactionCase):
 
     def test_01_website_favicon(self):
@@ -34,3 +37,18 @@ class TestWebsiteResetPassword(TransactionCase):
         self.assertEqual(image.format, 'ICO')
         self.assertEqual(image.size, (256, 256))
         self.assertEqual(image.getpixel((0, 0)), bg_color)
+
+
+@tagged('-at_install', 'post_install')
+class TestWebsiteHttp(HttpCase):
+    def test_website_default_social_media(self):
+        # Demo data are setting the twitter account of the main company, we need
+        # to remove it for demo data to not interfere with the test
+        self.env.ref('base.main_company').social_twitter = None
+        website = self.env['website'].create({
+            'name': 'Test Website',
+        })
+        self.assertFalse(website.social_twitter)
+        r = self.url_open('/website/social/twitter', allow_redirects=False)
+        self.assertEqual(r.status_code, 303, "Should redirect to Odoo network")
+        self.assertEqual(r.headers.get('Location'), 'https://twitter.com/Odoo', "Should redirect to Odoo network (2)")


### PR DESCRIPTION
There is a mechanism in place that will use the Odoo social media URLs as default social media URL for the websites.

It's done this way:
- `base.main_company` company has its social fields populated in XML in `social_media` module
- website depend of social_media
- website social fields have default value set to `self.env.ref('base.main_company').social_xxx` in its fields:
```py
social_twitter = fields.Char('Twitter Account', default=_default_social_twitter)
```

But if one does empty those fields on the company, it won't bootstrap those values on website creation.
Maybe some other flows are possible to lead to those empty fields.

Seems like a low effort to be 100% sure we don't have empty fields by default.
