### PR TITLE
[FIX] core: prevent KeyError when module is uninstalled

### DIFF
--- a/odoo/service/model.py
+++ b/odoo/service/model.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from functools import partial
 
 from psycopg2 import IntegrityError, OperationalError, errorcodes
+from werkzeug.exceptions import NotFound
 
 import odoo
 from odoo.exceptions import UserError, ValidationError
@@ -163,7 +164,8 @@ def retrying(func, env):
         else:
             # handled in the "if not tryleft" case
             raise RuntimeError("unreachable")
-
+    except KeyError as e:
+        raise NotFound() from e
     except Exception:
         env.reset()
         env.registry.reset_changes()


### PR DESCRIPTION
When the user uninstalls the module and still tries to access the fields of
that module in settings, a KeyError will be generated.

Steps to reproduce the error:
- Go to settings > enable Use a Gmail Server
- Uninstall google_gmail
- Enter a value for ID > Discard

Traceback:
```
KeyError: 'google_gmail_client_identifier'
  File "odoo/http.py", line 2254, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1830, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1850, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1828, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1835, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2060, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 742, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 871, in onchange
    defaults = self.default_get(missing_names)
  File "odoo/addons/base/models/res_config.py", line 464, in default_get
    classified = self._get_classified_fields(fields)
  File "odoo/addons/base/models/res_config.py", line 424, in _get_classified_fields
    field = self._fields[name]
```

sentry-4636111851

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
