### PR TITLE
[FIX] sale: fix two slashed prices bug in product page

### DIFF
--- a/addons/sale/static/src/js/variant_mixin.js
+++ b/addons/sale/static/src/js/variant_mixin.js
@@ -548,7 +548,7 @@ var VariantMixin = {
         }
         this._toggleDisable($parent, isCombinationPossible);
 
-        if (combination.has_discounted_price) {
+        if (combination.has_discounted_price && !combination.compare_list_price) {
             $default_price
                 .closest('.oe_website_sale')
                 .addClass("discount");


### PR DESCRIPTION
Steps to Reproduce:
- Configure a pricelist to lower the price of any product, and set the Discount
  Policy to `Show public price & discount to the customer`.
- Activate the `Comparison Price` setting in the website app.
- Set the `Compare to Price` of the product to an amount higher than the price
  in the webshop.
- Go to the product in the webshop: there are two struck-through prices.

Cause:
In the `_onChangeCombination` function, the `d-none` class was removed if
`has_discounted_price` was true. However, it should also check if
`compare_list_price` is set or not, which causes both struckthrough prices to
become visible.

Fix:
I added an extra condition to the if statement that will remove the `d-none`
class only if `has_discounted_price` is set and `compare_list_price` is not set.

opw-3864087