### PR TITLE
 [IMP] web_editor: ensure muted text appears only on active lines

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -238,7 +238,8 @@ export class OdooEditor extends EventTarget {
                 getPowerboxElement: () => {
                     const selection = document.getSelection();
                     if (selection.isCollapsed && selection.rangeCount) {
-                        return closestElement(selection.anchorNode, 'P, DIV');
+                        const elementSelectors = ['DIV', 'LI', ...paragraphRelatedElements];
+                        return closestElement(selection.anchorNode, elementSelectors.join(', '));
                     }
                 },
                 preHistoryUndo: () => {},
@@ -4473,9 +4474,7 @@ export class OdooEditor extends EventTarget {
             H4: this.options._t('Heading 4'),
             H5: this.options._t('Heading 5'),
             H6: this.options._t('Heading 6'),
-            'UL LI': this.options._t('List'),
-            'OL LI': this.options._t('List'),
-            'CL LI': this.options._t('To-do'),
+            LI: this.options._t('List'),
         };
 
         for (const hint of this.editable.querySelectorAll('.oe-hint')) {
@@ -4501,19 +4500,13 @@ export class OdooEditor extends EventTarget {
             }
         }
 
-        if (this.options.showEmptyElementHint) {
-            for (const [selector, text] of Object.entries(selectors)) {
-                for (const el of this.editable.querySelectorAll(selector)) {
-                    if (!this.options.isHintBlacklisted(el)) {
-                        this._makeHint(el, text);
-                    }
-                }
-            }
-        }
-
         const block = this.options.getPowerboxElement();
-        if (block) {
-            this._makeHint(block, this.options._t('Type "/" for commands'), true);
+        if (block && !this.options.isHintBlacklisted(block)) {
+            if (block.nodeName in selectors && this.options.showEmptyElementHint) {
+                this._makeHint(block, selectors[block.nodeName], true);
+            } else if (block.nodeName === 'P' || block.nodeName === 'DIV') {
+                this._makeHint(block, this.options._t('Type "/" for commands'), true);
+            }
         }
 
         // placeholder hint

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/style.scss
@@ -391,7 +391,7 @@ i.oe-powerbox-commandImg {
 .oe-hint {
     position: relative;
 
-    &:before {
+    &:after {
         content: attr(placeholder);
         position: absolute;
         top: 0;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
@@ -98,14 +98,14 @@ describe('List', () => {
                                 <table class="table table-bordered o_selected_table">
                                     <tbody>
                                         <tr>
-                                            <td class="o_selected_td">[<ul><li placeholder="List" class="oe-hint"><br></li></ul></td>
-                                            <td class="o_selected_td"><ul><li placeholder="List" class="oe-hint"><br></li></ul></td>
-                                            <td class="o_selected_td"><ul><li placeholder="List" class="oe-hint"><br></li></ul></td>
+                                            <td class="o_selected_td">[<ul><li><br></li></ul></td>
+                                            <td class="o_selected_td"><ul><li><br></li></ul></td>
+                                            <td class="o_selected_td"><ul><li><br></li></ul></td>
                                         </tr>
                                         <tr>
-                                            <td class="o_selected_td"><ul><li placeholder="List" class="oe-hint"><br></li></ul></td>
-                                            <td class="o_selected_td"><ul><li placeholder="List" class="oe-hint"><br></li></ul></td>
-                                            <td class="o_selected_td"><ul><li placeholder="List" class="oe-hint"><br></li></ul>]</td>
+                                            <td class="o_selected_td"><ul><li><br></li></ul></td>
+                                            <td class="o_selected_td"><ul><li><br></li></ul></td>
+                                            <td class="o_selected_td"><ul><li><br></li></ul>]</td>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -381,14 +381,14 @@ describe('List', () => {
                                 <table class="table table-bordered o_selected_table">
                                     <tbody>
                                         <tr>
-                                            <td class="o_selected_td">[<ol><li placeholder="List" class="oe-hint"><br></li></ol></td>
-                                            <td class="o_selected_td"><ol><li placeholder="List" class="oe-hint"><br></li></ol></td>
-                                            <td class="o_selected_td"><ol><li placeholder="List" class="oe-hint"><br></li></ol></td>
+                                            <td class="o_selected_td">[<ol><li><br></li></ol></td>
+                                            <td class="o_selected_td"><ol><li><br></li></ol></td>
+                                            <td class="o_selected_td"><ol><li><br></li></ol></td>
                                         </tr>
                                         <tr>
-                                            <td class="o_selected_td"><ol><li placeholder="List" class="oe-hint"><br></li></ol></td>
-                                            <td class="o_selected_td"><ol><li placeholder="List" class="oe-hint"><br></li></ol></td>
-                                            <td class="o_selected_td"><ol><li placeholder="List" class="oe-hint"><br></li></ol>]</td>
+                                            <td class="o_selected_td"><ol><li><br></li></ol></td>
+                                            <td class="o_selected_td"><ol><li><br></li></ol></td>
+                                            <td class="o_selected_td"><ol><li><br></li></ol>]</td>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -744,14 +744,14 @@ describe('List', () => {
                                 <table class="table table-bordered o_selected_table">
                                     <tbody>
                                         <tr>
-                                            <td class="o_selected_td">[<ul class="o_checklist"><li placeholder="List" class="oe-hint"><br></li></ul></td>
-                                            <td class="o_selected_td"><ul class="o_checklist"><li placeholder="List" class="oe-hint"><br></li></ul></td>
-                                            <td class="o_selected_td"><ul class="o_checklist"><li placeholder="List" class="oe-hint"><br></li></ul></td>
+                                            <td class="o_selected_td">[<ul class="o_checklist"><li><br></li></ul></td>
+                                            <td class="o_selected_td"><ul class="o_checklist"><li><br></li></ul></td>
+                                            <td class="o_selected_td"><ul class="o_checklist"><li><br></li></ul></td>
                                         </tr>
                                         <tr>
-                                            <td class="o_selected_td"><ul class="o_checklist"><li placeholder="List" class="oe-hint"><br></li></ul></td>
-                                            <td class="o_selected_td"><ul class="o_checklist"><li placeholder="List" class="oe-hint"><br></li></ul></td>
-                                            <td class="o_selected_td"><ul class="o_checklist"><li placeholder="List" class="oe-hint"><br></li></ul>]</td>
+                                            <td class="o_selected_td"><ul class="o_checklist"><li><br></li></ul></td>
+                                            <td class="o_selected_td"><ul class="o_checklist"><li><br></li></ul></td>
+                                            <td class="o_selected_td"><ul class="o_checklist"><li><br></li></ul>]</td>
                                         </tr>
                                     </tbody>
                                 </table>
@@ -5933,7 +5933,7 @@ describe('List', () => {
                                 '<ul class="o_checklist"><li>ab</li><li class="o_checked"><a href="#">[cd</a></li><li>ef]</li><li>gh</li></ul>',
                             stepFunction: deleteBackward,
                             contentAfterEdit:
-                                '<ul class="o_checklist"><li>ab</li><li placeholder="List" class="oe-hint">[]<br></li><li>gh</li></ul>',
+                                '<ul class="o_checklist"><li>ab</li><li placeholder="List" class="oe-hint oe-command-temporary-hint">[]<br></li><li>gh</li></ul>',
                             contentAfter:
                                 '<ul class="o_checklist"><li>ab</li><li>[]<br></li><li>gh</li></ul>',
                         });
@@ -6265,7 +6265,7 @@ describe('List', () => {
                         await testEditor(BasicEditor, {
                             contentBefore,
                             stepFunction: deleteBackward,
-                            contentAfterEdit: '<ul><li>ab</li><li placeholder="List" class="oe-hint">[]<br></li><li>ij</li></ul>',
+                            contentAfterEdit: '<ul><li>ab</li><li placeholder="List" class="oe-hint oe-command-temporary-hint">[]<br></li><li>ij</li></ul>',
                             contentAfter: '<ul><li>ab</li><li>[]<br></li><li>ij</li></ul>',
                         });
                     });

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -66,6 +66,8 @@ const getRangePosition = OdooEditorLib.getRangePosition;
 const childNodeIndex = OdooEditorLib.childNodeIndex;
 const fillEmpty = OdooEditorLib.fillEmpty;
 const isVisible = OdooEditorLib.isVisible;
+const getDeepestPosition = OdooEditorLib.getDeepestPosition;
+const paragraphRelatedElements = OdooEditorLib.paragraphRelatedElements;
 
 function getJqueryFromDocument(doc) {
     if (doc.defaultView && doc.defaultView.$) {
@@ -448,8 +450,14 @@ export class Wysiwyg extends Component {
             getPowerboxElement: () => {
                 const selection = (this.options.document || document).getSelection();
                 if (selection.isCollapsed && selection.rangeCount) {
-                    const baseNode = closestElement(selection.anchorNode, 'P:not([t-field]), DIV:not([t-field]):not(.o_not_editable)');
-                    const fieldContainer = closestElement(selection.anchorNode, '[data-oe-field]');
+                    const [deepestNode] = getDeepestPosition(selection.anchorNode, selection.anchorOffset);
+                    const elementSelectors = [
+                        'LI:not([t-field])',
+                        'DIV:not([t-field]):not(.o_not_editable)',
+                        ...paragraphRelatedElements.map(tag => `${tag}:not([t-field])`),
+                    ];
+                    const baseNode = closestElement(deepestNode, elementSelectors.join(', '));
+                    const fieldContainer = closestElement(deepestNode, '[data-oe-field]');
                     if (!baseNode ||
                         (
                             fieldContainer &&

--- a/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
+++ b/addons/website/static/src/components/wysiwyg_adapter/wysiwyg_adapter.js
@@ -485,7 +485,6 @@ export class WysiwygAdapterComponent extends Wysiwyg {
             powerboxCommands: powerboxItems[0],
             powerboxCategories: powerboxItems[1],
             bindLinkTool: true,
-            showEmptyElementHint: false,
             getReadOnlyAreas: this._getReadOnlyAreas.bind(this),
             getUnremovableElements: this._getUnremovableElements.bind(this),
             direction: this.websiteService.currentWebsite.metadata.direction,


### PR DESCRIPTION
Purpose:

- Ensure that muted text is displayed exclusively on active
  lines while remaining absent from other lines.

- Resolve the issue where muted text wasn't displaying on the
  checklist when the selection or cursor was on it.

task-3875225