### PR TITLE
[FIX] auth_signup: use get_base_url on template

### DIFF
--- a/addons/auth_signup/data/mail_template_data.xml
+++ b/addons/auth_signup/data/mail_template_data.xml
@@ -286,7 +286,7 @@
                         Your login is <strong><t t-out="object.email or ''">mark.brown23@example.com</t></strong><br/>
                         To gain access to your account, you can use the following link:
                         <div style="margin: 16px 0px 16px 0px;">
-                            <a t-attf-href="/web/login?auth_login={{object.email}}"
+                            <a t-attf-href="{{object.get_base_url()}}/web/login?auth_login={{object.email}}"
                                 style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
                                 Go to My Account
                             </a>


### PR DESCRIPTION
Use get_base_url in the new user invite email template to avoid defaulting to the current web.base.url because of local paths.

If a database had multiple domains, the customer would receive an email with a link for a domain that they could not log into. This is because we would use the t-attf-href attribute with a local path and in turn just default to the web.base.url.

Changing this to get_base_url on the object now properly returns the domain that the user signed up on if the shared customer accounts setting is off on the database/user has website_id set.

opw-3759881

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
