### PR TITLE
[FIX] web: fix columns truncated in x2m

### DIFF
--- a/addons/web/static/src/legacy/js/views/list/list_editable_renderer.js
+++ b/addons/web/static/src/legacy/js/views/list/list_editable_renderer.js
@@ -616,7 +616,7 @@ ListRenderer.include({
             } else {
                 const width = this._getColumnWidth(column);
                 if (width.match(/[a-zA-Z]/)) { // absolute width with measure unit (e.g. 100px)
-                    if (isListEmpty) {
+                    if (column.attrs.width) {
                         th.style.width = width;
                     } else {
                         // If there are records, we force a min-width for fields with an absolute

--- a/addons/web/static/tests/legacy/views/list_tests.js
+++ b/addons/web/static/tests/legacy/views/list_tests.js
@@ -12981,6 +12981,55 @@ QUnit.module('Views', {
         assert.verifySteps(['create']);
     });
 
+    QUnit.test('form view: check one2many list view with relative and absolute field, column headings not truncated', async function (assert) {
+        assert.expect(2);
+
+        serverData.models.foo.fields.foo_o2m = {
+                string: "Foo O2M",
+                type: "one2many",
+                relation: "foo",
+        };
+
+            var form = await createView({
+            View: FormView,
+            model: 'foo',
+            data: this.data,
+            res_id: 1,
+            viewOptions: { mode: 'edit' },
+            arch: `
+                    <form>
+                        <sheet>
+                            <group>
+                                <field name="foo" sring='name'/>
+                            </group>
+                            <notebook>
+                                <page string='Testing x2m without records'>
+                                    <field name="foo_o2m">
+                                        <tree>
+                                            <field name="foo" />
+                                            <field name="bar" string="Testing for very big text in column" />
+                                            <field name="date" string="Testing for fixed width in column" width="100px"/>
+                                        </tree>
+                                    </field>
+                                </page>
+                            </notebook>
+                        </sheet>
+                    </form>`,
+            });
+
+        const relativeFieldHeading = form.el.querySelectorAll('th')
+        assert.strictEqual(
+            relativeFieldHeading[1].style.minWidth,
+            "70px",
+            "Absolute field heading should have min-width of 70px i.e. default width of boolean without any record"
+        );
+        assert.strictEqual(
+            relativeFieldHeading[2].style.width,
+            "100px",
+            "Field heading should have width of 100px without record as defined in inline css"
+        );
+        form.destroy();
+    });
 });
 
 });


### PR DESCRIPTION
Before this commit, columns in the x2m field within a form view with empty records were being truncated and not displayed properly.

Steps to Reproduce:

- Open documents and navigate to actions in the configuration.
- Click on any action and add a rule for any many-to-many field.
- Try to add many-to-many values to that rule.

Observed Behavior:
The columns of the x2m fields without any records were given hardcoded widths, causing the text to be truncated and not properly visible.

Expected Behavior:
The columns of the x2m fields should take up the appropriate space, just as they do when they contain some records.

After this commit, the columns in the x2m field within a form view with empty records will no longer truncate and will be properly visible.

Task ID: 3858802

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
