### PR TITLE
[IMP] web: add tooltip on clicking 'copy the full error to clipboard'

### DIFF
--- a/addons/base_automation/static/tests/base_automation_error_dialog.js
+++ b/addons/base_automation/static/tests/base_automation_error_dialog.js
@@ -10,6 +10,7 @@ import { browser } from "@web/core/browser/browser";
 import { dialogService } from "@web/core/dialog/dialog_service";
 import { errorService } from "@web/core/errors/error_service";
 import { hotkeyService } from "@web/core/hotkeys/hotkey_service";
+import { popoverService } from "@web/core/popover/popover_service";
 import { MainComponentsContainer } from "@web/core/main_components_container";
 import { notificationService } from "@web/core/notifications/notification_service";
 import { registry } from "@web/core/registry";
@@ -27,6 +28,7 @@ QUnit.module("base_automation", {}, function () {
     QUnit.module("Error Dialog", {
         async beforeEach() {
             serviceRegistry.add("dialog", dialogService);
+            serviceRegistry.add("popover", popoverService);
             serviceRegistry.add("ui", uiService);
             serviceRegistry.add("error", errorService);
             serviceRegistry.add("hotkey", hotkeyService);

--- a/addons/web/static/src/core/errors/error_dialogs.js
+++ b/addons/web/static/src/core/errors/error_dialogs.js
@@ -2,10 +2,12 @@ import { browser } from "../browser/browser";
 import { Dialog } from "../dialog/dialog";
 import { _t } from "@web/core/l10n/translation";
 import { registry } from "../registry";
+import { Tooltip } from "@web/core/tooltip/tooltip";
+import { usePopover } from "@web/core/popover/popover_hook";
 import { useService } from "@web/core/utils/hooks";
 import { capitalize } from "../utils/strings";
 
-import { Component, useState, markup } from "@odoo/owl";
+import { Component, useRef, useState, markup } from "@odoo/owl";
 
 // This props are added by the error handler
 export const standardErrorDialogProps = {
@@ -46,11 +48,20 @@ export class ErrorDialog extends Component {
         this.state = useState({
             showTraceback: false,
         });
+        this.copyButtonRef = useRef("copyButton");
+        this.popover = usePopover(Tooltip);
     }
+
+    showTooltip() {
+        this.popover.open(this.copyButtonRef.el, { tooltip: _t("Copied") });
+        browser.setTimeout(this.popover.close, 800);
+    }
+
     onClickClipboard() {
         browser.navigator.clipboard.writeText(
             `${this.props.name}\n${this.props.message}\n${this.props.traceback}`
         );
+        this.showTooltip();
     }
 }
 
@@ -105,6 +116,7 @@ export class RPCErrorDialog extends ErrorDialog {
         browser.navigator.clipboard.writeText(
             `${this.props.name}\n${this.props.message}\n${this.traceback}`
         );
+        this.showTooltip();
     }
 }
 

--- a/addons/web/static/src/core/errors/error_dialogs.xml
+++ b/addons/web/static/src/core/errors/error_dialogs.xml
@@ -69,7 +69,7 @@
         </div>
         <t t-set-slot="footer">
           <button class="btn btn-primary o-default-button" t-on-click="props.close">Close</button>
-          <button class="btn btn-secondary" t-on-click="onClickClipboard">
+          <button class="btn btn-secondary" t-ref="copyButton" t-on-click="onClickClipboard">
             <i class="fa fa-clipboard mr8"/><t>Copy error to clipboard</t>
           </button>
         </t>

--- a/addons/web/static/tests/core/errors/error_dialogs.test.js
+++ b/addons/web/static/tests/core/errors/error_dialogs.test.js
@@ -103,6 +103,29 @@ test("button clipboard copy error traceback", async () => {
     await tick();
 });
 
+test("Display a tooltip on clicking Copy error to clipboard button", async () => {
+    expect.assertions(2);
+    mockService("popover", () => ({
+        add(el, comp, params) {
+            expect(el).toHaveText("Copy error to clipboard");
+            expect(params).toEqual({ tooltip: "Copied" });
+            return () => {};
+        },
+    }));
+
+    const env = await makeDialogMockEnv();
+    await mountWithCleanup(ErrorDialog, {
+        env,
+        props: {
+            message: "This is the message",
+            name: "ERROR_NAME",
+            traceback: "This is a traceback",
+            close() {},
+        },
+    });
+    click(".fa-clipboard");
+});
+
 test("WarningDialog", async () => {
     expect(".o_dialog").toHaveCount(0);
     const env = await makeDialogMockEnv();


### PR DESCRIPTION
Before this commit there was no feedback when clicking on 
'copy the full error to clipboard' button in an error dialog.

After this commit there will be a feedback - 'Copied' when clicking 
on 'copy the full error to clipboard' button in an error dialog.

Task-2752234

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
