### PR TITLE
[IMP] point_of_sale: handle internal notes nicely

### DIFF
--- a/addons/point_of_sale/__manifest__.py
+++ b/addons/point_of_sale/__manifest__.py
@@ -198,6 +198,7 @@
             "point_of_sale/static/src/app/generic_components/order_widget/*",
             "point_of_sale/static/src/app/generic_components/orderline/*",
             "point_of_sale/static/src/app/generic_components/centered_icon/*",
+            "point_of_sale/static/src/app/generic_components/internal_note/*",
             "point_of_sale/static/src/utils.js",
             "point_of_sale/static/src/customer_display/**/*",
         ],

--- a/addons/point_of_sale/data/pos_note_data.xml
+++ b/addons/point_of_sale/data/pos_note_data.xml
@@ -3,17 +3,21 @@
     <record id="pos_note_wait" model="pos.note">
         <field name="name">Wait</field>
         <field name="sequence">1</field>
+        <field name="color">8</field>
     </record>
     <record id="pos_note_serve" model="pos.note">
         <field name="name">To Serve</field>
         <field name="sequence">2</field>
+        <field name="color">2</field>
     </record>
     <record id="pos_note_emergency" model="pos.note">
         <field name="name">Emergency</field>
         <field name="sequence">3</field>
+        <field name="color">3</field>
     </record>
     <record id="pos_note_no_dressing" model="pos.note">
         <field name="name">No Dressing</field>
         <field name="sequence">4</field>
+        <field name="color">5</field>
     </record>
 </odoo>

--- a/addons/point_of_sale/models/pos_note.py
+++ b/addons/point_of_sale/models/pos_note.py
@@ -10,6 +10,7 @@ class PosNote(models.Model):
 
     name = fields.Char(required=True)
     sequence = fields.Integer('Sequence', default=1)
+    color = fields.Integer(string='Color')
 
     _sql_constraints = [('name_unique', 'unique (name)', "A note with this name already exists")]
 
@@ -19,4 +20,4 @@ class PosNote(models.Model):
 
     @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['name']
+        return ['name', 'color']

--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.js
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.js
@@ -1,6 +1,8 @@
 import { Component } from "@odoo/owl";
+import { TagsList } from "@web/core/tags_list/tags_list";
 
 export class Orderline extends Component {
+    static components = { TagsList };
     static template = "point_of_sale.Orderline";
     static props = {
         class: { type: Object, optional: true },

--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -39,10 +39,8 @@
                         <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
                         <t t-esc="line.customerNote" />
                     </li>
-                    <div class="internal-note-container d-flex gap-2">
-                        <t t-foreach="line.internalNote?.split?.('\n') or []" t-as="note" t-key="note_index">
-                            <li t-if="note.trim() !== ''" t-esc="note" class="internal-note badge mt-2 p-2 rounded-pill bg-info text-info bg-opacity-25" style="font-size: 0.85rem;" />
-                        </t>
+                    <div t-if="line.internalNote" class="d-flex flex-wrap gap-1 pt-2 bg-opacity-75">
+                        <TagsList tags="props.line.internalNote" />
                     </div>
                     <li t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />
                     <t t-slot="default" />

--- a/addons/point_of_sale/static/src/app/models/pos_order_line.js
+++ b/addons/point_of_sale/static/src/app/models/pos_order_line.js
@@ -629,7 +629,7 @@ export class PosOrderline extends Base {
                 : "",
             discount: this.get_discount_str(),
             customerNote: this.get_customer_note() || "",
-            internalNote: this.getNote(),
+            internalNote: this.internalNotes(),
             comboParent: this.combo_parent_id?.get_full_product_name?.() || "",
             packLotLines: this.pack_lot_ids.map(
                 (l) =>
@@ -670,6 +670,20 @@ export class PosOrderline extends Base {
     }
     set_price_extra(price_extra) {
         this.price_extra = parseFloat(price_extra) || 0.0;
+    }
+    internalNotes() {
+        const allnotes = [];
+        const notesArray = this.note.split("\n");
+
+        for (const noteName of notesArray) {
+            const defaultNote = this.models["pos.note"].getAll().find(note => note.name === noteName);
+            if (defaultNote && noteName.trim()) {
+                allnotes.push({ id: 1, text: defaultNote.name, colorIndex: defaultNote.color });
+            } else if (noteName.trim()) {
+                allnotes.push({ id: 1, text: noteName, colorIndex: Math.floor(Math.random() * 11) });
+            }
+        }
+        return allnotes;
     }
     getNote() {
         return this.note || "";

--- a/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/control_buttons/customer_note_button/customer_note_button.js
@@ -33,7 +33,6 @@ export class OrderlineNoteButton extends Component {
         const selectedNote = this.props.getter(selectedOrderline);
         const oldNote = selectedOrderline.getNote();
         const payload = await this.openTextInput(selectedNote);
-
         var quantity_with_note = 0;
         const changes = this.pos.getOrderChanges();
         for (const key in changes.orderlines) {
@@ -68,6 +67,7 @@ export class OrderlineNoteButton extends Component {
         if (this._isInternalNote() || this.props.label == _t("General Note")) {
             buttons = this.pos.models["pos.note"].getAll().map((note) => ({
                 label: note.name,
+                class: note.color ? `o_colorlist_item_color_${note.color}` : "",
                 isSelected: selectedNote.split("\n").includes(note.name), // Check if the note is already selected
             }));
         }

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1107,7 +1107,6 @@ export class PosStore extends Reactive {
             if (orders.length === 0 && !context.force) {
                 return;
             }
-
             // Re-compute all taxes, prices and other information needed for the backend
             for (const order of orders) {
                 order.recomputeOrderData();
@@ -1147,7 +1146,6 @@ export class PosStore extends Reactive {
             if (options.throw) {
                 throw error;
             }
-
             console.warn("Offline mode active, order will be synced later");
             return error;
         }

--- a/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.xml
+++ b/addons/point_of_sale/static/src/app/utils/input_popups/text_input_popup.xml
@@ -2,9 +2,14 @@
 <templates id="template" xml:space="preserve">
 
     <t t-name="point_of_sale.TextInputPopup">
+        <!-- buttons to show -->
         <Dialog title="props.title">
             <t t-foreach="props.buttons" t-as="button" t-key="button_index">
-                <button t-on-click="() => this.buttonClick(button)" type="button" t-attf-class="btn btn-lg me-2 mb-2 toggle-button {{button.isSelected? 'btn-primary' : 'btn-secondary'}} lh-lg" >
+                <button
+                    t-on-click="() => this.buttonClick(button)"
+                    type="button"
+                    class="btn me-2 mb-2 toggle-button"
+                    t-attf-class="{{ button.isSelected ? 'btn-primary' : (button.class || 'btn-secondary') }}">
                     <t t-esc="button.label"/>
                 </button>
             </t>

--- a/addons/point_of_sale/static/tests/tours/customer_display_tour.js
+++ b/addons/point_of_sale/static/tests/tours/customer_display_tour.js
@@ -14,11 +14,11 @@ function amountIs(method, amount) {
     };
 }
 const ADD_PRODUCT =
-    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":"","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
+    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":[],"comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[],"change":0,"onlinePaymentData":{}}';
 const PAY_WITH_CASH =
-    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":"","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
+    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":[],"comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":true,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":false,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
 const ORDER_IS_FINALIZED =
-    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":"","comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":false,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":true,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
+    '{"lines":[{"productName":"Letter Tray","price":"$ 2,972.75","qty":"1.00","unit":"Units","unitPrice":"$ 2,972.75","oldUnitPrice":"","customerNote":"","internalNote":[],"comboParent":"","packLotLines":[],"price_without_discount":"$ 2,972.75","isSelected":false,"imageSrc":"/web/image/product.product/855/image_128"}],"finalized":true,"amount":"2,972.75","paymentLines":[{"name":"Cash","amount":"2,972.75"}],"change":0,"onlinePaymentData":{}}';
 const NEW_ORDER =
     '{"lines":[],"finalized":false,"amount":"0.00","paymentLines":[],"change":0,"onlinePaymentData":{}}';
 

--- a/addons/point_of_sale/views/pos_note_view.xml
+++ b/addons/point_of_sale/views/pos_note_view.xml
@@ -7,6 +7,7 @@
             <list string="Note Models" editable="bottom">
                 <field name="sequence" widget="handle" />
                 <field name="name" />
+                <field name="color" widget="color_picker"/>
             </list>
         </field>
     </record>

--- a/addons/pos_restaurant/static/src/overrides/models/pos_order_line.js
+++ b/addons/pos_restaurant/static/src/overrides/models/pos_order_line.js
@@ -12,13 +12,6 @@ patch(PosOrderline.prototype, {
         orderline.note = this.note;
         return orderline;
     },
-    get_line_diff_hash() {
-        if (this.getNote()) {
-            return this.id + "|" + this.getNote();
-        } else {
-            return "" + this.id;
-        }
-    },
     toggleSkipChange() {
         if (this.uiState.hasChange || this.skip_change) {
             this.setDirty();


### PR DESCRIPTION
Before this commit:
==============
- Note tags displayed long text in a way that extended beyond the background pill, causing a visual issue.
- Additionally, internal notes were not associated with any colors.

![Screenshot from 2024-06-20 15-02-04](https://github.com/odoo/odoo/assets/157005705/a5119400-e48d-428b-9e9f-7316c4cc609a)

After this commit:
==============
- Handling of long text in note tags has been improved, ensuring that it is displayed properly within the background pill.
- Colors are now displayed for note tags in the product screen and internal notes popup.

![Screenshot from 2024-06-21 17-39-50](https://github.com/odoo/odoo/assets/157005705/52115390-2318-4bd9-a14c-ab0e52c8f463)

task-3850741

https://github.com/odoo/enterprise/pull/61204