### PR TITLE
[FIX] web_editor: tooltip with wrong information shows up

### DIFF
--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -174,12 +174,15 @@
                                     t-att-name="snippet.displayName"
                                     t-att-data-oe-snippet-id="snippet.id"
                                     t-att-data-module-id="snippet.moduleId"
-                                    t-on-click="_onSnippetClick"
-                                    data-tooltip="This block cannot be dropped anywhere on this page.">
+                                    t-on-click="_onSnippetClick">
                                     <t t-if="snippet.disabled">
                                         <img src="/web_editor/static/src/img/snippet_disabled.svg" class="o_snippet_undroppable"/>
                                     </t>
-                                    <div class="oe_snippet_thumbnail" t-att-class="{ 'o_we_already_dragging': snippet.renaming }" t-att-data-snippet="snippet.baseBody.dataset.snippet">
+                                    <div class="oe_snippet_thumbnail"
+                                        t-att-class="{ 'o_we_already_dragging': snippet.renaming }"
+                                        t-att-data-snippet="snippet.baseBody.dataset.snippet"
+                                        t-att-style="snippet.disabled ? 'pointer-events: auto; cursor: not-allowed;' : false"
+                                        t-att-data-tooltip="snippet.disabled ? 'This block cannot be dropped anywhere on this page.' : false">
                                         <div class="oe_snippet_thumbnail_img" t-attf-style="background-image: url({{snippet.thumbnailSrc}});"/>
                                         <t t-if="snippet.isCustom and snippet.renaming">
                                             <we-input class="o_we_user_value_widget w-100 mx-1">


### PR DESCRIPTION
**Current behaviour before commit:**

- Hovering on any block of snippet options pannel shows up a tooltip with text 'This block cannot be dropped anywhere
 on this page' which is not true. The block can be dropped anywhere. This happens because of this commit [1]. 

- However, the popover should be shown only when the snippet  cannot be dropped anywhere. This situation occurs when a 
 user has no editing rights. This can be reproduced like this:

1. Login as admin and edit demo user, only give him the restricted editor right, remove everything else (alternatively switch the user from internal to public user to remove all rights then back from public to internal user, this field is only in debug mode).
2. Now login as demo user.
3. Go to website home page.
4. Enter edit mode.
5. All snippets are disabled, because you don't have access rights to edit.

- Right now, when we try to show tooltip on this particular condition it doesn't work because the block element contains
 `'o_disabled'` class which applies a CSS rule `'pointer-events: none'` that prevents to show tooltip.

**Desired behaviour after commit:**

The tooltip should be shown only when block is disabled.

[1]: https://github.com/odoo/odoo/commit/91293fe4a8125f65cd7e5f487aacbc62c35c0f74

task-3875067




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
