### PR TITLE
[FIX] web: hide the 'Duplicate' action for users without create access

### DIFF
--- a/addons/web/static/src/views/utils.js
+++ b/addons/web/static/src/views/utils.js
@@ -161,13 +161,15 @@ export function getFormattedValue(record, fieldName, attrs) {
  * @returns {ViewActiveActions}
  */
 export function getActiveActions(rootNode) {
-    return {
+    const activeActions = {
         type: "view",
         edit: archParseBoolean(rootNode.getAttribute("edit"), true),
         create: archParseBoolean(rootNode.getAttribute("create"), true),
         delete: archParseBoolean(rootNode.getAttribute("delete"), true),
-        duplicate: archParseBoolean(rootNode.getAttribute("duplicate"), true),
     };
+    activeActions.duplicate =
+        activeActions.create && archParseBoolean(rootNode.getAttribute("duplicate"), true);
+    return activeActions;
 }
 
 export function getClassNameFromDecoration(decoration) {

--- a/addons/web/static/tests/views/list_view_tests.js
+++ b/addons/web/static/tests/views/list_view_tests.js
@@ -779,6 +779,26 @@ QUnit.module("Views", (hooks) => {
         assert.containsNone(target, ".o_list_export_xlsx");
     });
 
+   QUnit.test("hide duplicate action for user without create access rights", async (assert) => {
+        await makeView({
+            type: "list",
+            resModel: "foo",
+            serverData,
+            actionMenus: {},
+            arch: '<tree create="0"><field name="foo"/></tree>',
+        });
+
+        await click(target.querySelector("tbody td.o_list_record_selector input"));
+
+        await toggleActionMenu(target);
+
+        assert.deepEqual(
+            getNodesTextContent(target.querySelectorAll(".o-dropdown--menu .o_menu_item")),
+            ["Export", "Delete"],
+            "The action menu should not include the duplicate button"
+        );
+    });
+
     QUnit.test("list view with adjacent buttons", async function (assert) {
         await makeView({
             type: "list",


### PR DESCRIPTION
Previously:
- Users without create access could see the 'Duplicate' action.

After this fix:
- Users without create access cannot see the 'Duplicate' action.

task-3898435