### PR TITLE
[FIX] test_lint: relax constraint on countries in manifest

### DIFF
--- a/odoo/addons/test_lint/tests/test_manifests.py
+++ b/odoo/addons/test_lint/tests/test_manifests.py
@@ -54,10 +54,10 @@ class ManifestLinter(BaseCase):
             # todo installable ?
         ]
 
-        if 'countries' in manifest_data and 'l10n' not in module:
+        if len(manifest_data.get('countries', [])) == 1 and 'l10n' not in module:
             _logger.warning(
-                "Module %s specific to certain countries %s should contain `l10n` in their name.",
-                module, manifest_data['countries'])
+                "Module %r specific to one single country %r should contain `l10n` in their name.",
+                module, manifest_data['countries'][0])
 
         for key in manifest_data:
             value = manifest_data[key]


### PR DESCRIPTION
Modules related to multiple countries are historically named without `l10n_` prefix.
Also, it is not always linked to the country but just used for the `auto_install` feature like in `account_reports_cash_basis` for instance, where we don't want to make it sound like a localization feature.
