### PR TITLE
[IMP] expression: lateral join for m2m conditions

### DIFF
--- a/odoo/tools/query.py
+++ b/odoo/tools/query.py
@@ -26,6 +26,7 @@ def _sql_from_join(kind: SQL, alias: str, table: SQL | None, condition: SQL) -> 
 _SQL_JOINS = {
     "JOIN": SQL("JOIN"),
     "LEFT JOIN": SQL("LEFT JOIN"),
+    "LEFT JOIN LATERAL": SQL("LEFT JOIN LATERAL"),
 }
 
 
@@ -139,6 +140,10 @@ class Query(object):
         condition = SQL("%s = %s", SQL.identifier(lhs_alias, lhs_column), SQL.identifier(rhs_alias, rhs_column))
         self.add_join('LEFT JOIN', rhs_alias, rhs_table, condition)
         return rhs_alias
+
+    def lateral_join(self, alias: str, table: SQL):
+        self.add_join('LEFT JOIN LATERAL', alias, SQL("(%s)", table), SQL('TRUE'))
+        return alias
 
     @property
     def order(self) -> SQL | None:


### PR DESCRIPTION
Instead of using a (`NOT`) `EXISTS`, we can use a lateral JOIN. This can improve plans in 2 ways:
* avoid recomputing the same thing multiple times when the same leaf appears multiple times in one domain. For instance, considering this domains (taken from `ir.rules` in `<project.project>._compute_task_count` for Mitchel Admin): 
  ```python
  ['&', ('company_id', 'in', [1, False]),
        '|', '|', '|', '|', '&', ('project_id', '!=', False),
                                 '|', ('project_id.privacy_visibility', '!=', 'followers'),
                                      ('project_id.message_partner_ids', 'in', [3]),
                            '|', ('message_partner_ids', 'in', [3]),
                                 ('user_ids', 'in', 2),
                        '|', ('project_id', '!=', False),
                             ('user_ids', 'in', 2),
                   '&', ('project_id.privacy_visibility', '!=', 'followers'),
                        '|', '|', ('project_id', '!=', False),
                                  ('parent_id', '!=', False),
                             ('user_ids', 'in', 2),
             '&', '&', ('project_id', '=', False),
                       ('user_ids', 'in', 2),
                  ('parent_id', '=', False)] 
  ``` 
  We can see the `('user_ids', 'in', 2)` is there a few times and can be computed only once.
* the query planner seems to be able to do more optimization and parallelization.

Since both columns of the m2m relation table are part of the primary key, we don't need to worry about duplicating rows when joining.
