### PR TITLE
[FIX] account_payment: added missing indexes when deleting batch payment

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -45,6 +45,7 @@ class AccountBankStatementLine(models.Model):
         comodel_name='account.move',
         auto_join=True,
         string='Journal Entry', required=True, readonly=True, ondelete='cascade',
+        index=True,
         check_company=True)
     statement_id = fields.Many2one(
         comodel_name='account.bank.statement',

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -173,6 +173,7 @@ class AccountMove(models.Model):
         string="Statement Line",
         copy=False,
         check_company=True,
+        index='btree_not_null',
     )
 
     # === Cash basis feature fields === #
@@ -223,6 +224,7 @@ class AccountMove(models.Model):
         comodel_name='account.move',
         string='First recurring entry',
         readonly=True, copy=False,
+        index='btree_not_null',
     )
     hide_post_button = fields.Boolean(compute='_compute_hide_post_button', readonly=True)
     to_check = fields.Boolean(

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -16,6 +16,7 @@ class AccountPayment(models.Model):
     move_id = fields.Many2one(
         comodel_name='account.move',
         string='Journal Entry', required=True, readonly=True, ondelete='cascade',
+        index=True,
         check_company=True)
 
     is_reconciled = fields.Boolean(string="Is Reconciled", store=True,
@@ -38,6 +39,7 @@ class AccountPayment(models.Model):
     qr_code = fields.Char(string="QR Code URL",
         compute="_compute_qr_code")
     paired_internal_transfer_payment_id = fields.Many2one('account.payment',
+        index='btree_not_null',
         help="When an internal transfer is posted, a paired payment is created. "
         "They are cross referenced through this field", copy=False)
 

--- a/addons/account_debit_note/models/account_move.py
+++ b/addons/account_debit_note/models/account_move.py
@@ -6,7 +6,7 @@ from odoo import models, fields, api, _
 class AccountMove(models.Model):
     _inherit = "account.move"
 
-    debit_origin_id = fields.Many2one('account.move', 'Original Invoice Debited', readonly=True, copy=False)
+    debit_origin_id = fields.Many2one('account.move', 'Original Invoice Debited', readonly=True, copy=False, index='btree_not_null')
     debit_note_ids = fields.One2many('account.move', 'debit_origin_id', 'Debit Notes',
                                      help="The debit notes created for this invoice")
     debit_note_count = fields.Integer('Number of Debit Notes', compute='_compute_debit_count')

--- a/addons/account_edi/models/account_edi_document.py
+++ b/addons/account_edi/models/account_edi_document.py
@@ -19,7 +19,7 @@ class AccountEdiDocument(models.Model):
     _description = 'Electronic Document for an account.move'
 
     # == Stored fields ==
-    move_id = fields.Many2one('account.move', required=True, ondelete='cascade')
+    move_id = fields.Many2one('account.move', required=True, ondelete='cascade', index=True)
     edi_format_id = fields.Many2one('account.edi.format', required=True)
     attachment_id = fields.Many2one(
         comodel_name='ir.attachment',

--- a/addons/account_payment/models/account_payment.py
+++ b/addons/account_payment/models/account_payment.py
@@ -40,6 +40,7 @@ class AccountPayment(models.Model):
         related='payment_transaction_id.source_transaction_id.payment_id',
         readonly=True,
         store=True,  # Stored for the group by in `_compute_refunds_count`
+        index='btree_not_null',
     )
     refunds_count = fields.Integer(string="Refunds Count", compute='_compute_refunds_count')
 

--- a/addons/l10n_id_efaktur/models/account_move.py
+++ b/addons/l10n_id_efaktur/models/account_move.py
@@ -22,7 +22,7 @@ class AccountMove(models.Model):
     _inherit = "account.move"
 
     l10n_id_tax_number = fields.Char(string="Tax Number", copy=False)
-    l10n_id_replace_invoice_id = fields.Many2one('account.move', string="Replace Invoice",  domain="['|', '&', '&', ('state', '=', 'posted'), ('partner_id', '=', partner_id), ('reversal_move_id', '!=', False), ('state', '=', 'cancel')]", copy=False)
+    l10n_id_replace_invoice_id = fields.Many2one('account.move', string="Replace Invoice", domain="['|', '&', '&', ('state', '=', 'posted'), ('partner_id', '=', partner_id), ('reversal_move_id', '!=', False), ('state', '=', 'cancel')]", copy=False, index='btree_not_null')
     l10n_id_attachment_id = fields.Many2one('ir.attachment', readonly=True, copy=False)
     l10n_id_csv_created = fields.Boolean('CSV Created', compute='_compute_csv_created', copy=False)
     l10n_id_kode_transaksi = fields.Selection([

--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -28,7 +28,7 @@ class AccountAnalyticLine(models.Model):
     timesheet_invoice_type = fields.Selection(TIMESHEET_INVOICE_TYPES, string="Billable Type",
             compute='_compute_timesheet_invoice_type', compute_sudo=True, store=True, readonly=True)
     commercial_partner_id = fields.Many2one('res.partner', compute="_compute_commercial_partner")
-    timesheet_invoice_id = fields.Many2one('account.move', string="Invoice", readonly=True, copy=False, help="Invoice created from the timesheet")
+    timesheet_invoice_id = fields.Many2one('account.move', string="Invoice", readonly=True, copy=False, help="Invoice created from the timesheet", index='btree_not_null')
     so_line = fields.Many2one(compute="_compute_so_line", store=True, readonly=False,
         domain="[('is_service', '=', True), ('is_expense', '=', False), ('state', 'in', ['sale', 'done']), ('order_partner_id', 'child_of', commercial_partner_id)]",
         help="Sales order item to which the time spent will be added in order to be invoiced to your customer. Remove the sales order item for the timesheet entry to be non-billable.")

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -62,6 +62,7 @@ class StockLandedCost(models.Model):
         copy=False, readonly=True, tracking=True)
     account_move_id = fields.Many2one(
         'account.move', 'Journal Entry',
+        index='btree_not_null',
         copy=False, readonly=True)
     account_journal_id = fields.Many2one(
         'account.journal', 'Account Journal',

--- a/doc/cla/corporate/braintec.md
+++ b/doc/cla/corporate/braintec.md
@@ -17,3 +17,4 @@ Raul Martin raul.martin@braintec.com https://github.com/BT-rmartin
 Frédéric Garbely frederic.garbely@braintec.com https://github.com/BT-fgarbely
 Carlos Serra Toro carlos.serra@braintec.com https://github.com/BT-cserra
 Cristian Rodriguez Navarro cristian.rodriguez@braintec.com https://github.com/BT-crodriguez
+Olivier Jossen olivier.jossen@braintec.com https://github.com/BT-ojossen


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
When deleting a batch payment including all its payments (around 500) it took ages until the query was through.

Current behavior before PR:
To delete it takes more than 20 minutes.

Desired behavior after PR is merged:
After adding these indexes the time got reduced so that it took less than 2 minutes.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
