### PR TITLE
[FIX] stock: save move before adding move lines

### DIFF
--- a/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
+++ b/addons/stock/static/src/fields/stock_move_line_x2_many_field.js
@@ -49,7 +49,9 @@ export class SMLX2ManyField extends X2ManyField {
         if (alreadySelected.length) {
             domain.push(["id", "not in", alreadySelected.map((line) => line.data.quant_id[0])]);
         }
-        return this.selectCreate({ domain, context, title });
+        this.props.record.save().then(() => {
+            return this.selectCreate({ domain, context, title });
+        });
     }
 
     selectRecord(res_ids) {

--- a/addons/stock/static/tests/tours/stock_picking_tour.js
+++ b/addons/stock/static/tests/tours/stock_picking_tour.js
@@ -48,6 +48,71 @@ registry.category("web_tour.tours").add('test_detailed_op_no_save_1', { test: tr
     },
 ]});
 
+registry.category("web_tour.tours").add('test_pick_from_after_unlink', { test: true, steps: () => [
+    {trigger: ".fa-list"},
+    {trigger: "h4:contains('Stock move')"},
+    {
+        trigger: ".o_field_cell[name=quant_id]",
+        run: () => {
+            const nbLines = document.querySelectorAll(".o_field_cell[name=quant_id]").length;
+            if (nbLines !== 2){
+                throw new TourError("wrong number of move lines generated. " + nbLines + " instead of 2");
+            }
+        },
+    },
+    // delete the two reserved move lines
+    {trigger: '.fa-trash-o'},
+    {
+        trigger: ".o_field_cell[name=quant_id]",
+        run: () => {
+            const nbLines = document.querySelectorAll(".o_field_cell[name=quant_id]").length;
+            if (nbLines !== 1){
+                throw new TourError("wrong number of move lines generated. " + nbLines + " instead of 1");
+            }
+        },
+    },
+    {trigger: '.fa-trash-o'},
+    {
+        trigger: "thead",
+        run: () => {
+            const nbLines = document.querySelectorAll(".o_field_cell[name=quant_id]").length;
+            if (nbLines !== 0){
+                throw new TourError("wrong number of move lines generated. " + nbLines + " instead of 0");
+            }
+        },
+    },
+    {trigger: '.o_field_x2many_list_row_add > a'},
+    {trigger: 'h4:contains("Add line:")'},
+    {trigger: '.o_data_cell:contains("50.00")'},
+    {
+        trigger: '.o_list_number:contains("50.00")',
+        run: () => {
+            const nbLines = document.querySelectorAll(".o_field_cell[name=quant_id]").length;
+            if (nbLines !== 1){
+                throw new TourError("wrong number of move lines generated. " + nbLines + " instead of 1");
+            }
+        },
+    },
+    {trigger: '.o_field_x2many_list_row_add > a'},
+    {trigger: 'h4:contains("Add line:")'},
+    {trigger: 'td.o_data_cell:contains("40.00")'},
+    {
+        trigger: '.o_list_number:contains("90.00")',
+        run: () => {
+            const nbLines = document.querySelectorAll(".o_field_cell[name=quant_id]").length;
+            if (nbLines !== 2){
+                throw new TourError("wrong number of move lines generated. " + nbLines + " instead of 2");
+            }
+        },
+    },
+    {trigger: ".o_form_button_save"},
+    {trigger: ".btn-primary[name=button_validate]"},
+    {
+        trigger: ".o_control_panel_actions button:contains('Traceability')",
+        isCheck: true,
+    },
+]}),
+
 registry.category("web_tour.tours").add('test_generate_serial_1', { test: true, steps: () => [
     {trigger: '.o_field_x2many_list_row_add > a'},
     {


### PR DESCRIPTION
In the detailed operation view, adding a new move line will show the available quants with their free quantity. This free quantity may be dependant on the move lines of the current stock move. To be sure this quantity is correct and reflect all move line added or deleted before, we trigger a save to the server to update the free quantity.


see 

[screencast-bpconcjcammlapcogcnnelfmaeghhagj-2024.04.24-09_49_04.webm](https://github.com/odoo/odoo/assets/12071695/2b20659f-dd8f-47bc-80ff-6d5234c532db)




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
