### PR TITLE
[15.0][FIX] mail: prevent duplicated mail activity notifications

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -260,7 +260,9 @@ class MailActivity(models.Model):
 
     @api.model_create_multi
     def create(self, vals_list):
-        activities = super(MailActivity, self).create(vals_list)
+        quick_update_context = self.env.context.get('mail_activity_quick_update', False)
+        activities = super(MailActivity, self.with_context(mail_activity_quick_update=True)).create(vals_list)
+        activities = activities.with_context(mail_activity_quick_update=quick_update_context)
         for activity in activities:
             need_sudo = False
             try:  # in multicompany, reading the partner might break


### PR DESCRIPTION
Both methods, create and write can call action_notify method:

https://github.com/odoo/odoo/blob/15.0/addons/mail/models/mail_activity.py#L282

https://github.com/odoo/odoo/blob/15.0/addons/mail/models/mail_activity.py#L311

That is fine unless one method calls the other. That is not happening right now. But there is potential for this bug in Odoo. You just need to add a related field to the user like the one added in this OCA module:

https://github.com/OCA/social/blob/15.0/mail_activity_team/models/mail_activity.py#L24

This related field will be calculated on the create method, and, consequently, it will trigger a write on the user_id field:

https://github.com/odoo/odoo/blob/15.0/odoo/fields.py#L1304

Consequently the action_notify method is called in the write method first. Then the action_notify is called again in the create method, and you end up sending 2 emails in one click.

The solution is to call super for the create with the context that prevent the write method to call action_notify. In this case the action notify method will be called in the create only.

If there are further editions in the activity, the write method will still call the action_notify method, that is, this is not changing the original intended behavior.

Edit: this issue is also in v16 and v17.
