### PR TITLE
[FIX] hr_timesheet: round the value of the progress field in the portal 

### DIFF
--- a/addons/hr_timesheet/views/project_task_portal_templates.xml
+++ b/addons/hr_timesheet/views/project_task_portal_templates.xml
@@ -23,7 +23,7 @@
             </div>
         </xpath>
         <xpath expr="//div[@name='portal_my_task_allocated_hours']" position="after">
-            <div t-if="task.allocated_hours > 0 and allow_timesheets"><strong>Progress:</strong> <span t-esc="task.progress * 100"/>%</div>
+            <div t-if="task.allocated_hours > 0 and allow_timesheets"><strong>Progress:</strong> <span t-esc="task.progress * 100" t-options='{"widget": "float", "precision": 0}'/>%</div>
         </xpath>
         <xpath expr="//div[@name='portal_my_task_allocated_hours']/t" position="replace">
             <t t-call="hr_timesheet.portal_my_task_allocated_hours_template"></t>


### PR DESCRIPTION
 Steps to reproduce:
    - Install the hr_timesheet module.
    - Create a Project with timesheets selected.
    - Create a Task and set the allocated time to 5.
    - Add a timesheet entry with hours set to 23.
    - Open the task in the portal view.

Currently, the progress field value is not rounded, and a large number of decimal places are
displayed in the portal view. We have fixed this issue by adding the float widget.

task-3888878