### PR TITLE
[IMP] l10n_in: verify GST number status

### DIFF
--- a/addons/l10n_in/models/res_config_settings.py
+++ b/addons/l10n_in/models/res_config_settings.py
@@ -11,3 +11,4 @@ class ResConfigSettings(models.TransientModel):
     module_l10n_in_edi = fields.Boolean('Indian Electronic Invoicing')
     module_l10n_in_edi_ewaybill = fields.Boolean('Indian Electronic Waybill')
     l10n_in_hsn_code_digit = fields.Selection(related='company_id.l10n_in_hsn_code_digit', readonly=False)
+    module_l10n_in_check_gst_status = fields.Boolean('Verify GSTIN Status')

--- a/addons/l10n_in/views/res_config_settings_views.xml
+++ b/addons/l10n_in/views/res_config_settings_views.xml
@@ -15,6 +15,9 @@
                 <setting help="Connect to NIC (National Informatics Center) to submit e-waybill on posting." name="electronic_waybill_in" invisible="country_code != 'IN'" documentation="/applications/finance/accounting/fiscal_localizations/localizations/india.html#indian-e-waybill">
                     <field name="module_l10n_in_edi_ewaybill" class="oe_inline" widget="upgrade_boolean"/>
                 </setting>
+                <setting help="Enable this to check the GSTIN status" name="gstin_status_api_settings" string="GST Status API Service" invisible="country_code != 'IN'">
+                    <field name="module_l10n_in_check_gst_status" class="oe_inline"/>
+                </setting>
             </block>
             <xpath expr="//app[@name='account']" position="inside">
                 <div id="india_integration_section" invisible="1">

--- a/addons/l10n_in_check_gst_status/__init__.py
+++ b/addons/l10n_in_check_gst_status/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/l10n_in_check_gst_status/__manifest__.py
+++ b/addons/l10n_in_check_gst_status/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    "name": "Indian - Check GST Status",
+    'countries': ['in'],
+    "category": "Accounting/Localizations",
+    "depends": ["l10n_in_edi"],
+    "data": [
+        "views/account_move_views.xml",
+        "views/res_partner_base_vat_views.xml",
+    ],
+    "installable": True,
+    "license": "LGPL-3",
+}

--- a/addons/l10n_in_check_gst_status/models/__init__.py
+++ b/addons/l10n_in_check_gst_status/models/__init__.py
@@ -1,0 +1,4 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import account_move
+from . import res_partner

--- a/addons/l10n_in_check_gst_status/models/account_move.py
+++ b/addons/l10n_in_check_gst_status/models/account_move.py
@@ -1,0 +1,40 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import api, fields, models
+
+
+class AccountMove(models.Model):
+    _inherit = "account.move"
+
+    l10n_in_partner_gstin_status = fields.Boolean(
+        string="GST Status",
+        compute="_compute_l10n_in_partner_gstin_status_and_date",
+    )
+    l10n_in_show_gstin_status = fields.Boolean(compute="_compute_l10n_in_show_gstin_status")
+    l10n_in_gstin_verified_date = fields.Date(compute="_compute_l10n_in_partner_gstin_status_and_date")
+
+    @api.depends('partner_id', 'state', 'payment_state', 'l10n_in_gst_treatment')
+    def _compute_l10n_in_show_gstin_status(self):
+        indian_moves = self.filtered(lambda m: m.country_code == 'IN')
+        (self - indian_moves).l10n_in_show_gstin_status = False
+        for move in indian_moves:
+            move.l10n_in_show_gstin_status = (
+                move.partner_id and
+                move.state == 'posted' and
+                move.move_type != 'entry' and
+                move.payment_state not in ['paid', 'reversed'] and
+                move.l10n_in_gst_treatment in ['regular', 'composition', 'special_economic_zone', 'deemed_export', 'uin_holders']
+            )
+
+    @api.depends('partner_id')
+    def _compute_l10n_in_partner_gstin_status_and_date(self):
+        for move in self:
+            if move.country_code == 'IN' and move.payment_state not in ['paid', 'reversed'] and move.state != 'cancel':
+                move.l10n_in_partner_gstin_status = move.partner_id.l10n_in_gstin_verified_status
+                move.l10n_in_gstin_verified_date = move.partner_id.l10n_in_gstin_verified_date
+            else:
+                move.l10n_in_partner_gstin_status = False
+                move.l10n_in_gstin_verified_date = False
+
+    def l10n_in_verify_partner_gstin_status(self):
+        self.ensure_one()
+        return self.partner_id.get_l10n_in_gstin_verified_status()

--- a/addons/l10n_in_check_gst_status/models/res_partner.py
+++ b/addons/l10n_in_check_gst_status/models/res_partner.py
@@ -1,0 +1,96 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import logging
+from odoo import api, fields, models, _
+from odoo.addons.iap import jsonrpc
+from odoo.exceptions import UserError, AccessError, ValidationError
+from odoo.addons.l10n_in_edi.models.account_edi_format import DEFAULT_IAP_ENDPOINT, DEFAULT_IAP_TEST_ENDPOINT
+
+_logger = logging.getLogger(__name__)
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    l10n_in_gstin_verified_status = fields.Boolean(
+        string="GST Status",
+        compute="_compute_l10n_in_gst_status",
+        store=True,
+        tracking=True,
+    )
+    l10n_in_gstin_verified_date = fields.Date(
+        string="GSTIN Verified Date",
+        compute="_compute_l10n_in_gst_status",
+        store=True,
+        tracking=True,
+    )
+
+    @api.depends('vat')
+    def _compute_l10n_in_gst_status(self):
+        """
+        Reset GST Status Whenever the `vat` of partner changes
+        """
+        for partner in self:
+            if partner.country_code == 'IN':
+                partner.l10n_in_gstin_verified_status = False
+                partner.l10n_in_gstin_verified_date = False
+
+    def _l10n_in_gstin_status_get_url(self, company):
+        if company.sudo().l10n_in_edi_production_env:
+            default_endpoint = DEFAULT_IAP_ENDPOINT
+        else:
+            default_endpoint = DEFAULT_IAP_TEST_ENDPOINT
+        endpoint = self.env["ir.config_parameter"].sudo().get_param("l10n_in_check_gst_status.endpoint", default_endpoint)
+        url = "%s%s" % (endpoint, '/iap/l10n_in_reports/1/public/search')
+        return url
+
+    def get_l10n_in_gstin_verified_status(self):
+        self.ensure_one()
+        if not self.vat:
+            raise ValidationError(_("Please enter the GSTIN"))
+        url = self._l10n_in_gstin_status_get_url(self.env.company)
+        params = {
+            "account_token": self.env["iap.account"].get("l10n_in_edi").account_token,
+            "dbuuid": self.env["ir.config_parameter"].sudo().get_param("database.uuid"),
+            "gstin_to_search": self.vat,
+        }
+        try:
+            response = jsonrpc(url, params=params, timeout=25)
+        except AccessError:
+            raise UserError(_("Unable to connect with GST network"))
+        if response.get('error') and any(e.get('code') == 'no-credit' for e in response['error']):
+            return self.env["bus.bus"]._sendone(self.env.user.partner_id, "iap_notification",
+                {
+                    "type": "no_credit",
+                    "title": "Not enough credits to check GSTIN status",
+                    "get_credits_url": self.env["iap.account"].get_credits_url(service_name="l10n_in_edi"),
+                },
+            )
+        gst_status = response.get('data', {}).get('sts', "")
+        if gst_status.casefold() == 'active':
+            l10n_in_gstin_verified_status = True
+        elif gst_status:
+            l10n_in_gstin_verified_status = False
+            self.message_post(
+                body=_(
+                    "GSTIN %(vat)s is %(status)s and Effective from %(date_from)s",
+                    vat=self.vat,
+                    status=gst_status,
+                    date_from=response.get("data", {}).get("cxdt", ""),
+                )
+            )
+        else:
+            _logger.info("GST status check error %s", response)
+            raise UserError(_("Error in getting GST status. please try again"))
+        self.write({
+            "l10n_in_gstin_verified_status": l10n_in_gstin_verified_status,
+            "l10n_in_gstin_verified_date": fields.Date.today(),
+        })
+        return {
+            "type": "ir.actions.client",
+            "tag": "display_notification",
+            "params": {
+                "type": "info",
+                "message": _("GSTIN Status Updated Successfully"),
+                "next": {"type": "ir.actions.act_window_close"},
+            },
+        }

--- a/addons/l10n_in_check_gst_status/tests/__init__.py
+++ b/addons/l10n_in_check_gst_status/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_check_status

--- a/addons/l10n_in_check_gst_status/tests/test_check_status.py
+++ b/addons/l10n_in_check_gst_status/tests/test_check_status.py
@@ -1,0 +1,96 @@
+from unittest.mock import patch
+from freezegun import freeze_time
+
+from odoo.tests.common import TransactionCase, tagged
+from odoo.exceptions import UserError
+from datetime import date
+
+
+@tagged('post_install_l10n', 'post_install', '-at_install')
+class TestGSTStatusFeature(TransactionCase):
+    def setUp(self):
+        self.partner1 = self.env["res.partner"].create(
+            {"name": "Active GSTIN", "vat": "36AAACM4154G1ZO"}
+        )
+        self.partner2 = self.env["res.partner"].create(
+            {"name": "Cancelled GSTIN", "vat": "19AABCT1332L2ZD"}
+        )
+        self.partner3 = self.env["res.partner"].create(
+            {"name": "Invalid GSTIN", "vat": "19AACCT6304M1ZB"}
+        )
+        self.partner4 = self.env["res.partner"].create(
+            {"name": "No Records GSTIN", "vat": "19AACCT6304M1DB"}
+        )
+        self.partner5 = self.env["res.partner"].create(
+            {
+                "name": "Partner Vat Reset",
+                "vat": "36AAACM4154G1ZO",
+                "country_id": 104,
+                "l10n_in_gstin_verified_status": "active",
+                "l10n_in_gstin_verified_date": "2024-06-01",
+            }
+        )
+        self.mock_responses = {
+            "active": {
+                "data": {"sts": "Active"}
+            },
+            "cancelled": {
+                "data": {"sts": "Cancelled"}
+            },
+            "invalid": {
+                "error": [{"code": "SWEB_9035", "message": "Invalid GSTIN / UID"}],
+            },
+            "no_records": {
+                "error": [{"code": "FO8000", "message": "No records found for the provided GSTIN."}],
+            },
+        }
+
+    @freeze_time('2024-05-20')
+    def check_gstin_status(self, partner, expected_status, mock_response, raises_exception=False):
+        with patch("odoo.addons.l10n_in_check_gst_status.models.res_partner.jsonrpc") as mock_jsonrpc:
+            mock_jsonrpc.return_value = mock_response
+            if raises_exception:
+                with self.assertRaises(UserError):
+                    partner.get_l10n_in_gstin_verified_status()
+            else:
+                partner.get_l10n_in_gstin_verified_status()
+                self.assertEqual(partner.l10n_in_gstin_verified_status, expected_status)
+                self.assertEqual(partner.l10n_in_gstin_verified_date, date(2024, 5, 20))
+
+    def test_gstin_status(self):
+        """Test GSTIN status for various cases"""
+        self.check_gstin_status(
+            self.partner1,
+            expected_status="active",
+            mock_response=self.mock_responses["active"]
+        )
+        self.check_gstin_status(
+            self.partner2,
+            expected_status="inactive",
+            mock_response=self.mock_responses["cancelled"]
+        )
+        self.check_gstin_status(
+            self.partner3,
+            expected_status=False,
+            raises_exception=True,
+            mock_response=self.mock_responses["invalid"],
+        )
+        self.check_gstin_status(
+            self.partner4,
+            expected_status=False,
+            raises_exception=True,
+            mock_response=self.mock_responses["no_records"],
+        )
+
+    def test_gst_status_reset_on_vat_change(self):
+        """ Change the VAT number of the partner """
+        partner = self.partner5
+        partner.vat = "19AABCT1332L2ZD"
+
+        self.assertRecordValues(
+            partner,
+            [{
+                'l10n_in_gstin_verified_status': False,
+                'l10n_in_gstin_verified_date': False
+            }]
+        )

--- a/addons/l10n_in_check_gst_status/views/account_move_views.xml
+++ b/addons/l10n_in_check_gst_status/views/account_move_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="move_form_inherit_l10n_in_gst_verification" model="ir.ui.view">
+        <field name="name">account.move.form.inherit.l10n.in.gst.verification</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='ref']" position="before">
+                <field name="l10n_in_show_gstin_status" invisible="1"/>
+                <label for="l10n_in_partner_gstin_status"
+                    invisible="not l10n_in_show_gstin_status"/>
+                <div name="status_date_container"
+                    invisible="not l10n_in_show_gstin_status" >
+                    <field name="l10n_in_partner_gstin_status" class="d-none"/>
+                    <span class="text-nowrap" readonly="1">
+                        <span invisible="not l10n_in_partner_gstin_status"
+                            class="oe_inline text-success">Active</span>
+                        <span invisible="not l10n_in_gstin_verified_date or l10n_in_partner_gstin_status"
+                            class="oe_inline text-danger">Inactive</span>
+                        <span class="text-muted oe_inline">
+                            <span invisible="l10n_in_gstin_verified_date">Not Checked</span>
+                            <span invisible="not l10n_in_gstin_verified_date" class="ps-3">Checked: </span>
+                            <field name="l10n_in_gstin_verified_date" class="oe_inline" widget="remaining_days"/>
+                            <button name="l10n_in_verify_partner_gstin_status"
+                                type="object" icon="fa-refresh"
+                                class="oe_link p-0 ps-3" title="Verify GSTIN status" />
+                        </span>
+                    </span>
+                </div>
+            </xpath>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_in_check_gst_status/views/res_partner_base_vat_views.xml
+++ b/addons/l10n_in_check_gst_status/views/res_partner_base_vat_views.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="l10n_in_view_partner_base_vat_form" model="ir.ui.view">
+            <field name="name">l10n.in.view.partner.base.vat.inherit</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="base_vat.view_partner_base_vat_form" />
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='vies_valid']" position="after">
+                    <span invisible="country_code != 'IN' or not vat">
+                        <span invisible="not l10n_in_gstin_verified_date or not l10n_in_gstin_verified_status"
+                            class="oe_inline text-success">Active</span>
+                        <span invisible="not l10n_in_gstin_verified_date or l10n_in_gstin_verified_status"
+                            class="oe_inline text-danger">Inactive</span>
+                        <span invisible="not l10n_in_gstin_verified_date and not l10n_in_gstin_verified_status" class="text-muted">
+                            <span class="ps-2">checked: </span>
+                            <field name="l10n_in_gstin_verified_date" widget="remaining_days" class="oe_inline" readonly="1" />
+                            <button name="get_l10n_in_gstin_verified_status" type="object" icon="fa-refresh"
+                                class="oe_link p-0 ps-2" title="Reverify GSTIN status" />
+                        </span>
+                        <button string="Check Status" name="get_l10n_in_gstin_verified_status" type="object"
+                            icon="fa-check" class="oe_link p-0" title="Check GSTIN status"
+                            invisible="l10n_in_gstin_verified_date" />
+                    </span>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This PR introduces a new module enabling users to check the GSTIN status of
vendors. We can install it manually or with 'GST Status API Service' in the 'Customer
Invoices' section in the Accounting settings.

After installation, Users will find a 'Check Status'  button on the partner
form. By clicking, the system retrieves the latest GSTIN status from the service
provider, displaying it on the partner form, vendor bills, and credit notes.
This enhancement ensures users have up-to-date information regarding vendor
compliance directly within Odoo.

**task**-3707122