### PR TITLE
[FIX] mail: wrongly assigned attachment as main attachment

### DIFF
--- a/addons/mail/models/ir_attachment.py
+++ b/addons/mail/models/ir_attachment.py
@@ -55,7 +55,9 @@ class IrAttachment(models.Model):
                 #Ignore AccessError, if you don't have access to modify the document
                 #Just don't set the value
                 try:
-                    related_record.message_main_attachment_id = self
+                    not_allowed_mimetypes = ["application/xml", "application/pkcs7-mime"]
+                    if self.mimetype not in not_allowed_mimetypes:
+                        related_record.message_main_attachment_id = self
                 except AccessError:
                     pass
 


### PR DESCRIPTION
### Before this PR:
Sometimes attachments with extension ```p7m``` or ```xml``` were incorrectly assigned 
as the main attachment. This caused the attachment viewer to treat these 
attachments as previews that could be displayed.

### Approach to fix this issue:
Added a check for attachments with file extensions ```xml``` and ```p7m``` to prevent 
them from being considered as the main attachment.

### After this PR:
Attachments with mimetypes ```xml``` and ```p7m``` will no longer be considered as the 
main attachment, preventing them from appearing in the attachment viewer.

**task-3669465**

