### PR TITLE
[IMP] hr_recruitment: load applicant kanban view after creating job position

### DIFF
--- a/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
+++ b/addons/hr_recruitment/static/src/js/tours/hr_recruitment.js
@@ -47,12 +47,6 @@ registry.category("web_tour.tours").add('hr_recruitment_tour',{
     position: 'bottom',
     run: "click .modal:visible .btn.btn-primary",
 }, {
-    trigger: ".oe_kanban_action_button",
-    extra_trigger: '.o_hr_recruitment_kanban',
-    content: _t("Let\'s have a look at the applications pipeline."),
-    position: "bottom",
-    run: "click",
-}, {
     trigger: ".o_copy_paste_email",
     content: _t("Copy this email address, to paste it in your email composer, to apply."),
     position: "bottom",

--- a/addons/hr_recruitment/views/hr_job_views.xml
+++ b/addons/hr_recruitment/views/hr_job_views.xml
@@ -158,7 +158,7 @@
                     </div>
                 </group>
                 <footer>
-                    <button string="Create" type="object" name="close_dialog" class="btn-primary o_create_job" data-hotkey="q"/>
+                    <button string="Create" name="%(action_hr_job_applications)d" type="action" class="btn-primary o_create_job" data-hotkey="q"/>
                     <button string="Discard" class="btn-secondary" special="cancel" data-hotkey="x"/>
                 </footer>
             </form>


### PR DESCRIPTION
after creating a new job position form the popup, load the applicant kanban view of the job position that was just created
changed the tour in js file for the same

Task-3850770