### PR TITLE
[16.0] [FIX] l10n_es_edi_tbai fix errors getting tbai invoice line description

### DIFF
--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -346,7 +346,7 @@ class AccountEdiFormat(models.Model):
                 'discount': discount * refund_sign,
                 'unit_price': (line.balance + discount) / line.quantity * refund_sign,
                 'total': total,
-                'description': regex_sub(r'[^0-9a-zA-Z ]', '', line.name)[:250]
+                'description': regex_sub(r'[^0-9a-zA-Z ]', 'X', line.name)[:250] if line.name and line.name.strip() else "X"
             })
         values['invoice_lines'] = invoice_lines
         # Tax details (desglose)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Fix problems getting tbai invoice line description.

Current behavior before PR:

Invoice line name is not required in Odoo, in the case that the user leave it empty, an exception is raised by re Python library (TypeError: expected string or bytes-like object)

Description (the result of regex_sub) could be an empty string or a string of white spaces, in these cases, the invoice is not accepted by TicketBAI systems becasue TicketBAI xml file is not valid according to XSD schema for type 'TextMax250ObligatorioType'.

Desired behavior after PR is merged:

Description is correct, no errors are raised, invoice is posted and TicketBAI XML file is created and posted to the agency.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
