### PR TITLE
[FIX] account_peppol: display warning if missing info

### DIFF
--- a/addons/account_peppol/i18n/account_peppol.pot
+++ b/addons/account_peppol/i18n/account_peppol.pot
@@ -771,6 +771,13 @@ msgid "This verification code has expired. Please request a new one."
 msgstr ""
 
 #. module: account_peppol
+#: model_terms:ir.ui.view,arch_db:account_peppol.res_partner_form_account_peppol
+msgid ""
+"To generate electronic invoices, also set a country and a bank account for "
+"this partner."
+msgstr ""
+
+#. module: account_peppol
 #. odoo-python
 #: code:addons/account_peppol/models/res_config_settings.py:0
 #, python-format

--- a/addons/account_peppol/views/res_partner_views.xml
+++ b/addons/account_peppol/views/res_partner_views.xml
@@ -8,11 +8,18 @@
             <field name="arch" type="xml">
             <data>
                 <xpath expr="//field[@name='ubl_cii_format']" position="before">
-                    <div class="alert alert-warning"
+                    <field name="bank_account_count" invisible="1"/>
+                    <div class="alert alert-warning mb-0"
                          colspan="2"
                          role="alert"
                          invisible="country_code != 'BE' or ubl_cii_format in (False, 'facturx') or peppol_eas in (False, '0208')">
                          The recommended EAS code for Belgium is 0208. The Endpoint should be the Company Registry number.
+                    </div>
+                    <div class="alert alert-warning"
+                         colspan="2"
+                         role="alert"
+                         invisible="not account_peppol_is_endpoint_valid or (bank_account_count != 0 and country_code)">
+                         To generate electronic invoices, also set a country and a bank account for this partner.
                     </div>
                 </xpath>
                 <xpath expr="//field[@name='peppol_endpoint']" position="after">


### PR DESCRIPTION
Issue
-----
When a partner has a valid peppol endpoint set but no bank account or country set, the user may not realize that the automatic generation for an electronic document has failed. For example when creating an invoice automatically for a subscription, there will only be an error note from odoobot, but no warning for the user like when creating an invoice manually.

Fix
-----
Display a warning to the user if some information is missing that would result in failling to generate the expected electronic document.

opw-3720730