### PR TITLE
[IMP] stock: picked flag on stock move only if all move lines are picked

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -206,7 +206,8 @@ class StockMove(models.Model):
     @api.depends('move_line_ids.picked', 'state')
     def _compute_picked(self):
         for move in self:
-            if move.state == 'done' or any(ml.picked for ml in move.move_line_ids):
+            move.picked = False
+            if move.state == 'done' or (move.move_line_ids and all(ml.picked for ml in move.move_line_ids)):
                 move.picked = True
 
     def _inverse_picked(self):


### PR DESCRIPTION
### Current behavior before PR:
The stock move is marked as picked also if only one move line is picked 

### Desired behavior after PR is merged:
The stock move will be marked as picked only if all stock move lines are "picked" 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
