### PR TITLE
[IMP] point_of_sale: Download Invoice POS

### DIFF
--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -177,6 +177,7 @@ class PosConfig(models.Model):
                                                    "In the meantime, you can use the 'Load Customers' button to load partners from database.")
     limited_partners_amount = fields.Integer(default=10000)
     partner_load_background = fields.Boolean(default=False)
+    download_invoice = fields.Boolean(default=True)
 
     @api.depends('payment_method_ids')
     def _compute_cash_control(self):

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -103,6 +103,7 @@ class ResConfigSettings(models.TransientModel):
     pos_use_pricelist = fields.Boolean(related='pos_config_id.use_pricelist', readonly=False)
     pos_warehouse_id = fields.Many2one(related='pos_config_id.warehouse_id', readonly=False, string="Warehouse (PoS)")
     point_of_sale_use_ticket_qr_code = fields.Boolean(related='company_id.point_of_sale_use_ticket_qr_code', readonly=False)
+    pos_download_invoice = fields.Boolean(related="pos_config_id.download_invoice", readonly=False)
 
     @api.model
     def _keep_new_vals(self, pos_config, pos_fields_vals):

--- a/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
+++ b/addons/point_of_sale/static/src/js/Screens/PaymentScreen/PaymentScreen.js
@@ -210,7 +210,7 @@ odoo.define('point_of_sale.PaymentScreen', function (require) {
                 syncOrderResult = await this.env.pos.push_single_order(this.currentOrder);
 
                 // 2. Invoice.
-                if (this.shouldDownloadInvoice() && this.currentOrder.is_to_invoice()) {
+                if (this.shouldDownloadInvoice() && this.currentOrder.is_to_invoice() && this.env.pos.config.download_invoice) {
                     if (syncOrderResult.length) {
                         await this.env.legacyActionManager.do_action(this.env.pos.invoiceReportAction, {
                             additional_context: {

--- a/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
+++ b/addons/point_of_sale/static/src/js/Screens/TicketScreen/ControlButtons/InvoiceButton.js
@@ -26,6 +26,7 @@ odoo.define('point_of_sale.InvoiceButton', function (require) {
         }
         async _downloadInvoice(orderId) {
             try {
+                if (!this.env.pos.config.download_invoice) return;
                 const [orderWithInvoice] = await this.rpc({
                     method: 'read',
                     model: 'pos.order',

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -343,6 +343,17 @@
                                     </div>
                                 </div>
                             </div>
+                            <div class="col-12 col-lg-6 o_setting_box" id="download_invoice">
+                                <div class="o_setting_left_pane">
+                                    <field name="pos_download_invoice"/>
+                                </div>
+                                <div class="o_setting_right_pane">
+                                    <label for="pos_download_invoice"/>
+                                    <div class="text-muted">
+                                        Download the invoice after it has been created
+                                    </div>
+                                </div>
+                            </div>
                             <div class="col-12 col-lg-6 o_setting_box" id="auto_printing">
                                 <div class="o_setting_left_pane">
                                     <field name="pos_iface_print_auto"/>


### PR DESCRIPTION
When an Invoice is made from the Point of Sale, it is downloaded or printed. For cases in which billing is mandatory when placing more than +100 daily orders, these files take up space on the device.

So a configuration is created to choose if it is downloaded automatically or if its download is skipped.

Current behavior before PR:

It is downloaded or printed automatically after the invoice has been created.

Desired behavior after PR is merged:

It will start with the configuration turned on so it is expected to continue its natural operation.

If this is deactivated, the invoice will not download

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
