### PR TITLE
[IMP] crm,*: display proper opportunity and its count

### DIFF
--- a/addons/crm/tests/__init__.py
+++ b/addons/crm/tests/__init__.py
@@ -15,4 +15,5 @@ from . import test_crm_ui
 from . import test_crm_pls
 from . import test_digest
 from . import test_performances
+from . import test_res_partner
 from . import test_sales_team_ui

--- a/addons/crm/tests/test_res_partner.py
+++ b/addons/crm/tests/test_res_partner.py
@@ -1,0 +1,73 @@
+from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.tests import tagged, users
+
+
+# This is explicit: we want CRM only check, to test base method
+@tagged('res_partner', '-post_install', 'at_install')
+class TestResPartner(TestCrmCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.contact_1_1, cls.contact_1_2 = cls.env['res.partner'].create([
+            {
+                'name': 'Philip J Fry Bouffe-tête',
+                'email': 'bouffe.tete@test.example.com',
+                'function': 'Bouffe-Tête',
+                'lang': cls.lang_en.code,
+                'phone': False,
+                'parent_id': cls.contact_1.id,
+                'is_company': False,
+                'street': 'Same as Fry',
+                'city': 'New York',
+                'country_id': cls.env.ref('base.us').id,
+                'zip': '54321',
+            }, {
+                'name': 'Philip J Fry Banjo',
+                'email': 'banjo@test.example.com',
+                'function': 'Being a banjo',
+                'lang': cls.lang_en.code,
+                'phone': False,
+                'parent_id': cls.contact_1.id,
+                'is_company': False,
+                'street': 'Same as Fry',
+                'city': 'New York',
+                'country_id': cls.env.ref('base.us').id,
+                'zip': '54321',
+            }
+        ])
+
+        cls.test_leads = cls.env['crm.lead'].create([
+            {
+                'name': 'CompanyLead',
+                'type': 'lead',
+                'partner_id': cls.contact_company_1.id,
+            }, {
+                'name': 'ChildLead',
+                'type': 'lead',
+                'partner_id': cls.contact_1.id,
+            }, {
+                'name': 'GrandChildLead',
+                'type': 'lead',
+                'partner_id': cls.contact_1_1.id,
+            }, {
+                'name': 'GrandChildOpp',
+                'type': 'opportunity',
+                'partner_id': cls.contact_1_1.id,
+            }, {
+                'name': 'Nobody',
+                'type': 'opportunity',
+            },
+        ])
+
+    @users('user_sales_manager')
+    def test_fields_opportunity_count(self):
+        (
+            contact_company_1, contact_1, contact_1_1, contact_1_2
+        ) = (
+            self.contact_company_1 + self.contact_1 + self.contact_1_1 + self.contact_1_2
+        ).with_env(self.env)
+        self.assertEqual(contact_company_1.opportunity_count, 4, 'Should contain own + children leads')
+        self.assertEqual(contact_1.opportunity_count, 3, 'Should contain own + child leads')
+        self.assertEqual(contact_1_1.opportunity_count, 2, 'Should contain own, aka 2')
+        self.assertEqual(contact_1_2.opportunity_count, 0, 'Should contain own, aka none')

--- a/addons/website_crm_partner_assign/models/res_partner.py
+++ b/addons/website_crm_partner_assign/models/res_partner.py
@@ -55,32 +55,30 @@ class ResPartner(models.Model):
         for partner in self:
             partner.partner_weight = partner.grade_id.partner_weight if partner.grade_id else 0
 
+    def _get_contact_opportunities_domain(self):
+        all_partners = self._fetch_children_partners_for_hierarchy().ids
+        return ['|', ('partner_assigned_id', 'in', all_partners), ('partner_id', 'in', all_partners)]
+
     def _compute_opportunity_count(self):
-        super()._compute_opportunity_count()
-        if not self.env.user.has_group('sales_team.group_sale_salesman'):
-            return
+        if not self.ids or not self.env.user.has_group('sales_team.group_sale_salesman'):
+            return super()._compute_opportunity_count()
 
+        self.opportunity_count = 0
         opportunity_data = self.env['crm.lead'].with_context(active_test=False)._read_group(
-            [('partner_assigned_id', 'in', self.ids)],
-            ['partner_assigned_id'], ['__count']
+            self._get_contact_opportunities_domain(),
+            ['partner_assigned_id', 'partner_id'], ['__count']
         )
-        assign_counts = {partner_assigned.id: count for partner_assigned, count in opportunity_data}
-        for partner in self:
-            partner.opportunity_count += assign_counts.get(partner.id, 0)
+        current_pids = set(self._ids)
 
-    def action_view_opportunity(self):
-        self.ensure_one()  # especially here as we are doing an id, in, IDS domain
-        action = super().action_view_opportunity()
-        action_domain_origin = action.get('domain')
-        action_context_origin = action.get('context') or {'active_test': False}
-        action_domain_assign = [('partner_assigned_id', '=', self.id)]
-        if not action_domain_origin:
-            action['domain'] = action_domain_assign
-            return action
-        # perform searches independently as having OR with those leaves seems to
-        # be counter productive
-        Lead = self.env['crm.lead'].with_context(**action_context_origin)
-        ids_origin = Lead.search(action_domain_origin).ids
-        ids_new = Lead.search(action_domain_assign).ids
-        action['domain'] = [('id', 'in', sorted(list(set(ids_origin) | set(ids_new))))]
-        return action
+        for assign_partner, partner, count in opportunity_data:
+            # this variable is used to keep the track of the partner
+            seen_partners = set()
+            while partner or assign_partner:
+                if assign_partner and assign_partner.id in current_pids and assign_partner not in seen_partners:
+                    assign_partner.opportunity_count += count
+                    seen_partners.add(assign_partner)
+                if partner and partner.id in current_pids and partner not in seen_partners:
+                    partner.opportunity_count += count
+                    seen_partners.add(partner)
+                assign_partner = assign_partner.parent_id
+                partner = partner.parent_id

--- a/addons/website_crm_partner_assign/tests/__init__.py
+++ b/addons/website_crm_partner_assign/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_partner_assign
+from . import test_res_partner

--- a/addons/website_crm_partner_assign/tests/test_partner_assign.py
+++ b/addons/website_crm_partner_assign/tests/test_partner_assign.py
@@ -42,66 +42,6 @@ class TestPartnerAssign(TransactionCase):
         patcher = patch('odoo.addons.base_geolocalize.models.base_geocoder.BaseGeocoder.geo_find', wraps=geo_find)
         self.startPatcher(patcher)
 
-    def test_opportunity_count(self):
-        self.customer_uk.write({
-            'is_company': True,
-            'child_ids': [
-                (0, 0, {'name': 'Uk Children 1',
-                       }),
-                (0, 0, {'name': 'Uk Children 2',
-                       }),
-            ],
-        })
-        lead_uk_assigned = self.env['crm.lead'].create({
-            'name': 'Office Design and Architecture',
-            'partner_assigned_id': self.customer_uk.id,
-            'type': 'opportunity',
-        })
-        children_leads = self.env['crm.lead'].create([
-            {'name': 'Children 1 Lead 1',
-             'partner_id': self.customer_uk.child_ids[0].id,
-             'type': 'lead'},
-            {'name': 'Children 1 Lead 2',
-             'partner_id': self.customer_uk.child_ids[0].id,
-             'type': 'lead'},
-            {'name': 'Children 2 Lead 1',
-             'partner_id': self.customer_uk.child_ids[1].id,
-             'type': 'lead'},
-            {'name': 'Children 2 Lead 2',
-             'partner_id': self.customer_uk.child_ids[1].id,
-             'type': 'lead'},
-        ])
-        children_leads_assigned = self.env['crm.lead'].create([
-            {'name': 'Children 1 Lead 1',
-             'partner_assigned_id': self.customer_uk.child_ids[0].id,
-             'type': 'lead'},
-            {'name': 'Children 1 Lead 2',
-             'partner_assigned_id': self.customer_uk.child_ids[0].id,
-             'type': 'lead'},
-            {'name': 'Children 2 Lead 1',
-             'partner_assigned_id': self.customer_uk.child_ids[1].id,
-             'type': 'lead'},
-            {'name': 'Children 2 Lead 2',
-             'partner_assigned_id': self.customer_uk.child_ids[1].id,
-             'type': 'lead'},
-        ])
-
-        self.assertEqual(
-            repr(self.customer_uk.action_view_opportunity()['domain']),
-            repr([('id', 'in', sorted(self.lead_uk.ids + lead_uk_assigned.ids + children_leads.ids))]),
-            'Parent: own + children leads + assigned'
-        )
-        self.assertEqual(
-            repr(self.customer_uk.child_ids[0].action_view_opportunity()['domain']),
-            repr([('id', 'in', sorted(children_leads[0:2].ids + children_leads_assigned[0:2].ids))]),
-            'Children: own leads + assigned'
-        )
-        self.assertEqual(
-            repr(self.customer_uk.child_ids[1].action_view_opportunity()['domain']),
-            repr([('id', 'in', sorted(children_leads[2:].ids + children_leads_assigned[2:].ids))]),
-            'Children: own leads + assigned'
-        )
-
     def test_partner_assign(self):
         """ Test the automatic assignation using geolocalisation """
         partner_be = self.env['res.partner'].create({

--- a/addons/website_crm_partner_assign/tests/test_res_partner.py
+++ b/addons/website_crm_partner_assign/tests/test_res_partner.py
@@ -1,0 +1,39 @@
+from odoo.addons.crm.tests.test_res_partner import TestResPartner
+from odoo.tests import tagged, users
+from odoo.tests.common import warmup
+
+
+@tagged('res_partner', 'post_install', '-at_install')
+class TestResPartnerWAssign(TestResPartner):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.test_leads[3:].write({
+            'partner_assigned_id': cls.contact_1_2.id,
+        })
+
+    @users('user_sales_manager')
+    @warmup
+    def test_fields_opportunity_count(self):
+        # this query counter is there to ensure prefetching works and we don't
+        # browse partner sequentially
+        with self.assertQueryCount(4):
+            (
+                contact_company_1, contact_1, contact_1_1, contact_1_2
+            ) = (
+                self.contact_company_1 + self.contact_1 + self.contact_1_1 + self.contact_1_2
+            ).with_env(self.env)
+            self.assertEqual(
+                contact_company_1.opportunity_count, 5,
+                'Should contain own + children leads / assigned')
+            self.assertEqual(
+                contact_1.opportunity_count, 4,
+                'Should contain own + child leads / assigned')
+            self.assertEqual(
+                contact_1_1.opportunity_count, 2,
+                'Should contain own, aka 2')
+            self.assertEqual(
+                contact_1_2.opportunity_count, 2,
+                'Should contain own, aka assigned')


### PR DESCRIPTION
*= website_crm_partner_assign

**Issue 1**
In an opportunity if a partner is set as a customer and that
opportunity is assigned to that same partner then the
opportunity counts in the Stat button is wrong.
Ref video link -: https://youtu.be/8wmhRwcVJ4g

**Issue 2**
If a partner is created with this hierarchy
Parent (company) -> Child-1 (individual) -> Child-1's Child (individual)
and in an opportunity customer is set as Child-1's child then its count is
propagated to all parents but when Child-1 clicks on the stat button
it shows nothing.
Ref video link -: https://shorturl.at/K3Ddy

Specifications
==============
1). Improve the opportunity count computation.
2). Propagate the opportunities to parents when a child is assigned,
similar to when a child is set as a customer.

Technical
=========
**For issue 1:**
When a partner is designated as a customer, the `_compute_opportunity_count`
method in CRM increases the opportunity count by 1. If the same partner is
then assigned to that opportunity, the `_compute_opportunity_count` method in
website_crm_partner_assign will increase the count by an additional 1,
resulting in the count being incremented twice.

**For issue 2:**
Currently, when a company clicks on the stat button, it can view its child
opportunities because in the `commercial_partner_id` that parent is set.
However, if an individual parent partner clicks on the stat button, they
will not be able to see their child opportunities because our parent is
individual `commercial_partner_id` is empty so it will show no records.

After this PR
===========
So now if the above scenario happens, the opportunity count will only compute once.
and now every parent will able to see their child's opportunity

Task-3871399