### PR TITLE
[FIX] hr: only show the employee from the multi company widget

### DIFF
--- a/addons/hr/security/hr_security.xml
+++ b/addons/hr/security/hr_security.xml
@@ -28,9 +28,8 @@
     <record id="hr_employee_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee"/>
-        <field name="domain_force">['|', '|', '|',
+        <field name="domain_force">['|', '|',
             ('company_id', 'in', company_ids + [False]),
-            ('parent_id.user_id', '=', user.id),
             ('id', '=', user.employee_id.parent_id.id),
             ('user_id', '=', user.id)
         ]</field>
@@ -45,9 +44,8 @@
     <record id="hr_employee_public_comp_rule" model="ir.rule">
         <field name="name">Employee multi company rule</field>
         <field name="model_id" ref="model_hr_employee_public"/>
-        <field name="domain_force">['|', '|', '|',
+        <field name="domain_force">['|', '|',
             ('company_id', 'in', company_ids + [False]),
-            ('parent_id.user_id', '=', user.id),
             ('id', '=', user.employee_id.parent_id.id),
             ('user_id', '=', user.id)
         ]</field>

--- a/addons/hr_org_chart/views/hr_views.xml
+++ b/addons/hr_org_chart/views/hr_views.xml
@@ -4,7 +4,7 @@
         <field name="name">Org Chart</field>
         <field name="res_model">hr.employee</field>
         <field name="view_mode">hierarchy,kanban,tree,form,activity,graph,pivot</field>
-        <field name="domain">[]</field>
+        <field name="domain">[('company_id', 'in', allowed_company_ids)]</field>
         <field name="context">{'chat_icon': True}</field>
         <field name="view_id" eval="False"/>
         <field name="search_view_id" ref="hr.view_employee_filter"/>


### PR DESCRIPTION
In the Org chart view, we can see employees from other companies which is inconvenient

In this commit, We will only display the employee from the selected company in the multi-company widget

Task-3815744
