### PR TITLE
[FIX] tools: traceback in sending E-invoice to SII (ES)

### DIFF
--- a/odoo/tools/zeep/client.py
+++ b/odoo/tools/zeep/client.py
@@ -80,6 +80,9 @@ class Client:
             for key, operation in service._operations.items()
         })
 
+    def bind(self, service_name, port_name):
+        return self.__obj.bind(service_name, port_name)
+
 
 class ReadOnlyMethodNamespace(SimpleNamespace):
     """A read-only attribute-based namespace not prefixed by `_` and restricted to functions.


### PR DESCRIPTION
With ES Company setup
In Settings > Registro de Libros connection SII select a Tax Agency and enable 'Test' flag
Create a new invoice
Process EDI

Traceback - AttributeError: 'Client' object has no attribute 'bind'
It occurs because in our wrapper of Zeep the bind method is missing

opw-3888556
opw-3885287
opw-3888257
opw-3888559
opw-3888155