### PR TITLE
[FIX] point_of_sale: remove taxes on gift card

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -131,7 +131,7 @@ export class Orderline extends PosModel {
                 }
             }
 
-            this.tax_ids = validTax.length > 0 ? validTax : undefined;
+            this.tax_ids = validTax.length > 0 ? validTax : [];
         }
     }
 

--- a/addons/pos_loyalty/static/tests/tours/GiftCardProgramTours.js
+++ b/addons/pos_loyalty/static/tests/tours/GiftCardProgramTours.js
@@ -36,6 +36,25 @@ registry.category("web_tour.tours").add("GiftCardProgramCreateSetTour2", {
 });
 //#endregion
 
+//#region GiftCardProgramPriceTour
+registry.category("web_tour.tours").add("GiftCardProgramPriceNoTaxTour", {
+    test: true,
+    url: "/pos/web",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+
+            // Use gift card
+            ProductScreen.addOrderline("Magnetic Board", "1", "1.98", "1.98"),
+            PosLoyalty.enterCode("043123456"),
+            Dialog.confirm(),
+            ProductScreen.clickOrderline("Gift Card"),
+            ProductScreen.selectedOrderlineHas("Gift Card", "1.00", "-1.00"),
+            PosLoyalty.orderTotalIs("0.98"),
+        ].flat(),
+});
+//#endregion
+
 //#region GiftCardProgramScanUseTour
 registry.category("web_tour.tours").add("GiftCardProgramScanUseTour", {
     test: true,


### PR DESCRIPTION
Problem:
There is taxes added to the gift card discount

Steps to reproduce:
- Install "Point of sale" app
- Go to Settings and activate gift cards
- Create a gift card (for ex 100€)
- Copy the code
- Open PoS > Add a product (more than the price of the gift card to understand better) > add the gift card
- The card value is not 100€ but more because it includes taxes

Solution:
Set an empty Array as tax will allow this.tax_ids to be evaluated as true in a if statement and will define an empty Array for the tax of the gift card

https://github.com/odoo/odoo/blob/7df8fc435c6ea199292f47954202d4f3c93b2629/addons/point_of_sale/static/src/app/store/models.js#L745-L749

opw-3862427

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
