### PR TITLE
[IMP] stock: inventory back2basics

### DIFF
--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -1076,4 +1076,4 @@ class Warehouse(models.Model):
         }
 
     def get_current_warehouses(self):
-        return self.env['stock.warehouse'].search_read(fields=['id', 'name', 'code'], order='name')
+        return self.env['stock.warehouse'].search_read(fields=['id', 'name', 'code'])

--- a/addons/stock/views/product_views.xml
+++ b/addons/stock/views/product_views.xml
@@ -527,7 +527,7 @@
             <field name="model">product.product</field>
             <field name="priority" eval="100"/>
             <field name="arch" type="xml">
-                <tree sample="1" js_class="stock_report_list_view">
+                <tree sample="1" js_class="stock_report_list_view" duplicate="0">
                     <header>
                         <button name="%(action_inventory_at_date)d" invisible="((context.get('inventory_mode') and not context.get('inventory_report_mode')) or context.get('no_at_date'))" string="Inventory at Date" type="action" class="btn-primary ms-1" display="always"/>
                     </header>

--- a/addons/stock/views/stock_location_views.xml
+++ b/addons/stock/views/stock_location_views.xml
@@ -102,6 +102,7 @@
             <tree string="Stock Location" decoration-info="usage=='view'" decoration-danger="usage=='internal'" multi_edit="1">
                 <field name="company_id" column_invisible="True"/>
                 <field name="active" column_invisible="True"/>
+                <field name="sequence" widget="handle"/>
                 <field name="complete_name" string="Location"/>
                 <field name="usage"/>
                 <field name="is_empty" invisible="usage not in ['internal', 'transit']"/>

--- a/addons/stock/views/stock_move_line_views.xml
+++ b/addons/stock/views/stock_move_line_views.xml
@@ -4,7 +4,7 @@
         <field name="name">stock.move.line.tree</field>
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
-            <tree string="Move Lines" create="0" default_order="id desc" action="action_open_reference" type="object">
+            <tree string="Move Lines" create="0" default_order="id desc" action="action_open_reference" type="object" duplicate="0" >
                 <field name="location_usage" column_invisible="True"/>
                 <field name="location_dest_usage" column_invisible="True"/>
                 <field name="date"/>

--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -29,7 +29,7 @@
             <field name="model">stock.move</field>
             <field eval="8" name="priority"/>
             <field name="arch" type="xml">
-                <tree string="Moves" create="0" default_order="date desc">
+                <tree string="Moves" create="0" default_order="date desc" duplicate="0">
                     <field name="date" groups="base.group_no_one" decoration-danger="(state not in ('cancel','done')) and date > current_date"/>
                     <field name="reference"/>
                     <field name="picking_type_id" column_invisible="True"/>

--- a/addons/stock/views/stock_quant_views.xml
+++ b/addons/stock/views/stock_quant_views.xml
@@ -114,7 +114,7 @@
         <field name="arch" type="xml">
             <tree editable="bottom"
                   create="1" edit="1" js_class="inventory_report_list"
-                  sample="1">
+                  sample="1" duplicate="0">
                 <header>
                     <button name="action_stock_quant_relocate" string="Relocate" type="object" groups="stock.group_stock_manager" invisible="context.get('hide_location', False)" context="{'action_ref': 'stock.action_view_quants'}"/>
                 </header>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -43,7 +43,7 @@
         <field name="arch" type="xml">
             <tree default_order="id desc" create="0"
                   import="0" js_class="inventory_report_list"
-                  action="action_open_reference" type="object">
+                  action="action_open_reference" type="object" duplicate="0">
                 <header>
                     <button name="action_valuation_at_date" string="Valuation at Date" type="object"
                             invisible="((context.get('inventory_mode') and not context.get('inventory_report_mode')) or context.get('no_at_date'))"


### PR DESCRIPTION
In this commit:
====================
- Prevent updating to 'Inventory loss' or 'Scrap Location' of parent/child location when it has stock.
- Resolve issues where warehouse (WH) sequence fails to update in certain scenarios, ensuring consistency across Reporting Stock and Replenishment.
- Remove duplicate actions from Inventory menus to streamline user experience and improve functionality.
- Implement default location assignments based on operation type: -For internal transfers, manufacturing, and repair, default source and destination to 'WH/Stock'. -For Dropship, the default source to 'partner/vendors' and the destination to 'partners/customers'.

task-3837207

