### PR TITLE
[IMP] base: add batching fetch method

### DIFF
--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -279,6 +279,9 @@ class Cursor(BaseCursor):
         return [self.__build_dict(row) for row in self._obj.fetchmany(size)]
     def dictfetchall(self):
         return [self.__build_dict(row) for row in self._obj.fetchall()]
+    def batched_dictfetchall(self, size):
+        for _ in range(0, int(self._obj.rowcount/size) + 1):
+            yield self.dictfetchmany(size)
 
     def __del__(self):
         if not self._closed and not self._cnx.closed:


### PR DESCRIPTION
As per tickets 3859206,3332771,3349879, there is a need to batch a dictfetchall call if the number of rows x columns generated by a query is very large.

This batching method prevents overutilization of memory by limiting the allocations made in `__build_dict`. We do so by using `dictfetchmany` and a batch `size`.

Rudimentary example --> 
![image](https://github.com/odoo/odoo/assets/93154859/c8d86549-7466-4320-bf25-a4a44bcc612a)

Example usage -->
```
BATCH_SIZE = some_uint
self.env.cr.execute(<query>)
for vals in self.env.cr.batched_dictfetchall(BATCH_SIZE):
    for val in vals:
        # do stuff
```
