### PR TITLE
[FIX] pos_gift_card: handle refund gift cards

### DIFF
--- a/addons/pos_gift_card/static/src/js/GiftCardPopup.js
+++ b/addons/pos_gift_card/static/src/js/GiftCardPopup.js
@@ -145,6 +145,11 @@ odoo.define("pos_gift_card.GiftCardPopup", function (require) {
       let giftCard = await this.getGiftCard();
       if (!giftCard) return;
 
+      if (this.props.isRefund) {
+        this.props.order_line.gift_card_id = giftCard.id;
+        this.confirm();
+      }
+
       let gift =
         this.env.pos.db.product_by_id[
           this.env.pos.config.gift_card_product_id[0]

--- a/addons/pos_gift_card/static/src/xml/GiftCardPopup.xml
+++ b/addons/pos_gift_card/static/src/xml/GiftCardPopup.xml
@@ -6,12 +6,12 @@
             <Draggable>
                 <div class="popup popup-textarea">
                     <header class="title drag-handle">
-                        Gift Card
+                        <t t-if="props.isRefund">Refund </t>Gift Card
                     </header>
 
                     <main class="giftCardPopupMain">
                         <div class="giftCardPopupContainer" t-if="!state.showBarcodeGeneration">
-                            <span t-if="state.giftCardConfig == 'create_set'"
+                            <span t-if="state.giftCardConfig == 'create_set' &amp;&amp; !props.isRefund"
                                   class="giftCardPopupButton button"
                                   t-on-click="switchBarcodeView">Generate barcode</span>
                             <span t-if="state.giftCardConfig == 'scan_set'"
@@ -24,7 +24,7 @@
 
                         <div t-if="!state.showUseGiftCardMenu &amp;&amp; !state.showGiftCardDetails">
                             <div class="giftCardPopupContainer"
-                                 t-if="state.showBarcodeGeneration &amp;&amp; state.giftCardConfig == 'create_set'">
+                                 t-if="state.showBarcodeGeneration &amp;&amp; state.giftCardConfig == 'create_set' &amp;&amp; !props.isRefund">
                                 <div>
                                     <span>Amount of the gift card:</span><br/>
                                     <div>
@@ -98,7 +98,7 @@
                         </div>
 
                         <div class="giftCardPopupContainer"
-                             t-if="state.showBarcodeGeneration &amp;&amp; state.showGiftCardDetails">
+                             t-if="state.showBarcodeGeneration &amp;&amp; state.showGiftCardDetails &amp;&amp; !props.isRefund">
                             <div>
                                 Gift Card Barcode:
                                 <input t-model="state.giftCardBarcode" class="giftCardPopupInput" type="text"/>
@@ -119,9 +119,10 @@
 
                         <div class="giftCardPopupContainer" t-if="!state.showBarcodeGeneration">
                             <div class="button giftCardPopupConfirmButton" t-on-click="switchToUseGiftCardMenu">
-                                Use a gift card
+                                <t t-if="!props.isRefund">Use a gift card</t>
+                                <t t-else="">Enter card code</t>
                             </div>
-                                <div class="button giftCardPopupConfirmButton" t-on-click="switchToShowGiftCardDetails">
+                                <div class="button giftCardPopupConfirmButton" t-on-click="switchToShowGiftCardDetails" t-if="!props.isRefund">
                                 Check a gift card
                             </div>
                         </div>


### PR DESCRIPTION
**Current behavior:**
Gift cards cannot be refunded.

**Expected behavior:**
We can refund gift cards.

**Steps to reproduce:**
1. Allow gift cards to be used in the PoS session and create one in the backend

2. Create an order in the PoS session with some product and apply the gift card

3. Complete the order and then try to initiate a refund for the order -> you cannot for the gift card line

**Cause of the issue:**
You are prevented from creating a refund for a gift card.

**Fix:**
Detect when a user is trying to do a refund for a gift card. Use the existing UI controls to allow the user to enter a card code at the point of validating the order which will have its balance refunded the amount initially used in the original order.

opw-3865913