### PR TITLE
[IMP] hr_holidays: add expiration date for carried over accruals

### DIFF
--- a/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
+++ b/addons/hr_holidays/models/hr_leave_accrual_plan_level.py
@@ -127,6 +127,15 @@ class AccrualPlanLevel(models.Model):
     postpone_max_days = fields.Integer("Maximum amount of accruals to transfer",
         help="Set a maximum of accruals an allocation keeps at the end of the year.")
     can_modify_value_type = fields.Boolean(compute="_compute_can_modify_value_type")
+    accrual_validity = fields.Boolean(string="Accrual Validity")
+    accrual_validity_count = fields.Integer(
+        "Accrual Validity Count",
+        help="You can define a period of time where the days carried over will be available", default="1")
+    accrual_validity_type = fields.Selection(
+        [('day', 'Days'),
+         ('month', 'Months')],
+        default='day', string="Accrual Validity Type", required=True,
+        help="This field defines the unit of time after which the accrual ends.")
 
     _sql_constraints = [
         ('check_dates',

--- a/addons/hr_holidays/views/hr_leave_accrual_views.xml
+++ b/addons/hr_holidays/views/hr_leave_accrual_views.xml
@@ -95,6 +95,19 @@
                                 </span>
                             </span>
                         </div>
+                        <field name="postpone_max_days" class="w-25" invisible="action_with_unused_accruals != 'postponed'"/>
+                        <div class="o_td_label" invisible="action_with_unused_accruals == 'lost'">
+                            <label for="accrual_validity_count" string="Carry Over Validity"/>
+                        </div>
+                        <div class="col-lg-2 d-flex" invisible="action_with_unused_accruals == 'lost'">
+                            <div>
+                                <field name="accrual_validity" style="width: 9.35rem"/>
+                                <div class="d-flex" invisible="not accrual_validity">
+                                    <field name="accrual_validity_count" />
+                                    <field name="accrual_validity_type" />
+                                </div>
+                            </div>
+                        </div>
                     </group>
                 </sheet>
             </form>
@@ -160,6 +173,8 @@
                             <kanban default_order="sequence">
                                 <field name="sequence"/>
                                 <field name="action_with_unused_accruals"/>
+                                <field name="accrual_validity_count"/>
+                                <field name="accrual_validity_type"/>
                                 <field name="cap_accrued_time"/>
                                 <templates>
                                     <div t-name="kanban-card" class="bg-transparent border-0">
@@ -226,9 +241,10 @@
                                                     <div class="pe-0 me-0" style="width: 6rem;">
                                                         Carry over:
                                                     </div>
-                                                    <div class="col-3 m-0 ps-1">
-                                                        <t t-if="record.action_with_unused_accruals.raw_value === 'all'">all</t>
-                                                        <t t-elif="record.action_with_unused_accruals.raw_value == 'maximum'">up to <field name="postpone_max_days" /> <field name="added_value_type" /></t>
+                                                    <div class="col-6 m-0 ps-1">
+                                                        <t t-if="record.action_with_unused_accruals.raw_value === 'all'">all - Valid for <field name="accrual_validity_count"/> <field name="accrual_validity_type"/></t>
+                                                        <t t-elif="record.action_with_unused_accruals.raw_value === 'maximum'">up to <field name="postpone_max_days" /> <t t-esc="record.added_value_type.raw_value" />
+                                                        - Valid for <field name="accrual_validity_count"/> <field name="accrual_validity_type"/></t>
                                                         <t t-else="">no</t>
                                                     </div>
                                                 </div>

--- a/addons/hr_holidays/views/hr_leave_allocation_views.xml
+++ b/addons/hr_holidays/views/hr_leave_allocation_views.xml
@@ -91,6 +91,13 @@
             <form string="Allocation Request">
                 <field name="can_approve" invisible="1"/>
                 <field name="validation_type" invisible="1"/>
+                <!--
+                The following two lines are required so that the two fields are sent as part of the `vals_list` 
+                to the create method when the allocation is created. Otherwise, carried_over_days_expiration_date
+                wouldn't be set and the days won't expire on that date.
+                -->
+                <field name="expiring_carryover_days" invisible="1"/>
+                <field name="carried_over_days_expiration_date" invisible="1"/>
                 <header>
                     <field name="state" widget="statusbar" statusbar_visible="confirm,validate,validate1" invisible="validation_type != 'both'"/>
                     <field name="state" widget="statusbar" statusbar_visible="confirm,validate" invisible="validation_type == 'both'"/>


### PR DESCRIPTION
These changes add an expiration date for carried-over accruals. with this addition, we can set carryover validity for accruals.

The changes also fix a minor bug where cap_accrued_time_yearly couldn't be set to False without setting it to true first and specifying the cap.

task-3508065