### PR TITLE
[IMP] point_of_sale: show instantly attribute in popup

### DIFF
--- a/addons/point_of_sale/models/product.py
+++ b/addons/point_of_sale/models/product.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
@@ -93,9 +92,9 @@ class ProductProduct(models.Model):
     @api.model
     def _load_pos_data_fields(self, config_id):
         return [
-            'id', 'display_name', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode',
-            'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'product_tmpl_id', 'tracking',
-            'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids',
+            'id', 'display_name', 'lst_price', 'standard_price', 'categ_id', 'pos_categ_ids', 'taxes_id', 'barcode', 'name',
+            'default_code', 'to_weight', 'uom_id', 'description_sale', 'description', 'product_tmpl_id', 'tracking', 'type',
+            'write_date', 'available_in_pos', 'attribute_line_ids', 'active', 'image_128', 'combo_ids', 'product_template_variant_value_ids',
         ]
 
     def _load_pos_data(self, data):
@@ -226,12 +225,8 @@ class ProductAttribute(models.Model):
     _inherit = ['product.attribute', 'pos.load.mixin']
 
     @api.model
-    def _load_pos_data_domain(self, data):
-        return [('create_variant', '=', 'no_variant')]
-
-    @api.model
     def _load_pos_data_fields(self, config_id):
-        return ['name', 'display_type', 'template_value_ids', 'attribute_line_ids']
+        return ['name', 'display_type', 'template_value_ids', 'attribute_line_ids', 'create_variant']
 
 
 class ProductAttributeCustomValue(models.Model):

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.js
@@ -1,0 +1,61 @@
+import { Component, useEffect, useState } from "@odoo/owl";
+import { usePos } from "@point_of_sale/app/store/pos_hook";
+import { useTrackedAsync } from "@point_of_sale/app/utils/hooks";
+import { useService } from "@web/core/utils/hooks";
+
+export class ProductInfoBanner extends Component {
+    static template = "point_of_sale.ProductInfoBanner";
+    static components = {};
+    static props = {
+        product: Object,
+        info: { type: Object, optional: true },
+    };
+
+    setup() {
+        this.pos = usePos();
+        this.fetchStock = useTrackedAsync((p) => this.pos.getProductInfo(p, 1));
+        this.ui = useState(useService("ui"));
+        this.state = useState({
+            available_quantity: 0,
+            price_with_tax: 0,
+            price_without_tax: 0,
+            tax_name: "",
+            tax_amount: 0,
+        });
+
+        useEffect(
+            () => {
+                const fetchStocks = async () => {
+                    let result = {};
+                    if (!this.props.info) {
+                        await this.fetchStock.call(this.props.product);
+                        result = this.fetchStock.result;
+                    } else {
+                        result = this.props.info;
+                    }
+
+                    if (result) {
+                        const productInfo = result.productInfo;
+                        this.state.available_quantity =
+                            productInfo.warehouses[0]?.available_quantity;
+                        this.state.price_with_tax = productInfo.all_prices.price_with_tax;
+                        this.state.price_without_tax = productInfo.all_prices.price_without_tax;
+                        this.state.tax_name = productInfo.all_prices.tax_details[0]?.name || "";
+                        this.state.tax_amount = productInfo.all_prices.tax_details[0]?.amount || 0;
+                    }
+                };
+
+                fetchStocks();
+            },
+            () => [this.props.product]
+        );
+    }
+
+    get bannerBackground() {
+        if (this.props.product.type === "service" || this.state.available_quantity > 10) {
+            return "bg-info";
+        }
+
+        return this.state.available_quantity < 5 ? "bg-danger" : "bg-warning";
+    }
+}

--- a/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
+++ b/addons/point_of_sale/static/src/app/components/product_info_banner/product_info_banner.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.ProductInfoBanner">
+        <div t-attf-class="{{ this.ui.isSmall ? 'flex-column' : 'justify-content-between' }} {{ this.bannerBackground}}"
+            class="d-flex text-info bg-opacity-25 mx-n3 mt-n3 px-3 pb-2 pt-3 mb-3">
+            <div class="d-flex flex-column">
+                <span class="h4">
+                    <span>Internal reference: </span>
+                    <span t-esc="props.product.name"/>
+                </span>
+                <span t-if="this.props.product.type !== 'service'" class="h4">
+                    <span>On hand: </span>
+                    <span t-if="this.fetchStock.status === 'success' || this.props.info"><t t-esc="this.state.available_quantity"/></span>
+                    <span t-elif="this.fetchStock.status === 'error'">N/A</span>
+                    <i t-else="" class="fa fa-fw fa-spin fa-circle-o-notch" aria-hidden="true" />
+                </span>
+            </div>
+            <div t-att-class="{ 'align-items-end': !this.ui.isSmall }" class="d-flex flex-column">
+                <span class="h4"><t t-esc="this.env.utils.formatCurrency(state.price_with_tax)"/></span>
+                <span class="h4">VAT: <t t-esc="state.tax_name || 0" /> | VAT: <t t-esc="this.env.utils.formatCurrency(state.tax_amount)" /></span>
+            </div>
+        </div>
+    </t>
+</templates>

--- a/addons/point_of_sale/static/src/app/models/data_service.js
+++ b/addons/point_of_sale/static/src/app/models/data_service.js
@@ -142,6 +142,12 @@ export class PosData extends Reactive {
             }
         }
 
+        if (data["product.product"]) {
+            data["product.product"] = data["product.product"].filter(
+                (p) => !this.models["product.product"].get(p.id)
+            );
+        }
+
         const results = this.models.loadData(data, [], true);
         for (const [model, data] of Object.entries(results)) {
             for (const record of data) {

--- a/addons/point_of_sale/static/src/app/models/data_service_options.js
+++ b/addons/point_of_sale/static/src/app/models/data_service_options.js
@@ -36,6 +36,16 @@ export class DataServiceOptions {
                     );
                 },
             },
+            {
+                name: "product.attribute.custom.value",
+                key: "id",
+                condition: (record) => {
+                    return record.models["pos.order.line"].find((l) => {
+                        const customAttrIds = l.custom_attribute_value_ids.map((v) => v.id);
+                        return customAttrIds.includes(record.id);
+                    });
+                },
+            },
         ];
     }
 

--- a/addons/point_of_sale/static/src/app/models/product_product.js
+++ b/addons/point_of_sale/static/src/app/models/product_product.js
@@ -38,7 +38,7 @@ export class ProductProduct extends Base {
     async _onScaleNotAvailable() {}
 
     isConfigurable() {
-        return this.attribute_line_ids.some((line) => line.attribute_id);
+        return this.attribute_line_ids.map((a) => a.product_template_value_ids).flat().length > 1;
     }
 
     isCombo() {

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -1,10 +1,11 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { usePos } from "@point_of_sale/app/store/pos_hook";
 import { Component } from "@odoo/owl";
+import { ProductInfoBanner } from "@point_of_sale/app/components/product_info_banner/product_info_banner";
 
 export class ProductInfoPopup extends Component {
     static template = "point_of_sale.ProductInfoPopup";
-    static components = { Dialog };
+    static components = { Dialog, ProductInfoBanner };
     static props = ["info", "product", "close"];
 
     setup() {
@@ -23,5 +24,10 @@ export class ProductInfoPopup extends Component {
     editProduct() {
         this.pos.editProduct(this.props.product);
         this.props.close();
+    }
+    get isVariant() {
+        return this.pos.models["product.product"].filter(
+            (p) => p.raw.product_tmpl_id === this.props.product.raw.product_tmpl_id
+        );
     }
 }

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.xml
@@ -2,20 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.ProductInfoPopup">
         <Dialog title="'Product information'">
-            <div class="section-product-info-title d-flex flex-column flex-sm-row text-start gap-3 bg-info text-info bg-opacity-25 mx-n3 mt-n3 p-3">
-                <div class="d-flex flex-column flex-grow-1 text-start w-100 w-sm-25">
-                    <span t-esc="props.product.display_name" class="global-info-title fs-2 fw-bolder text-truncate"/>
-                    <span class="fs-3"><t t-if="props.product.default_code" t-esc="props.product.default_code"/> <t t-if="props.product.default_code and props.product.barcode"> - </t> <t t-if="props.product.barcode" t-esc="props.product.barcode"/></span>
-                </div>
-                <div class="d-flex flex-column justify-content-center text-start text-sm-end w-100 w-sm-25">
-                    <span t-esc="env.utils.formatCurrency(props.info.productInfo.all_prices.price_with_tax)" class="global-info-title fs-2 fw-bolder" />
-                    <span class="fs-3">
-                        <t t-foreach="props.info.productInfo.all_prices.tax_details" t-as="tax" t-key="tax.name">
-                            <div><t t-esc="tax.name"/>: <t t-esc="env.utils.formatCurrency(tax.amount)"/></div>
-                        </t>
-                    </span>
-                </div>
-            </div>
+            <ProductInfoBanner product="props.product" info="props.info"/>
             <div class="section-financials mt-3 mb-4 pb-4 border-bottom text-start">
                 <h3 class="section-title">Financials</h3>
                 <div class="section-financials-body d-flex flex-column flex-sm-row">
@@ -43,9 +30,9 @@
                     </table>
                 </div>
             </div>
-            <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="props.info.productInfo.warehouses.length > 0">
+            <div class="section-inventory mt-3 mb-4 pb-4 border-bottom text-start" t-if="!isVariant and props.info.productInfo.warehouses.length > 0">
                 <h3 class="section-title">
-                    Inventory 
+                    Inventory
                     <t t-if="pos.session.update_stock_at_closing">(as of opening)</t>
                 </h3>
                 <div class="section-inventory-body">
@@ -59,7 +46,7 @@
                                 <span class="me-1 fw-bolder"><t t-esc="warehouse.available_quantity" class="table-name"/></span>
                                 <t t-esc="warehouse.uom"/> available,
                             </div>
-                            <div> 
+                            <div>
                                 <span class="me-1 fw-bolder"><t t-esc="warehouse.forecasted_quantity"/></span>
                                 forecasted
                             </div>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_screen.xml
@@ -26,7 +26,7 @@
                         <ProductCard
                             t-foreach="productsToDisplay" t-as="product" t-key="product.id"
                             class="pos.productViewMode"
-                            name="product.display_name"
+                            name="getProductName(product)"
                             productId="product.id"
                             color="product.pos_categ_ids?.at(-1)?.color"
                             price="pos.getProductPriceFormatted(product)"

--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -113,6 +113,7 @@ export class PosStore extends Reactive {
 
         this.synch = { status: "connected", pending: 0 };
         this.hardwareProxy = hardware_proxy;
+        this.hiddenProductIds = new Set();
         this.selectedOrderUuid = null;
         this.selectedPartner = null;
         this.selectedCategory = null;
@@ -194,6 +195,33 @@ export class PosStore extends Reactive {
         );
 
         this.computeProductPricelistCache();
+        await this.processProductAttributes();
+    }
+
+    async processProductAttributes() {
+        const productIds = [];
+        const productTmplIds = [];
+
+        for (const product of this.models["product.product"].getAll()) {
+            if (product.product_template_variant_value_ids.length > 0) {
+                productTmplIds.push(product.raw.product_tmpl_id);
+                productIds.push(product.id);
+            }
+        }
+
+        if (productIds.length) {
+            await this.data.searchRead("product.product", [
+                "&",
+                ["id", "not in", productIds],
+                ["product_tmpl_id", "in", productTmplIds],
+            ]);
+        }
+
+        for (const product of this.models["product.product"].getAll()) {
+            if (!product.isConfigurable() && productTmplIds.includes(product.raw.product_tmpl_id)) {
+                product.available_in_pos = false;
+            }
+        }
     }
 
     computeProductPricelistCache(data) {
@@ -326,7 +354,6 @@ export class PosStore extends Reactive {
     // The configure parameter is available if the orderline already contains all
     // the information without having to be calculated. For example, importing a SO.
     async addLineToCurrentOrder(vals, opts = {}, configure = true) {
-        const product = vals.product_id;
         let merge = true;
 
         let order = this.get_order();
@@ -353,7 +380,8 @@ export class PosStore extends Reactive {
             price_unit: 0,
             order_id: this.get_order(),
             qty: 1,
-            tax_ids: product.taxes_id[0] ? [["link", product.taxes_id[0]]] : [],
+            product_id: vals.product_id,
+            tax_ids: vals.product_id.taxes_id[0] ? [["link", vals.product_id.taxes_id[0]]] : [],
             ...vals,
         };
 
@@ -374,15 +402,32 @@ export class PosStore extends Reactive {
         // We assign the payload to the current values object.
         // ---
         // This actions cannot be handled inside pos_order.js or pos_order_line.js
-        if (product.isConfigurable() && configure) {
-            const payload = await this.openConfigurator(product);
+        if (values.product_id.isConfigurable() && configure) {
+            const payload = await this.openConfigurator(values.product_id);
 
             if (payload) {
+                const productFound = this.models["product.product"]
+                    .filter((p) => p.raw.product_template_variant_value_ids.length > 0)
+                    .find((p) =>
+                        p.raw.product_template_variant_value_ids.every((v) =>
+                            payload.attribute_value_ids.includes(v)
+                        )
+                    );
+
                 Object.assign(values, {
-                    attribute_value_ids: payload.attribute_value_ids.map((id) => [
-                        "link",
-                        this.data.models["product.template.attribute.value"].get(id),
-                    ]),
+                    attribute_value_ids: payload.attribute_value_ids
+                        .filter((a) => {
+                            if (productFound) {
+                                const attr =
+                                    this.data.models["product.template.attribute.value"].get(a);
+                                return attr.is_custom;
+                            }
+                            return true;
+                        })
+                        .map((id) => [
+                            "link",
+                            this.data.models["product.template.attribute.value"].get(id),
+                        ]),
                     custom_attribute_value_ids: Object.entries(payload.attribute_custom_values).map(
                         ([id, cus]) => {
                             return [
@@ -397,21 +442,29 @@ export class PosStore extends Reactive {
                             ];
                         }
                     ),
-                    price_extra: values.price_extra + payload.price_extra,
+                    price_extra: productFound ? 0 : values.price_extra + payload.price_extra,
                     qty: payload.qty || values.qty,
+                    product_id: productFound || values.product_id,
                 });
             } else {
                 return;
             }
+        } else if (values.product_id.product_template_variant_value_ids.length > 0) {
+            // Verify price extra of variant products
+            const priceExtra = values.product_id.product_template_variant_value_ids.reduce(
+                (acc, attr) => acc + attr.price_extra,
+                0
+            );
+            values.price_extra += priceExtra;
         }
 
         // In case of clicking a combo product a popup will be shown to the user
         // It will return the combo prices and the selected products
         // ---
         // This actions cannot be handled inside pos_order.js or pos_order_line.js
-        if (product.isCombo() && configure) {
+        if (values.product_id.isCombo() && configure) {
             const payload = await makeAwaitable(this.dialog, ComboConfiguratorPopup, {
-                product: product,
+                product: values.product_id,
             });
 
             if (!payload) {
@@ -419,7 +472,7 @@ export class PosStore extends Reactive {
             }
 
             const comboPrices = computeComboLines(
-                product,
+                values.product_id,
                 payload,
                 order.pricelist_id,
                 this.data.models["decimal.precision"].getAll(),
@@ -461,15 +514,15 @@ export class PosStore extends Reactive {
         // It will return an instance of pos.pack.operation.lot
         // ---
         // This actions cannot be handled inside pos_order.js or pos_order_line.js
-        if (product.isTracked() && configure) {
+        if (values.product_id.isTracked() && configure) {
             const code = opts.code;
             let pack_lot_ids = {};
             const packLotLinesToEdit =
-                (!product.isAllowOnlyOneLot() &&
+                (!values.product_id.isAllowOnlyOneLot() &&
                     this.get_order()
                         .get_orderlines()
                         .filter((line) => !line.get_discount())
-                        .find((line) => line.product_id.id === product.id)
+                        .find((line) => line.product_id.id === values.product_id.id)
                         ?.getPackLotLinesToEdit()) ||
                 [];
 
@@ -482,7 +535,7 @@ export class PosStore extends Reactive {
                 const newPackLotLines = [{ lot_name: code.code }];
                 pack_lot_ids = { modifiedPackLotLines, newPackLotLines };
             } else {
-                pack_lot_ids = await this.editLots(product, packLotLinesToEdit);
+                pack_lot_ids = await this.editLots(values.product_id, packLotLinesToEdit);
             }
 
             if (!pack_lot_ids) {
@@ -497,23 +550,23 @@ export class PosStore extends Reactive {
         // It will return the weight of the product as quantity
         // ---
         // This actions cannot be handled inside pos_order.js or pos_order_line.js
-        if (product.to_weight && this.config.iface_electronic_scale && configure) {
-            if (product.isScaleAvailable) {
+        if (values.product_id.to_weight && this.config.iface_electronic_scale && configure) {
+            if (values.product_id.isScaleAvailable) {
                 const weight = await makeAwaitable(this.env.services.dialog, ScaleScreen, {
-                    product,
+                    product: values.product_id,
                 });
                 if (!weight) {
                     return;
                 }
                 values.qty = weight;
             } else {
-                await product._onScaleNotAvailable();
+                await values.product_id._onScaleNotAvailable();
             }
         }
 
         // Handle price unit
-        if (!product.isCombo() && !vals.price_unit) {
-            values.price_unit = product.get_price(order.pricelist_id, values.qty);
+        if (!values.product_id.isCombo() && !vals.price_unit) {
+            values.price_unit = values.product_id.get_price(order.pricelist_id, values.qty);
         }
 
         if (values.price_extra > 0) {
@@ -978,13 +1031,13 @@ export class PosStore extends Reactive {
             ["state", "=", "draft"],
         ]);
     }
-    async getProductInfo(product, quantity) {
+    async getProductInfo(product, quantity, priceExtra = 0) {
         const order = this.get_order();
         // check back-end method `get_product_info_pos` to see what it returns
         // We do this so it's easier to override the value returned and use it in the component template later
         const productInfo = await this.data.call("product.product", "get_product_info_pos", [
             [product.id],
-            product.get_price(order.pricelist_id, quantity),
+            product.get_price(order.pricelist_id, quantity, priceExtra),
             quantity,
             this.config.id,
         ]);
@@ -1087,7 +1140,7 @@ export class PosStore extends Reactive {
         }
     }
 
-    getProductPrice(product, p = false) {
+    getProducePriceDetails(product, p = false) {
         const pricelist = this.getDefaultPricelist();
         let price = p === false ? product.get_price(pricelist, 1) : p;
 
@@ -1117,7 +1170,11 @@ export class PosStore extends Reactive {
             this.company,
             this.currency
         );
+        return taxesData;
+    }
 
+    getProductPrice(product, p = false) {
+        const taxesData = this.getProducePriceDetails(product, p);
         if (this.config.iface_tax_included === "total") {
             return taxesData.total_included;
         } else {

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.js
@@ -1,13 +1,16 @@
 import { Dialog } from "@web/core/dialog/dialog";
 import { Component, onMounted, useRef, useState, useSubEnv } from "@odoo/owl";
+import { usePos } from "../pos_hook";
+import { useRefListener, useService } from "@web/core/utils/hooks";
+import { ProductInfoBanner } from "@point_of_sale/app/components/product_info_banner/product_info_banner";
 
 export class BaseProductAttribute extends Component {
     static template = "";
     static props = ["attributeLine"];
     setup() {
         this.env.attribute_components.push(this);
-        this.attribute = this.props.attributeLine.attribute_id;
-        this.values = this.props.attributeLine.product_template_value_ids;
+        this.attributeLine = this.props.attributeLine;
+        this.values = this.attributeLine.product_template_value_ids;
         this.state = useState({
             attribute_value_ids: parseFloat(this.values[0].id),
             custom_value: "",
@@ -16,7 +19,7 @@ export class BaseProductAttribute extends Component {
 
     getValue() {
         const attribute_value_ids =
-            this.attribute.display_type === "multi"
+            this.attributeLine.attribute_id.display_type === "multi"
                 ? this.values.filter((val) => this.state.attribute_value_ids[val.id])
                 : [this.values.find((val) => val.id === parseInt(this.state.attribute_value_ids))];
 
@@ -98,6 +101,7 @@ export class ProductConfiguratorPopup extends Component {
     static template = "point_of_sale.ProductConfiguratorPopup";
     static components = {
         RadioProductAttribute,
+        ProductInfoBanner,
         PillsProductAttribute,
         SelectProductAttribute,
         ColorProductAttribute,
@@ -108,18 +112,24 @@ export class ProductConfiguratorPopup extends Component {
 
     setup() {
         useSubEnv({ attribute_components: [] });
-    }
+        this.pos = usePos();
+        this.ui = useState(useService("ui"));
+        this.inputArea = useRef("input-area");
+        this.state = useState({
+            product: this.props.product,
+            payload: this.env.attribute_components,
+        });
 
-    get attributeLines() {
-        return this.props.product.attribute_line_ids.filter((attr) => attr.attribute_id);
+        this.computeProductProduct();
+        useRefListener(this.inputArea, "touchend", this.computeProductProduct.bind(this));
+        useRefListener(this.inputArea, "click", this.computeProductProduct.bind(this));
     }
-
     computePayload() {
         const attribute_custom_values = [];
         let attribute_value_ids = [];
         var price_extra = 0.0;
 
-        this.env.attribute_components.forEach((attribute_component) => {
+        this.state.payload.forEach((attribute_component) => {
             const { valueIds, extra, custom_value } = attribute_component.getValue();
             attribute_value_ids.push(valueIds);
 
@@ -138,12 +148,37 @@ export class ProductConfiguratorPopup extends Component {
             price_extra,
         };
     }
+    computeProductProduct() {
+        let product = this.props.product;
+        const formattedPayload = this.computePayload();
+        const alwaysVariants = this.props.product.attribute_line_ids.every(
+            (line) => line.attribute_id.create_variant === "always"
+        );
+
+        if (alwaysVariants) {
+            const newProduct = this.pos.models["product.product"]
+                .filter((p) => p.raw.product_template_variant_value_ids.length > 0)
+                .find((p) =>
+                    p.raw.product_template_variant_value_ids.every((v) =>
+                        formattedPayload.attribute_value_ids.includes(v)
+                    )
+                );
+            if (newProduct) {
+                product = newProduct;
+            }
+        }
+
+        this.state.product = product;
+    }
     get imageUrl() {
         const product = this.props.product;
         return `/web/image?model=product.product&field=image_128&id=${product.id}&unique=${product.write_date}`;
     }
     get unitPrice() {
         return this.env.utils.formatCurrency(this.props.product.lst_price);
+    }
+    close() {
+        this.props.close();
     }
     confirm() {
         this.props.getPayload(this.computePayload());

--- a/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
+++ b/addons/point_of_sale/static/src/app/store/product_configurator_popup/product_configurator_popup.xml
@@ -6,8 +6,8 @@
             <div class="d-flex flex-wrap gap-3">
                 <t t-foreach="values" t-as="value" t-key="value.id">
                     <div class="attribute-name-cell form-check">
-                        <input class="form-check-input radio-check" type="radio" t-model="state.attribute_value_ids" t-att-name="attribute.id"
-                                t-attf-id="{{ attribute.id }}_{{ value.id }}" t-att-value="value.id"/>
+                        <input class="form-check-input radio-check" type="radio" t-model="state.attribute_value_ids" t-att-name="value.attribute_id.id"
+                                t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" t-att-value="value.id"/>
                         <span t-esc="value.name"/>
                         <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                             <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
@@ -28,12 +28,12 @@
             <div class="d-flex flex-wrap gap-2">
                 <t t-foreach="values" t-as="value" t-key="value.id">
                     <div class="attribute-name-cell">
-                        <input class="form-check-input d-none" type="radio" t-model="state.attribute_value_ids" t-att-name="attribute.id"
-                            t-attf-id="{{ attribute.id }}_{{ value.id }}" t-att-value="value.id"/>
+                        <input class="form-check-input d-none" type="radio" t-model="state.attribute_value_ids" t-att-name="value.attribute_id.id"
+                            t-attf-id="{{ value.attribute_id.id }}_{{ value.id }}" t-att-value="value.id"/>
                         <label
                             t-attf-class="btn btn-lg d-flex {{ value.id == state.attribute_value_ids ? 'btn-primary' : 'btn-secondary' }}"
                             t-att-name="value.name"
-                            t-attf-for="{{ attribute.id }}_{{ value.id }}">
+                            t-attf-for="{{ value.attribute_id.id }}_{{ value.id }}">
                             <span t-esc="value.name"/>
                             <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                                 <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
@@ -80,7 +80,7 @@
                     <span class="d-flex flex-row justify-content-center align-items-center">
                         <label t-attf-class="configurator_color rounded-circle border {{ value.id == state.attribute_value_ids ? 'active border-3 border-primary' : 'border-3 border-secondary' }}"
                             t-attf-style="{{ img_style or color_style }}" t-att-data-color="value.name">
-                            <input class="m-2 opacity-0" type="radio" t-model="state.attribute_value_ids" t-att-value="value.id" t-att-name="attribute.id"/>
+                            <input class="m-2 opacity-0" type="radio" t-model="state.attribute_value_ids" t-att-value="value.id" t-att-name="value.attribute_id.id"/>
                         </label>
                         <div t-if="value.price_extra" class="price-extra-cell d-inline-block ms-2">
                             <span class="price_extra px-2 py-1 rounded-pill text-bg-info">
@@ -120,18 +120,21 @@
     </t>
 
     <t t-name="point_of_sale.ProductConfiguratorPopup">
-        <Dialog title="props.product.display_name">
-            <div t-foreach="attributeLines" t-as="attributeLine" t-key="attributeLine.id" class="attribute mb-3">
-                <t t-set="attribute" t-value="attributeLine.attribute_id"/>
-                <div class="attribute_name mb-2 fw-bolder" t-esc="attribute.name"/>
-                <RadioProductAttribute t-if="attribute.display_type === 'radio'" attributeLine="attributeLine"/>
-                <PillsProductAttribute t-elif="attribute.display_type === 'pills'" attributeLine="attributeLine"/>
-                <SelectProductAttribute t-elif="attribute.display_type === 'select'" attributeLine="attributeLine"/>
-                <ColorProductAttribute t-elif="attribute.display_type === 'color'" attributeLine="attributeLine"/>
-                <MultiProductAttribute t-elif="attribute.display_type === 'multi'" attributeLine="attributeLine"/>
+        <Dialog title="'Attribute selection'">
+            <ProductInfoBanner product="this.state.product" />
+            <div t-ref="input-area">
+                <div t-foreach="this.props.product.attribute_line_ids" t-as="attributeLine" t-key="attributeLine.id" class="attribute mb-3">
+                    <div class="attribute_name mb-2 fw-bolder" t-esc="attributeLine.attribute_id.name"/>
+                    <RadioProductAttribute t-if="attributeLine.attribute_id.display_type === 'radio'" attributeLine="attributeLine"/>
+                    <PillsProductAttribute t-elif="attributeLine.attribute_id.display_type === 'pills'" attributeLine="attributeLine"/>
+                    <SelectProductAttribute t-elif="attributeLine.attribute_id.display_type === 'select'" attributeLine="attributeLine"/>
+                    <ColorProductAttribute t-elif="attributeLine.attribute_id.display_type === 'color'" attributeLine="attributeLine"/>
+                    <MultiProductAttribute t-elif="attributeLine.attribute_id.display_type === 'multi'" attributeLine="attributeLine"/>
+                </div>
             </div>
             <t t-set-slot="footer">
                 <button class="btn btn-primary o-default-button" t-on-click="confirm">Ok</button>
+                <button class="btn btn-secondary o-default-button" t-on-click="close">Discard</button>
             </t>
         </Dialog>
     </t>

--- a/addons/point_of_sale/static/tests/unit/pos_app_tests.js
+++ b/addons/point_of_sale/static/tests/unit/pos_app_tests.js
@@ -163,6 +163,7 @@ export class MockPosData {
                 "pos.payment": { relations: {}, fields: {}, data: [] },
                 "pos.pack.operation.lot": { relations: {}, fields: {}, data: [] },
                 "product.pricelist.item": { relations: {}, fields: {}, data: [] },
+                "product.attribute.custom.value": { relations: {}, fields: {}, data: [] },
             },
         };
     }

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -584,7 +584,11 @@ class TestUi(TestPointOfSaleHttpCommon):
         configurable_product = self.env['product.product'].search([('name', '=', 'Configurable Chair'), ('available_in_pos', '=', 'True')], limit=1)
         fabrics_line = configurable_product.attribute_line_ids[2]
         fabrics_line.product_template_value_ids[1].ptav_active = False
-
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('stock.group_stock_manager').id),
+            ]
+        })
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('ProductConfiguratorTour')
 
@@ -1084,30 +1088,32 @@ class TestUi(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
         })
 
-        color_attribute = self.env['product.attribute'].create({'name': 'Color', 'sequence': 4})
-        self.env['product.attribute.value'].create([{
-            'name': name,
-            'attribute_id': color_attribute.id,
-            'sequence': 1,
-        } for name in ('White', 'Red')])
+        color_attribute = self.env['product.attribute'].create({
+            'name': 'Color',
+            'sequence': 4,
+            'value_ids': [(0, 0, {
+                'name': 'White',
+                'sequence': 1,
+            }), (0, 0, {
+                'name': 'Red',
+                'sequence': 2,
+                'default_extra_price': 50,
+            })],
+        })
 
-        product_2 = self.env['product.product'].create({
+        product_2_template = self.env['product.template'].create({
             'name': 'Test Product 2',
             'list_price': 200,
             'taxes_id': False,
             'available_in_pos': True,
+            'attribute_line_ids': [(0, 0, {
+                'attribute_id': color_attribute.id,
+                'value_ids': [(6, 0, color_attribute.value_ids.ids)]
+            })],
         })
 
-        product_2_template = product_2.product_tmpl_id
-        product_2_color_attribute_line = self.env['product.template.attribute.line'].create([{
-            'product_tmpl_id': product_2_template.id,
-            'attribute_id': color_attribute.id,
-            'value_ids': [(6, 0, color_attribute.value_ids.ids)]
-        }])
         # Check that two product variant are created
         self.assertEqual(product_2_template.product_variant_count, 2)
-
-        product_2_color_attribute_line.product_template_value_ids[1].price_extra = 50
         product_2_template.product_variant_ids[0].write({'barcode': '0100201'})
         product_2_template.product_variant_ids[1].write({'barcode': '0100202'})
 
@@ -1136,11 +1142,15 @@ class TestUi(TestPointOfSaleHttpCommon):
             'fixed_price': 120,
         }])
         self.main_pos_config.pricelist_id.write({'item_ids': [(6, 0, pricelist_item.ids)]})
-
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'limitedProductPricelistLoading', login="pos_user")
 
     def test_multi_product_options(self):
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('stock.group_stock_manager').id),
+            ]
+        })
         product_a = self.env['product.product'].create({
             'name': 'Product A',
             'available_in_pos': True,

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -200,7 +200,11 @@ class TestFrontend(TestPointOfSaleHttpCommon):
         cls.pos_config.write({'pricelist_id': pricelist.id})
 
     def test_01_pos_restaurant(self):
-
+        self.pos_user.write({
+            'groups_id': [
+                (4, self.env.ref('account.group_account_invoice').id),
+            ]
+        })
         self.pos_config.with_user(self.pos_user).open_ui()
 
         self.start_pos_tour('pos_restaurant_sync')


### PR DESCRIPTION
Before this commit when a product have attribute in instantly mode, the product was duplicated in the list of products as many times as there were possible combinations.

Now, the product is displayed only once and when the user clicks on it, a popup is displayed with the possible combinations.

Before:
![image](https://github.com/odoo/odoo/assets/63289800/5262a820-4747-41c7-954c-5b55670d3fbf)

After:
![image](https://github.com/odoo/odoo/assets/63289800/56ce7744-736c-41cd-b9fb-dedcc76d5ae4)

taskId: 3884515

Related: https://github.com/odoo/enterprise/pull/61907