### PR TITLE
[FIX] mrp: _run_pull creates many pickings

### DIFF
--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -84,7 +84,11 @@ class StockRule(models.Model):
             warehouse_id = rule.warehouse_id
             if not warehouse_id:
                 warehouse_id = rule.location_dest_id.warehouse_id
-            if rule.picking_type_id == warehouse_id.sam_type_id or (warehouse_id.sam_loc_id and warehouse_id.sam_loc_id.parent_path in rule.location_src_id.parent_path):
+            if rule.picking_type_id == warehouse_id.sam_type_id or (
+                warehouse_id.manufacture_steps == 'pbm_sam'
+                and warehouse_id.sam_loc_id
+                and warehouse_id.sam_loc_id.parent_path in rule.location_src_id.parent_path
+            ):
                 if float_compare(procurement.product_qty, 0, precision_rounding=procurement.product_uom.rounding) < 0:
                     procurement.values['group_id'] = procurement.values['group_id'].stock_move_ids.filtered(
                         lambda m: m.state not in ['done', 'cancel']).move_orig_ids.group_id[:1]


### PR DESCRIPTION
The steps to reproduce:
- Go to a warehouse. Under the technical information tab, change the field sam_loc_id from "WH/Post-Production" to "WH/Stock".
- Create a sales order with 2 different products and confirm it.
- 2 pickings will be created with different group_id MO/XXXX instead of a single picking.

After this commit we only check the sam_loc_id if we are in 3 steps manufacturing.

OPW-3871886

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
