### PR TITLE
[IMP] website_sale_*: cleanup dead code

### DIFF
--- a/addons/website_sale/static/src/js/website_sale.js
+++ b/addons/website_sale/static/src/js/website_sale.js
@@ -16,7 +16,6 @@ import { Component } from "@odoo/owl";
 export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerMixin, {
     selector: '.oe_website_sale',
     events: Object.assign({}, VariantMixin.events || {}, {
-        'change form .js_product:first input[name="add_qty"]': '_onChangeAddQuantity',
         'mouseup .js_publish': '_onMouseupPublish',
         'touchend .js_publish': '_onMouseupPublish',
         'change .oe_cart input.js_quantity[data-product-id]': '_onChangeCartQuantity',
@@ -31,7 +30,6 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
         'click #add_to_cart, .o_we_buy_now, #products_grid .o_wsale_product_btn .a-submit': 'async _onClickAdd',
         'click input.js_product_change': 'onChangeVariant',
         'change .js_main_product [data-attribute_exclusions]': 'onChangeVariant',
-        'change oe_advanced_configurator_modal [data-attribute_exclusions]': 'onChangeVariant',
         'click .o_product_page_reviews_link': '_onClickReviewsLink',
         'mousedown .o_wsale_filmstip_wrapper': '_onMouseDown',
         'mouseleave .o_wsale_filmstip_wrapper': '_onMouseLeave',
@@ -55,7 +53,6 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
         this.filmStripScrollLeft = 0;
         this.filmStripMoved = false;
 
-        delete this.events['change .main_product:not(.in_cart) input.js_quantity'];
         delete this.events['change [data-attribute_exclusions]'];
     },
     /**
@@ -445,13 +442,6 @@ export const WebsiteSale = publicWidget.Widget.extend(VariantMixin, cartHandlerM
      */
     _onClickAddCartJSON: function (ev) {
         this.onClickAddCartJSON(ev);
-    },
-    /**
-     * @private
-     * @param {Event} ev
-     */
-    _onChangeAddQuantity: function (ev) {
-        this.onChangeAddQuantity(ev);
     },
     /**
      * @private

--- a/addons/website_sale/static/src/js/website_sale_utils.js
+++ b/addons/website_sale/static/src/js/website_sale_utils.js
@@ -8,7 +8,6 @@ export const cartHandlerMixin = {
     getRedirectOption() {
         const html = document.documentElement;
         this.stayOnPageOption = html.dataset.add2cartRedirect === '1';
-        this.forceDialog = html.dataset.add2cartRedirect === '2';
     },
     getCartHandlerOptions(ev) {
         this.isBuyNow = ev.currentTarget.classList.contains('o_we_buy_now');

--- a/addons/website_sale/static/src/scss/product_configurator.scss
+++ b/addons/website_sale/static/src/scss/product_configurator.scss
@@ -54,10 +54,8 @@
         display: none;
     }
 
-    .js_add,
     .oe_price,
-    .oe_default_price,
-    .oe_optional {
+    .oe_default_price {
         display: none;
     }
 }
@@ -230,26 +228,6 @@ label.css_attribute_color.css_not_available {
     }
 }
 
-.o_product_configurator {
-    .product_detail_img {
-        max-height: 240px;
-    }
-}
-
-.table-striped tbody tr:nth-of-type(odd) {
-    .o_select_options {
-        background-color: rgba(0, 0, 0, 0.025);
-    }
-
-    .o_total_row {
-        @include font-size(1.2rem);
-    }
-}
-
-.modal.o_technical_modal .oe_advanced_configurator_modal .btn.js_add_cart_json {
-    padding: 0.075rem 0.75rem;
-}
-
 .js_product {
 
     .td-product_name {
@@ -298,21 +276,7 @@ label.css_attribute_color.css_not_available {
         .td-qty {
             width: 60px;
         }
-
-        #modal_optional_products table thead,
-        .oe_cart table thead {
-            display: none;
-        }
-
-        #modal_optional_products table td.td-img,
-        .oe_cart table td.td-img {
-            display: none;
-        }
     }
-}
-
-.o_total_row {
-    height: 50px;
 }
 
 .oe_striked_price {

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -28,18 +28,6 @@ $input-border-color: $gray-400;
                 display: revert;
             }
         }
-
-        @media screen and (max-width: 768px){
-            .oe_advanced_configurator_modal {
-                table, tbody, tr, td {
-                    display: block;
-                    width: 100%;
-                }
-                thead {
-                    display: none;
-                }
-            }
-        }
     }
 }
 

--- a/addons/website_sale_stock/static/src/js/variant_mixin.js
+++ b/addons/website_sale_stock/static/src/js/variant_mixin.js
@@ -33,7 +33,7 @@ VariantMixin._onChangeCombinationStock = function (ev, $parent, combination) {
         product_id = $parent.find('.product_id').val();
     }
     const isMainProduct = combination.product_id &&
-        ($parent.is('.js_main_product') || $parent.is('.main_product')) &&
+        $parent.is('.js_main_product') &&
         combination.product_id === parseInt(product_id);
 
     if (!this.isWebsite || !isMainProduct) {


### PR DESCRIPTION
This change cleans up dead code which was used by the legacy product
configurator (which was removed in https://github.com/odoo/odoo/pull/153779).