### PR TITLE
[IMP] stock, product: back to basics usability improvements

### DIFF
--- a/addons/product/views/product_category_views.xml
+++ b/addons/product/views/product_category_views.xml
@@ -60,6 +60,11 @@
         <field name="path">product-categories</field>
         <field name="search_view_id" ref="product_category_search_view"/>
         <field name="view_id" ref="product_category_list_view"/>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face">
+                Create a new product category
+            </p>
+        </field>
     </record>
 
 </odoo>

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -38,7 +38,10 @@ class StockPickingType(models.Model):
         'stock.location', 'Destination Location', compute='_compute_default_location_dest_id',
         check_company=True, store=True, readonly=False, precompute=True, required=True,
         help="This is the default destination location when this operation is manually created. However, it is possible to change it afterwards or that the routes use another one by default.")
-    code = fields.Selection([('incoming', 'Receipt'), ('outgoing', 'Delivery'), ('internal', 'Internal Transfer')], 'Type of Operation', default='incoming', required=True)
+    code = fields.Selection([
+        ('incoming', 'Receipt'),
+        ('outgoing', 'Delivery'),
+        ('internal', 'Internal Transfer')], 'Operation Category', default='incoming', required=True)
     return_picking_type_id = fields.Many2one(
         'stock.picking.type', 'Operation Type for Returns',
         index='btree_not_null',
@@ -549,9 +552,7 @@ class StockPicking(models.Model):
     name = fields.Char(
         'Reference', default='/',
         copy=False, index='trigram', readonly=True)
-    origin = fields.Char(
-        'Source Document', index='trigram',
-        help="Reference of the document")
+    origin = fields.Char('Source Document', index='trigram')
     note = fields.Html('Notes')
     backorder_id = fields.Many2one(
         'stock.picking', 'Back Order of',

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -29,7 +29,7 @@
                                             t-options='{"widget": "contact", "fields": ["address", "name", "phone"], "no_marker": True, "phone_icons": True}'>
                                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 opacity-75 text-muted text-center">
                                                     <strong>Delivery address</strong>
-                                                    <div>Presence depends on the type of operation.</div>
+                                                    <div>Presence depends on the operation category.</div>
                                                 </div>
                                         </div>
                                     </div>
@@ -43,7 +43,7 @@
                                                 t-options='{"widget": "contact", "fields": ["address", "name", "phone", "vat"] if show_full_address else ["name"], "no_marker": True, "phone_icons": True}'>
                                                 <div class="bg-light border-1 rounded h-100 d-flex flex-column align-items-center justify-content-center p-4 opacity-75 text-muted text-center">
                                                 <strong>Recipient address</strong>
-                                                <div>Presence depends on the type of operation.</div>
+                                                <div>Presence depends on the operation category.</div>
                                             </div>
                                         </div>
                                     </div>

--- a/addons/stock/views/res_config_settings_views.xml
+++ b/addons/stock/views/res_config_settings_views.xml
@@ -33,13 +33,13 @@
                                     </div>
                                 </div>
                             </setting>
-                            <setting id="annual_inventory_date" groups='stock.group_stock_manager' string="Annual Inventory Day and Month" help="Day and month that annual inventory counts should occur.">
+                            <setting id="annual_inventory_date" groups='stock.group_stock_manager' string="Annual Inventory Date" help="By default, next physical inventory will be scheduled at this date">
                                 <div class="content-group">
                                     <field name="annual_inventory_day" class="o_light_label" style="width: 30px;"/>
                                     <field name="annual_inventory_month" class="o_light_label"/>
                                 </div>
                             </setting>
-                            <setting id="reception_report" help="View and allocate received quantities.">
+                            <setting id="reception_report" help="View and allocate received quantities">
                                 <field name="group_stock_reception_report"/>
                             </setting>
                         </block>
@@ -61,7 +61,7 @@
                             <setting id="stock_fleet" help="Transport management: organize packs in your fleet, or carriers.">
                                 <field name="module_stock_fleet"/>
                             </setting>
-                            <setting id="stock_move_email" company_dependent="1" string="Email Confirmation" help="Send an automatic confirmation email when Delivery Orders are done">
+                            <setting id="stock_move_email" company_dependent="1" string="Confirmation Email" help="Send an automatic confirmation email when Delivery Orders are done">
                                 <field name="stock_move_email_validation"/>
                             </setting>
                             <setting id="stock_text_confirmation" company_dependent="1" help="Send an automatic confirmation Text Message when Delivery Orders are done" string="Text Confirmation">

--- a/addons/stock/views/stock_orderpoint_views.xml
+++ b/addons/stock/views/stock_orderpoint_views.xml
@@ -172,8 +172,8 @@
             You are good, no replenishment to perform!
           </p><p>
             You'll find here smart replenishment propositions based on inventory forecasts.
-            Choose the quantity to buy or manufacture and launch orders in a click.
-            To save time in the future, set the rules as "automated".
+            Create new replenishment rules if you want to maintain minimum stock levels for
+            some products, and automate these rules to create RFQs or Manufacturing Orders.
           </p>
         </field>
     </record>

--- a/addons/stock/views/stock_picking_type_views.xml
+++ b/addons/stock/views/stock_picking_type_views.xml
@@ -48,7 +48,7 @@
                 <filter name="favorites" string="Favorites" domain="[('is_favorite', '=', True)]"/>
                 <filter string="Archived" name="inactive" domain="[('active','=',False)]"/>
                 <group>
-                    <filter string="Type of Operation" name="groupby_code" domain="[]" context="{'group_by': 'code'}"/>
+                    <filter string="Operation Category" name="groupby_code" domain="[]" context="{'group_by': 'code'}"/>
                     <filter string="Warehouse" name="groupby_warehouse_id" domain="[]" context="{'group_by': 'warehouse_id'}"/>
                 </group>
             </search>
@@ -134,6 +134,12 @@
                         <page name="hardware" string="Hardware" invisible="code not in ['incoming', 'outgoing', 'internal']" >
                             <group name="auto_print">
                                 <group string="Print on Validation">
+                                    <div colspan="2" class="alert alert-info" role="alert">
+                                        Odoo opens a PDF preview by default. If you (Enterprise users only) want to print instantly,
+                                        install the IoT App on a computer that is on the same local network as the
+                                        barcode operator and configure the routing of the reports.
+                                        <widget name="documentation_link" path="/applications/productivity/iot/devices/printer.html" label=" Documentation" icon="fa-arrow-right"/>
+                                    </div>
                                     <field name="auto_print_delivery_slip" string="Delivery Slip"/>
                                     <field name="auto_print_return_slip" string="Return Slip"/>
                                     <label for="auto_print_product_labels" string="Product Labels"/>
@@ -151,15 +157,6 @@
                                     <field name="auto_print_reception_report" string="Reception Report" invisible="code == 'outgoing'" groups="stock.group_reception_report"/>
                                     <field name="auto_print_reception_report_labels" string="Reception Report Labels" invisible="code == 'outgoing'" groups="stock.group_reception_report"/>
                                     <field name="auto_print_packages" string="Package Content" groups="stock.group_tracking_lot"/>
-                                </group>
-                                <group string="">
-                                    <div colspan="2">
-                                        Odoo opens a PDF preview by default. If you (Enterprise users only) want to print instantly,
-                                        install the IoT App on a computer that is on the same local network as the
-                                        barcode operator and configure the routing of the reports.
-                                        <br/>
-                                        <widget name="documentation_link" path="/applications/productivity/iot/devices/printer.html" label=" Documentation" icon="fa-arrow-right"/>
-                                    </div>
                                 </group>
                                 <group string='Print on "Put in Pack"' groups="stock.group_tracking_lot">
                                     <label for="auto_print_package_label" string="Package Label"/>

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -69,7 +69,6 @@
             <field name="arch" type="xml">
                 <list string="Picking list" multi_edit="1" sample="1" js_class="stock_list_view">
                     <header>
-                        <button name="do_unreserve" type="object" string="Unreserve"/>
                         <button name="action_assign" type="object" string="Check Availability"/>
                     </header>
                     <field name="company_id" column_invisible="True"/>
@@ -237,7 +236,7 @@
                             <label for="scheduled_date"/>
                             <div class="o_row">
                                 <field name="scheduled_date" readonly="not is_date_editable" required="id"
-                                    decoration-warning="state not in ('done', 'cancel') and scheduled_date &lt; now"
+                                    decoration-warning="id and state not in ('done', 'cancel') and scheduled_date &lt; now"
                                     decoration-danger="state not in ('done', 'cancel') and scheduled_date &lt; current_date"
                                     decoration-bf="state not in ('done', 'cancel') and (scheduled_date &lt; current_date or scheduled_date &lt; now)"/>
                                 <field name="json_popover" nolabel="1" widget="stock_rescheduling_popover" invisible="not json_popover"/>
@@ -466,7 +465,7 @@
             <field name="name">Unreserve</field>
             <field name="model_id" ref="stock.model_stock_picking"/>
             <field name="binding_model_id" ref="stock.model_stock_picking"/>
-            <field name="binding_view_types">form</field>
+            <field name="binding_view_types">form,list</field>
             <field name="state">code</field>
             <field name="code">
             if records:


### PR DESCRIPTION
With this commit:
-----------------
This commit improves usability, UI/UX, and readability in the Inventory App.

- To improve terminology and reduce confusion:
  * `Type of Operation` renamed to `Operation Category` to prevent confusion
    with `Operation Type`.
- To improve guidance, refine UI/UX consistency, and reduce redundancy:
  * Added and improved helper text in Product Category and Replenishment for
    better user guidance and clarity.
  * Repositioned the info banner under `Operation Type > Hardware >
    Print Validation` and applied info banner styling.
  * Removed the `Unreserve` button from the list view, since a dedicated server
    action already exists for the form view and can be used from the list view
    as well.
  * Removed the orange highlight on `Scheduled Date` for newly created transfer,
    as it is unnecessary and creates a confusing visuals when the record is just
    being created.
  * Removed the tooltip for Source Document in transfers as the field is
    self-explanatory.
- To improve Inventory settings clarity and consistency:
  * Renamed `Annual Inventory Day and Month` to `Annual Inventory Date` and
    updated the description.
  * Removed terminal punctuation from descriptions for style consistency.
  * Refined description texts for Annual Inventory Date and Warnings.
  * Renamed `Email Confirmation` to `Confirmation Email` to align with
    terminology patterns.

task-3836703