### PR TITLE
[FIX] base: notify archived user on login attempt

### DIFF
--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -29294,6 +29294,15 @@ msgid ""
 msgstr ""
 
 #. module: base
+#. odoo-python
+#: code:addons/base/models/res_users.py:0
+#, python-format
+msgid ""
+"This account is archived. Please contact the systems administrator for more "
+"information."
+msgstr ""
+
+#. module: base
 #: model:ir.module.module,description:base.module_test_spreadsheet
 msgid ""
 "This module contains tests related to spreadsheet.\n"


### PR DESCRIPTION
**Current behavior:**
When there is a login attempt from credentials belonging to a previously archived/access revoked user record, the current log messages they see will indicate that this login does not exist. This can lead to confusion as it implies a new account may be created with that email/login- even though it is still in the database (so this cannot be done).

**Expected behavior:**
Provide a more accurate log/error message to the user which will not indicate that creating a new account with the provided credentials is possible.

**Steps to reproduce:**
1. Install the Portal module, revoke access from the demo portal user

2. Attempt to login with the demo portal user from a separate session -> current messaging can be misinterpreted

**Cause of the issue:**
We treat archived users as if they didn't exist when validating logins.

**Fix:**
Check whether the credentials used belong to an archived user and propagate a distinct AccessError when this is the case.

opw-3894589