### PR TITLE
[FIX] sale_loyalty, _*: set a partner for next order coupons

### DIFF
--- a/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
+++ b/addons/pos_loyalty/static/src/overrides/components/payment_screen/payment_screen.js
@@ -80,7 +80,10 @@ patch(PaymentScreen.prototype, {
                 points: pe.points - order._getPointsCorrection(ProgramModel.get(pe.program_id)),
             });
             const program = ProgramModel.get(pe.program_id);
-            if (program.is_nominative && partner) {
+            if (
+                (program.is_nominative || program.program_type == "next_order_coupons") &&
+                partner
+            ) {
                 agg[pe.coupon_id].partner_id = partner.id;
             }
             return agg;

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -1107,7 +1107,7 @@ class SaleOrder(models.Model):
                 all_points = [p for p in all_points if p]
                 partner = False
                 # Loyalty programs and ewallets are nominative
-                if program.is_nominative:
+                if program.is_nominative or program.program_type == 'next_order_coupons':
                     partner = self.partner_id.id
                 coupons = self.env['loyalty.card'].sudo().with_context(loyalty_no_mail=True, tracking_disable=True).create([{
                     'program_id': program.id,


### PR DESCRIPTION
_* = pos_loyalty

Before:
When a next order coupon was created, it was not linked to the customer. As a
result, when the customers shopped again, the coupons weren't suggested to them.

After:
Each next order coupon generated is assigned to a specific customer.

Why this solution?
Even though the coupon is linked to a customer, it should still be usable by
another user who has the code (this does not apply to eWallet and loyalty
cards). The eWallet and loyalty cards are nominative, but including the next
order coupon in this category would prevent other users with the same code
from using it. Adding the next order coupon to the nominative category may
impact other flows too where the condition is_nominative is checked leading to
unintended behavior for next order coupons.

task-3746887