### PR TITLE
[IMP] website, *: restore delay translation

### DIFF
--- a/addons/html_builder/static/src/core/save_plugin.js
+++ b/addons/html_builder/static/src/core/save_plugin.js
@@ -130,9 +130,7 @@ export class SavePlugin extends Plugin {
             return;
         }
 
-        // TODO: Restore the delay translation feature once it's fixed, see
-        // commit msg for more info.
-        const delay = delayTranslations ? { delay_translations: false } : {};
+        const delay = delayTranslations ? { delay_translations: true } : {};
         const context = {
             website_id: this.services.website.currentWebsite.id,
             lang: this.services.website.currentWebsite.metadata.lang,

--- a/addons/test_website/static/tests/tours/translation.js
+++ b/addons/test_website/static/tests/tours/translation.js
@@ -1,0 +1,499 @@
+import {
+    clickOnEditAndWaitEditMode,
+    clickOnSave,
+    insertSnippet,
+    registerWebsitePreviewTour,
+} from "@website/js/tours/tour_utils";
+import { stepUtils } from "@web_tour/tour_utils";
+import { translationIsReady } from "@web/core/l10n/translation";
+
+function createNewPage() {
+    return [
+        {
+            content: "Open +New content",
+            trigger: ".o_menu_systray .o_menu_systray_item.o_new_content_container button",
+            run: "click",
+        },
+        {
+            content: "Create a New page",
+            trigger: `button.o_new_content_element img[src="/website/static/description/icon.png"]`,
+            run: "click",
+        },
+        {
+            content: "Select Blank page",
+            trigger: ".o_page_template:has(div.text-muted) .o_button_area:not(:visible)",
+            run: "click",
+        },
+        {
+            content: "Page name",
+            trigger: ".modal-dialog .o_website_dialog input",
+            run: "edit Test",
+        },
+        {
+            content: "Confirm creation",
+            trigger: ".modal-dialog .o_website_dialog .btn-primary",
+            run: "click",
+        },
+        {
+            trigger: ".o_builder_sidebar_open",
+            timeout: 20000,
+        },
+        ...insertSnippet({
+            id: "s_banner",
+            name: "Banner",
+            groupName: "Intro",
+        }),
+        {
+            content: "Click on the link",
+            trigger: ":iframe main section.s_banner a",
+            async run(helpers) {
+                await helpers.click();
+                const el = this.anchor;
+                const sel = el.ownerDocument.getSelection();
+                sel.collapse(el, 0);
+                el.focus();
+            },
+        },
+        {
+            content: "Click on Edit link",
+            trigger: ".o_we_edit_link",
+            run: "click",
+        },
+        {
+            content: "Replace URL",
+            trigger: ".o-we-linkpopover .o_we_href_input_link",
+            run: "edit /test_view",
+        },
+        {
+            content: "Apply",
+            trigger: ".o-we-linkpopover .btn-primary",
+            run: "click",
+        },
+        ...clickOnSave("bottom", 50000, false),
+    ];
+}
+
+function openHtmlEditor() {
+    return [
+        {
+            content: "Open Site menu",
+            trigger: ".o_menu_sections [data-menu-xmlid='website.menu_site']",
+            run: "click",
+        },
+        {
+            content: "Open HTML editor",
+            trigger: ".o-overlay-item .dropdown-item[data-menu-xmlid='website.menu_ace_editor']",
+            run: "click",
+        },
+        {
+            content: "Edit anyway",
+            trigger: ".o_resource_editor_wrapper [role='alert'] button.btn-link",
+            run: "click",
+        },
+    ];
+}
+
+function saveHtmlEditor() {
+    return [
+        {
+            content: "Save the html editor",
+            trigger: ".o_resource_editor button.btn-primary",
+            run: "click",
+        },
+        {
+            content: "Close the html editor",
+            trigger: ".o_resource_editor button.btn-secondary",
+            run: "click",
+        },
+    ];
+}
+
+function singleLanguage() {
+    return [
+        {
+            content: "Ensure single language site",
+            trigger: ":iframe body:not(:has(.js_language_selector))",
+        },
+        // new page
+        ...createNewPage(),
+        ...openHtmlEditor(),
+        {
+            content: "Change text",
+            trigger: 'div.ace_line .ace_xml:contains("oe_structure")',
+            run() {
+                window.ace.edit(document.querySelector("#resource-editor div"))
+                    .getSession()
+                    .insert({row: 8, column: 1}, '<p>More text</p>\n');
+            },
+        },
+        ...saveHtmlEditor(),
+        {
+            content: "Ensure page is updated",
+            trigger: ":iframe body:contains(More text)",
+        },
+        // xml record
+        {
+            content: "Go to test_view page",
+            trigger: ":iframe main section.s_banner a",
+            run: "click",
+        },
+        {
+            content: "Wait until page is reached",
+            trigger: ":iframe body:contains(Test View)",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Edit template text",
+            trigger: ":iframe main p.o_editable[data-oe-field='arch'][contenteditable='true']",
+            run: "editor Modified Text",
+        },
+        ...clickOnSave("bottom", 50000, false),
+        ...openHtmlEditor(),
+        {
+            content: "Change text",
+            trigger: 'div.ace_line .ace_xml:contains("test_website.test_view")',
+            run() {
+                window.ace.edit(document.querySelector("#resource-editor div"))
+                   .getSession()
+                   .insert({row: 2, column: 36}, 'Further ');
+            },
+        },
+        ...saveHtmlEditor(),
+        {
+            content: "Ensure view is updated",
+            trigger: ":iframe body:contains(Further Modified Text)",
+        },
+    ];
+}
+
+const ensureFrUser = {
+    content: "Ensure FR user",
+    trigger: ".o_website_systray:contains(Publié)",
+};
+
+const ensureEnUser = {
+    content: "Ensure EN user",
+    trigger: ".o_website_systray:contains(Published)",
+};
+
+const ensureFrSite = {
+    content: "Ensure FR site",
+    trigger: ":iframe .o_main_nav:contains(Accueil)",
+};
+
+const ensureEnSite = {
+    content: "Ensure EN site",
+    trigger: ":iframe .o_main_nav:contains(Home)",
+};
+
+registerWebsitePreviewTour(
+    "translation_single_language_fr_user_fr_site",
+    {
+        url: "/",
+    },
+    () => [
+        ensureFrUser,
+        ensureFrSite,
+        ...singleLanguage(),
+    ]
+);
+
+registerWebsitePreviewTour(
+    "translation_single_language_en_user_fr_site",
+    {
+        url: "/",
+    },
+    () => [
+        ensureEnUser,
+        ensureFrSite,
+        ...singleLanguage(),
+    ]
+);
+
+registerWebsitePreviewTour(
+    "translation_single_language_fr_user_en_site",
+    {
+        url: "/",
+    },
+    () => [
+        ensureFrUser,
+        ensureEnSite,
+        ...singleLanguage(),
+    ]
+);
+
+function switchLanguage(lang, timeout = 50000) {
+    return [
+        {
+            content: "Ensure was in other language",
+            trigger: `:iframe .o_header_language_selector:contains(${lang !== "fr" ? "Français" : "English"})`,
+            timeout,
+        }, {
+            content: "Open language dropdown",
+            trigger: ":iframe .o_header_language_selector .dropdown-toggle",
+            run: "click",
+        }, {
+            content: "Select language",
+            trigger: `:iframe .o_header_language_selector .js_change_lang[data-url_code=${lang}]`,
+            run: "click",
+        }, {
+            content: "Wait until target page is loaded",
+            trigger: `:iframe .o_header_language_selector:contains(${lang === "fr" ? "Français" : "English"})`,
+            timeout,
+        }
+    ];
+}
+
+// TODO Such a step should not be needed, but test randomly fails without it.
+const awaitTranslationIsReady = {
+    content: "Await translationIsReady",
+    trigger: "body",
+    run: async () => {
+        await translationIsReady;
+    },
+};
+
+function openTranslate(timeout = 50000) {
+    return [
+        stepUtils.waitIframeIsReady(),
+        awaitTranslationIsReady,
+        {
+            content: "Open edit dropdown",
+            trigger: ".o_edit_website_container button",
+            run: "click",
+        }, {
+            content: "Enter translate mode",
+            trigger: ".o_translate_website_dropdown_item",
+            run: "click",
+        }, {
+            content: "Effect's 200ms setTimeout passed",
+            trigger: ".o_builder_open .o_main_navbar.d-none:not(:visible)",
+        }, {
+            content: "Translatable text became highlighted",
+            trigger: ":iframe [data-oe-translation-state=to_translate]",
+            timeout,
+        }, {
+            content: "Confirm popup",
+            trigger: ".o_website_dialog .btn-secondary",
+            run: "click",
+        }
+    ];
+}
+
+function saveTranslation(timeout = 50000) {
+    return [
+        {
+            content: "Save translation",
+            trigger: ".o-website-builder_sidebar button[data-action=save]",
+            run: "click",
+        }, {
+            content: "Back to preview mode",
+            trigger: ".o_edit_website_container button",
+            timeout,
+        }, {
+            trigger: "body:not(.o_builder_open)",
+            noPrepend: true,
+            timeout,
+        },
+        stepUtils.waitIframeIsReady(),
+        awaitTranslationIsReady,
+    ];
+}
+
+function multiLanguage(mainLanguage, secondLanguage) {
+    return [
+        {
+            content: "Ensure multi language site",
+            trigger: ":iframe body:has(.js_language_selector)",
+        },
+        // new page
+        ...createNewPage(),
+        ...switchLanguage(secondLanguage),
+        ...openTranslate(),
+        {
+            content: "Translate some text",
+            trigger: ":iframe h1 [data-oe-translation-state=to_translate]",
+            run: "editor Some translated text",
+        },
+        ...saveTranslation(),
+        {
+            content: "Check translation is displayed",
+            trigger: ":iframe h1:contains(Some translated text)",
+        },
+        ...openHtmlEditor(),
+        {
+            content: "Change text",
+            trigger: 'div.ace_line .ace_xml:contains("oe_structure")',
+            run() {
+                window.ace.edit(document.querySelector("#resource-editor div"))
+                    .getSession()
+                    .insert({row: 6, column: 50}, "more text ");
+            },
+        },
+        {
+            content: "Pollute old DOM to detect reload",
+            trigger: ":iframe body",
+            run() {
+                this.anchor.dataset.reloaded = false;
+            },
+        },
+        ...saveHtmlEditor(),
+        {
+            content: "Ensure page is NOT updated",
+            trigger: ":iframe body:not([data-reloaded=false]) h1:not(:contains(more text))",
+        },
+        ...switchLanguage(mainLanguage),
+        {
+            content: "Ensure French page IS updated",
+            trigger: ":iframe h1:contains(more text)",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Change text again",
+            trigger: ":iframe h1",
+            run: "editor Yet another version of the text.",
+        },
+        ...clickOnSave("bottom", 50000, false),
+        ...switchLanguage(secondLanguage),
+        {
+            content: "Ensure English page is NOT updated",
+            trigger: ":iframe h1:not(:contains(Yet another))",
+        },
+        ...openTranslate(),
+        {
+            content: "Ensure English page is updated",
+            trigger: ":iframe h1:contains(Yet another)",
+        },
+        {
+            content: "Translate again",
+            trigger: ":iframe h1 [data-oe-translation-state=to_translate]",
+            run: "editor Yet another translated text",
+        },
+        ...saveTranslation(),
+        {
+            content: "Check translation is displayed",
+            trigger: ":iframe h1:contains(Yet another translated text)",
+        },
+        // xml record
+        {
+            content: "Go to test_view page",
+            trigger: ":iframe main section.s_banner a",
+            run: "click",
+        },
+        {
+            content: "Wait until page is reached",
+            trigger: ":iframe body:contains(Test View)",
+        },
+        ...switchLanguage(mainLanguage),
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Edit template text",
+            trigger: ":iframe main p.o_editable[contenteditable='true']",
+            run: "editor Modified View",
+        },
+        ...clickOnSave("bottom", 50000, false),
+        ...switchLanguage(secondLanguage),
+        ...openTranslate(),
+        {
+            content: "Translate test view",
+            trigger: ":iframe main > p > span[data-oe-translation-state=to_translate]",
+            run: "editor Some translated view",
+        },
+        ...saveTranslation(),
+        {
+            content: "Check translation is displayed",
+            trigger: ":iframe p:contains(Some translated view)",
+        },
+        ...switchLanguage(mainLanguage),
+        ...openHtmlEditor(),
+        {
+            content: "Change text",
+            trigger: 'div.ace_line .ace_xml:contains("test_website.test_view")',
+            run() {
+                window.ace.edit(document.querySelector("#resource-editor div"))
+                   .getSession()
+                   .insert({row: 2, column: 36}, 'Further ');
+            },
+        },
+        ...saveHtmlEditor(),
+        {
+            content: "Ensure view is updated",
+            trigger: ":iframe body:contains(Further Modified View)",
+        },
+        ...clickOnEditAndWaitEditMode(),
+        {
+            content: "Edit template text",
+            trigger: ":iframe main p.o_editable[data-oe-field='arch'][contenteditable='true']",
+            run: "editor Even more modified Text",
+        },
+        ...clickOnSave("bottom", 50000, false),
+        ...switchLanguage(secondLanguage),
+        {
+            content: "Check old translation is displayed",
+            trigger: ":iframe p:contains(Some translated view)",
+        },
+        ...openTranslate(),
+        {
+            content: "Check new original is displayed",
+            trigger: ":iframe p:contains(Even more modified text)",
+        },
+        {
+            content: "Translate test view",
+            trigger: ":iframe main > p > span[data-oe-translation-state=to_translate]",
+            run: "editor Even more translated text",
+        },
+        ...saveTranslation(),
+        {
+            content: "Check new translation is displayed",
+            trigger: ":iframe p:contains(Even more translated text)",
+        },
+    ];
+}
+
+registerWebsitePreviewTour(
+    "translation_multi_language_fr_user_fr_en_site",
+    {
+        url: "/fr",
+    },
+    () => [
+        ensureFrUser,
+        ensureFrSite,
+        ...multiLanguage("fr", "en"),
+    ]
+);
+
+registerWebsitePreviewTour(
+    "translation_multi_language_fr_user_en_fr_site",
+    {
+        url: "/en",
+    },
+    () => [
+        ensureFrUser,
+        ensureEnSite,
+        ...multiLanguage("en", "fr"),
+    ]
+);
+
+registerWebsitePreviewTour(
+    "translation_multi_language_en_user_fr_en_site",
+    {
+        url: "/fr",
+    },
+    () => [
+        ensureEnUser,
+        ensureFrSite,
+        ...multiLanguage("fr", "en"),
+    ]
+);
+
+registerWebsitePreviewTour(
+    "translation_multi_language_en_user_en_fr_site",
+    {
+        url: "/en",
+    },
+    () => [
+        ensureEnUser,
+        ensureEnSite,
+        ...multiLanguage("en", "fr"),
+    ]
+);

--- a/addons/test_website/tests/__init__.py
+++ b/addons/test_website/tests/__init__.py
@@ -22,6 +22,7 @@ from . import test_session
 from . import test_settings
 from . import test_snippet_background_video
 from . import test_systray
+from . import test_translation
 from . import test_views_during_module_operation
 from . import test_website_controller_page
 from . import test_website_page_properties

--- a/addons/test_website/tests/test_translation.py
+++ b/addons/test_website/tests/test_translation.py
@@ -1,0 +1,129 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import Command
+from odoo.tests import HttpCase, tagged
+
+
+@tagged('post_install', '-at_install', 'is_tour')
+class TestTranslation(HttpCase):
+
+    def _single_language_fr_user_fr_site(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_single_language_fr_user_fr_site', login='admin')
+
+    def _single_language_en_user_fr_site(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_single_language_en_user_fr_site', login='admin')
+
+    def _single_language_fr_user_en_site(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_single_language_fr_user_en_site', login='admin')
+
+    def _multi_language_fr_user_fr_en_site(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_multi_language_fr_user_fr_en_site', login='admin', timeout=250)
+
+    def _multi_language_fr_user_en_fr_site(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_multi_language_fr_user_en_fr_site', login='admin', timeout=250)
+
+    def _multi_language_en_user_fr_en_site(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_multi_language_en_user_fr_en_site', login='admin', timeout=250)
+
+    def _multi_language_en_user_en_fr_site(self):
+        self.start_tour(self.env['website'].get_client_action_url('/'), 'translation_multi_language_en_user_en_fr_site', login='admin', timeout=250)
+
+    def _fr_db(self):
+        self._fr_en_db()
+        lang_en = self.env.ref('base.lang_en')
+        lang_en.active = False
+
+    def _fr_en_db(self):
+        lang_en = self.env.ref('base.lang_en')
+        lang_fr = self.env.ref('base.lang_fr')
+        self.env["base.language.install"].create({
+            'overwrite': True,
+            'lang_ids': [(6, 0, [lang_fr.id])],
+        }).lang_install()
+        for website in self.env['website'].search([]):
+            website.language_ids += lang_fr
+            website.default_lang_id = lang_fr
+            website.language_ids -= lang_en
+        self.env['website'].create({
+            'sequence': 1,
+            'name': 'Test FR Website',
+            'language_ids': [
+                Command.link(lang_fr.id),
+            ],
+            'default_lang_id': lang_fr.id,
+        })
+
+        for user in self.env['res.users'].search([]):
+            user.lang = lang_fr.code
+        for partner in self.env['res.partner'].search([]):
+            partner.lang = lang_fr.code
+        for user in self.env['res.users'].with_context(active_test=False).search([]):
+            user.lang = lang_fr.code
+
+    def _en_fr_db(self):
+        lang_fr = self.env.ref('base.lang_fr')
+        self.env["base.language.install"].create({
+            'overwrite': True,
+            'lang_ids': [(6, 0, [lang_fr.id])],
+        }).lang_install()
+
+    def test_fr_db_fr_site(self):
+        self._fr_db()
+        self._single_language_fr_user_fr_site()
+
+    def test_fr_en_db_fr_site(self):
+        self._fr_en_db()
+        self._single_language_fr_user_fr_site()
+
+    def test_fr_en_db_en_site(self):
+        self._fr_en_db()
+        lang_en = self.env.ref('base.lang_en')
+        lang_fr = self.env.ref('base.lang_fr')
+        for website in self.env['website'].search([]):
+            website.language_ids += lang_en
+            website.default_lang_id = lang_en
+            website.language_ids -= lang_fr
+        self._single_language_fr_user_en_site()
+
+    def test_fr_en_db_fr_en_site(self):
+        self._fr_en_db()
+        lang_en = self.env.ref('base.lang_en')
+        for website in self.env['website'].search([]):
+            website.language_ids += lang_en
+        self._multi_language_fr_user_fr_en_site()
+
+    def test_fr_en_db_en_fr_site(self):
+        self._fr_en_db()
+        lang_en = self.env.ref('base.lang_en')
+        for website in self.env['website'].search([]):
+            website.language_ids += lang_en
+            website.default_lang_id = lang_en
+        self._multi_language_fr_user_en_fr_site()
+
+    def test_en_fr_db_fr_site(self):
+        self._en_fr_db()
+        lang_en = self.env.ref('base.lang_en')
+        lang_fr = self.env.ref('base.lang_fr')
+        self.env["base.language.install"].create({
+            'overwrite': True,
+            'lang_ids': [(6, 0, [lang_fr.id])],
+        }).lang_install()
+        for website in self.env['website'].search([]):
+            website.language_ids += lang_fr
+            website.default_lang_id = lang_fr
+            website.language_ids -= lang_en
+        self._single_language_en_user_fr_site()
+
+    def test_en_fr_db_fr_en_site(self):
+        self._en_fr_db()
+        lang_fr = self.env.ref('base.lang_fr')
+        for website in self.env['website'].search([]):
+            website.language_ids += lang_fr
+            website.default_lang_id = lang_fr
+        self._multi_language_en_user_fr_en_site()
+
+    def test_en_fr_db_en_fr_site(self):
+        self._en_fr_db()
+        lang_fr = self.env.ref('base.lang_fr')
+        for website in self.env['website'].search([]):
+            website.language_ids += lang_fr
+        self._multi_language_en_user_en_fr_site()

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -766,7 +766,10 @@ class Website(Home):
 
     @http.route('/website/save_xml', type='jsonrpc', auth='user', website=True)
     def save_xml(self, view_id, arch):
-        request.env['ir.ui.view'].browse(view_id).with_context(lang=request.website.default_lang_id.code).arch = arch
+        request.env['ir.ui.view'].browse(view_id).with_context(
+            lang=request.website.default_lang_id.code,
+            delay_translations=True,
+        ).arch = arch
 
     @http.route("/website/get_switchable_related_views", type="jsonrpc", auth="user", website=True, readonly=True)
     def get_switchable_related_views(self, key):

--- a/addons/website/static/src/components/resource_editor/resource_editor.js
+++ b/addons/website/static/src/components/resource_editor/resource_editor.js
@@ -408,6 +408,10 @@ export class ResourceEditor extends Component {
     }
 
     showErrorLine() {
+        if (!this.editorRef.el) {
+            // Possibly destroyed.
+            return;
+        }
         const resourceId = this.state.currentResource.id;
         const error = this.errors.find(({ resource }) => resource.id === resourceId)?.error;
         if (error) {
@@ -422,6 +426,10 @@ export class ResourceEditor extends Component {
     }
 
     clearErrorLine() {
+        if (!this.editorRef.el) {
+            // Possibly destroyed.
+            return;
+        }
         const allGutterCells = this.editorRef.el.querySelectorAll(".ace_gutter-cell");
         for (const gutterCell of allGutterCells) {
             gutterCell.classList.remove("o_error");

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -293,7 +293,7 @@ export function clickOnSnippet(snippet, position = "bottom") {
     ];
 }
 
-export function clickOnSave(position = "bottom", timeout = 50000) {
+export function clickOnSave(position = "bottom", timeout = 50000, withContains = true) {
     return [
         {
             trigger: ".o-snippets-menu:not(:has(.o_we_ongoing_insertion))",
@@ -303,7 +303,7 @@ export function clickOnSave(position = "bottom", timeout = 50000) {
             noPrepend: true,
         },
         {
-            trigger: "button[data-action=save]:enabled:contains(save)",
+            trigger: withContains ? "button[data-action=save]:enabled:contains(save)" : "button[data-action=save]:enabled",
         content: markup(_t("Good job! It's time to <b>Save</b> your work.")),
             tooltipPosition: position,
             run: "click",

--- a/addons/website/static/src/js/tours/tour_utils.js
+++ b/addons/website/static/src/js/tours/tour_utils.js
@@ -240,7 +240,7 @@ export function clickOnElement(elementName, selector) {
 export function clickOnEditAndWaitEditMode(position = "bottom") {
     return [{
         content: markup(_t("<b>Click Edit</b> to start designing your homepage.")),
-        trigger: "body .o_menu_systray button:contains('Edit')",
+        trigger: "body .o_menu_systray .o_menu_systray_item.o_edit_website_container button",
         tooltipPosition: position,
         run: "click",
     }, {

--- a/addons/website/static/tests/tours/translate_menu_name.js
+++ b/addons/website/static/tests/tours/translate_menu_name.js
@@ -3,6 +3,8 @@ import {
     clickOnSave,
     registerWebsitePreviewTour,
 } from '@website/js/tours/tour_utils';
+import { stepUtils } from "@web_tour/tour_utils";
+import { translationIsReady } from "@web/core/l10n/translation";
 
 registerWebsitePreviewTour('translate_menu_name', {
     url: '/pa_GB',
@@ -30,4 +32,19 @@ registerWebsitePreviewTour('translate_menu_name', {
         run: "editor value pa-GB",
     },
     ...clickOnSave(),
+    {
+        content: "Back to preview mode",
+        trigger: ".o_edit_website_container button",
+    }, {
+        trigger: "body:not(.o_builder_open)",
+        noPrepend: true,
+    },
+    stepUtils.waitIframeIsReady(),
+    {
+        content: "Await translationIsReady",
+        trigger: "body",
+        run: async () => {
+            await translationIsReady;
+        },
+    },
 ]);


### PR DESCRIPTION
The delayed translation mechanism was disabled by [1].
This commit restores it and also adds a visual feedback to inform the
user that some texts have to be translated.

[1]: https://github.com/odoo/odoo/commit/0e0a74f8c5fc9f45311e629a76608c6c986d635d

task-3621753