### PR TITLE
[IMP] website_event: add state in the location of an event

### DIFF
--- a/addons/website_event/views/event_templates_list.xml
+++ b/addons/website_event/views/event_templates_list.xml
@@ -374,12 +374,7 @@
                             </small>
                         </div>
                         <!-- Location -->
-                        <t t-set="has_city_or_country" t-value="event.address_id.sudo().city or event.address_id.sudo().country_id"/>
-                        <div t-if="not event.address_id or has_city_or_country" class="d-flex align-items-center">
-                            <i class="fa fa-map-marker me-2" title="Location"/>
-                            <small t-if="event.address_id" class="o_not_editable fw-bold" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city'], 'no_marker': 'true'}"/>
-                            <small t-else="" class="o_not_editable fw-bold" itemprop="location">Online event</small>
-                        </div>
+                        <small class="o_not_editable fw-bold" itemprop="location" t-out="event.address_id" t-options="{'widget': 'contact', 'fields': ['city', 'country_id'], 'null_text': 'Online event'}"/>
                     </main>
                     
                     <!-- Footer -->

--- a/odoo/addons/base/views/ir_qweb_widget_templates.xml
+++ b/odoo/addons/base/views/ir_qweb_widget_templates.xml
@@ -28,12 +28,19 @@
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
                 <span class="w-100 lh-sm text-truncate d-block" itemprop="streetAddress" t-esc="address"/>
             </div>
-            <div t-if="city and 'city' in fields" t-attf-class="d-flex align-items-baseline gap-1">
+            <t t-set="has_city" t-value="city and 'city' in fields"/>
+            <t t-set="has_state" t-value="object.state_id and object.country_id.state_required"/>
+            <div t-if="has_city or (country_id and 'country_id' in fields)" t-attf-class="d-flex align-items-baseline gap-1">
                 <i t-if="not options.get('no_marker')" class="fa fa-map-marker fa-fw" role="img" aria-label="Address" title="Address"/>
                 <span>
                     <div>
-                        <span itemprop="addressLocality" t-esc="city"/>,
-                        <span itemprop="addressCountry" t-esc="country_id"/>
+                        <t t-if="has_city">
+                            <span itemprop="addressLocality" t-out="city"/><t t-if="country_id">,</t>
+                        </t>
+                        <t t-if="has_state">
+                            <span itemprop="addressRegion" t-out="object.state_id.code"/>,
+                        </t>
+                        <span itemprop="addressCountry" t-out="country_id"/>
                     </div>
                 </span>
             </div>


### PR DESCRIPTION
Earlier state was not present in the location which led to confusion
regarding the location of the event as there may be many cities having the same
name in the country. Besides this, only the location icon was displayed for the
case in which only the country is set to the venue which seems to weird.

This commit addresses the issue now city, state and country will be displayed
with the location icon whatever is set in the venue.

Task-3889871