### PR TITLE
[FIX] point_of_sale: number buffer when pressing +/-

### DIFF
--- a/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
+++ b/addons/point_of_sale/static/src/app/utils/number_buffer_service.js
@@ -275,14 +275,6 @@ class NumberBuffer extends EventBus {
             if (this.state.buffer[0] === "-") {
                 this.state.buffer = this.state.buffer.substring(1, this.state.buffer.length);
             }
-        } else if (input === "-") {
-            if (isFirstInput) {
-                this.state.buffer = "-0";
-            } else if (this.state.buffer[0] === "-") {
-                this.state.buffer = this.state.buffer.substring(1, this.state.buffer.length);
-            } else {
-                this.state.buffer = "-" + this.state.buffer;
-            }
         } else if (input[0] === "+" && !isNaN(parseFloat(input))) {
             // when input is like '+10', '+50', etc
             const inputValue = oParseFloat(input.slice(1));

--- a/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/payment_screen_tour.js
@@ -92,7 +92,7 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingUp", {
             Chrome.clickMenuOption("Orders"),
             Chrome.createFloatingOrder(),
 
-            ProductScreen.addOrderline("Product Test", "-1"),
+            ProductScreen.addOrderline("Product Test", "-"),
             ProductScreen.clickPayButton(),
 
             PaymentScreen.totalIs("-2.00"),
@@ -114,7 +114,7 @@ registry.category("web_tour.tours").add("PaymentScreenRoundingDown", {
             Chrome.clickMenuOption("Orders"),
             Chrome.createFloatingOrder(),
 
-            ProductScreen.addOrderline("Product Test", "-1"),
+            ProductScreen.addOrderline("Product Test", "-"),
             ProductScreen.clickPayButton(),
 
             PaymentScreen.totalIs("-1.95"),

--- a/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
+++ b/addons/point_of_sale/static/tests/tours/ticket_screen_tour.js
@@ -132,18 +132,14 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
                 // Error popup should show.
                 Numpad.click("2"),
                 Dialog.confirm(),
-                // Change the refund line quantity to -3 -- not allowed
+                // Change the refund line quantity to -13 -- not allowed
                 // so error popup.
                 ...["+/-", "3"].map(Numpad.click),
                 Dialog.confirm(),
-                // Change the refund line quantity to -2 -- allowed.
-                ...["+/-", "2"].map(Numpad.click),
-                ...ProductScreen.selectedOrderlineHasDirect("Desk Pad", "-2.00"),
             ]),
-            // Check if the amount being refunded changed to 2.
             ...ProductScreen.clickRefund(),
             TicketScreen.selectOrder("-0005"),
-            TicketScreen.toRefundTextContains("Refunding 2.00"),
+            TicketScreen.toRefundTextContains("Refunding 1.00"),
             TicketScreen.clickDiscard(),
             { ...ProductScreen.back(), isActive: ["mobile"] },
             // Pay the refund order.
@@ -155,7 +151,7 @@ registry.category("web_tour.tours").add("TicketScreenTour", {
             // Check refunded quantity.
             ...ProductScreen.clickRefund(),
             TicketScreen.selectOrder("-0005"),
-            TicketScreen.refundedNoteContains("2.00 Refunded"),
+            TicketScreen.refundedNoteContains("1.00 Refunded"),
         ].flat(),
 });
 

--- a/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
+++ b/addons/pos_loyalty/static/src/overrides/components/product_screen/order_summary/order_summary.js
@@ -60,7 +60,7 @@ patch(OrderSummary.prototype, {
      *
      * @override
      */
-    _setValue(val) {
+    _setValue(val, key) {
         const selectedLine = this.currentOrder.get_selected_orderline();
         if (!selectedLine) {
             return;
@@ -81,7 +81,7 @@ patch(OrderSummary.prototype, {
             !selectedLine.is_reward_line ||
             (selectedLine.is_reward_line && ["", "remove"].includes(val))
         ) {
-            super._setValue(val);
+            super._setValue(val, key);
         }
         if (!selectedLine.is_reward_line || (selectedLine.is_reward_line && val === "remove")) {
             this.pos.updateRewards();


### PR DESCRIPTION
Before this commit
===============
Previously, when adding a product and clicking the "+/-" button, the quantity and price would change to "0" instead of becoming negative.

After this commit
=============
After implementing this commit, pressing the +/- button now results in the quantity and price value changing to negative instead of changing it to 0.

task- 3869556