### PR TITLE
[FIX] microsoft_calendar: remove check on create

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -431,6 +431,12 @@ class Meeting(models.Model):
                     )
                 )
 
+    def _check_organizer_validation_conditions(self, vals_list):
+        """ Method for check in the microsoft_calendar module that needs to be
+            overridden in appointment.
+        """
+        return [True] * len(vals_list)
+
     @api.depends('recurrence_id', 'recurrency')
     def _compute_rrule_type_ui(self):
         defaults = self.env["calendar.recurrence"].default_get(["interval", "rrule_type"])

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -82,7 +82,8 @@ class Meeting(models.Model):
         if self._check_microsoft_sync_status() and not notify_context and recurrency_in_batch:
             self._forbid_recurrence_creation()
 
-        for vals in vals_list:
+        vals_check_organizer = self._check_organizer_validation_conditions(vals_list)
+        for vals in [vals for vals, check_organizer in zip(vals_list, vals_check_organizer) if check_organizer]:
             # If event has a different organizer, check its sync status and verify if the user is listed as attendee.
             sender_user, partner_ids = self._get_organizer_user_change_info(vals)
             partner_included = partner_ids and len(partner_ids) > 0 and sender_user.partner_id.id in partner_ids


### PR DESCRIPTION
Added condition on check that ensured the organizer was an attendee on the event on
create. This was added in a change that allowed the organizer to be
changed on the Odoo side. However, this caused issues with the
appointments app when creating an appointment that only used resources.
The "organizer" who in this case is the creator of the appointment type
would not be an attendee and therefore would cause an error and make the
appointment type unbookable.

Adding this condition allows the appointment to bypass the check if the
appointment type uses resources instead of users.

opw-3841495
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
