### PR TITLE
[FIX] base: stop sending duplicate attachments for mail marketing

### DIFF
--- a/odoo/addons/base/models/ir_attachment.py
+++ b/odoo/addons/base/models/ir_attachment.py
@@ -560,6 +560,8 @@ class IrAttachment(models.Model):
         for row in self._cr.dictfetchall():
             if not row['res_model'] or row['public']:
                 continue
+            if not row['res_id'] and (self.env.is_system() or row["create_uid"] == self.env.uid):
+                continue
             # model_attachments = {res_model: {res_id: set(ids)}}
             model_attachments[row['res_model']][row['res_id']].add(row['id'])
             # Should not retrieve binary fields attachments if not explicitly required


### PR DESCRIPTION
## Issue: 

There's a special case where attachments can have a res_id of 0, meaning they are not directly attached to a specific record. This will cause that after the search there are additional checks in the code, that will remove the records with this conditions (public=False and res_id = 0), after removing it then we will perform another internal _search call to fill the void since we need to send 30 records. Now when clicking in "Load More", another search_read is called with a limit of 30 but an offset of 30, the problem is that this call doesn't know that a few of the records where already sent.

## Steps to reproduce:

1. Make around 20 ir.attachment records, with res_model as "mailing.mailing", public set to True and resource_id as 0.
2. Now create another attachment, that can be a copie of the previous ones and modify it so this one has public = False.
3. Now fill more attachments like in the 1 step until we have more than 30.
4. Go to Email Marketing > New > Select any template with image > click on replace media > and when the popup of media is loaded, try to load more images.

## Solution: 

Following the behavior of newer versions, we could fix this issue by avoiding sending in the first place the attachments that are going to be filter out later on, we will only send them if the user is a superuser or is the one who uploaded the image, this way we will ensure that the search results do not include attachments that the user should not have access to.

opw-3826743
