### PR TITLE
[IMP] mail: mention #channels in the chatter

### DIFF
--- a/addons/im_livechat/static/tests/embed/livechat_service.test.js
+++ b/addons/im_livechat/static/tests/embed/livechat_service.test.js
@@ -131,6 +131,7 @@ test("Only necessary requests are made when creating a new chat", async () => {
             },
             post_data: {
                 body: "Hello!",
+                channel_ids: [],
                 message_type: "comment",
                 subtype_xmlid: "mail.mt_comment",
             },

--- a/addons/mail/models/discuss/__init__.py
+++ b/addons/mail/models/discuss/__init__.py
@@ -2,6 +2,7 @@
 
 # mail
 from . import mail_message
+from . import mail_thread
 
 # discuss
 from . import discuss_channel_member

--- a/addons/mail/models/discuss/mail_thread.py
+++ b/addons/mail/models/discuss/mail_thread.py
@@ -1,0 +1,31 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from markupsafe import Markup
+
+from odoo import models, _
+
+
+class MailThread(models.AbstractModel):
+    _inherit = "mail.thread"
+
+    def _notify_thread(self, message, msg_vals=False, **kwargs):
+        rdata = super()._notify_thread(message, msg_vals, **kwargs)
+        self._notify_mentioned_channel(message, **kwargs)
+        return rdata
+
+    def _notify_mentioned_channel(self, message, channel_ids=None, **kwargs):
+        """ Notify channels that have been mentioned in message"""
+        if channel_ids and self._name != "discuss.channel":
+            body = Markup(_("This channel was mentioned in %s")) % (
+                Markup('<a href="/mail/message/%s" data-oe-type="notification">%s</a>') % (
+                    message.id, self.display_name
+                )
+            )
+            for channel in self.env['discuss.channel'].browse(channel_ids):
+                channel.message_post(body=body, message_type="notification", subtype_xmlid="mail.mt_comment")
+
+    def _get_allowed_message_post_params(self):
+        return super()._get_allowed_message_post_params() | {"channel_ids"}
+
+    def _get_notify_valid_parameters(self):
+        return super()._get_notify_valid_parameters() | {"channel_ids"}

--- a/addons/mail/static/src/core/common/message.js
+++ b/addons/mail/static/src/core/common/message.js
@@ -265,6 +265,10 @@ export class Message extends Component {
         return this.env.inChatter ? 3 : this.env.inChatWindow ? 2 : 4;
     }
 
+    get showAuthorName() {
+        return !this.props.message.body.includes('data-oe-type="notification"');
+    }
+
     get showSubtypeDescription() {
         return (
             this.message.subtype_description &&

--- a/addons/mail/static/src/core/common/message.xml
+++ b/addons/mail/static/src/core/common/message.xml
@@ -4,7 +4,7 @@
     <t t-name="mail.Message">
         <div t-if="message.isNotification" class="o-mail-NotificationMessage text-break mx-auto text-muted opacity-75 px-3 text-center smaller" t-on-click="onClickNotificationMessage"  t-att-class="props.className" t-ref="root">
             <i t-if="message.notificationIcon" t-attf-class="{{ message.notificationIcon }} me-1"/>
-            <span class="o-mail-NotificationMessage-author d-inline" t-if="message.author and !message.body.includes(escape(message.author.name))" t-esc="message.author.name"/> <t t-out="message.body"/>
+            <span class="o-mail-NotificationMessage-author d-inline" t-if="message.author and !message.body.includes(escape(message.author.name)) and showAuthorName" t-esc="message.author.name"/> <t t-out="message.body"/>
         </div>
         <ActionSwiper t-else="" onRightSwipe="hasTouch() and props.thread?.eq(store.inbox) ? { action: () => this.message.setDone(), bgColor: 'bg-success', icon: 'fa-check-circle' } : undefined">
             <div class="o-mail-Message position-relative rounded-0"

--- a/addons/mail/static/src/core/common/store_service.js
+++ b/addons/mail/static/src/core/common/store_service.js
@@ -452,6 +452,7 @@ export class Store extends BaseStore {
             mentionedPartners,
         });
         const partner_ids = validMentions?.partners.map((partner) => partner.id) ?? [];
+        const channel_ids = validMentions?.threads.map((thread) => thread.id) ?? [];
         const recipientEmails = [];
         const recipientAdditionalValues = {};
         if (!isNote) {
@@ -468,6 +469,7 @@ export class Store extends BaseStore {
         }
         postData = {
             body: await prettifyMessageContent(body, validMentions),
+            channel_ids,
             message_type: "comment",
             subtype_xmlid: subtype,
         };

--- a/addons/mail/static/tests/chatter/web/chatter.test.js
+++ b/addons/mail/static/tests/chatter/web/chatter.test.js
@@ -67,6 +67,7 @@ test("can post a message on a record thread", async () => {
             context: args.context,
             post_data: {
                 body: "hey",
+                channel_ids: [],
                 message_type: "comment",
                 subtype_xmlid: "mail.mt_comment",
             },
@@ -97,6 +98,7 @@ test("can post a note on a record thread", async () => {
             context: args.context,
             post_data: {
                 body: "hey",
+                channel_ids: [],
                 message_type: "comment",
                 subtype_xmlid: "mail.mt_note",
             },

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -599,6 +599,15 @@ class TestChannelInternals(MailCommon, HttpCase):
         ):
             channel.name = "test test"
 
+    def test_channel_mention_should_send_message_in_channel(self):
+        channel = self.env['discuss.channel'].create({"name": "Test", "channel_type": "channel"})
+        partner = self.env["res.partner"].create({"name": "Test Partner"})
+        partner.message_post(body="#Test", channel_ids=[channel.id], message_type="comment", subtype_xmlid="mail.mt_comment")
+        # Check that the mentioned channel containt a message with id of channel
+        message_in_db = self.env['mail.message'].search([('res_id', '=', channel.id), ('model', '=', 'discuss.channel')])
+        self.assertEqual(len(message_in_db), 1)
+        self.assertIn('This channel was mentioned in', message_in_db.body)
+
     def test_channel_write_should_send_notification_if_image_128_changed(self):
         channel = self.env['discuss.channel'].create({'name': '', 'uuid': 'test-uuid'})
         # do the operation once before the assert to grab the value to expect


### PR DESCRIPTION
**PURPOSE:**

Previously, when mentioning a channel in the message, the mentioned channel did not receive any notification.

**SPECIFICAITONS:**

This commit addresses the issue by ensuring that when someone mentions a channel in message, a message notification is logged in the mentioned channel, such as "This channel was mentioned in [thread_name](#)".

Task-3293567

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
