### PR TITLE
[FIX] project: create projects linked to company-specific customer

### DIFF
--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -196,22 +196,19 @@ class TestProjectBase(TestProjectCommon):
         self.project_pigs.company_id = company_1
         self.assertEqual(self.project_pigs.company_id, company_1, "The company of the project should have been updated.")
         self.project_pigs.company_id = False
+        # if the partner company is set, the project's should also be set
         partner.company_id = company_1
 
-        # The partner has a company, but the project has none. The partner can have any new company, but the project can only be set to False/partner.company
-        with self.assertRaises(UserError):
-            # Cannot change the company of a project if the company of the partner is different
-            self.project_pigs.company_id = company_2
-        partner.company_id = company_2
-        partner.company_id = False
-        partner.company_id = company_1
-        self.project_pigs.company_id = company_1
-        self.assertEqual(self.project_pigs.company_id, company_1, "The company of the project should have been updated.")
+        # If the partner has a company, the project must have the same
+        self.assertEqual(partner.company_id, self.project_pigs.company_id, "The company of the project should have been updated.")
 
-        # The partner has a company and the project has a company. The project can only be set to False, the partner can not be changed
+        # The partner has a company and the project has a company. The partner's can only be set to False, the project's can not be changed
         with self.assertRaises(UserError):
             # Cannot change the company of a project if both the project and its partner have a company
             self.project_pigs.company_id = company_2
+        with self.assertRaises(UserError):
+            # Cannot unset the project's company if its associated partner has a company
+            self.project_pigs.company_id = False
         with self.assertRaises(UserError):
             # Cannot change the company of a partner if both the project and its partner have a company
             partner.company_id = company_2


### PR DESCRIPTION
[FIX] project,hr_timesheet: create projects with company-specific customer

Problem
---
When creating projects with a customer whose company field is set,
`_check_company` raises an Error because of a mismatch with
the analytic account's company (False).

Steps
---
(from fresh db, with demo data)
1. install `project` and `sale_management` (so that projects can be
   billable)
2. in the settings, create a second company,
   (so that contacts' 'Company' field can be set)
3. on a contact, set the 'Company' field (under: Sales & Purchase > Misc)
   to the current company ('YourCompany')
4. In Setting > Project: enable 'Timesheets'
5. Try to create a new billable project with 'Timesheets' enabled
   and the customer from step 3

Fix
---
Never set the partner on the analytic account when creating a new
project.
Note that we have to modify the corresponding test.
This is acceptable because in some flows (create project with
no partner, **then** set the partner) this is what
already happens and seems to not be a problem.

opw-3865150

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
