### PR TITLE
[IMP] tests: autoretry and cursor commit

### DIFF
--- a/addons/l10n_it_edi/models/account_move.py
+++ b/addons/l10n_it_edi/models/account_move.py
@@ -6,7 +6,7 @@ import logging
 from lxml import etree
 import uuid
 
-from odoo import _, api, Command, fields, models
+from odoo import _, api, Command, fields, models, modules
 from odoo.addons.base.models.ir_qweb_fields import Markup, nl2br, nl2br_enclose
 from odoo.addons.account_edi_proxy_client.models.account_edi_proxy_user import AccountEdiProxyError
 from odoo.exceptions import UserError
@@ -717,14 +717,17 @@ class AccountMove(models.Model):
                 invoice_data['key'],
                 proxy_user,
             ):
-                self.env.cr.commit()
+
+                if not modules.module.current_test:
+                    self.env.cr.commit()
                 moves |= move
             proxy_acks.append(id_transaction)
 
         # Extend created moves with the related attachments and commit
         for move in moves:
             move._extend_with_attachments(move.l10n_it_edi_attachment_id, new=True)
-            self.env.cr.commit()
+            if not modules.module.current_test:
+                self.env.cr.commit()
 
         return {"retrigger": retrigger, "proxy_acks": proxy_acks}
 

--- a/odoo/addons/base/tests/test_test_retry.py
+++ b/odoo/addons/base/tests/test_test_retry.py
@@ -80,3 +80,27 @@ class TestRetrySubtestFailures(TestRetryCommon):
             with self.subTest():
                 _logger.error('Failure')
                 self.assertFalse(1 == 1)
+
+@tagged('-standard', 'test_retry', 'test_retry_disable')
+class TestRetry1Disable(TestRetryCommon):
+
+    def test_retry_0_retry_success(self):
+        tests_run_count = self.get_tests_run_count()
+        self.update_count()
+        if tests_run_count != self.count:
+            raise Exception('Should success on retry')
+
+    def test_retry_1_fails(self):
+        raise Exception('Should fail twice')
+
+    def test_retry_2_fails(self):
+        raise Exception('Should fail without retry 1')
+
+    def test_retry_3_fails(self):
+        raise Exception('Should fail without retry 2')
+
+@tagged('-standard', 'test_retry', 'test_retry_disable')
+class TestRetry2Disable(TestRetryCommon):
+
+    def test_retry_second_class_fails(self):
+        raise Exception('Should fail without retry other class')


### PR DESCRIPTION
This should improve autoretry mecanism overall, and also avoid chain error, even without autoretry, when commiting/rollbacking/closing the cursor opened from a TransactionCase. 
