### PR TITLE
[IMP] mail: navigating livechat sessions

### DIFF
--- a/addons/im_livechat/controllers/main.py
+++ b/addons/im_livechat/controllers/main.py
@@ -253,3 +253,12 @@ class LivechatController(http.Controller):
         in conversation with an operator, it's not possible to send the visitor a chat request."""
         if channel := request.env["discuss.channel"].search([("id", "=", channel_id)]):
             channel._close_livechat_session()
+
+    @http.route("/im_livechat/session_history", methods=["POST"], type="json", auth="public")
+    @add_guest_to_context
+    def livechats_session_history(self, channel_id):
+        channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
+        filteredChannels = request.env["discuss.channel"].search([("channel_type", "=", channel.channel_type)]).filtered(lambda record: record.create_date.date() == channel.create_date.date())
+        if not filteredChannels:
+            return
+        return filteredChannels._channel_info()

--- a/addons/im_livechat/static/src/views/discuss_channel_list/discuss_channel_list_view_controller.js
+++ b/addons/im_livechat/static/src/views/discuss_channel_list/discuss_channel_list_view_controller.js
@@ -15,7 +15,8 @@ export class DiscussChannelListController extends ListController {
         if (!this.ui.isSmall) {
             return this.actionService.doAction("mail.action_discuss", {
                 name: _t("Discuss"),
-                additionalContext: { active_id: record.resId },
+                //isLiveChatSession is set to true when the session open from Session History
+                additionalContext: { active_id: record.resId, isLivechatSession: true },
             });
         }
         let thread = this.store.Thread.get({

--- a/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
+++ b/addons/im_livechat/static/tests/tours/im_livechat_session_history_open.js
@@ -1,0 +1,30 @@
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add("im_livechat_session_history_open", {
+    test: true,
+    steps: () => [
+        {
+            trigger: "body",
+            run: "press ctrl+k",
+        },
+        {
+            trigger: ".o_command_palette_search input",
+            run: "fill /",
+        },
+        {
+            trigger: ".o_command_palette_search input",
+            run: "fill Live Chat",
+        },
+        {
+            trigger: ".o_command:contains(Sessions History)",
+        },
+        {
+            trigger: ".o_data_cell:contains(test 1)",
+            run: "click",
+        },
+        {
+            trigger: ".o-mail-DiscussSidebar-item:contains(test 2)",
+            run: "click",
+        },
+    ],
+});

--- a/addons/im_livechat/tests/__init__.py
+++ b/addons/im_livechat/tests/__init__.py
@@ -14,3 +14,4 @@ from . import test_js
 from . import test_message
 from . import test_upload_attachment
 from . import test_session_history
+from . import test_session_history_open

--- a/addons/im_livechat/tests/test_session_history_open.py
+++ b/addons/im_livechat/tests/test_session_history_open.py
@@ -1,0 +1,37 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import Command
+from odoo.tests import new_test_user
+from odoo.addons.im_livechat.tests.common import TestImLivechatCommon
+from odoo.tests.common import users, tagged
+
+
+@tagged("-at_install", "post_install")
+class TestImLivechatSessionHistoryOpen(TestImLivechatCommon):
+    @users('admin')
+    def test_session_history_open(self):
+        operator = new_test_user(self.env, login="operator", groups="base.group_user,im_livechat.im_livechat_group_manager")
+        [user_1, user_2] = self.env['res.partner'].create(
+        [{
+                'name': 'test 1',
+            },
+            {
+                'name': 'test 2',
+            }
+        ])
+        self.env["discuss.channel"].create(
+            [{
+                "name": "test 1",
+                "channel_type": "livechat",
+                "livechat_channel_id": 1,
+                "livechat_operator_id": operator.partner_id.id,
+                "channel_member_ids": [Command.create({"partner_id": user_1.id})],
+            },
+            {
+                "name": "test 2",
+                "channel_type": "livechat",
+                "livechat_channel_id": 1,
+                "livechat_operator_id": operator.partner_id.id,
+                "channel_member_ids": [Command.create({"partner_id": user_2.id})],
+            }]
+        )
+        self.start_tour("/web", "im_livechat_session_history_open", login="operator", step_delay=25)

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -42,9 +42,16 @@ class ChannelController(http.Controller):
     @add_guest_to_context
     def discuss_channel_info(self, channel_id):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
-        if not channel:
+        allChannels = request.env["discuss.channel"].search([("channel_type", "=", channel.channel_type)])
+        filteredChannels = request.env["discuss.channel"].browse([])
+        if allChannels:
+            for record in allChannels:
+                if record.create_date.date() == channel.create_date.date():
+                    filteredChannels |= record
+
+        if not filteredChannels:
             return
-        return channel._channel_info()[0]
+        return filteredChannels._channel_info()
 
     @http.route("/discuss/channel/messages", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -42,16 +42,9 @@ class ChannelController(http.Controller):
     @add_guest_to_context
     def discuss_channel_info(self, channel_id):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
-        allChannels = request.env["discuss.channel"].search([("channel_type", "=", channel.channel_type)])
-        filteredChannels = request.env["discuss.channel"].browse([])
-        if allChannels:
-            for record in allChannels:
-                if record.create_date.date() == channel.create_date.date():
-                    filteredChannels |= record
-
-        if not filteredChannels:
+        if not channel:
             return
-        return filteredChannels._channel_info()
+        return channel._channel_info()[0]
 
     @http.route("/discuss/channel/messages", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/static/src/core/web/discuss_client_action.js
+++ b/addons/mail/static/src/core/web/discuss_client_action.js
@@ -56,7 +56,8 @@ export class DiscussClientAction extends Component {
             this.store.Thread.localIdToActiveId(this.store.discuss.thread?.localId) ??
             "mail.box_inbox";
         const [model, id] = this.parseActiveId(rawActiveId);
-        const activeThread = await this.store.Thread.getOrFetch({ model, id });
+        const isLivechatSession = props.action.context?.isLivechatSession;
+        const activeThread = await this.store.Thread.getOrFetch({ model, id, isLivechatSession });
         if (activeThread && activeThread.notEq(this.store.discuss.thread)) {
             activeThread.setAsDiscussThread(false);
         }

--- a/addons/mail/static/src/discuss/core/common/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/common/thread_model_patch.js
@@ -88,6 +88,10 @@ const threadPatch = {
             const data = await rpc("/discuss/channel/info", { channel_id: this.id });
             if (data) {
                 this.update(data);
+                for (let index = 0; index < data.length; index++) {
+                    const newThread = this.store.Thread.insert(data[index]);
+                    newThread.isLocallyPinned = true;
+                }
             } else {
                 this.delete();
             }

--- a/addons/mail/static/src/discuss/core/web/thread_model_patch.js
+++ b/addons/mail/static/src/discuss/core/web/thread_model_patch.js
@@ -19,7 +19,7 @@ patch(Thread, {
         thread.fetchChannelInfoState = "fetching";
         const def = new Deferred();
         thread.fetchChannelInfoDeferred = def;
-        thread.fetchChannelInfo().then(
+        thread.fetchChannelInfo(data.isLivechatSession).then(
             (result) => {
                 if (thread.exists()) {
                     thread.fetchChannelInfoState = "fetched";


### PR DESCRIPTION
**Purpose:**

Since v17, we open all the livechat sessions in Discuss, which is better in
terms of UX, but doesn't allow you to switch from one session to another,
as we only open the selected one. The agent has to go back to the session
history each time.

**Spec:**

This commit improve this when in livechat a session is opened from the session
history, all sessions of that day should be loaded into Discuss (all operators)

Task-3764236



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
