### PR TITLE
[IMP] sale, _*: add language to product document

### DIFF
--- a/addons/product/models/product_document.py
+++ b/addons/product/models/product_document.py
@@ -13,6 +13,10 @@ class ProductDocument(models.Model):
     }
     _order = 'sequence, name'
 
+    @api.model
+    def _lang_get(self):
+        return self.env['res.lang'].get_installed()
+
     ir_attachment_id = fields.Many2one(
         'ir.attachment',
         string="Related attachment",
@@ -21,6 +25,8 @@ class ProductDocument(models.Model):
 
     active = fields.Boolean(default=True)
     sequence = fields.Integer(default=10)
+    lang = fields.Selection(_lang_get, string='Language')
+    active_lang_count = fields.Integer(compute='_compute_active_lang_count')
 
     @api.onchange('url')
     def _onchange_url(self):
@@ -31,6 +37,11 @@ class ProductDocument(models.Model):
                     "Please enter a valid URL.\nExample: https://www.odoo.com\n\nInvalid URL: %s",
                     attachment.url
                 ))
+
+    @api.depends('lang')
+    def _compute_active_lang_count(self):
+        lang_count = len(self.env['res.lang'].get_installed())
+        self.active_lang_count = lang_count
 
     #=== CRUD METHODS ===#
 

--- a/addons/product/views/product_document_views.xml
+++ b/addons/product/views/product_document_views.xml
@@ -19,6 +19,7 @@
                                invisible="type == 'url'"
                                required="type == 'binary'"
                                class="oe_inline"/>
+                        <field name="lang" invisible="active_lang_count &lt;= 1"/>
                         <field name="url" widget="url" invisible="type == 'binary'" required="type == 'url'"/>
                         <field name="res_name" string="Product Variant" invisible="res_model != 'product.product'"/>
                     </group>
@@ -92,6 +93,16 @@
                                         <div class="mt-2" invisible="res_model != 'product.product'">
                                             <field name="res_name" style="font-style: italic; text-decoration-line: underline;"/>
                                         </div>
+                                        <div invisible="active_lang_count &lt;= 1" class="mt-2" name="language">
+                                            <div class="row">
+                                                <div class="col-4">
+                                                    <span>Language</span>
+                                                </div>
+                                                <div class="col-8">
+                                                    <field name="lang" widget="selection" class="w-100"/>
+                                                </div>
+                                            </div>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -111,6 +122,7 @@
                 <field name="sequence" widget="handle"/>
                 <field name="name"/>
                 <field name="company_id" groups="base.group_multi_company" optional="show"/>
+                <field name="lang" optional="hide"/>
             </tree>
         </field>
     </record>

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1922,10 +1922,13 @@ class SaleOrder(models.Model):
         return self._filter_product_documents(documents).sorted()
 
     def _filter_product_documents(self, documents):
+        customer_lang = self.partner_id.lang or self.partner_id.parent_id.lang
+
         return documents.filtered(
             lambda document:
-                document.attached_on_sale == 'quotation'
-                or (self.state == 'sale' and document.attached_on_sale == 'sale_order')
+                document.lang in (False, customer_lang) and
+                (document.attached_on_sale == 'quotation'
+                or (self.state == 'sale' and document.attached_on_sale == 'sale_order'))
         )
 
     def _update_order_line_info(self, product_id, quantity, **kwargs):

--- a/addons/sale/views/product_document_views.xml
+++ b/addons/sale/views/product_document_views.xml
@@ -19,7 +19,7 @@
         <field name="model">product.document</field>
         <field name="inherit_id" ref="product.product_document_kanban"/>
         <field name="arch" type="xml">
-            <div name="bottom" position="inside">
+            <div name="language" position="before">
                 <div class="mt-2">
                     <span>Sales visibility</span>
                     <field name="attached_on_sale" class="ms-2" widget="selection"/>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1136,7 +1136,11 @@
                                     </t>
                                 </table>
                             </div>
-                            <t t-set="product_documents" t-value="product.sudo().product_document_ids.filtered(lambda doc: doc.shown_on_product_page)"/>
+                            <t t-set="active_lang" t-value="frontend_languages[lang].code"/>
+                            <t t-set="product_documents"
+                               t-value="product.sudo().product_document_ids.filtered(
+                                    lambda doc: doc.shown_on_product_page
+                                        and (not doc.lang or doc.lang == active_lang))"/>
                             <div id="product_documents" class="my-2" t-if="product_documents">
                                 <h5>Documents</h5>
                                 <t t-foreach="product_documents" t-as="document_sudo">


### PR DESCRIPTION
_*= sale_pdf_quote_builder, product, website_sale

Before the Commit:
The existing logic filters product documents based solely on their attached_on
field to determine their visibility (e.g., `quotation` or `sale_order`). The
logic doesn't consider the language preferences of the customer or their
company.

After the Commit:
The new logic further filters the documents based on language preferences,
ensuring that:
- Documents with no language specified are included.
- If the customer's language is set, only documents matching the customer's
  language are included.
- If the customer's language is not set, documents matching the company's
  language are included.
- (For e-commerce) Documents with no language set or the ones that are in the
  website's language are shown

task-3581717