### PR TITLE
[FIX] calendar: close the popup after deletion

### DIFF
--- a/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.js
+++ b/addons/calendar/static/src/views/attendee_calendar/common/attendee_calendar_common_popover.js
@@ -94,6 +94,7 @@ export class AttendeeCalendarCommonPopover extends CalendarCommonPopover {
     }
 
     async onClickArchive() {
+        this.props.close();
         await this.props.model.archiveRecord(this.props.record);
     }
 }


### PR DESCRIPTION
Version:
-----------
16.0

Steps to reproduce:
---------------------------
- open the Calendar module
- make sure google sync is enabled
- when to click on a event, a popup appears
- when you press on delete, a confirmation message is shown but the popup is not closed

Issue:
----------
The popup is not disappearing which allows the user to click multiple times on the delete option which can cause error when the user confirm the deletion as the user cannot delete a deleted record.

Cause:
-----------
​When google sync is enabled the event becomes achievable so when you delete the event instead of onDeleteEvent() function of CalendarCommonPopover component the onClickArchive() of AttendeeCalendarCommonPopover is called which do not handle the closing of the popup.

Solution:
-------------
In the onClickArchive() function, call the close function which is passed in the props of the parent component.

task-3875211


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
