### PR TITLE
[FIX] website_event_exhibitor: correct long name display

### DIFF
--- a/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.xml
+++ b/addons/website_event_exhibitor/static/src/components/exhibitor_connect_closed_dialog/exhibitor_connect_closed_dialog.xml
@@ -50,9 +50,9 @@
                 </div>
                 <div class="col-10">
                     <div class="d-flex align-items-top mb-3">
-                        <div class="d-flex flex-column">
-                            <div class="d-flex align-items-center">
-                                <h4 t-out="sponsorData.name" class="mb4"/>
+                        <div class="d-flex flex-column me-2">
+                            <div class="mb4">
+                                <h4 class="d-inline" t-out="sponsorData.name"/>
                                 <span class="badge text-bg-primary ms-2"
                                     t-out="sponsorData.sponsor_type_name"/>
                             </div>


### PR DESCRIPTION
Ensures that the exhibitor level badge is correctly displayed, as it was shown on a separate column for longer sponsor names. Now, it always appears inline, after the name of the sponsor.

Task-3874059

