### PR TITLE
[FIX] web: searchpanel not fully visible

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.scss
+++ b/addons/web/static/src/search/control_panel/control_panel.scss
@@ -19,7 +19,7 @@
         }
 
         .o_control_panel_actions {
-            min-width: MIN(500px, 33%);
+            min-width: 600px;
         }
     }
 


### PR DESCRIPTION
Before this commit
-The searchpanel wasn't fully visible on large screens when the Comparison 
feature is enabled.

Changes:
-Increased and fixed the minimum width of o_control_panel_actions so the 
 searchpanel appears more to the right.
-Decreased minimum width of o_comparison_menu for the title to go to multiline

Task-3866695

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
