### PR TITLE
[IMP] hr_holidays: improve hourly time off type allocation

### DIFF
--- a/addons/hr_holidays/data/hr_holidays_data.xml
+++ b/addons/hr_holidays/data/hr_holidays_data.xml
@@ -287,7 +287,7 @@
             <field name="employee_requests">yes</field>
             <field name="leave_validation_type">manager</field>
             <field name="allocation_validation_type">hr</field>
-            <field name="request_unit">hour</field>
+            <field name="request_unit">day</field>
             <field name="leave_notif_subtype_id" ref="mt_leave"/>
             <field name="responsible_ids" eval="[(4, ref('base.user_admin'))]"/>
             <field name="icon_id" ref="hr_holidays.icon_4"/>

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -232,11 +232,7 @@ class HolidaysAllocation(models.Model):
     @api.depends('number_of_days', 'holiday_status_id', 'employee_id', 'holiday_type')
     def _compute_number_of_hours_display(self):
         for allocation in self:
-            allocation_calendar = allocation.holiday_status_id.company_id.resource_calendar_id
-            if allocation.holiday_type == 'employee' and allocation.employee_id:
-                allocation_calendar = allocation.employee_id.sudo().resource_calendar_id
-
-            allocation.number_of_hours_display = allocation.number_of_days * (allocation_calendar.hours_per_day or HOURS_PER_DAY)
+            allocation.number_of_hours_display = allocation.number_of_days * HOURS_PER_DAY
 
     @api.depends('number_of_hours_display', 'number_of_days_display')
     def _compute_duration_display(self):


### PR DESCRIPTION
This PR addresses the hourly time off type allocations. 
Previously, the number of hours were determined based on
the working schedule of the employee or company. 
After this commit, the hours will be set directly from the
allocation form without considering the employee working schedule.

task-3884359
