### PR TITLE
[IMP] l10n_din5008: address display and footer size

### DIFF
--- a/addons/l10n_din5008/report/din5008_report.xml
+++ b/addons/l10n_din5008/report/din5008_report.xml
@@ -70,6 +70,13 @@
                                         <span>|</span> <span t-field="company.country_id.name"/>
                                     </t>
                                     <hr class="company_invoice_line" />
+                                    <t t-if="o and 'l10n_din5008_addresses' in o" t-set="address">
+                                        <address class="mb-0" t-field="o.partner_id.commercial_partner_id" t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True}'/>
+                                        <div t-if="o.partner_id.commercial_partner_id.vat" id="partner_vat_address_same_as_shipping">
+                                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-out="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.commercial_partner_id.vat"/>
+                                        </div>
+                                    </t>
                                     <div t-if="address">
                                         <t t-out="address"/>
                                     </div>

--- a/addons/l10n_din5008/static/src/scss/report_din5008.scss
+++ b/addons/l10n_din5008/static/src/scss/report_din5008.scss
@@ -98,6 +98,7 @@
         .company_details {
             margin-top: 4.23mm;
             width: 100%;
+            font-size: 0.8em;
             table {
                 border-top: solid 1px;
                 table-layout: fixed;


### PR DESCRIPTION
The first commit is about the display of the address block, we always had the address of the partner even if the address
were the same. Now, depending on the address in the customer field or delivery address, we can
decide to display the invoicing address or shipping address or both.

The other one is about the size of the footer because the general scaling of the footer font is too big. Normal Sized company names cannot be displayed. In Fact, the Iban numbers etc. are cut off at the bottom.

task: 3817563

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
