### PR TITLE
[FIX] pos_viva_wallet: tb in viva wallet when send request

### DIFF
--- a/addons/pos_viva_wallet/models/pos_payment_method.py
+++ b/addons/pos_viva_wallet/models/pos_payment_method.py
@@ -157,6 +157,8 @@ class PosPaymentMethod(models.Model):
                 self.viva_wallet_merchant_id,
                 self.viva_wallet_api_key
                 )
+            if not self.viva_wallet_webhook_verification_key:
+                raise UserError(_("Can't update payment method. Please check the data and update it."))
 
         return record
 
@@ -171,6 +173,8 @@ class PosPaymentMethod(models.Model):
                     record.viva_wallet_merchant_id,
                     record.viva_wallet_api_key,
                 )
+                if not record.viva_wallet_webhook_verification_key:
+                    raise UserError(_("Can't create payment method. Please check the data and update it."))
 
         return records
 

--- a/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
+++ b/addons/pos_viva_wallet/static/src/app/payment_viva_wallet.js
@@ -88,7 +88,7 @@ export class PaymentVivaWallet extends PaymentInterface {
             "cashRegisterId": this.pos.get_cashier().name,
             "amount": line.amount * 100,
             "currencyCode": 978, // Viva wallet only uses EUR 978 need add a new field numeric_code in res.currency
-            "merchantReference": line.sessionId + '/' + this.pos.pos_session.id,
+            "merchantReference": line.sessionId + '/' + this.pos.session.id,
             "customerTrns": customerTrns,
             "preauth": false,
             "maxInstalments": 0,


### PR DESCRIPTION
Steps to reproduce:
- Open POS
- Go to configuration > Payment methods
- Create new > Journal > Bank
- Integration select viva wallet
- Use any fake credential
- Use this payment method in any active POS
- Open POS and pay using viva wallet

Issue:
Throws traceback while payment request.

Cause:
Used to fetch POS session id from undefined session.

FIX:
Fetched the session id of the pos model
using the this.pos.session (correct position of data).

task- 3883584