### PR TITLE
[IMP] hr_contract: add contract kanban state in list view

### DIFF
--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -269,6 +269,7 @@
                     <field name="wage" widget="monetary" readonly="1" optional="hidden"/>
                     <field name="resource_calendar_id" optional="show"/>
                     <field name="structure_type_id" optional="hidden"/>
+                    <field name="kanban_state" widget="state_selection" nolabel="1"/>
                     <field name="state" widget="badge" decoration-info="state == 'draft'" decoration-warning="state == 'close'" decoration-success="state == 'open'"/>
                     <field name="company_id" groups="base.group_multi_company" readonly="1" optional="hidden"/>
                 </tree>


### PR DESCRIPTION
Before this commit, there is no kanban state shown in the list view of employee contracts like kanban view.

This commit brings the kanban state of employee contract in the list view. When click on the state, then a small state window will popup and it will show  current state of contract and if user wants to change, then they can do from list view itself.

task-3843063