### PR TITLE
[FIX] website_sale: use complete address for pick-up location

### DIFF
--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -474,6 +474,7 @@ class SaleOrder(models.Model):
             # name, street, city, state, zip, country
             name = order.partner_shipping_id.name
             street = order_location['pick_up_point_address']
+            house_number = order_location['pick_up_point_house_number']
             city = order_location['pick_up_point_town']
             zip_code = order_location['pick_up_point_postal_code']
             country = order.env['res.country'].search([('code', '=', order_location['pick_up_point_country'])]).id
@@ -484,7 +485,7 @@ class SaleOrder(models.Model):
 
             # we can check if the current partner has a partner of type "delivery" that has the same address
             existing_partner = order.env['res.partner'].search(['&', '&', '&', '&',
-                                                                ('street', '=', street),
+                                                                ('street', '=', street + ' ' + house_number),
                                                                 ('city', '=', city),
                                                                 ('state_id', '=', state),
                                                                 ('country_id', '=', country),
@@ -498,7 +499,7 @@ class SaleOrder(models.Model):
                     'parent_id': parent_id,
                     'type': 'delivery',
                     'name': name,
-                    'street': street,
+                    'street': street + ' ' + house_number,
                     'city': city,
                     'state_id': state,
                     'zip': zip_code,


### PR DESCRIPTION
Steps to reproduce:
1. Configure Sendcloud shipping with pick-up location
2. Go to website, use the shipping method and select a pick-up location
3. Go to the backend, confirm the sale order and validate the delivery
4. Get Error from Sendcloud that the `house_number` is required

If we check the delivery address, we see that the house number is not taken into account when creating a new partner, and the address is incomplete.

This commit adds the house number to the `street` field of the address to have a complete address.

opw-3864382

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
