### PR TITLE
[FIX] gamification: update goals after a time-limited challenge is finished

### DIFF
--- a/addons/gamification/models/gamification_challenge.py
+++ b/addons/gamification/models/gamification_challenge.py
@@ -217,6 +217,9 @@ class Challenge(models.Model):
             self._generate_goals_from_challenge()
 
         elif vals.get('state') == 'done':
+            self.env['gamification.goal'].search([
+                ('challenge_id', 'in', self.ids),
+            ]).update_goal()
             self._check_challenge_reward(force=True)
 
         elif vals.get('state') == 'draft':


### PR DESCRIPTION
I'm aware that I shouldn't open an issue and a PR for the same problem, but initially I wasn't planning to fix this by myself.

**Description of the issue/feature this PR addresses:**

See #164125.

**Current behavior before PR:**

After a time-limited challenge is finished, the cron job "Gamification: Goal Challenge Check" correctly marks the challenge done, but leaves the related goals hanging in "inprogress" state.

**Desired behavior after PR is merged:**

The related goals of a finished challenge aren't left hanging in progress. Their state will be updated to `reached` or `failed`.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
