### PR TITLE
[IMP] website_sale: Enhance category header & footer

### DIFF
--- a/addons/website_sale/models/product_public_category.py
+++ b/addons/website_sale/models/product_public_category.py
@@ -55,6 +55,28 @@ class ProductPublicCategory(models.Model):
         translate=html_translate,
     )
 
+    website_wide_header = fields.Html(
+        string="Category Wide Header",
+        sanitize_attributes=False,  # required for the `data-editor-message` attribute.
+        sanitize_form=False,
+        translate=html_translate,
+    )
+
+
+    website_footer = fields.Html(
+        string="Category Footer",
+        sanitize_attributes=False,  # required for the `data-editor-message` attribute.
+        sanitize_form=False,
+        translate=html_translate,
+    )
+
+    website_wide_footer = fields.Html(
+        string="Category Wide Footer",
+        sanitize_attributes=False,  # required for the `data-editor-message` attribute.
+        sanitize_form=False,
+        translate=html_translate,
+    )
+
     #=== COMPUTE METHODS ===#
 
     def _compute_parents_and_self(self):

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -323,6 +323,18 @@
             <div id="wrap" class="js_sale o_wsale_products_page">
                 <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_products_1"/>
                 <div class="container oe_website_sale pt-2">
+                    <t t-if="category">
+                        <t t-set='wide_header_editor_message'>
+                            Drag building blocks here to customize the wide header for
+                            "<t t-esc='category.name'/>" category.
+                        </t>
+                        <div
+                            class="mb16"
+                            id="category_wide_header"
+                            t-att-data-editor-message="wide_header_editor_message"
+                            t-field="category.website_wide_header"
+                        />
+                    </t>
                     <div class="row o_wsale_products_main_row align-items-start flex-nowrap">
                         <aside t-if="hasLeftColumn" id="products_grid_before" class="d-none d-lg-block position-sticky col-3 px-3 clearfix">
                             <div class="o_wsale_products_grid_before_rail vh-100 ms-n2 mt-n2 pt-2 pe-lg-2 pb-lg-5 ps-2 overflow-y-scroll">
@@ -430,9 +442,33 @@
                             <div class="products_pager d-flex justify-content-center pt-5 pb-3">
                                 <t t-call="website.pager"/>
                             </div>
+                            <t t-if="category">
+                                <t t-set='footer_editor_message'>
+                                    Drag building blocks here to customize the footer for
+                                    "<t t-esc='category.name'/>" category.
+                                </t>
+                                <div
+                                    class="mb16"
+                                    id="category_wide_footer"
+                                    t-att-data-editor-message="footer_editor_message"
+                                    t-field="category.website_footer"
+                                />
+                            </t>
                         </div>
                     </div>
 
+                    <t t-if="category">
+                        <t t-set='wide_footer_editor_message'>
+                            Drag building blocks here to customize the wide footer for
+                            "<t t-esc='category.name'/>" category.
+                        </t>
+                        <div
+                            class="mb16"
+                            id="category_wide_footer"
+                            t-att-data-editor-message="wide_footer_editor_message"
+                            t-field="category.website_wide_footer"
+                        />
+                    </t>
                     <t t-call="website_sale.o_wsale_offcanvas"/>
                 </div>
                 <div class="oe_structure oe_empty oe_structure_not_nearest" id="oe_structure_website_sale_products_2"/>


### PR DESCRIPTION
Allows building blocks to be added directly after the shared website header and into the footer of specific eCommerce category pages.

This update allows each category page to have unique header and footer elements.

This feature ensures category-specific customization:
- Building blocks can be placed in the category-specific footer.
- Blocks can be added to the header right after the website-wide header.
- Visibility of these blocks is restricted to their respective category pages.
- Ensures Headers & footers are not shared between parent and child categories.

task-3747565