### PR TITLE
[FIX] website: ensuring unique 'Key' value while duplicating view

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -120,6 +120,7 @@ class Page(models.Model):
             if not default.get('view_id'):
                 new_view = page.view_id.copy({'website_id': default.get('website_id')})
                 vals['view_id'] = new_view.id
+                vals['key'] = new_view.key
             vals['url'] = default.get('url', self.env['website'].get_unique_path(page.url))
         return vals_list
 

--- a/addons/website/static/tests/tours/page_manager.js
+++ b/addons/website/static/tests/tours/page_manager.js
@@ -73,6 +73,71 @@ const deleteSelectedPage = [
 ];
 const homePage = 'tr:contains("Home")';
 
+const refreshPage = [
+    {
+        trigger: "body",
+        run: () => {
+            window.location.reload();
+        },
+    },
+];
+const duplicateSinglePage = [
+    {
+        content: "Click on checkbox",
+        trigger:
+            '.o_list_renderer tr:contains("/test-duplicate") td.o_list_record_selector input[type="checkbox"]',
+    },
+    {
+        content: "Click on Action button",
+        trigger: ".o_cp_action_menus button",
+    },
+    {
+        content: "Click on Duplicate",
+        trigger: '.o-dropdown--menu span:contains("Duplicate")',
+    },
+    {
+        content: "Put your website name as 'Test Duplicate' here",
+        trigger: 'main.modal-body input[type="text"]',
+        run: "text Test Duplicate",
+    },
+    {
+        content: "Click on OK",
+        trigger: ".modal-footer button.btn-primary",
+    },
+    ...refreshPage,
+];
+
+const duplicateMultiplePage = [
+    {
+        content: "Click on checkbox",
+        trigger:
+            '.o_list_renderer tr:contains("/test-duplicate") td.o_list_record_selector input[type="checkbox"]',
+    },
+    {
+        content: "Click on checkbox",
+        trigger:
+            '.o_list_renderer tr:contains("/test-duplicate-1") td.o_list_record_selector input[type="checkbox"]',
+    },
+    {
+        content: "Click on Action button",
+        trigger: ".o_cp_action_menus button",
+    },
+    {
+        content: "Click on Duplicate",
+        trigger: '.o-dropdown--menu span:contains("Duplicate")',
+    },
+    {
+        content: "Put your website name as 'Test Duplicate' here",
+        trigger: 'main.modal-body input[type="text"]',
+        run: "text Test Duplicate",
+    },
+    {
+        content: "Click on OK",
+        trigger: ".modal-footer button.btn-primary",
+    },
+    ...refreshPage,
+];
+
 wTourUtils.registerWebsitePreviewTour('website_page_manager', {
     test: true,
     url: '/',
@@ -148,3 +213,23 @@ registry.category("web_tour.tours").add('website_page_manager_direct_access', {
 	trigger: ".o_dropdown_container.o_website_menu > .dropdown-item:contains('My Website 2')",
     run: () => null, // it's a check
 }]});
+
+wTourUtils.registerWebsitePreviewTour(
+    "website_clone_pages",
+    {
+        test: true,
+        url: "/",
+    },
+    () => [
+        {
+            content: "Click on Site",
+            trigger: 'button.dropdown-toggle[data-menu-xmlid="website.menu_site"]',
+        },
+        {
+            content: "Click on Pages",
+            trigger: 'a.dropdown-item[data-menu-xmlid="website.menu_website_pages_list"]',
+        },
+        ...duplicateSinglePage,
+        ...duplicateMultiplePage,
+    ]
+);

--- a/addons/website/tests/test_page_manager.py
+++ b/addons/website/tests/test_page_manager.py
@@ -54,3 +54,33 @@ class TestWebsitePageManager(odoo.tests.HttpCase):
         website_2 = Website.create({'name': 'website 2'})
         locs = website_2.with_context(website_id=website_2.id)._enumerate_pages(query_string="/test_diverged")
         self.assertEqual(len(list(locs)), 1, "Generic page should be shown")
+
+    def test_unique_view_key_on_duplication_pages(self):
+        Page = self.env['website.page']
+        View = self.env['ir.ui.view']
+
+        test_view = View.create({
+            'name': 'Base',
+            'type': 'qweb',
+            'arch': '<div>Test View</div>',
+            'key': 'website.test-duplicate',
+        })
+        original_page = Page.create({
+            'view_id': test_view.id,
+            'url': '/test-duplicate',
+            'name': 'Test Duplicate',
+            'website_id': 1,
+        })
+
+        pages = Page.search([('name', 'like', 'Test Duplicate')])
+        self.assertEqual(len(pages), 1)
+
+        url = self.env['website'].get_client_action_url('/')
+        self.start_tour(url, 'website_clone_pages', login="admin")
+
+        pages = Page.search([('name', 'like', 'Test Duplicate')])
+        self.assertEqual(len(pages), 4)
+
+        original_view = View.get_related_views(original_page.view_id.key)
+
+        self.assertEqual(len(original_view), 1)


### PR DESCRIPTION
When a user duplicates a view of a website page and then attempts to open either the original or duplicated view and click on ``edit``, a traceback will appear.

Steps to reproduce:
- Install the ``website`` module
- Website > Site > Pages
- Create one new page > Actions > Duplicate
- Repeat 2-3 times
- Click on the newly created page or a duplicated one > ``Edit``

Traceback : - 
``Expected singleton: ir.ui.view(2224, 2225)``

When duplicating a website page view, we encounter an issue where the ``key`` value remains unchanged, leading to an error. This occurs because, after calling the super in the ``copy_data`` method, the ``key`` is already set on the fields that
are being copied to the new record, and ``website.page`` delegates some of its fields to the ``ir.ui.view`` that it holds.

This commit will fix the above error by calling the ``copy`` method instead of ``copy_data``.

sentry - 4991676595
opw-3936237

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
