### PR TITLE
[FIX] l10n_es_edi_sii: support missing ref

### DIFF
--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -292,7 +292,7 @@ class AccountEdiFormat(models.Model):
                     invoice_node['ClaveRegimenEspecialOTrascendencia'] = '02'
             else:
                 info['IDFactura']['IDEmisorFactura'] = partner_info
-                info['IDFactura']['NumSerieFacturaEmisor'] = invoice.ref[:60]
+                info["IDFactura"]["NumSerieFacturaEmisor"] = (invoice.ref or "")[:60]
                 if not is_simplified:
                     invoice_node['Contraparte'] = {
                         **partner_info,


### PR DESCRIPTION
This field isn't required. However, if not supplied, Odoo fails to notify *all* invoices in a cron run, without speaking about it. Not good.

The traceback:

    2024-04-29 11:43:01,356 29 ERROR odoo odoo.addons.base.models.ir_cron: Call from cron EDI : Perform web services operations for server action #282 failed in Job #15 
    Traceback (most recent call last):
      File "/opt/odoo/custom/src/odoo/odoo/tools/safe_eval.py", line 383, in safe_eval
        return unsafe_eval(c, globals_dict, locals_dict)
      File "ir.actions.server(282,)", line 1, in <module>
      File "/opt/odoo/auto/addons/account_edi/models/account_edi_document.py", line 276, in _cron_process_documents_web_services
        nb_remaining_jobs = edi_documents._process_documents_web_services(job_count=job_count)
      File "/opt/odoo/auto/addons/account_edi/models/account_edi_document.py", line 263, in _process_documents_web_services
        self._process_job(job)
      File "/opt/odoo/auto/addons/account_edi/models/account_edi_document.py", line 217, in _process_job
        edi_result = method_to_call(moves)
      File "/opt/odoo/auto/addons/l10n_es_edi_sii/models/account_edi_format.py", line 660, in _l10n_es_edi_sii_post_invoices
        info_list = self._l10n_es_edi_get_invoices_info(invoices)
      File "/opt/odoo/auto/addons/l10n_es_edi_sii/models/account_edi_format.py", line 291, in _l10n_es_edi_get_invoices_info
        info['IDFactura']['NumSerieFacturaEmisor'] = invoice.ref[:60]
    TypeError: 'bool' object is not subscriptable
    
    During handling of the above exception, another exception occurred:
    
    Traceback (most recent call last):
      File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_cron.py", line 391, in _callback
        self.env['ir.actions.server'].browse(server_action_id).run()
      File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_actions.py", line 674, in run
        res = runner(run_self, eval_context=eval_context)
      File "/opt/odoo/auto/addons/website/models/ir_actions_server.py", line 61, in _run_action_code_multi
        res = super(ServerAction, self)._run_action_code_multi(eval_context)
      File "/opt/odoo/custom/src/odoo/odoo/addons/base/models/ir_actions.py", line 544, in _run_action_code_multi
        safe_eval(self.code.strip(), eval_context, mode="exec", nocopy=True, filename=str(self))  # nocopy allows to return 'action'
      File "/opt/odoo/custom/src/odoo/odoo/tools/safe_eval.py", line 397, in safe_eval
        raise ValueError('%s: "%s" while evaluating\n%r' % (ustr(type(e)), ustr(e), expr))
    ValueError: <class 'TypeError'>: "'bool' object is not subscriptable" while evaluating
    'model._cron_process_documents_web_services(job_count=20)'


@moduon MT-5819


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
