### PR TITLE
[FIX] stock_picking_batch: update batches with backorder processes

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -137,6 +137,13 @@ class StockPicking(models.Model):
 
         return res
 
+    def _create_backorder(self):
+        for picking in self:
+            # Avoid inconsistencies in states of the same batch when validating a single picking in a batch.
+            if picking.batch_id and picking.state != 'done':
+                picking.batch_id = None
+        return super()._create_backorder()
+
     def action_cancel(self):
         res = super().action_cancel()
         for picking in self:

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -801,3 +801,72 @@ class TestBatchPicking02(TransactionCase):
         action = batch.action_done()
         Form(self.env[action['res_model']].with_context(action['context'])).save().process_cancel_backorder()
         self.assertEqual(batch.state, 'done')
+
+    def test_backorder_batching(self):
+        """
+        With autobatch receipts, check that you can create backorders for
+        pickings related to the batch.
+        """
+        warehouse = self.env['stock.warehouse'].create({
+            'name': 'Warehouse test',
+            'code': 'WHTEST',
+            'company_id': self.env.company.id,
+        })
+        warehouse.in_type_id.auto_batch = True
+        warehouse.in_type_id.batch_group_by_partner = True
+        productA, productB = self.productA, self.productB
+        partner = self.env['res.partner'].create({'name': 'Mr. Belougat'})
+        pickings = self.env['stock.picking'].create([
+            {
+                'picking_type_id': warehouse.in_type_id.id,
+                'company_id': self.env.company.id,
+                'partner_id': partner.id,
+            },
+            {
+                'picking_type_id': warehouse.in_type_id.id,
+                'company_id': self.env.company.id,
+                'partner_id': partner.id,
+            },
+        ])
+        picking_1, picking_2 = pickings
+        self.env['stock.move'].create([
+            {
+                'name': productA.name,
+                'product_id': productA.id,
+                'product_uom_qty': 1.0,
+                'product_uom': productA.uom_id.id,
+                'picking_id': picking_1.id,
+                'location_id': picking_1.location_id.id,
+                'location_dest_id': picking_1.location_dest_id.id,
+            },
+            {
+                'name': productA.name,
+                'product_id': productA.id,
+                'product_uom_qty': 1.0,
+                'product_uom': productA.uom_id.id,
+                'picking_id': picking_2.id,
+                'location_id': picking_2.location_id.id,
+                'location_dest_id': picking_2.location_dest_id.id,
+            },
+            {
+                'name': productB.name,
+                'product_id': productB.id,
+                'product_uom_qty': 1.0,
+                'product_uom': productB.uom_id.id,
+                'picking_id': picking_2.id,
+                'location_id': picking_2.location_id.id,
+                'location_dest_id': picking_2.location_dest_id.id,
+            },
+        ])
+        pickings.action_confirm()
+        batch = pickings.batch_id
+        self.assertEqual(batch.picking_ids, picking_1 | picking_2)
+        picking_2.move_ids.filtered(lambda m: m.product_id == productA).quantity = 0.0
+        backorder_wizard_dict = picking_2.button_validate()
+        backorder_wizard = Form(self.env[backorder_wizard_dict['res_model']].with_context(backorder_wizard_dict['context'])).save()
+        backorder_wizard.process()
+        self.assertEqual(picking_2.state, 'done')
+        self.assertFalse(picking_2 in batch.picking_ids)
+        backorder = batch.picking_ids - picking_1
+        self.assertTrue(backorder)
+        self.assertRecordValues(backorder.move_ids, [{'product_id': productA.id, 'quantity': 1.0}])

--- a/addons/stock_picking_batch/tests/test_wave_picking.py
+++ b/addons/stock_picking_batch/tests/test_wave_picking.py
@@ -547,8 +547,9 @@ class TestBatchPicking(TransactionCase):
             'picking_ids': [Command.link(picking_1.id), Command.link(picking_2.id)],
         })
         wave.move_ids.filtered(lambda m: m.product_id == self.productB).quantity = 0.0
+        wave.move_ids.picked = True
         wave.action_done()
         self.assertEqual(wave.state, 'done')
         self.assertEqual(wave.picking_ids, picking_1)
         self.assertEqual([picking_1.state, picking_1.move_ids.quantity, picking_1.move_ids.picked], ['done', 2.0, True])
-        self.assertEqual([picking_2.state, picking_2.move_ids.quantity, picking_2.move_ids.picked], ['assigned', 0.0, False])
+        self.assertEqual([picking_2.state, picking_2.move_ids.quantity, picking_2.move_ids.picked], ['assigned', 0.0, True])


### PR DESCRIPTION
### Steps to reproduce:

- Enable Batch Transfers in the settings
- Go to Inventory > Config> Warehouse Management > Operation Types
- On  receipts, enable "Automatic Batches" group by contact
- Create and confirm a purchase order for any contact with:
  - 1 X storable product P1
- Create and confirm a purchase order for the same contact with:
  - 1 X storable product P1
  - 1 x storable product P2
- Go to the assocated stock picking > change the quantity of P1 to 0
- Validate and create a backorder

#### > invalid operation: The following transfers cannot be added to batch

### Cause of the issue:

When the backorder is processed, the stock picking that currently belongs to our batch is validated and a backorder is created: https://github.com/odoo/odoo/blob/f168c4ba9d64a05a4a55715c44016a15230fe706/addons/stock/models/stock_move.py#L1891-L1892 The picking associated to this backorder is then added to our batch https://github.com/odoo/odoo/blob/f168c4ba9d64a05a4a55715c44016a15230fe706/addons/stock_picking_batch/models/stock_picking.py#L160-L162 But for this action to be performed, we need to pass the sanity check verifying that the pickings associated to our batch are allowed: https://github.com/odoo/odoo/blob/f168c4ba9d64a05a4a55715c44016a15230fe706/addons/stock_picking_batch/models/stock_picking_batch.py#L282-L286 And here comes the problem, the picking that created the backorder was not yet removed from our batch but is not allowed anymore since it is now in 'done' state:
https://github.com/odoo/odoo/blob/f168c4ba9d64a05a4a55715c44016a15230fe706/addons/stock_picking_batch/models/stock_picking_batch.py#L76-L77

opw-3893543
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
