### PR TITLE
[IMP] website: match navbar toggler color to overlay header text color

### DIFF
--- a/addons/website/static/src/scss/website.scss
+++ b/addons/website/static/src/scss/website.scss
@@ -1368,6 +1368,15 @@ header {
                     }
                 }
             }
+            .o_header_mobile_buttons_wrap, .btn[data-bs-toggle="offcanvas"] {
+                color: inherit;
+            }
+            .navbar-toggler-icon {
+                background-color: currentColor;
+                background-image: none;
+                mask: $navbar-light-toggler-icon-bg;
+                -webkit-mask: $navbar-light-toggler-icon-bg;
+            }
         }
     }
 }

--- a/addons/website/static/tests/tours/website_page_options.js
+++ b/addons/website/static/tests/tours/website_page_options.js
@@ -31,6 +31,33 @@ wTourUtils.registerWebsitePreviewTour('website_page_options', {
     },
     ...wTourUtils.clickOnEditAndWaitEditMode(),
     wTourUtils.clickOnSnippet({id: 'o_header_standard', name: 'Header'}),
+    wTourUtils.changeOption("topMenuColor", '[data-page-option-name="header_text_color"]'),
+    wTourUtils.changeOption("topMenuColor", 'button[style="background-color:#FF0000;"]', "text color", "bottom", true),
+    ...wTourUtils.clickOnSave(),
+    {
+        content: "Check that text color of the header is in red",
+        trigger: 'iframe header#top[style=" color: #FF0000;"]',
+        isCheck: true,
+    },
+    {
+        content: "Enable the mobile view",
+        trigger: ".o_mobile_preview > a",
+    },
+    {
+        content: "Check that text color of the navbar toggler icon is in red",
+        trigger: 'iframe header#top [data-bs-toggle="offcanvas"] .navbar-toggler-icon',
+        run: function () {
+            if (getComputedStyle(this.$anchor[0]).color !== "rgb(255, 0, 0)") {
+                console.error("The navbar toggler icon is not in red");
+            }
+        },
+    },
+    {
+        content: "Disable the mobile view",
+        trigger: ".o_mobile_preview > a",
+    },
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    wTourUtils.clickOnSnippet({id: "o_header_standard", name: "Header"}),
     wTourUtils.changeOption('TopMenuVisibility', 'we-select:has([data-visibility]) we-toggler'),
     wTourUtils.changeOption('TopMenuVisibility', 'we-button[data-visibility="hidden"]'),
     ...wTourUtils.clickOnSave(),

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -326,7 +326,7 @@
             <!-- Brand -->
             <t t-call="website.placeholder_header_brand"/>
             <ul class="o_header_mobile_buttons_wrap navbar-nav flex-row align-items-center gap-2 mb-0">
-                <li>
+                <li class="o_not_editable">
                     <button
                         class="nav-link btn me-auto p-2 o_not_editable"
                         type="button"


### PR DESCRIPTION
**[IMP] website: match navbar toggler color to overlay header text color**

Before this commit, the navbar hamburger button didn't have the same
color as the text color defined for the "Over The Content" header, which
led to situations where it wasn't visible.

Steps to reproduce:

- Go to the website edit mode.
- Click on the header and choose "Over The Content" for the "Header
Position" option.
- Use the color picker to set the "Text Color" option to white.
- Drag and drop a "Text-Image" snippet onto the page.
- Apply a dark background color to the "Text-Image" snippet.
- Click on the "Mobile Preview" button.
=> The navbar hamburger button is not visible in the header.

After this commit, the navbar hamburger button in the "Over The Content"
header matches the color of the header's text.

task-3853573

---------------------------------
**[FIX] website: hide the overlay on the mobile menu navbar toggler**

Before this commit, after clicking on the mobile menu navbar toggler in
Website edit mode, the blue overlay was covering the button.

This commit fixes this. Indeed, this element is not editable, so there's
no need for an overlay on it.

task-3853573