### PR TITLE
[FIX] website_sale_loyalty: prevent error while remove product from cart

### DIFF
--- a/addons/website_sale_loyalty/models/sale_order.py
+++ b/addons/website_sale_loyalty/models/sale_order.py
@@ -159,7 +159,7 @@ class SaleOrder(models.Model):
     def _cart_update(self, *args, **kwargs):
         product_id, set_qty = kwargs['product_id'], kwargs.get('set_qty')
 
-        line = self.order_line.filtered(lambda l: l.product_id.id == product_id)
+        line = self.order_line.filtered(lambda l: l.product_id.id == product_id)[0:1]
         reward_id = line.reward_id
         if set_qty == 0 and line.coupon_id and reward_id and reward_id.reward_type == 'discount':
             # Force the deletion of the line even if it's a temporary record created by new()


### PR DESCRIPTION
Currently, an error is generated when removing a reward product that has been added multiple times  in the cart.

Step to produce:

- Install a 'website_sale_loyalty' module.
- Navigate to the website / eCommerce / Loyalty / Discount & Loyalty to create a record.
- Set the Loyalty Program name and Program Type as 'Loyalty Cards'.(Ensure it's available on sale and on the website.)
-  And add 'Rewards' and set a Reward Type as 'Discount' which is applied on Cheapest Product.
 - Go to the website shop add any product on a card, Open a cart increase the quantity of the product, and claim the discount reward multiple times.
- Now try to remove a reward product that has been added multiple times in cart.

See Traceback:

```
ValueError: Expected singleton: sale.order.line(33, 34)
  File "odoo/http.py", line 2251, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1827, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1847, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1825, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1832, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2057, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 739, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale_loyalty/controllers/main.py", line 128, in cart_update_json
    return super().cart_update_json(*args, set_qty=set_qty, **kwargs)
  File "odoo/http.py", line 739, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale/controllers/main.py", line 822, in cart_update_json
    values = order._cart_update(
  File "addons/website_sale_loyalty/models/sale_order.py", line 171, in _cart_update
    kwargs['line_id'] = line.id
  File "odoo/fields.py", line 5170, in __get__
    raise ValueError("Expected singleton: %s" % record)

```

The issue occurs when 'Remove' a reward product that is added multiple times in a cart. As a results the system receives multiple lines at[1], and from it gets an id [2].

link [1]: https://github.com/odoo/odoo/blob/499056a82db26f7d9caa86314e666e2bd49cc79c/addons/website_sale_loyalty/models/sale_order.py#L162

link [2]: https://github.com/odoo/odoo/blob/499056a82db26f7d9caa86314e666e2bd49cc79c/addons/website_sale_loyalty/models/sale_order.py#L166

To resolve the issue, Add indexing so system will now target and remove only one an product of the duplicate product from cart.

sentry-5091141573

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
