### PR TITLE
[IMP] hw_drivers: more detailed IoT version

### DIFF
--- a/addons/hw_drivers/main.py
+++ b/addons/hw_drivers/main.py
@@ -49,7 +49,7 @@ class Manager(Thread):
                 'identifier': helpers.get_mac_address(),
                 'ip': domain,
                 'token': helpers.get_token(),
-                'version': helpers.get_version(),
+                'version': helpers.get_version(detailed_version=True),
             }
             devices_list = {}
             for device in iot_devices:
@@ -86,7 +86,7 @@ class Manager(Thread):
         """
 
         helpers.start_nginx_server()
-        _logger.info("IoT Box Image version: %s", helpers.get_version())
+        _logger.info("IoT Box Image version: %s", helpers.get_version(detailed_version=True))
         if platform.system() == 'Linux' and helpers.get_odoo_server_url():
             helpers.check_git_branch()
             helpers.generate_password()

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -21,7 +21,7 @@ import contextlib
 import requests
 import secrets
 
-from odoo import _, http, service
+from odoo import _, http, release, service
 from odoo.tools.func import lazy_property
 from odoo.tools.misc import file_path
 from odoo.modules.module import get_resource_path
@@ -233,7 +233,7 @@ def get_certificate_status(is_first=True):
                                               "The HTTPS certificate was generated correctly")
 
 def get_img_name():
-    major, minor = get_version().split('.')
+    major, minor = get_version()[1:].split('.')
     return 'iotboxv%s_%s.zip' % (major, minor)
 
 def get_ip():
@@ -273,11 +273,29 @@ def get_odoo_server_url():
 def get_token():
     return read_file_first_line('token')
 
-def get_version():
+
+def get_commit_hash():
+    return subprocess.run(
+        ['git', '--work-tree=/home/pi/odoo/', '--git-dir=/home/pi/odoo/.git', 'rev-parse', '--short', 'HEAD'],
+        stdout=subprocess.PIPE,
+        check=True,
+    ).stdout.decode('ascii').strip()
+
+
+def get_version(detailed_version=False):
     if platform.system() == 'Linux':
-        return read_file_first_line('/var/odoo/iotbox_version')
+        image_version = read_file_first_line('/var/odoo/iotbox_version')
     elif platform.system() == 'Windows':
-        return 'W22_11'
+        # updated manually when big changes are made to the windows virtual IoT
+        image_version = '22.11'
+
+    version = platform.system()[0] + image_version
+    if detailed_version:
+        # Note: on windows IoT, the `release.version` finish with the build date
+        version += f"-{release.version}"
+        if platform.system() == 'Linux':
+            version += f'#{get_commit_hash()}'
+    return version
 
 def get_wifi_essid():
     wifi_options = []


### PR DESCRIPTION
Before this commit:
The version of the IoT was ambiguous and was needed to be updated manually for windows. As windows IoT does not have the concept of "image" (as it depends on the installer build) the version should give this information.
This information can be found in odoo release.py file

Benefit from this PR to add more details on the IoT box version to also give more information as an IoT box can be on a certain image and "code release" independently. The image shown on the homepage is the same as before, but the detailed/revision information is now sent to the odoo's synced server in order to be visible and used by the support

After this commit:

Windows IoT version:
- Before: W22_11
- After:  W22.11 (detailed version: `W22.11-16.0+e-20240412` )

IoT box version:
- Before: 24.01
- After:  L24.01  (detailed version: `L24.01-16.0#71bd27465` )
