### PR TITLE
[FIX] website: make facebook snippet dynamically responsive

### DIFF
--- a/addons/website/static/src/snippets/s_facebook_page/000.js
+++ b/addons/website/static/src/snippets/s_facebook_page/000.js
@@ -3,6 +3,7 @@ odoo.define('website.s_facebook_page', function (require) {
 
 var publicWidget = require('web.public.widget');
 var utils = require('web.utils');
+const { debounce } = require("@web/core/utils/timing");
 
 const FacebookPageWidget = publicWidget.Widget.extend({
     selector: '.o_facebook_page',
@@ -13,8 +14,7 @@ const FacebookPageWidget = publicWidget.Widget.extend({
      */
     start: function () {
         var def = this._super.apply(this, arguments);
-
-        this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerUnactive();
+        this.previousWidth = 0;
 
         const params = _.pick(this.$el[0].dataset, 'href', 'id', 'height', 'tabs', 'small_header', 'hide_cover');
         if (!params.href) {
@@ -24,24 +24,11 @@ const FacebookPageWidget = publicWidget.Widget.extend({
             params.href = `https://www.facebook.com/${params.id}`;
         }
         delete params.id;
-        params.width = utils.confine(Math.floor(this.$el.width()), 180, 500);
 
-        var src = $.param.querystring('https://www.facebook.com/plugins/page.php', params);
-        this.$iframe = $('<iframe/>', {
-            src: src,
-            width: params.width,
-            height: params.height,
-            css: {
-                border: 'none',
-                overflow: 'hidden',
-            },
-            scrolling: 'no',
-            frameborder: '0',
-            allowTransparency: 'true',
-        });
-        this.$el.append(this.$iframe);
+        this._renderIframe(params);
+        this.resizeObserver = new ResizeObserver(debounce(this._renderIframe.bind(this, params), 100));
+        this.resizeObserver.observe(this.el.parentElement);
 
-        this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerActive();
         return def;
     },
     /**
@@ -49,11 +36,44 @@ const FacebookPageWidget = publicWidget.Widget.extend({
      */
     destroy: function () {
         this._super.apply(this, arguments);
-
-        this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerUnactive();
-        if (this.$iframe) {
-            this.$iframe.remove();
+        if (this.iframeEl) {
+            this.iframeEl.remove();
         }
+        this.resizeObserver.disconnect();
+    },
+
+    //--------------------------------------------------------------------------
+    // Private
+    //--------------------------------------------------------------------------
+
+    /**
+     * Prepare iframe element & replace it with existing iframe.
+     *
+     * @private
+     * @param {Object} params
+    */
+    _renderIframe(params) {
+        this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerUnactive();
+
+        params.width = utils.confine(Math.floor(this.$el.width()), 180, 500);
+        if (this.previousWidth !== params.width) {
+            this.previousWidth = params.width;
+            const src = $.param.querystring("https://www.facebook.com/plugins/page.php", params);
+            this.iframeEl = Object.assign(document.createElement("iframe"), {
+                src: src,
+                width: params.width,
+                height: params.height,
+                css: {
+                    border: "none",
+                    overflow: "hidden",
+                },
+                scrolling: "no",
+                frameborder: "0",
+                allowTransparency: "true",
+            });
+            this.el.replaceChildren(this.iframeEl);
+        }
+
         this.options.wysiwyg && this.options.wysiwyg.odooEditor.observerActive();
     },
 });


### PR DESCRIPTION
This PR aims to fix an issue with the Facebook snippet not being dynamically responsive for mobile views.

Steps to reproduce
1. Drop inner content facebook (dynamic content) anywhere
2. Go to mobile view
3. Try to scroll horizontally.

As you can see, facebook iframe is overflowing

Before v16, the mechanism for mobile view was different. The switch between mobile and desktop views caused snippets/pages to be re-render because a new dialog for mobile was opened every time. Starting from version 16, we have removed the dialog and introduced a mobile frame. As a result, the rendering now occurs only when the start function is called. Consequently, the params width does not change when we switch to mobile view.

![2024-04-29_14-34](https://github.com/odoo/odoo/assets/157009134/75a5fb69-8a46-4908-8814-0673084ed1d0)

After this PR, the snippet will be re-render every time the window resizes, ensuring that the width adjustment is responsive. This enhancement also allows parameters to be provided at the time of rendering.

![2024-04-29_14-35](https://github.com/odoo/odoo/assets/157009134/30a5c2f9-1e47-4902-a7c1-89506a541a26)

Task-2736174