### PR TITLE
[IMP] expression: Use field context on many2many _search

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -809,7 +809,7 @@ class expression(object):
                     # determine ids2 in comodel
                     ids2 = to_ids(right, comodel, leaf)
                     domain = HIERARCHY_FUNCS[operator]('id', ids2, comodel)
-                    ids2 = comodel._search(domain, order='id')
+                    ids2 = comodel.with_context(**field.context)._search(domain, order='id')
 
                     # rewrite condition in terms of ids2
                     if comodel == model:


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When a domain includes child_of or parent_of search on a many2many field, the comodel is searched and the leaf is replaced with an "in" search on the resulting ids.

Given:
[('other_model_ids', 'child_of', 1)]

"other_model" is searched for "child_of" 1. If the result is [1, 2, 3], the leaf is replaced with:
[('other_model_ids', 'in', [1, 2, 3])]

Inactive records of "other_model" is only included if active_test is disabled for the whole search, but this isn't (always) what you want.

Other places related models are searched with active_test forced to False - or context taken from the field definition. I suggest the last, since it's the minimal change.

Current behavior before PR:
Search depends on context from calling part.

Desired behavior after PR is merged:
Field definition can override active_test in context.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
