### PR TITLE
[FIX] sale_timesheet: create partners for employees created in demo data

### DIFF
--- a/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
+++ b/addons/pos_loyalty/static/tests/tours/PosLoyaltyLoyaltyProgramTour.js
@@ -15,18 +15,18 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             // Order1: Generates 2 points.
             ProductScreen.addOrderline("Whiteboard Pen", "2"),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner AAA"),
+            ProductScreen.clickCustomer("AAA Test Partner"),
             PosLoyalty.orderTotalIs("6.40"),
             PosLoyalty.finalizeOrder("Cash", "10"),
 
             // Order2: Consumes points to get free product.
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner AAA"),
+            ProductScreen.clickCustomer("AAA Test Partner"),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "1.00"),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "2.00"),
-            // At this point, Test Partner AAA has 4 points.
+            // At this point, AAA Test Partner has 4 points.
             PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "3.00"),
@@ -43,7 +43,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram1", {
             ProductScreen.addOrderline("Whiteboard Pen", "4"),
             PosLoyalty.orderTotalIs("12.80"),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner AAA"),
+            ProductScreen.clickCustomer("AAA Test Partner"),
             PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
@@ -74,12 +74,12 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
     url: "/pos/web",
     steps: () =>
         [
-            // Order1: Immediately set the customer to Test Partner AAA which has 4 points.
+            // Order1: Immediately set the customer to AAA Test Partner which has 4 points.
             // - He has enough points to purchase a free product but since there is still
             //   no product in the order, reward button should not yet be highlighted.
             // - Furthermore, clicking the reward product should not add it as reward product.
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner AAA"),
+            ProductScreen.clickCustomer("AAA Test Partner"),
             // No item in the order, so reward button is off.
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
@@ -90,11 +90,11 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
             PosLoyalty.orderTotalIs("3.20"),
             PosLoyalty.finalizeOrder("Cash", "10"),
 
-            // Order2: Generate 4 points for Test Partner CCC.
+            // Order2: Generate 4 points for CCC Test Partner.
             // - Reference: Order2_CCC
-            // - But set Test Partner BBB first as the customer.
+            // - But set BBB Test Partner first as the customer.
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner BBB"),
+            ProductScreen.clickCustomer("BBB Test Partner"),
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickDisplayedProduct("Whiteboard Pen"),
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "1.00"),
@@ -107,21 +107,21 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "4.00"),
             PosLoyalty.isRewardButtonHighlighted(true),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner CCC"),
-            PosLoyalty.customerIs("Test Partner CCC"),
+            ProductScreen.clickCustomer("CCC Test Partner"),
+            PosLoyalty.customerIs("CCC Test Partner"),
             PosLoyalty.orderTotalIs("12.80"),
             PosLoyalty.finalizeOrder("Cash", "20"),
 
-            // Order3: Generate 3 points for Test Partner BBB.
+            // Order3: Generate 3 points for BBB Test Partner.
             // - Reference: Order3_BBB
-            // - But set Test Partner CCC first as the customer.
+            // - But set CCC Test Partner first as the customer.
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner CCC"),
+            ProductScreen.clickCustomer("CCC Test Partner"),
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.addOrderline("Whiteboard Pen", "3"),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner BBB"),
-            PosLoyalty.customerIs("Test Partner BBB"),
+            ProductScreen.clickCustomer("BBB Test Partner"),
+            PosLoyalty.customerIs("BBB Test Partner"),
             PosLoyalty.orderTotalIs("9.60"),
             PosLoyalty.finalizeOrder("Cash", "10"),
 
@@ -131,7 +131,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram2", {
             ProductScreen.selectedOrderlineHas("Whiteboard Pen", "1.00"),
             PosLoyalty.isRewardButtonHighlighted(false),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner CCC"),
+            ProductScreen.clickCustomer("CCC Test Partner"),
             PosLoyalty.isRewardButtonHighlighted(true),
             PosLoyalty.claimReward("Free Product - Whiteboard Pen"),
             PosLoyalty.hasRewardLine("Free Product - Whiteboard Pen", "-3.20", "1.00"),
@@ -154,7 +154,7 @@ registry.category("web_tour.tours").add("PosLoyaltyLoyaltyProgram3", {
             // Generates 10.2 points and use points to get the reward product with zero sale price
             ProductScreen.addOrderline("Desk Organizer", "2"),
             ProductScreen.clickPartnerButton(),
-            ProductScreen.clickCustomer("Test Partner AAA"),
+            ProductScreen.clickCustomer("AAA Test Partner"),
 
             // At this point, the free_product program is triggered.
             // The reward button should be highlighted.

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -342,9 +342,9 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         (self.promo_programs | self.coupon_program).write({'active': False})
 
-        partner_aaa = self.env['res.partner'].create({'name': 'Test Partner AAA'})
-        partner_bbb = self.env['res.partner'].create({'name': 'Test Partner BBB'})
-        partner_ccc = self.env['res.partner'].create({'name': 'Test Partner CCC'})
+        partner_aaa = self.env['res.partner'].create({'name': 'AAA Test Partner'})
+        partner_bbb = self.env['res.partner'].create({'name': 'BBB Test Partner'})
+        partner_ccc = self.env['res.partner'].create({'name': 'CCC Test Partner'})
 
         # Part 1
         self.start_tour(
@@ -408,7 +408,7 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         (self.promo_programs | self.coupon_program).write({'active': False})
 
-        partner_aaa = self.env['res.partner'].create({'name': 'Test Partner AAA'})
+        partner_aaa = self.env['res.partner'].create({'name': 'AAA Test Partner'})
 
         self.start_tour(
             "/pos/web?config_id=%d" % self.main_pos_config.id,

--- a/addons/sale_timesheet/data/sale_service_demo.xml
+++ b/addons/sale_timesheet/data/sale_service_demo.xml
@@ -20,6 +20,12 @@
             <field name="contract_type_id" ref="hr.contract_type_permanent"/>
         </record>
 
+        <record id="work_contact_jjo" model="res.partner">
+            <field name="name">Jessica Johnson</field>
+            <field name="email">jessica.johnson45@example.com</field>
+            <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jjo-image.jpg"/>
+        </record>
+
         <record id="employee_jjo" model="hr.employee">
             <field name="name">Jessica Johnson</field>
             <field name="parent_id" ref="hr.employee_al"/>
@@ -28,9 +34,15 @@
             <field name="category_ids" eval="[(6, 0, [ref('hr.employee_category_4')])]"/>
             <field name="work_location_id" ref="hr.work_location_1"/>
             <field name="work_phone">(535)-495-4164</field>
-            <field name="work_contact_id" ref="hr.work_contact_al"/>
+            <field name="work_contact_id" ref="sale_timesheet.work_contact_jjo"/>
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jjo-image.jpg"/>
             <field name="create_date">2020-02-02 00:00:00</field>
+        </record>
+
+        <record id="work_contact_awa" model="res.partner">
+            <field name="name">Amy Watson</field>
+            <field name="email">amy.watson21@example.com</field>
+            <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_awa-image.jpg"/>
         </record>
 
         <record id="employee_awa" model="hr.employee">
@@ -41,9 +53,15 @@
             <field name="category_ids" eval="[(6, 0, [ref('hr.employee_category_4')])]"/>
             <field name="work_location_id" ref="hr.work_location_1"/>
             <field name="work_phone">(535)-495-4222</field>
-            <field name="work_contact_id" ref="hr.work_contact_mit"/>
+            <field name="work_contact_id" ref="sale_timesheet.work_contact_awa"/>
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_awa-image.jpg"/>
             <field name="create_date">2020-01-01 00:00:00</field>
+        </record>
+
+        <record id="work_contact_jsm" model="res.partner">
+            <field name="name">Justin Smith</field>
+            <field name="email">justin.smith57@example.com</field>
+            <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jsm-image.jpg"/>
         </record>
 
         <record id="employee_jsm" model="hr.employee">
@@ -54,7 +72,7 @@
             <field name="category_ids" eval="[(6, 0, [ref('hr.employee_category_4')])]"/>
             <field name="work_location_id" ref="hr.work_location_1"/>
             <field name="work_phone">(535)-495-4444</field>
-            <field name="work_contact_id" ref="hr.work_contact_niv"/>
+            <field name="work_contact_id" ref="sale_timesheet.work_contact_jsm"/>
             <field name="image_1920" type="base64" file="sale_timesheet/static/img/employee_jsm-image.jpg"/>
             <field name="create_date">2020-02-02 00:00:00</field>
         </record>


### PR DESCRIPTION
The employees created in the demo data (see https://github.com/odoo/odoo/pull/108795) of sale_timesheet were linked to the wrong partners, we then create new partners dedicated to those new employees.

version-17.1
task-3874828

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
