### PR TITLE
[FIX] l10n_no: remove extra repartition lines

### DIFF
--- a/addons/l10n_no/data/account_tax_data.xml
+++ b/addons/l10n_no/data/account_tax_data.xml
@@ -96,22 +96,12 @@
                     'plus_report_expression_ids': [ref('tax_report_line_code_5_tag')],
                 }),
 
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-
                 (0,0, {'repartition_type': 'tax'}),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'repartition_type': 'base',
                     'minus_report_expression_ids': [ref('tax_report_line_code_5_tag')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
                 }),
 
                 (0,0, {'repartition_type': 'tax'}),
@@ -131,22 +121,12 @@
                     'plus_report_expression_ids': [ref('tax_report_line_code_6_tag')],
                 }),
 
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-
                 (0,0, {'repartition_type': 'tax'}),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'repartition_type': 'base',
                     'minus_report_expression_ids': [ref('tax_report_line_code_6_tag')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
                 }),
 
                 (0,0, {'repartition_type': 'tax'}),
@@ -479,22 +459,12 @@
                     'plus_report_expression_ids': [ref('tax_report_line_code_51_tag')],
                 }),
 
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-
                 (0,0, {'repartition_type': 'tax'}),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'repartition_type': 'base',
                     'minus_report_expression_ids': [ref('tax_report_line_code_51_tag')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
                 }),
 
                 (0,0, {'repartition_type': 'tax'}),
@@ -514,22 +484,12 @@
                     'plus_report_expression_ids': [ref('tax_report_line_code_52_tag')],
                 }),
 
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-
                 (0,0, {'repartition_type': 'tax'}),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'repartition_type': 'base',
                     'minus_report_expression_ids': [ref('tax_report_line_code_52_tag')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
                 }),
 
                 (0,0, {'repartition_type': 'tax'}),
@@ -709,22 +669,12 @@
                     'plus_report_expression_ids': [ref('tax_report_line_code_85_tag')],
                 }),
 
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
-                }),
-
                 (0,0, {'repartition_type': 'tax'}),
             ]"/>
             <field name="refund_repartition_line_ids" eval="[(5,0,0),
                 (0,0, {
                     'repartition_type': 'base',
                     'minus_report_expression_ids': [ref('tax_report_line_code_85_tag')],
-                }),
-
-                (0,0, {
-                    'factor_percent': 100,
-                    'repartition_type': 'tax',
                 }),
 
                 (0,0, {'repartition_type': 'tax'}),


### PR DESCRIPTION
In a pervious [forward port](https://github.com/odoo/odoo/pull/112808) for a tax update, some Norwegian taxes got extra lines, resulting in a total of 4 lines per tax in version 15.0, 6 lines in 16.0, and then later 4 lines again in 17.0 after the refactor of 16.2.

The extra lines were not added in the original commit



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
