### PR TITLE
[IMP] payment*: compare notification data with transaction values

### DIFF
--- a/addons/payment/tests/test_payment_transaction.py
+++ b/addons/payment/tests/test_payment_transaction.py
@@ -169,6 +169,12 @@ class TestPaymentTransaction(PaymentCommon):
             msg="The partner of the partial capture should be that of the source transaction.",
         )
 
+    def test_compare_notification_data_throws(self):
+        """ Test that `_compare_notification_data` throws if not overridden by the provider. """
+        tx = self._create_transaction('redirect')
+        with self.assertRaises(NotImplementedError):
+            tx._compare_notification_data({})
+
     def test_capturing_child_tx_triggers_source_tx_state_update(self):
         self.provider.support_manual_capture = 'partial'
         self.provider.capture_manually = True

--- a/addons/payment_adyen/tests/common.py
+++ b/addons/payment_adyen/tests/common.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.tests.common import PaymentCommon
 
 
@@ -24,11 +25,11 @@ class AdyenCommon(PaymentCommon):
         cls.original_reference = 'FEDCBA9876543210'
         cls.webhook_notification_payload = {
             'additionalData': {
-                'hmacSignature': 'kK6vSQvfWP3AtT2TTK1ePj9e7XPb7bF5jHC7jDWyU5c='
+                'hmacSignature': 'VcoiMGe4ClMsMhLlgSOgZRZMBNqaVh1NfTTn+vAuXa8='
             },
             'amount': {
-                'currency': 'USD',
-                'value': 999,
+                'currency': cls.currency.name,
+                'value': payment_utils.to_minor_currency_units(cls.amount, cls.currency),
             },
             'eventCode': 'AUTHORISATION',
             'merchantAccountCode': 'DuckSACom123',

--- a/addons/payment_adyen/tests/test_adyen.py
+++ b/addons/payment_adyen/tests/test_adyen.py
@@ -86,10 +86,10 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         data = dict(
             self.webhook_notification_payload,
             amount={
-                'currency': 'USD',
+                'currency': self.currency.name,
                 'value': payment_utils.to_minor_currency_units(
-                    -source_tx.amount, refund_tx.currency_id
-                )
+                    source_tx.amount, refund_tx.currency_id
+                ),
             },
             eventCode='REFUND',
         )
@@ -102,9 +102,10 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         )
         data = dict(
             self.webhook_notification_payload,
-            amount={'currency': 'USD', 'value': payment_utils.to_minor_currency_units(
-                -self.amount, source_tx.currency_id
-            )},
+            amount={
+                'currency': self.currency.name,
+                'value': payment_utils.to_minor_currency_units(self.amount, source_tx.currency_id),
+            },
             eventCode='REFUND',
         )
         refund_tx = self.env['payment.transaction']._get_tx_from_notification_data('adyen', data)
@@ -131,7 +132,7 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         data = dict(
             self.webhook_notification_payload,
             amount={
-                'currency': 'USD',
+                'currency': self.currency.name,
                 'value': payment_utils.to_minor_currency_units(
                     source_tx.amount-10, capture_tx.currency_id
                 ),
@@ -148,9 +149,12 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         )
         data = dict(
             self.webhook_notification_payload,
-            amount={'currency': 'USD', 'value': payment_utils.to_minor_currency_units(
-                self.amount - 10, source_tx.currency_id
-            )},
+            amount={
+                'currency': self.currency.name,
+                'value': payment_utils.to_minor_currency_units(
+                    self.amount - 10, source_tx.currency_id
+                ),
+            },
             eventCode='CAPTURE',
         )
         capture_tx = self.env['payment.transaction']._get_tx_from_notification_data('adyen', data)
@@ -177,7 +181,7 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         data = dict(
             self.webhook_notification_payload,
             amount={
-                'currency': 'USD',
+                'currency': self.currency.name,
                 'value': payment_utils.to_minor_currency_units(
                     source_tx.amount - 10, cancel_tx.currency_id
                 ),
@@ -194,9 +198,12 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         )
         data = dict(
             self.webhook_notification_payload,
-            amount={'currency': 'USD', 'value': payment_utils.to_minor_currency_units(
-                self.amount - 10, source_tx.currency_id
-            )},
+            amount={
+                'currency': self.currency.name,
+                'value': payment_utils.to_minor_currency_units(
+                    self.amount - 10, source_tx.currency_id
+                ),
+            },
             eventCode='CANCELLATION',
         )
         void_tx = self.env['payment.transaction']._get_tx_from_notification_data('adyen', data)
@@ -348,7 +355,14 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
             'direct', state='authorized', provider_reference=self.original_reference, amount=9.99
         )
         payload = dict(self.webhook_notification_batch_data, notificationItems=[{
-            'NotificationRequestItem': dict(self.webhook_notification_payload, eventCode='CAPTURE')
+            'NotificationRequestItem': dict(
+                self.webhook_notification_payload,
+                amount={
+                    'currency': self.currency.name,
+                    'value': payment_utils.to_minor_currency_units(9.99, tx.currency_id),
+                },
+                eventCode='CAPTURE',
+            )
         }])
         self._webhook_notification_flow(payload)
         self.assertEqual(
@@ -362,7 +376,12 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         )
         payload = dict(self.webhook_notification_batch_data, notificationItems=[{
             'NotificationRequestItem': dict(
-                self.webhook_notification_payload, eventCode='CANCELLATION'
+                self.webhook_notification_payload,
+                amount={
+                    'currency': self.currency.name,
+                    'value': payment_utils.to_minor_currency_units(9.99, tx.currency_id),
+                },
+                eventCode='CANCELLATION',
             )
         }])
         self._webhook_notification_flow(payload)
@@ -379,9 +398,12 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         payload = dict(self.webhook_notification_batch_data, notificationItems=[{
             'NotificationRequestItem': dict(
                 self.webhook_notification_payload,
-                amount={'currency': 'USD', 'value': payment_utils.to_minor_currency_units(
-                    -self.amount, source_tx.currency_id
-                )},
+                amount={
+                    'currency': self.currency.name,
+                    'value': payment_utils.to_minor_currency_units(
+                        self.amount, source_tx.currency_id
+                    ),
+                },
                 eventCode='REFUND',
             )
         }])
@@ -442,9 +464,12 @@ class AdyenTest(AdyenCommon, PaymentHttpCommon):
         payload = dict(self.webhook_notification_batch_data, notificationItems=[{
             'NotificationRequestItem': dict(
                 self.webhook_notification_payload,
-                amount={'currency': 'USD', 'value': payment_utils.to_minor_currency_units(
-                    -self.amount, source_tx.currency_id
-                )},
+                amount={
+                    'currency': self.currency.name,
+                    'value': payment_utils.to_minor_currency_units(
+                        self.amount, source_tx.currency_id
+                    ),
+                },
                 eventCode='REFUND',
                 success='false',
             )

--- a/addons/payment_aps/models/payment_transaction.py
+++ b/addons/payment_aps/models/payment_transaction.py
@@ -105,6 +105,23 @@ class PaymentTransaction(models.Model):
 
         return tx
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to compare the transaction based on APS data.
+
+        :param dict notification_data: The notification data sent by the provider.
+        :return: None
+        :raise ValidationError: If the transaction's amount and currency don't match the
+            notification data.
+        """
+        if self.provider_code != 'aps':
+            return super()._compare_notification_data(notification_data)
+
+        amount = payment_utils.to_major_currency_units(
+            float(notification_data.get('amount', 0)), self.currency_id
+        )
+        currency_code = notification_data.get('currency')
+        self._validate_amount_and_currency(amount, currency_code)
+
     def _process_notification_data(self, notification_data):
         """ Override of `payment' to process the transaction based on APS data.
 

--- a/addons/payment_asiapay/models/payment_transaction.py
+++ b/addons/payment_asiapay/models/payment_transaction.py
@@ -131,6 +131,22 @@ class PaymentTransaction(models.Model):
 
         return tx
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to compare the transaction based on AsiaPay data.
+
+        :param dict notification_data: The notification data sent by the provider.
+        :return: None
+        :raise ValidationError: If the transaction's amount and currency don't match the
+            notification data.
+        """
+        if self.provider_code != 'asiapay':
+            return super()._compare_notification_data(notification_data)
+
+        amount = notification_data.get('Amt')
+        # AsiaPay supports only one currency per account.
+        currency_code = self.provider_id.available_currency_ids[0].name
+        self._validate_amount_and_currency(amount, currency_code)
+
     def _process_notification_data(self, notification_data):
         """ Override of `payment' to process the transaction based on AsiaPay data.
 

--- a/addons/payment_authorize/tests/test_authorize.py
+++ b/addons/payment_authorize/tests/test_authorize.py
@@ -49,10 +49,14 @@ class AuthorizeTest(AuthorizeCommon):
     def test_voiding_confirmed_tx_cancels_it(self):
         """ Test that voiding a transaction cancels it even if it's already confirmed. """
         source_tx = self._create_transaction('direct', state='done')
-        source_tx._handle_notification_data('authorize', {
-            'response': {
-                'x_response_code': '1',
-                'x_type': 'void',
-            },
-        })
+        with patch(
+            'odoo.addons.payment_authorize.models.authorize_request.AuthorizeAPI'
+            '.get_transaction_details', return_value={'transaction': {'authAmount': self.amount}},
+        ):
+            source_tx._handle_notification_data('authorize', {
+                'response': {
+                    'x_response_code': '1',
+                    'x_type': 'void',
+                },
+            })
         self.assertEqual(source_tx.state, 'cancel')

--- a/addons/payment_buckaroo/models/payment_transaction.py
+++ b/addons/payment_buckaroo/models/payment_transaction.py
@@ -72,6 +72,21 @@ class PaymentTransaction(models.Model):
 
         return tx
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to compare the transaction based on Buckaroo data.
+
+        :param dict notification_data: The notification data sent by the provider.
+        :return: None
+        :raise ValidationError: If the transaction's amount and currency don't match the
+            notification data.
+        """
+        if self.provider_code != 'buckaroo':
+            return super()._compare_notification_data(notification_data)
+
+        amount = notification_data.get('brq_amount')
+        currency_code = notification_data.get('brq_currency')
+        self._validate_amount_and_currency(amount, currency_code)
+
     def _process_notification_data(self, notification_data):
         """ Override of payment to process the transaction based on Buckaroo data.
 

--- a/addons/payment_buckaroo/tests/common.py
+++ b/addons/payment_buckaroo/tests/common.py
@@ -24,8 +24,8 @@ class BuckarooCommon(PaymentCommon):
             'brq_statuscode': '190',  # confirmed
             'brq_statusmessage': 'Transaction successfully processed',
             'brq_invoicenumber': cls.reference,
-            'brq_amount': '1111.11',
-            'brq_currency': 'USD',
+            'brq_amount': str(cls.amount),
+            'brq_currency': cls.currency.name,
             'brq_timestamp': '2022-01-01 12:00:00',
             'brq_transactions': '0123456789ABCDEF0123456789ABCDEF',
             'brq_signature': '5d389aa4f563cd99666a2e6bef79da3d4a32eb50',
@@ -37,9 +37,9 @@ class BuckarooCommon(PaymentCommon):
             'brq_statuscode': '190',  # confirmed
             'brq_statusmessage': 'Transaction successfully processed',
             'brq_invoicenumber': cls.reference,
-            'brq_amount': '1111.11',
-            'brq_currency': 'USD',
+            'brq_amount': str(cls.amount),
+            'brq_currency': cls.currency.name,
             'brq_timestamp': '2022-01-01 12:00:00',
             'brq_transaction_type': 'V010',
-            'brq_signature': '9ba976c3a6a3d2d1b5b58d3aa8c2c6fe269a9c27',
+            'brq_signature': 'fa3444e135c366a1d2660adb406fb47efdc28130',
         }

--- a/addons/payment_custom/models/payment_transaction.py
+++ b/addons/payment_custom/models/payment_transaction.py
@@ -71,6 +71,15 @@ class PaymentTransaction(models.Model):
             )
         return tx
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to skip the transaction comparison for custom flows.
+
+        :param dict notification_data: The custom data.
+        :return: None
+        """
+        if self.provider_code != 'custom':
+            return super()._compare_notification_data(notification_data)
+
     def _process_notification_data(self, notification_data):
         """ Override of payment to process the transaction based on custom data.
 

--- a/addons/payment_demo/models/payment_transaction.py
+++ b/addons/payment_demo/models/payment_transaction.py
@@ -145,6 +145,15 @@ class PaymentTransaction(models.Model):
             )
         return tx
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to skip the transaction comparison for dummy flows.
+
+        :param dict notification_data: The dummy notification data.
+        :return: None
+        """
+        if self.provider_code != 'demo':
+            return super()._compare_notification_data(notification_data)
+
     def _process_notification_data(self, notification_data):
         """ Override of payment to process the transaction based on dummy data.
 

--- a/addons/payment_dpo/controllers/main.py
+++ b/addons/payment_dpo/controllers/main.py
@@ -27,6 +27,11 @@ class DPOController(http.Controller):
 
     @staticmethod
     def _verify_and_handle_notification_data(data):
+        """ Verify and process the notification data sent by DPO.
+
+        :param dict data: The notification data.
+        :return: None
+        """
         tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
             'dpo', data
         )

--- a/addons/payment_dpo/models/payment_transaction.py
+++ b/addons/payment_dpo/models/payment_transaction.py
@@ -112,6 +112,21 @@ class PaymentTransaction(models.Model):
             )
         return tx
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to compare the transaction based on DPO data.
+
+        :param dict notification_data: The notification data sent by the provider.
+        :return: None
+        :raise ValidationError: If the transaction's amount and currency don't match the
+            notification data.
+        """
+        if self.provider_code != 'dpo':
+            return super()._compare_notification_data(notification_data)
+
+        amount = notification_data.get('TransactionAmount')
+        currency_code = notification_data.get('TransactionCurrency')
+        self._validate_amount_and_currency(amount, currency_code)
+
     def _process_notification_data(self, notification_data):
         """ Override of `payment` to process the transaction based on DPO data.
 

--- a/addons/payment_flutterwave/controllers/main.py
+++ b/addons/payment_flutterwave/controllers/main.py
@@ -30,7 +30,7 @@ class FlutterwaveController(http.Controller):
 
         # Handle the notification data.
         if data.get('status') != 'cancelled':
-            request.env['payment.transaction'].sudo()._handle_notification_data('flutterwave', data)
+            self._verify_and_handle_notification_data(data)
         else:  # The customer cancelled the payment by clicking on the close button.
             pass  # Don't try to process this case because the transaction id was not provided.
 
@@ -92,3 +92,19 @@ class FlutterwaveController(http.Controller):
         if not hmac.compare_digest(received_signature, expected_signature):
             _logger.warning("Received notification with invalid signature.")
             raise Forbidden()
+
+    @staticmethod
+    def _verify_and_handle_notification_data(data):
+        """ Verify and process the notification data sent by Flutterwave.
+
+        :param dict data: The notification data.
+        :return: None
+        """
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
+            'flutterwave', data
+        )
+        # Verify the notification data.
+        verified_data = tx_sudo.provider_id._flutterwave_make_request(
+            'transactions/verify_by_reference', payload={'tx_ref': tx_sudo.reference}, method='GET',
+        )['data']
+        tx_sudo._handle_notification_data('flutterwave', verified_data)

--- a/addons/payment_flutterwave/tests/test_payment_transaction.py
+++ b/addons/payment_flutterwave/tests/test_payment_transaction.py
@@ -39,11 +39,7 @@ class TestPaymentTransaction(FlutterwaveCommon):
         """ Test that the transaction state is set to 'done' when the notification data indicate a
         successful payment. """
         tx = self._create_transaction(flow='redirect')
-        with patch(
-            'odoo.addons.payment_flutterwave.models.payment_provider.PaymentProvider'
-            '._flutterwave_make_request', return_value=self.verification_data
-        ):
-            tx._process_notification_data(self.redirect_notification_data)
+        tx._process_notification_data(self.verification_data['data'])
         self.assertEqual(tx.state, 'done')
 
     def test_processing_notification_data_tokenizes_transaction(self):
@@ -51,11 +47,8 @@ class TestPaymentTransaction(FlutterwaveCommon):
         include token data. """
         tx = self._create_transaction(flow='redirect', tokenize=True)
         with patch(
-            'odoo.addons.payment_flutterwave.models.payment_provider.PaymentProvider'
-            '._flutterwave_make_request', return_value=self.verification_data
-        ), patch(
             'odoo.addons.payment_flutterwave.models.payment_transaction.PaymentTransaction'
             '._flutterwave_tokenize_from_notification_data'
         ) as tokenize_mock:
-            tx._process_notification_data(self.redirect_notification_data)
+            tx._process_notification_data(self.verification_data['data'])
         self.assertEqual(tokenize_mock.call_count, 1)

--- a/addons/payment_flutterwave/tests/test_processing_flows.py
+++ b/addons/payment_flutterwave/tests/test_processing_flows.py
@@ -22,6 +22,9 @@ class TestProcessingFlows(FlutterwaveCommon, PaymentHttpCommon):
         self._create_transaction(flow='redirect')
         url = self._build_url(FlutterwaveController._return_url)
         with patch(
+            'odoo.addons.payment_flutterwave.models.payment_provider.PaymentProvider'
+            '._flutterwave_make_request', return_value=self.verification_data
+        ), patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
             '._handle_notification_data'
         ) as handle_notification_data_mock:

--- a/addons/payment_mercado_pago/controllers/main.py
+++ b/addons/payment_mercado_pago/controllers/main.py
@@ -24,9 +24,7 @@ class MercadoPagoController(http.Controller):
         # Handle the notification data.
         _logger.info("Handling redirection from Mercado Pago with data:\n%s", pprint.pformat(data))
         if data.get('payment_id') != 'null':
-            request.env['payment.transaction'].sudo()._handle_notification_data(
-                'mercado_pago', data
-            )
+            self._verify_and_handle_notification_data(data)
         else:  # The customer cancelled the payment by clicking on the return button.
             pass  # Don't try to process this case because the payment id was not provided.
 
@@ -55,10 +53,25 @@ class MercadoPagoController(http.Controller):
         if data.get('action') in ('payment.created', 'payment.updated'):
             # Handle the notification data.
             try:
-                payment_id = data.get('data', {}).get('id')
-                request.env['payment.transaction'].sudo()._handle_notification_data(
-                    'mercado_pago', {'external_reference': reference, 'payment_id': payment_id}
+                self._verify_and_handle_notification_data(
+                    {'external_reference': reference, 'payment_id': data.get('data', {}).get('id')}
                 )  # Use 'external_reference' as the reference key like in the redirect data.
             except ValidationError:  # Acknowledge the notification to avoid getting spammed.
                 _logger.exception("Unable to handle the notification data; skipping to acknowledge")
         return ''  # Acknowledge the notification.
+
+    @staticmethod
+    def _verify_and_handle_notification_data(data):
+        """ Verify and process the notification data sent by Mercado Pago.
+
+        :param dict data: The notification data.
+        :return: None
+        """
+        tx_sudo = request.env['payment.transaction'].sudo()._get_tx_from_notification_data(
+            'mercado_pago', data
+        )
+        # Verify the notification data.
+        verified_data = tx_sudo.provider_id._mercado_pago_make_request(
+            f'/v1/payments/{data.get("payment_id")}', method='GET'
+        )
+        tx_sudo._handle_notification_data('mercado_pago', verified_data)

--- a/addons/payment_mercado_pago/models/payment_transaction.py
+++ b/addons/payment_mercado_pago/models/payment_transaction.py
@@ -126,6 +126,27 @@ class PaymentTransaction(models.Model):
             )
         return tx
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to compare the transaction based on Mercado Pago data.
+
+        :param dict notification_data: The notification data sent by the provider.
+        :return: None
+        :raise ValidationError: If the transaction's amount and currency don't match the
+            notification data.
+        """
+        if self.provider_code != 'mercado_pago':
+            return super()._compare_notification_data(notification_data)
+
+        amount = notification_data.get('additional_info', {}).get('items', [{}])[0].get(
+            'unit_price'
+        )
+        # The currency code isn't included in the notification data, so we can't validate it.
+        self._validate_amount_and_currency(
+            amount,
+            self.currency_id.name,
+            precision_digits=const.CURRENCY_DECIMALS.get(self.currency_id.name),
+        )
+
     def _process_notification_data(self, notification_data):
         """ Override of `payment` to process the transaction based on Mercado Pago data.
 
@@ -140,18 +161,13 @@ class PaymentTransaction(models.Model):
             return
 
         # Update the provider reference.
-        payment_id = notification_data.get('payment_id')
+        payment_id = notification_data.get('id')
         if not payment_id:
             raise ValidationError("Mercado Pago: " + _("Received data with missing payment id."))
         self.provider_reference = payment_id
 
-        # Verify the notification data.
-        verified_payment_data = self.provider_id._mercado_pago_make_request(
-            f'/v1/payments/{self.provider_reference}', method='GET'
-        )
-
         # Update the payment method.
-        payment_method_type = verified_payment_data.get('payment_type_id', '')
+        payment_method_type = notification_data.get('payment_type_id', '')
         for odoo_code, mp_codes in const.PAYMENT_METHODS_MAPPING.items():
             if any(payment_method_type == mp_code for mp_code in mp_codes.split(',')):
                 payment_method_type = odoo_code
@@ -166,7 +182,7 @@ class PaymentTransaction(models.Model):
         self.payment_method_id = payment_method or self.payment_method_id
 
         # Update the payment state.
-        payment_status = verified_payment_data.get('status')
+        payment_status = notification_data.get('status')
         if not payment_status:
             raise ValidationError("Mercado Pago: " + _("Received data with missing status."))
 
@@ -177,7 +193,7 @@ class PaymentTransaction(models.Model):
         elif payment_status in const.TRANSACTION_STATUS_MAPPING['canceled']:
             self._set_canceled()
         elif payment_status in const.TRANSACTION_STATUS_MAPPING['error']:
-            status_detail = verified_payment_data.get('status_detail')
+            status_detail = notification_data.get('status_detail')
             _logger.warning(
                 "Received data for transaction with reference %s with status %s and error code: %s",
                 self.reference, payment_status, status_detail

--- a/addons/payment_mercado_pago/tests/common.py
+++ b/addons/payment_mercado_pago/tests/common.py
@@ -24,8 +24,10 @@ class MercadoPagoCommon(PaymentCommon):
             'data': {'id': cls.payment_id},
         }
         cls.verification_data = {
+            'id': cls.payment_id,
             'status': 'approved',
         }
         cls.verification_data_for_error_state = {
+            'id': cls.payment_id,
             'status': 404,
         }

--- a/addons/payment_mercado_pago/tests/test_payment_transaction.py
+++ b/addons/payment_mercado_pago/tests/test_payment_transaction.py
@@ -63,11 +63,7 @@ class TestPaymentTransaction(MercadoPagoCommon, PaymentHttpCommon):
         """ Test that the transaction state is set to 'done' when the notification data indicate a
         successful payment. """
         tx = self._create_transaction(flow='redirect')
-        with patch(
-            'odoo.addons.payment_mercado_pago.models.payment_provider.PaymentProvider'
-            '._mercado_pago_make_request', return_value=self.verification_data
-        ):
-            tx._process_notification_data(self.redirect_notification_data)
+        tx._process_notification_data(self.verification_data)
         self.assertEqual(tx.state, 'done')
 
     @mute_logger('odoo.addons.payment_mercado_pago.models.payment_transaction')
@@ -75,11 +71,7 @@ class TestPaymentTransaction(MercadoPagoCommon, PaymentHttpCommon):
         """ Test that the transaction state is set to 'error' when the notification data indicate a status of
         404 error payment. """
         tx = self._create_transaction(flow='redirect')
-        with patch(
-            'odoo.addons.payment_mercado_pago.models.payment_provider.PaymentProvider'
-            '._mercado_pago_make_request', return_value=self.verification_data_for_error_state
-        ):
-            tx._process_notification_data(self.redirect_notification_data)
+        tx._process_notification_data(self.verification_data_for_error_state)
         self.assertEqual(tx.state, 'error')
 
     def test_cop_currency_rounding(self):

--- a/addons/payment_mercado_pago/tests/test_processing_flows.py
+++ b/addons/payment_mercado_pago/tests/test_processing_flows.py
@@ -20,6 +20,9 @@ class TestProcessingFlows(MercadoPagoCommon, PaymentHttpCommon):
         self._create_transaction(flow='redirect')
         url = self._build_url(MercadoPagoController._return_url)
         with patch(
+            'odoo.addons.payment_mercado_pago.models.payment_provider.PaymentProvider'
+            '._mercado_pago_make_request', return_value=self.verification_data
+        ), patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
             '._handle_notification_data'
         ) as handle_notification_data_mock:
@@ -33,6 +36,9 @@ class TestProcessingFlows(MercadoPagoCommon, PaymentHttpCommon):
         tx = self._create_transaction(flow='redirect')
         url = self._build_url(f'{MercadoPagoController._webhook_url}/{tx.reference}')
         with patch(
+            'odoo.addons.payment_mercado_pago.models.payment_provider.PaymentProvider'
+            '._mercado_pago_make_request', return_value=self.verification_data
+        ), patch(
             'odoo.addons.payment.models.payment_transaction.PaymentTransaction'
             '._handle_notification_data'
         ) as handle_notification_data_mock:

--- a/addons/payment_mollie/tests/test_mollie.py
+++ b/addons/payment_mollie/tests/test_mollie.py
@@ -32,7 +32,10 @@ class MollieTest(MollieCommon, PaymentHttpCommon):
         with patch(
             'odoo.addons.payment_mollie.models.payment_provider.PaymentProvider'
             '._mollie_make_request',
-            return_value={'status': 'paid'},
+            return_value={
+                'status': 'paid',
+                'amount': {'value': str(self.amount), 'currency': self.currency.name},
+            },
         ):
             self._make_http_post_request(url, data=self.notification_data)
         self.assertEqual(tx.state, 'done')

--- a/addons/payment_nuvei/models/payment_transaction.py
+++ b/addons/payment_nuvei/models/payment_transaction.py
@@ -133,6 +133,21 @@ class PaymentTransaction(models.Model):
 
         return tx
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to compare the transaction based on Nuvei data.
+
+        :param dict notification_data: The notification data sent by the provider.
+        :return: None
+        :raise ValidationError: If the transaction's amount and currency don't match the
+            notification data.
+        """
+        if self.provider_code != 'nuvei':
+            return super()._compare_notification_data(notification_data)
+
+        amount = notification_data.get('totalAmount')
+        currency_code = notification_data.get('currency')
+        self._validate_amount_and_currency(amount, currency_code)
+
     def _process_notification_data(self, notification_data):
         """ Override of `payment` to process the transaction based on Nuvei data.
 

--- a/addons/payment_razorpay/models/payment_transaction.py
+++ b/addons/payment_razorpay/models/payment_transaction.py
@@ -372,6 +372,23 @@ class PaymentTransaction(models.Model):
             converted_amount, is_refund=True, provider_reference=refund_provider_reference
         )
 
+    def _compare_notification_data(self, notification_data):
+        """ Override of `payment` to compare the transaction based on Razorpay data.
+
+        :param dict notification_data: The notification data sent by the provider.
+        :return: None
+        :raise ValidationError: If the transaction's amount and currency don't match the
+            notification data.
+        """
+        if self.provider_code != 'razorpay':
+            return super()._compare_notification_data(notification_data)
+
+        amount = payment_utils.to_major_currency_units(
+            notification_data.get('amount', 0), self.currency_id
+        )
+        currency_code = notification_data.get('currency')
+        self._validate_amount_and_currency(amount, currency_code)
+
     def _process_notification_data(self, notification_data):
         """ Override of `payment` to process the transaction based on Razorpay data.
 

--- a/addons/payment_stripe/tests/common.py
+++ b/addons/payment_stripe/tests/common.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.tests.common import PaymentCommon
 
 
@@ -18,6 +19,10 @@ class StripeCommon(PaymentCommon):
 
         cls.provider = cls.stripe
 
+        cls.notification_amount_and_currency = {
+            'amount': payment_utils.to_minor_currency_units(cls.amount, cls.currency),
+            'currency': cls.currency.name.lower(),
+        }
         cls.notification_data = {
             'data': {
                 'object': {
@@ -27,26 +32,25 @@ class StripeCommon(PaymentCommon):
                     'payment_method': {'type': 'pm_1KVZSNAlCFm536g8sYB92I1G'},
                     'description': cls.reference,
                     'status': 'succeeded',
+                    **cls.notification_amount_and_currency,
                 }
             },
             'type': 'payment_intent.succeeded'
         }
 
         cls.refund_object = {
-            'amount': cls.amount,
             'charge': 'ch_000000000000000000000000',
-            'currency': 'eur',
             'id': 're_000000000000000000000000',
             'object': 'refund',
             'payment_intent': 'pi_000000000000000000000000',
             'status': 'succeeded',
+            **cls.notification_amount_and_currency,
         }
         cls.refund_notification_data = {
             'data': {
                 'object': {
                     'id': 'ch_000000000000000000000000',
                     'object': 'charge',
-                    'amount': cls.amount,
                     'description': cls.reference,
                     'refunds': {
                         'object': 'list',
@@ -54,6 +58,7 @@ class StripeCommon(PaymentCommon):
                         'has_more': False,
                     },
                     'status': 'succeeded',
+                    **cls.notification_amount_and_currency,
                 }
             },
             'type': 'charge.refunded'

--- a/addons/payment_stripe/tests/test_stripe.py
+++ b/addons/payment_stripe/tests/test_stripe.py
@@ -47,7 +47,11 @@ class StripeTest(StripeCommon, PaymentHttpCommon):
         with patch(
             'odoo.addons.payment_stripe.models.payment_provider.PaymentProvider'
             '._stripe_make_request',
-            return_value={'id': 'pi_3KTk9zAlCFm536g81Wy7RCPH', 'status': 'succeeded'},
+            return_value={
+                'id': 'pi_3KTk9zAlCFm536g81Wy7RCPH',
+                'status': 'succeeded',
+                **self.notification_amount_and_currency,
+            },
         ):
             tx._send_capture_request()
         self.assertEqual(
@@ -62,7 +66,11 @@ class StripeTest(StripeCommon, PaymentHttpCommon):
         with patch(
             'odoo.addons.payment_stripe.models.payment_provider.PaymentProvider'
             '._stripe_make_request',
-            return_value={'id': 'pi_3KTk9zAlCFm536g81Wy7RCPH', 'status': 'canceled'},
+            return_value={
+                'id': 'pi_3KTk9zAlCFm536g81Wy7RCPH',
+                'status': 'canceled',
+                **self.notification_amount_and_currency,
+            },
         ):
             tx._send_void_request()
         self.assertEqual(

--- a/addons/payment_worldline/tests/common.py
+++ b/addons/payment_worldline/tests/common.py
@@ -1,5 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.payment import utils as payment_utils
 from odoo.addons.payment.tests.common import PaymentCommon
 
 
@@ -19,6 +20,10 @@ class WorldlineCommon(PaymentCommon):
 
         cls.provider = cls.worldline
         cls.currency = cls.currency_euro
+        cls.notification_amount_and_currency = {
+            'amount': payment_utils.to_minor_currency_units(cls.amount, cls.currency),
+            'currencyCode': cls.currency.name,
+        }
 
         cls.notification_data = {
             'payment': {
@@ -33,6 +38,7 @@ class WorldlineCommon(PaymentCommon):
                         },
                         'token': 'whateverToken'
                     },
+                    'amountOfMoney': cls.notification_amount_and_currency,
                 },
                 'id': '1234567890_0',
                 'status': 'CAPTURED',
@@ -61,7 +67,7 @@ class WorldlineCommon(PaymentCommon):
                     'id': '7777777000_0',
                     'paymentOutput': {
                         'acquiredAmount': {'amount': 0, 'currencyCode': 'EUR'},
-                        'amountOfMoney': {'amount': 4990, 'currencyCode': 'EUR'},
+                        'amountOfMoney': cls.notification_amount_and_currency,
                         'cardPaymentMethodSpecificOutput': {
                             'acquirerInformation': {'name': "Test Pay"},
                             'card': {
@@ -110,7 +116,7 @@ class WorldlineCommon(PaymentCommon):
                 'id': '9999999999_0',
                 'paymentOutput': {
                     'acquiredAmount': {'amount': 0, 'currencyCode': 'EUR'},
-                    'amountOfMoney': {'amount': 4980, 'currencyCode': 'EUR'},
+                    'amountOfMoney': cls.notification_amount_and_currency,
                     'cardPaymentMethodSpecificOutput': {
                         'acquirerInformation': {'name': "Test Pay"},
                         'card': {

--- a/addons/payment_xendit/tests/common.py
+++ b/addons/payment_xendit/tests/common.py
@@ -15,29 +15,31 @@ class XenditCommon(PaymentCommon):
             'xendit_webhook_token': 'xnd_webhook_token',
         })
         cls.provider = cls.xendit
+        cls.amount = 11100
+        cls.currency = cls._enable_currency('IDR')
         cls.webhook_notification_data = {
-            'amount': 1740,
+            'amount': cls.amount,
             'status': 'PAID',
             'created': '2023-07-12T09:31:13.111Z',
             'paid_at': '2023-07-12T09:31:22.830Z',
             'updated': '2023-07-12T09:31:23.577Z',
             'user_id': '64118d86854d7d89206e732d',
-            'currency': 'IDR',
+            'currency': cls.currency.name,
             'bank_code': 'BNI',
             'description': cls.reference,
             'external_id': cls.reference,
-            'paid_amount': 1740,
+            'paid_amount': cls.amount,
             'merchant_name': 'Odoo',
-            'initial_amount': 1740,
+            'initial_amount': cls.amount,
             'payment_method': 'BANK_TRANSFER',
             'payment_channel': 'BNI',
             'payment_destination': '880891384013',
         }
         cls.charge_notification_data = {
             'status': 'CAPTURED',
-            'authorized_amount': 11100,
-            'capture_amount': 11100,
-            'currency': 'IDR',
+            'authorized_amount': cls.amount,
+            'capture_amount': cls.amount,
+            'currency': cls.currency.name,
             'metadata': {},
             'credit_card_token_id': '6645aaa2f00da60017cdc669',
             'business_id': '64118d86854d7d89206e732d',

--- a/addons/payment_xendit/tests/test_payment_transaction.py
+++ b/addons/payment_xendit/tests/test_payment_transaction.py
@@ -110,7 +110,7 @@ class TestPaymentTransaction(PaymentHttpCommon, XenditCommon):
         tx = self._create_transaction('redirect', amount=1000.50, currency_id=currency_idr.id)
         with patch(
             'odoo.addons.payment_xendit.models.payment_provider.PaymentProvider'
-            '._xendit_make_request', return_value=self.charge_notification_data
+            '._xendit_make_request', return_value={**self.charge_notification_data, 'amount': 1000}
         ) as mock_req:
             tx._xendit_create_charge('dummytoken')
             payload = mock_req.call_args.kwargs.get('payload')


### PR DESCRIPTION
After making a payment/refund/capture/... request to a payment provider, it
sends back some notification data allowing to process the corresponding
transaction in Odoo. The purpose of this change is to ensure that the amount and
currency included in the notification data match the ones of the transaction. If
there's a mismatch, an error is thrown and the transaction isn't processed.

This check highlighed a few transaction processing and currency
conversion/rounding issues which have been resolved as well (see task for
details).

task-3797660

Documentation PR: https://github.com/odoo/documentation/pull/13284