### PR TITLE
[FIX] purchase: disable variant grid alongside variants

### DIFF
--- a/addons/purchase/models/res_config_settings.py
+++ b/addons/purchase/models/res_config_settings.py
@@ -38,6 +38,19 @@ class ResConfigSettings(models.TransientModel):
         if not self.use_po_lead:
             self.po_lead = 0.0
 
+    @api.onchange('group_product_variant')
+    def _onchange_group_product_variant_purchase(self):
+        """If the user disables the product variants -> disable the product configurator as well"""
+        if self.module_purchase_product_matrix and not self.group_product_variant:
+            self.module_purchase_product_matrix = False
+
+    @api.onchange('module_purchase_product_matrix')
+    def _onchange_module_purchase_product_matrix(self):
+        """The product variant grid requires the product variants activated
+        If the user enables the product configurator -> enable the product variants as well"""
+        if self.module_purchase_product_matrix and not self.group_product_variant:
+            self.group_product_variant = True
+
     def set_values(self):
         super(ResConfigSettings, self).set_values()
         self.po_lock = 'lock' if self.lock_confirmed_po else 'edit'


### PR DESCRIPTION
Problem
---
In sales, when variants are disabled from the settings, the variant grid entry / variant configurator is disabled as well. In purchase, it is not.

Fix
---
Adapt the onchanges from the sale module to get consistent behavior, ie:
* variants disabled -> grid disabled
* grid enabled -> variants enabled

Note: the onchanges are adapted from their equivalent for sales in `product/models/res_config_settings.py`: https://github.com/odoo/odoo/blob/11bd6708111f9063e8927be2ee5ea26a8b816398/addons/product/models/res_config_settings.py#L37-L52

opw-3884106

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
