### PR TITLE
[FIX] mrp : Re-compute duration expected in case of backorder

### DIFF
--- a/addons/mrp/models/mrp_workorder.py
+++ b/addons/mrp/models/mrp_workorder.py
@@ -329,7 +329,7 @@ class MrpWorkorder(models.Model):
     @api.depends('operation_id', 'workcenter_id', 'qty_production')
     def _compute_duration_expected(self):
         for workorder in self:
-            if workorder.state not in ['done', 'cancel']:
+            if workorder.state not in ['done', 'cancel'] or workorder.production_id.backorder_sequence != 0:
                 workorder.duration_expected = workorder._get_duration_expected()
 
     @api.depends('time_ids.duration', 'qty_produced')


### PR DESCRIPTION
**Steps to reproduce:**
	1- Install MRP module
	2- Create a MO for more than 1 unit of Finished Product (example: 5)
	3- Process MO for only 1 Unit, creating a backorder for the rest
	4- inspect the Real Duration of the first MO (not Backorder) or Details/Cost Analysis
	5- Real Duration is set to the full amount of time to create all products on Original MO, while backorders account for the time it would take to make the rest of the products

**Current behavior before PR:**
When process a MO and produce quatity less than the quantity inserted at first and you create a backorder for the remaining quantity the expected duration will not be re-computed and will have the same expected duration for the whole quantity. This issue was introduce in this commit:
https://github.com/odoo/odoo/commit/e4f5be29810a97b9fb893424bd6e4d21969a22e4

**Desired behavior after PR is merged:**
We are now checking if there is a backorder created after processing the MO and if there is we will re-compute the expected duration

opw-3873108