### PR TITLE
[IMP] calendar, web: enhance calendar filter for easier meeting scheduling

### DIFF
--- a/addons/hr_calendar/__manifest__.py
+++ b/addons/hr_calendar/__manifest__.py
@@ -7,7 +7,8 @@
     'depends': ['hr', 'calendar'],
     'auto_install': True,
     'data': [
-        'views/calendar_views_calendarApp.xml'
+        'views/calendar_views_calendarApp.xml',
+        'views/res_partner_views.xml',
     ],
     'assets': {
         'web.assets_backend': [

--- a/addons/hr_calendar/static/src/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/hr_calendar/static/src/calendar/filter_panel/calendar_filter_panel.js
@@ -1,0 +1,15 @@
+/** @odoo-module **/
+
+import { CalendarFilterPanel } from "@web/views/calendar/filter_panel/calendar_filter_panel";
+import { patch } from "@web/core/utils/patch";
+
+
+patch(CalendarFilterPanel.prototype, {
+    updateSelectCreateDialogProps(props) {
+        const updatedProps = super.updateSelectCreateDialogProps(props);
+        updatedProps.context = {
+            search_view_ref: 'hr_calendar.view_res_partner_filter_inherit_calendar',
+        };
+        return updatedProps;
+    }
+})

--- a/addons/hr_calendar/views/res_partner_views.xml
+++ b/addons/hr_calendar/views/res_partner_views.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<odoo>
+    <record id="view_res_partner_filter_inherit_calendar" model="ir.ui.view">
+        <field name="name">res.partner.view.search.inherit.calendar</field>
+        <field name="model">res.partner</field>
+        <field name="mode">primary</field>
+        <field name="inherit_id" ref="base.view_res_partner_filter"/>
+        <field name="arch" type="xml">
+                <filter name="type_company" position="after">
+                    <filter string="My Team" name="type_team" domain="[('employee_ids.department_id.manager_id.user_id', '=', uid)]"/>
+                </filter>
+        </field>
+    </record>
+</odoo>

--- a/addons/web/static/src/legacy/scss/fields.scss
+++ b/addons/web/static/src/legacy/scss/fields.scss
@@ -6,4 +6,11 @@
             color: $o-brand-primary;
         }
     }
+    &.o_calendar_dropdown_option > a {
+        color: #017e84;
+
+        &.ui-state-active {
+            color: #017e84;
+        }
+    }
 }

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -156,17 +156,24 @@ export class CalendarModel extends Model {
 
     async createFilter(fieldName, filterValue) {
         const info = this.meta.filtersInfo[fieldName];
-        if (info && info.writeFieldName && info.writeResModel) {
+        if (!info || !info.writeFieldName || !info.writeResModel) {
+            return;
+        }
+
+        const normalizedFilterValue = Array.isArray(filterValue) ? filterValue : [filterValue];
+        const dataArray = normalizedFilterValue.map(value => {
             const data = {
                 user_id: user.userId,
-                [info.writeFieldName]: filterValue,
+                [info.writeFieldName]: value
             };
             if (info.filterFieldName) {
                 data[info.filterFieldName] = true;
             }
-            await this.orm.create(info.writeResModel, [data]);
-            await this.load();
-        }
+            return data;
+        });
+
+        await this.orm.create(info.writeResModel, dataArray);
+        await this.load();
     }
     async createRecord(record) {
         const rawRecord = this.buildRawRecord(record);

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.js
@@ -43,6 +43,7 @@ export class CalendarFilterPanel extends Component {
                 {
                     placeholder: _t("Loading..."),
                     options: (request) => this.loadSource(section, request),
+                    optionTemplate: "web.CalendarFilterPanel.autocomplete.options",
                 },
             ],
             onSelect: (option, params = {}) => {
@@ -72,12 +73,14 @@ export class CalendarFilterPanel extends Component {
         const options = records.map((result) => ({
             value: result[0],
             label: result[1],
+            model: resModel,
         }));
 
         if (records.length > 7) {
             options.push({
                 label: _t("Search More..."),
                 action: () => this.onSearchMore(section, resModel, domain, request),
+                classList: "o_calendar_dropdown_option",
             });
         }
 
@@ -107,16 +110,23 @@ export class CalendarFilterPanel extends Component {
             });
         }
         const title = _t("Search: %s", section.label);
-        this.addDialog(SelectCreateDialog, {
+        const dialogProps = {
             title,
             noCreate: true,
-            multiSelect: false,
+            multiSelect: true,
             resModel,
             context: {},
             domain,
-            onSelected: ([resId]) => this.props.model.createFilter(section.fieldName, resId),
+            onSelected: (resId) => this.props.model.createFilter(section.fieldName, resId),
             dynamicFilters,
-        });
+        };
+
+        const updatedProps = this.updateSelectCreateDialogProps(dialogProps);
+        this.addDialog(SelectCreateDialog, updatedProps);
+    }
+
+    updateSelectCreateDialogProps(props) {
+        return props;
     }
 
     get nextFilterId() {

--- a/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
+++ b/addons/web/static/src/views/calendar/filter_panel/calendar_filter_panel.xml
@@ -110,4 +110,10 @@
         </div>
     </t>
 
+    <t t-name="web.CalendarFilterPanel.autocomplete.options">
+        <img t-if='option.value' t-attf-src="/web/image/{{option.model}}/{{option.value}}/avatar_128"
+                class="rounded me-1 o_avatar"
+        />
+        <t t-esc="option.label" />
+    </t>
 </templates>


### PR DESCRIPTION
### Before PR:

- Users could only choose one record at a time in the autocomplete feature.
- The dropdown list didn't show avatars, making the UI less appealing and records harder to recognize quickly.
- Scheduling meetings was slow because users could only add one attendee at a time.


### After PR:

- Users can now configure the autocomplete to allow the selection of multiple records or restrict it to a single record based on their needs.
- Each record in the dropdown now includes an avatar, enhancing recognition and providing more context without cluttering the interface.
- Users can select multiple attendees at once, making the process of scheduling meetings faster and more efficient.

---

| Before Changes | After Changes |
|----------------|---------------|
| ![Before Changes](https://cdn.discordapp.com/attachments/1248492991627399222/1261199195457589340/before.png?ex=6699ffc8&is=6698ae48&hm=90b1aa875501b5d0ee5d815ebe926c971d06fb7222493b10fcefb49fdac42c8d&) | ![After Changes](https://cdn.discordapp.com/attachments/1248492991627399222/1261199195721957416/after.png?ex=6699ffc8&is=6698ae48&hm=29134fb723fbae5a1779f0dfc0e357727bc38929d4cbc8f34b7c05dc490112a3&) |
---

- **Task ID**: 3852520
