### PR TITLE
[IMP] base_automation: exclude no fields models from automation rules

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -10,8 +10,7 @@ from uuid import uuid4
 from dateutil.relativedelta import relativedelta
 
 from odoo import _, api, exceptions, fields, models
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
-from odoo.tools import safe_eval
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, safe_eval
 from odoo.http import request
 
 _logger = logging.getLogger(__name__)
@@ -83,7 +82,8 @@ class BaseAutomation(models.Model):
     name = fields.Char(string="Automation Rule Name", required=True, translate=True)
     description = fields.Html(string="Description")
     model_id = fields.Many2one(
-        "ir.model", string="Model", required=True, ondelete="cascade", help="Model on which the automation rule runs."
+        "ir.model", string="Model", domain=[("field_id", "!=", False)], required=True, ondelete="cascade",
+        help="Model on which the automation rule runs."
     )
     model_name = fields.Char(related="model_id.model", string="Model Name", readonly=True, inverse="_inverse_model_name")
     model_is_mail_thread = fields.Boolean(related="model_id.is_mail_thread")

--- a/addons/base_automation/tests/test_automation.py
+++ b/addons/base_automation/tests/test_automation.py
@@ -155,3 +155,21 @@ class TestAutomation(TransactionCaseWithUserDemo):
         }
         server_action.with_context(context).run()
         self.assertEqual(partner.name, 'Reset Name', 'The automatic action must not be performed')
+
+    def test_create_automation_rule_for_valid_model(self):
+        """
+        Automation rules cannot be created for models that have no fields.
+        """
+        model_field = self.env['base.automation']._fields['model_id']
+        base_model = self.env['base']
+
+        # Verify that the base model is abstract and has _auto set to False
+        self.assertTrue(base_model._abstract, "The base model should be abstract")
+        self.assertFalse(base_model._auto, "The base model should have _auto set to False")
+
+        # check whether the field hase domain attribute
+        self.assertTrue(model_field.domain)
+        domain = model_field.domain
+
+        allowed_models = self.env['ir.model'].search(domain)
+        self.assertTrue(base_model._name not in allowed_models.mapped('model'), "The base model should not be in the allowed models")


### PR DESCRIPTION
Before this commit:

Previously, when creating automation rules, users could select models that did
not have any fields. This would result in either an invalid domain warning or an
error.

Steps to reproduce:

- Install base_automation.
- Navigate to Settings > Technical > Automation > Automation Rules.
- Give an appropriate name to the rule and select base as the model.

After this commit:

Users will no longer be able to create automation rules for models without
fields.

Task-3874560

---

