### PR TITLE
[IMP] website_*: add color field in tags of Blog, Forum

### DIFF
--- a/addons/website_blog/data/website_blog_demo.xml
+++ b/addons/website_blog/data/website_blog_demo.xml
@@ -15,18 +15,23 @@
         <!-- TAGS -->
         <record id="blog_tag_1" model="blog.tag">
             <field name="name">hotels</field>
+            <field name="color">1</field>
         </record>
         <record id="blog_tag_2" model="blog.tag">
             <field name="name">adventure</field>
+            <field name="color">2</field>
         </record>
         <record id="blog_tag_3" model="blog.tag">
             <field name="name">guides</field>
+            <field name="color">3</field>
         </record>
         <record id="blog_tag_4" model="blog.tag">
             <field name="name">telescopes</field>
+            <field name="color">4</field>
         </record>
         <record id="blog_tag_5" model="blog.tag">
             <field name="name">discovery</field>
+            <field name="color">5</field>
         </record>
 
         <!-- POSTS -->

--- a/addons/website_blog/models/website_blog.py
+++ b/addons/website_blog/models/website_blog.py
@@ -142,6 +142,7 @@ class BlogTag(models.Model):
 
     name = fields.Char('Name', required=True, translate=True)
     category_id = fields.Many2one('blog.tag.category', 'Category', index=True)
+    color = fields.Integer('Color')
     post_ids = fields.Many2many('blog.post', string='Posts')
 
     _sql_constraints = [

--- a/addons/website_blog/views/website_blog_components.xml
+++ b/addons/website_blog/views/website_blog_components.xml
@@ -102,12 +102,12 @@
         <div t-if="not hide_title and categ_title" class="text-muted mb-1 h6" t-esc="categ_title"/>
         <t t-foreach="tags" t-as="tag">
             <t t-if="tag.post_ids">
-                <span t-if="dismissibleBtn and tag.id in active_tag_ids" class="align-items-baseline border d-inline-flex ps-2 rounded mb-2">
+                <span t-if="dismissibleBtn and tag.id in active_tag_ids" t-attf-class="align-items-baseline border d-inline-flex ps-2 rounded mb-2 fs-6 o_tag #{'o_tag_color_%s' % tag.color}">
                     <i class="fa fa-tag me-2 text-muted"/>
                     <t t-esc="tag.name"/>
                     <a t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" class="btn border-0 py-1 post_link" t-att-rel="len(active_tag_ids) and 'nofollow'">&#215;</a>
                 </span>
-                <a t-elif="showInactive" t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" t-attf-class="badge mb-2 mw-100 text-truncate text-decoration-none #{tag.id in active_tag_ids and 'text-bg-primary' or 'border text-primary'} post_link" t-att-rel="len(active_tag_ids) and 'nofollow'" t-esc="tag.name"/>
+                <a t-elif="showInactive" t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, tag.id))}" t-attf-class="badge mb-2 mw-100 text-truncate text-decoration-none o_tag o_tag_color_#{tag.color} post_link" t-att-rel="len(active_tag_ids) and 'nofollow'" t-esc="tag.name"/>
             </t>
         </t>
     </t>
@@ -300,7 +300,7 @@ Display a sidebar beside the post content.
             <t t-if="blog_post.tag_ids">
                 <div class="h5">
                     <t t-foreach="blog_post.tag_ids" t-as="one_tag">
-                        <a class="badge border post_link text-decoration-none text-primary" t-attf-href="#{blog_url(tag=slug(one_tag))}" t-esc="one_tag.name"/>
+                        <a t-attf-class="badge border post_link text-decoration-none text-primary o_tag o_tag_color_#{one_tag.color}" t-attf-href="#{blog_url(tag=slug(one_tag))}" t-esc="one_tag.name"/>
                     </t>
                 </div>
             </t>

--- a/addons/website_blog/views/website_blog_posts_loop.xml
+++ b/addons/website_blog/views/website_blog_posts_loop.xml
@@ -211,7 +211,7 @@ according to the enabled options.
     <div t-if="len(blog_post.tag_ids)" class="o_wblog_post_short_tag_section d-flex align-items-center flex-wrap pt-2">
         <t t-foreach="blog_post.tag_ids" t-as="one_tag">
             <a t-attf-href="#{blog_url(tag=tags_list(active_tag_ids, one_tag.id))}"
-               t-attf-class="badge mb-2 me-1 text-truncate #{one_tag.id in active_tag_ids and 'bg-primary text-light' or 'border text-primary'} post_link"
+               t-attf-class="badge mb-2 me-1 text-truncate o_tag o_tag_color_#{one_tag.color} post_link"
                t-att-rel="len(active_tag_ids) and 'nofollow'"
                t-esc="one_tag.name"/>
         </t>

--- a/addons/website_blog/views/website_blog_templates.xml
+++ b/addons/website_blog/views/website_blog_templates.xml
@@ -249,7 +249,7 @@ list of filtered posts (by date or tag).
         <div t-if="len(blogs) > 1">in <a t-attf-href="#{blog_url(blog=blog_post.blog_id)}"><b t-field="blog.name"/></a></div>
         <div t-if="len(blog_post.tag_ids) > 0">#
             <t t-foreach="blog_post.tag_ids" t-as="one_tag">
-                <a class="badge text-primary border me-1 post_link" t-attf-href="#{blog_url(tag=slug(one_tag), date_begin=False, date_end=False)}" t-esc="one_tag.name"/>
+                <a t-attf-class="badge text-primary border me-1 o_tag o_tag_color_#{one_tag.color} post_link" t-attf-href="#{blog_url(tag=slug(one_tag), date_begin=False, date_end=False)}" t-esc="one_tag.name"/>
             </t>
         </div>
     </div>

--- a/addons/website_blog/views/website_blog_views.xml
+++ b/addons/website_blog/views/website_blog_views.xml
@@ -56,6 +56,7 @@
                 <tree string="Tag List">
                     <field name="name"/>
                     <field name="category_id"/>
+                    <field name="color" widget="color_picker"/>
                     <field name="post_ids"/>
                 </tree>
             </field>
@@ -70,6 +71,7 @@
                         <group>
                             <field name="name"/>
                             <field name="category_id"/>
+                            <field name="color" widget="color_picker"/>
                         </group>
                         <label for="post_ids" string="Used in: "/>
                         <field name="post_ids"/>

--- a/addons/website_blog/views/website_pages_views.xml
+++ b/addons/website_blog/views/website_pages_views.xml
@@ -16,7 +16,7 @@
                     <field name="active" invisible="1"/>
                     <field name="name" placeholder="Blog Post Title"/>
                     <field name="subtitle" placeholder="Blog Subtitle"/>
-                    <field name="tag_ids" widget="many2many_tags"/>
+                    <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                     <field name="website_id" groups="website.group_multi_website"/>
                 </group>
                 <group name="publishing_details" string="Publishing Options">

--- a/addons/website_forum/data/forum_tag_demo.xml
+++ b/addons/website_forum/data/forum_tag_demo.xml
@@ -3,18 +3,22 @@
     <!-- Tag -->
     <record id="tags_0" model="forum.tag">
         <field name="name">Contract</field>
+        <field name="color">1</field>
         <field name="forum_id" ref="website_forum.forum_help"/>
     </record>
     <record id="tags_1" model="forum.tag">
         <field name="name">Action</field>
+        <field name="color">2</field>
         <field name="forum_id" ref="website_forum.forum_help"/>
     </record>
     <record id="tags_2" model="forum.tag">
         <field name="name">ecommerce</field>
+        <field name="color">3</field>
         <field name="forum_id" ref="website_forum.forum_help"/>
     </record>
     <record id="tags_3" model="forum.tag">
         <field name="name">Development</field>
+        <field name="color">4</field>
         <field name="forum_id" ref="website_forum.forum_help"/>
     </record>
 </data></odoo>

--- a/addons/website_forum/models/forum_tag.py
+++ b/addons/website_forum/models/forum_tag.py
@@ -16,6 +16,7 @@ class Tags(models.Model):
     ]
 
     name = fields.Char('Name', required=True)
+    color = fields.Integer('Color')
     forum_id = fields.Many2one('forum.forum', string='Forum', required=True, index=True)
     post_ids = fields.Many2many(
         'forum.post', 'forum_tag_rel', 'forum_tag_id', 'forum_post_id',

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -40,7 +40,7 @@
                 t-value="'/forum/' + slug(question_tag.forum_id) + '/tag/' + slug(question_tag) + '/questions?' + keep_query( 'search', 'sorting', 'my', 'create_uid', filters='tag')"/>
 
             <a t-att-href="click_action"
-                t-attf-class="badge position-relative z-1 #{ 'text-bg-primary' if tag and tag.name == question_tag.name else 'text-bg-secondary' } fw-normal"
+                t-attf-class="badge position-relative z-1 #{ 'text-bg-primary' if tag and tag.name == question_tag.name else 'text-bg-secondary' } fw-normal o_tag o_tag_color_#{question_tag.color}"
                 t-field="question_tag.name"/>
         </t>
     </div>
@@ -165,7 +165,7 @@
     <div t-if="question.tag_ids" class="o_wforum_index_entry_tags ms-0">
         <a  t-foreach="question.tag_ids" t-as="question_tag"
             t-attf-href="/forum/#{slug(question_tag.forum_id)}/tag/#{slug(question_tag)}/questions?#{keep_query(filters='tag')}"
-            t-attf-class="badge text-bg-secondary #{'ms-1' if not question_tag_first else ''} fw-normal"
+            t-attf-class="badge text-bg-secondary #{'ms-1' if not question_tag_first else ''} fw-normal o_tag o_tag_color_#{question_tag.color}"
             t-field="question_tag.name"/>
     </div>
     <div class="ms-auto d-flex">

--- a/addons/website_forum/views/forum_post_views.xml
+++ b/addons/website_forum/views/forum_post_views.xml
@@ -27,7 +27,7 @@
                         <field name="parent_id" invisible="not parent_id"/>
                     </group>
                     <group name="post_details">
-                        <field name="tag_ids" widget="many2many_tags"/>
+                        <field name="tag_ids" widget="many2many_tags" options="{'color_field': 'color'}"/>
                         <field name="state"/>
                         <field name="closed_reason_id" invisible="not closed_reason_id"/>
                         <field name="closed_uid" invisible="not closed_uid"/>

--- a/addons/website_forum/views/forum_tag_views.xml
+++ b/addons/website_forum/views/forum_tag_views.xml
@@ -7,6 +7,7 @@
         <field name="arch" type="xml">
             <tree string="Tags" editable="bottom">
                 <field name="name"/>
+                <field name="color" widget="color_picker"/>
                 <field name="forum_id" options="{'no_create_edit': True}"/>
             </tree>
         </field>
@@ -20,6 +21,7 @@
                 <sheet>
                     <group>
                         <field name="name"/>
+                        <field name="color" widget="color_picker"/>
                         <field name="forum_id" options="{'no_create_edit': True}"/>
                     </group>
                 </sheet>
@@ -29,7 +31,7 @@
     </record>
 
     <record id="forum_tag_action" model="ir.actions.act_window">
-        <field name="name">Tags</field>
+        <field name="name">Forum Tags</field>
         <field name="res_model">forum.tag</field>
         <field name="view_mode">tree,form</field>
         <field name="help" type="html">


### PR DESCRIPTION
*: blog, forum

Specification:

Prior to this commit, tags were displayed in a standard format, lacking visual appeal.

Changes introduced:

1. Enhanced the blog and forum tag functionality by introducing a new color field in the blog's and  forum's tags model.
2. Renamed the forum tag section to 'Forum Tags' for clarity.

This implementation allows users  to customize tag appearance, improving visual appeal and usability across the platform.

Change in UI are as follow:

website_Blog

1. Blog Tag Form View
![image](https://github.com/odoo/odoo/assets/157005855/73008dea-d129-4de1-8585-dde9f3fd699d)

2. Blogs Page:
![image](https://github.com/odoo/odoo/assets/157005855/9f75b9a5-9d98-4881-bd16-299b33ce62f3)

3. Blog Detail Page:
![image](https://github.com/odoo/odoo/assets/157005855/379533aa-661a-4d35-94f5-3a6e6e45c61b)

website_forum:

1. Forum Tag Tree View:
![image](https://github.com/odoo/odoo/assets/157005855/1dd52379-19e4-4ef8-88bb-548d100236bc)

2. Forum Page:
![image](https://github.com/odoo/odoo/assets/157005855/3a516f65-1e20-42f9-9233-28f1155ba966)

3. Forum Detail Page:
![image](https://github.com/odoo/odoo/assets/157005855/434474bb-a83b-4abd-9ebc-781e755fa4ad)


task-3890442