### PR TITLE
[IMP] mrp: mrp ui improvements v2

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -16,6 +16,7 @@
         'data/digest_data.xml',
         'data/mail_templates.xml',
         'data/mrp_data.xml',
+        'data/mail_message_subtype_data.xml',
         'wizard/change_production_qty_views.xml',
         'wizard/mrp_workcenter_block_view.xml',
         'wizard/stock_warn_insufficient_qty_views.xml',

--- a/addons/mrp/data/mail_message_subtype_data.xml
+++ b/addons/mrp/data/mail_message_subtype_data.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="1">
+    <!-- new state-related subtypes-->
+    <record id="mrp_mo_in_confirmed" model="mail.message.subtype">
+        <field name="name">MO Confirmed</field>
+        <field name="res_model">mrp.production</field>
+        <field name="default" eval="False"/>
+        <field name="sequence" eval="101"/>
+        <field name="description">MO Confirmed</field>
+    </record>
+    <record id="mrp_mo_in_progress" model="mail.message.subtype">
+        <field name="name">MO Progress</field>
+        <field name="res_model">mrp.production</field>
+        <field name="default" eval="False"/>
+        <field name="sequence" eval="102"/>
+        <field name="description">MO Progress</field>
+    </record>
+    <record id="mrp_mo_in_to_close" model="mail.message.subtype">
+        <field name="name">MO To Close</field>
+        <field name="res_model">mrp.production</field>
+        <field name="default" eval="False"/>
+        <field name="sequence" eval="103"/>
+        <field name="description">MO To Close</field>
+    </record>
+    <record id="mrp_mo_in_done" model="mail.message.subtype">
+        <field name="name">MO Done</field>
+        <field name="res_model">mrp.production</field>
+        <field name="default" eval="False"/>
+        <field name="sequence" eval="104"/>
+        <field name="description">MO Done</field>
+    </record>
+    <record id="mrp_mo_in_cancelled" model="mail.message.subtype">
+        <field name="name">MO Cancelled</field>
+        <field name="res_model">mrp.production</field>
+        <field name="default" eval="False"/>
+        <field name="sequence" eval="105"/>
+        <field name="description">MO Cancelled</field>
+    </record>
+</odoo>

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -25,7 +25,7 @@ SIZE_BACK_ORDER_NUMERING = 3
 class MrpProduction(models.Model):
     """ Manufacturing Orders """
     _name = 'mrp.production'
-    _description = 'Production Order'
+    _description = 'Manufacturing Order'
     _date_name = 'date_start'
     _inherit = ['mail.thread', 'mail.activity.mixin', 'product.catalog.mixin']
     _order = 'priority desc, date_start asc,id'
@@ -2804,6 +2804,20 @@ class MrpProduction(models.Model):
         self.ensure_one()
         if self.state == "confirmed":
             self.state = "progress"
+
+    def _track_subtype(self, init_values):
+        self.ensure_one()
+        if 'state' in init_values and self.state == 'confirmed':
+            return self.env.ref('mrp.mrp_mo_in_confirmed')
+        elif 'state' in init_values and self.state == 'progress':
+            return self.env.ref('mrp.mrp_mo_in_progress')
+        elif 'state' in init_values and self.state == 'to_close':
+            return self.env.ref('mrp.mrp_mo_in_to_close')
+        elif 'state' in init_values and self.state == 'done':
+            return self.env.ref('mrp.mrp_mo_in_done')
+        elif 'state' in init_values and self.state == 'cancel':
+            return self.env.ref('mrp.mrp_mo_in_cancelled')
+        return super()._track_subtype(init_values)
 
     # -------------------------------------------------------------------------
     # CATALOG

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -44,7 +44,6 @@
                 <tree string="Manufacturing Orders" multi_edit="1" sample="1" decoration-info="state == 'draft'">
                     <header>
                         <button name="button_plan" type="object" string="Plan"/>
-                        <button name="do_unreserve" type="object" string="Unreserve"/>
                         <button name="action_assign"  type="object" string="Check availability"/>
                         <button name="action_cancel" type="object" string="Cancel"/>
                     </header>
@@ -134,6 +133,17 @@
             <field name="code">
             if records:
                 action = records.button_scrap()</field>
+        </record>
+
+        <record id="action_print_labels" model="ir.actions.server">
+            <field name="name">Print Labels</field>
+            <field name="model_id" ref="mrp.model_mrp_production"/>
+            <field name="binding_model_id" ref="mrp.model_mrp_production"/>
+            <field name="binding_view_types">form</field>
+            <field name="state">code</field>
+            <field name="code">
+            if records:
+                action = records.action_open_label_type()</field>
         </record>
 
         <record id="action_plan_with_components_availability" model="ir.actions.server">
@@ -641,10 +651,11 @@
                     <field name="origin"/>
                     <filter string="To Do" name="todo" domain="[('state', 'in', ('draft', 'confirmed', 'progress', 'to_close'))]"
                         help="Manufacturing Orders which are in confirmed state."/>
-                    <filter string="Starred" name="starred" domain="[('priority', '=', '1')]"/>
                     <filter string="Unbuilt" name="filter_unbuilt" domain="[('unbuild_ids.state', '=', 'done')]"/>
                     <filter string="Done" name="filter_done" domain="[('state', '=', 'done')]"/>
                     <filter string="Cancelled" name="filter_cancel" domain="[('state', '=', 'cancel')]"/>
+                    <separator/>
+                    <filter string="Starred" name="starred" domain="[('priority', '=', '1')]"/>
                     <separator/>
                     <filter string="Draft" name="filter_draft" domain="[('state', '=', 'draft')]"/>
                     <filter string="Confirmed" name="filter_confirmed" domain="[('state', '=', 'confirmed')]"/>
@@ -655,7 +666,7 @@
                     <filter string="MO Pending" name="waiting" domain="[('reservation_state', 'in', ('waiting', 'confirmed'))]"/>
                     <filter string="MO Ready" name="filter_ready" domain="[('reservation_state', '=', 'assigned')]"/>
                     <separator/>
-                    <filter string="Delays" name="planning_issues" help="Late MO or Late delivery of components"
+                    <filter string="Delayed Productions" name="planning_issues" help="Late MO or Late delivery of components"
                         domain="['|', ('delay_alert_date', '!=', False), ('is_delayed', '=', True)]"/>
                     <filter string="Components Available" name="available" domain="[('components_availability_state', '=', 'available')]"/>
                     <filter string="Late Availability" name="late" domain="[('components_availability_state', '=', 'late')]"/>

--- a/addons/mrp/views/res_config_settings_views.xml
+++ b/addons/mrp/views/res_config_settings_views.xml
@@ -29,7 +29,7 @@
                                     </div>
                                 </div>
                             </setting>
-                            <setting help="Subcontract the production of some products" documentation="/applications/inventory_and_mrp/manufacturing/management/subcontracting.html">
+                            <setting help="Delegate part of the production process to subcontractors" documentation="/applications/inventory_and_mrp/manufacturing/management/subcontracting.html">
                                 <field name="module_mrp_subcontracting"/>
                             </setting>
                             <setting id="process_mrp_barcodes" help="Process manufacturing orders from the barcode application">
@@ -53,7 +53,7 @@
                             <setting id="mrp_byproduct" help="Produce residual products (A + B -> C + D)" title="Add by-products to bills of materials. This can be used to get several finished products as well. Without this option you only do: A + B = C. With the option: A + B = C + D.">
                                 <field name="group_mrp_byproducts"/>
                             </setting>
-                            <setting id="mrp_reception_report" help="View and allocate manufactured quantities">
+                            <setting id="mrp_reception_report" help="View and allocate production quantities to customer orders or other manufacturing orders">
                                 <field name="group_mrp_reception_report"/>
                             </setting>
                         </block>
@@ -65,7 +65,7 @@
                                 <field name="use_manufacturing_lead"/>
                                 <div class="content-group" invisible="not use_manufacturing_lead">
                                     <div class="mt16" >
-                                        <field name="manufacturing_lead" class="oe_inline"/> days
+                                        <field name="manufacturing_lead" class="oe_inline" widget="integer"/> days before
                                     </div>
                                 </div>
                             </setting>


### PR DESCRIPTION
In this commit:
=====================
- renamed the 'delays' filter to 'Delayed Productions' and added separators to
  starred filters.
- moved the 'Print Labels' button to actions in MO form view.
- added stage changes to the subscription modal.
- renamed 'Production Order' to 'Manufacturing Order' in MO form view chatter.
- removed 'Unreserve' as the main action, retaining it only in the action menu.
- renamed help attributes to 'MRP Settings' for subcontracting and
  'Allocation Report' for MO.
- edit widget in security lead time in MRP settings to integer and rename 'days'
  to 'days before'.

task-3836580
