### PR TITLE
[FIX] mrp_account: bypass the timesheet analytic access rule for MRP

### DIFF
--- a/addons/mrp_account/tests/test_mrp_account.py
+++ b/addons/mrp_account/tests/test_mrp_account.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.addons.mrp.tests.common import TestMrpCommon
 from odoo.addons.stock_account.tests.test_account_move import TestAccountMove
 from odoo.tests import Form, tagged
@@ -320,3 +321,37 @@ class TestMrpAccountMove(TestAccountMove):
         productB_credit_line = self.env['account.move.line'].search([('ref', 'ilike', 'UB%Product B'), ('debit', '=', 0)])
         self.assertEqual(productB_debit_line.account_id, self.stock_valuation_account)
         self.assertEqual(productB_credit_line.account_id, wip_incoming_account)
+
+
+@tagged("post_install", "-at_install")
+class TestMrpAnalyticAccount(TestMrpCommon):
+    def test_mo_analytic_account(self):
+        """
+            Check that an mrp user without accounting rights is able to mark as done
+            an MO linked to an analytic account.
+        """
+        if not (self.env.ref('mrp_account_enterprise.account_assembly_hours', raise_if_not_found=False) and self.env.ref('hr_timesheet.group_hr_timesheet_user', raise_if_not_found=False)):
+            self.skipTest("This test requires the installation of hr_timesheet")
+        mrp_user = self.user_mrp_user
+        mrp_user.groups_id = [Command.set([self.ref('mrp.group_mrp_user'), self.ref('hr_timesheet.group_hr_timesheet_user')])]
+        analytic_account = self.env.ref('mrp_account_enterprise.account_assembly_hours')
+        bom = self.bom_4
+        product = bom.product_id
+        bom.bom_line_ids.product_id.standard_price = 1.0
+        bom.analytic_account_id = analytic_account
+        mo = self.env['mrp.production'].with_user(mrp_user.id).create({
+            'product_id': product.id,
+            'product_uom_id': product.uom_id.id,
+            'product_qty':1,
+            'bom_id': bom.id,
+        })
+        mo_form = Form(mo)
+        mo_form.bom_id = self.bom_4
+        mo = mo_form.save()
+        mo.with_user(mrp_user.id).action_confirm()
+        action = mo.with_user(mrp_user.id).button_mark_done()
+        wizard = Form(self.env[action['res_model']].with_context(action['context']).with_user(mrp_user.id)).save()
+        wizard.with_user(mrp_user.id).process()
+        self.assertTrue(mo.move_raw_ids.move_line_ids)
+        self.assertEqual(mo.move_raw_ids.quantity_done, bom.bom_line_ids.product_qty)
+        self.assertEqual(mo.move_raw_ids.state, 'done')

--- a/addons/stock_account/models/stock_move.py
+++ b/addons/stock_account/models/stock_move.py
@@ -528,7 +528,7 @@ class StockMove(models.Model):
         analytic_lines_vals = []
         moves_to_link = []
         for move in self:
-            analytic_line_vals = move._prepare_analytic_line()
+            analytic_line_vals = move.sudo()._prepare_analytic_line()
             if not analytic_line_vals:
                 continue
             moves_to_link.append(move.id)


### PR DESCRIPTION
### Steps to reproduce:
- Go to settings and activate Analytic Accounting
- Create a product with a BOM
- In the Miscellaneous tab of the BOM, add: [ASML - HOUR] Costing Account For Hours of Assembly as analytic account.
- Settings > Users and companies > Users
- Change the access rights of Marc Demo to:
  - Timesheets: User: own timesheets only
  - Accounting: None
- Connect as mark Demo and create an manufactoring order with your BOM
- "Confirm" the MO and "Mark as Done":

#### > Access Error: you are not allowed to modify 'Analytic Line'

### Cause of the issue:

The error is raised due to the ir.rule:
"account.analytic.line.timesheet.user.update-unlink": https://github.com/odoo/enterprise/blob/c5ab16b0464cc396fdb02f3968d3d61e68f7cb2e/timesheet_grid/security/timesheet_security.xml#L12-L28 
as the analytic lines created from the MO will not be linked to a project and will therefore never pass the domain.

opw-3836624
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
