### PR TITLE
[FIX]  web: broken empty list view

### DIFF
--- a/addons/web/static/src/views/list/list_renderer.scss
+++ b/addons/web/static/src/views/list/list_renderer.scss
@@ -481,8 +481,7 @@
 
     .o_data_row,
     .o_list_footer,
-    .o_group_header,
-    thead .o_list_record_selector {
+    .o_group_header {
         @include o-sample-data-disabled;
         border-color: rgba(0, 0, 0, 0.02);
     }


### PR DESCRIPTION
Before this commit:

The content of list view is empty, the outline of the `<thead>` tag (the line below the first `<tr>` inside `<thead>`)  would disappear, means its opacity reduced.

After this commit:

This commit fixes the issue by ensuring that the outline of the `<thead>` tag remains visible even when the list view is empty.

task - 3834758