### PR TITLE
[FIX] core: update publisher url

### DIFF
--- a/odoo/addons/base/tests/test_configmanager.py
+++ b/odoo/addons/base/tests/test_configmanager.py
@@ -20,7 +20,7 @@ class TestConfigManager(TransactionCase):
             # options not exposed on the command line
             'admin_passwd': 'admin',
             'csv_internal_sep': ',',
-            'publisher_warranty_url': 'http://services.openerp.com/publisher-warranty/',
+            'publisher_warranty_url': 'http://services.odoo.com/publisher-warranty/',
             'reportgz': False,
             'root_path': f'{ROOT_PATH}/odoo',
             'websocket_rate_limit_burst': 10,
@@ -338,7 +338,7 @@ class TestConfigManager(TransactionCase):
             'dev_mode': [],
             'init': {},
             'language': None,
-            'publisher_warranty_url': 'http://services.openerp.com/publisher-warranty/',
+            'publisher_warranty_url': 'http://services.odoo.com/publisher-warranty/',
             'save': None,
             'shell_interface': None,
             'stop_after_init': False,

--- a/odoo/tools/config.py
+++ b/odoo/tools/config.py
@@ -75,7 +75,7 @@ class configmanager(object):
         self.options = {
             'admin_passwd': 'admin',
             'csv_internal_sep': ',',
-            'publisher_warranty_url': 'http://services.openerp.com/publisher-warranty/',
+            'publisher_warranty_url': 'http://services.odoo.com/publisher-warranty/',
             'reportgz': False,
             'root_path': None,
             'websocket_keep_alive_timeout': 3600,


### PR DESCRIPTION
Update the publisher warranty URL to be Odoo branded instead of openerp. RIM tried to make this change in Odoo 10 but never retargeted for master.

See: https://github.com/odoo/odoo/pull/30272

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr