### PR TITLE
[FIX] website_sale: Parent company tax on branch product page

### DIFF
--- a/addons/website_sale/models/product_template.py
+++ b/addons/website_sale/models/product_template.py
@@ -507,7 +507,7 @@ class ProductTemplate(models.Model):
 
 
         product_taxes = product_or_template.sudo().taxes_id.filtered(
-            lambda t: t.company_id == self.env.company)
+            lambda t: t.company_id in self.env.company.parent_ids)
         taxes = self.env['account.tax']
         if product_taxes:
             taxes = fiscal_position.map_tax(product_taxes)


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

On the product page of a branch company's website, the tax is only displayed if it is a tax directly from that branch. But branch companies have access to the parent companies taxes and it should be possible to use those.

Current behavior before PR: No tax is displayed if the only tax is from the parent company

Desired behavior after PR is merged: Tax from the parent company is used

1. install ecommerce (website_sale) and accounting (account_accountant)
2. Have a company A and a branch B
3. create a product P with a tax from company A
4. create a website for company B with product P sold on it and tax-included in the price
5. Go to the product page, the tax is not included

OPW-3873659



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
