### PR TITLE
[FIX] analytics: remove partner_id from the name_search

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -14,7 +14,7 @@ class AccountAnalyticAccount(models.Model):
     _description = 'Analytic Account'
     _order = 'plan_id, name asc'
     _check_company_auto = True
-    _rec_names_search = ['name', 'code', 'partner_id']
+    _rec_names_search = ['name', 'code']
 
     name = fields.Char(
         string='Analytic Account',


### PR DESCRIPTION
Before this commit, our distribution analytics process included searching the table res.partner for potential matches, which negatively impacted performance. However, this is no longer necessary as the default name of the account matches the name of the partner. This change removes the unnecessary performance overhead.

