### PR TITLE
[FIX] pos_sale: duplicate down paytment lines

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -47,6 +47,9 @@ class PosOrder(models.Model):
     @api.model
     def create_from_ui(self, orders, draft=False):
         order_ids = super(PosOrder, self).create_from_ui(orders, draft)
+        if draft:
+            return order_ids
+
         for order in self.sudo().browse([o['id'] for o in order_ids]):
             for line in order.lines.filtered(lambda l: l.product_id == order.config_id.down_payment_product_id and l.qty != 0 and (l.sale_order_origin_id or l.refunded_orderline_id.sale_order_origin_id)):
                 sale_lines = line.sale_order_origin_id.order_line or line.refunded_orderline_id.sale_order_origin_id.order_line


### PR DESCRIPTION
Before this commit:
===================
Duplicate down payment lines were being generated multiple times upon
clicking the order button after importing the Quotation/Order.

Steps To Reproduced:
=====================
- Step 1: Create order in Sales and save it  
- Step 2: Open POS Restaurant and click on Quotation/Order 
- Step 3: Select order and Settle order as Down-payment 
- Step 4: Once added into cart click on the order button multiple times.
- Step 5: Go to back-end and open Sales order 

  You'll see multiple down-payment entries corresponding to each click on the
  order button.

After this commit:
===================
The creation of duplicate down payment lines is prevented.

task - 3877380