### PR TITLE
[FIX] sale: portal button fix.

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1654,6 +1654,7 @@ class SaleOrder(models.Model):
         - it requires a payment;
         - the last transaction's state isn't `done`;
         - the total amount is strictly positive.
+        - confirmation amount is not reached
 
         Note: self.ensure_one()
 
@@ -1661,13 +1662,12 @@ class SaleOrder(models.Model):
         :rtype: bool
         """
         self.ensure_one()
-        transaction = self.get_portal_last_transaction()
         return (
             self.state in ['draft', 'sent']
             and not self.is_expired
             and self.require_payment
-            and transaction.state != 'done'
             and self.amount_total > 0
+            and not self._is_confirmation_amount_reached()
         )
 
     def _get_portal_return_action(self):

--- a/addons/sale/tests/test_payment_flow.py
+++ b/addons/sale/tests/test_payment_flow.py
@@ -122,6 +122,9 @@ class TestSalePayment(AccountPaymentCommon, SaleCommon, PaymentHttpCommon):
         self.assertEqual(tx_sudo.sale_order_ids.transaction_ids, tx_sudo)
 
         tx_sudo._set_done()
+
+        self.sale_order.require_payment = True
+        self.assertTrue(self.sale_order._has_to_be_paid())
         with mute_logger('odoo.addons.sale.models.payment_transaction'):
             tx_sudo._finalize_post_processing()
         self.assertEqual(self.sale_order.state, 'draft') # Only a partial amount was paid


### PR DESCRIPTION
Due to introduction of downpayment mechanism, if downpayment was made,
Sale Order would no longer be in "has to be payed" state and it would
prevent client from further payments.

opw-3891128