### PR TITLE
[ADD] l10n_fr_invoice_addr: adapt documents for 2024-07-01 french law

### DIFF
--- a/addons/l10n_fr/models/res_company.py
+++ b/addons/l10n_fr/models/res_company.py
@@ -12,8 +12,14 @@ class ResCompany(models.Model):
     ape = fields.Char(string='APE')
 
     @api.model
-    def _get_unalterable_country(self):
+    def _get_france_country_codes(self):
+        """Returns every country code that can be used to represent France
+        """
         return ['FR', 'MF', 'MQ', 'NC', 'PF', 'RE', 'GF', 'GP', 'TF'] # These codes correspond to France and DOM-TOM.
+
+    @api.model
+    def _get_unalterable_country(self):
+        return self._get_france_country_codes()
 
     def _is_accounting_unalterable(self):
         if not self.vat and not self.country_id:

--- a/addons/l10n_fr_invoice_addr/__init__.py
+++ b/addons/l10n_fr_invoice_addr/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/l10n_fr_invoice_addr/__manifest__.py
+++ b/addons/l10n_fr_invoice_addr/__manifest__.py
@@ -1,0 +1,21 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+{
+    'name': "France - Adding Mandatory Invoice Mentions (Decree no. 2022-1299)",
+    'version': '1.0',
+    'category': 'Accounting/Localizations',
+    'description': """
+Add new address fields necessary to respect the new 2024-07-01 French law
+(https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046383394) to invoices.
+""",
+    'depends': [
+        'l10n_fr',
+        'sale',
+    ],
+    'auto_install': True,
+    'data': [
+        'views/report_invoice.xml',
+        'views/account_move_views.xml',
+    ],
+    'license': 'LGPL-3',
+}

--- a/addons/l10n_fr_invoice_addr/i18n/fr.po
+++ b/addons/l10n_fr_invoice_addr/i18n/fr.po
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_fr_invoice_addr
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-06-03 09:47+0000\n"
+"PO-Revision-Date: 2024-06-03 09:47+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Customer Address:"
+msgstr "Adresse du client\u00a0:"
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Goods Delivery"
+msgstr "Livraison de biens"
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Mixed Operation"
+msgstr "Opération mixte"
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Operation Type:"
+msgstr "Type d'opération\u00a0:"
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Option to pay tax on debits"
+msgstr "Option pour le paiement de la taxe d'après les débits"
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "SIRET:"
+msgstr "SIRET\u00a0:"
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Service Delivery"
+msgstr "Prestation de services"

--- a/addons/l10n_fr_invoice_addr/i18n/l10n_fr_invoice_addr.pot
+++ b/addons/l10n_fr_invoice_addr/i18n/l10n_fr_invoice_addr.pot
@@ -1,0 +1,51 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_fr_invoice_addr
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 15.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-06-03 09:47+0000\n"
+"PO-Revision-Date: 2024-06-03 09:47+0000\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Customer Address:"
+msgstr ""
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Goods Delivery"
+msgstr ""
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Mixed Operation"
+msgstr ""
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Operation Type:"
+msgstr ""
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Option to pay tax on debits"
+msgstr ""
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "SIRET:"
+msgstr ""
+
+#. module: l10n_fr_invoice_addr
+#: model_terms:ir.ui.view,arch_db:l10n_fr_invoice_addr.report_invoice_document
+msgid "Service Delivery"
+msgstr ""

--- a/addons/l10n_fr_invoice_addr/models/__init__.py
+++ b/addons/l10n_fr_invoice_addr/models/__init__.py
@@ -1,0 +1,1 @@
+from . import account_move

--- a/addons/l10n_fr_invoice_addr/models/account_move.py
+++ b/addons/l10n_fr_invoice_addr/models/account_move.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = 'account.move'
+
+    l10n_fr_is_company_french = fields.Boolean(compute='_compute_l10n_fr_is_company_french')
+
+    @api.depends('company_id.country_code')
+    def _compute_l10n_fr_is_company_french(self):
+        for record in self:
+            record.l10n_fr_is_company_french = record.country_code in record.company_id._get_france_country_codes()

--- a/addons/l10n_fr_invoice_addr/views/account_move_views.xml
+++ b/addons/l10n_fr_invoice_addr/views/account_move_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="account_move_form_l10n_fr_invoice_addr" model="ir.ui.view">
+        <field name="name">l10n_fr_invoice_addr.account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='partner_shipping_id']" position="attributes">
+                <attribute name="groups"/>
+                <attribute name="t-if">
+                    (o.l10n_fr_is_company_french and o.move_type.startswith('out_')) or o.env.user.has_group('sale.group_delivery_invoice_address')
+                </attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_fr_invoice_addr/views/report_invoice.xml
+++ b/addons/l10n_fr_invoice_addr/views/report_invoice.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="sale.report_invoice_document_inherit_sale">
+        <xpath expr="//address" position="after">
+            <div class="mb-3" t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret">
+                SIRET: <t t-esc="o.partner_id.commercial_partner_id.siret"/>
+            </div>
+        </xpath>
+
+        <xpath expr="//address" position="attributes">
+            <attribute name="t-attf-class">{{'mb-0' if o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id.siret else ''}}</attribute>
+        </xpath>
+
+        <xpath expr="//div[@id='informations']" position="inside">
+            <t t-if="o.l10n_fr_is_company_french and o.partner_id.commercial_partner_id != o.partner_id and o.move_type.startswith('out_')">
+                <t t-set="partner" t-value="o.partner_id.commercial_partner_id"/>
+                <div class="col-auto col-3 mw-100 mb-2">
+                    <div class="font-weight-bold">Customer Address:</div>
+                    <address t-field="partner.self" class="m-0" t-options="{'widget': 'contact', 'fields': ['address'], 'no_marker': True}"/>
+                </div>
+            </t>
+        </xpath>
+
+        <xpath expr="//div[@id='informations']" position="inside">
+            <t t-if="o.l10n_fr_is_company_french and o.move_type.startswith('out_')">
+                <t t-set="tax_scopes" t-value="o.invoice_line_ids.mapped('tax_ids.tax_scope')"/>
+                <t t-set="has_service" t-value="'service' in tax_scopes"/>
+                <t t-set="has_consu" t-value="'consu' in tax_scopes"/>
+
+                <t t-if="has_service or has_consu">
+                    <div class="col-auto col-3 mw-100 mb-2">
+                        <div class="font-weight-bold">Operation Type:</div>
+                        <t t-if="has_service and has_consu">
+                            Mixed Operation
+                        </t>
+                        <t t-elif="has_service and not has_consu">
+                            Service Delivery
+                        </t>
+                        <t t-else="">
+                            Goods Delivery
+                        </t>
+                    </div>
+                </t>
+            </t>
+        </xpath>
+
+        <xpath expr="//p[@name='payment_communication']" position="after">
+            <p t-if="o.l10n_fr_is_company_french and o.move_type.startswith('out_') and 'on_invoice' in o.invoice_line_ids.mapped('tax_ids.tax_exigibility')">
+                Option to pay tax on debits
+            </p>
+        </xpath>
+    </template>
+</odoo>

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -14222,6 +14222,11 @@ msgid "France - Accounting Reports"
 msgstr ""
 
 #. module: base
+#: model:ir.module.module,shortdesc:base.module_l10n_fr_invoice_addr
+msgid "France - Adding Mandatory Invoice Mentions (Decree no. 2022-1299)"
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_fr_fec
 msgid "France - FEC Export"
 msgstr ""

--- a/odoo/addons/base/i18n/fr.po
+++ b/odoo/addons/base/i18n/fr.po
@@ -18426,6 +18426,11 @@ msgid "France - Accounting Reports"
 msgstr "France - Rapports Comptables"
 
 #. module: base
+#: model:ir.module.module,shortdesc:base.module_l10n_fr_invoice_addr
+msgid "France - Adding Mandatory Invoice Mentions (Decree no. 2022-1299)"
+msgstr "France - Ajout des mentions obligatoires des factures (Décret n° 2022-1299)"
+
+#. module: base
 #: model:ir.module.module,shortdesc:base.module_l10n_fr_fec
 msgid "France - FEC Export"
 msgstr "France - Export FEC"


### PR DESCRIPTION
This requires adding the following elements to the customer invoice / credit note / sales receipt:
- The recipient's SIREN/SIRET if any
- Customer address, if different from billing address
- Delivery address, if different from billing address
- Type of operation: goods delivery, service delivery or mixed operation
- Option to pay VAT on a debit basis

All of that should be added as long as the issuer is french

The billing/delivery addresses are customizable on a per-invoice basis

This adds a dependency on `sale` since it adds `partner_shipping_id` which is required for all this to work. Because of this, a new module is required

See: https://www.legifrance.gouv.fr/jorf/id/JORFTEXT000046383394

task-3856826

**Documentation PR:** odoo/documentation#9820