### PR TITLE
[FIX] account: display taxes for chid in fiscal position

### DIFF
--- a/addons/account/views/partner_view.xml
+++ b/addons/account/views/partner_view.xml
@@ -65,8 +65,7 @@
                                     <field name="tax_src_id"
                                         domain="[
                                             ('type_tax_use', '!=', 'none'),
-                                            ('country_id', '=', parent.company_country_id),
-                                            '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)
+                                            ('country_id', '=', parent.company_country_id)
                                         ]"
                                         context="{'append_type_to_tax_name': True}"
                                     />
@@ -74,8 +73,8 @@
                                     <field name="tax_dest_id"
                                         domain="[
                                             ('type_tax_use', '!=', 'none'),
-                                            ('country_id', '=', parent.country_id if parent.foreign_vat else parent.company_country_id),
-                                            '|', ('company_id', '=', False), ('company_id', 'parent_of', parent.company_id)]"
+                                            ('country_id', '=', parent.country_id if parent.foreign_vat else parent.company_country_id)
+                                        ]"
                                         context="{'append_type_to_tax_name': True}"
                                     />
                                 </tree>


### PR DESCRIPTION
Steps to reproduce:
- Have a parent an a child company
- create a fiscal position in child company
- select taxes

Issue:
You don't have access to parent taxes

Solution:
We take out the manually written company domain to let the logic of company branches
be applied: https://github.com/odoo/odoo/blob/18119d446bdca9c04b7085bd1a1bd2f0e0b94ff3/addons/account/models/partner.py#L274-L280
https://github.com/odoo/odoo/blob/84f7ddc5a029a25524d58867ae4a5497de907d5a/addons/account/models/account_tax.py#L81-L87

opw-3876889