### PR TITLE
[IMP] purchase,sale: improve product sales history

### DIFF
--- a/addons/pos_sale/report/sale_report.py
+++ b/addons/pos_sale/report/sale_report.py
@@ -34,6 +34,10 @@ class SaleReport(models.Model):
             SUM(l.qty - l.qty_delivered) AS qty_to_deliver,
             CASE WHEN pos.state = 'invoiced' THEN SUM(l.qty) ELSE 0 END AS qty_invoiced,
             CASE WHEN pos.state != 'invoiced' THEN SUM(l.qty) ELSE 0 END AS qty_to_invoice,
+            SUM(l.price_unit)
+                / MIN({self._case_value_or_one('pos.currency_rate')})
+                * {self._case_value_or_one('currency_table.rate')}
+            AS price_unit,
             SUM(l.price_subtotal_incl)
                 / MIN({self._case_value_or_one('pos.currency_rate')})
                 * {self._case_value_or_one('currency_table.rate')}

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -37,7 +37,7 @@ class PurchaseOrderLine(models.Model):
     product_id = fields.Many2one('product.product', string='Product', domain=[('purchase_ok', '=', True)], change_default=True, index='btree_not_null')
     product_type = fields.Selection(related='product_id.type', readonly=True)
     price_unit = fields.Float(
-        string='Unit Price', required=True, digits='Product Price', aggregator=None,
+        string='Unit Price', required=True, digits='Product Price', aggregator='avg',
         compute="_compute_price_unit_and_date_planned_and_name", readonly=False, store=True)
     price_unit_discounted = fields.Float('Unit Price (Discounted)', compute='_compute_price_unit_discounted')
 
@@ -671,3 +671,12 @@ class PurchaseOrderLine(models.Model):
                 business_domain='purchase_order',
                 company_id=line.company_id.id,
             )
+
+    def action_open_order(self):
+        self.ensure_one()
+        return {
+            'type': 'ir.actions.act_window',
+            'res_model': 'purchase.order',
+            'res_id': self.order_id.id,
+            'view_mode': 'form',
+        }

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -800,11 +800,19 @@
                     <field name="product_id"/>
                     <field name="partner_id" string="Vendor"/>
                     <filter name="hide_cancelled" string="Hide cancelled lines" domain="[('state', '!=', 'cancel')]"/>
+                    <filter string="Status" name="purchase_state" domain="[('state', '=', 'purchase')]"/>
+                    <separator/>
+                    <filter name="filter_date_order" date="date_order" default_period="month"/>
+                    <filter name="order_date_last_year" string="Order Date: Last 365 Days"
+                        domain="[
+                            ('date_order', '>', ((context_today() - relativedelta(years=1)).strftime('%Y-%m-%d')))
+                        ]" invisible="1"/>
                     <group expand="0" string="Group By">
                         <filter name="groupby_supplier" string="Vendor" domain="[]" context="{'group_by' : 'partner_id'}" />
                         <filter name="groupby_product" string="Product" domain="[]" context="{'group_by' : 'product_id'}" />
                         <filter string="Order Reference" name="order_reference" domain="[]" context="{'group_by' :'order_id'}"/>
-                        <filter string="Status" name="status" domain="[]" context="{'group_by' : 'state'}" />
+                        <separator/>
+                        <filter string="Order Date" name="group_by_date_order" context="{'group_by': 'date_order'}"/>
                     </group>
                 </search>
             </field>
@@ -814,21 +822,51 @@
         <field name="name">purchase.history.tree</field>
         <field name="model">purchase.order.line</field>
         <field name="arch" type="xml">
-            <tree create="false" default_order="order_id asc">
+            <tree create="false" default_order="order_id asc" action="action_open_order" type="object">
+                <field name="currency_id" column_invisible="True"/>
                 <field name="order_id" widget="many2one"/>
                 <field name="date_approve"/>
-                <field name="partner_id"/>
-                <field name="product_uom_qty"/>
-                <field name="price_unit"/>
+                <field name="partner_id" string="Vendor"/>
+                <field name="company_id" optional="show" groups="base.group_multi_company"/>
+                <field name="product_uom_qty" string="Quantity"/>
+                <field name="price_unit" widget="monetary"/>
+                <field name="price_subtotal" widget="monetary" string="Total Untaxed"/>
+                <field name="state" optional="hide"/>
             </tree>
         </field>
     </record>
 
+    <record id="purchase_history_pivot" model="ir.ui.view">
+         <field name="name">purchase.history.pivot</field>
+         <field name="model">purchase.order.line</field>
+         <field name="arch" type="xml">
+             <pivot>
+                <field name="price_total" string="Total purchased amount" type="measure"/>
+                <field name="product_uom_qty" string="Total Qty purchased" type="measure"/>
+             </pivot>
+         </field>
+    </record>
+
+     <record id="purchase_history_graph" model="ir.ui.view">
+         <field name="name">purchase.history.graph</field>
+         <field name="model">purchase.order.line</field>
+         <field name="arch" type="xml">
+             <graph type="line">
+                <field name="date_order" interval="month"/>
+                <field name="product_uom_qty" type="measure"/>
+             </graph>
+         </field>
+    </record>
+
     <record id="action_purchase_history" model="ir.actions.act_window">
         <field name="res_model">purchase.order.line</field>
-        <field name="view_mode">tree</field>
+        <field name="view_mode">tree,pivot,graph</field>
         <field name="view_id" ref="purchase.purchase_history_tree"/>
-        <field name="context">{}</field>
+        <field name="context">{
+                'search_default_purchase_state': 1,
+                'search_default_order_date_last_year': 1,
+                'search_default_groupby_supplier': 1,
+        }</field>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face">
                 No purchase order were made for this product yet!

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -146,6 +146,7 @@ class ProductTemplate(models.Model):
             'active_model': 'sale.report',
             'search_default_Sales': 1,
             'search_default_filter_order_date': 1,
+            'search_default_group_by_date': 1,
         }
         return action
 

--- a/addons/sale/report/sale_report_views.xml
+++ b/addons/sale/report/sale_report_views.xml
@@ -8,7 +8,7 @@
              <pivot string="Sales Analysis" sample="1">
                  <field name="team_id" type="col"/>
                  <field name="date" interval="month" type="row"/>
-                 <field name="price_subtotal" type="measure"/>
+                 <field name="product_uom_qty" type="measure"/>
              </pivot>
          </field>
     </record>
@@ -18,8 +18,8 @@
          <field name="model">sale.report</field>
          <field name="arch" type="xml">
              <graph string="Sales Analysis" type="line" sample="1">
-                 <field name="date" interval="day"/>
-                 <field name="price_subtotal" type="measure"/>
+                 <field name="date" interval="month"/>
+                 <field name="product_uom_qty" type="measure"/>
              </graph>
          </field>
     </record>
@@ -53,17 +53,20 @@
         <field name="name">sale.report.view.tree</field>
         <field name="model">sale.report</field>
         <field name="arch" type="xml">
-            <tree string="Sales Analysis">
+            <tree string="Sales Analysis" action="action_open_order" type="object">
                 <field name="date"/>
                 <field name="order_reference" optional="show"/>
-                <field name="partner_id" optional="hide"/>
                 <field name="product_id" string="Product" optional="show"/>
+                <field name="partner_id"/>
                 <field name="user_id" optional="show" widget="many2one_avatar_user"/>
-                <field name="team_id" optional="show"/>
+                <field name="team_id" optional="hide"/>
                 <field name="company_id" optional="show" groups="base.group_multi_company"/>
+                <field name="product_uom_qty" string="Quantity" sum="Sum of Quantity"/>
                 <field name="price_subtotal" optional="hide" sum="Sum of Untaxed Total"/>
+                <field name="price_unit" widget="monetary" avg="Average"/>
                 <field name="price_total" optional="show" sum="Sum of Total"/>
                 <field name="state" optional="hide"/>
+                <field name="pricelist_id" optional="hide"/>
                 <field name="line_invoice_status" optional="hide"/>
                 <field name="currency_id" column_invisible="True"/>
             </tree>
@@ -110,7 +113,7 @@
                     <filter string="Status" name="status" context="{'group_by':'state'}"/>
                     <filter string="Company" name="company" groups="base.group_multi_company" context="{'group_by':'company_id'}"/>
                     <separator/>
-                    <filter string="Order Date" name="date" context="{'group_by':'date'}"
+                    <filter string="Order Date" name="group_by_date" context="{'group_by':'date'}"
                             invisible="context.get('sale_report_view_hide_date')"/>
                     <filter string="Order Date" name="group_by_date_day" context="{'group_by':'date:day'}"
                             invisible="not context.get('sale_report_view_hide_date')"/>
@@ -163,7 +166,7 @@
     <record id="report_all_channels_sales_action" model="ir.actions.act_window">
         <field name="name">Sales Analysis</field>
         <field name="res_model">sale.report</field>
-        <field name="view_mode">pivot,tree,graph</field>
+        <field name="view_mode">tree,pivot,graph,form</field>
     </record>
 
     <record id="action_order_report_quotation_salesteam" model="ir.actions.act_window">


### PR DESCRIPTION
Before this PR:

-> The default view for product actions in the Sale module was the pivot view. -> Clicking on a line in the Sale report list view redirected to the form view. -> Clicking on a line in the Purchase Report list view did not redirect to another view.

After this PR:

-> The default view for product actions is now the list view. -> Clicking on a sale order in the list view redirects to the Sale Order page. -> Additional fields have been added to the Sale report list view. -> Clicking on a line in the Purchase Report list view now directs to the purchase order.
-> Additional fields and views (Graph, Pivot, Kanban) have been added to the purchase report.
-> Default filters have been applied to Purchase Orders, and field names have been updated from "Partner" to "Vendor" and "Total Quantity" to "Quantity".

Task-3250969