### PR TITLE
[FIX] web_editor: apply commands correctly inside oe_structure div

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -3454,6 +3454,10 @@ export class OdooEditor extends EventTarget {
 
     _onBeforeInput(ev) {
         this._lastBeforeInputType = ev.inputType;
+        const selection = this.document.getSelection();
+        if (selection?.isCollapsed && selection?.anchorNode?.nodeType === Node.ELEMENT_NODE && selection?.anchorNode?.matches('div.oe_structure:empty')) {
+            fillEmpty(selection.anchorNode);
+        }
     }
 
     /**


### PR DESCRIPTION
Issue:
=====
List directly inside empty div with class `oe_structure` doesn't work as
expected

Steps to reproduce the issue:
=============================
- Install sale and studio
- Open studio
- Go to sale/reports invoice report
- Put cursor just on top of Description header of the table
- try to add list or seperator ...
- Commands doesn't work as expected.

Origin of the issue:
====================
Since the div is empty , the selection moves to the next element and the
command is then applied on the next element.

Solution:
=========
There are a lot of reports using empty `div` element with `oe_structure`
class to indicate that you can add some content there. To solve the
problem, we just fill those empty divs to be able to add some content
inside them correctly.

opw-3750346