### PR TITLE
[FIX] web_editor: correct Big boxes snippet layout in email

### DIFF
--- a/addons/web_editor/static/src/js/backend/convert_inline.js
+++ b/addons/web_editor/static/src/js/backend/convert_inline.js
@@ -532,46 +532,11 @@ function enforceTablesResponsivity(editable) {
         .filter(tr => [...tr.children].some(td => td.classList.contains('o_converted_col')))
         .reverse();
     for (const tr of trs) {
-        const commonTable = _createTable();
-        commonTable.style.height = '100%';
-        const commonTr = document.createElement('tr');
-        const commonTd = document.createElement('td');
-        commonTr.appendChild(commonTd);
-        commonTable.appendChild(commonTr);
         const tds = [...tr.children].filter(child => child.nodeName === 'TD');
-        let index = 0;
         for (const td of tds) {
-            const width = td.style.maxWidth;
-            const div = document.createElement('div');
-            div.style.display = 'inline-block';
-            div.style.verticalAlign = 'top';
-            div.classList.add('o_stacking_wrapper');
-            commonTd.appendChild(div);
-            const newTable = _createTable();
-            newTable.style.width = width;
-            newTable.classList.add('o_stacking_wrapper');
-            div.appendChild(newTable);
-            const newTr = document.createElement('tr');
-            newTable.appendChild(newTr);
-            newTr.appendChild(td);
-            td.style.width = '100%';
-            td.removeAttribute('width');
-            if (index === 0) {
-                div.before(_createMso(`
-                    <table cellpadding="0" cellspacing="0" border="0" role="presentation" style="width: 100%;">
-                        <tr>
-                            <td valign="top" style="width: ${width};">`));
-            } else {
-                div.before(_createMso(`</td><td valign="top" style="width: ${width};">`));
-            }
-            if (index === tds.length - 1) {
-                div.after(_createMso(`</td></tr></table>`));
-            }
-            index++;
+            td.style.verticalAlign = 'top';
+            td.classList.add("o_stacking_wrapper");
         }
-        const topTd = document.createElement('td');
-        topTd.appendChild(commonTable);
-        tr.prepend(topTd);
     }
 }
 // Masonry has crazy nested tables that require some extra treatment.
@@ -792,6 +757,16 @@ async function toInline($editable, cssRules, $iframe) {
         node.style.setProperty('display', displayValue);
     }
     $editable.addClass('odoo-editor-editable');
+    // Added a style here because we can't update the template in stable
+    // TODO : add it in xml template in master instead of here
+    const styleElement = document.createElement("style");
+    styleElement.innerHTML = `
+        @media screen and (max-width: 1135px) {
+            .o_stacking_wrapper {
+                display:inline-block;
+            }
+    `;
+    $editable.get(0).appendChild(styleElement);
 }
 /**
  * Take all elements with a `background-image` style and convert them to `vml`


### PR DESCRIPTION
Issue:
======
disorted layout with big boxes in email view.

Steps to reproduce the issue:
=============================
- Create a new mailing
- Add big boxes template and remove some content from the first one
- Test send it
- The layout is disorted in the sent email.

Origin of the issue:
====================
The issue first originated from this commit [1] where we convert the
list of `td` of a single `tr` to one single `td` but with multiple
`divs` in this case we will loose the same height property of all the
`td`.

Solution:
=========
To overcome this problem, we keep the formatting of the tds which works
correctly in all email engines in desktop view and to make it responsive
in mobile view , we add `display:inline-block` when the window width is
small so they will be stacked on top of each other in this case.

Before:
=====
![before_block](https://github.com/odoo/odoo/assets/61123610/c82bac80-1211-4cad-9cb3-d7d4ef9ca6a3)

![before_block_mobile](https://github.com/odoo/odoo/assets/61123610/36dd0aa3-8abd-4f33-bef9-e98b4eae6896)


After:
====
![after_block](https://github.com/odoo/odoo/assets/61123610/44d0c76f-9c58-48c9-933c-dc83678d5182)

![after_block_mobile](https://github.com/odoo/odoo/assets/61123610/39d86c78-de6d-4b0c-a5d5-f9930266fe08)



task-3471136

[1]: https://github.com/odoo/odoo/commit/e961757c19e5052ee27e6354c021980e0d026929