### PR TITLE
[FIX] base: set the state to required in netherland country data

### DIFF
--- a/odoo/addons/base/data/res_country_data.xml
+++ b/odoo/addons/base/data/res_country_data.xml
@@ -1056,6 +1056,7 @@
         <record id="nl" model="res.country">
             <field name="name">Netherlands</field>
             <field name="code">nl</field>
+            <field name='state_required'>1</field>
             <field eval="'%(street)s\n%(street2)s\n%(zip)s %(city)s\n%(country_name)s'" name="address_format" />
             <field name="currency_id" ref="EUR" />
             <field eval="31" name="phone_code" />


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
The state field is now required by default for the Netherlands. 
It is possible to change it manually in the contact page of the Netherlands.

Current behavior before PR: 
1) Set the country to the Netherlands for Mitchell Admin.
2) Buy something on the website and create a shipping address.
3) The field state / province is not required. Leave it empty and create a new address. There will not be a warning.

Desired behavior after PR is merged:
1) Set the country to the Netherlands for Mitchell Admin.
2) Buy something on the website and create a shipping address.
3) The field state / province is required. If you create a new address, leave it empty and validate, there will be a warning.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
