### PR TITLE
[FIX] account: prevent update sanitized_acc_number

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -280,14 +280,19 @@ class ResPartnerBank(models.Model):
         # leaves them vulnerable to edits via the shell/... So we need to ensure that the user has the rights to edit
         # these fields when writing too.
         # While we do lock changes if the account is trusted, we still want to allow to change them if we go from not trusted -> trusted or from trusted -> not trusted.
-        any_trusted_accounts = any(account.lock_trust_fields for account in self)
+        trusted_accounts = self.filtered(lambda x: x.lock_trust_fields)
+        any_trusted_accounts = bool(trusted_accounts)
         if not any_trusted_accounts:
             should_allow_changes = True  # If we were on a non-trusted account, we will allow to change (setting/... one last time before trusting)
         else:
             # If we were on a trusted account, we only allow changes if the account is moving to untrusted.
             should_allow_changes = ('allow_out_payment' in vals and vals['allow_out_payment'] is False)
 
-        if ('acc_number' in vals or 'partner_id' in vals) and not should_allow_changes:
+        lock_fields = {'acc_number', 'sanitized_acc_number', 'partner_id', 'acc_type'}
+        updated_lock_fields = lock_fields & set(vals.keys())
+        if not should_allow_changes and updated_lock_fields and \
+            any(any(account[u].id != vals[u] if account._fields[u].type == 'many2one' else account[u] != vals[u]
+                    for u in updated_lock_fields) for account in trusted_accounts):
             raise UserError(_("You cannot modify the account number or partner of an account that has been trusted."))
 
         if 'allow_out_payment' in vals and not self.user_has_groups('account.group_validate_bank_account'):

--- a/addons/account/tests/test_account_partner.py
+++ b/addons/account/tests/test_account_partner.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged
+from odoo.exceptions import UserError
 from freezegun import freeze_time
 
 
@@ -27,3 +28,26 @@ class TestAccountPartner(AccountTestInvoicingCommon):
         self.init_invoice("out_invoice", partner, "2023-05-15", amounts=[1500], taxes=self.tax_sale_a, post=True)
         self.env.invalidate_all()
         self.assertEqual(partner.days_sales_outstanding, 50)
+
+    def test_res_partner_bank(self):
+        partner = self.env['res.partner'].create({'name': 'MyCustomer'})
+        account = self.env['res.partner.bank'].create({
+            'acc_number': '123456789',
+            'partner_id': partner.id,
+        })
+        account.env.user.groups_id |= self.env.ref('account.group_validate_bank_account')
+        account.allow_out_payment = True
+
+        with self.assertRaises(UserError), self.cr.savepoint():
+            account.write({'acc_number': '1234567890999'})
+        with self.assertRaises(UserError), self.cr.savepoint():
+            account.write({'sanitized_acc_number': '1234567890999'})
+        with self.assertRaises(UserError), self.cr.savepoint():
+            account.write({'partner_id': self.env['res.partner'].create({'name': 'MyCustomer 2'}).id})
+
+        account.allow_out_payment = False
+        account.write({'acc_number': '1234567890999000'})
+
+        account.env.user.groups_id -= self.env.ref('account.group_validate_bank_account')
+        with self.assertRaises(UserError), self.cr.savepoint():
+            account.write({'allow_out_payment': True})

--- a/odoo/addons/base/models/res_bank.py
+++ b/odoo/addons/base/models/res_bank.py
@@ -6,6 +6,7 @@ from collections.abc import Iterable
 
 from odoo import api, fields, models, _
 from odoo.osv import expression
+from odoo.exceptions import ValidationError
 
 def sanitize_account_number(acc_number):
     if acc_number:
@@ -95,6 +96,12 @@ class ResPartnerBank(models.Model):
     def _compute_sanitized_acc_number(self):
         for bank in self:
             bank.sanitized_acc_number = sanitize_account_number(bank.acc_number)
+
+    @api.constrains('sanitized_acc_number')
+    def _check_sanitized_acc_number(self):
+        for bank in self:
+            if bank.sanitized_acc_number and bank.acc_number and bank.sanitized_acc_number != sanitize_account_number(bank.acc_number):
+                raise ValidationError(_('The sanitized account number is invalid.'))
 
     @api.depends('acc_number')
     def _compute_acc_type(self):

--- a/odoo/addons/base/tests/test_res_partner_bank.py
+++ b/odoo/addons/base/tests/test_res_partner_bank.py
@@ -4,6 +4,7 @@
 # Copyright (c) 2015 ACSONE SA/NV (<http://acsone.eu>)
 
 from odoo.addons.base.tests.common import SavepointCaseWithUserDemo
+from odoo.exceptions import ValidationError
 
 
 class TestResPartnerBank(SavepointCaseWithUserDemo):
@@ -31,6 +32,7 @@ class TestResPartnerBank(SavepointCaseWithUserDemo):
 
         # sanitaze the acc_number
         sanitized_acc_number = 'BE001251882303'
+        self.assertEqual(partner_bank.sanitized_acc_number, sanitized_acc_number)
         vals = partner_bank_model.search(
             [('acc_number', '=', sanitized_acc_number)])
         self.assertEqual(1, len(vals))
@@ -49,3 +51,7 @@ class TestResPartnerBank(SavepointCaseWithUserDemo):
         vals = partner_bank_model.search(
             [('acc_number', '=', acc_number.lower())])
         self.assertEqual(1, len(vals))
+
+        # prevent diff between acc_number and sanitized_acc_number
+        with self.assertRaises(ValidationError):
+            partner_bank.write({'sanitized_acc_number': 'BE001251882303WRONG'})


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Before this fix it was possible to update sanitized_acc_number even if it is locked.

@vin-odoo @odony 




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
