### PR TITLE
[IMP] hr_contract: improve contract history button access

### DIFF
--- a/addons/hr_contract/models/hr_contract.py
+++ b/addons/hr_contract/models/hr_contract.py
@@ -54,7 +54,7 @@ class Contract(models.Model):
     company_country_id = fields.Many2one('res.country', string="Company country", related='company_id.country_id', readonly=True)
     country_code = fields.Char(related='company_country_id.code', depends=['company_country_id'], readonly=True)
     contract_type_id = fields.Many2one('hr.contract.type', "Contract Type", tracking=True)
-    contracts_count = fields.Integer(related='employee_id.contracts_count')
+    contracts_count = fields.Integer(related='employee_id.contracts_count', groups="hr_contract.group_hr_contract_employee_manager")
 
     """
         kanban_state:

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -156,7 +156,7 @@
                                 icon="fa-book"
                                 type="object"
                                 invisible="contracts_count == 0"
-                                groups="hr_contract.group_hr_contract_manager">
+                                groups="hr_contract.group_hr_contract_employee_manager">
                                 <div class="o_stat_info">
                                     <span class="o_stat_value">
                                         <field name="contracts_count"/>


### PR DESCRIPTION
When you have Payroll Manager rights, you should be able to see contracts history from the smart button on a contract
After this commit the Employee manager can access the contract history smart button

Task-3833801