### PR TITLE
[FIX] base_import_module: fix traceback when manifest file datatype is not list

### DIFF
--- a/addons/base_import_module/i18n/base_import_module.pot
+++ b/addons/base_import_module/i18n/base_import_module.pot
@@ -295,6 +295,13 @@ msgstr ""
 #. odoo-python
 #: code:addons/base_import_module/models/ir_module.py:0
 #, python-format
+msgid "The manifest data of the uploaded file must be in list datatype"
+msgstr ""
+
+#. module: base_import_module
+#. odoo-python
+#: code:addons/base_import_module/models/ir_module.py:0
+#, python-format
 msgid "The module %s cannot be downloaded"
 msgstr ""
 

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -229,7 +229,10 @@ class IrModule(models.Model):
                             terp = ast.literal_eval(f.read().decode())
                     except Exception:
                         continue
-                    files_to_import = terp.get('data', []) + terp.get('init_xml', []) + terp.get('update_xml', [])
+                    trep_data = [terp.get('data', []), terp.get('init_xml', []), terp.get('update_xml', [])]
+                    if any(not isinstance(data, list) for data in trep_data):
+                        raise UserError(_("The manifest data of the uploaded file must be in list datatype"))
+                    files_to_import = trep_data[0] + trep_data[1] + trep_data[2]
                     if with_demo:
                         files_to_import += terp.get('demo', [])
                     for filename in files_to_import:


### PR DESCRIPTION
This traceback occurs when the user tries to upload a `zip file` through 
import module in apps with the wrong datatype (not list ) in the `manifest` data.

To reproduce this issue:

1) create a `zip file` with the manifest data other than list
2) open apps with debugger mode on
3) upload this zip file through `import module`
4) A traceback occurs

Error:- 
```
TypeError: unsupported operand type(s) for +: 'set' and 'list'
```

https://github.com/odoo/odoo/blob/1882d8f89f760bd1ff8a2bf0ae798939402647a3/addons/base_import_module/models/ir_module.py#L228-L232

When the user defines manifest data with different datatype
(other than list) it leads to the above traceback.

After applying this commit will resolve this issue by checking the datatype before concatenation, 
which makes code more robust.

sentry-5168971980
