### PR TITLE
[IMP] website: reduce input size of the url field

### DIFF
--- a/addons/website/static/src/components/fields/fields.xml
+++ b/addons/website/static/src/components/fields/fields.xml
@@ -7,9 +7,10 @@
     </t>
     <t t-else="">
         <div class="d-flex">
+            <t t-set="slicingLength" t-value="env.isSmall ? 30 : 45"/>
             <div
                 class="input-group-text rounded-start text-lowercase border-0"
-                t-esc="serverUrl.length > 30 ? serverUrl.slice(0,14) + '..' + serverUrl.slice(-14) : serverUrl"
+                t-esc="serverUrl.length > slicingLength ? serverUrl.slice(0, (slicingLength / 2) - 1) + '..' + serverUrl.slice((-slicingLength / 2) + 1) : serverUrl"
             />
             <input
                 class="o_input"


### PR DESCRIPTION
This PR aims to increase the maximum slicing length for `serverurl` field to 45 characters, providing more space to display server URL and effectively reducing the size of the URL field.
Note that, for mobile viewports the maximum slicing length is kept to 30 characters only.

Changes in UI is as follows:

Before: 
![image before](https://github.com/odoo/odoo/assets/100135102/36497402-7ea4-4233-9633-8c9d8356122a)

After:
![image after](https://github.com/odoo/odoo/assets/100135102/2f663d72-9f41-4afc-a6be-43a62692a992)


task-3890498
