### PR TITLE
[FIX] sale_project: keep the partner in task when project becomes non-billable

### DIFF
--- a/addons/sale_project/models/project.py
+++ b/addons/sale_project/models/project.py
@@ -839,12 +839,6 @@ class ProjectTask(models.Model):
                 task.partner_id = sale_order_id.partner_id
             task.sale_order_id = sale_order_id
 
-    @api.depends('allow_billable')
-    def _compute_partner_id(self):
-        billable_task = self.filtered(lambda t: t.allow_billable or (not self._origin and t.parent_id.allow_billable))
-        (self - billable_task).partner_id = False
-        super(ProjectTask, billable_task)._compute_partner_id()
-
     @api.depends('partner_id', 'sale_line_id.order_partner_id', 'parent_id.sale_line_id', 'project_id.sale_line_id', 'milestone_id.sale_line_id', 'allow_billable')
     def _compute_sale_line(self):
         for task in self:

--- a/addons/sale_project/tests/test_child_tasks.py
+++ b/addons/sale_project/tests/test_child_tasks.py
@@ -117,9 +117,9 @@ class TestNestedTaskUpdate(TransactionCase):
         })
         self.assertFalse(child.partner_id)
         parent.write({'partner_id': self.user.partner_id.id})
-        self.assertNotEqual(child.partner_id, parent.partner_id)
+        self.assertEqual(child.partner_id, parent.partner_id)
         parent.write({'partner_id': False})
-        self.assertNotEqual(child.partner_id, self.user.partner_id)
+        self.assertEqual(child.partner_id, self.user.partner_id)
 
     def test_write_sale_line_id_on_parent_write_on_child_if_same_partner(self):
         parent = self.env['project.task'].create({'name': 'parent', 'partner_id': self.partner.id, 'project_id': self.project.id})

--- a/addons/sale_project/views/project_task_views.xml
+++ b/addons/sale_project/views/project_task_views.xml
@@ -28,6 +28,20 @@
         </field>
     </record>
 
+    <record id="view_task_kanban_inherit" model="ir.ui.view">
+        <field name="name">project.task.kanban.inherit</field>
+        <field name="model">project.task</field>
+        <field name="inherit_id" ref="project.view_task_kanban"/>
+        <field name="arch" type="xml">
+            <xpath expr="//templates" position="before">
+                <field name="allow_billable" invisible="1"/>
+            </xpath>
+            <xpath expr="//div[hasclass('o_kanban_record_headings')]//field[@name='partner_id']" position="attributes">
+                <attribute name="t-if">record.allow_billable.raw_value</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="project_project_view_tree_inherit_sale_project" model="ir.ui.view">
         <field name="name">project.project.tree.inherit.sale.project</field>
         <field name="model">project.project</field>

--- a/addons/sale_timesheet/tests/test_project_billing.py
+++ b/addons/sale_timesheet/tests/test_project_billing.py
@@ -270,7 +270,7 @@ class TestProjectBilling(TestCommonSaleTimesheet):
 
         self.assertFalse(subtask.allow_billable, "Subtask in non billable project should be non billable too")
         self.assertFalse(subtask.project_id.allow_billable, "The subtask project is non billable even if the subtask is")
-        self.assertFalse(subtask.partner_id, "Subtask in non billable project should not have a customer")
+        self.assertEqual(subtask.partner_id, self.partner_a, "Subtask in non billable project should have the customer set on the parent task")
 
         # log timesheet on subtask
         timesheet2 = Timesheet.create({
@@ -368,7 +368,7 @@ class TestProjectBilling(TestCommonSaleTimesheet):
             'project_id': self.project_subtask.id,
         })
 
-        self.assertFalse(subtask.partner_id, "Subtask should not have the customer if it's project is not billable")
+        self.assertEqual(subtask.partner_id, task.partner_id, "Subtask should have the customer set on the parent task")
 
         # log timesheet on subtask
         timesheet2 = Timesheet.create({


### PR DESCRIPTION
Before this commit, when the user makes the project non-billable then the partner set on the tasks is removed. The problem is if the user would like to make the project billable again, he will have to set manually the tasks on all tasks which could be very annoying if the partner is different on each task.

This commit avoids resetting the partner on the tasks when the project will become non-billable or if the project changed and that project is non-billable.

task-3893551
