### PR TITLE
[IMP] l10n_in_*: update supplier trade name assignment

### DIFF
--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -500,6 +500,8 @@ class AccountEdiFormat(models.Model):
                     (tax_details.get("base_amount") + tax_details.get("tax_amount")) * sign),
             },
         }
+        if saler_buyer.get("seller_details").commercial_partner_id.ref and json_payload['SellerDtls'].get('LglNm'):
+            json_payload['SellerDtls']['LglNm'] = saler_buyer.get("seller_details").commercial_partner_id.ref
         if invoice.company_currency_id != invoice.currency_id:
             json_payload["ValDtls"].update({
                 "TotInvValFc": self._l10n_in_round_value(

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -386,7 +386,7 @@ class AccountEdiFormat(models.Model):
             "docNo": invoices.is_purchase_document(include_receipts=True) and invoices.ref or invoices.name,
             "docDate": invoices.date.strftime("%d/%m/%Y"),
             "fromGstin": seller_details.commercial_partner_id.vat or "URP",
-            "fromTrdName": seller_details.commercial_partner_id.name,
+            "fromTrdName": seller_details.commercial_partner_id.ref or seller_details.commercial_partner_id.name,
             "fromAddr1": dispatch_details.street or "",
             "fromAddr2": dispatch_details.street2 or "",
             "fromPlace": dispatch_details.city or "",


### PR DESCRIPTION
Previously, the supplier trade name was set to the company partner name. 

With this PR:
Assign supplier trade name based on company partner reference availability. 
If no reference is available, default to partner name.


Task Id: 3887828
