### PR TITLE
[FIX] web_editor: consider border-radius for background layers

### DIFF
--- a/addons/web_editor/static/src/scss/web_editor.common.scss
+++ b/addons/web_editor/static/src/scss/web_editor.common.scss
@@ -751,9 +751,34 @@ blockquote {
     }
 }
 %o-we-background-layer {
-    @include o-position-absolute(0, 0, 0, 0);
+    // Position the layer on top of the parent
     position: absolute !important;
+
+    // Place it at the center, independently from the way its size is computed
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+
+    // Make its inner-width (borders not included) the same size as the width of
+    // the parent (borders not included too).
     display: block;
+    box-sizing: content-box;
+    width: 100%;
+    height: 100%;
+
+    // Add the same border as the parent but transparent
+    border: inherit;
+    border-color: transparent;
+
+    // Add the same border-radius as the parent. This only works (following the
+    // exact same curve as the parent) because the same border was added on the
+    // layer itself too.
+    border-radius: inherit;
+
+    // Make sure the layer's transparent border lets the parent border appear,
+    // independently of the layer's background.
+    background-clip: padding-box;
+
     overflow: hidden;
     background-repeat: no-repeat;
     pointer-events: none;

--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -563,9 +563,8 @@ registry.Parallax = Animation.extend({
     destroy: function () {
         this._super.apply(this, arguments);
         this._updateBgCss({
+            height: '',
             transform: '',
-            top: '',
-            bottom: '',
         });
 
         $(window).off('.animation_parallax');
@@ -606,8 +605,7 @@ registry.Parallax = Animation.extend({
         // Provide a "safe-area" to limit parallax
         const absoluteRatio = Math.abs(this.ratio);
         this._updateBgCss({
-            top: -absoluteRatio,
-            bottom: -absoluteRatio,
+            height: `calc(100% + ${2 * absoluteRatio}px)`,
         });
     },
     /**
@@ -653,7 +651,9 @@ registry.Parallax = Animation.extend({
         var vpEndOffset = scrollOffset + this.viewport;
         if (vpEndOffset >= this.visibleArea[0]
          && vpEndOffset <= this.visibleArea[1]) {
-            this._updateBgCss({'transform': 'translateY(' + _getNormalizedPosition.call(this, vpEndOffset) + 'px)'});
+            const pos = _getNormalizedPosition.call(this, vpEndOffset);
+            // Default is to center the layer with `-50%, -50%`
+            this._updateBgCss({'transform': `translate(-50%, calc(-50% + ${pos}px))`});
         }
 
         function _getNormalizedPosition(pos) {
@@ -1679,11 +1679,10 @@ registry.ZoomedBackgroundShape = publicWidget.Widget.extend({
      * Updates the left and right offset of the shape.
      *
      * @private
-     * @param {string} offset
+     * @param {string} [offset]
      */
-    _updateShapePosition(offset = '') {
-        this.el.style.left = offset;
-        this.el.style.right = offset;
+    _updateShapePosition(offset) {
+        this.el.style.width = offset ? `calc(100% - ${2 * offset}px)` : '';
     },
 
     //--------------------------------------------------------------------------
@@ -1706,7 +1705,7 @@ registry.ZoomedBackgroundShape = publicWidget.Widget.extend({
             let offset = (decimalPart < 0.5 ? decimalPart : decimalPart - 1) / 2;
             // This never causes the horizontal scrollbar to appear because it
             // only appears if the overflow to the right exceeds 0.333px.
-            this._updateShapePosition(offset + 'px');
+            this._updateShapePosition(offset);
         }
     },
 });

--- a/addons/website/static/src/snippets/s_masonry_block/001.scss
+++ b/addons/website/static/src/snippets/s_masonry_block/001.scss
@@ -2,7 +2,6 @@
     display: flex;
     flex-direction: column;
     justify-content: center;
-    overflow: hidden;
 }
 
 .s_masonry_block[data-vcss='001'] .row.o_grid_mode {

--- a/addons/website/static/tests/tours/parallax.js
+++ b/addons/website/static/tests/tours/parallax.js
@@ -52,7 +52,7 @@ registerWebsitePreviewTour("test_parallax", {
     changeOption("Parallax", 'we-button[data-select-data-attribute="1.5"]'),
 {
     content: "Check that the option was correctly applied",
-    trigger: ':iframe span.s_parallax_bg[style*=top][style*=bottom][style*=transform]',
+    trigger: ':iframe span.s_parallax_bg[style*=height][style*=transform]',
 },
     ...clickOnSave(),
     ...clickOnEditAndWaitEditMode(),


### PR DESCRIPTION
Previously, layer options of a block (color filters, shapes, parallax
effects, videos, ...) were ignoring the parent border-radius.

This commit ensures that all these background options layers follow
the rounded borders.

Steps to reproduce **:
- Drag and drop a Masonry snippet.
- Select any item of the snippet.
- Through the inner item's options, add an image.
- Set a border radius and apply a color filter.
- Color filter extends beyond the rounded corners of the block.

This issue also applies to shapes, parallax effects and videos by
following the same steps.

** The steps to reproduce are not possible to use to actually reproduce
   the issue using the masonry snippet as described because a new CSS
   `overflow: hidden` rule was added by [1] to hide the issue. We don't
   want such rules, this commit is thus removing it at the same time, in
   which case this fixed bug would happen. Note that those steps are
   true in stable versions though, where we might want to backport this.

Note: there are also many other `overflow: hidden` rules in the codebase
that we might want to remove in the future. But those are older and more
complicated.

[1]: https://github.com/odoo/odoo/commit/4660f06e6835347769d925cedd4bd5035b609c7b

task-3358501