### PR TITLE
[IMP] calendar: default privacy copy from Default User Template

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -4,13 +4,21 @@
 import datetime
 
 from odoo import api, fields, models, modules, _
+from odoo.exceptions import AccessError
+
 from pytz import timezone, UTC
 
 
 class Users(models.Model):
     _inherit = 'res.users'
 
-    calendar_default_privacy = fields.Selection(related='res_users_settings_id.calendar_default_privacy', readonly=False, required=True)
+    calendar_default_privacy = fields.Selection(
+        [('public', 'Public'),
+         ('private', 'Private'),
+         ('confidential', 'Only internal users')],
+        compute="_compute_calendar_default_privacy",
+        inverse="_inverse_calendar_res_users_settings",
+    )
 
     @property
     def SELF_READABLE_FIELDS(self):
@@ -38,6 +46,52 @@ class Users(models.Model):
         if include_user:
             partner_ids += [self.env.user.partner_id.id]
         return partner_ids
+
+    @api.model_create_multi
+    def create(self, vals_list):
+        """ Set the calendar default privacy as the same as Default User Template when defined. """
+        # Get the calendar default privacy from the Default User Template, set public as default.
+        default_privacy = 'public'
+        default_user = self.env.ref('base.default_user', raise_if_not_found=False)
+        if default_user and default_user.calendar_default_privacy:
+            default_privacy = default_user.calendar_default_privacy
+
+        # Update the dictionaries in vals_list with the calendar default privacy.
+        for vals_dict in vals_list:
+            if not vals_dict.get('calendar_default_privacy'):
+                vals_dict.update(calendar_default_privacy=default_privacy)
+
+        res = super().create(vals_list)
+        return res
+
+    def write(self, vals):
+        """ Forbid the calendar default privacy update from different users for keeping private events secured. """
+        privacy_update = 'calendar_default_privacy' in vals
+        default_user = self.env.ref('base.default_user', raise_if_not_found=False)
+        if default_user and privacy_update and any(user not in [default_user, self.env.user] for user in self):
+            raise AccessError(_("You are not allowed to change the calendar default privacy of another user due to privacy constraints."))
+        res = super().write(vals)
+        return res
+
+    @api.depends("res_users_settings_id.calendar_default_privacy")
+    def _compute_calendar_default_privacy(self):
+        for user in self:
+            user.calendar_default_privacy = user.res_users_settings_id.calendar_default_privacy
+
+    def _inverse_calendar_res_users_settings(self):
+        """
+        Updates the values of the calendar fields in 'res_users_settings_ids' to have the same values as their related
+        fields in 'res.users'. If there is no 'res.users.settings' record for the user, then the record is created.
+        """
+        for user in self:
+            settings = self.env["res.users.settings"]._find_or_create_for_user(user)
+            configuration = {field: user[field] for field in self._get_user_calendar_configuration_fields()}
+            settings.update(configuration)
+
+    @api.model
+    def _get_user_calendar_configuration_fields(self) -> list[str]:
+        """ Return the list of configurable fields for the user related to the res.users.settings table. """
+        return ['calendar_default_privacy']
 
     def _systray_get_calendar_event_domain(self):
         # Determine the domain for which the users should be notified. This method sends notification to

--- a/addons/calendar/tests/__init__.py
+++ b/addons/calendar/tests/__init__.py
@@ -11,3 +11,4 @@ from . import test_event_notifications
 from . import test_mail_activity_mixin
 from . import test_res_partner
 from . import test_recurrence_rule
+from . import test_res_users

--- a/addons/calendar/tests/test_access_rights.py
+++ b/addons/calendar/tests/test_access_rights.py
@@ -19,6 +19,7 @@ class TestAccessRights(TransactionCase):
         cls.george = new_test_user(cls.env, login='george', groups='base.group_user')
         cls.portal = new_test_user(cls.env, login='pot', groups='base.group_portal')
         cls.admin_user = new_test_user(cls.env, login='admin_user', groups='base.group_partner_manager,base.group_user')
+        cls.admin_system_user = new_test_user(cls.env, login='admin_system_user', groups='base.group_system')
 
     def create_event(self, user, **values):
         return self.env['calendar.event'].with_user(user).create({
@@ -163,7 +164,7 @@ class TestAccessRights(TransactionCase):
     def test_event_default_privacy_as_private(self):
         """ Check the privacy of events with owner's event default privacy as 'private'. """
         # Set organizer default privacy as 'private' and create event privacies default, public, private and confidential.
-        self.george.calendar_default_privacy = 'private'
+        self.george.with_user(self.george).calendar_default_privacy = 'private'
         default_event = self.create_event(self.george)
         public_event = self.create_event(self.george, privacy='public')
         private_event = self.create_event(self.george, privacy='private')
@@ -198,19 +199,23 @@ class TestAccessRights(TransactionCase):
         events_partners = [self.john.partner_id.id, self.raoul.partner_id.id]
 
         # Set calendar default privacy as private and create a normal event, only attendees/organizer can edit it.
-        self.john.res_users_settings_id.calendar_default_privacy = 'private'
+        self.john.with_user(self.john).calendar_default_privacy = 'private'
         johns_default_privacy_event = self.create_event(self.john, name='my event with default privacy', attendee_ids=events_attendees, partner_ids=events_partners)
         ensure_user_can_update_event(self, johns_default_privacy_event, self.john)
         ensure_user_can_update_event(self, johns_default_privacy_event, self.raoul)
         with self.assertRaises(AccessError):
+            self.assertEqual(len(self.john.res_users_settings_id), 1, "Res Users Settings for the user is not defined.")
+            self.assertEqual(self.john.res_users_settings_id.calendar_default_privacy, 'private', "Privacy field update was lost.")
             johns_default_privacy_event.with_user(self.george).write({'name': 'blocked-update-by-non-attendee'})
 
         # Set calendar default privacy as public and create a private event, only attendees/organizer can edit it.
-        self.john.res_users_settings_id.calendar_default_privacy = 'public'
+        self.john.with_user(self.john).calendar_default_privacy = 'public'
         johns_private_event = self.create_event(self.john, name='my private event', privacy='private', attendee_ids=events_attendees, partner_ids=events_partners)
         ensure_user_can_update_event(self, johns_private_event, self.john)
         ensure_user_can_update_event(self, johns_private_event, self.raoul)
         with self.assertRaises(AccessError):
+            self.assertEqual(len(self.john.res_users_settings_id), 1, "Res Users Settings for the user is not defined.")
+            self.assertEqual(self.john.res_users_settings_id.calendar_default_privacy, 'public', "Privacy field update was lost.")
             johns_private_event.with_user(self.george).write({'name': 'blocked-update-by-non-attendee'})
 
     def test_admin_cant_fetch_uninvited_private_events(self):
@@ -286,9 +291,23 @@ class TestAccessRights(TransactionCase):
         """
         Ensure that administrators and normal users can update their own calendar
         default privacy from the 'res.users' related field without throwing any error.
+        Updates from others users are blocked during write (except for Default User Template from admins).
         """
+        default_user = self.env.ref('base.default_user', raise_if_not_found=False)
+
         for privacy in ['public', 'private', 'confidential']:
-            self.john.write({'calendar_default_privacy': privacy})
-            self.admin_user.write({'calendar_default_privacy': privacy})
+            # Update normal user and administrator 'calendar_default_privacy' simulating their own update.
+            self.john.with_user(self.john).write({'calendar_default_privacy': privacy})
+            self.admin_system_user.with_user(self.admin_system_user).write({'calendar_default_privacy': privacy})
             self.assertEqual(self.john.calendar_default_privacy, privacy, 'Normal user must be able to update its calendar default privacy.')
-            self.assertEqual(self.admin_user.calendar_default_privacy, privacy, 'Admin must be able to update its calendar default privacy.')
+            self.assertEqual(self.admin_system_user.calendar_default_privacy, privacy, 'Admin must be able to update its calendar default privacy.')
+
+            # Update the Default User Template's 'calendar_default_privacy' as an administrator.
+            default_user.with_user(self.admin_system_user).write({'calendar_default_privacy': privacy})
+            self.assertEqual(default_user.calendar_default_privacy, privacy, 'Admin must be able to update the Default User Template calendar privacy.')
+
+            # All calendar default privacy updates (except for Default user Template) must be blocked during write.
+            with self.assertRaises(AccessError):
+                self.john.with_user(self.admin_system_user).write({'calendar_default_privacy': privacy})
+            with self.assertRaises(AccessError):
+                self.admin_system_user.with_user(self.john).write({'calendar_default_privacy': privacy})

--- a/addons/calendar/tests/test_res_users.py
+++ b/addons/calendar/tests/test_res_users.py
@@ -1,0 +1,51 @@
+from odoo.tests.common import TransactionCase
+
+
+class TestResUsers(TransactionCase):
+
+    def test_same_calendar_default_privacy_as_user_template(self):
+        """
+        The 'calendar default privacy' variable can be set in the Default User Template
+        for defining which privacy the new user's calendars will have when creating a
+        user. Ensure that when creating a new user, its calendar default privacy will
+        have the same value as defined in the template.
+        """
+        def create_user(name, login, email, privacy=None):
+            vals = {'name': name, 'login': login, 'email': email}
+            if privacy is not None:
+                vals['calendar_default_privacy'] = privacy
+            return self.env['res.users'].create(vals)
+
+        # Get Default User Template and define expected outputs for each privacy update test.
+        default_user = self.env.ref('base.default_user', raise_if_not_found=False)
+        privacy_and_output = [
+            (False, 'public'),
+            ('public', 'public'),
+            ('private', 'private'),
+            ('confidential', 'confidential')
+        ]
+        for (privacy, expected_output) in privacy_and_output:
+            # Update privacy of Default User Template (required field).
+            if privacy:
+                default_user.write({'calendar_default_privacy': privacy})
+
+            # If Calendar Default Privacy isn't defined in vals: get the privacy from Default User Template.
+            username = 'test_%s_%s' % (str(privacy), expected_output)
+            new_user = create_user(username, username, username + '@user.com')
+            self.assertEqual(
+                new_user.calendar_default_privacy,
+                expected_output,
+                'Calendar default privacy %s should be %s, same as in the Default User Template.'
+                % (new_user.calendar_default_privacy, expected_output)
+            )
+
+            # If Calendar Default Privacy is defined in vals: override the privacy from Default User Template.
+            for custom_privacy in ['public', 'private', 'confidential']:
+                custom_name = str(custom_privacy) + username
+                custom_user = create_user(custom_name, custom_name, custom_name + '@user.com', privacy=custom_privacy)
+                self.assertEqual(
+                    custom_user.calendar_default_privacy,
+                    custom_privacy,
+                    'Custom %s privacy from in vals must override the privacy %s from Default User Template.'
+                    % (custom_privacy, privacy)
+                )

--- a/addons/calendar/views/res_users_views.xml
+++ b/addons/calendar/views/res_users_views.xml
@@ -12,5 +12,16 @@
                 </xpath>
             </field>
         </record>
+        <!-- Update User form !-->
+        <record id="res_users_form_view" model="ir.ui.view">
+            <field name="name">res.users.form.calendar</field>
+            <field name="model">res.users</field>
+            <field name="inherit_id" ref="base.view_users_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='signature']" position="after">
+                    <field name="calendar_default_privacy" readonly="0" string="Calendar Default Privacy" invisible="share"/>
+                </xpath>
+            </field>
+        </record>
     </data>
 </odoo>

--- a/addons/microsoft_calendar/tests/test_create_events.py
+++ b/addons/microsoft_calendar/tests/test_create_events.py
@@ -510,18 +510,21 @@ class TestSyncOdoo2MicrosoftMail(TestCommon, MailCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cls.users = cls.env['res.users'].create({
-            'name': f'user{n}',
-            'login': f'user{n}',
-            'email': f'user{n}@odoo.com',
-            'microsoft_calendar_rtoken': f'abc{n}',
-            'microsoft_calendar_token': f'abc{n}',
-            'microsoft_calendar_token_validity': datetime(9999, 12, 31),
-            'res_users_settings_ids': [(0, 0, {
+        cls.users = []
+        for n in range(1, 3):
+            user = cls.env['res.users'].create({
+                'name': f'user{n}',
+                'login': f'user{n}',
+                'email': f'user{n}@odoo.com',
+                'microsoft_calendar_rtoken': f'abc{n}',
+                'microsoft_calendar_token': f'abc{n}',
+                'microsoft_calendar_token_validity': datetime(9999, 12, 31),
+            })
+            user.res_users_settings_id.write({
                 'microsoft_synchronization_stopped': False,
                 'microsoft_calendar_sync_token': f'{n}_sync_token',
-            })]
-        } for n in range(1, 3)).user_ids
+            })
+            cls.users += [user]
 
     @freeze_time("2020-01-01")
     @patch.object(User, '_get_microsoft_calendar_token', lambda user: user.microsoft_calendar_token)


### PR DESCRIPTION
This commit allows defining a calendar default privacy setting in the User form of the Default User Template so that new users created with unspecified calendar default privacy will get the setting from the template by default. This improvement makes the life of administrators easier if they want to set the default calendar privacy as something else than public, such as 'private' or 'confidential'.

The 'calendar_default_privacy' field in 'res.users' is now a non-stored computed field which makes updates in res.users.settings' when changed. By means of this change, it is now possible saving the default privacy field in the Default User Template. Tests were added in order to ensure the good functionality of the new features.

task-3850837