### PR TITLE
[IMP] website, *: review and standardize `.badge` and `.o_badge` design and options

### DIFF
--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -82,7 +82,7 @@
                                     <div t-if="assignees" class="flex-nowrap ps-3">
                                         <img class="rounded o_portal_contact_img me-2" t-attf-src="#{image_data_uri(assignees[:1].avatar_1024)}" alt="User" style="width: 20px; height: 20px;"/>
                                         <span t-att-title="'\n'.join(assignees.mapped('name'))">
-                                            <span t-field="assignees[:1].name"/><span t-if="len(assignees) &gt; 1" class="badge ms-1 rounded-pill text-bg-light"> +<span t-out="len(assignees) - 1"/></span>
+                                            <span t-field="assignees[:1].name"/><span t-if="len(assignees) &gt; 1" class="badge ms-1 rounded-pill bg-light"> +<span t-out="len(assignees) - 1"/></span>
                                         </span>
                                     </div>
                                 </td>

--- a/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
+++ b/addons/test_website_slides_full/static/tests/tours/slides_certification_member.js
@@ -153,7 +153,7 @@ var certificationCompletionSteps = [{
     run: "click",
 }, {
     content: 'eLearning: course should be completed',
-    trigger: '.o_wslides_course_card:contains("DIY Furniture") .rounded-pill:contains("Completed")',
+    trigger: '.o_wslides_course_card:contains("DIY Furniture") .badge:contains("Completed")',
 }];
 
 var profileSteps = [{

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -212,63 +212,63 @@
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                                 <li class="list-group-item list-group-item-primary d-flex justify-content-between align-items-start">
                                                     <div class="ms-2 me-auto">
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                                 <li class="list-group-item list-group-item-secondary d-flex justify-content-between align-items-start">
                                                     <div class="ms-2 me-auto">
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                                 <li class="list-group-item list-group-item-success d-flex justify-content-between align-items-start">
                                                     <div class="ms-2 me-auto">
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                                 <li class="list-group-item list-group-item-danger d-flex justify-content-between align-items-start">
                                                     <div class="ms-2 me-auto">
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                                 <li class="list-group-item list-group-item-warning d-flex justify-content-between align-items-start">
                                                     <div class="ms-2 me-auto">
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                                 <li class="list-group-item list-group-item-info d-flex justify-content-between align-items-start">
                                                     <div class="ms-2 me-auto">
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                                 <li class="list-group-item list-group-item-light d-flex justify-content-between align-items-start">
                                                     <div class="ms-2 me-auto">
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                                 <li class="list-group-item list-group-item-dark d-flex justify-content-between align-items-start">
                                                     <div class="ms-2 me-auto">
                                                         <div class="fw-bold">Subheading</div>
                                                         Cras justo odio
                                                     </div>
-                                                    <span class="badge bg-primary rounded-pill">14</span>
+                                                    <span class="badge bg-primary">14</span>
                                                 </li>
                                             </ol>
                                         </div>

--- a/addons/website/static/src/scss/bootstrap_overridden.scss
+++ b/addons/website/static/src/scss/bootstrap_overridden.scss
@@ -323,6 +323,9 @@ $popover-border-color: $border-color !default;
 $popover-arrow-color: $body-bg !default;
 $popover-arrow-outer-color: $border-color !default;
 
+// Badge
+$badge-border-radius: $border-radius-pill !default;
+
 // Shadows
 $box-shadow: 0px 4px 16px rgba($black, 0.12) !default;
 $box-shadow-sm: 0px 1px 3px rgba($black, .1) !default;

--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -606,6 +606,73 @@ font[class*='bg-'] {
     }
 }
 
+// Badges
+.badge, .o_filter_tag {
+    background: var(--background-color, var(--bg-light)) !important;
+    color: var(--color, var(--color-light)) !important;
+    border: $border-width solid var(--bg-solid) !important;
+
+    // Similarly to list-group-item-x and alert-* classes, override text-bg-*
+    // classes behavior when used on badges.
+    @each $-color, $-value in $theme-colors {
+        &.text-bg-#{$-color} {
+            --bg-light: #{tint-color($-value, 90%)};
+            --color-light: #{increase-contrast($-value, tint-color($-value, 90%))};
+            --bg-solid: #{$-value};
+            --bg-solid-contrast: #{color-contrast($-value, $min-contrast-ratio: 3)};
+        }
+
+        // Restore old badge design (needed as an exit door for some contexts)
+        //(e.g cart_quantity, dropdown toggle.badge)
+        &.bg-#{$-color} {
+            --bg-light: #{$-value};
+            --color-light: #{color-contrast($-value, $min-contrast-ratio: 3)};
+            --bg-solid: var(--bg-light);
+            --bg-solid-contrast: var(--color-light);
+        }
+    }
+
+    @at-root a.badge:hover, a:not(.dropdown-item):hover > .badge, .o_badge_clickable.badge:hover {
+        --background-color: var(--bg-solid);
+        --color: var(--bg-solid-contrast);
+
+        text-decoration: none;
+    }
+
+    .btn {
+        --btn-color: var(--color, var(--color-light));
+    }
+}
+
+@for $-size from 1 through length($o-colors) {
+    .o_color_#{$-size - 1} {
+       // Compute background-color and text-color values for different uses,
+       // allowing to apply the value from colorfield on desired UI elements.
+       // this set of variables covers all the possible scenarios.
+
+        $-color: nth($o-colors, $-size);
+
+        $-is-website-palette-dark: color-contrast($body-color) == $color-contrast-dark;
+        $-bg-lightness-adjusted: if($-is-website-palette-dark, -40%, 0%);
+
+        $-bg-solid: $-color;
+        $-bg-solid-contrast: color-contrast($-bg-solid, $min-contrast-ratio: 3);
+
+        $-bg-light: if($-is-website-palette-dark, adjust-color($-color, $lightness: $-bg-lightness-adjusted, $saturation: 5%), tint-color($-bg-solid, 90%));
+        $-color-light: increase-contrast($-bg-solid, $-bg-light);
+
+        $-bg-light-contrast: color-contrast($-bg-light, $min-contrast-ratio: 3);
+
+        // Print CSS variables.
+        --bg-solid: #{$-bg-solid};
+        --bg-solid-contrast: #{$-bg-solid-contrast};
+
+        --bg-light: #{$-bg-light};
+        --color-light: #{$-color-light};
+
+        --bg-light-contrast: #{$-bg-light-contrast};
+    }
+}
 
 // Background Images
 .oe_img_bg {

--- a/addons/website/static/src/snippets/s_badge/000.scss
+++ b/addons/website/static/src/snippets/s_badge/000.scss
@@ -3,7 +3,7 @@
     padding: $s-badge-padding;
     margin: $s-badge-margin;
     border-radius: if($s-badge-border-radius != null, $s-badge-border-radius, $badge-border-radius);
-    @include font-size($font-size-sm);
+
     .fa {
         margin: $s-badge-i-margin;
     }

--- a/addons/website/views/snippets/s_badge.xml
+++ b/addons/website/views/snippets/s_badge.xml
@@ -2,7 +2,7 @@
 <odoo>
 
 <template name="Badge" id="s_badge">
-    <span class="s_badge badge text-bg-secondary o_animable" data-name="Badge">
+    <span class="s_badge badge text-bg-secondary o_animable" data-name="Badge" data-vxml="001">
         <i class="fa fa-1x fa-fw fa-folder o_not-animable"/>Category
     </span>
 </template>
@@ -10,10 +10,16 @@
 <template id="s_badge_options" inherit_id="website.snippet_options">
     <xpath expr="//div[@data-js='Box']" position="before">
         <div data-selector=".s_badge">
-            <we-colorpicker string="Color" data-name="badge_colorpicker_opt"
-                data-select-style="true"
-                data-css-property="background-color"
-                data-color-prefix="bg-"/>
+            <we-select string="Style">
+                <we-button data-select-class="text-bg-primary">Primary</we-button>
+                <we-button data-select-class="text-bg-secondary">Secondary</we-button>
+                <we-button data-select-class="text-bg-success">Success</we-button>
+                <we-button data-select-class="text-bg-info">Info</we-button>
+                <we-button data-select-class="text-bg-warning">Warning</we-button>
+                <we-button data-select-class="text-bg-danger">Danger</we-button>
+                <we-button data-select-class="text-bg-light">Light</we-button>
+                <we-button data-select-class="text-bg-dark">Dark</we-button>
+            </we-select>
         </div>
     </xpath>
 </template>

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -102,12 +102,12 @@
         <div t-if="not hide_title and categ_title" class="text-muted mb-1 h6" t-esc="categ_title"/>
         <t t-foreach="tags" t-as="tag">
             <t t-if="tag.post_ids">
-                <span t-if="dismissibleBtn and tag.id in active_tag_ids" t-attf-class="align-items-baseline border d-inline-flex ps-2 rounded mb-2 fs-6 o_tag #{'o_tag_color_%s' % tag.color}">
-                    <i class="fa fa-tag me-2 text-muted"/>
+                <span t-if="dismissibleBtn and tag.id in active_tag_ids" t-attf-class="align-items-baseline d-inline-flex ps-2 rounded mb-2 o_filter_tag #{'o_color_%s' % tag.color}">
+                    <i class="fa fa-tag me-2"/>
                     <t t-esc="tag.name"/>
                     <a t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" class="btn border-0 py-1 post_link" t-att-rel="len(active_tag_ids) and 'nofollow'">&#215;</a>
                 </span>
-                <a t-elif="showInactive" t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" t-attf-class="badge mb-2 mw-100 text-truncate text-decoration-none o_tag o_tag_color_#{tag.color} post_link" t-att-rel="len(active_tag_ids) and 'nofollow'" t-esc="tag.name"/>
+                <a t-elif="showInactive" t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" t-attf-class="badge mb-2 mw-100 text-truncate text-decoration-none o_tag o_color_#{tag.color} post_link" t-att-rel="len(active_tag_ids) and 'nofollow'" t-esc="tag.name"/>
             </t>
         </t>
     </t>
@@ -300,7 +300,7 @@ Display a sidebar beside the post content.
             <t t-if="blog_post.tag_ids">
                 <div class="h5">
                     <t t-foreach="blog_post.tag_ids" t-as="one_tag">
-                        <a t-attf-class="badge border post_link text-decoration-none text-primary o_tag o_tag_color_#{one_tag.color}" t-attf-href="#{blog_url(tag=slug(one_tag))}" t-esc="one_tag.name"/>
+                        <a t-attf-class="badge post_link text-decoration-none o_tag o_color_#{one_tag.color}" t-attf-href="#{blog_url(tag=slug(one_tag))}" t-esc="one_tag.name"/>
                     </t>
                 </div>
             </t>

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -211,7 +211,7 @@ according to the enabled options.
     <div t-if="len(blog_post.tag_ids)" class="o_wblog_post_short_tag_section d-flex align-items-center flex-wrap pt-2">
         <t t-foreach="blog_post.tag_ids" t-as="one_tag">
             <a t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, one_tag.id))}"
-               t-attf-class="badge mb-2 me-1 text-truncate o_tag o_tag_color_#{one_tag.color} post_link"
+               t-attf-class="badge mb-2 me-1 text-truncate o_tag o_color_#{one_tag.color} post_link"
                t-att-rel="len(active_tag_ids) and 'nofollow'"
                t-esc="one_tag.name"/>
         </t>

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -249,7 +249,7 @@ list of filtered posts (by date or tag).
         <div t-if="len(blogs) > 1">in <a t-attf-href="#{blog_url(blog=blog_post.blog_id)}"><b t-field="blog.name"/></a></div>
         <div t-if="len(blog_post.tag_ids) > 0">#
             <t t-foreach="blog_post.tag_ids" t-as="one_tag">
-                <a t-attf-class="badge text-primary border me-1 o_tag o_tag_color_#{one_tag.color} post_link" t-attf-href="#{blog_url(tag=slug(one_tag), date_begin=False, date_end=False)}" t-esc="one_tag.name"/>
+                <a t-attf-class="badge me-1 o_tag o_color_#{one_tag.color} post_link" t-attf-href="#{blog_url(tag=slug(one_tag), date_begin=False, date_end=False)}" t-esc="one_tag.name"/>
             </t>
         </div>
     </div>

--- a/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
+++ b/addons/website_crm_partner_assign/views/website_crm_partner_assign_templates.xml
@@ -431,7 +431,7 @@
                             <span t-field="opp.probability" />%
                         </td>
                         <td>
-                            <span class="badge text-bg-info rounded-pill" title="Current stage of the opportunity" t-esc="opp.stage_id.name" />
+                            <span class="badge text-bg-info" title="Current stage of the opportunity" t-esc="opp.stage_id.name" />
                         </td>
                     </tr>
                 </tbody>
@@ -635,7 +635,7 @@
                                 <t t-if="opportunity.company_currency" t-out="opportunity.expected_revenue"
                                     t-options="{'widget': 'monetary', 'display_currency': opportunity.company_currency}"/>
                                 <t t-else="" t-out="opportunity.expected_revenue"/> at  </span>
-                            <span class="badge text-bg-info rounded-pill"><span t-field="opportunity.probability"/>%</span>
+                            <span class="badge text-bg-info"><span t-field="opportunity.probability"/>%</span>
                         </h5>
                         <button type="button" data-bs-toggle="modal" data-bs-target=".modal_edit_opp" class="btn btn-link btn-sm"><i class="fa fa-pencil me-1"/>Edit</button>
                     </div>

--- a/addons/website_customer/models/res_partner.py
+++ b/addons/website_customer/models/res_partner.py
@@ -29,12 +29,12 @@ class Tags(models.Model):
 
     @api.model
     def get_selection_class(self):
-        classname = ['light', 'primary', 'success', 'warning', 'danger']
+        classname = ['info', 'primary', 'success', 'warning', 'danger']
         return [(x, str.title(x)) for x in classname]
 
     name = fields.Char('Category Name', required=True, translate=True)
     partner_ids = fields.Many2many('res.partner', 'res_partner_res_partner_tag_rel', 'tag_id', 'partner_id', string='Partners')
-    classname = fields.Selection('get_selection_class', 'Class', default='light', help="Bootstrap class to customize the color", required=True)
+    classname = fields.Selection('get_selection_class', 'Class', default='info', help="Bootstrap class to customize the color", required=True)
     active = fields.Boolean('Active', default=True)
 
     def _default_is_published(self):

--- a/addons/website_customer/views/website_customer_templates.xml
+++ b/addons/website_customer/views/website_customer_templates.xml
@@ -107,7 +107,7 @@
                                 <div class="o_wc_offcanvas_tags accordion-collapse collapse">
                                     <div class="accordion-body">
                                         <div class="d-flex flex-wrap align-items-center gap-1 mb-4" t-if="len(tags)">
-                                            <a class="badge text-bg-light" t-attf-href="/customers/#{ current_industry_id and 'industry/%s/' % slug(current_industry) or '' }#{ current_country_id and 'country/%s' % slug(current_country) or '' }">
+                                            <a class="badge text-bg-info" t-attf-href="/customers/#{ current_industry_id and 'industry/%s/' % slug(current_industry) or '' }#{ current_country_id and 'country/%s' % slug(current_country) or '' }">
                                                 <span class="fa fa-1x fa-tags"/> All </a>
                                             <t t-foreach="tags" t-as="o_tag">
                                                 <a t-attf-class="badge text-bg-#{o_tag.classname}" t-out="o_tag.name" t-att-style="tag and tag.id==o_tag.id and 'text-decoration: underline'"
@@ -239,7 +239,7 @@
 <template id="opt_tag_list" inherit_id="website_customer.index" name="Filter on Tags" priority="40">
     <xpath expr="//div[hasclass('o_wcrm_filters_top')]" position="after">
         <div class="d-flex align-items-center gap-2 my-4" t-if="len(tags)">
-            <a class="badge text-bg-light" t-attf-href="/customers/#{ current_industry_id and 'industry/%s/' % slug(current_industry) or '' }#{ current_country_id and 'country/%s' % slug(current_country) or '' }">
+            <a class="badge text-bg-info" t-attf-href="/customers/#{ current_industry_id and 'industry/%s/' % slug(current_industry) or '' }#{ current_country_id and 'country/%s' % slug(current_country) or '' }">
                 <span class="fa fa-1x fa-tags"/> All
             </a>
             <t t-foreach="tags" t-as="o_tag">

--- a/addons/website_event/static/src/scss/event_templates_common.scss
+++ b/addons/website_event/static/src/scss/event_templates_common.scss
@@ -6,57 +6,17 @@ $o-wevent-color: $body-color;
 
 .o_wevent_index, .o_wevent_event {
 
-    @for $-size from 1 through length($o-colors) {
-        .o_event_color_#{$-size - 1}, .o_badge_color_#{$-size - 1} {
-            // Get the actual color from "backend tags" (or custom grey in case of event_0)
-            $-color: if($-size == 1, $o-wevent-bg-color-dark, nth($o-colors, $-size));
-
-            // Check if the website palette is dark and adjust lightness
-            // according to the website palette.
-            $-is-website-palette-dark: color-contrast($body-color) == $color-contrast-dark;
-            $-bg-lightness-adjusted: if($-is-website-palette-dark, -30%, -5%);
-
-            // Compute background-color and text-color values for different uses
-            $-bg-solid: adjust-color($-color, $lightness: $-bg-lightness-adjusted, $saturation: 5%);
-            $-color-solid: color-contrast($-bg-solid, $min-contrast-ratio: 3);
-
-            $-bg-solid-hover: if($-color-solid == $color-contrast-light, shade-color($-bg-solid, $btn-hover-bg-shade-amount), tint-color($-bg-solid, $btn-hover-bg-tint-amount));
-            $-color-solid-hover: color-contrast($-bg-solid-hover, $min-contrast-ratio: 3);
-
-            $-bg-light: mix($-bg-solid, $body-bg, 5%);
-            $-color-light: color-contrast($-bg-light, $min-contrast-ratio: 3);
-
-            // Print CSS variables.
-            --base: #{$-color};
-
-            --bg-solid: #{$-bg-solid};
-            --color-solid: #{$-color-solid};
-
-            --bg-solid--hover: #{$-bg-solid-hover};
-            --color-solid--hover: #{$-color-solid-hover};
-
-            --bg-light: #{$-bg-light};
-            --color-light: #{$-color-light};
-
-            // Assign default values
-            background-color: var(--bg, var(--bg-solid));
-            color: var(--color, var(--color-solid));
-        }
+    .event_track > div {
+        border-top: $border-width * 3 solid var(--bg-solid);
+        background-color: var(--bg-light);
+        color: var(--bg-light-contrast);
     }
 
-    .o_event_color_light {
-        --bg: var(--bg-light);
-        --color: var(--color-light);
-    }
-
-    .o_badge, .o_badge_clickable {
-        --bg: var(--bg-solid);
-        --color: var(--color-solid);
-    }
-
-    .o_badge_clickable:hover {
-        --bg: var(--bg-solid--hover);
-        --color: var(--color-solid--hover);
+    .o_wesession_list_item {
+        background: var(--bg-light);
+        color: var(--bg-light-contrast);
+        border: $border-width solid var(--o-border-color);
+        border-left: $border-width * 3 solid var(--bg-solid);
     }
 
     /*
@@ -82,12 +42,6 @@ $o-wevent-color: $body-color;
 
         .o_wesession_list_item {
             margin: map-get($spacers, 2) 0;
-            border: 1px solid var(--o-border-color);
-            border-left: 3px solid var(--base);
-        }
-
-        .event_track > div {
-            border-top: 3px solid var(--base);
         }
 
         .o_wevent_online_page_container {

--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -55,7 +55,7 @@
                             <a href="#" role="button" class="btn btn-light dropdown-toggle" data-bs-toggle="dropdown">
                                 <t t-out="category.name"/>
                                 <span t-if="len(searched_category_tags)" t-out="len(searched_category_tags)"
-                                    class="badge rounded-pill text-bg-primary ms-1"/>
+                                    class="badge bg-primary ms-1"/>
                             </a>
                             <div class="dropdown-menu">
                                 <span t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - searched_category_tags).ids), prevent_redirect=True)"
@@ -136,7 +136,7 @@
 <template id="searched_tags" name="Searched tags">
     <div class="d-lg-none d-flex align-items-center flex-wrap gap-2 mt-2">
         <t t-foreach="search_tags" t-as="tag">
-            <span t-attf-class="d-inline-flex align-items-baseline rounded border ps-2 #{'o_badge_color_%s' % tag.color if tag.color else ''}">
+            <span t-attf-class="o_filter_tag d-inline-flex align-items-baseline rounded ps-2 #{'o_color_%s' % tag.color if tag.color else ''}">
                 <t t-out="tag.display_name"/>
                 <span t-att-data-post="'/event?%s' % keep_query('*', tags=str((search_tags - tag).ids), prevent_redirect=True)"
                     class="post_link cursor-pointer btn border-0 py-1 px-2 text-reset opacity-75-hover">
@@ -161,7 +161,7 @@
                         <t t-set="is_active" t-value="searches.get('date') == date[0]"/>
                         <a t-att-href="keep('/event', date=date[0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}">
                             <t t-out="date[1]"/>
-                            <span t-if="date[3]" t-out="date[3]" t-attf-class="badge rounded-pill ms-3 #{is_active and 'text-bg-light' or 'text-bg-primary'}"/>
+                            <span t-if="date[3]" t-out="date[3]" t-attf-class="badge ms-3 text-bg-primary"/>
                         </a>
                     </t>
                 </t>
@@ -191,7 +191,7 @@
                                         <input class="form-check-input pe-none" type="radio" t-attf-name="#{date[1]}" t-att-checked="is_active"/>
                                         <label class="form-check-label" t-attf-for="#{date[1]}" t-out="date[1]"/>
                                     </div>
-                                    <span t-if="date[3]" t-out="date[3]" class="badge rounded-pill text-bg-light"/>
+                                    <span t-if="date[3]" t-out="date[3]" class="badge text-bg-primary"/>
                                 </a>
                             </li>
                         </t>
@@ -216,14 +216,14 @@
                         <t t-set="is_active" t-value="searches.get('country') == str(country['country_id'] and country['country_id'][0])"/>
                         <a t-att-href="keep('/event', country=country['country_id'][0])" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}" t-att-title="country['country_id'][1]">
                             <t t-out="country['country_id'][1]"/>
-                            <span t-out="country['country_id_count']" t-attf-class="badge rounded-pill ms-3 #{is_active and 'text-bg-light' or 'text-bg-primary'}"/>
+                            <span t-out="country['country_id_count']" t-attf-class="badge ms-3 text-bg-primary"/>
                         </a>
                     </t>
                     <t t-else="">
                         <t t-set="is_active" t-value="searches.get('country') == 'online'"/>
                         <a t-att-href="keep('/event', country='online')" t-attf-class="dropdown-item d-flex align-items-center justify-content-between #{is_active and 'active'}" title="Online Events">
                             <span>Online Events</span>
-                            <span t-out="country['country_id_count']" t-attf-class="badge rounded-pill ms-3 #{is_active and 'text-bg-light' or 'text-bg-primary'}"/>
+                            <span t-out="country['country_id_count']" t-attf-class="badge ms-3 text-bg-primary"/>
                         </a>
                     </t>
                 </t>
@@ -253,7 +253,7 @@
                                         <input class="form-check-input pe-none" type="radio" t-attf-name="#{country['country_id'][1]}" t-att-checked="is_active"/>
                                         <label class="form-check-label" t-attf-for="#{country['country_id'][1]}" t-out="country['country_id'][1]"/>
                                     </div>
-                                    <span t-out="country['country_id_count']" class="badge rounded-pill text-bg-light ms-auto"/>
+                                    <span t-out="country['country_id_count']" class="badge text-bg-primary ms-auto"/>
                                 </a>
                             </t>
                             <t t-else="">
@@ -263,7 +263,7 @@
                                         <input class="form-check-input pe-none" type="radio" name="Online Events" t-att-checked="is_active"/>
                                         <label class="form-check-label" for="Online Events">Online Events</label>
                                     </div>
-                                    <span t-out="country['country_id_count']" class="badge rounded-pill text-bg-light ms-auto"/>
+                                    <span t-out="country['country_id_count']" class="badge rounded-pill text-bg-primary ms-auto"/>
                                 </a>
                             </t>
                         </li>
@@ -356,7 +356,7 @@
                             <div class="d-flex flex-wrap gap-1 small">
                                 <t t-foreach="event.tag_ids.filtered(lambda tag: tag.category_id.website_id == website or not tag.category_id.website_id)" t-as="tag">
                                     <span t-if="tag.color"
-                                        t-attf-class="badge rounded-pill #{'o_badge_color_%s' % tag.color if tag.color else 'text-bg-light'}">
+                                        t-attf-class="badge #{'o_color_%s' % tag.color if tag.color else 'text-bg-light'}">
                                         <t t-out="tag.name"/>
                                     </span>
                                 </t>

--- a/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_exhibitor_templates.scss
@@ -104,18 +104,15 @@
 
             // Ribbon color (FIXME)
             .ribbon_Gold {
-                background-color: #e3aa24;
-                color:$white;
+                background-color: #e3aa24 !important;
             }
 
             .ribbon_Silver {
-                background-color: #adb5bd;
-                color: $white;
+                background-color: #adb5bd !important;
             }
 
             .ribbon_Bronze {
-                background-color: #c7632a;
-                color: $white;
+                background-color: #c7632a !important;
             }
         }
     }

--- a/addons/website_event_exhibitor/static/src/scss/event_templates_sponsor.scss
+++ b/addons/website_event_exhibitor/static/src/scss/event_templates_sponsor.scss
@@ -16,30 +16,30 @@
 }
 
 .o_wevent_event .ribbon_Gold {
-    background-color: #FDE21B;
-    background-image: -webkit-gradient(linear, left top, left bottom, from(#E9CE0C), to(#FDE21B));
-    background-image: -webkit-linear-gradient(top, #E9CE0C, #FDE21B);
-    background-image: -moz-linear-gradient(top, #E9CE0C, #FDE21B);
-    background-image: -ms-linear-gradient(top, #E9CE0C, #FDE21B);
-    background-image: -o-linear-gradient(top, #E9CE0C, #FDE21B);
+    background-color: #FDE21B !important;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#E9CE0C), to(#FDE21B)) !important;
+    background-image: -webkit-linear-gradient(top, #E9CE0C, #FDE21B) !important;
+    background-image: -moz-linear-gradient(top, #E9CE0C, #FDE21B) !important;
+    background-image: -ms-linear-gradient(top, #E9CE0C, #FDE21B) !important;
+    background-image: -o-linear-gradient(top, #E9CE0C, #FDE21B) !important;
 }
 
 .o_wevent_event .ribbon_Silver {
-    background-color: #CCCCCC;
-    background-image: -webkit-gradient(linear, left top, left bottom, from(#BBBBBB), to(#CCCCCC));
-    background-image: -webkit-linear-gradient(top, #BBBBBB, #CCCCCC);
-    background-image: -moz-linear-gradient(top, #BBBBBB, #CCCCCC);
-    background-image: -ms-linear-gradient(top, #BBBBBB, #CCCCCC);
-    background-image: -o-linear-gradient(top, #BBBBBB, #CCCCCC);
+    background-color: #CCCCCC !important;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#BBBBBB), to(#CCCCCC)) !important;
+    background-image: -webkit-linear-gradient(top, #BBBBBB, #CCCCCC) !important;
+    background-image: -moz-linear-gradient(top, #BBBBBB, #CCCCCC) !important;
+    background-image: -ms-linear-gradient(top, #BBBBBB, #CCCCCC) !important;
+    background-image: -o-linear-gradient(top, #BBBBBB, #CCCCCC) !important;
 }
 
 .o_wevent_event .ribbon_Bronze {
-    background-color: #DB9141;
-    background-image: -webkit-gradient(linear, left top, left bottom, from(#C2792A), to(#DB9141));
-    background-image: -webkit-linear-gradient(top, #C2792A, #DB9141);
-    background-image: -moz-linear-gradient(top, #C2792A, #DB9141);
-    background-image: -ms-linear-gradient(top, #C2792A, #DB9141);
-    background-image: -o-linear-gradient(top, #C2792A, #DB9141);
+    background-color: #DB9141 !important;
+    background-image: -webkit-gradient(linear, left top, left bottom, from(#C2792A), to(#DB9141)) !important;
+    background-image: -webkit-linear-gradient(top, #C2792A, #DB9141) !important;
+    background-image: -moz-linear-gradient(top, #C2792A, #DB9141) !important;
+    background-image: -ms-linear-gradient(top, #C2792A, #DB9141) !important;
+    background-image: -o-linear-gradient(top, #C2792A, #DB9141) !important;
 }
 
 /*

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -187,9 +187,9 @@
                             t-att-src="sponsor_other.partner_id.country_id.image_url"
                             t-att-alt="sponsor_other.partner_id.country_id.name"/>
                             <span t-if="sponsor_other.sponsor_type_id.display_ribbon_style not in [False, 'no_ribbon']"
-                                t-att-class="'badge text-bg-light ribbon_%s' % sponsor_other.sponsor_type_id.display_ribbon_style"
+                                t-att-class="'badge text-white ribbon_%s' % sponsor_other.sponsor_type_id.display_ribbon_style"
                                 t-out="sponsor_other.sponsor_type_id.name"/>
-                            <span t-else="" class="badge text-bg-light"
+                            <span t-else="" class="badge text-bg-info"
                                 t-out="sponsor_other.sponsor_type_id.name"/>
                         </div>
                         <div class="flex-grow-1 overflow-auto px-2">

--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -34,7 +34,7 @@
             <span itemprop="price" class="d-none" t-out="ticket.price"/>
             <span itemprop="priceCurrency" class="d-none" t-out="website.currency_id.name"/>
         </t>
-        <span t-else="" class="badge text-bg-success rounded-pill p-2 px-3">Free</span>
+        <span t-else="" class="badge text-bg-success p-2 px-3">Free</span>
     </xpath>
     <xpath expr="//div[hasclass('o_wevent_price_range')]" position="inside">
         <t t-if="website.show_line_subtotals_tax_selection == 'tax_excluded'" t-set="all_prices" t-value="event.event_ticket_ids.mapped('price_reduce')"/>

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -131,8 +131,8 @@
                                 <t t-if="tracks">
                                     <t t-foreach="tracks" t-as="track">
                                         <t t-set="_classes"
-                                            t-value="'o_event_color_light text-center %s %s %s' % (
-                                                'o_event_color_%s' % (track.color or 0),
+                                            t-value="'text-center %s %s %s' % (
+                                                'o_color_%s' % (track.color or 0),
                                                 'event_track h-100' if track else '',
                                                 'o_location_size_%d' % len(locations),
                                             )"/>
@@ -197,7 +197,7 @@
             <div>
                 <t t-foreach="track.tag_ids" t-as="tag">
                     <span t-if="tag.color" t-att-title="tag.name"
-                        t-attf-class="me-1 mt-1 badge o_badge_clickable #{'o_badge_color_'+str(tag.color)}" t-out="tag.name"
+                        t-attf-class="me-1 mt-1 badge o_badge_clickable #{'o_color_'+str(tag.color)}" t-out="tag.name"
                         t-attf-onclick="
                         var value = '#{tag.name}' ;
                         var target = $('#event_track_search');

--- a/addons/website_event_track/views/event_track_templates_list.xml
+++ b/addons/website_event_track/views/event_track_templates_list.xml
@@ -268,7 +268,7 @@
                 <div t-attf-class="collapse {{ '' if tracks_info['default_collapsed'] else 'show' }}"
                     t-attf-id="collapse_session_list_{{ tracks_info_index }}">
                     <div t-foreach="tracks" t-as="track"
-                        t-att-class="'o_wesession_list_item o_event_color_light p-3 o_event_color_%d' % (track.color)">
+                        t-att-class="'o_wesession_list_item p-3 o_color_%d' % (track.color)">
                         <div class="row g-0">
                             <div class="col-12 d-flex justify-content-between">
                                 <!-- Hour: Live > Remaining > Hour: desktop only -->
@@ -464,23 +464,23 @@
             slug(event),
             keep_query('*', tags=str((search_tags - tag).ids if tag in search_tags else (tag | search_tags).ids), prevent_redirect=True)
         )"
-        t-att-class="'post_link cursor-pointer badge rounded-pill text-decoration-none %s' % ('text-bg-primary opacity-75-hover' if tag in search_tags else 'o_badge o_badge_clickable o_badge_color_0')"
+        t-att-class="'post_link cursor-pointer badge rounded-pill text-decoration-none %s' % ('text-bg-primary opacity-75-hover' if tag in search_tags else 'o_badge o_badge_clickable o_color_0')"
         t-out="tag.name"/>
     <span t-else=""
         t-att-data-post="'/event/%s/track?%s'% (
             slug(event),
             keep_query('*', tags=str(tag.ids), prevent_redirect=True)
         )"
-        t-att-class="'post_link cursor-pointer badge rounded-pill text-decoration-none o_badge o_badge_clickable o_badge_color_%s' % (tag.color)"
+        t-att-class="'post_link cursor-pointer badge rounded-pill text-decoration-none o_badge o_badge_clickable o_color_%s' % (tag.color)"
         t-out="tag.name"/>
 </template>
 
 <template id="track_tag_badge_info" name="Track: Tag Badge Info">
     <span t-if="search_tags"
-        t-att-class="'badge %s' % ('text-bg-primary' if tag in search_tags else 'o_badge_color_0')"
+        t-att-class="'badge %s' % ('text-bg-primary' if tag in search_tags else 'o_color_0')"
         t-out="tag.name"/>
     <span t-else=""
-        t-att-class="'badge rounded-pill o_badge_color_%s' % (tag.color)"
+        t-att-class="'badge rounded-pill o_color_%s' % (tag.color)"
         t-out="tag.name"/>
 </template>
 

--- a/addons/website_event_track/views/event_track_templates_page.xml
+++ b/addons/website_event_track/views/event_track_templates_page.xml
@@ -85,7 +85,7 @@
                     <div class="d-flex flex-wrap gap-1">
                         <t t-foreach="track.tag_ids" t-as="tag">
                             <span t-if="tag.color"
-                                t-att-class="'badge o_badge_color_%s' % (tag.color)"
+                                t-att-class="'badge o_color_%s' % (tag.color)"
                                 t-out="tag.name"/>
                         </t>
                     </div>
@@ -233,14 +233,14 @@
             <small t-if="track_other.is_track_live and not track_other.is_track_done"
                 class="badge text-bg-danger">Live</small>
             <small t-elif="track_other.is_track_done"
-                class="badge text-bg-light">Done</small>
+                class="badge text-bg-info">Done</small>
             <small t-elif="track_other.is_track_today and track_other.track_start_remaining"
-                class="badge text-bg-secondary">
+                class="badge text-bg-info">
                 <span t-out="track_other.track_start_remaining"
                     t-options="{'widget': 'duration', 'digital': False, 'add_direction': True,
                                 'unit': 'second', 'round': 'minute', 'format': 'narrow'}"/>
             </small>
-            <div t-elif="track_other.date" class="badge text-bg-light">
+            <div t-elif="track_other.date" class="badge text-bg-info">
                 <span t-out="track_other.date" t-options="{'widget': 'datetime', 'tz_name': track_other.event_id.date_tz, 'format': 'MMM. dd'}"/>
             </div>
         </div>

--- a/addons/website_forum/static/src/js/website_forum.js
+++ b/addons/website_forum/static/src/js/website_forum.js
@@ -378,7 +378,7 @@ publicWidget.registry.websiteForum = publicWidget.Widget.extend({
                     if (countFlaggedPosts) {
                         countFlaggedPosts.classList.remove('bg-light');
                         countFlaggedPosts.classList.remove('d-none');
-                        countFlaggedPosts.classList.add('bg-danger');
+                        countFlaggedPosts.classList.add('text-bg-danger');
                         countFlaggedPosts.innerText = parseInt(countFlaggedPosts.innerText, 10) + 1;
                     }
                     $(elem).nextAll('.flag_validator').removeClass('d-none');

--- a/addons/website_forum/views/forum_forum_templates_forum_all.xml
+++ b/addons/website_forum/views/forum_forum_templates_forum_all.xml
@@ -44,12 +44,12 @@
                 <div class="mt-5 pt-5">
                     <h3 class="mb-0 fw-bold" t-field="forum.name"/>
                     <t t-if="is_view_active('website_forum.opt_post_count')">
-                        <span t-if="forum.total_posts > 0" class="badge text-bg-dark">
+                        <span t-if="forum.total_posts > 0" class="badge text-bg-info">
                             <span t-out="forum.total_posts" class="me-1"/>
                             <t t-if="forum.total_posts > 1">posts</t>
                             <t t-else="">post</t>
                         </span>
-                        <span t-else="" class="badge text-dark">No posts yet</span>
+                        <span t-else="" class="badge text-bg-dark">No posts yet</span>
                     </t>
                     <div t-if="is_view_active('website_forum.opt_last_post') and forum.last_post_id" class="text-truncate">
                         <span class="badge bg-dark me-1">Last post:</span>

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -45,7 +45,7 @@
                     <h3 t-attf-class="col-lg-10 my-0" t-out="question.name"/>
                     <div class="col d-flex justify-content-end align-items-center">
                         <i t-if="question.state == 'close'" class="fa fa-lock ms-2 fs-4" title="Closed" data-bs-toggle="tooltip" data-bs-placement="top"/>
-                        <span t-elif="not question.active" class="badge bg-danger">
+                        <span t-elif="not question.active" class="badge text-bg-danger">
                             <t t-if="question.state!='offensive'">Deleted</t>
                             <t t-if="question.state=='offensive'">Offensive</t>
                             <t t-if="question.state=='offensive' and question.closed_reason_id">

--- a/addons/website_forum/views/forum_forum_templates_moderation.xml
+++ b/addons/website_forum/views/forum_forum_templates_moderation.xml
@@ -152,9 +152,9 @@
                             t-out="question.name"/>
                     </div>
                     <div class="col-lg-3 d-lg-flex align-items-baseline">
-                        <span t-if="not question.active and question.state=='offensive'" class="badge bg-warning text-wrap flex-grow-1">Offensive</span>
-                        <span t-if="not question.active and question.state=='offensive' and question.closed_reason_id" class="badge bg-warning text-wrap flex-grow-1" t-out="question.closed_reason_id.name.capitalize()"/>
-                        <span t-if="question.closed_reason_id" class="badge bg-danger text-wrap flex-grow-1" t-out="question.closed_reason_id.name.capitalize()"/>
+                        <span t-if="not question.active and question.state=='offensive'" class="badge text-bg-warning text-wrap flex-grow-1">Offensive</span>
+                        <span t-if="not question.active and question.state=='offensive' and question.closed_reason_id" class="badge text-bg-warning text-wrap flex-grow-1" t-out="question.closed_reason_id.name.capitalize()"/>
+                        <span t-if="question.closed_reason_id" class="badge text-bg-danger text-wrap flex-grow-1" t-out="question.closed_reason_id.name.capitalize()"/>
                     </div>
                 </div>
             </div>

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -40,7 +40,7 @@
                 t-value="'/forum/' + slug(question_tag.forum_id) + '/tag/' + slug(question_tag) + '/questions?' + keep_query( 'search', 'sorting', 'my', 'create_uid', filters='tag')"/>
 
             <a t-att-href="click_action"
-                t-attf-class="badge position-relative z-1 #{ 'text-bg-primary' if tag and tag.name == question_tag.name else 'text-bg-secondary' } fw-normal o_tag o_tag_color_#{question_tag.color}"
+                t-attf-class="badge position-relative z-1 fw-normal o_tag o_color_#{question_tag.color}"
                 t-field="question_tag.name"/>
         </t>
     </div>
@@ -165,7 +165,7 @@
     <div t-if="question.tag_ids" class="o_wforum_index_entry_tags ms-0">
         <a  t-foreach="question.tag_ids" t-as="question_tag"
             t-attf-href="/forum/#{slug(question_tag.forum_id)}/tag/#{slug(question_tag)}/questions?#{keep_query(filters='tag')}"
-            t-attf-class="badge text-bg-secondary #{'ms-1' if not question_tag_first else ''} fw-normal o_tag o_tag_color_#{question_tag.color}"
+            t-attf-class="badge #{'ms-1' if not question_tag_first else ''} fw-normal o_tag o_color_#{question_tag.color}"
             t-field="question_tag.name"/>
     </div>
     <div class="ms-auto d-flex">
@@ -326,7 +326,7 @@
                     <span class="o_wforum_relative_datetime ms-2 opacity-75 small text-muted">
                     </span>
                     <t t-if="answer">
-                        <span t-if="_question_creator == _answer_creator" class="badge ms-2 border border-dark rounded-pill text-reset">
+                        <span t-if="_question_creator == _answer_creator" class="badge ms-2 border border-dark text-reset">
                             Author
                         </span>
                         <span t-if="question.forum_id.mode == 'questions'" t-attf-class="o_wforum_answer_correct_badge badge #{ 'd-inline' if answer.is_correct else 'd-none' } ms-auto border border-success rounded-pill text-success">
@@ -559,7 +559,7 @@
                             <t t-set="show_name" t-value="True"/>
                         </span>
                         <span class="ms-2 mb-2 small text-muted"><small class="o_wforum_relative_datetime"/></span>
-                        <span t-if="_question_creator == _comment_author" class="badge ms-2 border border-dark rounded-pill text-reset">
+                        <span t-if="_question_creator == _comment_author" class="badge ms-2 border border-dark text-reset">
                             Author
                         </span>
                     </header>

--- a/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
+++ b/addons/website_hr_recruitment/views/website_hr_recruitment_templates.xml
@@ -58,7 +58,7 @@
                                         <div class="card-body p-4">
                                             <div class="mt0 d-flex justify-content-between align-items-center">
                                                 <h3 t-field="job.name"/>
-                                                <span t-if="not job.website_published" class="badge bg-danger mb8">unpublished</span>
+                                                <span t-if="not job.website_published" class="badge text-bg-danger mb8">unpublished</span>
                                             </div>
                                             <h5 t-if="job.no_of_recruitment >= 1" class="text-reset">
                                                 <span t-field="job.no_of_recruitment"/> open positions
@@ -721,7 +721,7 @@
     <xpath expr="//ul[hasclass('o_jobs_topbar_filters')]" position="inside">
         <t t-set="non_country_params" t-valuef="#{current_department_param}#{current_office_param}#{current_employment_type_param}"/>
         <li t-attf-class="nav-item dropdown w-100 w-md-auto me-2 my-1 flex-fill">
-            <button type="button" class="btn btn-outline-primary dropdown-toggle w-100" data-bs-toggle="dropdown" id="countriesDropdown">
+            <button type="button" class="btn btn-light dropdown-toggle w-100" data-bs-toggle="dropdown" id="countriesDropdown">
                 <i class="fa fa-map-marker"/>
                 <t t-if="country_id" t-out="country_id.name"/>
                 <t t-elif="is_remote">Remote</t>
@@ -731,21 +731,21 @@
                 <a t-attf-href="/jobs?all_countries=1#{non_country_params}"
                     t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link#{'' if country_id or is_remote else ' active'}">
                     All Countries
-                    <span t-attf-class="badge rounded-pill#{' bg-primary' if country_id or is_remote else ' bg-light text-primary'} ms-2" t-out="count_per_country.get('all', '0')"/>
+                    <span t-attf-class="badge text-bg-primary ms-2" t-out="count_per_country.get('all', '0')"/>
                 </a>
                 <t t-foreach="countries" t-as="country">
                     <t t-if="country">
                         <a t-attf-href="/jobs?country_id=#{country.id}#{non_country_params}"
                             t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link #{' active' if country_id and country_id.id == country.id else ''}">
                             <t t-out="country.name"/>
-                            <span t-attf-class="badge rounded-pill#{' bg-light text-primary' if country_id and country_id.id == country.id else ' bg-primary'} ms-2" t-out="count_per_country.get(country, '0')"/>
+                            <span t-attf-class="badge #{' bg-light text-primary' if country_id and country_id.id == country.id else ' text-bg-primary'} ms-2" t-out="count_per_country.get(country, '0')"/>
                         </a>
                     </t>
                     <t t-else="">
                         <a t-attf-href="/jobs?is_remote=1#{current_department_param}#{current_employment_type_param}"
                             t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link#{' active' if is_remote else ''}">
                             Remote
-                            <span t-attf-class="badge rounded-pill#{' bg-light text-primary' if is_remote else ' bg-primary'} ms-2" t-out="count_per_country.get(None, '0')"/>
+                            <span t-attf-class="badge #{' bg-light text-primary' if is_remote else ' text-bg-primary'} ms-2" t-out="count_per_country.get(None, '0')"/>
                         </a>
                     </t>
                 </t>
@@ -759,7 +759,7 @@
     <xpath expr="//ul[hasclass('o_jobs_topbar_filters')]" position="inside">
         <t t-set="non_department_params" t-valuef="#{current_country_param}#{current_office_param}#{current_employment_type_param}"/>
         <li t-attf-class="nav-item dropdown w-100 w-md-auto me-2 my-1 flex-fill">
-            <button type="button" class="btn btn-outline-primary dropdown-toggle w-100" data-bs-toggle="dropdown" id="departmentsDropdown">
+            <button type="button" class="btn btn-light dropdown-toggle w-100" data-bs-toggle="dropdown" id="departmentsDropdown">
                 <i class="fa fa-sitemap"/>
                 <t t-if="department_id" t-out="department_id.name"/>
                 <t t-elif="is_other_department">Others</t>
@@ -769,21 +769,21 @@
                 <a t-attf-href="/jobs?all_departments=1#{non_department_params}"
                     t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link#{'' if department_id or is_other_department else ' active'}">
                     All Departments
-                    <span t-attf-class="badge rounded-pill#{' bg-primary' if department_id or is_other_department else ' bg-light text-primary'} ms-2" t-out="count_per_department.get('all', '0')"/>
+                    <span t-attf-class="badge text-bg-primary ms-2" t-out="count_per_department.get('all', '0')"/>
                 </a>
                 <t t-foreach="departments" t-as="department">
                     <t t-if="department">
                         <a t-attf-href="/jobs?department_id=#{department.id}#{non_department_params}"
                             t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link #{' active' if department_id and department_id.id == department.id else ''}">
                             <t t-out="department.name"/>
-                            <span t-attf-class="badge rounded-pill#{' bg-light text-primary' if department_id and department_id.id == department.id else ' bg-primary'} ms-2" t-out="count_per_department.get(department, '0')"/>
+                            <span t-attf-class="badge #{' text-bg-primary' if department_id and department_id.id == department.id else ' text-bg-primary'} ms-2" t-out="count_per_department.get(department, '0')"/>
                         </a>
                     </t>
                     <t t-else="">
                         <a t-attf-href="/jobs?is_other_department=1#{non_department_params}"
                             t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link #{' active' if is_other_department else ''}">
                             Others
-                            <span t-attf-class="badge rounded-pill#{' bg-light text-primary' if is_other_department else ' bg-primary'} ms-2" t-out="count_per_department.get(None, '0')"/>
+                            <span t-attf-class="badge #{' text-bg-primary' if is_other_department else ' text-bg-primary'} ms-2" t-out="count_per_department.get(None, '0')"/>
                         </a>
                     </t>
                 </t>
@@ -797,7 +797,7 @@
     <xpath expr="//ul[hasclass('o_jobs_topbar_filters')]" position="inside">
         <t t-set="non_location_params" t-valuef="#{current_department_param}#{current_employment_type_param}"/>
         <li t-attf-class="nav-item dropdown w-100 w-md-auto me-2 my-1 flex-fill">
-            <button type="button" class="btn btn-outline-primary dropdown-toggle w-100" data-bs-toggle="dropdown" id="officesDropdown">
+            <button type="button" class="btn btn-light dropdown-toggle w-100" data-bs-toggle="dropdown" id="officesDropdown">
                 <i class="fa fa-building"/>
                 <t t-if="office_id">
                     <span t-if="len(office_id.contact_address) &lt;= 5" class="fst-italic">No address specified</span>
@@ -810,7 +810,7 @@
                 <a t-attf-href="/jobs?#{'all_countries=1' if is_remote else current_country_path}#{non_location_params}"
                     t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link#{'' if office_id or is_remote else ' active'}">
                     All Offices
-                    <span t-attf-class="badge rounded-pill#{' bg-primary' if office_id or is_remote else ' bg-light text-primary'} ms-2" t-out="count_per_office.get('all', '0')"/>
+                    <span t-attf-class="badge text-bg-primary ms-2" t-out="count_per_office.get('all', '0')"/>
                 </a>
                 <t t-foreach="offices" t-as="thisoffice">
                     <t t-if="thisoffice">
@@ -820,14 +820,14 @@
                             <t t-else="">
                                 <t t-out="thisoffice.city"/><t t-if="thisoffice.country_id">, <t t-out="thisoffice.country_id.name"/></t>
                             </t>
-                            <span t-attf-class="badge rounded-pill#{' bg-light text-primary' if office_id and office_id.id == thisoffice.id else ' bg-primary'} ms-2" t-out="count_per_office.get(thisoffice, '0')"/>
+                            <span t-attf-class="badge #{' text-bg-primary' if office_id and office_id.id == thisoffice.id else ' text-bg-primary'} ms-2" t-out="count_per_office.get(thisoffice, '0')"/>
                         </a>
                     </t>
                     <t t-else="">
                         <a t-attf-href="/jobs?is_remote=1#{non_location_params}"
                             t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link#{' active' if is_remote else ''}">
                             Remote
-                            <span t-attf-class="badge rounded-pill#{' bg-light text-primary' if is_remote else ' bg-primary'} ms-2" t-out="count_per_office.get(None, '0')"/>
+                            <span t-attf-class="badge #{' text-bg-primary' if is_remote else ' text-bg-primary'} ms-2" t-out="count_per_office.get(None, '0')"/>
                         </a>
                     </t>
                 </t>
@@ -841,7 +841,7 @@
     <xpath expr="//ul[hasclass('o_jobs_topbar_filters')]" position="inside">
         <t t-set="non_employment_type_params" t-valuef="#{current_country_param}#{current_department_param}#{current_office_param}"/>
         <li t-attf-class="nav-item dropdown w-100 w-md-auto me-2 my-1 flex-fill">
-            <button type="button" class="btn btn-outline-primary dropdown-toggle w-100" data-bs-toggle="dropdown" id="officesDropdown">
+            <button type="button" class="btn btn-light dropdown-toggle w-100" data-bs-toggle="dropdown" id="officesDropdown">
                 <i class="fa fa-suitcase"/>
                 <t t-if="contract_type_id and 'name' in contract_type_id" t-out="contract_type_id.name"/>
                 <t t-elif="is_untyped">Unspecified type</t>
@@ -851,14 +851,14 @@
                 <a t-attf-href="/jobs?all_employment_types=1#{non_employment_type_params}"
                     t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link#{'' if contract_type_id or is_untyped else ' active'}">
                     All Types
-                    <span t-attf-class="badge rounded-pill#{' bg-primary' if contract_type_id else ' bg-light text-primary'} ms-2" t-out="count_per_employment_type.get('all', '0')"/>
+                    <span t-attf-class="badge text-bg-primary ms-2" t-out="count_per_employment_type.get('all', '0')"/>
                 </a>
                 <t t-foreach="employment_types" t-as="employment_type">
                     <t t-if="employment_type">
                         <a t-attf-href="/jobs?contract_type_id=#{employment_type.id}#{non_employment_type_params}"
                             t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link #{' active' if contract_type_id and contract_type_id == employment_type.id else ''}">
                             <t t-out="employment_type.name"/>
-                            <span t-attf-class="badge rounded-pill#{' bg-light text-primary' if contract_type_id and contract_type_id == employment_type.id else ' bg-primary'} ms-2" t-out="count_per_employment_type.get(employment_type, '0')"/>
+                            <span t-attf-class="badge #{' text-bg-primary' if contract_type_id and contract_type_id == employment_type.id else ' text-bg-primary'} ms-2" t-out="count_per_employment_type.get(employment_type, '0')"/>
                         </a>
                     </t>
                 </t>
@@ -866,7 +866,7 @@
                     <a t-attf-href="/jobs?is_untyped=1#{non_employment_type_params}"
                         t-attf-class="dropdown-item d-flex align-items-center justify-content-between nav-link#{' active' if is_untyped else ''}">
                         Unspecified type
-                        <span t-attf-class="badge rounded-pill#{' bg-light text-primary' if is_remote else ' bg-primary'} ms-2" t-out="count_per_employment_type.get(None, '0')"/>
+                        <span t-attf-class="badge #{' text-bg-primary' if is_remote else ' text-bg-primary'} ms-2" t-out="count_per_employment_type.get(None, '0')"/>
                     </a>
                 </t>
             </div>

--- a/addons/website_membership/views/website_membership_templates.xml
+++ b/addons/website_membership/views/website_membership_templates.xml
@@ -86,7 +86,7 @@
                 <li t-if="country['country_id']" class="nav-item">
                     <a t-attf-href="/members#{ membership_id and '/association/%s' % membership_id or '' }#{ country['country_id'][0] and '/country/%s' % slug(country['country_id']) or '' }#{ search }"
                         t-attf-class="nav-link#{country['country_id'] and country['country_id'][0] == current_country_id and ' active' or ''}"><t t-esc="country['country_id'][1]"/>
-                        <span class="badge rounded-pill float-end"><t t-esc="country['country_id_count'] or '0'"/></span>
+                        <span class="badge float-end"><t t-esc="country['country_id_count'] or '0'"/></span>
                     </a>
                 </li>
             </t>

--- a/addons/website_profile/views/website_profile.xml
+++ b/addons/website_profile/views/website_profile.xml
@@ -607,7 +607,7 @@
                 <span class="badge text-bg-danger fw-normal" t-if="not user['website_published']">Unpublished</span>
                 <strong class="text-muted" t-esc="user['rank']"/>
                 <div class="h3 my-2" t-if="user['karma_gain']">
-                    <span t-attf-class="badge rounded-pill #{ 'text-bg-success' if user['karma_gain'] > 0 else 'text-bg-warning'}">
+                    <span t-attf-class="badge #{ 'text-bg-success' if user['karma_gain'] > 0 else 'text-bg-warning'}">
                         <t t-if="user['karma_gain'] > 0">+ </t><t t-esc="user['karma_gain']"/> XP
                     </span>
                 </div>
@@ -632,7 +632,7 @@
         </td>
         <td class="align-middle text-nowrap">
             <t t-if="user['karma_gain']">
-                <span t-attf-class="badge rounded-pill d-inline #{ 'text-bg-success' if user['karma_gain'] > 0 else 'text-bg-warning'}">
+                <span t-attf-class="badge d-inline #{ 'text-bg-success' if user['karma_gain'] > 0 else 'text-bg-warning'}">
                     <t t-if="user['karma_gain'] > 0">+ </t><t t-esc="user['karma_gain']"/> XP
                 </span>
                 <span class="text-muted ps-2 pe-3">

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -17,7 +17,7 @@
                 <a href="/shop/cart" t-attf-class="#{_link_class}" aria-label="eCommerce cart">
                     <div t-attf-class="#{_icon_wrap_class}">
                         <i t-if="_icon" class="fa fa-shopping-cart fa-stack"/>
-                        <sup t-attf-class="my_cart_quantity badge text-bg-primary #{_badge_class} #{'d-none' if (website_sale_cart_quantity == 0) else ''}" t-esc="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', '')"/>
+                        <sup t-attf-class="my_cart_quantity badge bg-primary #{_badge_class} #{'d-none' if (website_sale_cart_quantity == 0) else ''}" t-esc="website_sale_cart_quantity" t-att-data-order-id="request.session.get('sale_order_id', '')"/>
                     </div>
                     <span t-if="_text" t-attf-class="#{_text_class}">My Cart</span>
                 </a>
@@ -1434,7 +1434,7 @@
                             <label t-attf-for="radio_variant_#{variant_id.id}" label-default="label-default" class="form-check-label fw-normal">
                                 <span t-out="combination_info['display_name']"/>
                                 <t t-set="diff_price" t-value="website.currency_id.compare_amounts(combination_info['price'], template_combination_info['price'])"/>
-                                <span t-attf-class="badge rounded-pill text-bg-{{navClass}} border" t-if="diff_price != 0">
+                                <span t-attf-class="badge text-bg-{{navClass}} border" t-if="diff_price != 0">
                                     <span class="sign_badge_price_extra" t-out="diff_price > 0 and '+' or '-'"/>
                                     <span t-out="abs(combination_info['price'] - template_combination_info['price'])"
                                           t-options="{'widget': 'monetary', 'display_currency': website.currency_id}"

--- a/addons/website_sale/views/variant_templates.xml
+++ b/addons/website_sale/views/variant_templates.xml
@@ -137,7 +137,7 @@
     </template>
     <template id="badge_extra_price" name="Badge Extra Price">
         <t t-set="price_extra" t-value="ptav._get_extra_price(combination_info)"/>
-        <span t-if="price_extra" class="badge rounded-pill text-bg-light border">
+        <span t-if="price_extra" class="badge text-bg-info border">
             <!--
                 price_extra is displayed as catalog price instead of
                 price after pricelist because it is impossible to

--- a/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_quiz_finish_dialog.xml
+++ b/addons/website_slides/static/src/js/public/components/slide_quiz_finish_dialog/slide_quiz_finish_dialog.xml
@@ -20,7 +20,7 @@
                     <div class="pb-3">
                         <h4 class="pb-2 d-flex fade" t-att-class="state.animateKarmaGain ? 'show in': ''">
                             <t t-if="props.quiz.quizKarmaWon > 0">
-                                You gained <span class="badge rounded-pill text-bg-success text-white fw-bold ms-2 me-1"><t t-out="props.quiz.quizKarmaWon"/> XP</span>!
+                                You gained <span class="badge text-bg-success text-white fw-bold ms-2 me-1"><t t-out="props.quiz.quizKarmaWon"/> XP</span>!
                             </t>
                             <t t-else="">You did it!</t>
                         </h4>

--- a/addons/website_slides/static/src/scss/website_slides.scss
+++ b/addons/website_slides/static/src/scss/website_slides.scss
@@ -78,35 +78,6 @@ $line-height-truncate: 1.5em;
     }
 }
 
-// Color tags according to assigned background color.
-.o_wslides_channel_tag {
-    vertical-align: middle;
-    @for $size from 1 through length($o-colors) {
-        &.o_tag_color_#{$size - 1} {
-            $background-color: white;
-            // no color selected
-            @if $size == 1 {
-                & {
-                    color: black;
-                    background-color: $background-color;
-                    box-shadow: inset 0 0 0 1px nth($o-colors, $size);
-                }
-            } @else {
-                $background-color: nth($o-colors, $size);
-                & {
-                    color: white;
-                    background-color: $background-color;
-                }
-            }
-            @at-root a#{&} {
-                &:hover {
-                    color: color-contrast($background-color);
-                    background-color: darken($background-color, 10%);
-                }
-            }
-        }
-    }
-}
 
 .o_wslides_body {
     > #wrapwrap > main {

--- a/addons/website_slides/static/src/xml/slide_quiz.xml
+++ b/addons/website_slides/static/src/xml/slide_quiz.xml
@@ -69,7 +69,7 @@
                             </a>
                         </b>
                         <span class="my-0 h4">
-                            <span title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge rounded-pill bg-warning text-white fw-bold ms-3">
+                            <span title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge bg-warning fw-bold ms-3">
                                 + <t t-esc="widget.quiz.quizKarmaGain"/> XP
                             </span>
                         </span>
@@ -86,7 +86,7 @@
                             </span>
                         </b>
                         <span class="my-0 h4">
-                            <span title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge rounded-pill bg-warning text-white fw-bold ms-3">
+                            <span title="Succeed and gain karma" aria-label="Succeed and gain karma" class="badge bg-warning fw-bold ms-3">
                                 + <t t-esc="widget.quiz.quizKarmaGain"/> XP
                             </span>
                         </span>
@@ -104,7 +104,7 @@
                         class="btn btn-primary text-uppercase fw-bold o_wslides_js_lesson_quiz_submit">Check your answers</button>
                     <b t-else="" class="my-0 h5">Done!</b>
                     <span class="my-0 h5" style="line-height: 1">
-                        <span role="button" title="Succeed and gain karma" class="badge rounded-pill bg-warning text-white fw-bold ms-3">
+                        <span role="button" title="Succeed and gain karma" class="badge bg-warning fw-bold ms-3">
                             + <t t-if="!widget.slide.completed" t-esc="widget.quiz.quizKarmaGain"/><t t-else="" t-esc="widget.quiz.quizKarmaWon"/> XP
                         </span>
                     </span>

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -211,11 +211,11 @@
                                          class="mb-1 pt-1">
                                         <t t-if="channel_frontend_tags">
                                             <t t-foreach="channel_frontend_tags" t-as="channel_tag">
-                                                <span t-attf-class="badge o_wslides_channel_tag #{'o_tag_color_'+str(channel_tag.color)}" t-esc="channel_tag.name"/>
+                                                <span t-attf-class="badge o_wslides_channel_tag #{'o_color_'+str(channel_tag.color)}" t-esc="channel_tag.name"/>
                                             </t>
                                         </t>
                                         <a t-if="channel.can_upload"
-                                            class="o_wslides_js_channel_tag_add border badge text-bg-light fw-normal m-1 o_not_editable"
+                                            class="o_wslides_js_channel_tag_add badge text-bg-primary fw-normal m-1 o_not_editable"
                                             role="button"
                                             aria-label="Add Tag"
                                             href="#"
@@ -409,7 +409,7 @@
                 <i class="fa fa-times"/>
             </button>
             <div class="d-flex align-items-center pt-3">
-                <span t-attf-class="o_wslides_channel_completion_completed badge rounded-pill text-bg-success mx-auto #{'d-none' if not channel.completed else ''}">
+                <span t-attf-class="o_wslides_channel_completion_completed badge text-bg-success mx-auto #{'d-none' if not channel.completed else ''}">
                     <i class="fa fa-check"/> Completed
                 </span>
                 <div t-attf-class="o_wslides_channel_completion_progressbar #{'d-none' if channel.completed else 'd-flex'} w-100 align-items-center">
@@ -605,10 +605,10 @@
 
         <div class="d-flex flex-row o_not_editable align-items-center">
             <a name="o_wslides_list_slide_add_quizz" t-if="channel.can_upload and not slide.question_ids" t-attf-href="/slides/slide/#{slug(slide)}?quiz_quick_create" aria-label="Add quiz">
-                <span class="badge text-bg-light badge-hide border fw-normal m-1">Add Quiz</span>
+                <span class="badge text-bg-primary badge-hide fw-normal m-1">Add Quiz</span>
             </a>
             <a t-if="channel.can_upload" href="#" name="o_wslides_slide_toggle_is_preview" aria-label="Preview">
-                <span t-att-data-slide-id="slide.id" t-attf-class="o_wslides_js_slide_toggle_is_preview badge #{'text-bg-success' if slide.is_preview else 'text-bg-light badge-hide border'} fw-normal m-1"><span>Preview</span></span>
+                <span t-att-data-slide-id="slide.id" t-attf-class="o_wslides_js_slide_toggle_is_preview badge #{'text-bg-success' if slide.is_preview else 'text-bg-primary badge-hide'} fw-normal m-1"><span>Preview</span></span>
             </a>
             <t t-elif="slide.is_preview and not channel.is_member">
                 <span class="badge text-bg-success fw-normal m-1"><span>Preview</span></span>
@@ -658,8 +658,8 @@
                     <div class="o_wslides_desc_truncate_10 mt-3" t-field="slide_promoted.description"/>
                     <div t-if="slide_promoted.tag_ids" class="mt-2 pt-1">
                         <t t-foreach="slide_promoted.tag_ids" t-as="tag">
-                            <h4 t-if="invite_preview" class="badge text-bg-light" t-esc="tag.name"/>
-                            <a t-else="" t-attf-href="/slides/#{slug(slide_promoted.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-light" t-esc="tag.name"/>
+                            <h4 t-if="invite_preview" class="badge text-bg-info" t-esc="tag.name"/>
+                            <a t-else="" t-attf-href="/slides/#{slug(slide_promoted.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-primary" t-esc="tag.name"/>
                         </t>
                     </div>
                 </div>
@@ -696,7 +696,7 @@
                                             <a t-att-href="'/slides/%s/category/%s?%s' % (slug(channel), slug(search_category), keep_query(slide_category=slide_category_key))"
                                                t-att-class="'nav-link d-flex align-items-center justify-content-between me-1 %s' % ('active' if search_slide_category == slide_category_key else '')">
                                                <t t-esc="slide_categories[slide_category_key]"/>
-                                               <span t-attf-class="badge rounded-pill ms-1 #{'text-bg-info' if search_slide_category == slide_category_key else 'bg-400'}" t-esc="search_category['nbr_%s' % slide_category_key]"/>
+                                               <span t-attf-class="badge ms-1 #{'text-bg-info' if search_slide_category == slide_category_key else 'bg-400'}" t-esc="search_category['nbr_%s' % slide_category_key]"/>
                                             </a>
                                         </li>
                                     </t>
@@ -705,7 +705,7 @@
                                             <a t-att-href="'/slides/%s?%s' % (slug(channel), keep_query(slide_category=slide_category_key))"
                                                t-att-class="'nav-link d-flex align-items-center justify-content-between me-1 %s' % ('active' if search_slide_category == slide_category_key else '')">
                                                <t t-esc="slide_categories[slide_category_key]"/>
-                                               <span t-attf-class="badge rounded-pill ms-1 #{'text-bg-info' if search_slide_category == slide_category_key else 'bg-400'}" t-esc="channel['nbr_%s' % slide_category_key]"/>
+                                               <span t-attf-class="badge ms-1 #{'text-bg-info' if search_slide_category == slide_category_key else 'bg-400'}" t-esc="channel['nbr_%s' % slide_category_key]"/>
                                             </a>
                                         </li>
                                     </t>
@@ -763,11 +763,11 @@
             <div class="mb-2 pt-1 text-start col">
                 <t t-if="channel_frontend_tags">
                     <t t-foreach="channel_frontend_tags" t-as="channel_tag">
-                        <span t-attf-class="badge o_wslides_channel_tag #{'o_tag_color_'+str(channel_tag.color)}" t-esc="channel_tag.name"/>
+                        <span t-attf-class="badge o_wslides_channel_tag #{'o_color_'+str(channel_tag.color)}" t-esc="channel_tag.name"/>
                     </t>
                 </t>
                 <a t-if="channel.can_upload"
-                    class="o_wslides_js_channel_tag_add border badge text-bg-light fw-normal m-1"
+                    class="o_wslides_js_channel_tag_add badge text-bg-primary fw-normal m-1"
                     role="button"
                     aria-label="Add Tag"
                     href="#"
@@ -865,11 +865,11 @@
             </div>
             <div class="text-muted o_wslides_desc_truncate_2 my-2">
                 <t t-foreach="slide.tag_ids" t-as="tag">
-                    <h4 t-if="invite_preview" class="badge text-bg-light" t-esc="tag.name"/>
-                    <a t-else="" t-attf-href="/slides/#{slug(slide.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-light" t-esc="tag.name"/>
+                    <h4 t-if="invite_preview" class="badge text-bg-info" t-esc="tag.name"/>
+                    <a t-else="" t-attf-href="/slides/#{slug(slide.channel_id)}/tag/#{slug(tag)}" class="badge text-bg-primary" t-esc="tag.name"/>
                 </t>
             </div>
-            <span t-if="channel.is_member and channel_progress[slide.id].get('completed')" class="badge rounded-pill text-bg-success align-self-start"><i class="fa fa-check me-1"/>Completed</span>
+            <span t-if="channel.is_member and channel_progress[slide.id].get('completed')" class="badge text-bg-success align-self-start"><i class="fa fa-check me-1"/>Completed</span>
         </div>
         <div class="card-footer bg-white text-600">
             <div class="d-flex align-items-center small">

--- a/addons/website_slides/views/website_slides_templates_homepage.xml
+++ b/addons/website_slides/views/website_slides_templates_homepage.xml
@@ -352,11 +352,11 @@
                     <t t-foreach="channel_frontend_tags" t-as="tag">
                         <t t-if="search_tags">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                t-attf-class="post_link cursor-pointer badge #{'text-bg-primary' if tag in search_tags else 'o_wslides_channel_tag o_tag_color_0'}" t-esc="tag.name"/>
+                                t-attf-class="post_link cursor-pointer badge o_badge_clickable #{'text-bg-primary' if tag in search_tags else 'o_wslides_channel_tag o_color_0'}" t-esc="tag.name"/>
                         </t>
                         <t t-else="">
                             <span t-att-data-post="slide_query_url(tag=slugify_tags(search_tags.ids, toggle_tag_id=tag.id), my=search_my, search=search_term, slide_category=search_slide_category, prevent_redirect=True)"
-                                t-attf-class="post_link cursor-pointer badge o_wslides_channel_tag #{'o_tag_color_'+str(tag.color)}" t-esc="tag.name"/>
+                                t-attf-class="post_link cursor-pointer badge o_badge_clickable o_wslides_channel_tag #{'o_color_'+str(tag.color)}" t-esc="tag.name"/>
                         </t>
                     </t>
                 </div>
@@ -367,7 +367,7 @@
                 <small t-if="channel.total_time" class="fw-bold" t-esc="channel.total_time" t-options="{'widget': 'duration', 'unit': 'hour', 'round': 'minute'}"/>
                 <div class="d-flex flex-grow-1 justify-content-end">
                     <t t-if="channel.is_member and channel.completed">
-                        <span class="badge rounded-pill text-bg-success pull-right"><i class="fa fa-check"/> Completed</span>
+                        <span class="badge text-bg-success pull-right"><i class="fa fa-check"/> Completed</span>
                     </t>
                     <div t-elif="channel.is_member and channel.channel_type != 'documentation'" class="progress w-50" style="height: 6px">
                         <div class="progress-bar" role="progressbar" t-att-aria-valuenow="channel.completion" aria-valuemin="0" aria-valuemax="100" t-attf-style="width:#{channel.completion}%;" aria-label="Progress bar"/>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -39,7 +39,7 @@
                             </div>
                             <div t-attf-class="o_wslides_channel_completion_completed col-12 col-sm-3 #{'d-none' if not slide.channel_id.completed else ''}">
                                 <h2>
-                                    <small><span class="badge rounded-pill text-bg-success fw-normal"><i class="fa fa-check"/> Completed</span></small>
+                                    <small><span class="badge text-bg-success fw-normal"><i class="fa fa-check"/> Completed</span></small>
                                 </h2>
                             </div>
                         </div>
@@ -167,7 +167,7 @@
                             <div class="o_wslides_lesson_link_name text-truncate" t-att-title="aside_slide.name">
                                 <span t-esc="aside_slide.name"/>
                                 <span class="align-items-end" t-if="aside_slide.question_ids">
-                                    <span t-att-class="'badge rounded-pill %s' % ('text-bg-success' if channel_progress[aside_slide.id].get('completed') else 'text-bg-light text-600')">
+                                    <span t-att-class="'badge rounded-pill %s' % ('text-bg-success' if channel_progress[aside_slide.id].get('completed') else 'text-bg-info')">
                                         <t t-esc="channel_progress[aside_slide.id].get('quiz_karma_won') if channel_progress[aside_slide.id].get('completed') else channel_progress[aside_slide.id].get('quiz_karma_gain')"/> xp
                                     </span>
                                 </span>

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -64,7 +64,7 @@
                                 <span t-field="slide.channel_id.name"/>
                             </a>
                             <div t-if="not is_public_user">
-                                <span t-attf-class="o_wslides_channel_completion_completed badge rounded-pill text-bg-success #{'d-none' if not slide.channel_id.completed else ''}">
+                                <span t-attf-class="o_wslides_channel_completion_completed badge text-bg-success #{'d-none' if not slide.channel_id.completed else ''}">
                                     <i class="fa fa-check"/> Completed
                                 </span>
                                 <div t-attf-class="o_wslides_channel_completion_progressbar #{'d-none' if slide.channel_id.completed else 'd-flex'} w-100 align-items-center">

--- a/addons/website_slides/views/website_slides_templates_profile.xml
+++ b/addons/website_slides/views/website_slides_templates_profile.xml
@@ -57,7 +57,7 @@
 
                             <div class="overflow-hidden mb-1" style="height:24px">
                                 <t t-foreach="course.channel_id.tag_ids.filtered(lambda tag: tag.color)" t-as="tag">
-                                    <a t-att-href="'/slides/all/tag/%s' % slug(tag)" t-attf-class="badge o_wslides_channel_tag post_link #{'o_tag_color_'+str(tag.color)}" t-esc="tag.name"/>
+                                    <a t-att-href="'/slides/all/tag/%s' % slug(tag)" t-attf-class="badge o_wslides_channel_tag post_link #{'o_color_'+str(tag.color)}" t-esc="tag.name"/>
                                 </t>
                             </div>
 


### PR DESCRIPTION
task-3858047
- requires https://github.com/odoo/enterprise/pull/61646

| Master | This PR |
|--------|--------|
| <img alt="image" src="https://github.com/user-attachments/assets/b5cd8c0a-9e32-4bc4-9d67-4c22cf615a4c"> | <img alt="image" src="https://github.com/user-attachments/assets/136ea5c6-f8f8-4ecf-8209-92f0c8a46e52"> |

----------------------------------------------

This PR has two main goals :

### Standardize color management for tags
Rather than tweaking the `$o-colors` map differently in each module, we decided to expand the implementation made in https://github.com/odoo/odoo/commit/d767b0554ead887b6caf6e8b1813e50a2492f5d4 and make it standard to the `website_*` modules.

### Rework the badge and o_badge elements
The objective is to improve/harmonize the design, streamline bootstrap inheritance and ease edition.

The ability to apply arbitrary colors has been removed since using the "Style" dropdown ensures consistency and avoids issues related to text readability.

Moreover, the sizing of s_badge scale with its immediate parent element has been changed, in line with bootstrap default behavior.

### (Extra) Provide an exit door for corner cases scenarios
This new system shows its limits in some corner cases, mainly `dropdown-toggle.badge` and for our shopping cart button. To ensure a good visual result in any case, we allow the use of the old badge design, by using a combination of `.badge.bg-*`. This should be limited to corner cases scenarios of course, in order to consolidate the general front-end badges design.




-----------------------

**Note**: the data-xml of the snippet was increased because:

- Old untouched badges are still ok but not pretty
- Old badges whose class changed may not use the same color anymore
- Old badges with custom colors are now ugly and options do not work