### PR TITLE
[FIX] web_editor: fix component destroy error

### DIFF
--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -147,13 +147,10 @@ export class HtmlField extends Component {
         onMounted(() => {
             this.dynamicPlaceholder?.setElementRef(this.wysiwyg);
         });
-        onWillUnmount(() => {
+        onWillUnmount(async () => {
             if (!this.props.readonly && this._isDirty()) {
-                // If we still have uncommited changes, commit them with the
-                // urgent flag to avoid losing them. Urgent flag is used to be
-                // able to save the changes before the component is destroyed
-                // by the owl component manager.
-                this.commitChanges({ urgent: true });
+                // If we still have uncommited changes, commit them to avoid losing them.
+                await this.commitChanges();
             }
             if (this._qwebPlugin) {
                 this._qwebPlugin.destroy();


### PR DESCRIPTION
Steps:
- Install sale and editor apps.
- Click on varient new button.
- Add something in the description.
- Discard that record.

Issue:
- Traceback component destroyed.

Cause:
- `commit_changes` does not had await on it and because of that it was performing other operations before actually commit changes and we are actully
destroying record in `commit_changes` so there is
no point doing other operations.

Fix:
- Add await and remove urgent from `commit_changes` method in-order to properly unmount component.

opw-3892602

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
