### PR TITLE
[FIX] pos_sale: correctly compute untaxed amount invoiced

### DIFF
--- a/addons/pos_sale/models/sale_order.py
+++ b/addons/pos_sale/models/sale_order.py
@@ -99,3 +99,9 @@ class SaleOrderLine(models.Model):
         # do not delete downpayment lines created from pos
         pos_downpayment_lines = self.filtered(lambda line: line.is_downpayment and line.sudo().pos_order_line_ids)
         return super(SaleOrderLine, self - pos_downpayment_lines).unlink()
+
+    @api.depends('pos_order_line_ids')
+    def _compute_untaxed_amount_invoiced(self):
+        super()._compute_untaxed_amount_invoiced()
+        for line in self:
+            line.untaxed_amount_invoiced += sum(line.pos_order_line_ids.mapped('price_subtotal'))

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -5,6 +5,7 @@ import odoo
 
 from odoo.addons.point_of_sale.tests.test_frontend import TestPointOfSaleHttpCommon
 from odoo.tests.common import Form
+from odoo import fields
 
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPoSSale(TestPointOfSaleHttpCommon):
@@ -334,3 +335,83 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
 
         self.main_pos_config.open_session_cb()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'PosSettleOrderWithNote', login="accountman")
+
+    def test_untaxed_invoiced_amount(self):
+        """Make sure that orders invoiced in the pos gets their untaxed invoiced
+           amount updated accordingly"""
+
+        product_a = self.env['product.product'].create({
+            'name': 'Product A',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 10.0,
+            'taxes_id': [],
+        })
+
+        product_b = self.env['product.product'].create({
+            'name': 'Product B',
+            'available_in_pos': True,
+            'type': 'product',
+            'lst_price': 5.0,
+            'taxes_id': [],
+        })
+
+        partner_test = self.env['res.partner'].create({'name': 'Test Partner'})
+
+        sale_order = self.env['sale.order'].create({
+            'partner_id': partner_test.id,
+            'order_line': [(0, 0, {
+                'product_id': product_a.id,
+                'name': product_a.name,
+                'product_uom_qty': 1,
+                'product_uom': product_a.uom_id.id,
+                'price_unit': product_a.lst_price,
+            }),(0, 0, {
+                'product_id': product_b.id,
+                'name': product_b.name,
+                'product_uom_qty': 1,
+                'product_uom': product_b.uom_id.id,
+                'price_unit': product_b.lst_price,
+            })],
+        })
+        sale_order.action_confirm()
+        self.main_pos_config.open_session_cb()
+        current_session = self.main_pos_config.current_session_id
+
+        pos_order = {'data':
+          {'amount_paid': 10,
+           'amount_return': 0,
+           'amount_tax': 0,
+           'amount_total': 10,
+           'creation_date': fields.Datetime.to_string(fields.Datetime.now()),
+           'fiscal_position_id': False,
+           'to_invoice': True,
+           'partner_id': partner_test.id,
+           'pricelist_id': self.main_pos_config.available_pricelist_ids[0].id,
+           'lines': [[0,
+             0,
+             {'discount': 0,
+              'pack_lot_ids': [],
+              'price_unit': 10,
+              'product_id': product_a.id,
+              'price_subtotal': 10,
+              'price_subtotal_incl': 10,
+              'sale_order_line_id': sale_order.order_line[0],
+              'sale_order_origin_id': sale_order,
+              'qty': 1,
+              'tax_ids': []}]],
+           'name': 'Order 00044-003-0014',
+           'pos_session_id': current_session.id,
+           'sequence_number': self.main_pos_config.journal_id.id,
+           'statement_ids': [[0,
+             0,
+             {'amount': 10,
+              'name': fields.Datetime.now(),
+              'payment_method_id': self.main_pos_config.payment_method_ids[0].id}]],
+           'uid': '00044-003-0014',
+           'user_id': self.env.uid},
+            }
+
+        self.env['pos.order'].create_from_ui([pos_order])
+        self.assertEqual(sale_order.order_line[0].untaxed_amount_invoiced, 10, "Untaxed invoiced amount should be 10")
+        self.assertEqual(sale_order.order_line[1].untaxed_amount_invoiced, 0, "Untaxed invoiced amount should be 0")


### PR DESCRIPTION
Current behavior:
When settling and invoicing a sale order in the PoS, the untaxed 
invoiced amount was not taking the pos order lines into account

Steps to reproduce:
- Create a sale order
- Open a PoS and settle the sale order
- Validate it
- Go back to the original sale order and check the Untaxed Invoiced 
  Amount. 
  (The field might not be present in the form, you can add it with 
  studio)

opw-3798523
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
