### PR TITLE
[FIX] fields: add convert_to_cache method in id class in fields

### DIFF
--- a/odoo/addons/base/tests/test_ir_default.py
+++ b/odoo/addons/base/tests/test_ir_default.py
@@ -94,6 +94,8 @@ class TestIrDefault(TransactionCase):
             IrDefault.set('res.partner', 'partner_latitude', 'foo')
         with self.assertRaises(ValidationError):
             IrDefault.set('res.partner', 'color', 2147483648)
+        with self.assertRaises(ValidationError):
+            IrDefault.set('res.partner', 'id', 'Hello')
 
     def test_removal(self):
         """ check defaults for many2one with their value being removed """

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -5094,6 +5094,11 @@ class Id(Field):
     def __set__(self, record, value):
         raise TypeError("field 'id' cannot be assigned")
 
+    def convert_to_cache(self, value, record, validate=True):
+        if not isinstance(value, NewId):
+            return int(value)
+        return value
+
 
 class PrefetchMany2one:
     """ Iterable for the values of a many2one field on the prefetch set of a given record. """


### PR DESCRIPTION
This traceback occurs when the user tries to give a string as the default value through Studio.

To reproduce this issue:

1) Install `studio` and `inventory` module
2) Open any product in `studio` mode
3) Activate `show invisible elements` from `views` in the studio sidebar 
4) Now click on `id` in form view and set the default value with any `string` 
5) A traceback occurs

Error:- 
```
TypeError: '<' not supported between instances of 'int' and 'str
```

Because when the user gives a string as the default value 
it tries to parse the field with the `convert_to_cache` method.

But in our case the `ID` class does not have the method `convert_to_cache`
so it gives the parse value as it is.

This leads to the above traceback when the default value (string) tries to compare with integers.

https://github.com/odoo/odoo/blob/871121ab4a7a4ed5fc309823c5c41ccfeff7536d/odoo/addons/base/models/ir_default.py#L73-L82

sentry-5193548638
