### PR TITLE
[IMP] base: take advantage of CSS media query (print)

### DIFF
--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -290,6 +290,9 @@ class IrActionsReport(models.Model):
         if set_viewport_size:
             command_args.extend(['--viewport-size', landscape and '1024x1280' or '1280x1024'])
 
+        # Take advantage of CSS media query (print)
+        command_args.extend(['--print-media-type'])
+
         # Less verbose error messages
         command_args.extend(['--quiet'])
 


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
A PDF printout is basically printing a qweb template therefore it is legit to take advantage of the CSS media query argument to interpret CSS specifically to print.

**Current behavior before PR:**
No possibility to differentiate for PDF report layouts in CSS between screen and print.

**Desired behavior after PR is merged:**
Handle PDF reports as print designs.

Info: @wt-io-it




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
