### PR TITLE
[IMP] account, account_payment: overdue invoices

### DIFF
--- a/addons/account/controllers/portal.py
+++ b/addons/account/controllers/portal.py
@@ -3,7 +3,7 @@
 
 from collections import OrderedDict
 
-from odoo import http, _
+from odoo import fields, http, _
 from odoo.osv import expression
 from odoo.addons.portal.controllers.portal import CustomerPortal, pager as portal_pager
 from odoo.addons.account.controllers.download_docs import _get_headers, _build_zip_from_data
@@ -15,6 +15,8 @@ class PortalAccount(CustomerPortal):
 
     def _prepare_home_portal_values(self, counters):
         values = super()._prepare_home_portal_values(counters)
+        if 'overdue_invoice_count' in counters:
+            values['overdue_invoice_count'] = self._get_overdue_invoice_count()
         if 'invoice_count' in counters:
             invoice_count = request.env['account.move'].search_count(self._get_invoices_domain('out'), limit=1) \
                 if request.env['account.move'].check_access_rights('read', raise_exception=False) else 0
@@ -28,6 +30,11 @@ class PortalAccount(CustomerPortal):
     # ------------------------------------------------------------
     # My Invoices
     # ------------------------------------------------------------
+
+    def _get_overdue_invoice_count(self):
+        overdue_invoice_count = request.env['account.move'].search_count(self._get_overdue_invoices_domain()) \
+            if request.env['account.move'].check_access_rights('read', raise_exception=False) else 0
+        return overdue_invoice_count
 
     def _invoice_get_page_view_values(self, invoice, access_token, **kwargs):
         values = {
@@ -43,6 +50,15 @@ class PortalAccount(CustomerPortal):
             move_type = ('out_invoice', 'out_refund', 'in_invoice', 'in_refund', 'out_receipt', 'in_receipt')
         return [('state', 'not in', ('cancel', 'draft')), ('move_type', 'in', move_type)]
 
+    def _get_overdue_invoices_domain(self, partner_id=None):
+        return [
+            ('state', 'not in', ('cancel', 'draft')),
+            ('move_type', 'in', ('out_invoice', 'out_receipt')),
+            ('payment_state', 'not in', ('in_payment', 'paid')),
+            ('invoice_date_due', '<', fields.Date.today()),
+            ('partner_id', '=', partner_id or request.env.user.partner_id.id),
+        ]
+
     def _get_account_searchbar_sortings(self):
         return {
             'date': {'label': _('Date'), 'order': 'invoice_date desc'},
@@ -54,6 +70,7 @@ class PortalAccount(CustomerPortal):
     def _get_account_searchbar_filters(self):
         return {
             'all': {'label': _('All'), 'domain': []},
+            'overdue_invoices': {'label': _('Overdue invoices'), 'domain': self._get_overdue_invoices_domain()},
             'invoices': {'label': _('Invoices'), 'domain': [('move_type', 'in', ('out_invoice', 'out_refund', 'out_receipt'))]},
             'bills': {'label': _('Bills'), 'domain': [('move_type', 'in', ('in_invoice', 'in_refund', 'in_receipt'))]},
         }
@@ -126,6 +143,7 @@ class PortalAccount(CustomerPortal):
             'sortby': sortby,
             'searchbar_filters': OrderedDict(sorted(searchbar_filters.items())),
             'filterby': filterby,
+            'overdue_invoice_count': self._get_overdue_invoice_count(),
         })
         return values
 

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
-from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from dateutil.relativedelta import relativedelta
+
+from odoo import fields, Command
 from odoo.exceptions import UserError
 from odoo.tests import tagged, Form
-from odoo import fields, Command
+from odoo.tests.common import Like
 
-from dateutil.relativedelta import relativedelta
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 
 
 @tagged('post_install', '-at_install')
@@ -13,6 +15,8 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
+
+        cls.current_year = fields.Date.today().year
 
         cls.other_currency = cls.setup_other_currency('EUR')
         cls.other_currency_2 = cls.setup_other_currency('CAD', rates=[('2016-01-01', 3.0), ('2017-01-01', 0.01)])
@@ -174,7 +178,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'INV/2017/00001 INV/2017/00002',
+            'ref': Like(f'BATCH/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -208,7 +212,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'INV/2017/00001 INV/2017/00002',
+            'ref': Like(f'BATCH/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -243,7 +247,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'INV/2017/00001 INV/2017/00002',
+            'ref': Like(f'BATCH/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -286,7 +290,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'INV/2017/00001 INV/2017/00002',
+            'ref': Like(f'BATCH/{self.current_year}/...'),
             'payment_method_line_id': self.inbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -329,7 +333,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'BILL/2017/01/0001 BILL/2017/01/0002',
+            'ref': Like(f'BATCH/{self.current_year}/...'),
             'payment_method_line_id': self.outbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -372,7 +376,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
         })._create_payments()
 
         self.assertRecordValues(payments, [{
-            'ref': 'BILL/2017/01/0001 BILL/2017/01/0002',
+            'ref': Like(f'BATCH/{self.current_year}/...'),
             'payment_method_line_id': self.outbound_payment_method_line.id,
         }])
         self.assertRecordValues(payments.line_ids.sorted('balance'), [
@@ -529,7 +533,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         self.assertRecordValues(payments, [
             {
-                'ref': 'BILL/2017/01/0001 BILL/2017/01/0002 RBILL/2017/01/0001',
+                'ref': Like(f'BATCH/{self.current_year}/...'),
                 'payment_method_line_id': self.outbound_payment_method_line.id,
             },
         ])
@@ -656,7 +660,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
 
         self.assertRecordValues(payments, [
             {
-                'ref': 'BILL/2017/01/0001 BILL/2017/01/0002',
+                'ref': Like(f'BATCH/{self.current_year}/...'),
                 'payment_method_line_id': self.outbound_payment_method_line.id,
             },
             {
@@ -1640,7 +1644,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 1036.0,
             'installments_mode': 'full',
             'installments_switch_amount': 115.0,
-            'communication': wizard._get_communication(term_lines),
+            'communication': Like(f'BATCH/{self.current_year}/...'),
         }])
 
         # Case when at date of the first installment.
@@ -1660,7 +1664,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 1034.0,
             'installments_mode': 'full',
             'installments_switch_amount': 115.0,
-            'communication': wizard._get_communication(term_lines),
+            'communication': Like(f'BATCH/{self.current_year}/...'),
         }])
 
         # First installment is overdue.
@@ -1680,7 +1684,7 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 0.0,
             'installments_mode': 'overdue',
             'installments_switch_amount': 1150.0,
-            'communication': wizard._get_communication(term_lines[:2]),
+            'communication': Like(f'BATCH/{self.current_year}/...'),
         }])
 
         # Third installment is overdue.
@@ -1690,5 +1694,5 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'payment_difference': 0.0,
             'installments_mode': 'full',
             'installments_switch_amount': 0.0,
-            'communication': wizard._get_communication(term_lines),
+            'communication': Like(f'BATCH/{self.current_year}/...'),
         }])

--- a/addons/account/views/account_portal_templates.xml
+++ b/addons/account/views/account_portal_templates.xml
@@ -68,7 +68,10 @@
                             </a>
                         </td>
                         <td><span t-field="invoice.invoice_date"/></td>
-                        <td class='d-none d-md-table-cell'><span t-field="invoice.invoice_date_due"/></td>
+                        <td class='d-none d-md-table-cell'
+                            t-att-class="'text-danger' if invoice.invoice_date_due &lt; datetime.date.today() and invoice.payment_state in ['not_paid', 'partial'] else ''">
+                            <span t-field="invoice.invoice_date_due"/>
+                        </td>
                         <td class="text-end pe-3"><span t-out="-invoice.amount_residual if invoice.move_type == 'out_refund' else invoice.amount_residual" t-options='{"widget": "monetary", "display_currency": invoice.currency_id}'/></td>
                         <td name="invoice_status">
                             <t t-if="invoice.state == 'posted'" name="invoice_status_posted">

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -174,10 +174,12 @@ class AccountPaymentRegister(models.TransientModel):
         :param lines:           A recordset of the `account.move.line`'s that will be reconciled.
         :return:                A string representing a communication to be set on payment.
         '''
-        if lines:
-            labels = {line.name or line.move_id.ref or line.move_id.name for line in lines}
-            return ' '.join(sorted(labels))
-        return ''
+        if len(lines) == 1:
+            line = lines[0]
+            label = line.name or line.move_id.ref or line.move_id.name
+        else:
+            label = self.company_id.get_next_batch_payment_communication()
+        return label
 
     @api.model
     def _get_batch_available_journals(self, batch_result):

--- a/addons/account_payment/controllers/portal.py
+++ b/addons/account_payment/controllers/portal.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import http
+from odoo import _, fields, http
+from odoo.exceptions import AccessError, MissingError, ValidationError
 from odoo.http import request
 
 from odoo.addons.account.controllers import portal
@@ -22,26 +23,111 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
                 'payment': payment,  # We want to show the dialog even when everything has been paid (with a custom message)
             }
 
+        common_view_values = self._get_common_page_view_values(
+            invoices_data={
+                'partner': invoice.partner_id,
+                'company': invoice.company_id,
+                'total_amount': invoice.amount_total,
+                'currency': invoice.currency_id,
+                'amount_residual': invoice.amount_residual,
+                'landing_route': invoice.get_portal_url(),
+                'transaction_route': f'/invoice/transaction/{invoice.id}',
+            },
+            access_token=access_token,
+            **kwargs)
+        installment = invoice.get_next_installment_due()
+        next_installment = (
+            installment
+            and installment['type'] != 'early_payment_discount'
+            and installment['amount_residual_currency_unsigned'] != invoice.amount_residual
+        )
+        values |= {
+            **common_view_values,
+            'amount_custom': float(kwargs['amount']) if kwargs.get('amount') else 0.0,
+            'amount_next_installment': installment['amount_residual_currency_unsigned'] if next_installment else 0.0,
+            'payment': payment,
+            'invoice_id': invoice.id,
+            'invoice_name': invoice.name,
+            'invoice_name_installment': f"{invoice.name}-{installment['number']}" if next_installment else "",
+        }
+        return values
+
+    @http.route(['/my/invoices/overdue'], type='http', auth='public', methods=['GET'], website=True, sitemap=False)
+    def portal_my_overdue_invoices(self, access_token=None, **kw):
+        try:
+            request.env['account.move'].check_access_rights('read')
+        except (AccessError, MissingError):
+            return request.redirect('/my')
+
+        overdue_invoices = request.env['account.move'].search(self._get_overdue_invoices_domain())
+
+        values = self._overdue_invoices_get_page_view_values(overdue_invoices, **kw)
+        return request.render("account_payment.portal_overdue_invoices_page", values) if 'payment' in values else request.redirect('/my/invoices')
+
+    def _overdue_invoices_get_page_view_values(self, overdue_invoices, **kwargs):
+        values = {'page_name': 'overdue_invoices'}
+
+        if len(overdue_invoices) == 0:
+            return values
+
+        first_invoice = overdue_invoices[0]
+        partner = first_invoice.partner_id
+        company = first_invoice.company_id
+        currency = first_invoice.currency_id
+
+        if any(invoice.partner_id != partner for invoice in overdue_invoices):
+            raise ValidationError(_("Overdue invoices should share the same partner."))
+        if any(invoice.company_id != company for invoice in overdue_invoices):
+            raise ValidationError(_("Overdue invoices should share the same company."))
+        if any(invoice.currency_id != currency for invoice in overdue_invoices):
+            raise ValidationError(_("Overdue invoices should share the same currency."))
+
+        total_amount = sum(overdue_invoices.mapped('amount_total'))
+        amount_residual = sum(overdue_invoices.mapped('amount_residual'))
+        batch_name = company.get_next_batch_payment_communication() if len(overdue_invoices) > 1 else first_invoice.name
+        values['payment'] = {
+            'date': fields.Date.today(),
+            'reference': batch_name,
+            'amount': total_amount,
+            'currency': currency,
+        }
+
+        common_view_values = self._get_common_page_view_values(
+            invoices_data={
+                'partner': partner,
+                'company': company,
+                'total_amount': total_amount,
+                'currency': currency,
+                'amount_residual': amount_residual,
+                'payment_reference': batch_name,
+                'landing_route': '/my/invoices/',
+                'transaction_route': '/invoice/transaction/overdue',
+            },
+            **kwargs)
+        values |= common_view_values
+        return values
+
+    def _get_common_page_view_values(self, invoices_data, access_token=None, **kwargs):
         logged_in = not request.env.user._is_public()
         # We set partner_id to the partner id of the current user if logged in, otherwise we set it
         # to the invoice partner id. We do this to ensure that payment tokens are assigned to the
         # correct partner and to avoid linking tokens to the public user.
-        partner_sudo = request.env.user.partner_id if logged_in else invoice.partner_id
-        invoice_company = invoice.company_id or request.env.company
+        partner_sudo = request.env.user.partner_id if logged_in else invoices_data['partner']
+        invoice_company = invoices_data['company'] or request.env.company
 
         availability_report = {}
         # Select all the payment methods and tokens that match the payment context.
         providers_sudo = request.env['payment.provider'].sudo()._get_compatible_providers(
             invoice_company.id,
             partner_sudo.id,
-            invoice.amount_total,
-            currency_id=invoice.currency_id.id,
+            invoices_data['total_amount'],
+            currency_id=invoices_data['currency'].id,
             report=availability_report,
         )  # In sudo mode to read the fields of providers and partner (if logged out).
         payment_methods_sudo = request.env['payment.method'].sudo()._get_compatible_payment_methods(
             providers_sudo.ids,
             partner_sudo.id,
-            currency_id=invoice.currency_id.id,
+            currency_id=invoices_data['currency'].id,
             report=availability_report,
         )  # In sudo mode to read the fields of providers.
         tokens_sudo = request.env['payment.token'].sudo()._get_available_tokens(
@@ -56,39 +142,27 @@ class PortalAccount(portal.PortalAccount, PaymentPortal):
         portal_page_values = {
             'company_mismatch': company_mismatch,
             'expected_company': invoice_company,
-            'payment': payment,
         }
         payment_form_values = {
             'show_tokenize_input_mapping': PaymentPortal._compute_show_tokenize_input_mapping(
                 providers_sudo
             ),
         }
-        installment = invoice.get_next_installment_due()
-        next_installment = (
-            installment
-            and installment['type'] != 'early_payment_discount'
-            and installment['amount_residual_currency_unsigned'] != invoice.amount_residual
-        )
         payment_context = {
-            'amount': invoice.amount_residual,
-            'amount_custom': float(kwargs['amount']) if kwargs.get('amount') else 0.0,
-            'amount_next_installment': installment['amount_residual_currency_unsigned'] if next_installment else 0.0,
-            'currency': invoice.currency_id,
+            'amount': invoices_data['amount_residual'],
+            'currency': invoices_data['currency'],
             'partner_id': partner_sudo.id,
             'providers_sudo': providers_sudo,
             'payment_methods_sudo': payment_methods_sudo,
             'tokens_sudo': tokens_sudo,
             'availability_report': availability_report,
-            'invoice_id': invoice.id,
-            'invoice_name': invoice.name,
-            'invoice_name_installment': f"{invoice.name}-{installment['number']}" if next_installment else "",
-            'transaction_route': f'/invoice/transaction/{invoice.id}/',
-            'landing_route': invoice.get_portal_url(),
+            'transaction_route': invoices_data['transaction_route'],
+            'landing_route': invoices_data['landing_route'],
             'access_token': access_token,
+            'payment_reference': invoices_data.get('payment_reference', False),
         }
         # Merge the dictionaries while allowing the redefinition of keys.
-        new_values = portal_page_values | payment_form_values | payment_context | self._get_extra_payment_form_values(**kwargs)
-        values |= new_values
+        values = portal_page_values | payment_form_values | payment_context | self._get_extra_payment_form_values(**kwargs)
         return values
 
     @http.route()

--- a/addons/account_payment/static/src/js/payment_form.js
+++ b/addons/account_payment/static/src/js/payment_form.js
@@ -51,6 +51,8 @@ PaymentForm.include({
             }
         }
 
+        transactionRouteParams.payment_reference = this.paymentContext.paymentReference;
+
         return transactionRouteParams;
     },
 });

--- a/addons/account_payment/views/account_portal_templates.xml
+++ b/addons/account_payment/views/account_portal_templates.xml
@@ -1,4 +1,79 @@
 <odoo>
+    <template id="portal_my_home_overdue_invoice" name="Portal layout: overdue invoices" inherit_id="portal.portal_breadcrumbs" priority="30">
+        <xpath expr="//ol[hasclass('o_portal_submenu')]" position="inside">
+            <t t-if="page_name == 'overdue_invoices'">
+                <li t-attf-class="breadcrumb-item active">
+                    <a t-attf-href="/my/invoices?{{ keep_query() }}">Invoices &amp; Bills</a>
+                </li>
+                <li class="breadcrumb-item active">
+                    <t t-out="payment['reference']"/>
+                </li>
+            </t>
+        </xpath>
+
+        <xpath expr="//ol[hasclass('o_portal_submenu')]" position="after">
+            <a t-if="page_name == 'invoice' and not invoice and filterby != 'bills' and overdue_invoice_count > 0"
+                class='btn btn-primary'
+                href='/my/invoices/overdue'>
+                Pay overdue
+            </a>
+        </xpath>
+    </template>
+
+    <template id="account_payment.portal_docs_entry" inherit_id="portal.portal_docs_entry">
+        <xpath expr="//a" position="inside">
+            <button
+                t-if="show_pay_overdue_invoices_button"
+                onclick="event.preventDefault(); window.location.href='/my/invoices/overdue'"
+                class="btn btn-secondary ms-auto">
+                Pay Now
+            </button>
+        </xpath>
+    </template>
+
+    <template id="portal_my_home_account_payment" name="Overdue invoices" customize_show="True" inherit_id="portal.portal_my_home" priority="20">
+        <xpath expr="//div[hasclass('o_portal_docs')]" position="before">
+            <t t-set="portal_alert_category_enable" t-value="True"/>
+        </xpath>
+        <div id="portal_alert_category" position="inside">
+            <t t-call="portal.portal_docs_entry">
+                <t t-set="bg_color" t-value="'alert alert-primary align-items-center'"/>
+                <t t-set="placeholder_count" t-value="'overdue_invoice_count'"/>
+                <t t-set="title">Invoices to pay</t>
+                <t t-set="url" t-value="'/my/invoices?filterby=overdue_invoices'"/>
+                <t t-set="show_count" t-value="True"/>
+                <t t-set="show_pay_overdue_invoices_button" t-value="True"/>
+            </t>
+        </div>
+    </template>
+
+    <template id="portal_overdue_invoices_page" name="Overdue payments">
+        <t t-call="portal.portal_layout">
+            <div class="row justify-content-center my-3">
+                <div class="col-lg-7">
+                    <div class="text-bg-light row mx-0 rounded">
+                        <t t-call="payment.summary_item">
+                            <t t-set="name" t-value="'amount'"/>
+                            <t t-set="label">Amount</t>
+                            <t t-set="value" t-value="abs(payment['amount'])"/>
+                            <t t-set="options"
+                                t-value="{'widget': 'monetary', 'display_currency': currency}"/>
+                        </t>
+                        <t t-call="payment.summary_item">
+                            <t t-set="name" t-value="'reference'"/>
+                            <t t-set="label">Reference</t>
+                            <t t-set="value" t-value="payment['reference']"/>
+                            <t t-set="include_separator" t-value="True"/>
+                        </t>
+                    </div>
+                    <div class="mt-4">
+                        <t t-call="payment.form"/>
+                    </div>
+                </div>
+            </div>
+        </t>
+    </template>
+
     <template id="portal_my_invoices_payment" name="Payment on My Invoices" inherit_id="account.portal_my_invoices">
         <xpath expr="//t[@t-call='portal.portal_table']/thead/tr/th[last()]" position="after">
             <th class="d-none d-lg-table-cell"/>
@@ -58,8 +133,8 @@
             <div class="modal fade" id="pay_with" role="dialog">
                 <div class="modal-dialog">
                     <div class="modal-content">
-                        <div class="modal-header">
-                            <h3 class="modal-title">Pay Invoice</h3>
+                        <div class="modal-header pb-0">
+                            <h3 class="modal-title">Pay</h3>
                             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                         </div>
                         <div class="modal-body">

--- a/addons/account_payment/views/payment_form_templates.xml
+++ b/addons/account_payment/views/payment_form_templates.xml
@@ -7,6 +7,7 @@
             <attribute name="t-att-data-amount-overdue">amount_overdue</attribute>
             <attribute name="t-att-data-amount-next-installment">amount_next_installment</attribute>
             <attribute name="t-att-data-name-next-installment">name_next_installment</attribute>
+            <attribute name="t-att-data-payment-reference">payment_reference</attribute>
         </xpath>
     </template>
 


### PR DESCRIPTION
Overdue invoices online payment was improved in this commmit through the following:
1. Portal invoices now have a new filter of "Overdue invoices."
2. Overdue invoices dates are shown in red.
3. Overdue invoices can be paid in batch if there are a number of them, or if it's a single invoice, it can be paid alone.
4. A payment reference is generated based on the number of overdue invoices (single invoice or multiple invoices).
5. For an invoice on the portal, the pay now button redirects to the invoice page and opens the payment wizard as well.

This commit makes online payment of overdue invoices an easier process, which reduces time to pay them.

task-3386024


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
