### PR TITLE
[IMP] l10n_ar: l10n_ar_special_purchase_document_type_ids will be deprecated

### DIFF
--- a/addons/l10n_ar/i18n/es_419.po
+++ b/addons/l10n_ar/i18n/es_419.po
@@ -2007,12 +2007,8 @@ msgstr "Fecha del Servicio"
 #. module: l10n_ar
 #: model:ir.model.fields,help:l10n_ar.field_res_partner__l10n_ar_special_purchase_document_type_ids
 #: model:ir.model.fields,help:l10n_ar.field_res_users__l10n_ar_special_purchase_document_type_ids
-msgid ""
-"Set here if this partner can issue other documents further than invoices, "
-"credit notes and debit notes"
-msgstr ""
-"Defina acá si la empresa puede emitir otros documentos más alla que "
-"facturas, notas de crédito o notas de débito"
+msgid "This field will be deprecated in the next version as it is no longer needed."
+msgstr "Este campo va a ser depreciado en la siguiente versión porque ya no es necesario."
 
 #. module: l10n_ar
 #: model:l10n_latam.identification.type,name:l10n_ar.it_Sigd

--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -1963,9 +1963,7 @@ msgstr ""
 #. module: l10n_ar
 #: model:ir.model.fields,help:l10n_ar.field_res_partner__l10n_ar_special_purchase_document_type_ids
 #: model:ir.model.fields,help:l10n_ar.field_res_users__l10n_ar_special_purchase_document_type_ids
-msgid ""
-"Set here if this partner can issue other documents further than invoices, "
-"credit notes and debit notes"
+msgid "This field will be deprecated in the next version as it is no longer needed."
 msgstr ""
 
 #. module: l10n_ar

--- a/addons/l10n_ar/models/res_partner.py
+++ b/addons/l10n_ar/models/res_partner.py
@@ -29,8 +29,7 @@ class ResPartner(models.Model):
         ' type of operations and requirements they need.')
     l10n_ar_special_purchase_document_type_ids = fields.Many2many(
         'l10n_latam.document.type', 'res_partner_document_type_rel', 'partner_id', 'document_type_id',
-        string='Other Purchase Documents', help='Set here if this partner can issue other documents further than'
-        ' invoices, credit notes and debit notes')
+        string='Other Purchase Documents', help='This field will be deprecated in the next version as it is no longer needed.')
 
     @api.depends('l10n_ar_vat')
     def _compute_l10n_ar_formatted_vat(self):


### PR DESCRIPTION
Task Adhoc side: 34375
Task Latam side: 1177
Modify "help" attribute of l10n_ar_special_purchase_document_type_ids (Other Purchase Documents) field on model res.partner to tell that it will be deprecated on next version.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
