### PR TITLE
[ADD] l10n_in_trdname: add new module for set trade name in indian company

### DIFF
--- a/addons/l10n_in_trdname/__init__.py
+++ b/addons/l10n_in_trdname/__init__.py
@@ -1,0 +1,2 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import models

--- a/addons/l10n_in_trdname/__manifest__.py
+++ b/addons/l10n_in_trdname/__manifest__.py
@@ -1,0 +1,13 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+{
+    'name': 'Indian - Company trade Name',
+    'version': '1.0',
+    'description': """
+Company trade name
+    """,
+    'category': 'Accounting/Localizations',
+    'depends': ['l10n_in', 'l10n_in_edi'],
+    'data': ['views/res_company_views.xml'],
+    'license': 'LGPL-3',
+    'auto_install': True,
+}

--- a/addons/l10n_in_trdname/models/__init__.py
+++ b/addons/l10n_in_trdname/models/__init__.py
@@ -1,0 +1,3 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import res_company
+from . import account_edi_format

--- a/addons/l10n_in_trdname/models/account_edi_format.py
+++ b/addons/l10n_in_trdname/models/account_edi_format.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountEdiFormat(models.Model):
+    _inherit = "account.edi.format"
+
+    def _l10n_in_edi_generate_invoice_json(self, invoice):
+        json_payload = super()._l10n_in_edi_generate_invoice_json(invoice)
+        if json_payload['SellerDtls'].get('LglNm') and invoice.company_id.l10n_in_trade_name:
+            json_payload['SellerDtls']['LglNm'] = invoice.company_id.l10n_in_trade_name
+        return json_payload
+
+    def _l10n_in_edi_ewaybill_generate_json(self, invoices):
+        json_payload = super()._l10n_in_edi_ewaybill_generate_json(invoices)
+        if not invoices.is_purchase_document(include_receipts=True) and json_payload.get('fromTrdName') and invoices.company_id.l10n_in_trade_name:
+            json_payload['fromTrdName'] = invoices.company_id.l10n_in_trade_name
+        return json_payload

--- a/addons/l10n_in_trdname/models/res_company.py
+++ b/addons/l10n_in_trdname/models/res_company.py
@@ -1,0 +1,9 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class Company(models.Model):
+    _inherit = 'res.company'
+
+    l10n_in_trade_name = fields.Char(string="Trade name")

--- a/addons/l10n_in_trdname/views/res_company_views.xml
+++ b/addons/l10n_in_trdname/views/res_company_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="name">res.company.form.inherit.l10n_in_trdname</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='vat']" position="after">
+                <field name="l10n_in_trade_name" attrs="{'invisible': [('country_code', '!=', 'IN')]}"/>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Before this PR:
- Supplier trade name set to company partner name.

After this PR:
- Update logic to assign supplier trade name based on the company's official business name (trade name) if available.
- Use the company partner name as a fallback.

Impact:
- Enhances consistency in supplier data representation.
- It'll make sure that alignment with the company's official business name when applicable.

Task ID: 3887828