### PR TITLE
[FIX] web_editor: backport fixes to link zwnbsp mechanism

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -942,7 +942,11 @@ function isZwnbsp(node) {
 }
 
 function isTangible(node) {
-    return isVisible(node) || isZwnbsp(node);
+    return isVisible(node) || isZwnbsp(node) || hasTangibleContent(node);
+}
+
+function hasTangibleContent(node) {
+    return [...(node?.childNodes || [])].some(n => isTangible(n));
 }
 
 export function getDeepestPosition(node, offset) {
@@ -2200,7 +2204,7 @@ export function fillEmpty(el) {
         blockEl.appendChild(br);
         fillers.br = br;
     }
-    if (!isVisible(el) && !el.hasAttribute("data-oe-zws-empty-inline")) {
+    if (!isTangible(el) && !el.hasAttribute("data-oe-zws-empty-inline")) {
         // As soon as there is actual content in the node, the zero-width space
         // is removed by the sanitize function.
         const zws = document.createTextNode('\u200B');


### PR DESCRIPTION
Some fixes that were revealed to be needed during the saas-16.4 forward port of PR [1] (157200) and PR [2] (160718), are needed in saas-16.3 as well. This backports them from said forward port PR [3] (163548).

[1]: https://github.com/odoo/odoo/pull/157200
[2]: https://github.com/odoo/odoo/pull/160718
[3]: https://github.com/odoo/odoo/pull/163548


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
