### PR TITLE
[FIX] l10n_it_edi, base: add warning for public administration

### DIFF
--- a/addons/l10n_it_edi/i18n/it.po
+++ b/addons/l10n_it_edi/i18n/it.po
@@ -1292,11 +1292,11 @@ msgstr "Devi selezionare un rappresentante fiscale"
 #: code:addons/l10n_it_edi/models/account_move.py:0
 #, python-format
 msgid ""
-"Your company belongs to the Public Administration, please fill out Origin "
+"Partner(s) belongs to the Public Administration, please fill out Origin "
 "Document Type field in the Electronic Invoicing tab."
 msgstr ""
-"La tua Azienda appartiene alla Pubblica Amministrazione, per favore riempi "
-"il campo Tipo Documento Origine nella scheda Fatturazione Elettronica"
+"Il/i Partner appartiene alla Pubblica Amministrazione, compilare il campo "
+"Tipo Documento Origine nella scheda Fatturazione elettronica."
 
 #. module: l10n_it_edi
 #. odoo-python

--- a/addons/l10n_it_edi/i18n/l10n_it_edi.pot
+++ b/addons/l10n_it_edi/i18n/l10n_it_edi.pot
@@ -1194,7 +1194,7 @@ msgstr ""
 #: code:addons/l10n_it_edi/models/account_move.py:0
 #, python-format
 msgid ""
-"Your company belongs to the Public Administration, please fill out Origin "
+"Partner(s) belongs to the Public Administration, please fill out Origin "
 "Document Type field in the Electronic Invoicing tab."
 msgstr ""
 

--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -1168,9 +1168,9 @@ class AccountMove(models.Model):
             errors['move_reverse_charge_with_mixed_services_and_goods'] = build_error(
                 message=_("Cannot apply Reverse Charge to bills which contains both services and goods."),
                 records=moves)
-        if pa_moves := self.filtered(lambda move: move.company_id.partner_id._l10n_it_edi_is_public_administration()):
-            if moves := pa_moves.filtered(lambda move: move.l10n_it_origin_document_type):
-                message = _("Your company belongs to the Public Administration, please fill out Origin Document Type field in the Electronic Invoicing tab.")
+        if pa_moves := self.filtered(lambda move: move.commercial_partner_id._l10n_it_edi_is_public_administration()):
+            if moves := pa_moves.filtered(lambda move: not move.l10n_it_origin_document_type):
+                message = _("Partner(s) belongs to the Public Administration, please fill out Origin Document Type field in the Electronic Invoicing tab.")
                 errors['move_missing_origin_document'] = build_error(message=message, records=moves)
             if moves := pa_moves.filtered(lambda move: move.l10n_it_origin_document_date and move.l10n_it_origin_document_date > fields.Date.today()):
                 message = _("The Origin Document Date cannot be in the future.")

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2705,15 +2705,16 @@ class Model(models.AbstractModel):
         """ Return an action to open given records.
             If there's more than one record, it will be a List, otherwise it's a Form.
             Given keyword arguments will overwrite default ones. """
-        if len(self) == 0:
-            length_dependent = {'views': [(False, 'form')]}
-        elif len(self) == 1:
-            length_dependent = {'views': [(False, 'form')], 'res_id': self.id}
-        else:
-            length_dependent = {
-                'views': [(False, 'list'), (False, 'form')],
-                'domain': [('id', 'in', self.ids)]
-            }
+        match self.ids:  # `self.ids` will silently filter out new records (`NewId`s)
+            case []:
+                length_dependent = {'views': [(False, 'form')]}
+            case [res_id]:
+                length_dependent = {'views': [(False, 'form')], 'res_id': res_id}
+            case ids:
+                length_dependent = {
+                    'views': [(False, 'list'), (False, 'form')],
+                    'domain': [('id', 'in', ids)]
+                }
         return {
             'type': 'ir.actions.act_window',
             'res_model': self._name,


### PR DESCRIPTION
Problem:
For an Italian public company, when sending an invoice there is no warning triggered when the field "Origin Document Type" is empty

Steps to reproduce:
- Install "Contacts" and "Accounting" apps
- Create an Italian company and set its fiscal localization
- Create a new Italian contact and fill out the "Destination Code" with a six-digit code
- Create an invoice for this contact, in the "Electronic Invoicing" tab, leave the field "Origin Document Type" empty
- Confirm the invoice and click on "Send & Print", there is no warning saying that the field "Origin Document Type" must be filled out

Cause:
Errors in the conditions

Note:
Modification in the get_records_action because self.id returns an id of type NewId which raise an error (see below) in this fix workflow because it is called in an onchange function. self.ids[0] returns an id of type int

Error raised: TypeError: Object of type NewId is not JSON serializable

Steps to reproduce:
- Do the 4 first steps as above
- Create a second invoice with another customer which is not a public italian administration (can be from another country)
- Select the invoices and click on "Send & Print" in the "Actions" button

opw-3844664

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
