### PR TITLE
[IMP] various: make website_url relative instead of absolute

### DIFF
--- a/addons/hr_skills_slides/models/hr_resume_line.py
+++ b/addons/hr_skills_slides/models/hr_resume_line.py
@@ -15,6 +15,6 @@ class HrResumeLine(models.Model):
     def _compute_course_url(self):
         for line in self:
             if line.display_type == 'course':
-                line.course_url = line.channel_id.website_url
+                line.course_url = line.channel_id.website_absolute_url
             else:
                 line.course_url = False

--- a/addons/hr_skills_slides/models/slide_channel.py
+++ b/addons/hr_skills_slides/models/slide_channel.py
@@ -59,7 +59,7 @@ class SlideChannelPartner(models.Model):
             if self.env.user.employee_ids:
                 msg = _('The employee has completed the course %s',
                     Markup('<a href="%(link)s">%(course)s</a>') % {
-                        'link': scp.channel_id.website_url,
+                        'link': scp.channel_id.website_absolute_url,
                         'course': scp.channel_id.name,
                 })
                 self.env.user.employee_id.message_post(body=msg)
@@ -75,7 +75,7 @@ class SlideChannel(models.Model):
                 channel._message_employee_chatter(
                     _('The employee subscribed to the course %s',
                         Markup('<a href="%(link)s">%(course)s</a>') % {
-                            'link': channel.website_url,
+                            'link': channel.website_absolute_url,
                             'course': channel.name
                     }),
                     target_partners
@@ -91,7 +91,7 @@ class SlideChannel(models.Model):
             channel._message_employee_chatter(
                 _('The employee left the course %s',
                     Markup('<a href="%(link)s">%(course)s</a>') % {
-                        'link': channel.website_url,
+                        'link': channel.website_absolute_url,
                         'course': channel.name,
                 }),
                 partners)

--- a/addons/website/models/mixins.py
+++ b/addons/website/models/mixins.py
@@ -183,12 +183,22 @@ class WebsitePublishedMixin(models.AbstractModel):
     website_published = fields.Boolean('Visible on current website', related='is_published', readonly=False)
     is_published = fields.Boolean('Is Published', copy=False, default=lambda self: self._default_is_published(), index=True)
     can_publish = fields.Boolean('Can Publish', compute='_compute_can_publish')
-    website_url = fields.Char('Website URL', compute='_compute_website_url', help='The full URL to access the document through the website.')
+    website_url = fields.Char('Website URL', compute='_compute_website_url', help='The full relative URL to access the document through the website.')
+    # The compute dependency (for get_base_url) must be added and get_base_url must be overridden if needed
+    website_absolute_url = fields.Char('Website Absolute URL', compute='_compute_website_absolute_url',
+                                       help='The full absolute URL to access the document through the website.')
 
     @api.depends_context('lang')
     def _compute_website_url(self):
         for record in self:
             record.website_url = '#'
+
+    @api.depends('website_url')
+    def _compute_website_absolute_url(self):
+        self.website_absolute_url = '#'
+        for record in self:
+            if record.website_url != '#':
+                record.website_absolute_url = url_join(record.get_base_url(), record.website_url)
 
     def _default_is_published(self):
         return False

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -191,8 +191,11 @@ class EventSponsor(models.Model):
         super()._compute_website_url()
         for sponsor in self:
             if sponsor.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
-                base_url = sponsor.event_id.get_base_url()
-                sponsor.website_url = '%s/event/%s/exhibitor/%s' % (base_url, self.env["ir.http"]._slug(sponsor.event_id), self.env["ir.http"]._slug(sponsor))
+                sponsor.website_url = f'/event/{self.env["ir.http"]._slug(sponsor.event_id)}/exhibitor/{self.env["ir.http"]._slug(sponsor)}'
+
+    @api.depends('event_id.website_id.domain')
+    def _compute_website_absolute_url(self):
+        super()._compute_website_absolute_url()
 
     @api.model
     def _search_get_detail(self, website, order, options):
@@ -261,3 +264,10 @@ class EventSponsor(models.Model):
                 reason=_('Sponsor')
             )
         return recipients
+
+    # ------------------------------------------------------------
+    # Misc
+    # ------------------------------------------------------------
+    def get_base_url(self):
+        """As website_id is not defined on this record, we rely on event website_id for base URL."""
+        return self.event_id.get_base_url()

--- a/addons/website_event_exhibitor/models/event_sponsor.py
+++ b/addons/website_event_exhibitor/models/event_sponsor.py
@@ -245,12 +245,6 @@ class EventSponsor(models.Model):
     def get_backend_menu_id(self):
         return self.env.ref('event.event_main_menu').id
 
-    def open_website_url(self):
-        """ Overridden to use a relative URL instead of an absolute when website_id is False. """
-        if self.event_id.website_id:
-            return super().open_website_url()
-        return self.env['website'].get_client_action(f'/event/{self.env["ir.http"]._slug(self.event_id)}/exhibitor/{self.env["ir.http"]._slug(self)}')
-
     # ------------------------------------------------------------
     # MESSAGING
     # ------------------------------------------------------------

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_list.xml
@@ -278,7 +278,7 @@
             </div>
         </div>
         <div class="o_wesponsor_connect_button"
-            t-att-data-sponsor-url="sponsor.website_url"
+            t-att-data-sponsor-url="sponsor.website_absolute_url"
             t-att-data-is-participating="event.is_participating"
             t-att-data-sponsor-id="sponsor.id"
             t-att-data-event-is-ongoing="sponsor.event_id.is_ongoing"

--- a/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
+++ b/addons/website_event_exhibitor/views/event_exhibitor_templates_page.xml
@@ -179,7 +179,7 @@
             <ul id="collapse_exhibitor_aside" class="list-group list-group-flush collapse d-lg-block">
                 <li class="list-group-item list-group-item-action" t-foreach="sponsors_other" t-as="sponsor_other">
                     <a class="d-flex flex-wrap flex-md-nowrap text-decoration-none text-reset"
-                        t-att-href="sponsor_other.website_url"
+                        t-att-href="sponsor_other.website_absolute_url"
                         t-att-data-publish="sponsor_other.website_published and 'on' or 'off'">
                         <div class="d-flex flex-column align-items-center">
                             <img t-if="sponsor_other.partner_id.country_id"

--- a/addons/website_event_meet/models/event_meeting_room.py
+++ b/addons/website_event_meet/models/event_meeting_room.py
@@ -32,8 +32,7 @@ class EventMeetingRoom(models.Model):
         super(EventMeetingRoom, self)._compute_website_url()
         for meeting_room in self:
             if meeting_room.id:
-                base_url = meeting_room.event_id.get_base_url()
-                meeting_room.website_url = '%s/event/%s/meeting_room/%s' % (base_url, self.env["ir.http"]._slug(meeting_room.event_id), self.env["ir.http"]._slug(meeting_room))
+                meeting_room.website_url = f'/event/{self.env["ir.http"]._slug(meeting_room.event_id)}/meeting_room/{self.env["ir.http"]._slug(meeting_room)}'
 
     @api.model_create_multi
     def create(self, values_list):
@@ -51,6 +50,10 @@ class EventMeetingRoom(models.Model):
             ("room_participant_count", "=", 0),
             ("room_last_activity", "<", fields.Datetime.now() - self._DELAY_CLEAN),
         ]).active = False
+
+    def get_base_url(self):
+        """As website_id is not defined on this record, we rely on event website_id for base URL."""
+        return self.event_id.get_base_url()
 
     def open_website_url(self):
         """ Overridden to use a relative URL instead of an absolute when website_id is False. """

--- a/addons/website_event_meet/models/event_meeting_room.py
+++ b/addons/website_event_meet/models/event_meeting_room.py
@@ -54,9 +54,3 @@ class EventMeetingRoom(models.Model):
     def get_base_url(self):
         """As website_id is not defined on this record, we rely on event website_id for base URL."""
         return self.event_id.get_base_url()
-
-    def open_website_url(self):
-        """ Overridden to use a relative URL instead of an absolute when website_id is False. """
-        if self.event_id.website_id:
-            return super().open_website_url()
-        return self.env['website'].get_client_action(f'/event/{self.env["ir.http"]._slug(self.event_id)}/meeting_room/{self.env["ir.http"]._slug(self)}')

--- a/addons/website_slides/controllers/main.py
+++ b/addons/website_slides/controllers/main.py
@@ -950,7 +950,7 @@ class WebsiteSlides(WebsiteProfile):
             raise werkzeug.exceptions.NotFound()
         # redirection to channel's homepage for category slides
         if slide.is_category:
-            return request.redirect(slide.channel_id.website_url)
+            return request.redirect(slide.channel_id.website_absolute_url)
 
         if slide.can_self_mark_completed and not slide.user_has_completed \
            and slide.channel_id.channel_type == 'training' and slide.slide_category != 'video':
@@ -998,7 +998,7 @@ class WebsiteSlides(WebsiteProfile):
 
         if status == 'authorized':
             return request.redirect(
-                '%s?%s' % (user_slide_authorization['slide'].website_url, werkzeug.urls.url_encode(kwargs)))
+                '%s?%s' % (user_slide_authorization['slide'].website_absolute_url, werkzeug.urls.url_encode(kwargs)))
 
         channel_id = user_slide_authorization['channel_id']
         return request.redirect('/slides/%s?%s' % (channel_id, werkzeug.urls.url_encode({

--- a/addons/website_slides/data/mail_template_data.xml
+++ b/addons/website_slides/data/mail_template_data.xml
@@ -113,14 +113,14 @@
                         Hello<br/><br/>
                         <t t-out="user.name or ''">Mitchell Admin</t> shared the <strong t-out="object.name or ''">document</strong> with you!
                         <div style="margin: 16px 8px 16px 8px; text-align: center;">
-                            <a t-att-href="object.website_url">
+                            <a t-att-href="object.website_absolute_url">
                                 <img t-att-alt="object.name"
                                     t-attf-src="{{ ctx.get('base_url') }}/web/image/slide.channel/{{ object.id }}/image_256"
                                     style="height:auto; width:150px; margin: 16px;"/>
                             </a>
                         </div>
                         <div style="padding: 16px 8px 16px 8px; text-align: center;">
-                            <a t-att-href="object.website_url"
+                            <a t-att-href="object.website_absolute_url"
                                 style="background-color: #875a7b; padding: 8px 16px 8px 16px;
                                 text-decoration: none; color: #fff; border-radius: 5px;">
                                 View <strong t-out="object.name or ''">Document</strong></a>

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -649,13 +649,16 @@ class SlideChannel(models.Model):
         for channel in self:
             channel.website_default_background_image_url = f'website_slides/static/src/img/channel-{channel.channel_type}-default.jpg'
 
-    @api.depends('name', 'website_id.domain')
+    @api.depends('name')
     def _compute_website_url(self):
         super()._compute_website_url()
         for channel in self:
             if channel.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
-                base_url = channel.get_base_url()
-                channel.website_url = '%s/slides/%s' % (base_url, self.env['ir.http']._slug(channel))
+                channel.website_url = f"/slides/{self.env['ir.http']._slug(channel)}"
+
+    @api.depends('website_id.domain')
+    def _compute_website_absolute_url(self):
+        super()._compute_website_absolute_url()
 
     @api.depends('can_publish', 'is_member', 'karma_review', 'karma_slide_comment', 'karma_slide_vote')
     @api.depends_context('uid')

--- a/addons/website_slides/models/slide_channel.py
+++ b/addons/website_slides/models/slide_channel.py
@@ -1276,9 +1276,3 @@ class SlideChannel(models.Model):
         if field in image_fields:
             return self.website_default_background_image_url
         return super()._get_placeholder_filename(field)
-
-    def open_website_url(self):
-        """ Overridden to use a relative URL instead of an absolute when website_id is False. """
-        if self.website_id:
-            return super().open_website_url()
-        return self.env['website'].get_client_action(f'/slides/{self.env["ir.http"]._slug(self)}')

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -594,16 +594,18 @@ class SlideSlide(models.Model):
         super()._compute_website_url()
         for slide in self:
             if slide.id:  # avoid to perform a slug on a not yet saved record in case of an onchange.
-                base_url = slide.channel_id.get_base_url()
-                slide.website_url = '%s/slides/slide/%s' % (base_url, self.env['ir.http']._slug(slide))
+                slide.website_url = f"/slides/slide/{self.env['ir.http']._slug(slide)}"
 
-    @api.depends('is_published')
+    @api.depends('channel_id.website_id.domain')
+    def _compute_website_absolute_url(self):
+        super()._compute_website_absolute_url()
+
+    @api.depends('website_absolute_url', 'is_published')
     def _compute_website_share_url(self):
-        self.website_share_url = False
+        self.website_share_url = '#'
         for slide in self:
-            if slide.id:  # ensure we can build the URL
-                base_url = slide.channel_id.get_base_url()
-                slide.website_share_url = '%s/slides/slide/%s/share' % (base_url, slide.id)
+            if slide.website_absolute_url != '#':
+                slide.website_share_url = f'{slide.website_absolute_url}/share'
 
     @api.depends('channel_id.can_publish')
     def _compute_can_publish(self):
@@ -728,7 +730,7 @@ class SlideSlide(models.Model):
         if force_website or self.website_published:
             return {
                 'type': 'ir.actions.act_url',
-                'url': '%s' % self.website_url,
+                'url': self.website_absolute_url,
                 'target': 'self',
                 'target_type': 'public',
                 'res_id': self.id,
@@ -1380,10 +1382,14 @@ class SlideSlide(models.Model):
         results_data = super()._search_render_results(fetch_fields, mapping, icon, limit)
         for slide, data in zip(self, results_data):
             data['_fa'] = icon_per_category.get(slide.slide_category, 'fa-file-pdf-o')
-            data['url'] = slide.website_url
+            data['url'] = slide.website_absolute_url
             data['course'] = _('Course: %s', slide.channel_id.name)
-            data['course_url'] = slide.channel_id.website_url
+            data['course_url'] = slide.channel_id.website_absolute_url
         return results_data
+
+    def get_base_url(self):
+        """As website_id is not defined on this record, we rely on channel website_id for base URL."""
+        return self.channel_id.get_base_url()
 
     def open_website_url(self):
         """ Overridden to use a relative URL instead of an absolute when website_id is False. """

--- a/addons/website_slides/models/slide_slide.py
+++ b/addons/website_slides/models/slide_slide.py
@@ -1390,9 +1390,3 @@ class SlideSlide(models.Model):
     def get_base_url(self):
         """As website_id is not defined on this record, we rely on channel website_id for base URL."""
         return self.channel_id.get_base_url()
-
-    def open_website_url(self):
-        """ Overridden to use a relative URL instead of an absolute when website_id is False. """
-        if self.website_id:
-            return super().open_website_url()
-        return self.env['website'].get_client_action(f'/slides/slide/{self.env["ir.http"]._slug(self)}')

--- a/addons/website_slides/views/website_slides_templates_course.xml
+++ b/addons/website_slides/views/website_slides_templates_course.xml
@@ -277,7 +277,7 @@
             <div class="mt-3 d-grid o_not_editable">
                 <button role="button" class="o_wslides_share btn btn-link" title="Share Channel"
                         aria-label="Share Channel" t-att-data-id="channel.id" t-att-data-name="channel.name"
-                        t-att-data-url="channel.website_url" data-is-channel="True"
+                        t-att-data-url="channel.website_absolute_url" data-is-channel="True"
                         t-att-data-email-sharing="bool(channel.share_channel_template_id)">
                     <i class="fa fa-share-alt"/> Share
                 </button>

--- a/addons/website_slides/views/website_slides_templates_lesson.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson.xml
@@ -380,7 +380,7 @@
                     <t t-set="display_rating" t-value="False"/>
                 </t>
             </div>
-            <div role="tabpanel" class="tab-pane fade" groups="base.group_user" id="statistic" t-att-slide-url="slide.website_url">
+            <div role="tabpanel" class="tab-pane fade" groups="base.group_user" id="statistic" t-att-slide-url="slide.website_absolute_url">
                 <div class="row">
                     <div class="col-md-6">
                         <table class="table table-sm">

--- a/addons/website_slides/views/website_slides_templates_lesson_embed.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_embed.xml
@@ -21,7 +21,7 @@
                                 <div class="row align-items-center">
                                     <div class="col">
                                         <div class="oe_slides_ellipsis">
-                                            <a target="_new" t-att-href="slide.website_url">
+                                            <a target="_new" t-att-href="slide.website_absolute_url">
                                                 <span  t-esc="slide.name" t-att-title="slide.name"/>
                                             </a>
                                         </div>
@@ -55,12 +55,12 @@
                                     <t t-foreach="related_slides" t-as="suggest_slide">
                                         <div class="col-6 col-md-4 col-lg-3 oe_slides_suggestion_media">
                                             <div class="card mb-3">
-                                                <a t-att-href="suggest_slide.website_url" target="_new" class="card-img-top ratio ratio-16x9">
+                                                <a t-att-href="suggest_slide.website_absolute_url" target="_new" class="card-img-top ratio ratio-16x9">
                                                     <img t-att-src="website.image_url(suggest_slide, 'image_1024')" class="card-img-top embed-responsive-item" t-att-alt="suggest_slide.name"/>
                                                 </a>
                                                 <div class="card-body">
                                                     <h6 class="card-title">
-                                                        <a t-att-href="suggest_slide.website_url" target="_new">
+                                                        <a t-att-href="suggest_slide.website_absolute_url" target="_new">
                                                             <t t-esc="suggest_slide.name"/>
                                                         </a>
                                                     </h6>

--- a/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
+++ b/addons/website_slides/views/website_slides_templates_lesson_fullscreen.xml
@@ -4,7 +4,7 @@
 <!-- Slide template for the fullscreen mode -->
 <template id="slide_fullscreen" name="Fullscreen">
     <t t-set="head">
-        <link rel="canonical" t-att-href="slide.website_url" />
+        <link rel="canonical" t-att-href="slide.website_absolute_url" />
     </t>
     <t t-call="website.layout">
         <div class="o_wslides_fs_main d-flex flex-column"

--- a/addons/website_slides/views/website_slides_templates_utils.xml
+++ b/addons/website_slides/views/website_slides_templates_utils.xml
@@ -5,7 +5,7 @@
 <template id='slide_share_social' name="Slides Media Share">
     <t t-if="not website_share_url">
         <t t-set="website_share_url"
-           t-value="record.website_share_url if 'website_share_url' in record else record.website_url"/>
+           t-value="record.website_share_url if 'website_share_url' in record else record.website_absolute_url"/>
     </t>
     <div class="btn-group" role="group">
         <div class="s_share">
@@ -118,7 +118,7 @@
 <template id="slide_share_link">
     <t t-if="not website_share_url">
         <t t-set="website_share_url"
-           t-value="record.website_share_url if 'website_share_url' in record else record.website_url"/>
+           t-value="record.website_share_url if 'website_share_url' in record else record.website_absolute_url"/>
     </t>
     <h5>Share Link</h5>
     <div class="input-group">

--- a/addons/website_slides_survey/controllers/slides.py
+++ b/addons/website_slides_survey/controllers/slides.py
@@ -153,7 +153,7 @@ class WebsiteSlidesSurvey(WebsiteSlides):
 
         # 4. Getting all course url for each badge
         certification_slides = request.env['slide.slide'].sudo().search([('survey_id', 'in', certification_badges.mapped('survey_id').ids)])
-        certification_badge_urls = {slide.survey_id.certification_badge_id.id: slide.channel_id.website_url for slide in certification_slides}
+        certification_badge_urls = {slide.survey_id.certification_badge_id.id: slide.channel_id.website_absolute_url for slide in certification_slides}
 
         # 5. Applying changes
         values.update({

--- a/addons/website_slides_survey/data/mail_template_data.xml
+++ b/addons/website_slides_survey/data/mail_template_data.xml
@@ -15,7 +15,7 @@
         Unfortunately, you have failed the certification and are no longer a member of the course: <t t-out="object.slide_partner_id.channel_id.name or ''">Basics of Gardening</t>.<br/><br/>
         Don't hesitate to enroll again!
         <div style="margin: 16px 0px 16px 0px;">
-            <a t-att-href="(object.slide_partner_id.channel_id.website_url)"
+            <a t-att-href="(object.slide_partner_id.channel_id.website_absolute_url)"
                 style="background-color: #875A7B; padding: 8px 16px 8px 16px; text-decoration: none; color: #fff; border-radius: 5px; font-size:13px;">
                 Enroll now
             </a>

--- a/addons/website_slides_survey/views/survey_templates.xml
+++ b/addons/website_slides_survey/views/survey_templates.xml
@@ -5,7 +5,7 @@
             <xpath expr="//div[hasclass('o_survey_finished')]//a[hasclass('btn-primary')][1]" position="after">
                 <t t-if="channel_id">
                     <a role="button" class="o_wslides_share me-2 mt-2 mt-md-0 btn btn-secondary btn-lg" href="#"
-                       t-att-data-id="channel_id.id" t-att-data-name="channel_id.name" t-att-data-url="channel_id.website_url"
+                       t-att-data-id="channel_id.id" t-att-data-name="channel_id.name" t-att-data-url="channel_id.website_absolute_url"
                        data-is-channel="True" t-att-data-email-sharing="bool(channel_id.share_channel_template_id)">
                         <i class="fa fa-share-alt" aria-label="Share certification" title="Share certification"/>
                         Share your certification
@@ -16,7 +16,7 @@
                 <div t-if="channel_id" class="mt16">
                     <a role="button"
                         class="btn btn-primary btn-lg"
-                        t-att-href="channel_id.website_url">
+                        t-att-href="channel_id.website_absolute_url">
                         Go back to course
                     </a>
                 </div>

--- a/addons/website_slides_survey/views/website_profile.xml
+++ b/addons/website_slides_survey/views/website_profile.xml
@@ -80,7 +80,7 @@
                                         <a role="button" class="o_wslides_share me-2"
                                            t-att-data-id="certificate.slide_id.channel_id.id"
                                            t-att-data-name="certificate.slide_id.channel_id.name"
-                                           t-att-data-url="certificate.slide_id.channel_id.website_url"
+                                           t-att-data-url="certificate.slide_id.channel_id.website_absolute_url"
                                            t-att-data-email-sharing="bool(certificate.slide_id.channel_id.share_channel_template_id)"
                                            data-is-channel="True">
                                             <i class="fa fa-share-alt" aria-label="Share" title="Share"/>


### PR DESCRIPTION
In version 16.0, we have fixed the issue of the button “Go to website” that was redirecting users to the home page instead of the intended URL for record with no website (see odoo/odoo#148103).

However, this fix didn't solve the underlying problem which is that the website_url is an absolute URL instead of relative one in some model (slide_channel, slide_slide, ...).

We solve here the root cause by making the website_url relative and add a new field website_absolute_url. This field replaces website_url in the modified projects (mails, views, ...). Of course, we leave website_url untouched in other modules where it must be relative. Especially for the method open_website_url of website.published.mixin.

Note that in some places the absolute URL could be replaced by a relative one (when a link is displayed on the same website) but as it is functionally equivalent, we keep them absolute to keep the changes simple.

[REV] website_{slides|event_meet|event_exhibitor} revert fix "Go to website"

In version 16.0, we have introduced a temporary fix solving the issue of the button “Go to website” redirecting users to the home page instead of the intended URL for record with no website (see odoo/odoo#148103) in various app.

As we have now fixed the root cause (website_url being absolute instead of relative in some app), we revert that fix.

Task-3844851