### PR TITLE
[IMP] stock: add next transfers button

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -193,6 +193,16 @@
                                 <span class="o_stat_text">Moves</span>
                             </div>
                         </button>
+                        <button name="action_next_transfer"
+                            class="oe_stat_button"
+                            icon="fa-exchange"
+                            type="object"
+                            help="List view of next transfers"
+                            invisible="not show_next_pickings">
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_text">Next Transfer</span>
+                            </div>
+                        </button>
                     </div>
                     <div class="oe_title">
                         <h1 class="d-flex">


### PR DESCRIPTION
After validate a transfer, it is possible to check what is
the next transfers available to do some operations. A button
will appear side by the valuation, on the transfers form. The
visibility of that button is just when the transfer has next transfers. 
The behavior of the button is:
.when has not next transfers not show anything.
.else, if exist just one next transfer, open the view form of that
.otherwise, if there more than one, open a list of these transfers.

To test it, just create a transfers, and configure specific routes
for specifc products, to see more than one transfer.

task: 3818596