### PR TITLE
[FIX] web: add file in DataTransfer.items

### DIFF
--- a/addons/web/static/tests/legacy/utils.js
+++ b/addons/web/static/tests/legacy/utils.js
@@ -434,8 +434,12 @@ class Contains {
         if (this.options.dropFiles) {
             message = `${message} and dropped ${this.options.dropFiles.length} file(s)`;
             const ev = new Event("drop", { bubbles: true });
+            const dataTransfer = new window.DataTransfer();
+            for (const file of this.options.dropFiles) {
+                dataTransfer.items.add(file);
+            }
             Object.defineProperty(ev, "dataTransfer", {
-                value: createFakeDataTransfer(this.options.dropFiles),
+                value: dataTransfer,
             });
             el.dispatchEvent(ev);
         }


### PR DESCRIPTION
In Documents, we now allow the user to drag and drop folders on top of files. To allow the tests to work we need to add the files through the
DataTransferItemList.add() method.

Task-3895205





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
