### PR TITLE
[FIX] project: fixed issue with the progress bar when the task is done state

### DIFF
--- a/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
+++ b/addons/project/static/src/views/project_task_kanban/project_task_kanban_view.scss
@@ -14,4 +14,7 @@
         --bs-bg-opacity: 1;
         background-color: rgba(25, 135, 84, var(--bs-bg-opacity)) !important;
     }
+    .o_kanban_group {
+        @include o-kanban-css-filter(success-done, rgba(25, 135, 84, 1));
+    }
 }


### PR DESCRIPTION
Steps to reproduce:

- Open Project
- Go into any project in kanban view
- Mark any task as done.
- From the progress bar click on done section

Issue:

- You can see that the color is does not apply while grouping tasks using progress-bar.

Cause:

- Missing css-kanban-filter which supplies the color to be applied while grouping by progressbar.
- Adding CSS-filter is not done because success-done i.e. color of done tasks is not from standard CSS library(I.e. Bootstrap).

Solution:

- Add the CSS filter for done stage name as success-done.

task-3852596