### PR TITLE
[FIX] product: display barcode field on new products

### DIFF
--- a/addons/product/models/product_template.py
+++ b/addons/product/models/product_template.py
@@ -126,6 +126,7 @@ class ProductTemplate(models.Model):
 
     # related to display product product information if is_product_variant
     barcode = fields.Char('Barcode', compute='_compute_barcode', inverse='_set_barcode', search='_search_barcode')
+    is_barcode_visible = fields.Boolean('Is Barcode Visible', compute='_compute_is_barcode_visible')
     default_code = fields.Char(
         'Internal Reference', compute='_compute_default_code',
         inverse='_set_default_code', store=True)
@@ -732,6 +733,19 @@ class ProductTemplate(models.Model):
         """
         self.ensure_one()
         return any(a.create_variant == 'dynamic' for a in self.valid_product_template_attribute_line_ids.attribute_id)
+
+    @api.depends('valid_product_template_attribute_line_ids')
+    def _compute_is_barcode_visible(self):
+        for record in self:
+            record.is_barcode_visible = any(
+                len(al.value_ids) > 1 for al in record.valid_product_template_attribute_line_ids
+            ) or (
+                record.valid_product_template_attribute_line_ids and
+                all(
+                    al.attribute_id.create_variant == 'dynamic'
+                    for al in record.valid_product_template_attribute_line_ids
+                )
+            )
 
     @api.depends('attribute_line_ids.value_ids')
     def _compute_valid_product_template_attribute_line_ids(self):

--- a/addons/product/views/product_template_views.xml
+++ b/addons/product/views/product_template_views.xml
@@ -43,8 +43,8 @@
             </xpath>
             <field name="categ_id" position="after">
                 <field name="default_code" attrs="{'invisible': [('product_variant_count', '>', 1)]}"/>
-                <field name="valid_product_template_attribute_line_ids" invisible="1"/>
-                <field name="barcode" attrs="{'invisible': ['|', ('product_variant_count', '>', 1), '&amp;', ('product_variant_count', '=', 0), ('valid_product_template_attribute_line_ids', '!=', [])]}"/>
+                <field name="is_barcode_visible" invisible="1"/>
+                <field name="barcode" attrs="{'invisible': [('is_barcode_visible', '=', True)]}"/>
             </field>
 
             <div name="button_box" position="inside">


### PR DESCRIPTION
Previously, when creating a new product and adding the product attribute with
only one variant, the 'barcode' field would not appear on the new product form
until the form was saved.

With this commit, the 'barcode' field now appears on the product form
immediately after adding the product attribute with one variant, without
requiring the form to be saved.

