### PR TITLE
[IMP] payment(_paypal): add missing info

### DIFF
--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -49,9 +49,13 @@ class AccountPayment(models.Model):
     def _compute_amount_available_for_refund(self):
         for payment in self:
             tx_sudo = payment.payment_transaction_id.sudo()
+            payment_method = (
+                tx_sudo.payment_method_id.primary_payment_method_id
+                or tx_sudo.payment_method_id
+            )
             if (
                 tx_sudo.provider_id.support_refund
-                and tx_sudo.payment_method_id.support_refund
+                and payment_method.support_refund
                 and tx_sudo.operation != 'refund'
             ):
                 # Only consider refund transactions that are confirmed by summing the amounts of

--- a/addons/account_payment/wizards/payment_refund_wizard.py
+++ b/addons/account_payment/wizards/payment_refund_wizard.py
@@ -59,7 +59,8 @@ class PaymentRefundWizard(models.TransientModel):
     def _compute_support_refund(self):
         for wizard in self:
             p_support_refund = wizard.transaction_id.provider_id.support_refund
-            pm_support_refund = wizard.transaction_id.payment_method_id.support_refund
+            pm = wizard.transaction_id.payment_method_id
+            pm_support_refund = (pm.primary_payment_method_id or pm).support_refund
             if not p_support_refund or not pm_support_refund:
                 wizard.support_refund = False
             elif p_support_refund == 'full_only' or pm_support_refund == 'full_only':

--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -831,7 +831,7 @@
         <field name="image" type="base64" file="payment/static/img/card.png"/>
         <field name="support_tokenization">True</field>
         <field name="support_express_checkout">False</field>
-        <field name="support_refund"></field>
+        <field name="support_refund">partial</field>
     </record>
 
     <record id="payment_method_cash_app_pay" model="payment.method">

--- a/addons/payment/data/payment_provider_data.xml
+++ b/addons/payment/data/payment_provider_data.xml
@@ -267,6 +267,7 @@
                          ref('payment.payment_method_eps'),
                          ref('payment.payment_method_giropay'),
                          ref('payment.payment_method_ideal'),
+                         ref('payment.payment_method_kbc_cbc'),
                          ref('payment.payment_method_paypal'),
                          ref('payment.payment_method_paysafecard'),
                          ref('payment.payment_method_p24'),

--- a/addons/payment_mollie/const.py
+++ b/addons/payment_mollie/const.py
@@ -64,6 +64,7 @@ PAYMENT_METHODS_MAPPING = {
     'apple_pay': 'applepay',
     'card': 'creditcard',
     'bank_transfer': 'banktransfer',
+    'kbc_cbc': 'kbc',
     'p24': 'przelewy24',
     'sepa_direct_debit': 'directdebit',
 }

--- a/addons/payment_paypal/const.py
+++ b/addons/payment_paypal/const.py
@@ -41,6 +41,6 @@ DEFAULT_PAYMENT_METHODS_CODES = [
 # See https://developer.paypal.com/docs/api-basics/notifications/ipn/IPNandPDTVariables/
 PAYMENT_STATUS_MAPPING = {
     'pending': ('Pending',),
-    'done': ('Processed', 'Completed'),
+    'done': ('Processed', 'Completed', 'Cleared'),  # cleared status is required fo echeck
     'cancel': ('Voided', 'Expired'),
 }


### PR DESCRIPTION
KBC has been added to Mollie.
Cards support refund.
Refund is now checked based on payment method refund support, not brand. "Cleared" mapping has been added to done state in PayPal in order to properly support echeck.

opw-3880431