### PR TITLE
[FIX] web: only name_get if exists

### DIFF
--- a/addons/web/static/src/legacy/js/views/basic/basic_model.js
+++ b/addons/web/static/src/legacy/js/views/basic/basic_model.js
@@ -2682,9 +2682,17 @@ var BasicModel = AbstractModel.extend({
         var parent = datapoints[ids[0]][0];
         var def = self._rpc({
             model: model,
-            method: 'name_get',
+            method: 'exists',
             args: [ids],
             context: self.localData[parent].getContext({fieldName: fieldName}),
+        }).then(async function (existIds) {
+            const namedIds = await self._rpc({
+                model: model,
+                method: 'name_get',
+                args: [existIds],
+                context: self.localData[parent].getContext({fieldName: fieldName}),
+            })
+            return namedIds.concat(ids.flatMap((id) => existIds.includes(id) ? [] : [[id, ""]]));
         }).then(function (result) {
             _.each(result, function (el) {
                 var parentIDs = datapoints[el[0]];

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -419,6 +419,8 @@ export class MockServer {
             }
             case "create":
                 return this.mockCreate(args.model, args.args[0]);
+            case "exists":
+                return args.args[0];
             case "fields_get":
                 return this.mockFieldsGet(args.model);
             case "load_views":

--- a/addons/web/static/tests/legacy/helpers/mock_server.js
+++ b/addons/web/static/tests/legacy/helpers/mock_server.js
@@ -1981,6 +1981,9 @@ var MockServer = Class.extend({
             case 'create':
                 return this._mockCreate(args.model, args.args[0]);
 
+            case 'exists':
+                return args.args[0];
+
             case 'fields_get':
                 return this._mockFieldsGet(args.model, args.args);
 


### PR DESCRIPTION
Currently if you delete a record referenced by a reference field

The views that use the reference field will crash as "name_get" cannot find the record.

We should check the records exist before trying to get their name, and otherwise set their name to empty.

Issue:
- Create a new email template
- Go to an event
- Go to the communications tab
- Add a new communication step using that template
- Go delete the template
- Go back to the event
-> traceback

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
