### PR TITLE
[FIX] website_sale: use separate contact for pick-up point

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -483,12 +483,13 @@ class SaleOrder(models.Model):
             phone = order.partner_shipping_id.phone
 
             # we can check if the current partner has a partner of type "delivery" that has the same address
-            existing_partner = order.env['res.partner'].search(['&', '&', '&', '&',
+            existing_partner = order.env['res.partner'].search(['&', '&', '&', '&', '&',
                                                                 ('street', '=', street),
                                                                 ('city', '=', city),
                                                                 ('state_id', '=', state),
                                                                 ('country_id', '=', country),
-                                                                ('type', '=', 'delivery')], limit=1)
+                                                                ('type', '=', 'delivery'),
+                                                                ('parent_id', '=', parent_id)], limit=1)
 
             if existing_partner:
                 order.partner_shipping_id = existing_partner


### PR DESCRIPTION
Steps to reproduce:
1. Configure Sendcloud shipping with pick-up locations
2. Go to website and use the shipping method and select a pick-up location
3. Try step 2 again, using the same pick-up point but with a different name
4. Checking the delivery address of the second customer, we see the name of the first customer is used

The problem is that if a pick-up location is already saved, we re-use the same contact for the delivery address. This commit ensures separate contacts are created for different customers.

opw-3853716

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
