### PR TITLE
[IMP] purchase: improved Product Catalog action helper

### DIFF
--- a/addons/product/static/src/product_catalog/kanban_model.js
+++ b/addons/product/static/src/product_catalog/kanban_model.js
@@ -17,9 +17,18 @@ export class ProductCatalogKanbanModel extends RelationalModel {
     static Record = ProductCatalogRecord;
 
     async _loadData(params) {
+        // if orm have isSample field and its value set to be true then we have sample data as there is no product found for selected vendor, show sample data
+        const isSample = this.orm.isSample !== undefined ? this.orm.isSample : false;
         const result = await super._loadData(...arguments);
         if (!params.isMonoRecord && !params.groupBy.length) {
-            const orderLinesInfo = await rpc("/product/catalog/order_lines_info", this._getOrderLinesInfoParams(params, result.records.map((rec) => rec.id)));
+            let orderLinesInfo;
+            if(!isSample) {
+                orderLinesInfo = await rpc("/product/catalog/order_lines_info", this._getOrderLinesInfoParams(params, result.records.map((rec) => rec.id)));
+            }
+            else {
+                orderLinesInfo = this._getSampleOrderLineInfo()
+            }
+
             for (const record of result.records) {
                 record.productCatalogData = orderLinesInfo[record.id];
             }
@@ -34,5 +43,21 @@ export class ProductCatalogKanbanModel extends RelationalModel {
             res_model: params.context.product_catalog_order_model,
             child_field: params.context?.child_field,
         }
+    }
+
+    _getSampleOrderLineInfo() {
+         // this function only returns data for sample view similar to rpc call ("/product/catalog/order_lines_info) made in _loadData
+        const sampleOrderLineInfo = {};
+        const numRecords = 10; // Number of records to generate
+        for (let i = 1; i <= numRecords; i++) {
+            sampleOrderLineInfo[i] = {
+                quantity: Math.floor(Math.random() * 10),
+                min_qty: 0,
+                price: Math.floor(Math.random() * 500) + 100,
+                readOnly: false,
+                uom: { display_name: "Units", id: 1 }
+            };
+        }
+        return sampleOrderLineInfo;
     }
 }

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -839,6 +839,9 @@ class PurchaseOrder(models.Model):
         res = super().action_add_from_catalog()
         if res['context'].get('product_catalog_order_model') == 'purchase.order':
             res['search_view_id'] = [self.env.ref('purchase.product_view_search_catalog').id, 'search']
+        kanban_view_id = self.env.ref('purchase.product_view_kanban_catalog_purchase_only').id
+        res['views'][0] = (kanban_view_id, 'kanban')
+        res['context']['partner_id'] = self.partner_id.id
         return res
 
     def _get_action_add_from_catalog_extra_context(self):

--- a/addons/purchase/static/src/product_catalog/kanban_renderer.js
+++ b/addons/purchase/static/src/product_catalog/kanban_renderer.js
@@ -1,0 +1,40 @@
+import { useService } from "@web/core/utils/hooks";
+
+import { ProductCatalogKanbanRenderer } from "@product/product_catalog/kanban_renderer";
+
+export class PurchaseProductCatalogKanbanRenderer extends ProductCatalogKanbanRenderer {
+    static template = "PurchaseProductCatalogKanbanRenderer";
+
+    setup() {
+        super.setup();
+        this.action = useService("action");
+    }
+
+    get createProductContext() {
+        return {default_seller_ids: [{partner_id:this.props.list._config.context.partner_id}],};
+    }
+
+    async createProduct() {
+        await this.action.doAction(
+            {
+                type: "ir.actions.act_window",
+                res_model: "product.product",
+                target: "new",
+                views: [[false, "form"]],
+                view_mode: "form",
+                context: this.createProductContext,
+            },
+            {
+                props: {
+                    onSave: async (record, params) => {
+                        await this.props.list.model.load();
+                        this.props.list.model.useSampleModel = false;
+                        this.action.doAction({
+                            type: "ir.actions.act_window_close",
+                        });
+                    },
+                }
+            }
+        );
+    }
+}

--- a/addons/purchase/static/src/product_catalog/kanban_renderer.xml
+++ b/addons/purchase/static/src/product_catalog/kanban_renderer.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<templates xml:space="preserve">
+    <t t-name="PurchaseProductCatalogKanbanRenderer" t-inherit="web.KanbanRenderer" t-inherit-mode="primary">
+        <t t-if="showNoContentHelper" position="replace">
+            <t t-if="showNoContentHelper">
+                <div class="o_view_nocontent" role="alert">
+                    <div class="o_nocontent_help">
+                        <p class="o_view_nocontent_smiling_face">
+                            No Products for the selected Vendor.
+                        </p>
+                        <p>
+                            Try removing the top filter to broaden your search
+                            <br/>
+                            <button class="mt-2 btn btn-primary" t-on-click="this.createProduct">Create a product</button>
+                        </p>
+                    </div>
+                </div>
+            </t>
+        </t>
+    </t>
+</templates>

--- a/addons/purchase/static/src/product_catalog/kanban_view.js
+++ b/addons/purchase/static/src/product_catalog/kanban_view.js
@@ -1,0 +1,11 @@
+import { registry } from "@web/core/registry";
+
+import { productCatalogKanbanView } from "@product/product_catalog/kanban_view";
+import { PurchaseProductCatalogKanbanRenderer } from "./kanban_renderer.js";
+
+export const purchaseProductCatalogKanbanView = {
+    ...productCatalogKanbanView,
+    Renderer: PurchaseProductCatalogKanbanRenderer,
+};
+
+registry.category("views").add("purchase_product_kanban_catalog", purchaseProductCatalogKanbanView);

--- a/addons/purchase/views/product_views.xml
+++ b/addons/purchase/views/product_views.xml
@@ -171,6 +171,10 @@
             <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
             <field name="mode">primary</field>
             <field name="arch" type="xml">
+                <xpath expr="//kanban" position="attributes">
+                    <attribute name="js_class">purchase_product_kanban_catalog</attribute>
+                    <attribute name="sample">1</attribute> 
+                </xpath>
                 <field name="default_code" position="after">
                     <field name="uom_po_id" invisible="1"/>
                 </field>

--- a/addons/purchase_stock/views/product_views.xml
+++ b/addons/purchase_stock/views/product_views.xml
@@ -30,6 +30,10 @@
         <field name="inherit_id" ref="product.product_view_kanban_catalog"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
+            <xpath expr="//kanban" position="attributes">
+                    <attribute name="js_class">purchase_product_kanban_catalog</attribute>
+                    <attribute name="sample">1</attribute> 
+            </xpath>
             <div name="o_kanban_qty_available" position="after">
                 <div t-if="record.detailed_type.raw_value == 'product'"
                      name="o_kanban_qty_forecasted">


### PR DESCRIPTION
Before this commit:
==================
- Vendor will not be set by default when you create a product.
- No sample demo data in background if no product present for  selected vendor.

After this commit:
==================
- Vendor will selected by default, and value will be of vendor of the purchase order for which the catalog was open. This was done because user expect to create a product for the selected vendor as no product was found for that vendor.
- Sample demo data in the background if no product found for the selected vendor similar to other screens.
- UI improvement.

Steps to produce:
===============
- Open purchase RFQ
- Click on catalog button

task  3761712
