### PR TITLE
[IMP] l10n_it: Split Periodic & Annual Tax Reports

### DIFF
--- a/addons/l10n_it/__manifest__.py
+++ b/addons/l10n_it/__manifest__.py
@@ -2,7 +2,7 @@
 {
     'name': 'Italy - Accounting',
     'countries': ['it'],
-    'version': '0.6',
+    'version': '0.7',
     'depends': [
         'account',
         'base_iban',
@@ -19,6 +19,14 @@ Italian accounting chart and localization.
     'website': 'https://www.odoo.com/documentation/17.0/applications/finance/fiscal_localizations/italy.html',
     'data': [
         'data/account_account_tag.xml',
+        'data/tax_report/account_monthly_tax_report_data.xml',
+        'data/tax_report/annual_report_sections/va.xml',
+        'data/tax_report/annual_report_sections/ve.xml',
+        'data/tax_report/annual_report_sections/vf.xml',
+        'data/tax_report/annual_report_sections/vh.xml',
+        'data/tax_report/annual_report_sections/vj.xml',
+        'data/tax_report/annual_report_sections/vl.xml',
+        'data/tax_report/account_annual_tax_report_data.xml',
         'data/account_tax_report_data.xml',
         'data/report_invoice.xml',
         'views/account_tax_views.xml'

--- a/addons/l10n_it/data/account_tax_report_data.xml
+++ b/addons/l10n_it/data/account_tax_report_data.xml
@@ -5,6 +5,7 @@
         <field name="root_report_id" ref="account.generic_tax_report"/>
         <field name="country_id" ref="base.it"/>
         <field name="filter_fiscal_position" eval="True"/>
+        <field name="active" eval="False"/>
         <field name="availability_condition">country</field>
         <field name="column_ids">
             <record id="tax_report_vat_balance" model="account.report.column">
@@ -296,11 +297,11 @@
                 <field name="code">VE</field>
                 <field name="children_ids">
                     <record id="tax_report_line_turnover_section_1" model="account.report.line">
-                        <field name="name">Conferimenti di prodotti agricoli e cessioni da agricoltori esonerati (in caso di superamento di 1/3</field>
+                        <field name="name">Contributions of agricultural products and transfers from exempt farmers (in case of exceeding 1/3</field>
                         <field name="code">VE_section1</field>
                         <field name="children_ids">
                             <record id="tax_report_line_ve1" model="account.report.line">
-                                <field name="name">VE1 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 2%</field>
+                                <field name="name">VE1 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 2%</field>
                                 <field name="code">VE1</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve1_tag" model="account.report.expression">
@@ -311,7 +312,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve2" model="account.report.line">
-                                <field name="name">VE2 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 4%</field>
+                                <field name="name">VE2 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 4%</field>
                                 <field name="code">VE2</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve2_tag" model="account.report.expression">
@@ -322,7 +323,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve3" model="account.report.line">
-                                <field name="name">VE3 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 6,4%</field>
+                                <field name="name">VE3 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 6,4%</field>
                                 <field name="code">VE3</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve3_tag" model="account.report.expression">
@@ -333,7 +334,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve4" model="account.report.line">
-                                <field name="name">VE4 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 7,3%</field>
+                                <field name="name">VE4 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 7,3%</field>
                                 <field name="code">VE4</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve4_tag" model="account.report.expression">
@@ -344,7 +345,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve5" model="account.report.line">
-                                <field name="name">VE5 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 7,5%</field>
+                                <field name="name">VE5 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 7,5%</field>
                                 <field name="code">VE5</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve5_tag" model="account.report.expression">
@@ -355,7 +356,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve6" model="account.report.line">
-                                <field name="name">VE6 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,3%</field>
+                                <field name="name">VE6 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 8,3%</field>
                                 <field name="code">VE6</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve6_tag" model="account.report.expression">
@@ -366,7 +367,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve7" model="account.report.line">
-                                <field name="name">VE7 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,5%</field>
+                                <field name="name">VE7 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 8,5%</field>
                                 <field name="code">VE7</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve7_tag" model="account.report.expression">
@@ -377,7 +378,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve8" model="account.report.line">
-                                <field name="name">VE8 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 8,8%</field>
+                                <field name="name">VE8 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 8,8%</field>
                                 <field name="code">VE8</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve8_tag" model="account.report.expression">
@@ -388,7 +389,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve9" model="account.report.line">
-                                <field name="name">VE9 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 9,5%</field>
+                                <field name="name">VE9 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 9,5%</field>
                                 <field name="code">VE9</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve9_tag" model="account.report.expression">
@@ -399,7 +400,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve10" model="account.report.line">
-                                <field name="name">VE10 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 10%</field>
+                                <field name="name">VE10 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 10%</field>
                                 <field name="code">VE10</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve10_tag" model="account.report.expression">
@@ -410,7 +411,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve11" model="account.report.line">
-                                <field name="name">VE11 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione 12,3%</field>
+                                <field name="name">VE11 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 12,3%</field>
                                 <field name="code">VE11</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve11_tag" model="account.report.expression">
@@ -423,11 +424,11 @@
                         </field>
                     </record>
                     <record id="tax_report_line_turnover_section_2" model="account.report.line">
-                        <field name="name">Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili commerciali e professional</field>
+                        <field name="name">Agricultural taxable transactions (Article 34 paragraph 1) and commercial and professional taxable transactions</field>
                         <field name="code">VE_section2</field>
                         <field name="children_ids">
                             <record id="tax_report_line_ve20" model="account.report.line">
-                                <field name="name">VE20 - Operazioni imponibili aliquota 4%</field>
+                                <field name="name">VE20 - Taxable transactions rate 4%</field>
                                 <field name="code">VE20</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve20_tag" model="account.report.expression">
@@ -438,7 +439,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve21" model="account.report.line">
-                                <field name="name">VE21 - Operazioni imponibili aliquota 5%</field>
+                                <field name="name">VE21 - Taxable transactions rate 5%</field>
                                 <field name="code">VE21</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve21_tag" model="account.report.expression">
@@ -449,7 +450,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve22" model="account.report.line">
-                                <field name="name">VE22 - Operazioni imponibili aliquota 10%</field>
+                                <field name="name">VE22 - Taxable transactions rate 10%</field>
                                 <field name="code">VE22</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve22_tag" model="account.report.expression">
@@ -460,7 +461,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve23" model="account.report.line">
-                                <field name="name">VE23 - Operazioni imponibili aliquota 22%</field>
+                                <field name="name">VE23 - Taxable transactions rate 22%</field>
                                 <field name="code">VE23</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve23_tag" model="account.report.expression">
@@ -473,11 +474,11 @@
                         </field>
                     </record>
                     <record id="tax_report_line_turnover_section_3" model="account.report.line">
-                        <field name="name">Totale imponibile e imposta</field>
+                        <field name="name">Total taxable income and tax</field>
                         <field name="code">VE_section3</field>
                         <field name="children_ids">
                             <record id="tax_report_line_ve24" model="account.report.line">
-                                <field name="name">VE24 - Totale righe da VE1 a VE11 e linee da VE20 a VE23</field>
+                                <field name="name">VE24 - Total lines VE1 to VE11 and lines VE20 to VE23</field>
                                 <field name="code">VE24</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve24_tag" model="account.report.expression">
@@ -492,7 +493,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve25" model="account.report.line">
-                                <field name="name">VE25 - Variazioni e arrotondamenti (usare segno &#43;/&#8722;)</field>
+                                <field name="name">VE25 - Variations and rounding (use &#43;/&#8722; sign)</field>
                                 <field name="code">VE25</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve25_tag" model="account.report.expression">
@@ -503,7 +504,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve26" model="account.report.line">
-                                <field name="name">VE26 - Totale VE24 e VE25</field>
+                                <field name="name">VE26 - Total VE24 and VE25</field>
                                 <field name="code">VE26</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve26_tag" model="account.report.expression">
@@ -518,15 +519,15 @@
                         </field>
                     </record>
                     <record id="tax_report_line_turnover_section_4" model="account.report.line">
-                        <field name="name">Altre operazioni</field>
+                        <field name="name">Other operations</field>
                         <field name="code">VE_section4</field>
                         <field name="children_ids">
                             <record id="tax_report_line_ve30" model="account.report.line">
-                                <field name="name">VE30 - Operazioni che concorrono alla formazione del plafond</field>
+                                <field name="name">VE30 - Transactions that contribute to the formation of the ceiling</field>
                                 <field name="code">VE30</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_ve30_I" model="account.report.line">
-                                        <field name="name">VE30_I - Totale</field>
+                                        <field name="name">VE30_I - Total</field>
                                         <field name="code">VE30_I</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve30_i_tag" model="account.report.expression">
@@ -539,7 +540,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve30_ii" model="account.report.line">
-                                        <field name="name">VE30_II - Esportazioni</field>
+                                        <field name="name">VE30_II - Exports</field>
                                         <field name="code">VE30_II</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve30_ii_tag" model="account.report.expression">
@@ -550,7 +551,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve30_iii" model="account.report.line">
-                                        <field name="name">VE30_III - Cessioni intracomunitarie</field>
+                                        <field name="name">VE30_III - Intra-Community supplies</field>
                                         <field name="code">VE30_III</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve30_iii_tag" model="account.report.expression">
@@ -561,7 +562,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve30_iv" model="account.report.line">
-                                        <field name="name">VE30_IV - Cessioni verso San Marino</field>
+                                        <field name="name">VE30_IV - Transfers to San Marino</field>
                                         <field name="code">VE30_IV</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve30_iv_tag" model="account.report.expression">
@@ -572,7 +573,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve30_v" model="account.report.line">
-                                        <field name="name">VE30_V - Operazioni assimilate</field>
+                                        <field name="name">VE30_V - Assimilated operations</field>
                                         <field name="code">VE30_V</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve30_v_tag" model="account.report.expression">
@@ -585,7 +586,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve31" model="account.report.line">
-                                <field name="name">VE31 - Operazioni non imponibili a seguito di dichiarazioni di intento</field>
+                                <field name="name">VE31 - Non-taxable transactions as a result of declarations of intent</field>
                                 <field name="code">VE31</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve31_tag" model="account.report.expression">
@@ -596,7 +597,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve32" model="account.report.line">
-                                <field name="name">VE32 - Altre operazioni non imponibili</field>
+                                <field name="name">VE32 - Other non-taxable transactions</field>
                                 <field name="code">VE32</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve32_tag" model="account.report.expression">
@@ -607,7 +608,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve33" model="account.report.line">
-                                <field name="name">VE33 - Operazioni esenti (art.10</field>
+                                <field name="name">VE33 - Exempt transactions (art.10</field>
                                 <field name="code">VE33</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve33_tag" model="account.report.expression">
@@ -618,7 +619,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve34" model="account.report.line">
-                                <field name="name">VE34 - Operazioni non soggette all’imposta ai sensi degli articoli da 7 a 7-septies</field>
+                                <field name="name">VE34 - Transactions not subject to the tax under Articles 7 to 7-septies</field>
                                 <field name="code">VE34</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve34_tag" model="account.report.expression">
@@ -630,7 +631,7 @@
                             </record>
 
                             <record id="tax_report_line_ve35" model="account.report.line">
-                                <field name="name">VE35 - Operazioni con applicazione del reverse charge interno</field>
+                                <field name="name">VE35 - Transactions with application of internal reverse charge</field>
                                 <field name="code">VE35</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_ve35_I" model="account.report.line">
@@ -649,7 +650,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve35_ii" model="account.report.line">
-                                        <field name="name">VE35_II - Cessioni di rottami e altri materiali di recupero</field>
+                                        <field name="name">VE35_II - Disposal of scrap and other recovered materials</field>
                                         <field name="code">VE35_II</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve35_ii_tag" model="account.report.expression">
@@ -660,7 +661,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve35_iii" model="account.report.line">
-                                        <field name="name">VE35_III - Cessioni di oro e argento puro</field>
+                                        <field name="name">VE35_III - Disposals of pure gold and silver</field>
                                         <field name="code">VE35_III</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve35_iii_tag" model="account.report.expression">
@@ -671,7 +672,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve35_iv" model="account.report.line">
-                                        <field name="name">VE35_IV - Subappalto nel settore edile</field>
+                                        <field name="name">VE35_IV - Subcontracting in the construction industry</field>
                                         <field name="code">VE35_IV</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve35_iv_tag" model="account.report.expression">
@@ -682,7 +683,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve35_v" model="account.report.line">
-                                        <field name="name">VE35_V - Cessioni di fabbricati strumentali</field>
+                                        <field name="name">VE35_V - Disposal of capital buildings</field>
                                         <field name="code">VE35_V</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve35_v_tag" model="account.report.expression">
@@ -693,7 +694,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve35_vi" model="account.report.line">
-                                        <field name="name">VE35_VI - Cessioni di telefoni cellulari</field>
+                                        <field name="name">VE35_VI - Disposal of cell phones</field>
                                         <field name="code">VE35_VI</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve35_vi_tag" model="account.report.expression">
@@ -704,7 +705,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve35_vii" model="account.report.line">
-                                        <field name="name">VE35_VII - Cessioni di prodotti elettronici</field>
+                                        <field name="name">VE35_VII - Disposal of electronic products</field>
                                         <field name="code">VE35_VII</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve35_vii_tag" model="account.report.expression">
@@ -715,7 +716,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve35_viii" model="account.report.line">
-                                        <field name="name">VE35_VIII - Prestazioni comparto edile e settori connessi</field>
+                                        <field name="name">VE35_VIII - Benefits construction and related industries</field>
                                         <field name="code">VE35_VIII</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve35_viii_tag" model="account.report.expression">
@@ -726,7 +727,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve35_ix" model="account.report.line">
-                                        <field name="name">VE35_IX - Operazioni settore energetico</field>
+                                        <field name="name">VE35_IX - Energy sector operations</field>
                                         <field name="code">VE35_IX</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve35_ix_tag" model="account.report.expression">
@@ -739,7 +740,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve36" model="account.report.line">
-                                <field name="name">VE36 - Operazioni non soggette all&quot;imposta effettuate nei confronti dei terremotati</field>
+                                <field name="name">VE36 - Non-taxable transactions made to earthquake victims</field>
                                 <field name="code">VE36</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve36_tag" model="account.report.expression">
@@ -750,7 +751,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve37" model="account.report.line">
-                                <field name="name">VE37 - Operazioni effettuate nell&quot;anno ma con imposta esigibile negli anni successivi</field>
+                                <field name="name">VE37 - Transactions made during the year but with tax due in subsequent years</field>
                                 <field name="code">VE37</field>
                                 <field name="children_ids">
                                     <record id="tax_report_line_ve37_I" model="account.report.line">
@@ -765,7 +766,7 @@
                                         </field>
                                     </record>
                                     <record id="tax_report_line_ve37_ii" model="account.report.line">
-                                        <field name="name">VE37_II - ex art. 32-bis, DL n. 83/2012</field>
+                                        <field name="name">VE37_II - ex art. 32-bis, DL no. 83/2012</field>
                                         <field name="code">VE37_II</field>
                                         <field name="expression_ids">
                                             <record id="tax_report_line_ve37_ii_tag" model="account.report.expression">
@@ -778,7 +779,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve38" model="account.report.line">
-                                <field name="name">VE38 - Operazioni nei confronti di soggetti di cui all&quot;art.17-ter</field>
+                                <field name="name">VE38 - Transactions with parties referred to in Article 17-ter.</field>
                                 <field name="code">VE38</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve38_tag" model="account.report.expression">
@@ -789,7 +790,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve39" model="account.report.line">
-                                <field name="name">VE39 - (meno) Operazioni effettuate in anni precedenti ma con imposta esigibile nel 2022</field>
+                                <field name="name">VE39 - (minus) Transactions made in previous years but with tax due in 2022</field>
                                 <field name="code">VE39</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve39_tag" model="account.report.expression">
@@ -800,7 +801,7 @@
                                 </field>
                             </record>
                             <record id="tax_report_line_ve40" model="account.report.line">
-                                <field name="name">VE40 - (meno) Cessioni di beni ammortizzabili e passaggi interni</field>
+                                <field name="name">VE40 - (minus) Disposals of depreciable assets and internal transfers.</field>
                                 <field name="code">VE40</field>
                                 <field name="expression_ids">
                                     <record id="tax_report_line_ve40_tag" model="account.report.expression">

--- a/addons/l10n_it/data/tax_report/account_annual_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_annual_tax_report_data.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_annual_report_vat" model="account.report">
+        <field name="name">Annual Tax Report</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="country_id" ref="base.it"/>
+        <field name="availability_condition">country</field>
+        <field name="filter_fiscal_position" eval="True"/>
+        <field name="filter_hierarchy">never</field>
+        <field name="use_sections" eval="True"/>
+        <field name="section_report_ids" eval="[Command.set([ref('l10n_it.tax_annual_report_vat_va'),
+                                                            ref('l10n_it.tax_annual_report_vat_ve'),
+                                                            ref('l10n_it.tax_annual_report_vat_vf'),
+                                                            ref('l10n_it.tax_annual_report_vat_vh'),
+                                                            ref('l10n_it.tax_annual_report_vat_vj'),
+                                                            ref('l10n_it.tax_annual_report_vat_vl')])]"/>
+    </record>
+</odoo>

--- a/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
+++ b/addons/l10n_it/data/tax_report/account_monthly_tax_report_data.xml
@@ -1,0 +1,248 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_monthly_report_vat" model="account.report">
+        <field name="name">Monthly VAT Report</field>
+        <field name="root_report_id" ref="account.generic_tax_report"/>
+        <field name="country_id" ref="base.it"/>
+        <field name="filter_fiscal_position" eval="True"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_monthly_report_vat_balance" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="tax_monthly_report_line_operazione_imponibile" model="account.report.line">
+                <field name="name">Taxable transaction</field>
+                <field name="code">h1</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="tax_monthly_report_line_vp2" model="account.report.line">
+                        <field name="name">VP2 - Total active transactions</field>
+                        <field name="code">VP2</field>
+                        <field name="tax_tags_formula">02</field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp3" model="account.report.line">
+                        <field name="name">VP3 - Total passive transactions</field>
+                        <field name="code">VP3</field>
+                        <field name="tax_tags_formula">03</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_monthly_report_line_iva" model="account.report.line">
+                <field name="name">VAT</field>
+                <field name="code">h2</field>
+                <field name="hierarchy_level">0</field>
+                <field name="children_ids">
+                    <record id="tax_monthly_report_line_vp4" model="account.report.line">
+                        <field name="name">VP4 - VAT due</field>
+                        <field name="code">VP4</field>
+                        <field name="tax_tags_formula">4v</field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp5" model="account.report.line">
+                        <field name="name">VP5 - VAT Deductible</field>
+                        <field name="code">VP5</field>
+                        <field name="tax_tags_formula">5v</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_monthly_report_line_saldi_riporti_e_interessi" model="account.report.line">
+                <field name="name">Balances, carryovers and interest</field>
+                <field name="code">h3</field>
+                <field name="children_ids">
+                    <record id="tax_monthly_report_line_vp6" model="account.report.line">
+                        <field name="name">VP6 - VAT due</field>
+                        <field name="code">VP6</field>
+                        <field name="children_ids">
+                            <record id="tax_monthly_report_line_vp6a" model="account.report.line">
+                                <field name="name">VP6a - VAT due (payable)</field>
+                                <field name="code">VP6a</field>
+                                <field name="expression_ids">
+                                    <record id="tax_monthly_report_line_vp6a_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VP4.balance - VP5.balance</field>
+                                        <field name="subformula">if_above(EUR(0))</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp6b" model="account.report.line">
+                                <field name="name">VP6b - VAT due (credit)</field>
+                                <field name="code">VP6b</field>
+                                <field name="expression_ids">
+                                    <record id="tax_monthly_report_line_vp6b_formula" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VP4.balance - VP5.balance</field>
+                                        <field name="subformula">if_below(EUR(0))</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp7" model="account.report.line">
+                        <field name="name">VP7 - Previous period debt not to exceed 25,82</field>
+                        <field name="code">VP7</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp7_tag" model="account.report.expression">
+                                <field name="label">tag</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">vp7</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp7_applied_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_balance</field>
+                                <field name="engine">external</field>
+                                <field name="formula">most_recent</field>
+                                <field name="date_scope">previous_tax_period</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp7_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">VP7._applied_carryover_balance + VP7.tag</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp8" model="account.report.line">
+                        <field name="name">VP8 - Previous period credit</field>
+                        <field name="code">VP8</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp8_tag" model="account.report.expression">
+                                <field name="label">tag</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">vp8</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp8_applied_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_balance</field>
+                                <field name="engine">external</field>
+                                <field name="formula">most_recent</field>
+                                <field name="date_scope">previous_tax_period</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp8_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">VP8._applied_carryover_balance + VP8.tag</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp9" model="account.report.line">
+                        <field name="name">VP9 - Previous year credit</field>
+                        <field name="code">VP9</field>
+                        <field name="expression_ids">
+                            <record id="tax_monthly_report_line_vp9_tag" model="account.report.expression">
+                                <field name="label">tag</field>
+                                <field name="engine">tax_tags</field>
+                                <field name="formula">vp9</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp9_applied_carryover" model="account.report.expression">
+                                <field name="label">_applied_carryover_balance</field>
+                                <field name="engine">external</field>
+                                <field name="formula">most_recent</field>
+                                <field name="date_scope">previous_tax_period</field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp9_balance" model="account.report.expression">
+                                <field name="label">balance</field>
+                                <field name="engine">aggregation</field>
+                                <field name="formula">VP9._applied_carryover_balance + VP9.tag</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp10" model="account.report.line">
+                        <field name="name">VP10 - EU car payments</field>
+                        <field name="code">VP10</field>
+                        <field name="tax_tags_formula">vp10</field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp11" model="account.report.line">
+                        <field name="name">VP11 - Tax Credit</field>
+                        <field name="code">VP11</field>
+                        <field name="tax_tags_formula">vp11</field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp12" model="account.report.line">
+                        <field name="name">VP12 - Interest due for quarterly settlements</field>
+                        <field name="code">VP12</field>
+                        <field name="tax_tags_formula">vp12</field>
+                    </record>
+                    <record id="tax_monthly_report_line_vp13" model="account.report.line">
+                        <field name="name">VP13 - Down payment due</field>
+                        <field name="code">VP13</field>
+                        <field name="tax_tags_formula">vp13</field>
+                    </record>
+                </field>
+            </record>
+            <record id="tax_monthly_report_line_conto_corrente_iva" model="account.report.line">
+                <field name="name">VAT account</field>
+                <field name="code">h4</field>
+                <field name="children_ids">
+                    <record id="tax_monthly_report_line_vp14" model="account.report.line">
+                        <field name="name">VP14 - VAT payable</field>
+                        <field name="code">VP14</field>
+                        <field name="children_ids">
+                            <record id="tax_monthly_report_line_vp14a" model="account.report.line">
+                                <field name="name">VP14a - VAT payable (debit)</field>
+                                <field name="code">VP14a</field>
+                                <field name="expression_ids">
+                                    <record id="tax_monthly_report_line_vp14a_vp4_vp5_dif_pos" model="account.report.expression">
+                                        <field name="label">vp4_vp5_dif_pos</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VP4.balance - VP5.balance</field>
+                                        <field name="subformula">if_above(EUR(0))</field>
+                                    </record>
+                                    <record id="tax_monthly_report_line_vp14a_vp4_vp5_dif_neg" model="account.report.expression">
+                                        <field name="label">vp4_vp5_dif_neg</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VP4.balance - VP5.balance</field>
+                                        <field name="subformula">if_below(EUR(0))</field>
+                                    </record>
+                                    <record id="tax_monthly_report_line_vp14a_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">(VP14a.vp4_vp5_dif_pos + VP7.balance + VP12.balance) - (-VP14a.vp4_vp5_dif_neg + VP8.balance + VP9.balance + VP10.balance + VP11.balance + VP13.balance)</field>
+                                        <field name="subformula">if_above(EUR(0))</field>
+                                    </record>
+                                    <record id="tax_monthly_report_line_vp14a_carryover" model="account.report.expression">
+                                        <field name="label">_carryover_balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VP14a.balance</field>
+                                        <field name="subformula">if_between(EUR(0), EUR(25.82))</field>
+                                        <field name="carryover_target">VP7._applied_carryover_balance</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_monthly_report_line_vp14b" model="account.report.line">
+                                <field name="name">VP14b - VAT payable (credit)</field>
+                                <field name="code">VP14b</field>
+                                <field name="expression_ids">
+                                    <record id="tax_monthly_report_line_vp14b_vp4_vp5_dif_pos" model="account.report.expression">
+                                        <field name="label">vp4_vp5_dif_pos</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VP4.balance - VP5.balance</field>
+                                        <field name="subformula">if_above(EUR(0))</field>
+                                    </record>
+                                    <record id="tax_monthly_report_line_vp14b_vp4_vp5_dif_neg" model="account.report.expression">
+                                        <field name="label">vp4_vp5_dif_neg</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VP4.balance - VP5.balance</field>
+                                        <field name="subformula">if_below(EUR(0))</field>
+                                    </record>
+                                    <record id="tax_monthly_report_line_vp14b_balance" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">(-VP14b.vp4_vp5_dif_neg + VP8.balance + VP9.balance + VP10.balance + VP11.balance + VP13.balance) - (VP14b.vp4_vp5_dif_pos + VP7.balance + VP12.balance)</field>
+                                        <field name="subformula">if_above(EUR(0))</field>
+                                    </record>
+                                    <record id="tax_monthly_report_line_vp14b_carryover" model="account.report.expression">
+                                        <field name="label">_carryover_balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VP14b.balance</field>
+                                        <field name="subformula">if_above(EUR(0))</field>
+                                        <field name="carryover_target">VP8._applied_carryover_balance</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_it/data/tax_report/annual_report_sections/va.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/va.xml
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_annual_report_vat_va" model="account.report">
+        <field name="name">VA VAT Report</field>
+        <field name="sequence">1</field>
+        <field name="country_id" ref="base.it"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_annual_report_vat_balance_va" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+            <record id="tax_annual_report_vat_tax_va" model="account.report.column">
+                <field name="name">Tax</field>
+                <field name="expression_label">tax</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="tax_annual_report_line_dag" model="account.report.line">
+                <field name="name">Business Information</field>
+                <field name="code">VA</field>
+                <field name="children_ids">
+                    <record id="tax_annual_report_line_dag_section1" model="account.report.line">
+                        <field name="name">General analytical data</field>
+                        <field name="code">VA_section1</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_va1" model="account.report.line">
+                                <field name="name">VA1 - To be filled in by the entity of originator in cases of extraordinary transactions</field>
+                                <field name="code">VA1</field>
+                                <field name="children_ids">
+                                    <record id="tax_annual_report_line_va1_4" model="account.report.line">
+                                        <field name="name">VAT/2023 declaration credit transferred</field>
+                                        <field name="code">VA1.4</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_annual_report_line_va1_4_extval" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">external</field>
+                                                <field name="formula">sum</field>
+                                                <field name="subformula">editable;rounding=2</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_va5" model="account.report.line">
+                                <field name="name">VA5 - Terminals for mobile telecommunication radio service with more than 50% deduction</field>
+                                <field name="code">VA5</field>
+                                <field name="children_ids">
+                                    <record id="tax_annual_report_line_va5_section_1" model="account.report.line">
+                                        <field name="name">Equipment purchases</field>
+                                        <field name="code">VA5_AA</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_annual_report_line_va5_aa_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">external</field>
+                                                <field name="formula">sum</field>
+                                                <field name="subformula">editable;rounding=2</field>
+                                            </record>
+                                            <record id="tax_annual_report_line_va5_aa_tax" model="account.report.expression">
+                                                <field name="label">tax</field>
+                                                <field name="engine">aggregation</field>
+                                                <field name="formula">VA5_AA.balance * 0.5</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                    <record id="tax_annual_report_line_va5_section_2" model="account.report.line">
+                                        <field name="name">Management services</field>
+                                        <field name="code">VA5_SDG</field>
+                                        <field name="expression_ids">
+                                            <record id="tax_annual_report_line_va5_sdg_tag" model="account.report.expression">
+                                                <field name="label">balance</field>
+                                                <field name="engine">external</field>
+                                                <field name="formula">sum</field>
+                                                <field name="subformula">editable;rounding=2</field>
+                                            </record>
+                                            <record id="tax_annual_report_line_va5_sdg_tax" model="account.report.expression">
+                                                <field name="label">tax</field>
+                                                <field name="engine">aggregation</field>
+                                                <field name="formula">VA5_SDG.balance * 0.5</field>
+                                            </record>
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_dag_section2" model="account.report.line">
+                        <field name="name">Summary data for all activities</field>
+                        <field name="code">VA_section2</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_va16" model="account.report.line">
+                                <field name="name">VA11 - Data on amounts suspended as a result of the health emergency by COVID-19</field>
+                                <field name="code">VA11</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_va16_extval" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_va12" model="account.report.line">
+                                <field name="name">VA12 - Reserved for indication of surplus credit of former parent companies to be guaranteed</field>
+                                <field name="code">VA12</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_va12_extval" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_va13" model="account.report.line">
+                                <field name="name">VA13 - Transactions carried out with respect to condominiums</field>
+                                <field name="code">VA13</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_va13_extval" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">external</field>
+                                        <field name="formula">sum</field>
+                                        <field name="subformula">editable;rounding=2</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_it/data/tax_report/annual_report_sections/ve.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/ve.xml
@@ -1,0 +1,477 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_annual_report_vat_ve" model="account.report">
+        <field name="name">VE VAT Report</field>
+        <field name="sequence">1</field>
+        <field name="country_id" ref="base.it"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_annual_report_vat_balance_ve" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+            <record id="tax_annual_report_vat_tax_ve" model="account.report.column">
+                <field name="name">Tax</field>
+                <field name="expression_label">tax</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="tax_annual_report_line_turnover" model="account.report.line">
+                <field name="name">Turnover</field>
+                <field name="code">VE</field>
+                <field name="children_ids">
+                    <record id="tax_annual_report_line_turnover_section_1" model="account.report.line">
+                        <field name="name">Contributions of agricultural products and transfers from exempt farmers (in case of exceeding 1/3</field>
+                        <field name="code">VE_section1</field>
+                        <field name="foldable" eval="True"/>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_ve1" model="account.report.line">
+                                <field name="name">VE1 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 2%</field>
+                                <field name="code">VE1</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve1_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve1</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve1_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE1.balance * 0.02</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve2" model="account.report.line">
+                                <field name="name">VE2 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 4%</field>
+                                <field name="code">VE2</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve2_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve2</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve2_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE2.balance * 0.04</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve3" model="account.report.line">
+                                <field name="name">VE3 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 6,4%</field>
+                                <field name="code">VE3</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve3_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve3</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve3_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE3.balance * 0.064</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve4" model="account.report.line">
+                                <field name="name">VE4 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 7,3%</field>
+                                <field name="code">VE4</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve4_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve4</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve4_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE4.balance * 0.07</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve5" model="account.report.line">
+                                <field name="name">VE5 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 7,5%</field>
+                                <field name="code">VE5</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve5_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve5</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve5_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE5.balance * 0.073</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve6" model="account.report.line">
+                                <field name="name">VE6 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 8,3%</field>
+                                <field name="code">VE6</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve6_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve6</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve6_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE6.balance * 0.075</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve7" model="account.report.line">
+                                <field name="name">VE7 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 8,5%</field>
+                                <field name="code">VE7</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve7_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve7</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve7_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE7.balance * 0.083</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve8" model="account.report.line">
+                                <field name="name">VE8 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 8,8%</field>
+                                <field name="code">VE8</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve8_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve8</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve8_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE8.balance * 0.085</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve9" model="account.report.line">
+                                <field name="name">VE9 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 9,5%</field>
+                                <field name="code">VE9</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve9_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve9</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve9_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE9.balance * 0.088</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve10" model="account.report.line">
+                                <field name="name">VE10 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 10%</field>
+                                <field name="code">VE10</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve10_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve10</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve10_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE10.balance * 0.10</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve11" model="account.report.line">
+                                <field name="name">VE11 - Transfers to cooperatives art.34 paragraph 2 with compensation percentage 12,3%</field>
+                                <field name="code">VE11</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve11_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve11</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve11_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE11.balance * 0.123</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_turnover_section_2" model="account.report.line">
+                        <field name="name">Agricultural taxable transactions (Article 34 paragraph 1) and commercial and professional taxable transactions</field>
+                        <field name="code">VE_section2</field>
+                        <field name="foldable" eval="True"/>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_ve20" model="account.report.line">
+                                <field name="name">VE20 - Taxable transactions rate 4%</field>
+                                <field name="code">VE20</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve20_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve20</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve20_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE20.balance * 0.4</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve21" model="account.report.line">
+                                <field name="name">VE21 - Taxable transactions rate 5%</field>
+                                <field name="code">VE21</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve21_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve21</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve21_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE21.balance * 0.5</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve22" model="account.report.line">
+                                <field name="name">VE22 - Taxable transactions rate 10%</field>
+                                <field name="code">VE22</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve22_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve22</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve22_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE22.balance * 0.10</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve23" model="account.report.line">
+                                <field name="name">VE23 - Taxable transactions rate 22%</field>
+                                <field name="code">VE23</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve23_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">ve23</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve23_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE23.balance * 0.22</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_turnover_section_3" model="account.report.line">
+                        <field name="name">Total taxable income and tax</field>
+                        <field name="code">VE_section3</field>
+                        <field name="foldable" eval="True"/>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_ve24" model="account.report.line">
+                                <field name="name">VE24 - Total lines VE1 to VE11 and lines VE20 to VE23</field>
+                                <field name="code">VE24</field>
+                                <field name="aggregation_formula">
+                                            VE1.balance + VE2.balance + VE3.balance + VE4.balance + VE5.balance
+                                            + VE6.balance + VE7.balance + VE8.balance + VE9.balance + VE10.balance
+                                            + VE11.balance + VE20.balance + VE21.balance + VE22.balance + VE23.balance
+                                </field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_ve24_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">
+                                            VE1.tax + VE2.tax + VE3.tax + VE4.tax + VE5.tax
+                                            + VE6.tax + VE7.tax + VE8.tax + VE9.tax + VE10.tax
+                                            + VE11.tax + VE20.tax + VE21.tax + VE22.tax + VE23.tax
+                                        </field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve25" model="account.report.line">
+                                <field name="name">VE25 - Variations and rounding (use &#43;/&#8722; sign)</field>
+                                <field name="code">VE25</field>
+                                <field name="tax_tags_formula">ve25</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve26" model="account.report.line">
+                                <field name="name">VE26 - Total VE24 and VE25</field>
+                                <field name="code">VE26</field>
+                                <field name="aggregation_formula">VE24.balance + VE25.balance</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_turnover_section_4" model="account.report.line">
+                        <field name="name">Other operations</field>
+                        <field name="code">VE_section4</field>
+                        <field name="foldable" eval="True"/>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_ve30" model="account.report.line">
+                                <field name="name">VE30 - Transactions that contribute to the formation of the ceiling</field>
+                                <field name="code">VE30</field>
+                                <field name="children_ids">
+                                    <record id="tax_annual_report_line_ve30_I" model="account.report.line">
+                                        <field name="name">VE30_I - Total</field>
+                                        <field name="code">VE30_I</field>
+                                        <field name="aggregation_formula">VE30_II.balance + VE30_III.balance + VE30_IV.balance + VE30_V.balance</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve30_ii" model="account.report.line">
+                                        <field name="name">VE30_II - Exports</field>
+                                        <field name="code">VE30_II</field>
+                                        <field name="tax_tags_formula">ve30_ii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve30_iii" model="account.report.line">
+                                        <field name="name">VE30_III - Intra-Community supplies</field>
+                                        <field name="code">VE30_III</field>
+                                        <field name="tax_tags_formula">ve30_iii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve30_iv" model="account.report.line">
+                                        <field name="name">VE30_IV - Transfers to San Marino</field>
+                                        <field name="code">VE30_IV</field>
+                                        <field name="tax_tags_formula">ve30_iv</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve30_v" model="account.report.line">
+                                        <field name="name">VE30_V - Assimilated operations</field>
+                                        <field name="code">VE30_V</field>
+                                        <field name="tax_tags_formula">ve30_v</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve31" model="account.report.line">
+                                <field name="name">VE31 - Non-taxable transactions as a result of declarations of intent</field>
+                                <field name="code">VE31</field>
+                                <field name="tax_tags_formula">ve31</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve32" model="account.report.line">
+                                <field name="name">VE32 - Other non-taxable transactions</field>
+                                <field name="code">VE32</field>
+                                <field name="tax_tags_formula">ve32</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve33" model="account.report.line">
+                                <field name="name">VE33 - Exempt transactions (art.10</field>
+                                <field name="code">VE33</field>
+                                <field name="tax_tags_formula">ve33</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve34" model="account.report.line">
+                                <field name="name">VE34 - Transactions not subject to the tax under Articles 7 to 7-septies</field>
+                                <field name="code">VE34</field>
+                                <field name="tax_tags_formula">ve34</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve35" model="account.report.line">
+                                <field name="name">VE35 - Transactions with application of internal reverse charge</field>
+                                <field name="code">VE35</field>
+                                <field name="children_ids">
+                                    <record id="tax_annual_report_line_ve35_I" model="account.report.line">
+                                        <field name="name">VE35_I - Total</field>
+                                        <field name="code">VE35_I</field>
+                                        <field name="aggregation_formula">
+                                            VE35_II.balance + VE35_III.balance + VE35_IV.balance
+                                            + VE35_V.balance + VE35_VI.balance + VE35_VII.balance
+                                            + VE35_VIII.balance + VE35_IX.balance
+                                        </field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve35_ii" model="account.report.line">
+                                        <field name="name">VE35_II - Disposal of scrap and other recovered materials</field>
+                                        <field name="code">VE35_II</field>
+                                        <field name="tax_tags_formula">ve35_ii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve35_iii" model="account.report.line">
+                                        <field name="name">VE35_III - Disposals of pure gold and silver</field>
+                                        <field name="code">VE35_III</field>
+                                        <field name="tax_tags_formula">ve35_iii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve35_iv" model="account.report.line">
+                                        <field name="name">VE35_IV - Subcontracting in the construction industry</field>
+                                        <field name="code">VE35_IV</field>
+                                        <field name="tax_tags_formula">ve35_iv</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve35_v" model="account.report.line">
+                                        <field name="name">VE35_V - Disposal of capital buildings</field>
+                                        <field name="code">VE35_V</field>
+                                        <field name="tax_tags_formula">ve35_v</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve35_vi" model="account.report.line">
+                                        <field name="name">VE35_VI - Disposal of cell phones</field>
+                                        <field name="code">VE35_VI</field>
+                                        <field name="tax_tags_formula">ve35_vi</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve35_vii" model="account.report.line">
+                                        <field name="name">VE35_VII - Disposal of electronic products</field>
+                                        <field name="code">VE35_VII</field>
+                                        <field name="tax_tags_formula">ve35_vii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve35_viii" model="account.report.line">
+                                        <field name="name">VE35_VIII - Benefits construction and related industries</field>
+                                        <field name="code">VE35_VIII</field>
+                                        <field name="tax_tags_formula">ve35_viii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve35_ix" model="account.report.line">
+                                        <field name="name">VE35_IX - Energy sector operations</field>
+                                        <field name="code">VE35_IX</field>
+                                        <field name="tax_tags_formula">ve35_ix</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve36" model="account.report.line">
+                                <field name="name">VE36 - Non-taxable transactions made to earthquake victims</field>
+                                <field name="code">VE36</field>
+                                <field name="tax_tags_formula">ve36</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve37" model="account.report.line">
+                                <field name="name">VE37 - Transactions made during the year but with tax due in subsequent years</field>
+                                <field name="code">VE37</field>
+                                <field name="children_ids">
+                                    <record id="tax_annual_report_line_ve37_I" model="account.report.line">
+                                        <field name="name">VE37_I - Total</field>
+                                        <field name="code">VE37_I</field>
+                                        <field name="tax_tags_formula">ve37_i</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_ve37_ii" model="account.report.line">
+                                        <field name="name">VE37_II - ex art. 32-bis, DL no. 83/2012</field>
+                                        <field name="code">VE37_II</field>
+                                        <field name="tax_tags_formula">ve37_ii</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_ve38" model="account.report.line">
+                                <field name="name">VE38 - Transactions with parties referred to in Article 17-ter.</field>
+                                <field name="code">VE38</field>
+                                <field name="tax_tags_formula">ve38</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve39" model="account.report.line">
+                                <field name="name">VE39 - (minus) Transactions made in previous years but with tax due in 2022</field>
+                                <field name="code">VE39</field>
+                                <field name="tax_tags_formula">ve39</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve40" model="account.report.line">
+                                <field name="name">VE40 - (minus) Disposals of depreciable assets and internal transfers.</field>
+                                <field name="code">VE40</field>
+                                <field name="tax_tags_formula">ve40</field>
+                            </record>
+                            <record id="tax_annual_report_line_ve45" model="account.report.line">
+                                <field name="name">VE50 - TURNOVER</field>
+                                <field name="code">VE50</field>
+                                <field name="aggregation_formula">
+                                    VE24.balance + VE30_I.balance + VE31.balance
+                                    + VE32.balance + VE33.balance + VE34.balance
+                                    + VE35_I.balance + VE36.balance + VE37_I.balance
+                                    + VE37_II.balance + VE38.balance
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_it/data/tax_report/annual_report_sections/vf.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/vf.xml
@@ -1,0 +1,822 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_annual_report_vat_vf" model="account.report">
+        <field name="name">VF VAT Report</field>
+        <field name="sequence">1</field>
+        <field name="country_id" ref="base.it"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_annual_report_vat_balance_vf" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+            <record id="tax_annual_report_vat_tax_vf" model="account.report.column">
+                <field name="name">Tax</field>
+                <field name="expression_label">tax</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="tax_annual_report_line_passive_op" model="account.report.line">
+                <field name="name">Passive operations and VAT deduction allowed</field>
+                <field name="code">VF</field>
+                <field name="children_ids">
+                    <record id="tax_annual_report_line_passive_op_1" model="account.report.line">
+                        <field name="name">Purchases (Domestic, intra-Community and imports)</field>
+                        <field name="code">VF_1</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_VF1" model="account.report.line">
+                                <field name="name">VF1 - compensation percentage 2%</field>
+                                <field name="code">VF1</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF1_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf1</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF1_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF1.balance * 0.02</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF2" model="account.report.line">
+                                <field name="name">VF2 - compensation percentage 4%</field>
+                                <field name="code">VF2</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF2_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf2</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF2_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF2.balance * 0.04</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF3" model="account.report.line">
+                                <field name="name">VF3 - compensation percentage 5%</field>
+                                <field name="code">VF3</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF3_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf3</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF3_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF3.balance * 0.5</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF4" model="account.report.line">
+                                <field name="name">VF4 - compensation percentage 6,4%</field>
+                                <field name="code">VF4</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF4_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf4</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF4_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF4.balance * 0.064</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF5" model="account.report.line">
+                                <field name="name">VF5 - compensation percentage 7%</field>
+                                <field name="code">VF5</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF5_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf5</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF5_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF5.balance * 0.07</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF6" model="account.report.line">
+                                <field name="name">VF6 - compensation percentage 7,3%</field>
+                                <field name="code">VF6</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF6_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf6</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF6_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF6.balance * 0.073</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF7" model="account.report.line">
+                                <field name="name">VF7 - compensation percentage 7,5%</field>
+                                <field name="code">VF7</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF7_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf7</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF7_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF7.balance * 0.075</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF8" model="account.report.line">
+                                <field name="name">VF8 - compensation percentage 8,3%</field>
+                                <field name="code">VF8</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF8_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf8</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF8_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF8.balance * 0.083</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF9" model="account.report.line">
+                                <field name="name">VF9 - compensation percentage 8,5%</field>
+                                <field name="code">VF9</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF9_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf9</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF9_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF9.balance * 0.085</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF10" model="account.report.line">
+                                <field name="name">VF10 - compensation percentage 8,8%</field>
+                                <field name="code">VF10</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF10_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf10</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF10_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF10.balance * 0.088</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF11" model="account.report.line">
+                                <field name="name">VF11 - compensation percentage 10%</field>
+                                <field name="code">VF11</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF11_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf11</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF11_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF11.balance * 0.10</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF12" model="account.report.line">
+                                <field name="name">VF12 - compensation percentage 12,3%</field>
+                                <field name="code">VF12</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF12_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf12</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF12_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF12.balance * 0.123</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF13" model="account.report.line">
+                                <field name="name">VF13 - compensation percentage 22%</field>
+                                <field name="code">VF13</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF13_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf13</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF13_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF13.balance * 0.22</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF17" model="account.report.line">
+                                <field name="name">VF17 - Purchases and imports without payment of tax, with use of the ceiling</field>
+                                <field name="code">VF17</field>
+                                <field name="tax_tags_formula">vf17</field>
+                            </record>
+                            <record id="tax_annual_report_line_VF18_I" model="account.report.line">
+                                <field name="name">VF18 - Other non-tax purchases, not subject to tax and relating to certain special regimes</field>
+                                <field name="code">VF18_I</field>
+                                <field name="tax_tags_formula">vf18_I</field>
+                            </record>
+                            <record id="tax_annual_report_line_VF18_II" model="account.report.line">
+                                <field name="name">VF18 - Exempt purchases and imports not subject to the tax</field>
+                                <field name="code">VF18_II</field>
+                                <field name="tax_tags_formula">vf18_II</field>
+                            </record>
+                            <record id="tax_annual_report_line_VF19" model="account.report.line">
+                                <field name="name">VF19 - Purchases from subjects who have made use of concessional schemes</field>
+                                <field name="code">VF19</field>
+                                <field name="tax_tags_formula">vf19</field>
+                            </record>
+                            <record id="tax_annual_report_line_VF20" model="account.report.line">
+                                <field name="name">VF20 - Purchases and imports not subject to the tax made by earthquake victims</field>
+                                <field name="code">VF20</field>
+                                <field name="tax_tags_formula">vf20</field>
+                            </record>
+                            <record id="tax_annual_report_line_VF21" model="account.report.line">
+                                <field name="name">VF21 - Purchases and imports for which the deduction is excluded or reduced (art. 19-bis1)</field>
+                                <field name="code">VF21</field>
+                                <field name="tax_tags_formula">vf21</field>
+                            </record>
+                            <record id="tax_annual_report_line_VF22" model="account.report.line">
+                                <field name="name">VF22 - Purchases and imports for which the deduction is not permitted</field>
+                                <field name="code">VF22</field>
+                                <field name="tax_tags_formula">vf22</field>
+                            </record>
+                            <record id="tax_annual_report_line_VF23" model="account.report.line">
+                                <field name="name">VF23 - Purchases recorded in the year but with tax deduction deferred to subsequent years</field>
+                                <field name="code">VF23</field>
+                                <field name="tax_tags_formula">vf23</field>
+                            </record>
+                            <record id="tax_annual_report_line_VF24" model="account.report.line">
+                                <field name="name">VF24 - Purchases recorded in previous years but with tax</field>
+                                <field name="code">VF24</field>
+                                <field name="tax_tags_formula">vf24</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_passive_op_2" model="account.report.line">
+                        <field name="name">Total purchases and imports, total tax, purchases intra-community, imports and purchases</field>
+                        <field name="code">VF_2</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_VF25" model="account.report.line">
+                                <field name="name">VF25 - Total purchases and imports</field>
+                                <field name="code">VF25</field>
+                                <field name="aggregation_formula">VF1.tax + VF2.tax + VF3.tax + VF4.tax + VF5.tax + VF6.tax
+                                                    + VF7.tax + VF8.tax + VF9.tax + VF10.tax + VF11.tax + VF12.tax
+                                                    + VF13.tax + VF17.balance + VF18_I.balance + VF18_II.balance + VF19.balance
+                                                    + VF20.balance + VF21.balance + VF22.balance + VF23.balance - VF24.balance</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF25_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF1.tax + VF2.tax + VF3.tax + VF4.tax + VF5.tax + VF6.tax + VF7.tax
+                                                            + VF8.tax + VF9.tax + VF10.tax + VF11.tax + VF12.tax + VF13.tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF26" model="account.report.line">
+                                <field name="name">VF26 - Tax variations and roundings (indicate with the +/- sign)</field>
+                                <field name="code">VF26</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF26_tag" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf26</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF27" model="account.report.line">
+                                <field name="name">VF27 - Total tax on taxable purchases and imports</field>
+                                <field name="code">VF27</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF27_tag" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF25.tax + VF26.tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF28_I" model="account.report.line">
+                                <field name="name">VF28 - Intra-community purchases</field>
+                                <field name="code">VF28_I</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF28_I_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf28_i base</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF28_I_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf28_i tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF28_II" model="account.report.line">
+                                <field name="name">VF28 - Imports</field>
+                                <field name="code">VF28_II</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF28_II_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf28_ii base</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF28_II_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf28_ii tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF28_III" model="account.report.line">
+                                <field name="name">VF28 - Purchases from San Marino</field>
+                                <field name="code">VF28_III</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF28_III_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf28_iii base</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF28_III_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf28_iii tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF29" model="account.report.line">
+                                <field name="name">VF29 - Total distribution of purchases and imports</field>
+                                <field name="code">VF29</field>
+                                <field name="children_ids">
+                                    <record id="tax_annual_report_line_VF29_I" model="account.report.line">
+                                        <field name="name">Depreciable assets</field>
+                                        <field name="code">VF29_I</field>
+                                        <field name="tax_tags_formula">vf29_i</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF29_II" model="account.report.line">
+                                        <field name="name">Non-depreciable capital goods</field>
+                                        <field name="code">VF29_II</field>
+                                        <field name="tax_tags_formula">vf29_ii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF29_III" model="account.report.line">
+                                        <field name="name">Goods intended for resale or for the production of goods and services</field>
+                                        <field name="code">VF29_III</field>
+                                        <field name="tax_tags_formula">vf29_iii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF29_IV" model="account.report.line">
+                                        <field name="name">Other purchases and imports</field>
+                                        <field name="code">VF29_IV</field>
+                                        <field name="tax_tags_formula">vf29_iv</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_passive_op_3a" model="account.report.line">
+                        <field name="name">Exempt operations</field>
+                        <field name="code">VF_3A</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_VF31" model="account.report.line">
+                                <field name="name">VF31 - Purchases intended for occasional taxable transactions</field>
+                                <field name="code">VF31</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF31_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf31</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF31_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF1.tax + VF2.tax + VF3.tax + VF4.tax + VF5.tax + VF6.tax + VF7.tax
+                                                            + VF8.tax + VF9.tax + VF10.tax + VF11.tax + VF12.tax + VF13.tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF34" model="account.report.line">
+                                <field name="name">VF34 - Data for calculating the deduction percentage</field>
+                                <field name="code">VF34</field>
+                                <field name="children_ids">
+                                    <record id="tax_annual_report_line_VF34_I" model="account.report.line">
+                                        <field name="name">Exempt transactions relating to gold from investments made by the subjects referred to in the art. 19, co. 3, letter. d)</field>
+                                        <field name="code">VF34_I</field>
+                                        <field name="tax_tags_formula">vf34_i</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF34_II" model="account.report.line">
+                                        <field name="name">Exempt operations referred to in nos. from 1 to 9 of the art. 10 not included in their own business of the company or ancillary to taxable operations</field>
+                                        <field name="code">VF34_II</field>
+                                        <field name="tax_tags_formula">vf34_ii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF34_III" model="account.report.line">
+                                        <field name="name">Exempt operations referred to in art. 10, n. 27-quinquies</field>
+                                        <field name="code">VF34_III</field>
+                                        <field name="tax_tags_formula">vf34_iii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF34_IV" model="account.report.line">
+                                        <field name="name">Depreciable assets and transfers interiors exempt</field>
+                                        <field name="code">VF34_IV</field>
+                                        <field name="tax_tags_formula">vf34_iv</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF34_V" model="account.report.line">
+                                        <field name="name">Operations not subject</field>
+                                        <field name="code">VF34_V</field>
+                                        <field name="tax_tags_formula">vf34_v</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF34_VI" model="account.report.line">
+                                        <field name="name">Operations not subject to art. 74, co. 1</field>
+                                        <field name="code">VF34_VI</field>
+                                        <field name="tax_tags_formula">vf34_vi</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF34_VII" model="account.report.line">
+                                        <field name="name">Exempt operations art. 19, co. 3, letter. a-bis) and d-bis)</field>
+                                        <field name="code">VF34_VII</field>
+                                        <field name="tax_tags_formula">vf34_vii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF34_VIII" model="account.report.line">
+                                        <field name="name">Article operations 7 to 7-septies without right to deduction</field>
+                                        <field name="code">VF34_VIII</field>
+                                        <field name="tax_tags_formula">vf34_viii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF34_IX" model="account.report.line">
+                                        <field name="name">Operations exempted by law no. 178/2020</field>
+                                        <field name="code">VF34_IX</field>
+                                        <field name="tax_tags_formula">vf34_ix</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF35" model="account.report.line">
+                                <field name="name">VF35 - VAT not paid on purchases and imports indicated</field>
+                                <field name="code">VF35</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF35_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf35</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF36" model="account.report.line">
+                                <field name="name">VF36 - VAT deductible for gold purchases made by parties other than producers and transformers pursuant to art. 19, paragraph 5 bis</field>
+                                <field name="code">VF36</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF36_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf36</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF37" model="account.report.line">
+                                <field name="name">VF37 - VAT allowed as deduction</field>
+                                <field name="code">VF37</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF37_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">((VF27.tax + VF35.tax - VF36.tax) * (
+                                            VF34_I.balance + VF34_II.balance + VF34_III.balance + VF34_IV.balance + VF34_V.balance +
+                                            VF34_VI.balance + VF34_VII.balance + VF34_VIII.balance + VF34_IX.balance
+                                        )) - VF35.tax + VF36.tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_passive_op_3b" model="account.report.line">
+                        <field name="name">Agricultural businesses (art.34)</field>
+                        <field name="code">VF_3B</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_VF38" model="account.report.line">
+                                <field name="name">VF38 - Reserved for mixed agricultural enterprises</field>
+                                <field name="code">VF38</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF38_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf38 Base</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF38_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf38 Tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF39" model="account.report.line">
+                                <field name="name">VF39 - compensation percentage 2%</field>
+                                <field name="code">VF39</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF39_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf39</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF39_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF39.balance * 0.02</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF40" model="account.report.line">
+                                <field name="name">VF40 - compensation percentage 4%</field>
+                                <field name="code">VF40</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF40_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf40</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF40_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF40.balance * 0.04</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF41" model="account.report.line">
+                                <field name="name">VF41 - compensation percentage 6.4%</field>
+                                <field name="code">VF41</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF41_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf41</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF41_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF41.balance * 0.064</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF42" model="account.report.line">
+                                <field name="name">VF42 - compensation percentage 7%</field>
+                                <field name="code">VF42</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF42_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf42</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF42_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF42.balance * 0.07</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF43" model="account.report.line">
+                                <field name="name">VF43 - compensation percentage 7,3%</field>
+                                <field name="code">VF43</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF43_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf43</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF43_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF43.balance * 0.073</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF44" model="account.report.line">
+                                <field name="name">VF44 - compensation percentage 7,5%</field>
+                                <field name="code">VF44</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF44_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf44</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF44_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF44.balance * 0.075</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF45" model="account.report.line">
+                                <field name="name">VF45 - compensation percentage 8,3%</field>
+                                <field name="code">VF45</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF45_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf45</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF45_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF45.balance * 0.083</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF46" model="account.report.line">
+                                <field name="name">VF46 - compensation percentage 8,5%</field>
+                                <field name="code">VF46</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF46_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf46</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF46_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF46.balance * 0.085</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF47" model="account.report.line">
+                                <field name="name">VF47 - compensation percentage 9.5%</field>
+                                <field name="code">VF47</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF47_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf47</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF47_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF47.balance * 0.095</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF48" model="account.report.line">
+                                <field name="name">VF48 - compensation percentage 10%</field>
+                                <field name="code">VF48</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF48_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf48</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF48_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF48.balance * 0.10</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF49" model="account.report.line">
+                                <field name="name">VF49 - compensation percentage 12,3%</field>
+                                <field name="code">VF49</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF49_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf49</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF49_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF49.balance * 0.123</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF51" model="account.report.line">
+                                <field name="name">VF51 - Tax variations and roundings (indicate with the +/- sign)</field>
+                                <field name="code">VF51</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF51_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf51</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF52" model="account.report.line">
+                                <field name="name">VF52 - TOTALS Algebraic sum of lines from VF39 to VF51</field>
+                                <field name="code">VF52</field>
+                                <field name="aggregation_formula">VF39.balance + VF40.balance + VF41.balance + VF42.balance + VF43.balance +
+                                                        VF44.balance + VF45.balance + VF46.balance + VF47.balance + VF48.balance + 
+                                                        VF49.balance + VF51.tax</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF52_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF39.tax + VF40.tax + VF41.tax + VF42.tax + VF43.tax +
+                                                              VF44.tax + VF45.tax + VF46.tax + VF47.tax + VF48.tax +
+                                                              VF49.tax + VF51.tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF53" model="account.report.line">
+                                <field name="name">VF53 - Deductible VAT charged to the operations referred to in line VF38</field>
+                                <field name="code">VF53</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF53_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf53</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF54" model="account.report.line">
+                                <field name="name">VF54 - Deductible amount for transfers, including intra-community, of agricultural products referred to in art. 34</field>
+                                <field name="code">VF54</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF54_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf54</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF55" model="account.report.line">
+                                <field name="name">VF55 - TOTAL VAT allowed as deduction</field>
+                                <field name="code">VF55</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF55_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF52.tax + VF53.tax + VF54.tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_passive_op_3c" model="account.report.line">
+                        <field name="name">Special cases</field>
+                        <field name="code">VF_3C</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_VF62" model="account.report.line">
+                                <field name="name">VF62 - Reserved for agricultural businesses</field>
+                                <field name="code">VF62</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF62_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">vf62</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_VF62_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF62.balance * 0.5</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_passive_op_4" model="account.report.line">
+                        <field name="name">VAT allowed as deduction</field>
+                        <field name="code">VF_4</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_VF70" model="account.report.line">
+                                <field name="name">VF70 - TOTAL adjustments (indicate with the +/- sign)</field>
+                                <field name="code">VF70</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF70_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">tax_tags</field>
+                                        <field name="formula">VF70</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_VF71" model="account.report.line">
+                                <field name="name">VF71 - VAT allowed as deduction</field>
+                                <field name="code">VF71</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_VF71_tax" model="account.report.expression">
+                                        <field name="label">tax</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF26.tax + VF27.tax + VF37.tax + VF55.tax + VF70.tax</field>
+                                    </record>
+                                </field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_it/data/tax_report/annual_report_sections/vh.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/vh.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_annual_report_vat_vh" model="account.report">
+        <field name="name">VH VAT Report</field>
+        <field name="sequence">1</field>
+        <field name="country_id" ref="base.it"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_annual_report_vat_balance_vh" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="tax_annual_report_line_vari_communi_perd" model="account.report.line">
+                <field name="name">Changes in reporting periodicals</field>
+                <field name="code">VH</field>
+                <field name="children_ids">
+                    <record id="tax_annual_report_line_vh1" model="account.report.line">
+                        <field name="name">VH1 - January</field>
+                        <field name="code">VH1</field>
+                        <field name="tax_tags_formula">vh1</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh2" model="account.report.line">
+                        <field name="name">VH2 - February</field>
+                        <field name="code">VH2</field>
+                        <field name="tax_tags_formula">v2</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh3" model="account.report.line">
+                        <field name="name">VH3 - March</field>
+                        <field name="code">VH3</field>
+                        <field name="tax_tags_formula">vh3</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh4" model="account.report.line">
+                        <field name="name">VH4 - QUARTER I</field>
+                        <field name="code">VH4</field>
+                        <field name="aggregation_formula">VH1.balance + VH2.balance + VH3.balance</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh5" model="account.report.line">
+                        <field name="name">VH5 - April</field>
+                        <field name="code">VH5</field>
+                        <field name="tax_tags_formula">vh5</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh6" model="account.report.line">
+                        <field name="name">VH6 - May</field>
+                        <field name="code">VH6</field>
+                        <field name="tax_tags_formula">vh6</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh7" model="account.report.line">
+                        <field name="name">VH7 - June</field>
+                        <field name="code">VH7</field>
+                        <field name="tax_tags_formula">vh7</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh8" model="account.report.line">
+                        <field name="name">VH8 - QUARTER II</field>
+                        <field name="code">VH8</field>
+                        <field name="aggregation_formula">VH5.balance + VH6.balance + VH7.balance</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh9" model="account.report.line">
+                        <field name="name">VH9 - July</field>
+                        <field name="code">VH9</field>
+                        <field name="tax_tags_formula">vh9</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh10" model="account.report.line">
+                        <field name="name">VH10 - August</field>
+                        <field name="code">VH10</field>
+                        <field name="tax_tags_formula">vh10</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh11" model="account.report.line">
+                        <field name="name">VH11 - September</field>
+                        <field name="code">VH11</field>
+                        <field name="tax_tags_formula">vh11</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh12" model="account.report.line">
+                        <field name="name">VH12 - QUARTER III</field>
+                        <field name="code">VH12</field>
+                        <field name="aggregation_formula">VH9.balance + VH10.balance + VH11.balance</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh13" model="account.report.line">
+                        <field name="name">VH13 - October</field>
+                        <field name="code">VH13</field>
+                        <field name="tax_tags_formula">vh13</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh14" model="account.report.line">
+                        <field name="name">VH14 - November</field>
+                        <field name="code">VH14</field>
+                        <field name="tax_tags_formula">vh14</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh15" model="account.report.line">
+                        <field name="name">VH15 - December</field>
+                        <field name="code">VH15</field>
+                        <field name="tax_tags_formula">vh15</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh16" model="account.report.line">
+                        <field name="name">VH16 - QUARTER IV</field>
+                        <field name="code">VH16</field>
+                        <field name="aggregation_formula">VH13.balance + VH14.balance + VH15.balance</field>
+                    </record>
+                    <record id="tax_annual_report_line_vh17" model="account.report.line">
+                        <field name="name">VH17 - Deposit due</field>
+                        <field name="code">VH17</field>
+                        <field name="aggregation_formula">
+                            VH4.balance + VH8.balance + VH12.balance + VH16.balance
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_it/data/tax_report/annual_report_sections/vj.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/vj.xml
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_annual_report_vat_vj" model="account.report">
+        <field name="name">VJ VAT Report</field>
+        <field name="sequence">1</field>
+        <field name="country_id" ref="base.it"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_annual_report_vat_balance_vj" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="tax_annual_report_line_reverse_charge_iva" model="account.report.line">
+                <field name="name">Reverse Charge</field>
+                <field name="code">VJ</field>
+                <field name="children_ids">
+                    <record id="tax_annual_report_line_vj1" model="account.report.line">
+                        <field name="name">VJ1 - Purchases of goods from Vatican City and San Marino</field>
+                        <field name="code">VJ1</field>
+                        <field name="tax_tags_formula">vj1</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj2" model="account.report.line">
+                        <field name="name">VJ2 - Extraction of goods from VAT warehouses</field>
+                        <field name="code">VJ2</field>
+                        <field name="tax_tags_formula">vj2</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj3" model="account.report.line">
+                        <field name="name">VJ3 - Purchases of goods already in Italy or services, from non-residents</field>
+                        <field name="code">VJ3</field>
+                        <field name="tax_tags_formula">vj3</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj4" model="account.report.line">
+                        <field name="name">VJ4 - Fees paid to resellers of travel tickets and resellers of parking documents</field>
+                        <field name="code">VJ4</field>
+                        <field name="tax_tags_formula">vj4</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj5" model="account.report.line">
+                        <field name="name">VJ5 - Commissions paid by travel agents to their intermediaries</field>
+                        <field name="code">VJ5</field>
+                        <field name="tax_tags_formula">vj5</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj6" model="account.report.line">
+                        <field name="name">VJ6 - Purchases of scrap and other recovered materials</field>
+                        <field name="code">VJ6</field>
+                        <field name="tax_tags_formula">vj6</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj7" model="account.report.line">
+                        <field name="name">VJ7 - Purchases of industrial gold and pure silver made in Italy</field>
+                        <field name="code">VJ7</field>
+                        <field name="tax_tags_formula">vj7</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj8" model="account.report.line">
+                        <field name="name">VJ8 - Investment gold purchases made in Italy</field>
+                        <field name="code">VJ8</field>
+                        <field name="tax_tags_formula">vj8</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj9" model="account.report.line">
+                        <field name="name">VJ9 - Intra-EU Purchases of Goods</field>
+                        <field name="code">VJ9</field>
+                        <field name="tax_tags_formula">vj9</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj10" model="account.report.line">
+                        <field name="name">VJ10 - Imports of scrap and other recovered materials</field>
+                        <field name="code">VJ10</field>
+                        <field name="tax_tags_formula">vj10</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj11" model="account.report.line">
+                        <field name="name">VJ11 - Imports of industrial gold and pure silver</field>
+                        <field name="code">VJ11</field>
+                        <field name="tax_tags_formula">vj11</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj12" model="account.report.line">
+                        <field name="name">VJ12 - Subcontracting of services in the construction field</field>
+                        <field name="code">VJ12</field>
+                        <field name="tax_tags_formula">vj12</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj13" model="account.report.line">
+                        <field name="name">VJ13 - Purchases of buildings or portions of buildings used for capital purposes</field>
+                        <field name="code">VJ13</field>
+                        <field name="tax_tags_formula">vj13</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj14" model="account.report.line">
+                        <field name="name">VJ14 - Purchases of cell phones</field>
+                        <field name="code">VJ14</field>
+                        <field name="tax_tags_formula">vj14</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj15" model="account.report.line">
+                        <field name="name">VJ15 - Purchases of electronic products</field>
+                        <field name="code">VJ15</field>
+                        <field name="tax_tags_formula">vj15</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj16" model="account.report.line">
+                        <field name="name">VJ16 - Provision of services in the construction field</field>
+                        <field name="code">VJ16</field>
+                        <field name="tax_tags_formula">vj16</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj17" model="account.report.line">
+                        <field name="name">VJ17 - Purchases of energy sector goods and services</field>
+                        <field name="code">VJ17</field>
+                        <field name="tax_tags_formula">vj17</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj18" model="account.report.line">
+                        <field name="name">VJ18 - Purchases made by VAT-registered public administrations</field>
+                        <field name="code">VJ18</field>
+                        <field name="tax_tags_formula">vj18</field>
+                    </record>
+                    <record id="tax_annual_report_line_vj19" model="account.report.line">
+                        <field name="name">VJ19 - Total frame VJ</field>
+                        <field name="code">VJ19</field>
+                        <field name="aggregation_formula">VJ1.balance + VJ2.balance + VJ3.balance + VJ4.balance + VJ5.balance + VJ6.balance + VJ7.balance +
+                                                VJ8.balance + VJ9.balance + VJ10.balance + VJ11.balance + VJ12.balance + VJ13.balance + VJ14.balance +
+                                                VJ15.balance + VJ16.balance + VJ17.balance + VJ18.balance</field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_it/data/tax_report/annual_report_sections/vl.xml
+++ b/addons/l10n_it/data/tax_report/annual_report_sections/vl.xml
@@ -1,0 +1,245 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo auto_sequence="1">
+    <record id="tax_annual_report_vat_vl" model="account.report">
+        <field name="name">VL VAT Report</field>
+        <field name="sequence">1</field>
+        <field name="country_id" ref="base.it"/>
+        <field name="availability_condition">country</field>
+        <field name="column_ids">
+            <record id="tax_annual_report_vat_balance_vl" model="account.report.column">
+                <field name="name">Balance</field>
+                <field name="expression_label">balance</field>
+            </record>
+        </field>
+        <field name="line_ids">
+            <record id="tax_annual_report_line_comp_fram" model="account.report.line">
+                <field name="name">Annual tax for completed schedules</field>
+                <field name="code">VL</field>
+                <field name="children_ids">
+                    <record id="tax_annual_report_line_comp_fram_1" model="account.report.line">
+                        <field name="name">Determination of VAT due or credit for the tax period</field>
+                        <field name="code">VL_1</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_vl1" model="account.report.line">
+                                <field name="name">VL1 - VAT payable</field>
+                                <field name="code">VL1</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_vl1_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VE26.balance + VJ19.balance</field>
+                                        <field name="subformula">cross_report</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_vl2" model="account.report.line">
+                                <field name="name">VL2 - VAT deductible</field>
+                                <field name="code">VL2</field>
+                                <field name="expression_ids">
+                                    <record id="tax_annual_report_line_vl2_tag" model="account.report.expression">
+                                        <field name="label">balance</field>
+                                        <field name="engine">aggregation</field>
+                                        <field name="formula">VF71.tax</field>
+                                        <field name="subformula">cross_report</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_vl3" model="account.report.line">
+                                <field name="name">VL3 - Tax Due</field>
+                                <field name="code">VL3</field>
+                                <field name="aggregation_formula">VL1.balance - VL2.balance</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl4" model="account.report.line">
+                                <field name="name">VL4 - Tax Credit</field>
+                                <field name="code">VL4</field>
+                                <field name="aggregation_formula">VL2.balance - VL1.balance</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_comp_fram_2" model="account.report.line">
+                        <field name="name">Previous year credit</field>
+                        <field name="code">VL_2</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_vl8" model="account.report.line">
+                                <field name="name">VL8 - Credit resulting from the previous year's declaration</field>
+                                <field name="code">VL8</field>
+                                <field name="tax_tags_formula">vl8</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl9" model="account.report.line">
+                                <field name="name">VL9 - Credit offset in the template</field>
+                                <field name="code">VL9</field>
+                                <field name="tax_tags_formula">vl9</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl10" model="account.report.line">
+                                <field name="name">VL10 - Non-transferable credit surplus</field>
+                                <field name="code">VL10</field>
+                                <field name="tax_tags_formula">vl10</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl11" model="account.report.line">
+                                <field name="name">VL11 - Credits art. 8, paragraph 6-quater, Presidential Decree. n. 322/98</field>
+                                <field name="code">VL11</field>
+                                <field name="tax_tags_formula">vl11</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl12" model="account.report.line">
+                                <field name="name">VL12 - Periodic payments omitted</field>
+                                <field name="code">VL12</field>
+                                <field name="tax_tags_formula">vl12</field>
+                            </record>
+                        </field>
+                    </record>
+                    <record id="tax_annual_report_line_comp_fram_3" model="account.report.line">
+                        <field name="name">Determination of debit or credit VAT relating to all activities carried out</field>
+                        <field name="code">VL_3</field>
+                        <field name="children_ids">
+                            <record id="tax_annual_report_line_vl20" model="account.report.line">
+                                <field name="name">VL20 - Interim refunds required</field>
+                                <field name="code">VL20</field>
+                                <field name="tax_tags_formula">vl20</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl21" model="account.report.line">
+                                <field name="name">VL21 - Amount of credits transferred</field>
+                                <field name="code">VL21</field>
+                                <field name="tax_tags_formula">vl21</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl22" model="account.report.line">
+                                <field name="name">VL22 - VAT credit resulting from the first 3 quarters</field>
+                                <field name="code">VL22</field>
+                                <field name="tax_tags_formula">vl22</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl23" model="account.report.line">
+                                <field name="name">VL23 - Interest due for quarterly payments</field>
+                                <field name="code">VL23</field>
+                                <field name="tax_tags_formula">vl23</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl24" model="account.report.line">
+                                <field name="name">VL24 - Previous year transfers returned by the parent company</field>
+                                <field name="code">VL24</field>
+                                <field name="tax_tags_formula">vl24</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl25" model="account.report.line">
+                                <field name="name">VL25 - Previous year credit surplus</field>
+                                <field name="code">VL25</field>
+                                <field name="aggregation_formula">VL8.balance - VL9.balance</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl26" model="account.report.line">
+                                <field name="name">VL26 - Credit requested for reimbursement in previous years computable as a deduction following refusal by the office</field>
+                                <field name="code">VL26</field>
+                                <field name="tax_tags_formula">vl26</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl27" model="account.report.line">
+                                <field name="name">VL27 - Tax credits used in periodic payments and for the advance payment</field>
+                                <field name="code">VL27</field>
+                                <field name="tax_tags_formula">vl27</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl28" model="account.report.line">
+                                <field name="name">VL28 - Credits received from savings management companies used in periodic payments and for the advance payment</field>
+                                <field name="code">VL28</field>
+                                <field name="tax_tags_formula">vl28</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl29" model="account.report.line">
+                                <field name="name">VL29 - EU car payments relating to sales carried out during the year</field>
+                                <field name="code">VL29</field>
+                                <field name="tax_tags_formula">vl29</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl30" model="account.report.line">
+                                <field name="name">VL30 - Periodic VAT amount</field>
+                                <field name="code">VL30</field>
+                                <field name="children_ids">
+                                    <record id="tax_annual_report_line_vl30_I" model="account.report.line">
+                                        <field name="name">Periodic VAT due</field>
+                                        <field name="code">VL30_I</field>
+                                        <field name="tax_tags_formula">vl30_i</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_vl30_II" model="account.report.line">
+                                        <field name="name">Periodic VAT paid</field>
+                                        <field name="code">VL30_II</field>
+                                        <field name="tax_tags_formula">vl30_ii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_vl30_III" model="account.report.line">
+                                        <field name="name">Periodic VAT paid following notification of irregularities</field>
+                                        <field name="code">VL30_III</field>
+                                        <field name="tax_tags_formula">vl30_iii</field>
+                                    </record>
+                                    <record id="tax_annual_report_line_vl30_IV" model="account.report.line">
+                                        <field name="name">Periodic VAT paid following payment orders</field>
+                                        <field name="code">VL30_IV</field>
+                                        <field name="tax_tags_formula">vl30_iv</field>
+                                    </record>
+                                </field>
+                            </record>
+                            <record id="tax_annual_report_line_vl31" model="account.report.line">
+                                <field name="name">VL31 - Amount of debts transferred</field>
+                                <field name="code">VL31</field>
+                                <field name="tax_tags_formula">vl31</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl32" model="account.report.line">
+                                <field name="name">VL32 - VAT DUE</field>
+                                <field name="code">VL32</field>
+                                <field name="aggregation_formula">(VL3.balance + VL20.balance + VL21.balance + VL22.balance + VL23.balance)
+                                                    - (VL4.balance + VL11.balance + VL24.balance + VL25.balance + VL26.balance +
+                                                        VL27.balance + VL28.balance + VL29.balance + VL30_I.balance + VL30_II.balance +
+                                                        VL30_III.balance + VL30_IV.balance + VL31.balance)</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl33" model="account.report.line">
+                                <field name="name">VL33 - VAT CREDIT</field>
+                                <field name="code">VL33</field>
+                                <field name="aggregation_formula">(VL4.balance + VL11.balance + VL24.balance + VL25.balance + VL26.balance +
+                                                        VL27.balance + VL28.balance + VL29.balance + VL30_I.balance + VL30_II.balance +
+                                                        VL30_III.balance + VL30_IV.balance + VL31.balance) - (VL3.balance + VL20.balance +
+                                                        VL21.balance + VL22.balance + VL23.balance)</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl34" model="account.report.line">
+                                <field name="name">VL34 - Tax credits used in the annual return</field>
+                                <field name="code">VL34</field>
+                                <field name="tax_tags_formula">vl34</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl35" model="account.report.line">
+                                <field name="name">VL35 - Credits received from asset management companies used in the annual declaration</field>
+                                <field name="code">VL35</field>
+                                <field name="tax_tags_formula">vl35</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl36" model="account.report.line">
+                                <field name="name">VL36 - Interest due on the annual return</field>
+                                <field name="code">VL36</field>
+                                <field name="tax_tags_formula">vl36</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl37" model="account.report.line">
+                                <field name="name">VL37 - Credit transferred by savings management companies pursuant to art. 8 of the legislative decree n. 351/2001</field>
+                                <field name="code">VL37</field>
+                                <field name="tax_tags_formula">vl37</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl38" model="account.report.line">
+                                <field name="name">VL38 - TOTAL VAT DUE</field>
+                                <field name="code">VL38</field>
+                                <field name="aggregation_formula">VL32.balance - VL34.balance - VL35.balance + VL36.balance</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl39" model="account.report.line">
+                                <field name="name">VL39 - TOTAL VAT INPUT</field>
+                                <field name="code">VL39</field>
+                                <field name="aggregation_formula">VL33.balance - VL37.balance</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl40" model="account.report.line">
+                                <field name="name">VL40 - Payments made following excess use of credit</field>
+                                <field name="code">VL40</field>
+                                <field name="tax_tags_formula">vl40</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl41_I" model="account.report.line">
+                                <field name="name">VL41 - Difference between periodic VAT due and periodic VAT paid</field>
+                                <field name="code">VL41_I</field>
+                                <field name="aggregation_formula">VL30_I.balance - (VL30_II.balance + VL30_III.balance + VL30_IV.balance)</field>
+                            </record>
+                            <record id="tax_annual_report_line_vl41_II" model="account.report.line">
+                                <field name="name">VL41 - Difference between credit potential and actual credit</field>
+                                <field name="code">VL41_II</field>
+                                <field name="aggregation_formula">(VL4.balance + VL11.balance + VL12.balance + VL24.balance +
+                                                        VL25.balance + VL26.balance + VL27.balance + VL28.balance +
+                                                        VL29.balance + VL30_I.balance + VL31.balance) - (VL3.balance + VL20.balance +
+                                                        VL21.balance + VL22.balance + VL23.balance)</field>
+                            </record>
+                        </field>
+                    </record>
+                </field>
+            </record>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_it/i18n/it.po
+++ b/addons/l10n_it/i18n/it.po
@@ -17,9 +17,14 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_it
+#: model:ir.model,name:l10n_it.model_account_chart_template
+msgid "Account Chart Template"
+msgstr "Modello piano dei conti"
+
+#. module: l10n_it
 #: model:ir.model,name:l10n_it.model_account_report_expression
 msgid "Accounting Report Expression"
-msgstr "Espressione del rapporto contabile"
+msgstr "Espressione rendiconto contabile"
 
 #. module: l10n_it
 #: model:account.account.tag,name:l10n_it.account_tag_D_ATT
@@ -32,19 +37,57 @@ msgid "Accruals and deferrals - Liabilities"
 msgstr "Ratei e risconti - Passivi"
 
 #. module: l10n_it
-#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_4
-msgid "Altre operazioni"
-msgstr ""
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_3b
+msgid "Agricultural businesses (art.34)"
+msgstr "Aziende agricole (art. 34)"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover_section_2
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_2
+msgid ""
+"Agricultural taxable transactions (Article 34 paragraph 1) and commercial "
+"and professional taxable transactions"
+msgstr ""
+"Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili "
+"commerciali e professional"
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat
+msgid "Annual Tax Report"
+msgstr "Rapporto fiscale annuale"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_comp_fram
+msgid "Annual tax for completed schedules"
+msgstr "Imposta annuale per i piani compilati"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_VIII
+msgid "Article operations 7 to 7-septies without right to deduction"
+msgstr "Articolo operazioni da 7 a 7-septies senza diritto a detrazione"
+
+#. module: l10n_it
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_va
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_ve
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_vf
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_vh
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_vj
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_vl
+#: model:account.report.column,name:l10n_it.tax_monthly_report_vat_balance
 #: model:account.report.column,name:l10n_it.tax_report_vat_balance
 msgid "Balance"
 msgstr "Saldo"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_saldi_riporti_e_interessi
 #: model:account.report.line,name:l10n_it.tax_report_line_saldi_riporti_e_interessi
 msgid "Balances, carryovers and interest"
 msgstr "Saldi, riporti e interessi"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_dag
+msgid "Business Information"
+msgstr "Informazioni commerciali"
 
 #. module: l10n_it
 #: model:account.account.tag,name:l10n_it.account_tag_IMPEGNI
@@ -52,11 +95,14 @@ msgid "Commitments"
 msgstr "Impegni"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover_section_1
 #: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_1
 msgid ""
+"Contributions of agricultural products and transfers from exempt farmers (in"
+" case of exceeding 1/3"
+msgstr ""
 "Conferimenti di prodotti agricoli e cessioni da agricoltori esonerati (in "
 "caso di superamento di 1/3"
-msgstr ""
 
 #. module: l10n_it
 #: model:account.account.tag,name:l10n_it.account_tag_C_ATT
@@ -67,6 +113,69 @@ msgstr "Attivo circolante"
 #: model:account.account.tag,name:l10n_it.account_tag_D_PASS
 msgid "Debts"
 msgstr "Debiti"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29_I
+msgid "Depreciable assets"
+msgstr "Attività ammortizzabili"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_IV
+msgid "Depreciable assets and transfers interiors exempt"
+msgstr "Beni ammortizzabili e trasferimenti interni esenti"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_comp_fram_1
+msgid "Determination of VAT due or credit for the tax period"
+msgstr "Determinazione dell'IVA dovuta o a credito per il periodo d'imposta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_comp_fram_3
+msgid ""
+"Determination of debit or credit VAT relating to all activities carried out"
+msgstr ""
+"Determinazione dell'IVA a debito o a credito relativa a tutte le attività "
+"svolte"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va5_section_1
+msgid "Equipment purchases"
+msgstr "Acquisti apparecchiature"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_3a
+msgid "Exempt operations"
+msgstr "Operazioni esenti"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_VII
+msgid "Exempt operations art. 19, co. 3, letter. a-bis) and d-bis)"
+msgstr "Operazioni esenti art. 19, co. 3, lett. a-bis) e d-bis)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_III
+msgid "Exempt operations referred to in art. 10, n. 27-quinquies"
+msgstr "Operazioni esenti di cui all'art. 10, n. 27-quinquies"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_II
+msgid ""
+"Exempt operations referred to in nos. from 1 to 9 of the art. 10 not "
+"included in their own business of the company or ancillary to taxable "
+"operations"
+msgstr ""
+"Le operazioni esenti di cui ai nn. da 1 a 9 dell'art. 10 non sono operazioni"
+" di esenzione. 10 non rientranti nell'attività propria dell'impresa o "
+"accessorie alle operazioni imponibili"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_I
+msgid ""
+"Exempt transactions relating to gold from investments made by the subjects "
+"referred to in the art. 19, co. 3, letter. d)"
+msgstr ""
+"Esentare le operazioni relative all'oro dagli investimenti effettuati dai "
+"soggetti di cui all'art. 19, co. 3, lett. d)"
 
 #. module: l10n_it
 #: model:ir.model.fields,field_description:l10n_it.field_account_tax__l10n_it_exempt_reason
@@ -94,14 +203,25 @@ msgid "Fixed assets"
 msgstr "Immobilizzazioni"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_dag_section1
+msgid "General analytical data"
+msgstr "Dati analitici generali"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29_III
+msgid "Goods intended for resale or for the production of goods and services"
+msgstr "Beni destinati alla rivendita o alla produzione di beni e servizi"
+
+#. module: l10n_it
 #. odoo-python
 #: code:addons/l10n_it/models/account_tax.py:0
 #, python-format
 msgid ""
 "If the tax amount is 0%, you must enter the exoneration code and the related"
 " law reference."
-msgstr "Se l'importo della tassa è 0%, devi inserire il codice di esenzione "
-" ed il relativo riferimento legislativo"
+msgstr ""
+"Se l'importo della tassa è 0%, devi inserire il codice di esenzione  ed il "
+"relativo riferimento legislativo"
 
 #. module: l10n_it
 #: model:ir.model.fields,field_description:l10n_it.field_account_tax__l10n_it_law_reference
@@ -109,11 +229,75 @@ msgid "Law Reference"
 msgstr "Riferimento legislativo"
 
 #. module: l10n_it
-#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_2
-msgid ""
-"Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili "
-"commerciali e professional"
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va5_section_2
+msgid "Management services"
 msgstr ""
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_monthly_report_vat
+msgid "Monthly VAT Report"
+msgstr "Periodic Rapporto IVA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29_II
+msgid "Non-depreciable capital goods"
+msgstr "Beni strumentali non ammortizzabili"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_IX
+msgid "Operations exempted by law no. 178/2020"
+msgstr "Operazioni esenti dalla legge n. 178/2020"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_V
+msgid "Operations not subject"
+msgstr "Operazioni non soggette"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_VI
+msgid "Operations not subject to art. 74, co. 1"
+msgstr "Operazioni non soggette all'art. 74, co. 1"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover_section_4
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_4
+msgid "Other operations"
+msgstr "Altre operazioni"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29_IV
+msgid "Other purchases and imports"
+msgstr "Altri acquisti e importazioni"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op
+msgid "Passive operations and VAT deduction allowed"
+msgstr "Operazioni passive e detrazione dell'IVA consentita"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30_I
+msgid "Periodic VAT due"
+msgstr "IVA periodica dovuta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30_II
+msgid "Periodic VAT paid"
+msgstr "IVA periodica pagata"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30_III
+msgid "Periodic VAT paid following notification of irregularities"
+msgstr "Versamento periodico dell'IVA a seguito di notifica di irregolarità"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30_IV
+msgid "Periodic VAT paid following payment orders"
+msgstr "IVA periodica pagata a seguito di ordini di pagamento"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_comp_fram_2
+msgid "Previous year credit"
+msgstr "Credito dell'anno precedente"
 
 #. module: l10n_it
 #: model:account.account.tag,name:l10n_it.account_tag_B_PL
@@ -126,11 +310,17 @@ msgid "Provisions for risks and charges"
 msgstr "Fondi per rischi e oneri"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_1
+msgid "Purchases (Domestic, intra-Community and imports)"
+msgstr "Acquisti (nazionali, intracomunitari e importazioni)"
+
+#. module: l10n_it
 #: model:account.account.tag,name:l10n_it.account_tag_A_ATT
 msgid "Receivables from shareholders"
 msgstr "Crediti verso soci"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_reverse_charge_iva
 #: model:account.report.line,name:l10n_it.tax_report_line_reverse_charge_iva
 msgid "Reverse Charge"
 msgstr "Inversione Contabile"
@@ -151,6 +341,11 @@ msgid "Shareholders' Equity"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_3c
+msgid "Special cases"
+msgstr "Casi speciali"
+
+#. module: l10n_it
 #. odoo-python
 #: code:addons/l10n_it/models/account_tax.py:0
 #, python-format
@@ -158,6 +353,20 @@ msgid "Split Payment is not compatible with exoneration of kind 'N6'"
 msgstr "Lo Split Payment non è compatibile con l'esenzione di tipo 'N6'"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_dag_section2
+msgid "Summary data for all activities"
+msgstr "Dati riepilogativi relativi a tutte le attività"
+
+#. module: l10n_it
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_tax_va
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_tax_ve
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_tax_vf
+#: model:ir.model,name:l10n_it.model_account_tax
+msgid "Tax"
+msgstr "Imposta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_operazione_imponibile
 #: model:account.report.line,name:l10n_it.tax_report_line_operazione_imponibile
 msgid "Taxable transaction"
 msgstr "Operazione Imponibile"
@@ -168,16 +377,74 @@ msgid "Third party assets"
 msgstr "Beni di terzi"
 
 #. module: l10n_it
-#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_3
-msgid "Totale imponibile e imposta"
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_2
+msgid ""
+"Total purchases and imports, total tax, purchases intra-community, imports "
+"and purchases"
 msgstr ""
+"Totale acquisti e importazioni, totale imposte, acquisti intracomunitari, "
+"importazioni e acquisti"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover_section_3
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_3
+msgid "Total taxable income and tax"
+msgstr "Totale imponibile e imposta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover
 #: model:account.report.line,name:l10n_it.tax_report_line_turnover
 msgid "Turnover"
+msgstr "Fatturato"
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_va
+msgid "VA VAT Report"
+msgstr "Rapporto IVA VA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va1
+msgid ""
+"VA1 - To be filled in by the entity of originator in cases of extraordinary "
+"transactions"
+msgstr ""
+"VA1 - Da compilare a cura del soggetto dante causa nelle ipotesi di "
+"operazioni straordinarie"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va16
+msgid ""
+"VA11 - Data on amounts suspended as a result of the health emergency by "
+"COVID-19"
+msgstr ""
+"VA11 - Dati relativi agli importi sospesi a seguito dell'emergenza sanitaria"
+" da COVID-19"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va12
+msgid ""
+"VA12 - Reserved for indication of surplus credit of former parent companies "
+"to be guaranteed"
+msgstr ""
+"VA12 - Riservato all’indicazione di eccedenze di credito di società ex "
+"controllanti da garantire"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va13
+msgid "VA13 - Transactions carried out with respect to condominiums"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va5
+msgid ""
+"VA5 - Terminals for mobile telecommunication radio service with more than "
+"50% deduction"
+msgstr ""
+"VA5 - Terminali per il servizio radiomobile di telecomunicazione con "
+"detrazione superiore al 50%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_iva
 #: model:account.report.line,name:l10n_it.tax_report_line_iva
 msgid "VAT"
 msgstr "IVA"
@@ -188,286 +455,787 @@ msgid "VAT Report"
 msgstr "Rapporto IVA"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_conto_corrente_iva
 #: model:account.report.line,name:l10n_it.tax_report_line_conto_corrente_iva
 msgid "VAT account"
 msgstr "Conto IVA"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_4
+msgid "VAT allowed as deduction"
+msgstr "IVA ammessa in detrazione"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va1_4
+msgid "VAT/2023 declaration credit transferred"
+msgstr "Credito dichiarazione IVA/2023 ceduto"
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_ve
+msgid "VE VAT Report"
+msgstr "Rapporto IVA VE"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve1
 #: model:account.report.line,name:l10n_it.tax_report_line_ve1
 msgid ""
+"VE1 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 2%"
+msgstr ""
 "VE1 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 2%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve10
 #: model:account.report.line,name:l10n_it.tax_report_line_ve10
 msgid ""
+"VE10 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 10%"
+msgstr ""
 "VE10 - Passaggi a cooperative art.34 comma 2 con percentuale di "
 "compensazione 10%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve11
 #: model:account.report.line,name:l10n_it.tax_report_line_ve11
 msgid ""
+"VE11 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 12,3%"
+msgstr ""
 "VE11 - Passaggi a cooperative art.34 comma 2 con percentuale di "
 "compensazione 12,3%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve2
 #: model:account.report.line,name:l10n_it.tax_report_line_ve2
 msgid ""
+"VE2 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 4%"
+msgstr ""
 "VE2 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 4%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve20
 #: model:account.report.line,name:l10n_it.tax_report_line_ve20
-msgid "VE20 - Operazioni imponibili aliquota 4%"
-msgstr ""
+msgid "VE20 - Taxable transactions rate 4%"
+msgstr "VE20 - Operazioni imponibili aliquota 4%"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve21
 #: model:account.report.line,name:l10n_it.tax_report_line_ve21
-msgid "VE21 - Operazioni imponibili aliquota 5%"
-msgstr ""
+msgid "VE21 - Taxable transactions rate 5%"
+msgstr "VE21 - Operazioni imponibili aliquota 5%"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve22
 #: model:account.report.line,name:l10n_it.tax_report_line_ve22
-msgid "VE22 - Operazioni imponibili aliquota 10%"
-msgstr ""
+msgid "VE22 - Taxable transactions rate 10%"
+msgstr "VE22 - Operazioni imponibili aliquota 10%"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve23
 #: model:account.report.line,name:l10n_it.tax_report_line_ve23
-msgid "VE23 - Operazioni imponibili aliquota 22%"
-msgstr ""
+msgid "VE23 - Taxable transactions rate 22%"
+msgstr "VE23 - Operazioni imponibili aliquota 22%"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve24
 #: model:account.report.line,name:l10n_it.tax_report_line_ve24
-msgid "VE24 - Totale righe da VE1 a VE11 e linee da VE20 a VE23"
-msgstr ""
+msgid "VE24 - Total lines VE1 to VE11 and lines VE20 to VE23"
+msgstr "VE24 - Totale righe da VE1 a VE11 e linee da VE20 a VE23"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve25
 #: model:account.report.line,name:l10n_it.tax_report_line_ve25
-msgid "VE25 - Variazioni e arrotondamenti (usare segno +/−)"
-msgstr ""
+msgid "VE25 - Variations and rounding (use +/− sign)"
+msgstr "VE25 - Variazioni e arrotondamenti (usare segno +/−)"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve26
 #: model:account.report.line,name:l10n_it.tax_report_line_ve26
-msgid "VE26 - Totale VE24 e VE25"
-msgstr ""
+msgid "VE26 - Total VE24 and VE25"
+msgstr "VE26 - Totale VE24 e VE25"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve3
 #: model:account.report.line,name:l10n_it.tax_report_line_ve3
 msgid ""
+"VE3 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 6,4%"
+msgstr ""
 "VE3 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 6,4%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30
-msgid "VE30 - Operazioni che concorrono alla formazione del plafond"
-msgstr ""
+msgid "VE30 - Transactions that contribute to the formation of the ceiling"
+msgstr "VE30 - Operazioni che concorrono alla formazione del plafond"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_I
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_I
-msgid "VE30_I - Totale"
-msgstr ""
+msgid "VE30_I - Total"
+msgstr "VE30_I - Totale"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_ii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_ii
-msgid "VE30_II - Esportazioni"
-msgstr ""
+msgid "VE30_II - Exports"
+msgstr "VE30_II - Esportazioni"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_iii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_iii
-msgid "VE30_III - Cessioni intracomunitarie"
-msgstr ""
+msgid "VE30_III - Intra-Community supplies"
+msgstr "VE30_III - Cessioni intracomunitarie"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_iv
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_iv
-msgid "VE30_IV - Cessioni verso San Marino"
-msgstr ""
+msgid "VE30_IV - Transfers to San Marino"
+msgstr "VE30_IV - Cessioni verso San Marino"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_v
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_v
-msgid "VE30_V - Operazioni assimilate"
-msgstr ""
+msgid "VE30_V - Assimilated operations"
+msgstr "VE30_V - Operazioni assimilate"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve31
 #: model:account.report.line,name:l10n_it.tax_report_line_ve31
-msgid "VE31 - Operazioni non imponibili a seguito di dichiarazioni di intento"
+msgid "VE31 - Non-taxable transactions as a result of declarations of intent"
 msgstr ""
+"VE31 - Operazioni non imponibili a seguito di dichiarazioni di intento"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve32
 #: model:account.report.line,name:l10n_it.tax_report_line_ve32
-msgid "VE32 - Altre operazioni non imponibili"
-msgstr ""
+msgid "VE32 - Other non-taxable transactions"
+msgstr "VE32 - Altre operazioni non imponibili"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve33
 #: model:account.report.line,name:l10n_it.tax_report_line_ve33
-msgid "VE33 - Operazioni esenti (art.10"
-msgstr ""
+msgid "VE33 - Exempt transactions (art.10"
+msgstr "VE33 - Operazioni esenti (art.10"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve34
 #: model:account.report.line,name:l10n_it.tax_report_line_ve34
 msgid ""
+"VE34 - Transactions not subject to the tax under Articles 7 to 7-septies"
+msgstr ""
 "VE34 - Operazioni non soggette all’imposta ai sensi degli articoli da 7 a "
 "7-septies"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35
-msgid "VE35 - Operazioni con applicazione del reverse charge interno"
-msgstr ""
+msgid "VE35 - Transactions with application of internal reverse charge"
+msgstr "VE35 - Operazioni con applicazione del reverse charge interno"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_I
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_I
 msgid "VE35_I - Total"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_ii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_ii
-msgid "VE35_II - Cessioni di rottami e altri materiali di recupero"
-msgstr ""
+msgid "VE35_II - Disposal of scrap and other recovered materials"
+msgstr "VE35_II - Cessioni di rottami e altri materiali di recupero"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_iii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_iii
-msgid "VE35_III - Cessioni di oro e argento puro"
-msgstr ""
+msgid "VE35_III - Disposals of pure gold and silver"
+msgstr "VE35_III - Cessioni di oro e argento puro"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_iv
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_iv
-msgid "VE35_IV - Subappalto nel settore edile"
-msgstr ""
+msgid "VE35_IV - Subcontracting in the construction industry"
+msgstr "VE35_IV - Subappalto nel settore edile"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_ix
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_ix
-msgid "VE35_IX - Operazioni settore energetico"
-msgstr ""
+msgid "VE35_IX - Energy sector operations"
+msgstr "VE35_IX - Operazioni settore energetico"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_v
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_v
-msgid "VE35_V - Cessioni di fabbricati strumentali"
-msgstr ""
+msgid "VE35_V - Disposal of capital buildings"
+msgstr "VE35_V - Cessioni di fabbricati strumentali"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_vi
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_vi
-msgid "VE35_VI - Cessioni di telefoni cellulari"
-msgstr ""
+msgid "VE35_VI - Disposal of cell phones"
+msgstr "VE35_VI - Cessioni di telefoni cellulari"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_vii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_vii
-msgid "VE35_VII - Cessioni di prodotti elettronici"
-msgstr ""
+msgid "VE35_VII - Disposal of electronic products"
+msgstr "VE35_VII - Cessioni di prodotti elettronici"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_viii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_viii
-msgid "VE35_VIII - Prestazioni comparto edile e settori connessi"
-msgstr ""
+msgid "VE35_VIII - Benefits construction and related industries"
+msgstr "VE35_VIII - Prestazioni comparto edile e settori connessi"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve36
 #: model:account.report.line,name:l10n_it.tax_report_line_ve36
-msgid ""
+msgid "VE36 - Non-taxable transactions made to earthquake victims"
+msgstr ""
 "VE36 - Operazioni non soggette all\"imposta effettuate nei confronti dei "
 "terremotati"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve37
 #: model:account.report.line,name:l10n_it.tax_report_line_ve37
 msgid ""
+"VE37 - Transactions made during the year but with tax due in subsequent "
+"years"
+msgstr ""
 "VE37 - Operazioni effettuate nell\"anno ma con imposta esigibile negli anni "
 "successivi"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve37_I
 #: model:account.report.line,name:l10n_it.tax_report_line_ve37_I
 msgid "VE37_I - Total"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve37_ii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve37_ii
-msgid "VE37_II - ex art. 32-bis, DL n. 83/2012"
-msgstr ""
+msgid "VE37_II - ex art. 32-bis, DL no. 83/2012"
+msgstr "VE37_II - ex art. 32-bis, DL n. 83/2012"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve38
 #: model:account.report.line,name:l10n_it.tax_report_line_ve38
-msgid "VE38 - Operazioni nei confronti di soggetti di cui all\"art.17-ter"
-msgstr ""
+msgid "VE38 - Transactions with parties referred to in Article 17-ter."
+msgstr "VE38 - Operazioni nei confronti di soggetti di cui all\"art.17-ter"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve39
 #: model:account.report.line,name:l10n_it.tax_report_line_ve39
 msgid ""
+"VE39 - (minus) Transactions made in previous years but with tax due in 2022"
+msgstr ""
 "VE39 - (meno) Operazioni effettuate in anni precedenti ma con imposta "
 "esigibile nel 2022"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve4
 #: model:account.report.line,name:l10n_it.tax_report_line_ve4
 msgid ""
+"VE4 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 7,3%"
+msgstr ""
 "VE4 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 7,3%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve40
 #: model:account.report.line,name:l10n_it.tax_report_line_ve40
-msgid "VE40 - (meno) Cessioni di beni ammortizzabili e passaggi interni"
-msgstr ""
+msgid "VE40 - (minus) Disposals of depreciable assets and internal transfers."
+msgstr "VE40 - (meno) Cessioni di beni ammortizzabili e passaggi interni"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve5
 #: model:account.report.line,name:l10n_it.tax_report_line_ve5
 msgid ""
+"VE5 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 7,5%"
+msgstr ""
 "VE5 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 7,5%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve45
+msgid "VE50 - TURNOVER"
+msgstr "VE50 - VOLUME D’AFFARI"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve6
 #: model:account.report.line,name:l10n_it.tax_report_line_ve6
 msgid ""
+"VE6 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 8,3%"
+msgstr ""
 "VE6 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 8,3%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve7
 #: model:account.report.line,name:l10n_it.tax_report_line_ve7
 msgid ""
+"VE7 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 8,5%"
+msgstr ""
 "VE7 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 8,5%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve8
 #: model:account.report.line,name:l10n_it.tax_report_line_ve8
 msgid ""
+"VE8 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 8,8%"
+msgstr ""
 "VE8 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 8,8%"
-msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve9
 #: model:account.report.line,name:l10n_it.tax_report_line_ve9
 msgid ""
+"VE9 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 9,5%"
+msgstr ""
 "VE9 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
 " 9,5%"
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_vf
+msgid "VF VAT Report"
+msgstr "Rapporto IVA VF"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF1
+msgid "VF1 - compensation percentage 2%"
+msgstr "VF1 - percentuale di compensazione 2%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF10
+msgid "VF10 - compensation percentage 9.5%"
+msgstr "VF10 - percentuale di compensazione 9.5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF11
+msgid "VF11 - compensation percentage 10%"
+msgstr "VF11 - percentuale di compensazione 10%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF12
+msgid "VF12 - compensation percentage 12,3%"
+msgstr "VF12 - percentuale di compensazione 12,3%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF13
+msgid "VF13 - compensation percentage 22%"
+msgstr "VF13 - percentuale di compensazione 22%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF17
+msgid ""
+"VF17 - Purchases and imports without payment of tax, with use of the ceiling"
+msgstr ""
+"VF17 - Acquisti e importazioni senza pagamento dell'imposta, con utilizzo "
+"del plafond"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF18_II
+msgid "VF18 - Exempt purchases and imports not subject to the tax"
+msgstr "VF18 - Acquisti esenti e importazioni non soggette all'imposta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF18_I
+msgid ""
+"VF18 - Other non-tax purchases, not subject to tax and relating to certain "
+"special regimes"
+msgstr ""
+"VF18 - Altri acquisti non fiscali, non soggetti a imposta e relativi a "
+"determinati regimi speciali"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF19
+msgid ""
+"VF19 - Purchases from subjects who have made use of concessional schemes"
+msgstr "VF19 - Acquisti da soggetti che hanno usufruito di regimi agevolati"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF2
+msgid "VF2 - compensation percentage 4%"
+msgstr "VF2 - percentuale di compensazione 4%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF20
+msgid ""
+"VF20 - Purchases and imports not subject to the tax made by earthquake "
+"victims"
+msgstr ""
+"VF20 - Acquisti e importazioni non soggetti all'imposta effettuati dai "
+"terremotati"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF21
+msgid ""
+"VF21 - Purchases and imports for which the deduction is excluded or reduced "
+"(art. 19-bis1)"
+msgstr ""
+"VF21 - Acquisti e importazioni per i quali la detrazione è esclusa o ridotta"
+" (art. 19-bis1)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF22
+msgid "VF22 - Purchases and imports for which the deduction is not permitted"
+msgstr ""
+"VF22 - Acquisti e importazioni per i quali non è ammessa la detrazione"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF23
+msgid ""
+"VF23 - Purchases recorded in the year but with tax deduction deferred to "
+"subsequent years"
+msgstr ""
+"VF23 - Acquisti registrati nell'esercizio ma con deduzione fiscale rinviata "
+"agli esercizi successivi"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF24
+msgid "VF24 - Purchases recorded in previous years but with tax"
+msgstr "VF24 - Acquisti registrati negli anni precedenti ma con imposta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF25
+msgid "VF25 - Total purchases and imports"
+msgstr "VF25 - Acquisti e importazioni totali"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF26
+msgid "VF26 - Tax variations and roundings (indicate with the +/- sign)"
+msgstr ""
+"VF26 - Variazioni fiscali e arrotondamenti (indicare con il segno +/-)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF27
+msgid "VF27 - Total tax on taxable purchases and imports"
+msgstr "VF27 - Imposta totale sugli acquisti e sulle importazioni imponibili"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF28_II
+msgid "VF28 - Imports"
+msgstr "VF28 - Importazioni"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF28_I
+msgid "VF28 - Intra-community purchases"
+msgstr "VF28 - Acquisti intracomunitari"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF28_III
+msgid "VF28 - Purchases from San Marino"
+msgstr "VF28 - Acquisti da San Marino"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29
+msgid "VF29 - Total distribution of purchases and imports"
+msgstr "VF29 - Distribuzione totale degli acquisti e delle importazioni"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF3
+msgid "VF3 - compensation percentage 5%"
+msgstr "VF3 - percentuale di compensazione 5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF31
+msgid "VF31 - Purchases intended for occasional taxable transactions"
+msgstr "VF31 - Acquisti destinati ad operazioni occasionali imponibili"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34
+msgid "VF34 - Data for calculating the deduction percentage"
+msgstr "VF34 - Dati per il calcolo della percentuale di detrazione"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF35
+msgid "VF35 - VAT not paid on purchases and imports indicated"
+msgstr "VF35 - IVA non versata su acquisti e importazioni indicate"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF36
+msgid ""
+"VF36 - VAT deductible for gold purchases made by parties other than "
+"producers and transformers pursuant to art. 19, paragraph 5 bis"
+msgstr ""
+"VF36 - IVA detraibile per gli acquisti di oro effettuati da soggetti diversi"
+" dai produttori e trasformatori ai sensi dell'art. 19, comma 5 bis. 19, "
+"comma 5 bis"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF37
+msgid "VF37 - VAT allowed as deduction"
+msgstr "VF37 - IVA ammessa in detrazione"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF38
+msgid "VF38 - Reserved for mixed agricultural enterprises"
+msgstr "VF38 - Riservato alle imprese agricole miste"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF39
+msgid "VF39 - compensation percentage 2%"
+msgstr "VF39 - percentuale di compensazione 2%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF4
+msgid "VF4 - compensation percentage 6.4%"
+msgstr "VF4 - percentuale di compensazione 6.4%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF40
+msgid "VF40 - compensation percentage 4%"
+msgstr "VF40 - percentuale di compensazione 4%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF41
+msgid "VF41 - compensation percentage 6.4%"
+msgstr "VF41 - percentuale di compensazione 6.4%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF42
+msgid "VF42 - compensation percentage 7,3%"
+msgstr "VF42 - percentuale di compensazione 7,3%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF43
+msgid "VF43 - compensation percentage 7,5%"
+msgstr "VF43 - percentuale di compensazione 7,5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF44
+msgid "VF44 - compensation percentage 8,3%"
+msgstr "VF44 - percentuale di compensazione 8,3%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF45
+msgid "VF45 - compensation percentage 8,5%"
+msgstr "VF45 - percentuale di compensazione 8,5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF46
+msgid "VF46 - compensation percentage 8,8%"
+msgstr "VF46 - percentuale di compensazione 8,8%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF47
+msgid "VF47 - compensation percentage 9.5%"
+msgstr "VF47 - percentuale di compensazione 9.5%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF48
+msgid "VF48 - compensation percentage 10%"
+msgstr "VF48 - percentuale di compensazione 10%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF49
+msgid "VF49 - compensation percentage 12,3%"
+msgstr "VF49 - percentuale di compensazione 12,3%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF5
+msgid "VF5 - compensation percentage 7,3%"
+msgstr "VF5 - percentuale di compensazione 7,3%"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF51
+msgid "VF51 - Tax variations and roundings (indicate with the +/- sign)"
+msgstr ""
+"VF51 - Variazioni fiscali e arrotondamenti (indicare con il segno +/-)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF52
+msgid "VF52 - TOTALS Algebraic sum of lines from VF39 to VF51"
+msgstr "VF52 - TOTALI Somma algebrica delle righe da VF39 a VF51"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF53
+msgid ""
+"VF53 - Deductible VAT charged to the operations referred to in line VF38"
+msgstr "VF53 - IVA detraibile imputata alle operazioni di cui al rigo VF38"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF54
+msgid ""
+"VF54 - Deductible amount for transfers, including intra-community, of "
+"agricultural products referred to in art. 34"
+msgstr ""
+"VF54 - Importo deducibile per le cessioni, anche intracomunitarie, di "
+"prodotti agricoli di cui all'art. 34."
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF55
+msgid "VF55 - TOTAL VAT allowed as deduction"
+msgstr "VF55 - TOTALE IVA ammessa in detrazione"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF6
+msgid "VF6 - compensation percentage 7,5%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF62
+msgid "VF62 - Reserved for agricultural businesses"
+msgstr "VF62 - Riservato alle aziende agricole"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF7
+msgid "VF7 - compensation percentage 8,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF70
+msgid "VF70 - TOTAL adjustments (indicate with the +/- sign)"
+msgstr "VF70 - Regolazioni totali (indicare con il segno +/-)"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF71
+msgid "VF71 - VAT allowed as deduction"
+msgstr "VF71 - IVA ammessa in deduzione"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF8
+msgid "VF8 - compensation percentage 8,5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF9
+msgid "VF9 - compensation percentage 8,8%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_vh
+msgid "VH VAT Report"
+msgstr "Rapporto IVA VH"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh1
+msgid "VH1 - January"
+msgstr "VH1 - Gennaio"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh10
+msgid "VH10 - August"
+msgstr "VH10 - Agosto"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh11
+msgid "VH11 - September"
+msgstr "VH11 - Settembre"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh12
+msgid "VH12 - QUARTER III"
+msgstr "VH12 - QUARTO III"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh13
+msgid "VH13 - October"
+msgstr "VH13 - Ottobre"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh14
+msgid "VH14 - November"
+msgstr "VH14 - Novembre"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh15
+msgid "VH15 - December"
+msgstr "VH15 - Dicembre"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh16
+msgid "VH16 - QUARTER IV"
+msgstr "VH16 - QUARTO IV"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh17
+msgid "VH17 - Deposit due"
+msgstr "VH17 - Deposito dovuto"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh2
+msgid "VH2 - February"
+msgstr "VH2 - Febbraio"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh3
+msgid "VH3 - March"
+msgstr "VH3 - Marzo"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh4
+msgid "VH4 - QUARTER I"
+msgstr "VH4 - QUARTO I"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh5
+msgid "VH5 - April"
+msgstr "VH5 - Aprile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh6
+msgid "VH6 - May"
+msgstr "VH6 - Maggio"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh7
+msgid "VH7 - June"
+msgstr "VH7 - Giugno"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh8
+msgid "VH8 - QUARTER II"
+msgstr "VH8 - QUARTO II"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh9
+msgid "VH9 - July"
+msgstr "VH9 - Luglio"
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_vj
+msgid "VJ VAT Report"
+msgstr "Rapporto IVA VJ"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj1
 #: model:account.report.line,name:l10n_it.tax_report_line_vj1
 msgid "VJ1 - Purchases of goods from Vatican City and San Marino"
 msgstr "VJ1 - Importazioni di beni da Città del Vaticano e da San Marino"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj10
 #: model:account.report.line,name:l10n_it.tax_report_line_vj10
 msgid "VJ10 - Imports of scrap and other recovered materials"
 msgstr "VJ10 - Importazioni di rottami e altri materiali di recupero"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj11
 #: model:account.report.line,name:l10n_it.tax_report_line_vj11
 msgid "VJ11 - Imports of industrial gold and pure silver"
 msgstr "VJ11 - Importazioni di oro industriale e argento puro"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj12
 #: model:account.report.line,name:l10n_it.tax_report_line_vj12
 msgid "VJ12 - Subcontracting of services in the construction field"
 msgstr "VJ12 - Subappalto di servizi in campo edile"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj13
 #: model:account.report.line,name:l10n_it.tax_report_line_vj13
 msgid ""
 "VJ13 - Purchases of buildings or portions of buildings used for capital "
@@ -475,159 +1243,386 @@ msgid ""
 msgstr "VJ13 - Acquisti di fabbricati o porzioni di fabbricati strumentali"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj14
 #: model:account.report.line,name:l10n_it.tax_report_line_vj14
 msgid "VJ14 - Purchases of cell phones"
 msgstr "VJ14 - Acquisti di telefoni cellulari"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj15
 #: model:account.report.line,name:l10n_it.tax_report_line_vj15
 msgid "VJ15 - Purchases of electronic products"
 msgstr "VJ15 - Acquisti di prodotti elettronici"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj16
 #: model:account.report.line,name:l10n_it.tax_report_line_vj16
 msgid "VJ16 - Provision of services in the construction field"
 msgstr "VJ16 - Prestazioni di servizi in campo edile"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj17
 #: model:account.report.line,name:l10n_it.tax_report_line_vj17
 msgid "VJ17 - Purchases of energy sector goods and services"
 msgstr "VJ17 - Acquiti di beni e servizi del settore energetico"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj18
 #: model:account.report.line,name:l10n_it.tax_report_line_vj18
 msgid "VJ18 - Purchases made by VAT-registered public administrations"
-msgstr "VJ18 - Acquisti effettuati dalle pubbliche amministrazioni titolari di partita IVA"
+msgstr ""
+"VJ18 - Acquisti effettuati dalle pubbliche amministrazioni titolari di "
+"partita IVA"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj19
 #: model:account.report.line,name:l10n_it.tax_report_line_vj19
 msgid "VJ19 - Total frame VJ"
 msgstr "VJ19 - Totale quadro VJ"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj2
 #: model:account.report.line,name:l10n_it.tax_report_line_vj2
 msgid "VJ2 - Extraction of goods from VAT warehouses"
 msgstr "VJ2 - Estrazione di beni da depositi Iva"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj3
 #: model:account.report.line,name:l10n_it.tax_report_line_vj3
 msgid ""
 "VJ3 - Purchases of goods already in Italy or services, from non-residents"
-msgstr "VJ3 - Acquisti di beni giá presenti in Italia o servizi, da soggetti non residenti"
+msgstr ""
+"VJ3 - Acquisti di beni giá presenti in Italia o servizi, da soggetti non "
+"residenti"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj4
 #: model:account.report.line,name:l10n_it.tax_report_line_vj4
 msgid ""
 "VJ4 - Fees paid to resellers of travel tickets and resellers of parking "
 "documents"
-msgstr "VJ4 - Compensi corrisposti ai rivenditori di biglietti di viaggio ed ai rivenditori di documenti di sosta"
+msgstr ""
+"VJ4 - Compensi corrisposti ai rivenditori di biglietti di viaggio ed ai "
+"rivenditori di documenti di sosta"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj5
 #: model:account.report.line,name:l10n_it.tax_report_line_vj5
 msgid "VJ5 - Commissions paid by travel agents to their intermediaries"
-msgstr "VJ5 - Provvigioni corrisposte dalle agenzie di viaggio ai propri intermediari"
+msgstr ""
+"VJ5 - Provvigioni corrisposte dalle agenzie di viaggio ai propri "
+"intermediari"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj6
 #: model:account.report.line,name:l10n_it.tax_report_line_vj6
 msgid "VJ6 - Purchases of scrap and other recovered materials"
 msgstr "VJ6 - Acquisti di rottami e altri materiali di recupero"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj7
 #: model:account.report.line,name:l10n_it.tax_report_line_vj7
 msgid "VJ7 - Purchases of industrial gold and pure silver made in Italy"
 msgstr "VJ7 - Acquisti di oro industriale e argento puro effettuati in Italia"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj8
 #: model:account.report.line,name:l10n_it.tax_report_line_vj8
 msgid "VJ8 - Investment gold purchases made in Italy"
 msgstr "VJ8 - Acquisti di oro da investimento effettuati in Italia"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj9
 #: model:account.report.line,name:l10n_it.tax_report_line_vj9
 msgid "VJ9 - Intra-EU Purchases of Goods"
 msgstr "VJ9 - Acquisti intracomunitari di beni"
 
 #. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_vl
+msgid "VL VAT Report"
+msgstr "Rapporto IVA VL"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl1
+msgid "VL1 - VAT payable"
+msgstr "VL1 - IVA da pagare"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl10
+msgid "VL10 - Non-transferable credit surplus"
+msgstr "VL10 - Eccedenza di credito non trasferibile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl11
+msgid ""
+"VL11 - Credits art. 8, paragraph 6-quater, Presidential Decree. n. 322/98"
+msgstr "VL11 - Crediti art. 8, comma 6-quater, DPR. n. 322/98"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl12
+msgid "VL12 - Periodic payments omitted"
+msgstr "VL12 - Omissione di pagamenti periodici"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl2
+msgid "VL2 - VAT deductible"
+msgstr "VL2 - IVA deducibile"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl20
+msgid "VL20 - Interim refunds required"
+msgstr "VL20 - Rimborsi intermedi richiesti"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl21
+msgid "VL21 - Amount of credits transferred"
+msgstr "VL21 - Quantità di crediti trasferiti"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl22
+msgid "VL22 - VAT credit resulting from the first 3 quarters"
+msgstr "VL22 - Credito IVA risultante dai primi 3 trimestri"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl23
+msgid "VL23 - Interest due for quarterly payments"
+msgstr "VL23 - Interessi dovuti per pagamenti trimestrali"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl24
+msgid "VL24 - Previous year transfers returned by the parent company"
+msgstr ""
+"VL24 - Trasferimenti dell'anno precedente restituiti dalla società madre"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl25
+msgid "VL25 - Previous year credit surplus"
+msgstr "VL25 - Eccedenza di credito dell'anno precedente"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl26
+msgid ""
+"VL26 - Credit requested for reimbursement in previous years computable as a "
+"deduction following refusal by the office"
+msgstr ""
+"VL26 - Credito richiesto a rimborso in anni precedenti computabile in "
+"detrazione a seguito di diniego da parte dell'ufficio"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl27
+msgid ""
+"VL27 - Tax credits used in periodic payments and for the advance payment"
+msgstr ""
+"VL27 - Crediti d'imposta utilizzati nelle liquidazioni periodiche e per "
+"l'acconto"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl28
+msgid ""
+"VL28 - Credits received from savings management companies used in periodic "
+"payments and for the advance payment"
+msgstr ""
+"VL28 - Crediti ricevuti da società di gestione del risparmio utilizzati per "
+"i pagamenti periodici e per il pagamento anticipato"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl29
+msgid "VL29 - EU car payments relating to sales carried out during the year"
+msgstr ""
+"VL29 - Pagamenti auto UE relativi a vendite effettuate nel corso dell'anno"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl3
+msgid "VL3 - Tax Due"
+msgstr "VL3 - Imposta dovuta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30
+msgid "VL30 - Periodic VAT amount"
+msgstr "VL30 - Importo IVA periodico"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl31
+msgid "VL31 - Amount of debts transferred"
+msgstr "VL31 - Importo dei debiti trasferiti"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl32
+msgid "VL32 - VAT DUE"
+msgstr "VL32 - IVA DOVUTA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl33
+msgid "VL33 - VAT CREDIT"
+msgstr "VL33 - CREDITO IVA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl34
+msgid "VL34 - Tax credits used in the annual return"
+msgstr "VL34 - Crediti d'imposta utilizzati nella dichiarazione annuale"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl35
+msgid ""
+"VL35 - Credits received from asset management companies used in the annual "
+"declaration"
+msgstr ""
+"VL35 - Crediti ricevuti da società di gestione del risparmio utilizzati "
+"nella dichiarazione annuale"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl36
+msgid "VL36 - Interest due on the annual return"
+msgstr "VL36 - Interessi dovuti sulla dichiarazione annuale"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl37
+msgid ""
+"VL37 - Credit transferred by savings management companies pursuant to art. 8"
+" of the legislative decree n. 351/2001"
+msgstr ""
+"VL37 - Crediti ceduti da società di gestione del risparmio ai sensi "
+"dell'art. 8 del decreto legislativo n. 351/2001"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl38
+msgid "VL38 - TOTAL VAT DUE"
+msgstr "VL38 - TOTALE IVA DOVUTA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl39
+msgid "VL39 - TOTAL VAT INPUT"
+msgstr "VL39 - TOTALE IVA IN ENTRATA"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl4
+msgid "VL4 - Tax Credit"
+msgstr "VL4 - Credito d'imposta"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl40
+msgid "VL40 - Payments made following excess use of credit"
+msgstr ""
+"VL40 - Pagamenti effettuati a seguito di un utilizzo eccessivo del credito"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl41_II
+msgid "VL41 - Difference between credit potential and actual credit"
+msgstr "VL41 - Differenza tra credito potenziale e credito effettivo"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl41_I
+msgid "VL41 - Difference between periodic VAT due and periodic VAT paid"
+msgstr "VL41 - Differenza tra IVA periodica dovuta e IVA periodica versata"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl8
+msgid "VL8 - Credit resulting from the previous year's declaration"
+msgstr "VL8 - Credito risultante dalla dichiarazione dell'anno precedente"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl9
+msgid "VL9 - Credit offset in the template"
+msgstr "VL9 - Compensazione del credito nel modello"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp10
 #: model:account.report.line,name:l10n_it.tax_report_line_vp10
 msgid "VP10 - EU car payments"
 msgstr "VP10 - Versamenti auto UE"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp11
 #: model:account.report.line,name:l10n_it.tax_report_line_vp11
 msgid "VP11 - Tax Credit"
 msgstr "VP11 - Credito d'imposta"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp12
 #: model:account.report.line,name:l10n_it.tax_report_line_vp12
 msgid "VP12 - Interest due for quarterly settlements"
 msgstr "VP12 - Interessi dovuti per liquidazioni trimestrali"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp13
 #: model:account.report.line,name:l10n_it.tax_report_line_vp13
 msgid "VP13 - Down payment due"
 msgstr "VP13 - Acconto dovuto"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp14
 #: model:account.report.line,name:l10n_it.tax_report_line_vp14
 msgid "VP14 - VAT payable"
 msgstr "VP14 - IVA da versare"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp14a
 #: model:account.report.line,name:l10n_it.tax_report_line_vp14a
 msgid "VP14a - VAT payable (debit)"
 msgstr "VP14a - IVA da versare (debito)"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp14b
 #: model:account.report.line,name:l10n_it.tax_report_line_vp14b
 msgid "VP14b - VAT payable (credit)"
 msgstr "VP14b - IVA da versare (credito)"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp2
 #: model:account.report.line,name:l10n_it.tax_report_line_vp2
 msgid "VP2 - Total active transactions"
 msgstr "VP2 - Totale operazioni attive"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp3
 #: model:account.report.line,name:l10n_it.tax_report_line_vp3
 msgid "VP3 - Total passive transactions"
 msgstr "VP3 - Totale operazioni passive"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp4
 #: model:account.report.line,name:l10n_it.tax_report_line_vp4
 msgid "VP4 - VAT due"
 msgstr "VP4 - IVA esigibile"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp5
 #: model:account.report.line,name:l10n_it.tax_report_line_vp5
 msgid "VP5 - VAT Deductible"
 msgstr "VP5 - IVA detraibile"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp6
 #: model:account.report.line,name:l10n_it.tax_report_line_vp6
 msgid "VP6 - VAT due"
 msgstr "VP6 - IVA dovuta"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp6a
 #: model:account.report.line,name:l10n_it.tax_report_line_vp6a
 msgid "VP6a - VAT due (payable)"
 msgstr "VP6a - IVA dovuta (debito)"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp6b
 #: model:account.report.line,name:l10n_it.tax_report_line_vp6b
 msgid "VP6b - VAT due (credit)"
 msgstr "VP6b - IVA dovuta (credito)"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp7
 #: model:account.report.line,name:l10n_it.tax_report_line_vp7
 msgid "VP7 - Previous period debt not to exceed 25,82"
 msgstr "VP7 - Debito periodo precedente non superiore 25,82"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp8
 #: model:account.report.line,name:l10n_it.tax_report_line_vp8
 msgid "VP8 - Previous period credit"
 msgstr "VP8 - Credito periodo precedente"
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp9
 #: model:account.report.line,name:l10n_it.tax_report_line_vp9
 msgid "VP9 - Previous year credit"
 msgstr "VP9 - Credito anno precedente"
@@ -641,6 +1636,11 @@ msgstr "Rettifiche di valore di attività e passività finanziarie"
 #: model:account.account.tag,name:l10n_it.account_tag_A_PL
 msgid "Value of production"
 msgstr "Valore della produzione"
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vari_communi_perd
+msgid "Changes in reporting periodicals"
+msgstr "Variazioni dei periodici di comunicazione"
 
 #. module: l10n_it
 #: model:ir.model.fields.selection,name:l10n_it.selection__account_tax__l10n_it_exempt_reason__n1

--- a/addons/l10n_it/i18n/l10n_it.pot
+++ b/addons/l10n_it/i18n/l10n_it.pot
@@ -16,6 +16,11 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: l10n_it
+#: model:ir.model,name:l10n_it.model_account_chart_template
+msgid "Account Chart Template"
+msgstr ""
+
+#. module: l10n_it
 #: model:ir.model,name:l10n_it.model_account_report_expression
 msgid "Accounting Report Expression"
 msgstr ""
@@ -31,18 +36,54 @@ msgid "Accruals and deferrals - Liabilities"
 msgstr ""
 
 #. module: l10n_it
-#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_4
-msgid "Altre operazioni"
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_3b
+msgid "Agricultural businesses (art.34)"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover_section_2
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_2
+msgid ""
+"Agricultural taxable transactions (Article 34 paragraph 1) and commercial "
+"and professional taxable transactions"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat
+msgid "Annual Tax Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_comp_fram
+msgid "Annual tax for completed schedules"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_VIII
+msgid "Article operations 7 to 7-septies without right to deduction"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_va
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_ve
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_vf
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_vh
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_vj
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_balance_vl
+#: model:account.report.column,name:l10n_it.tax_monthly_report_vat_balance
 #: model:account.report.column,name:l10n_it.tax_report_vat_balance
 msgid "Balance"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_saldi_riporti_e_interessi
 #: model:account.report.line,name:l10n_it.tax_report_line_saldi_riporti_e_interessi
 msgid "Balances, carryovers and interest"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_dag
+msgid "Business Information"
 msgstr ""
 
 #. module: l10n_it
@@ -51,10 +92,11 @@ msgid "Commitments"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover_section_1
 #: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_1
 msgid ""
-"Conferimenti di prodotti agricoli e cessioni da agricoltori esonerati (in "
-"caso di superamento di 1/3"
+"Contributions of agricultural products and transfers from exempt farmers (in"
+" case of exceeding 1/3"
 msgstr ""
 
 #. module: l10n_it
@@ -65,6 +107,62 @@ msgstr ""
 #. module: l10n_it
 #: model:account.account.tag,name:l10n_it.account_tag_D_PASS
 msgid "Debts"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29_I
+msgid "Depreciable assets"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_IV
+msgid "Depreciable assets and transfers interiors exempt"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_comp_fram_1
+msgid "Determination of VAT due or credit for the tax period"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_comp_fram_3
+msgid ""
+"Determination of debit or credit VAT relating to all activities carried out"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va5_section_1
+msgid "Equipment purchases"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_3a
+msgid "Exempt operations"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_VII
+msgid "Exempt operations art. 19, co. 3, letter. a-bis) and d-bis)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_III
+msgid "Exempt operations referred to in art. 10, n. 27-quinquies"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_II
+msgid ""
+"Exempt operations referred to in nos. from 1 to 9 of the art. 10 not "
+"included in their own business of the company or ancillary to taxable "
+"operations"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_I
+msgid ""
+"Exempt transactions relating to gold from investments made by the subjects "
+"referred to in the art. 19, co. 3, letter. d)"
 msgstr ""
 
 #. module: l10n_it
@@ -93,6 +191,16 @@ msgid "Fixed assets"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_dag_section1
+msgid "General analytical data"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29_III
+msgid "Goods intended for resale or for the production of goods and services"
+msgstr ""
+
+#. module: l10n_it
 #. odoo-python
 #: code:addons/l10n_it/models/account_tax.py:0
 #, python-format
@@ -107,10 +215,74 @@ msgid "Law Reference"
 msgstr ""
 
 #. module: l10n_it
-#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_2
-msgid ""
-"Operazioni imponibili agricole (art.34 comma 1) e operazioni imponibili "
-"commerciali e professional"
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va5_section_2
+msgid "Management services"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_monthly_report_vat
+msgid "Monthly VAT Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29_II
+msgid "Non-depreciable capital goods"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_IX
+msgid "Operations exempted by law no. 178/2020"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_V
+msgid "Operations not subject"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34_VI
+msgid "Operations not subject to art. 74, co. 1"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover_section_4
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_4
+msgid "Other operations"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29_IV
+msgid "Other purchases and imports"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op
+msgid "Passive operations and VAT deduction allowed"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30_I
+msgid "Periodic VAT due"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30_II
+msgid "Periodic VAT paid"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30_III
+msgid "Periodic VAT paid following notification of irregularities"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30_IV
+msgid "Periodic VAT paid following payment orders"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_comp_fram_2
+msgid "Previous year credit"
 msgstr ""
 
 #. module: l10n_it
@@ -124,11 +296,17 @@ msgid "Provisions for risks and charges"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_1
+msgid "Purchases (Domestic, intra-Community and imports)"
+msgstr ""
+
+#. module: l10n_it
 #: model:account.account.tag,name:l10n_it.account_tag_A_ATT
 msgid "Receivables from shareholders"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_reverse_charge_iva
 #: model:account.report.line,name:l10n_it.tax_report_line_reverse_charge_iva
 msgid "Reverse Charge"
 msgstr ""
@@ -149,6 +327,11 @@ msgid "Shareholders' Equity"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_3c
+msgid "Special cases"
+msgstr ""
+
+#. module: l10n_it
 #. odoo-python
 #: code:addons/l10n_it/models/account_tax.py:0
 #, python-format
@@ -156,6 +339,20 @@ msgid "Split Payment is not compatible with exoneration of kind 'N6'"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_dag_section2
+msgid "Summary data for all activities"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_tax_va
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_tax_ve
+#: model:account.report.column,name:l10n_it.tax_annual_report_vat_tax_vf
+#: model:ir.model,name:l10n_it.model_account_tax
+msgid "Tax"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_operazione_imponibile
 #: model:account.report.line,name:l10n_it.tax_report_line_operazione_imponibile
 msgid "Taxable transaction"
 msgstr ""
@@ -166,16 +363,64 @@ msgid "Third party assets"
 msgstr ""
 
 #. module: l10n_it
-#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_3
-msgid "Totale imponibile e imposta"
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_2
+msgid ""
+"Total purchases and imports, total tax, purchases intra-community, imports "
+"and purchases"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover_section_3
+#: model:account.report.line,name:l10n_it.tax_report_line_turnover_section_3
+msgid "Total taxable income and tax"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_turnover
 #: model:account.report.line,name:l10n_it.tax_report_line_turnover
 msgid "Turnover"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_va
+msgid "VA VAT Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va1
+msgid ""
+"VA1 - To be filled in by the entity of originator in cases of extraordinary "
+"transactions"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va16
+msgid ""
+"VA11 - Data on amounts suspended as a result of the health emergency by "
+"COVID-19"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va12
+msgid ""
+"VA12 - Reserved for indication of surplus credit of former parent companies "
+"to be guaranteed"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va13
+msgid "VA13 - Transactions carried out with respect to condominiums"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va5
+msgid ""
+"VA5 - Terminals for mobile telecommunication radio service with more than "
+"50% deduction"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_iva
 #: model:account.report.line,name:l10n_it.tax_report_line_iva
 msgid "VAT"
 msgstr ""
@@ -186,286 +431,738 @@ msgid "VAT Report"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_conto_corrente_iva
 #: model:account.report.line,name:l10n_it.tax_report_line_conto_corrente_iva
 msgid "VAT account"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_passive_op_4
+msgid "VAT allowed as deduction"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_va1_4
+msgid "VAT/2023 declaration credit transferred"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_ve
+msgid "VE VAT Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve1
 #: model:account.report.line,name:l10n_it.tax_report_line_ve1
 msgid ""
-"VE1 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 2%"
+"VE1 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 2%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve10
 #: model:account.report.line,name:l10n_it.tax_report_line_ve10
 msgid ""
-"VE10 - Passaggi a cooperative art.34 comma 2 con percentuale di "
-"compensazione 10%"
+"VE10 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 10%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve11
 #: model:account.report.line,name:l10n_it.tax_report_line_ve11
 msgid ""
-"VE11 - Passaggi a cooperative art.34 comma 2 con percentuale di "
-"compensazione 12,3%"
+"VE11 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 12,3%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve2
 #: model:account.report.line,name:l10n_it.tax_report_line_ve2
 msgid ""
-"VE2 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 4%"
+"VE2 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 4%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve20
 #: model:account.report.line,name:l10n_it.tax_report_line_ve20
-msgid "VE20 - Operazioni imponibili aliquota 4%"
+msgid "VE20 - Taxable transactions rate 4%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve21
 #: model:account.report.line,name:l10n_it.tax_report_line_ve21
-msgid "VE21 - Operazioni imponibili aliquota 5%"
+msgid "VE21 - Taxable transactions rate 5%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve22
 #: model:account.report.line,name:l10n_it.tax_report_line_ve22
-msgid "VE22 - Operazioni imponibili aliquota 10%"
+msgid "VE22 - Taxable transactions rate 10%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve23
 #: model:account.report.line,name:l10n_it.tax_report_line_ve23
-msgid "VE23 - Operazioni imponibili aliquota 22%"
+msgid "VE23 - Taxable transactions rate 22%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve24
 #: model:account.report.line,name:l10n_it.tax_report_line_ve24
-msgid "VE24 - Totale righe da VE1 a VE11 e linee da VE20 a VE23"
+msgid "VE24 - Total lines VE1 to VE11 and lines VE20 to VE23"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve25
 #: model:account.report.line,name:l10n_it.tax_report_line_ve25
-msgid "VE25 - Variazioni e arrotondamenti (usare segno +/−)"
+msgid "VE25 - Variations and rounding (use +/− sign)"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve26
 #: model:account.report.line,name:l10n_it.tax_report_line_ve26
-msgid "VE26 - Totale VE24 e VE25"
+msgid "VE26 - Total VE24 and VE25"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve3
 #: model:account.report.line,name:l10n_it.tax_report_line_ve3
 msgid ""
-"VE3 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 6,4%"
+"VE3 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 6,4%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30
-msgid "VE30 - Operazioni che concorrono alla formazione del plafond"
+msgid "VE30 - Transactions that contribute to the formation of the ceiling"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_I
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_I
-msgid "VE30_I - Totale"
+msgid "VE30_I - Total"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_ii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_ii
-msgid "VE30_II - Esportazioni"
+msgid "VE30_II - Exports"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_iii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_iii
-msgid "VE30_III - Cessioni intracomunitarie"
+msgid "VE30_III - Intra-Community supplies"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_iv
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_iv
-msgid "VE30_IV - Cessioni verso San Marino"
+msgid "VE30_IV - Transfers to San Marino"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve30_v
 #: model:account.report.line,name:l10n_it.tax_report_line_ve30_v
-msgid "VE30_V - Operazioni assimilate"
+msgid "VE30_V - Assimilated operations"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve31
 #: model:account.report.line,name:l10n_it.tax_report_line_ve31
-msgid "VE31 - Operazioni non imponibili a seguito di dichiarazioni di intento"
+msgid "VE31 - Non-taxable transactions as a result of declarations of intent"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve32
 #: model:account.report.line,name:l10n_it.tax_report_line_ve32
-msgid "VE32 - Altre operazioni non imponibili"
+msgid "VE32 - Other non-taxable transactions"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve33
 #: model:account.report.line,name:l10n_it.tax_report_line_ve33
-msgid "VE33 - Operazioni esenti (art.10"
+msgid "VE33 - Exempt transactions (art.10"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve34
 #: model:account.report.line,name:l10n_it.tax_report_line_ve34
 msgid ""
-"VE34 - Operazioni non soggette all’imposta ai sensi degli articoli da 7 a "
-"7-septies"
+"VE34 - Transactions not subject to the tax under Articles 7 to 7-septies"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35
-msgid "VE35 - Operazioni con applicazione del reverse charge interno"
+msgid "VE35 - Transactions with application of internal reverse charge"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_I
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_I
 msgid "VE35_I - Total"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_ii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_ii
-msgid "VE35_II - Cessioni di rottami e altri materiali di recupero"
+msgid "VE35_II - Disposal of scrap and other recovered materials"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_iii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_iii
-msgid "VE35_III - Cessioni di oro e argento puro"
+msgid "VE35_III - Disposals of pure gold and silver"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_iv
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_iv
-msgid "VE35_IV - Subappalto nel settore edile"
+msgid "VE35_IV - Subcontracting in the construction industry"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_ix
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_ix
-msgid "VE35_IX - Operazioni settore energetico"
+msgid "VE35_IX - Energy sector operations"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_v
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_v
-msgid "VE35_V - Cessioni di fabbricati strumentali"
+msgid "VE35_V - Disposal of capital buildings"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_vi
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_vi
-msgid "VE35_VI - Cessioni di telefoni cellulari"
+msgid "VE35_VI - Disposal of cell phones"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_vii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_vii
-msgid "VE35_VII - Cessioni di prodotti elettronici"
+msgid "VE35_VII - Disposal of electronic products"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve35_viii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve35_viii
-msgid "VE35_VIII - Prestazioni comparto edile e settori connessi"
+msgid "VE35_VIII - Benefits construction and related industries"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve36
 #: model:account.report.line,name:l10n_it.tax_report_line_ve36
-msgid ""
-"VE36 - Operazioni non soggette all\"imposta effettuate nei confronti dei "
-"terremotati"
+msgid "VE36 - Non-taxable transactions made to earthquake victims"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve37
 #: model:account.report.line,name:l10n_it.tax_report_line_ve37
 msgid ""
-"VE37 - Operazioni effettuate nell\"anno ma con imposta esigibile negli anni "
-"successivi"
+"VE37 - Transactions made during the year but with tax due in subsequent "
+"years"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve37_I
 #: model:account.report.line,name:l10n_it.tax_report_line_ve37_I
 msgid "VE37_I - Total"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve37_ii
 #: model:account.report.line,name:l10n_it.tax_report_line_ve37_ii
-msgid "VE37_II - ex art. 32-bis, DL n. 83/2012"
+msgid "VE37_II - ex art. 32-bis, DL no. 83/2012"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve38
 #: model:account.report.line,name:l10n_it.tax_report_line_ve38
-msgid "VE38 - Operazioni nei confronti di soggetti di cui all\"art.17-ter"
+msgid "VE38 - Transactions with parties referred to in Article 17-ter."
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve39
 #: model:account.report.line,name:l10n_it.tax_report_line_ve39
 msgid ""
-"VE39 - (meno) Operazioni effettuate in anni precedenti ma con imposta "
-"esigibile nel 2022"
+"VE39 - (minus) Transactions made in previous years but with tax due in 2022"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve4
 #: model:account.report.line,name:l10n_it.tax_report_line_ve4
 msgid ""
-"VE4 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 7,3%"
+"VE4 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 7,3%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve40
 #: model:account.report.line,name:l10n_it.tax_report_line_ve40
-msgid "VE40 - (meno) Cessioni di beni ammortizzabili e passaggi interni"
+msgid "VE40 - (minus) Disposals of depreciable assets and internal transfers."
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve5
 #: model:account.report.line,name:l10n_it.tax_report_line_ve5
 msgid ""
-"VE5 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 7,5%"
+"VE5 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 7,5%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve45
+msgid "VE50 - TURNOVER"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve6
 #: model:account.report.line,name:l10n_it.tax_report_line_ve6
 msgid ""
-"VE6 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 8,3%"
+"VE6 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 8,3%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve7
 #: model:account.report.line,name:l10n_it.tax_report_line_ve7
 msgid ""
-"VE7 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 8,5%"
+"VE7 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 8,5%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve8
 #: model:account.report.line,name:l10n_it.tax_report_line_ve8
 msgid ""
-"VE8 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 8,8%"
+"VE8 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 8,8%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_ve9
 #: model:account.report.line,name:l10n_it.tax_report_line_ve9
 msgid ""
-"VE9 - Passaggi a cooperative art.34 comma 2 con percentuale di compensazione"
-" 9,5%"
+"VE9 - Transfers to cooperatives art.34 paragraph 2 with compensation "
+"percentage 9,5%"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_vf
+msgid "VF VAT Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF1
+msgid "VF1 - compensation percentage 2%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF10
+msgid "VF10 - compensation percentage 9.5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF11
+msgid "VF11 - compensation percentage 10%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF12
+msgid "VF12 - compensation percentage 12,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF13
+msgid "VF13 - compensation percentage 22%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF17
+msgid ""
+"VF17 - Purchases and imports without payment of tax, with use of the ceiling"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF18_II
+msgid "VF18 - Exempt purchases and imports not subject to the tax"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF18_I
+msgid ""
+"VF18 - Other non-tax purchases, not subject to tax and relating to certain "
+"special regimes"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF19
+msgid ""
+"VF19 - Purchases from subjects who have made use of concessional schemes"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF2
+msgid "VF2 - compensation percentage 4%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF20
+msgid ""
+"VF20 - Purchases and imports not subject to the tax made by earthquake "
+"victims"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF21
+msgid ""
+"VF21 - Purchases and imports for which the deduction is excluded or reduced "
+"(art. 19-bis1)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF22
+msgid "VF22 - Purchases and imports for which the deduction is not permitted"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF23
+msgid ""
+"VF23 - Purchases recorded in the year but with tax deduction deferred to "
+"subsequent years"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF24
+msgid "VF24 - Purchases recorded in previous years but with tax"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF25
+msgid "VF25 - Total purchases and imports"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF26
+msgid "VF26 - Tax variations and roundings (indicate with the +/- sign)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF27
+msgid "VF27 - Total tax on taxable purchases and imports"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF28_II
+msgid "VF28 - Imports"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF28_I
+msgid "VF28 - Intra-community purchases"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF28_III
+msgid "VF28 - Purchases from San Marino"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF29
+msgid "VF29 - Total distribution of purchases and imports"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF3
+msgid "VF3 - compensation percentage 5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF31
+msgid "VF31 - Purchases intended for occasional taxable transactions"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF34
+msgid "VF34 - Data for calculating the deduction percentage"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF35
+msgid "VF35 - VAT not paid on purchases and imports indicated"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF36
+msgid ""
+"VF36 - VAT deductible for gold purchases made by parties other than "
+"producers and transformers pursuant to art. 19, paragraph 5 bis"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF37
+msgid "VF37 - VAT allowed as deduction"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF38
+msgid "VF38 - Reserved for mixed agricultural enterprises"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF39
+msgid "VF39 - compensation percentage 2%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF4
+msgid "VF4 - compensation percentage 6.4%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF40
+msgid "VF40 - compensation percentage 4%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF41
+msgid "VF41 - compensation percentage 6.4%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF42
+msgid "VF42 - compensation percentage 7,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF43
+msgid "VF43 - compensation percentage 7,5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF44
+msgid "VF44 - compensation percentage 8,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF45
+msgid "VF45 - compensation percentage 8,5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF46
+msgid "VF46 - compensation percentage 8,8%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF47
+msgid "VF47 - compensation percentage 9.5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF48
+msgid "VF48 - compensation percentage 10%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF49
+msgid "VF49 - compensation percentage 12,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF5
+msgid "VF5 - compensation percentage 7,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF51
+msgid "VF51 - Tax variations and roundings (indicate with the +/- sign)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF52
+msgid "VF52 - TOTALS Algebraic sum of lines from VF39 to VF51"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF53
+msgid ""
+"VF53 - Deductible VAT charged to the operations referred to in line VF38"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF54
+msgid ""
+"VF54 - Deductible amount for transfers, including intra-community, of "
+"agricultural products referred to in art. 34"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF55
+msgid "VF55 - TOTAL VAT allowed as deduction"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF6
+msgid "VF6 - compensation percentage 7,5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF62
+msgid "VF62 - Reserved for agricultural businesses"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF7
+msgid "VF7 - compensation percentage 8,3%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF70
+msgid "VF70 - TOTAL adjustments (indicate with the +/- sign)"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF71
+msgid "VF71 - VAT allowed as deduction"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF8
+msgid "VF8 - compensation percentage 8,5%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_VF9
+msgid "VF9 - compensation percentage 8,8%"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_vh
+msgid "VH VAT Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh1
+msgid "VH1 - January"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh10
+msgid "VH10 - August"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh11
+msgid "VH11 - September"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh12
+msgid "VH12 - QUARTER III"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh13
+msgid "VH13 - October"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh14
+msgid "VH14 - November"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh15
+msgid "VH15 - December"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh16
+msgid "VH16 - QUARTER IV"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh17
+msgid "VH17 - Deposit due"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh2
+msgid "VH2 - February"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh3
+msgid "VH3 - March"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh4
+msgid "VH4 - QUARTER I"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh5
+msgid "VH5 - April"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh6
+msgid "VH6 - May"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh7
+msgid "VH7 - June"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh8
+msgid "VH8 - QUARTER II"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vh9
+msgid "VH9 - July"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_vj
+msgid "VJ VAT Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj1
 #: model:account.report.line,name:l10n_it.tax_report_line_vj1
 msgid "VJ1 - Purchases of goods from Vatican City and San Marino"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj10
 #: model:account.report.line,name:l10n_it.tax_report_line_vj10
 msgid "VJ10 - Imports of scrap and other recovered materials"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj11
 #: model:account.report.line,name:l10n_it.tax_report_line_vj11
 msgid "VJ11 - Imports of industrial gold and pure silver"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj12
 #: model:account.report.line,name:l10n_it.tax_report_line_vj12
 msgid "VJ12 - Subcontracting of services in the construction field"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj13
 #: model:account.report.line,name:l10n_it.tax_report_line_vj13
 msgid ""
 "VJ13 - Purchases of buildings or portions of buildings used for capital "
@@ -473,47 +1170,56 @@ msgid ""
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj14
 #: model:account.report.line,name:l10n_it.tax_report_line_vj14
 msgid "VJ14 - Purchases of cell phones"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj15
 #: model:account.report.line,name:l10n_it.tax_report_line_vj15
 msgid "VJ15 - Purchases of electronic products"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj16
 #: model:account.report.line,name:l10n_it.tax_report_line_vj16
 msgid "VJ16 - Provision of services in the construction field"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj17
 #: model:account.report.line,name:l10n_it.tax_report_line_vj17
 msgid "VJ17 - Purchases of energy sector goods and services"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj18
 #: model:account.report.line,name:l10n_it.tax_report_line_vj18
 msgid "VJ18 - Purchases made by VAT-registered public administrations"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj19
 #: model:account.report.line,name:l10n_it.tax_report_line_vj19
 msgid "VJ19 - Total frame VJ"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj2
 #: model:account.report.line,name:l10n_it.tax_report_line_vj2
 msgid "VJ2 - Extraction of goods from VAT warehouses"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj3
 #: model:account.report.line,name:l10n_it.tax_report_line_vj3
 msgid ""
 "VJ3 - Purchases of goods already in Italy or services, from non-residents"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj4
 #: model:account.report.line,name:l10n_it.tax_report_line_vj4
 msgid ""
 "VJ4 - Fees paid to resellers of travel tickets and resellers of parking "
@@ -521,111 +1227,308 @@ msgid ""
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj5
 #: model:account.report.line,name:l10n_it.tax_report_line_vj5
 msgid "VJ5 - Commissions paid by travel agents to their intermediaries"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj6
 #: model:account.report.line,name:l10n_it.tax_report_line_vj6
 msgid "VJ6 - Purchases of scrap and other recovered materials"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj7
 #: model:account.report.line,name:l10n_it.tax_report_line_vj7
 msgid "VJ7 - Purchases of industrial gold and pure silver made in Italy"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj8
 #: model:account.report.line,name:l10n_it.tax_report_line_vj8
 msgid "VJ8 - Investment gold purchases made in Italy"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vj9
 #: model:account.report.line,name:l10n_it.tax_report_line_vj9
 msgid "VJ9 - Intra-EU Purchases of Goods"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report,name:l10n_it.tax_annual_report_vat_vl
+msgid "VL VAT Report"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl1
+msgid "VL1 - VAT payable"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl10
+msgid "VL10 - Non-transferable credit surplus"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl11
+msgid ""
+"VL11 - Credits art. 8, paragraph 6-quater, Presidential Decree. n. 322/98"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl12
+msgid "VL12 - Periodic payments omitted"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl2
+msgid "VL2 - VAT deductible"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl20
+msgid "VL20 - Interim refunds required"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl21
+msgid "VL21 - Amount of credits transferred"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl22
+msgid "VL22 - VAT credit resulting from the first 3 quarters"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl23
+msgid "VL23 - Interest due for quarterly payments"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl24
+msgid "VL24 - Previous year transfers returned by the parent company"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl25
+msgid "VL25 - Previous year credit surplus"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl26
+msgid ""
+"VL26 - Credit requested for reimbursement in previous years computable as a "
+"deduction following refusal by the office"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl27
+msgid ""
+"VL27 - Tax credits used in periodic payments and for the advance payment"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl28
+msgid ""
+"VL28 - Credits received from savings management companies used in periodic "
+"payments and for the advance payment"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl29
+msgid "VL29 - EU car payments relating to sales carried out during the year"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl3
+msgid "VL3 - Tax Due"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl30
+msgid "VL30 - Periodic VAT amount"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl31
+msgid "VL31 - Amount of debts transferred"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl32
+msgid "VL32 - VAT DUE"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl33
+msgid "VL33 - VAT CREDIT"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl34
+msgid "VL34 - Tax credits used in the annual return"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl35
+msgid ""
+"VL35 - Credits received from asset management companies used in the annual "
+"declaration"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl36
+msgid "VL36 - Interest due on the annual return"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl37
+msgid ""
+"VL37 - Credit transferred by savings management companies pursuant to art. 8"
+" of the legislative decree n. 351/2001"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl38
+msgid "VL38 - TOTAL VAT DUE"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl39
+msgid "VL39 - TOTAL VAT INPUT"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl4
+msgid "VL4 - Tax Credit"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl40
+msgid "VL40 - Payments made following excess use of credit"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl41_II
+msgid "VL41 - Difference between credit potential and actual credit"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl41_I
+msgid "VL41 - Difference between periodic VAT due and periodic VAT paid"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl8
+msgid "VL8 - Credit resulting from the previous year's declaration"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vl9
+msgid "VL9 - Credit offset in the template"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp10
 #: model:account.report.line,name:l10n_it.tax_report_line_vp10
 msgid "VP10 - EU car payments"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp11
 #: model:account.report.line,name:l10n_it.tax_report_line_vp11
 msgid "VP11 - Tax Credit"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp12
 #: model:account.report.line,name:l10n_it.tax_report_line_vp12
 msgid "VP12 - Interest due for quarterly settlements"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp13
 #: model:account.report.line,name:l10n_it.tax_report_line_vp13
 msgid "VP13 - Down payment due"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp14
 #: model:account.report.line,name:l10n_it.tax_report_line_vp14
 msgid "VP14 - VAT payable"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp14a
 #: model:account.report.line,name:l10n_it.tax_report_line_vp14a
 msgid "VP14a - VAT payable (debit)"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp14b
 #: model:account.report.line,name:l10n_it.tax_report_line_vp14b
 msgid "VP14b - VAT payable (credit)"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp2
 #: model:account.report.line,name:l10n_it.tax_report_line_vp2
 msgid "VP2 - Total active transactions"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp3
 #: model:account.report.line,name:l10n_it.tax_report_line_vp3
 msgid "VP3 - Total passive transactions"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp4
 #: model:account.report.line,name:l10n_it.tax_report_line_vp4
 msgid "VP4 - VAT due"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp5
 #: model:account.report.line,name:l10n_it.tax_report_line_vp5
 msgid "VP5 - VAT Deductible"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp6
 #: model:account.report.line,name:l10n_it.tax_report_line_vp6
 msgid "VP6 - VAT due"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp6a
 #: model:account.report.line,name:l10n_it.tax_report_line_vp6a
 msgid "VP6a - VAT due (payable)"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp6b
 #: model:account.report.line,name:l10n_it.tax_report_line_vp6b
 msgid "VP6b - VAT due (credit)"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp7
 #: model:account.report.line,name:l10n_it.tax_report_line_vp7
 msgid "VP7 - Previous period debt not to exceed 25,82"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp8
 #: model:account.report.line,name:l10n_it.tax_report_line_vp8
 msgid "VP8 - Previous period credit"
 msgstr ""
 
 #. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_monthly_report_line_vp9
 #: model:account.report.line,name:l10n_it.tax_report_line_vp9
 msgid "VP9 - Previous year credit"
 msgstr ""
@@ -638,6 +1541,11 @@ msgstr ""
 #. module: l10n_it
 #: model:account.account.tag,name:l10n_it.account_tag_A_PL
 msgid "Value of production"
+msgstr ""
+
+#. module: l10n_it
+#: model:account.report.line,name:l10n_it.tax_annual_report_line_vari_communi_perd
+msgid "Changes in reporting periodicals"
 msgstr ""
 
 #. module: l10n_it

--- a/addons/l10n_it/migrations/0.7/post-map_carryover_to_new_report.py
+++ b/addons/l10n_it/migrations/0.7/post-map_carryover_to_new_report.py
@@ -1,0 +1,75 @@
+from odoo import api, SUPERUSER_ID, tools
+
+def migrate(cr, version):
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    vat_report_id = env.ref('l10n_it.tax_report_vat').id
+    monthly_vat_report_id = env.ref('l10n_it.tax_monthly_report_vat').id
+
+    external_value_cols = [
+        col
+        for col in tools.table_columns(env.cr, 'account_report_external_value')
+        if col not in ['id', 'carryover_origin_report_line_id', 'target_report_expression_id']
+    ]
+
+    cr.execute(f"""
+        SELECT report.id AS report_id,
+               expression.id AS expression_id,
+               report_line.code,
+               external_value.carryover_origin_report_line_id,
+               {', '.join(f'external_value.{col}' for col in external_value_cols)}
+          FROM account_report AS report
+          JOIN account_report_line AS report_line ON report.id = report_line.report_id
+          JOIN account_report_expression AS expression ON report_line.id = expression.report_line_id
+                                                      AND expression.engine = 'external'
+     LEFT JOIN account_report_external_value AS external_value ON expression.id = external_value.target_report_expression_id
+         WHERE (
+                   report.id = %s
+                   AND external_value.company_id IS NOT NULL
+               )
+            OR report.id = %s
+      ORDER BY expression_id;
+    """, (vat_report_id, monthly_vat_report_id))
+    report_info = cr.fetchall()
+
+    code2expression_id = {
+        report_line_code: expression_id
+        for report_id, expression_id, report_line_code, *_ in report_info
+        if report_id == monthly_vat_report_id
+    }
+
+    cr.execute("""
+        SELECT DISTINCT old_report_line.id AS old_origin,
+                        new_report_line.id AS new_origin
+                   FROM account_report_external_value external_value
+                   JOIN account_report_line AS old_report_line ON old_report_line.id = external_value.carryover_origin_report_line_id
+                                                              AND old_report_line.report_id = %s
+                   JOIN account_report_line AS new_report_line ON new_report_line.code = old_report_line.code
+                                                              AND new_report_line.report_id = %s;
+    """, (vat_report_id, monthly_vat_report_id))
+    carryover_origin_info = cr.fetchall()
+    old2new_origin = {old_origin: new_origin for old_origin, new_origin in carryover_origin_info}
+    data_to_insert = [
+        (code2expression_id[report_line_code], old2new_origin[carryover_origin_report_line_id], *other_external_vals)
+        for report_id, _, report_line_code, carryover_origin_report_line_id, *other_external_vals in report_info
+        if report_id == vat_report_id
+    ]
+
+    insert_query = f"""
+        INSERT INTO account_report_external_value (
+                        target_report_expression_id,
+                        carryover_origin_report_line_id,
+                        {', '.join(col for col in external_value_cols)}
+                    )
+             VALUES (%s, %s, {', '.join('%s' for _ in external_value_cols)})
+        ON CONFLICT DO NOTHING
+    """
+
+    if data_to_insert:
+        cr.executemany(insert_query, data_to_insert)
+
+    # Archive the old report
+    cr.execute("""
+        UPDATE account_report
+           SET active = FALSE
+         WHERE id = %s
+    """, (vat_report_id,))

--- a/addons/l10n_it/models/account_report.py
+++ b/addons/l10n_it/models/account_report.py
@@ -10,6 +10,8 @@ class AccountReportExpression(models.AbstractModel):
     def _get_carryover_target_expression(self, options):
         if self.report_line_id.code == 'VP14b' and fields.Date.from_string(options['date']['date_to']).month == 12:
             # For this line, if we are between two years, we want to carry over to vp9 instead of the line set in the XML file (vp8)
+            if self.report_line_id == self.env.ref('l10n_it.tax_monthly_report_line_vp14b', raise_if_not_found=False):
+                return self.env.ref('l10n_it.tax_monthly_report_line_vp9_applied_carryover')
             return self.env.ref('l10n_it.tax_report_line_vp9_applied_carryover')
 
         return super()._get_carryover_target_expression(options)


### PR DESCRIPTION
Description of the issue this commit addresses:

The Italian tax report lacks clarity and can be improved both in readabilty and
usability by splitting the monthly and the annual reports.

---

Desired behavior after this commit is merged:

The Italian tax report is now split in a monthly and an annual report.
The report uses the sections mechanism to be split in the different parts it is
made from and clean the UI by not having everything on the same sreen.

---

Enterprise PR: https://github.com/odoo/enterprise/pull/62405
Task-3479785

---

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr