### PR TITLE
[FIX] mass_mailing: don't show in mail list managment non public lists

### DIFF
--- a/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
+++ b/addons/mass_mailing/static/tests/tours/mailing_portal_unsubscribe_from_my.js
@@ -21,6 +21,9 @@ registry.category("web_tour.tours").add('mailing_portal_unsubscribe_from_my', {
         }, {
             content: "List4 is not proposed (not member but not private)",
             trigger: "ul#o_mailing_subscription_form_lists_additional:not(:has(li.list-group-item:contains('List4')))",
+        },{
+            content: "List5 is not proposed (not member and not public)",
+            trigger: "body:not(:has(li.list-group-item:contains('List5')))",
         }, {
             content: "Feedback area is not displayed (nothing done, no feedback required)",
             trigger: "div#o_mailing_portal_subscription:not(textarea)",

--- a/addons/mass_mailing/tests/test_mailing_controllers.py
+++ b/addons/mass_mailing/tests/test_mailing_controllers.py
@@ -487,6 +487,16 @@ class TestMailingControllers(TestMailingControllersCommon):
         _test_email, test_email_normalized = portal_user.email, portal_user.email_normalized
         opt_out_reasons = self.env['mailing.subscription.optout'].search([])
 
+        # list opted-out and non-public should not be displayed
+        private_list = self.env['mailing.list'].with_context(self._test_context).create({
+            'contact_ids': [
+                (0, 0, {'name': 'Déboulonneur User', 'email': 'fleurus@example.com'}),
+            ],
+            'name': 'List5',
+            'is_public': False
+        })
+        private_list.subscription_ids[0].opt_out = True
+
         # launch 'my' mailing' tour
         self.authenticate(portal_user.login, portal_user.login)
         with freeze_time(self._reference_now):

--- a/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_unsubscribe.xml
@@ -60,8 +60,9 @@
                                     class="list-group">
                                     <li t-foreach="(lists_optin + lists_optout)"
                                         t-as="mailing_list"
-                                        class="list-group-item d-flex align-items-center">
-                                        <t t-set="title" t-value="mailing_list.name if mailing_list.is_public else 'Mailing List #%s' % mailing_list.id"/>
+                                        class="list-group-item d-flex align-items-center"
+                                        t-if="mailing_list not in lists_optout or mailing_list.is_public">
+                                        <t t-set="title" t-value="mailing_list.name"/>
                                         <input type="checkbox"
                                                name="mailing_list_ids"
                                                t-att-data-member="1"


### PR DESCRIPTION
Issue: In the portal page for managing your mailing lists, to subscribe or unsubscribe, you can see also the ones that are supposely marked for not appearing in this view, when this happen the appear as "Mailing list .#number" which is not ideal, since it will still let us subscribe to it when we shouldn be able to.

Stesp to reproduce:

1. Install mass_mailing.
2. Create atleast 2 lists, one with "Show in Preferences" ticked and the other not.
3. Now go to "/mailing/my" to manage the lists and see how they appear.

Solution: It seems logical to filter out for the lists we are not subscribed the non public lists out (the ones that are not marked as "Show In Preferences"), with this we will only see the ones we should have access to see and subscribe/unsubscribe.

opw-3877385