### PR TITLE
[FIX] barcodes_gs1_nomenclature: FNC1 not escaped

### DIFF
--- a/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
+++ b/addons/barcodes_gs1_nomenclature/models/barcode_nomenclature.py
@@ -97,6 +97,11 @@ class BarcodeNomenclature(models.Model):
         separator_group = FNC1_CHAR + "?"
         if self.gs1_separator_fnc1:
             separator_group = "(?:%s)?" % self.gs1_separator_fnc1
+        # zxing-library patch, removing GS1 identifiers
+        for identifier in [']C1', ']e0', ']d2', ']Q3', ']J1']:
+            if barcode.startswith(identifier):
+                barcode = barcode.replace(identifier, '')
+                break
         results = []
         gs1_rules = self.rule_ids.filtered(lambda r: r.encoding == 'gs1-128')
 


### PR DESCRIPTION
Current behavior:
---
On a mobile phone, using Chrome, when scanning a barcode that begins 
with the FNC1 character, ']C1' will be added to the final code.

Expected behavior:
---
']C1' should be removed from the final code

Steps to reproduce:
---
1. On a mobile phone, with chrome
2. Go to the barcode module
3. Scan a barcode starting with FNC1
4. Code will begin with ]C1

Cause of the issue:
---
https://github.com/odoo/odoo/blob/321d16950ee9dcf4d722ecbfe0a49ca8f7d855a6/addons/web/static/lib/zxing-library/zxing-library.js#L6928 
zxing-library is adding ']C1' to barcodes starting with a FNC1 character

opw-3853913

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
