### PR TITLE
[FIX] account: log error in chatter when importing xml

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -6040,7 +6040,9 @@ msgstr ""
 #. odoo-python
 #: code:addons/account/models/account_move.py:0
 #, python-format
-msgid "Error importing attachment '%s' as invoice (decoder=%s)"
+msgid ""
+"Error importing attachment '%s' as invoice (decoder=%s). Check the file "
+"itself, or read the application logs for more information."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3184,7 +3184,12 @@ class AccountMove(models.Model):
                 except RedirectWarning:
                     raise
                 except Exception:
-                    message = _("Error importing attachment '%s' as invoice (decoder=%s)", file_data['filename'], decoder.__name__)
+                    message = _(
+                        "Error importing attachment '%s' as invoice (decoder=%s). Check the file itself, or read the "
+                        "application logs for more information.",
+                        file_data['filename'],
+                        decoder.__name__,
+                    )
                     invoice.sudo().message_post(body=message)
                     _logger.exception(message)
 


### PR DESCRIPTION
Before c02d8b177f04d6a7f9311d8cb621bb5fe02e70e6, an error occuring during the import was logged in the chatter. This commit restores this behaviour, as it is highly helpful to have the error message (it could probably avoid customers to open tickets in some cases).

Ticket link: https://www.odoo.com/web#model=project.task&id=3874857
opw-3874857
