### PR TITLE
[FIX] base_import_module: fix traceback when manifest file datatype is not list

### DIFF
--- a/addons/base_import_module/i18n/base_import_module.pot
+++ b/addons/base_import_module/i18n/base_import_module.pot
@@ -174,6 +174,12 @@ msgstr ""
 #. module: base_import_module
 #: code:addons/base_import_module/models/ir_module.py:0
 #, python-format
+msgid "The manifest data of the uploaded zip file must be in list datatype"
+msgstr ""
+
+#. module: base_import_module
+#: code:addons/base_import_module/models/ir_module.py:0
+#, python-format
 msgid ""
 "Unmet module dependencies: \n"
 "\n"

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -205,7 +205,10 @@ class IrModule(models.Model):
                             terp = ast.literal_eval(f.read().decode())
                     except Exception:
                         continue
-                    for filename in terp.get('data', []) + terp.get('init_xml', []) + terp.get('update_xml', []):
+                    terp_data = [terp.get('data', []), terp.get('init_xml', []), terp.get('update_xml', [])]
+                    if any(not isinstance(data, list) for data in terp_data):
+                        raise UserError(_("The manifest data of the uploaded zip file must be in list datatype"))
+                    for filename in sum(terp_data, []):
                         if os.path.splitext(filename)[1].lower() not in ('.xml', '.csv', '.sql'):
                             continue
                         module_data_files[mod_name].append('%s/%s' % (mod_name, filename))


### PR DESCRIPTION
This traceback occurs when the user tries to upload a zip file through the import module 
in apps with the wrong datatype(not list ) in the manifest file.

<h4>To reproduce this issue:</h4>

1) create a zip file with data in the manifest file other than list 
2) open apps with `debugger` mode on
3) upload this zip file through the `import module`
4) A traceback occurs

Error:-
```
TypeError: unsupported operand type(s) for +: 'set' and 'list'
```

https://github.com/odoo/odoo/blob/1882d8f89f760bd1ff8a2bf0ae798939402647a3/addons/base_import_module/models/ir_module.py#L228-L232

When the user defines manifest data with different datatype(other than list) leads to the above traceback.

After applying this commit will resolve this issue by checking the datatype before concatenation, 
which makes code more robust.

sentry-5168971980
