### PR TITLE
[FIX] base_automation: fix mail trigger based on `author_id`

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -841,7 +841,8 @@ class BaseAutomation(models.Model):
                     return message
 
                 # always execute actions when the author is a customer
-                mail_trigger = "on_message_received" if message_sudo.author_id.partner_share else "on_message_sent"
+                # if author is not set, it means the message is coming from outside
+                mail_trigger = "on_message_received" if not message_sudo.author_id or message_sudo.author_id.partner_share else "on_message_sent"
                 automations = self.env['base.automation']._get_actions(self, [mail_trigger])
                 for automation in automations.with_context(old_values=None):
                     records = automation._filter_pre(self, feedback=True)

--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -1012,6 +1012,11 @@ class TestCompute(common.TransactionCase):
         obj.message_post(author_id=internal_partner.id, subtype_xmlid="mail.mt_comment", message_type="comment")
         self.assertFalse(obj.active)
 
+        obj.active = True
+        # message doesn't have author_id, so it should be considered as external the automation should't be triggered
+        obj.message_post(author_id=False, email_from="test_abla@test.test", message_type="email", subtype_xmlid="mail.mt_comment")
+        self.assertTrue(obj.active)
+
         automation.trigger = "on_message_received"
         obj.active = True
         obj.message_post(author_id=internal_partner.id, subtype_xmlid="mail.mt_comment", message_type="comment")
@@ -1026,6 +1031,9 @@ class TestCompute(common.TransactionCase):
         obj.active = True
         obj.message_post(author_id=ext_partner.id, subtype_xmlid="mail.mt_comment")
         self.assertTrue(obj.active)
+
+        obj.message_post(author_id=False, email_from="test_abla@test.test", message_type="email", subtype_xmlid="mail.mt_comment")
+        self.assertFalse(obj.active)
 
     def test_multiple_mail_triggers(self):
         lead_model = self.env["ir.model"]._get("base.automation.lead.test")


### PR DESCRIPTION
To reproduce:
=============
- enable creating ticket in helpdesk with mail alias
- having to stages in helpdesk **New** and **In Progress**
- create an automated action that is triggered with `on_message_sent` that will move a ticket from **New** to **In Progress**
- send an email to the mail alias from an email that doesn't have a contact in the database -> the automated action will be triggered whereas it shouldn't

Problem:
========
To know if the email is from a customer and set the `mail_trigger` to `on_message_received` we were checking if the `author_id` of the message, which is `False` if the email is from an unknown contact.

Solution:
=========
if the `author_id` is `False`, it means that the email is from outside, so the `mail_trigger` should be `on_message_received`

opw-3833857

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
