### PR TITLE
[IMP] website_event: list/grid switcher for events

### DIFF
--- a/addons/website_event/__manifest__.py
+++ b/addons/website_event/__manifest__.py
@@ -63,6 +63,7 @@
             ('remove', 'website_event/static/src/snippets/**/options.js'),
         ],
         'web.assets_frontend': [
+            'website_event/static/src/js/website_event.js',
             'website_event/static/src/js/tours/**/*',
             'website_event/static/src/scss/event_templates_common.scss',
             'website_event/static/src/scss/event_templates_list.scss',

--- a/addons/website_event/controllers/main.py
+++ b/addons/website_event/controllers/main.py
@@ -127,6 +127,19 @@ class WebsiteEventController(http.Controller):
 
         searches['search'] = fuzzy_search_term or search
 
+        layout_mode = request.session.get('website_event_layout_mode')
+
+        if (layout_mode == 'list' and not website.is_view_active('website_event.opt_events_list_rows')) \
+        or (layout_mode == 'grid' and not website.is_view_active('website_event.opt_events_list_columns')):
+            layout_mode = False
+
+        if not layout_mode:
+            if website.is_view_active('website_event.opt_events_list_columns'):
+                layout_mode = 'grid'
+            else:
+                layout_mode = 'list'
+            request.session['website_event_layout_mode'] = layout_mode
+
         values = {
             'current_date': current_date,
             'current_country': current_country,
@@ -143,6 +156,7 @@ class WebsiteEventController(http.Controller):
             'keep': keep,
             'search_count': event_count,
             'original_search': fuzzy_search_term and search,
+            'layout_mode': layout_mode,
             'website': website
         }
 
@@ -400,6 +414,11 @@ class WebsiteEventController(http.Controller):
         ])
         return request.render("website_event.registration_complete",
             self._get_registration_confirm_values(event, attendees_sudo))
+
+    @http.route('/event/save_event_layout_mode', type='jsonrpc', auth='public', website=True)
+    def save_event_layout_mode(self, layout_mode):
+        assert layout_mode in ('grid', 'list'), _("Invalid event layout mode")
+        request.session['website_event_layout_mode'] = layout_mode
 
     def _get_registration_confirm_values(self, event, attendees_sudo):
         urls = event._get_event_resource_urls()

--- a/addons/website_event/static/src/js/website_event.js
+++ b/addons/website_event/static/src/js/website_event.js
@@ -1,0 +1,45 @@
+import publicWidget from "@web/legacy/js/public/public_widget";
+import { rpc } from "@web/core/network/rpc";
+
+publicWidget.registry.WebsiteEventLayout = publicWidget.Widget.extend({
+    selector: '.o_wevent_index',
+    disabledInEditableMode: false,
+    events: {
+        'change .o_wevent_apply_layout input': '_onApplyEventLayoutChange',
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onApplyEventLayoutChange: async function (ev) {
+        const wysiwyg = this.options.wysiwyg;
+        if (wysiwyg) {
+            wysiwyg.odooEditor.observerUnactive('_onApplyEventLayoutChange');
+        }
+        var clickedValue = ev.target.value;
+        if (!this.editableMode) {
+            await rpc('/event/save_event_layout_mode', {
+                'layout_mode': clickedValue,
+            });
+        }
+
+        // Update btn-group state
+        document.querySelector('input.o_wevent_apply_grid').checked = (clickedValue === 'grid');
+        document.querySelector('input.o_wevent_apply_list').checked = (clickedValue === 'list');
+        document.querySelector('label.o_wevent_apply_grid').classList.toggle('active')
+        document.querySelector('label.o_wevent_apply_list').classList.toggle('active')
+
+        // Update layout
+        document.querySelector('.o_wevent_event_grid_layout').classList.toggle('d-none');
+        document.querySelector('.o_wevent_event_list_layout').classList.toggle('d-none');
+
+        if (wysiwyg) {
+            wysiwyg.odooEditor.observerActive('_onApplyEventLayoutChange');
+        }
+    },
+});

--- a/addons/website_event/static/src/scss/event_templates_list.scss
+++ b/addons/website_event/static/src/scss/event_templates_list.scss
@@ -21,7 +21,7 @@
 .o_wevent_index {
     // Events List
     .o_wevent_events_list {
-        .opt_events_list_columns {
+        .o_wevent_event_grid_layout {
             .card-header {
                 height: 200px;
             }
@@ -29,7 +29,7 @@
                 color: color-contrast($card-bg);
             }
         }
-        .opt_events_list_rows {
+        .o_wevent_event_list_layout {
             .card-header {
                 min-height: 130px;
             }

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -10,8 +10,12 @@
 
         <div id="wrap" class="o_wevent_index">
             <!-- Options -->
+            <t t-set="opt_events_event_location" t-value="is_view_active('website_event.event_location')"/>
             <t t-set="opt_events_list_cards" t-value="is_view_active('website_event.opt_events_list_cards')"/>
             <t t-set="opt_events_list_columns" t-value="is_view_active('website_event.opt_events_list_columns')"/>
+            <t t-set="opt_events_list_rows" t-value="is_view_active('website_event.opt_events_list_rows')"/>
+            <t t-set="opt_index_sidebar" t-value="is_view_active('website_event.opt_index_sidebar')"/>
+
             <!-- Topbar -->
             <t t-call="website_event.index_topbar">
                 <t t-set="search" t-value="original_search or search or searches['search']"/>
@@ -22,11 +26,9 @@
             <div class="o_wevent_events_list">
                 <div class="container">
                     <div class="row">
-                        <div id="o_wevent_index_main_col" t-attf-class="col-md mb-3 #{opt_events_list_columns and 'opt_events_list_columns' or 'opt_events_list_rows'}">
-                            <div class="row g-4 g-lg-3 g-xxl-4">
-                                <!-- Events List -->
-                                <t t-call="website_event.events_list"/>
-                            </div>
+                        <div id="o_wevent_index_main_col" class="col-md mb-3">
+                            <!-- Events List (List & Grid Layout) -->
+                            <t t-call="website_event.events_list"/>
                         </div>
                     </div>
                 </div>
@@ -47,7 +49,7 @@
 <!-- Index Topbar -->
 <template id="index_topbar" name="Topbar">
         <div class="container mt-3 mb-4">
-            <div class="o_wevent_index_topbar_filters d-flex d-print-none align-items-center justify-content-end flex-wrap gap-2 w-100">
+            <div class="o_wevent_index_topbar_filters d-flex d-print-none align-items-center justify-content-end gap-2 w-100">
                 <h2 class="h4 my-0 me-auto pe-sm-4">Events</h2>
                     <t t-foreach="categories" t-as="category">
                         <div t-if="category.is_published and category.tag_ids and any(tag.color for tag in category.tag_ids)" class="dropdown d-none d-lg-block">
@@ -72,7 +74,7 @@
                             </div>
                         </div>
                     </t>
-                <div class="o_wevent_search d-flex w-100">
+                <div class="o_wevent_search btn-toolbar flex-nowrap gap-2">
                     <div class="w-100 flex-grow-1">
                         <t t-call="website.website_search_box_input">
                             <t t-set="_classes" t-valuef="o_wevent_event_searchbar_form flex-grow-1"/>
@@ -88,7 +90,8 @@
                             </t>
                         </t>
                     </div>
-                    <button class="btn btn-light position-relative ms-2 d-lg-none"
+                    <t t-if="opt_events_list_columns and opt_events_list_rows" t-call="website_event.grid_or_list_buttons"/>
+                    <button class="btn btn-light position-relative d-lg-none"
                         data-bs-toggle="offcanvas"
                         data-bs-target="#o_wevent_index_offcanvas">
                         <i class="fa fa-sliders"/>
@@ -290,13 +293,22 @@
     </xpath>
 </template>
 
+<!-- Grid or List Display Selection -->
+<template id="grid_or_list_buttons" name="Grid or List button">
+    <div t-attf-class="o_wevent_apply_layout btn-group d-flex">
+        <input type="radio" class="btn-check o_wevent_apply_grid" id="o_wevent_apply_grid"  t-att-checked="'checked' if layout_mode == 'grid' else None" value="grid"/>
+        <label t-attf-class="btn btn-light o_wevent_apply_grid {{ 'active' if layout_mode == 'grid' else '' }}" title="Grid" for="o_wevent_apply_grid">
+            <i class="fa fa-th-large"/>
+        </label>
+        <input type="radio" class="btn-check o_wevent_apply_list" id="o_wevent_apply_list" t-att-checked="'checked' if layout_mode == 'list' else None" value="list"/>
+        <label t-attf-class="btn btn-light o_wevent_apply_list {{ 'active' if layout_mode == 'list' else '' }}" title="List" for="o_wevent_apply_list">
+            <i class="oi oi-view-list"/>
+        </label>
+    </div>
+</template>
+
 <!-- Index - Events list -->
 <template id="events_list" name="Events list">
-    <!-- Options -->
-    <t t-set="opt_index_sidebar" t-value="is_view_active('website_event.opt_index_sidebar')"/>
-    <t t-set="opt_events_event_location" t-value="is_view_active('website_event.event_location')"/>
-    <t t-if="opt_events_list_columns" t-set="opt_event_size" t-value="opt_index_sidebar and 'col-md-6' or 'col-md-6 col-lg-4 col-xl-3'"/>
-    <t t-else="" t-set="opt_event_size" t-value="opt_index_sidebar and 'col-12' or 'col-xl-12'"/>
     <!-- No events -->
     <div t-if="not event_ids" class="col-12 text-center">
         <div t-call="website_event.event_empty_events_svg" class="my-4"/>
@@ -314,118 +326,181 @@
     <div t-if="event_ids and original_search" class="col-12 alert alert-warning mt8">
         No results found for '<span t-out="original_search"/>'. Showing results for '<span t-out="searches['search']"/>'.
     </div>
-    <!-- List -->
-    <div t-foreach="event_ids" t-as="event" t-attf-class=" #{opt_event_size}">
-        <a t-cache="event if not editable and event.website_published else None" t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset " t-att-data-publish="event.website_published and 'on' or 'off'">
-            <article t-attf-class="h-100 #{opt_events_list_cards and 'card'}" itemscope="itemscope" itemtype="http://schema.org/Event">
-                <div t-attf-class="h-100 #{opt_events_list_columns and 'd-flex flex-wrap flex-column' or 'row mx-0'}">
-                    <!-- Header -->
-                    <header t-attf-class="card-header overflow-hidden bg-secondary p-0 border-0 rounded-0 #{opt_events_list_columns and 'col-12' or 'col-4 col-lg-3'} #{(not opt_events_list_cards) and 'shadow-sm'}">
-                        <!-- Image + Link -->
-                        <div class="d-block h-100 w-100">
-                            <t t-call="website.record_cover">
-                                <t t-set="_record" t-value="event"/>
-                                <meta itemprop="startDate" t-att-content="event.date_begin.isoformat()"/>
-                                <!-- Short date + Country Flag -->
-                                <div t-if="opt_events_event_location" t-attf-class="o_wevent_date_with_flag o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
-                                    <div class="o_wevent_event_date_text">
-                                        <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
-                                        <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
-                                    </div>
-                                    <div class="o_wevent_event_country_flag">
-                                        <img t-if="event.country_id and event.country_id.image_url" class="h-100 align-baseline" t-att-src="event.country_id.image_url" t-att-alt="event.country_id.name"/>
-                                        <i t-elif="not event.country_id" class="fa fa-video-camera h-100"/>
-                                    </div>
-                                </div>
-                                <!-- Short Date -->
-                                <div t-else="" t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
-                                    <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
-                                    <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
-                                </div>
-                                <!-- Not open -->
-                                <span t-if="not event.event_registrations_open and (not opt_events_list_cards or not opt_events_list_columns)" class="position-absolute bottom-0 px-3 py-2 w-100 text-bg-light">
-                                    <t t-if="not event.event_registrations_started">
-                                        Registrations not yet open
-                                    </t>
-                                    <t t-elif="event.event_registrations_sold_out">
-                                        Sold Out
-                                    </t>
-                                    <t t-else="">
-                                        Registrations Closed
-                                    </t>
-                                </span>
-                                <!-- Participating -->
-                                <small t-if="event.is_participating" class="o_wevent_participating position-absolute bottom-0 px-3 py-2 w-100 text-bg-success">
-                                    <i class="fa fa-check me-2"/>Registered
-                                </small>
-                                <!-- Unpublished -->
-                                <small t-if="not event.website_published" class="o_wevent_unpublished position-absolute bottom-0 px-3 py-2 w-100 text-bg-danger">
-                                    <i class="fa fa-ban me-2"/>Unpublished
-                                </small>
-                            </t>
-                        </div>
-                    </header>
-                    
-                    <!-- Body -->
-                    <main t-attf-class="card-body position-relative d-flex flex-column justify-content-between gap-2 #{opt_events_list_columns and 'col-12 py-3' or 'col-8 col-lg-9 px-4'} #{not opt_events_list_cards and opt_events_list_columns and 'bg-transparent px-0'} #{not opt_events_list_cards and not opt_events_list_columns and 'bg-transparent py-0'}">
-                        <div id="event_details">
-                            <div class="d-flex flex-wrap gap-1 small">
-                                <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.website_id == website or not tag.category_id.website_id)" t-as="tag">
-                                    <span t-if="tag.color"
-                                        t-attf-class="badge #{'o_color_%s' % tag.color if tag.color else 'text-bg-light'}">
-                                        <t t-out="tag.name"/>
-                                    </span>
-                                </t>
-                            </div>
-                            <!-- Title -->
-                            <h5 t-attf-class="card-title my-2 #{(not event.website_published) and 'text-danger'}">
-                                <span t-field="event.name" itemprop="name"/>
-                            </h5>
-                            <!-- Start Date & Time -->
-                            <!-- TODO remove t-out one in master -->
-                            <small t-if="False" class="o_not_editable opacity-75" itemprop="description" t-out="event.subtitle">
-                            </small>
-                            <small class="opacity-75" itemprop="description" t-field="event.subtitle"/>
-                        </div>
-                        <!-- Location -->
-                        <small class="o_not_editable fw-bold" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city', 'country_id'], 'null_text': 'Online event'}"/>
-                    </main>
-                    
-                    <!-- Footer -->
-                    <footer t-if="not event.event_registrations_open and opt_events_list_columns and opt_events_list_cards"
-                        t-att-class="'small align-self-end w-100 %s %s' % (
-                            opt_events_list_cards and 'card-footer' or (not opt_events_list_columns and 'py-2 mt-2') or 'py-2',
-                            opt_events_list_cards and 'border-top' or 'px-2',
-                        )">
-                        <span t-if="not event.event_registrations_open">
-                            <t t-if="not event.event_registrations_started">
-                                Registrations not yet open
-                            </t>
-                            <t t-elif="event.event_registrations_sold_out">
-                                Sold Out
-                            </t>
-                            <t t-else="">
-                                Registrations Closed
-                            </t>
-                        </span>
-                    </footer>
-                </div>
-            </article>
-        </a>
-    </div>
+
+    <!-- Grid & List Layout -->
+    <t t-call="website_event.events_grid_layout"/>
+    <t t-call="website_event.events_list_layout"/>
+
     <!-- Pager -->
     <div class="d-flex justify-content-center my-3">
         <t t-call="website.pager"/>
     </div>
 </template>
 
+<template id="events_grid_layout" name="Events Grid Layout">
+    <div t-attf-class="o_wevent_event_grid_layout row mt-2 g-4 g-lg-3 g-xxl-4 #{layout_mode != 'grid' and 'd-none'}">
+        <div id="o_wevent_event_main_div" t-foreach="event_ids" t-as="event" t-attf-class="#{opt_index_sidebar and 'col-md-6' or 'col-md-6 col-lg-4 col-xl-3'}">
+            <a t-cache="event if not editable and event.website_published else None" t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset " t-att-data-publish="event.website_published and 'on' or 'off'">
+                <article t-attf-class="h-100 #{opt_events_list_cards and 'card'}" itemscope="itemscope" itemtype="http://schema.org/Event">
+                    <div id="o_wevent_event_article_div" class="h-100 d-flex flex-wrap flex-column">
+                        <header class="card-header overflow-hidden bg-secondary p-0 border-0 rounded-0 col-12">
+                            <!-- Image + Link -->
+                            <div class="d-block h-100 w-100">
+                                <t t-call="website.record_cover">
+                                    <t t-set="_record" t-value="event"/>
+                                    <meta itemprop="startDate" t-att-content="event.date_begin.isoformat()"/>
+                                    <!-- Short date + Country Flag -->
+                                    <div t-if="opt_events_event_location" t-attf-class="o_wevent_date_with_flag o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
+                                        <div class="o_wevent_event_date_text">
+                                            <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
+                                            <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
+                                        </div>
+                                        <div class="o_wevent_event_country_flag">
+                                            <img t-if="event.country_id and event.country_id.image_url" class="h-100 align-baseline" t-att-src="event.country_id.image_url" t-att-alt="event.country_id.name"/>
+                                            <i t-elif="not event.country_id" class="fa fa-video-camera h-100"/>
+                                        </div>
+                                    </div>
+                                    <!-- Short Date -->
+                                    <div t-else="" t-attf-class="o_wevent_event_date position-absolute shadow-sm o_not_editable #{(not opt_events_list_columns) and 'left'} ">
+                                        <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
+                                        <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
+                                    </div>
+                                    <!-- Not open -->
+                                    <span t-if="not event.event_registrations_open and not opt_events_list_cards" class="position-absolute bottom-0 px-3 py-2 w-100 text-bg-light">
+                                        <t t-call="website_event.event_registrations_state"/>
+                                    </span>
+                                    <!-- Participating -->
+                                    <small t-if="event.is_participating" class="o_wevent_participating position-absolute bottom-0 px-3 py-2 w-100 text-bg-success">
+                                        <i class="fa fa-check me-2"/>Registered
+                                    </small>
+                                    <!-- Unpublished -->
+                                    <small t-if="not event.website_published" class="o_wevent_unpublished position-absolute bottom-0 px-3 py-2 w-100 text-bg-danger">
+                                        <i class="fa fa-ban me-2"/>Unpublished
+                                    </small>
+                                </t>
+                            </div>
+                        </header>
+                        <main t-attf-class="card-body position-relative d-flex flex-column justify-content-between gap-2 col-12 py-3 #{not opt_events_list_cards and 'bg-transparent px-0'}">
+                            <div id="event_details">
+                                <!-- Tags -->
+                                <div class="d-flex flex-wrap gap-1 small">
+                                    <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.website_id == website or not tag.category_id.website_id)" t-as="tag">
+                                        <span t-if="tag.color"
+                                            t-attf-class="badge #{'o_color_%s' % tag.color if tag.color else 'text-bg-light'}">
+                                            <t t-out="tag.name"/>
+                                        </span>
+                                    </t>
+                                </div>
+                                <!-- Title -->
+                                <h5 t-attf-class="card-title my-2 #{(not event.website_published) and 'text-danger'}">
+                                    <span t-field="event.name" itemprop="name"/>
+                                </h5>
+                                <!-- Subtitle -->
+                                <small class="opacity-75" itemprop="description" t-field="event.subtitle"/>
+                            </div>
+                            <!-- Location -->
+                            <small class="o_not_editable fw-bold" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city', 'country_id'], 'null_text': 'Online event'}"/>
+                        </main>
+                        <footer t-if="not event.event_registrations_open and opt_events_list_cards" t-attf-class="small align-self-end w-100 card-footer border-top">
+                            <span t-if="not event.event_registrations_open">
+                                <t t-call="website_event.event_registrations_state"/>
+                            </span>
+                        </footer>
+                    </div>
+                </article>
+            </a>
+        </div>
+    </div>
+</template>
+
+<template id="events_list_layout" name="Events List Layout">
+    <div t-attf-class="o_wevent_event_list_layout #{not opt_events_list_cards and 'mt-2'} #{layout_mode != 'list' and 'd-none'}">
+        <div id="o_wevent_event_main_div" t-foreach="event_ids" t-as="event" t-attf-class="#{opt_events_list_cards and 'mt-3'}">
+            <a t-cache="event if not editable and event.website_published else None" t-attf-href="/event/#{ slug(event) }/#{(not event.menu_id) and 'register'}" class="text-decoration-none text-reset " t-att-data-publish="event.website_published and 'on' or 'off'">
+                <article t-attf-class="#{opt_events_list_cards and 'card'}" itemscope="itemscope" itemtype="http://schema.org/Event">
+                    <div id="o_wevent_event_article_div" class="h-100 row mx-0">
+                        <header class="p-0 w-auto">
+                            <meta itemprop="startDate" t-att-content="event.date_begin.isoformat()"/>
+                            <!-- Short date + Country Flag -->
+                            <div t-if="opt_events_event_location" class="o_wevent_date_with_flag o_wevent_event_date shadow-sm o_not_editable m-3">
+                                <div class="o_wevent_event_date_text">
+                                    <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
+                                    <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
+                                </div>
+                                <div class="o_wevent_event_country_flag">
+                                    <img t-if="event.country_id and event.country_id.image_url" class="h-100 align-baseline" t-att-src="event.country_id.image_url" t-att-alt="event.country_id.name"/>
+                                    <i t-elif="not event.country_id" class="fa fa-video-camera h-100"/>
+                                </div>
+                            </div>
+                            <!-- Short Date -->
+                            <div t-else="" class="o_wevent_event_date shadow-sm o_not_editable m-3">
+                                <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'LLL'}" class="o_wevent_event_month"/>
+                                <span t-out="event.date_begin" t-options="{'widget': 'datetime', 'tz_name': event.date_tz, 'format': 'dd'}" class="o_wevent_event_day oe_hide_on_date_edit"/>
+                            </div>
+                        </header>
+                        <main t-attf-class="card-body d-flex justify-content-between align-items-center col-8 col-lg-9 px-4 #{not opt_events_list_cards and 'bg-transparent py-0'}">
+                            <div>
+                                <!-- Title -->
+                                <h5 t-attf-class="card-title my-2 #{(not event.website_published) and 'text-danger'} #{(not event.event_registrations_open) and 'text-muted'}">
+                                    <span t-field="event.name" itemprop="name"/>
+                                </h5>
+                                <div class="d-inline-flex flex-wrap gap-3">
+                                    <!-- Location -->
+                                    <t t-set="has_city_or_country" t-value="event.address_id.sudo().city or event.address_id.sudo().country_id"/>
+                                    <div t-if="not event.address_id or has_city_or_country" class="d-flex align-items-center">
+                                        <i t-attf-class="fa fa-map-marker me-2 #{(not event.event_registrations_open) and 'text-muted'}" title="Location"/>
+                                        <small t-if="event.address_id" t-attf-class="o_not_editable fw-bold #{(not event.event_registrations_open) and 'text-muted'}" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
+                                        <small t-else="" t-attf-class="o_not_editable fw-bold #{(not event.event_registrations_open) and 'text-muted'}" itemprop="location">Online event</small>
+                                    </div>
+                                    <!-- Tags -->
+                                    <div class="d-flex flex-wrap gap-1 small">
+                                        <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.website_id == website or not tag.category_id.website_id)" t-as="tag">
+                                            <span t-if="tag.color"
+                                                t-attf-class="badge d-flex align-items-center #{'o_color_%s' % tag.color if tag.color else 'text-bg-light'}">
+                                                <t t-out="tag.name"/>
+                                            </span>
+                                        </t>
+                                    </div>
+                                </div>
+                            </div>
+                            <!-- Action Button -->
+                            <div t-attf-class="d-none #{opt_index_sidebar and 'd-xl-block' or 'd-lg-block'}">
+                                <div class="d-flex flex-column align-items-end gap-1">
+                                    <t t-if="not event.event_registrations_open">
+                                        <small class="text-muted fw-bold">
+                                            <t t-call="website_event.event_registrations_state"/>
+                                        </small>
+                                    </t>
+                                    <t t-if="event.event_registrations_open">
+                                        <button type="button" class="btn btn-primary">
+                                            Get Tickets <i class="fa fa-chevron-right"/>
+                                        </button>
+                                    </t>
+                                    <t t-else="">
+                                        <button type="button" class="btn btn-secondary">
+                                            Event Info <i class="fa fa-chevron-right"/>
+                                        </button>
+                                    </t>
+                                </div>
+                            </div>
+                        </main>
+                    </div>
+                </article>
+            </a>
+            <hr t-if="not opt_events_list_cards and event_index &lt; len(event_ids)-1" class="m-0 z-1 position-relative"/>
+        </div>
+    </div>
+</template>
+
 <template id="opt_events_list_columns" inherit_id="website_event.events_list" active="True" name="Layout • Columns"/>
+
+<template id="opt_events_list_rows" inherit_id="website_event.events_list" active="True" name="Layout • Rows"/>
 
 <template id="opt_events_list_cards" inherit_id="website_event.events_list" active="True" name="'Cards' Design"/>
 
-<template id="opt_events_list_categories" inherit_id="website_event.events_list" active="False" name="Show Templates">
+<template id="opt_events_list_categories" inherit_id="website_event.events_grid_layout" active="False" name="Show Templates">
     <xpath expr="//main/div[@id='event_details']" position="after">
-        <span t-if="event.event_type_id" t-attf-href="/event?type=#{event.event_type_id.id}" t-attf-class="badge text-bg-secondary o_wevent_badge #{opt_events_list_columns and 'o_wevent_badge_event' or 'position-absolute bottom-0 end-0 end-sm-0 start-sm-0'} #{not opt_events_list_columns and opt_events_list_cards and 'me-sm-3 mb-sm-3'}" t-field="event.event_type_id"/>
+        <span t-if="event.event_type_id" t-attf-href="/event?type=#{event.event_type_id.id}" class="badge text-bg-secondary o_wevent_badge o_wevent_badge_event" t-field="event.event_type_id"/>
     </xpath>
 </template>
 
@@ -497,10 +572,23 @@
     </xpath>
 </template>
 
+<template id="event_registrations_state" name="Event Registrations State">
+    <t t-if="not event.event_registrations_started and not event.event_registrations_sold_out">
+        Registrations not open
+    </t>
+    <t t-elif="event.event_registrations_sold_out">
+        Sold Out
+    </t>
+    <t t-else="">
+        Registrations Closed
+    </t>
+</template>
+
 <!-- Empty Placeholder used by website_event_track to show message on
     website_event_sale confirmation page without having to add a bridge module -->
 <template id="event_confirmation_end_page_hook">
     <div class="o_wevent_confirmation_end_page_hook"/>
 </template>
+
 
 </odoo>

--- a/addons/website_event/views/snippets/snippets.xml
+++ b/addons/website_event/views/snippets/snippets.xml
@@ -21,9 +21,10 @@
         <div data-selector="main:has(.o_wevent_events_list)" data-page-options="true" groups="website.group_website_designer" data-no-check="true" string="Events Page">
             <we-select string="Layout" data-no-preview="true" data-reload="/">
                 <we-button data-customize-website-views="website_event.opt_events_list_columns">Grid</we-button>
-                <we-button data-customize-website-views="">List</we-button>
+                <we-button data-customize-website-views="website_event.opt_events_list_rows">List</we-button>
+                <we-button data-customize-website-views="website_event.opt_events_list_columns, website_event.opt_events_list_rows">Grid &amp; List</we-button>
             </we-select>
-            <we-checkbox string="Card design"
+            <we-checkbox string="Card border"
                          data-customize-website-views="website_event.opt_events_list_cards"
                          data-no-preview="true"
                          data-reload="/"/>


### PR DESCRIPTION
[TASK-3869970](https://www.odoo.com/web#id=3869970&cids=1&menu_id=6478&action=4043&model=project.task&view_type=form)

This commit adds a switcher to the event list view to allow the user to switch between a list and a grid view of the events.
The switcher is only displayed if both grid and list views are enabled in the web editor.

Each time the user switches between the views, the preference is sent to the controller and saved in the session as a 'layout_mode' setting.
If no preference is set, the default view is the first view enabled of this list : grid, list.

This commit also changes the style and layout of the list view to make it more compact and simple.

As we want the switcher to be quick, it is not possible to reload the page when the user switches between the views.
Instead, we use some javascript to toggle or replace some CSS.

Note that as the grid and list view are really different, it was too complicated to switch views by using the same html elements.
I have decided to load both views in the DOM and to hide the one that is not displayed.
