### PR TITLE
[FIX] sale: multi-company issues

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -375,7 +375,6 @@
                                     <group invisible="display_type">
                                         <field name="product_updatable" invisible="1"/>
                                         <field name="product_id"
-                                            domain="[('sale_ok', '=', True)]"
                                             context="{'partner_id':parent.partner_id, 'quantity':product_uom_qty, 'pricelist':parent.pricelist_id, 'uom':product_uom, 'company_id': parent.company_id}"
                                             readonly="not product_updatable"
                                             required="not display_type"
@@ -414,8 +413,12 @@
                                         <field name="product_packaging_qty" invisible="not product_id or not product_packaging_id" groups="product.group_stock_packaging"/>
                                         <field name="product_packaging_id" invisible="not product_id" context="{'default_product_id': product_id, 'tree_view_ref':'product.product_packaging_tree_view', 'form_view_ref':'product.product_packaging_form_view'}" groups="product.group_stock_packaging" />
                                         <field name="price_unit"/>
-                                        <field name="tax_id" widget="many2many_tags" options="{'no_create': True}" context="{'search_view_ref': 'account.account_tax_view_search'}" domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
+                                        <field name="tax_id"
+                                            widget="many2many_tags"
+                                            options="{'no_create': True}"
+                                            context="{'search_view_ref': 'account.account_tax_view_search'}"
                                             readonly="qty_invoiced &gt; 0"/>
+                                        <field name="tax_country_id" invisible="1"/>
                                         <t groups="product.group_discount_per_so_line">
                                             <label for="discount"/>
                                             <div name="discount">
@@ -487,7 +490,6 @@
                                     options="{
                                         'no_open': True,
                                     }"
-                                    domain="[('sale_ok', '=', True)]"
                                     widget="sol_product_many2one"/>
                                 <field name="product_template_id"
                                     string="Product"
@@ -506,7 +508,6 @@
                                     options="{
                                         'no_open': True,
                                     }"
-                                    domain="[('sale_ok', '=', True)]"
                                     widget="sol_product_many2one"
                                     placeholder="Type to find a product..."/>
                                 <field name="name" widget="section_and_note_text" optional="show"/>
@@ -565,10 +566,10 @@
                                     name="tax_id"
                                     widget="many2many_tags"
                                     options="{'no_create': True}"
-                                    domain="[('type_tax_use', '=', 'sale'), ('company_id', 'parent_of', parent.company_id), ('country_id', '=', parent.tax_country_id)]"
                                     context="{'active_test': True}"
                                     readonly="qty_invoiced &gt; 0 or is_downpayment"
                                     optional="show"/>
+                                <field name="tax_country_id" column_invisible="True"/>
                                 <field name="discount" string="Disc.%" groups="product.group_discount_per_so_line" optional="show"/>
                                 <field name="is_downpayment" column_invisible="True"/>
                                 <field name="price_subtotal" string="Tax excl." invisible="is_downpayment"/>

--- a/addons/sale_management/models/sale_order_option.py
+++ b/addons/sale_management/models/sale_order_option.py
@@ -9,15 +9,18 @@ class SaleOrderOption(models.Model):
     _name = 'sale.order.option'
     _description = "Sale Options"
     _order = 'sequence, id'
+    _check_company_auto = True
 
     # FIXME ANVFE wtf is it not required ???
-    # TODO related to order.company_id and restrict product choice based on company
     order_id = fields.Many2one('sale.order', 'Sales Order Reference', ondelete='cascade', index=True)
+    company_id = fields.Many2one(related='order_id.company_id', depends=['order_id'])
 
     product_id = fields.Many2one(
         comodel_name='product.product',
         required=True,
-        domain=lambda self: self._product_id_domain())
+        domain=lambda self: self._product_id_domain(),
+        check_company=True,
+    )
     line_id = fields.Many2one(
         comodel_name='sale.order.line', ondelete='set null', copy=False)
     sequence = fields.Integer(

--- a/addons/sale_management/views/sale_order_views.xml
+++ b/addons/sale_management/views/sale_order_views.xml
@@ -13,8 +13,7 @@
                     <field name="sale_order_option_ids" mode="tree,kanban" readonly="state in ['cancel', 'sale']">
                         <form string="Optional Products">
                             <group>
-                                <field name="product_id"
-                                    domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
+                                <field name="product_id"/>
                                 <field name="name"/>
                                 <field name="quantity"/>
                                 <field name="product_uom_category_id" invisible="1"/>
@@ -22,6 +21,7 @@
                                 <field name="price_unit"/>
                                 <field name="discount" groups="product.group_discount_per_so_line"/>
                                 <field name="is_present" />
+                                <field name="company_id" invisible="1"/>
                             </group>
                         </form>
                         <kanban class="o_kanban_mobile">
@@ -77,8 +77,7 @@
                                 <create name="add_product_control" string="Add a product"/>
                             </control>
                             <field name="sequence" widget="handle"/>
-                            <field name="product_id"
-                                domain="[('sale_ok', '=', True), '|', ('company_id', '=', False), ('company_id', '=', parent.company_id)]"/>
+                            <field name="product_id"/>
                             <field name="name" optional="show"/>
                             <field name="quantity"/>
                             <field name="uom_id" string="UoM" groups="uom.group_uom" optional="show"/>
@@ -95,6 +94,7 @@
                                 icon="fa-shopping-cart"
                                 title="Add to order lines"
                                 invisible="is_present"/>
+                            <field name="company_id" column_invisible="True"/>
                         </tree>
                     </field>
                 </page>


### PR DESCRIPTION
Commit b0f0fd2ee3dcc3bbb24a123d4a1b38d17d0ce8c9 removed the multi-company check from SOL products, but this makes all products available (if in the env companies, or subsidiaries), even when they are not compatible with the SO company (and triggers an error when saving the SO).

Furthermore, some inherited views (rental) were not handled correctly nor the same way.

This commit make sure the right domain is applied to the product variant, product template and tax fields of the SOlines, by always handling the domain through the python field definition (not through the xml anymore).

Also fully delegates the multi-company checks to the orm, to rely on the valid generic behavior, reducing maintenance costs, incoherences, and issues.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
