### PR TITLE
[IMP] website: redesign `s_numbers` snippet

### DIFF
--- a/addons/website/views/new_page_template_templates.xml
+++ b/addons/website/views/new_page_template_templates.xml
@@ -538,22 +538,22 @@ overridden by modules), because:
 
 <template id="new_page_template_about_full_s_numbers" inherit_id="website.new_page_template_about_s_numbers" primary="True">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="o_cc3 o_colored_level" remove="o_cc2" separator=" "/>
+        <attribute name="class" add="o_cc3 o_colored_level" remove="o_cc1" separator=" "/>
     </xpath>
 </template>
 
 <template id="new_page_template_about_personal_s_numbers" inherit_id="website.new_page_template_about_s_numbers" primary="True">
     <xpath expr="//section" position="attributes">
-        <attribute name="class" add="pt0 o_cc3 o_colored_level" remove="o_cc2 pt24" separator=" "/>
+        <attribute name="class" add="pt0 o_cc3 o_colored_level" remove="o_cc1 pt80" separator=" "/>
     </xpath>
     <xpath expr="//h6" position="replace">
-        <h6 style="text-align: center;">Clients</h6>
+        <h6 class="lead" style="text-align: center;">Clients</h6>
     </xpath>
     <xpath expr="(//h6)[2]" position="replace">
-        <h6 style="text-align: center;">Amazing Pages</h6>
+        <h6 class="lead" style="text-align: center;">Amazing Pages</h6>
     </xpath>
     <xpath expr="(//h6)[3]" position="replace">
-        <h6 style="text-align: center;">Websites</h6>
+        <h6 class="lead" style="text-align: center;">Websites</h6>
     </xpath>
 </template>
 

--- a/addons/website/views/snippets/s_numbers.xml
+++ b/addons/website/views/snippets/s_numbers.xml
@@ -2,24 +2,28 @@
 <odoo>
 
 <template name="Numbers" id="s_numbers">
-    <section class="s_numbers o_cc o_cc2 pt24 pb24">
+    <section class="s_numbers o_cc o_cc1 pt80 pb80">
         <div class="container">
             <div class="row">
-                <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">12</span>
-                    <h6>Useful options</h6>
+                <div class="col-lg-4">
+                    <h3 class="mb-3 h4">Key Metrics of<br/>Company's Achievements</h3>
+                    <p class="lead">Analyzing the numbers behind our success: <br class="d-none d-xxl-inline"/>an in-depth look at the key metrics driving our company's achievements</p>
                 </div>
-                <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">45</span>
-                    <h6>Beautiful snippets</h6>
-                </div>
-                <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">8</span>
-                    <h6>Amazing pages</h6>
-                </div>
-                <div class="col-lg-3 text-center pt24 pb24">
-                    <span class="s_number display-4">37</span>
-                    <h6>Outstanding images</h6>
+                <div class="col-lg-7 offset-lg-1">
+                    <div class="row">
+                        <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
+                            <span class="s_number h1 display-1">12k</span>
+                            <h6 class="lead">Useful options</h6>
+                        </div>
+                        <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
+                            <span class="s_number h1 display-1">45%</span>
+                            <h6 class="lead">More leads</h6>
+                        </div>
+                        <div class="col-lg-4 pt24 pb24 text-center" data-name="Number Box">
+                            <span class="s_number h1 display-1">8+</span>
+                            <h6 class="lead">Amazing pages</h6>
+                        </div>
+                    </div>
                 </div>
             </div>
         </div>

--- a/addons/website/views/snippets/snippets.xml
+++ b/addons/website/views/snippets/snippets.xml
@@ -653,7 +653,7 @@
     </div>
 
     <!--  Vertical Alignment -->
-    <div data-js="vAlignment" id="row_valign_snippet_option" data-selector=".s_text_image, .s_image_text, .s_three_columns, .s_showcase" data-target=".row">
+    <div data-js="vAlignment" id="row_valign_snippet_option" data-selector=".s_text_image, .s_image_text, .s_three_columns, .s_showcase, .s_numbers" data-target=".row">
         <we-button-group class="o_we_sublevel_1" string="Vert. Alignment" title="Vertical Alignment" data-dependencies="normal_mode">
             <we-button title="Align Top"
                        data-select-class="align-items-start"


### PR DESCRIPTION
This PR is handled by @chgo-odoo 

---

The goal of this PR is to improve the visual design of the default `s_numbers` snippet.

task-3924624

Requires :
- https://github.com/odoo/design-themes/pull/822

---

| Before | After (still using the old font pair) |
|--------|--------|
| <img width="1420" alt="Screenshot 2024-04-26 at 16 43 17" src="https://github.com/odoo/odoo/assets/110090660/a5252517-ba8d-47ff-9960-dfe355f63dc4">  | <img width="1726" alt="image" src="https://github.com/user-attachments/assets/51acaa9e-98de-4c80-baa8-bfd4a7d135a5"> | 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
