### PR TITLE
[FIX] Fix sequence auto generation for repair order

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -292,7 +292,7 @@ class Repair(models.Model):
             picking_type = self.env['stock.picking.type'].browse(vals.get('picking_type_id', self.default_get('picking_type_id')))
             if 'picking_type_id' not in vals:
                 vals['picking_type_id'] = picking_type.id
-            if not vals.get('name', False) or vals['name'] == _('New'):
+            if not vals.get('name', False) or vals['name'] == 'New':
                 vals['name'] = picking_type.sequence_id.next_by_id()
             if not vals.get('procurement_group_id'):
                 vals['procurement_group_id'] = self.env["procurement.group"].create({'name': vals['name']}).id


### PR DESCRIPTION
**Issue:** In the upgraded version, we have implemented the condition vals['name'] == _('New').
       However, the data type of the 'name' field is character and translate = False [ref](https://github.com/odoo/odoo/blob/17.0/odoo/fields.py#L274).
       Additionally, the default value for the 'name' field is set to 'New', causing
       this condition to evaluate to false and consequently terminating the execution
       of the if block.Here is the reference to the issue posted by the customer ticket (3887638).

**Solution:** To address this, we propose changing the condition to vals['name'] == 'New'
	  to ensure correct comparison. This modification is warranted due to the configuration [ref](https://github.com/odoo/odoo/blob/17.0/addons/repair/models/repair.py#L31)
	  of the field:

	  The field is not translatable.
 	  The field is required and set to readonly true, preventing customers from inputting values.
	  The default value for the field is set to 'New'.

**Before:**
       Unable to obtain the auto-generated sequence (receiving default value 'New').

**After:**
      The sequence is generated automatically.





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
