### PR TITLE
[IMP] sale_crm: update expected_revenue based on sent quotations

### DIFF
--- a/addons/sale_crm/models/sale_order.py
+++ b/addons/sale_crm/models/sale_order.py
@@ -12,4 +12,7 @@ class SaleOrder(models.Model):
         domain="[('type', '=', 'opportunity'), '|', ('company_id', '=', False), ('company_id', '=', company_id)]")
 
     def action_confirm(self):
-        return super(SaleOrder, self.with_context({k:v for k,v in self._context.items() if k != 'default_tag_ids'})).action_confirm()
+        res = super(SaleOrder, self.with_context({k: v for k, v in self._context.items() if k != 'default_tag_ids'})).action_confirm()
+        for order in self:
+            order.opportunity_id._update_revenues_from_so(order)
+        return res

--- a/addons/sale_crm/tests/__init__.py
+++ b/addons/sale_crm/tests/__init__.py
@@ -3,3 +3,4 @@
 
 from . import test_crm_lead_convert_quotation
 from . import test_crm_lead_merge
+from . import test_sale_crm

--- a/addons/sale_crm/tests/test_sale_crm.py
+++ b/addons/sale_crm/tests/test_sale_crm.py
@@ -1,0 +1,60 @@
+from odoo.addons.crm.tests.common import TestCrmCommon
+from odoo.fields import Command
+
+
+class TestSaleCrm(TestCrmCommon):
+
+    def test_sale_crm_revenue(self):
+        """ Test the updation of the expected_revenue when the is confirmed.
+        If the expected_revenue of the lead is smaller than the total of quote which we are confirming, update it with that.
+        e.g. if the lead has a expected revenue of 40 $
+        Quotes - q1 = 45$
+        ===> The expected_revenue would be updated, from 40 to 45$.
+        """
+        product1, product2 = self.env['product.template'].create([{
+            'name': 'Test product1',
+            'list_price': 100.0,
+        }, {
+            'name': 'Test product2',
+            'list_price': 200.0,
+        }])
+
+        my_pricelist = self.env['product.pricelist'].create({
+            'name': 'Rupee',
+            'currency_id': self.ref('base.INR')
+        })
+        pricelist_expected_by_lead = self.env['product.pricelist'].create({
+            'name': 'Rupee',
+            'currency_id': self.ref('base.USD')
+        })
+
+        so_values = {
+            'partner_id': self.env.user.partner_id.id,
+            'opportunity_id': self.lead_1.id,
+        }
+        so1, so2 = self.env['sale.order'].create([{
+            **so_values,
+            'pricelist_id': my_pricelist.id,
+            'order_line': [
+                Command.create({
+                    'product_id': product1.product_variant_id.id,
+                }),
+            ],
+        }, {
+            **so_values,
+            'pricelist_id': pricelist_expected_by_lead.id,
+            'order_line': [
+                Command.create({
+                    'product_id': product2.product_variant_id.id,
+                }),
+            ],
+        }])
+
+        self.assertEqual(self.lead_1.expected_revenue, 0)
+
+        # Revenue should not be updated when the currency of sale order is different from lead.
+        so1.action_confirm()
+        self.assertEqual(self.lead_1.expected_revenue, 0)
+        # Revenue should be updated when the currency is same.
+        so2.action_confirm()
+        self.assertEqual(self.lead_1.expected_revenue, 200)


### PR DESCRIPTION
Purpose
=========
Help salespeople keep their opportunities up-to-date by propagating the revenues
they set on Quotations.

Specification
==============
When a quotation is confirmed, if the expected revenue of the lead is less than the
total of quote which we are confirming, the expected revenue of the lead should be
updated to match the total of the quote.

For example:

If the lead has an expected revenue of $40:

Quote 1: $45 and we confirm it then,
Then the expected revenue of the lead would be updated from $40 to $45.
Task-3806572
ENT PR https://github.com/odoo/enterprise/pull/61550