### PR TITLE
[IMP] project:  generic improvement project portal search view 

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -414,7 +414,12 @@ class ProjectCustomerPortal(CustomerPortal):
             domain = AND([domain, self._task_get_search_domain(search_in, search, milestones_allowed, project)])
 
         # content according to pager and archive selected
-        group_field = None if groupby == 'none' else groupby
+        if groupby == 'none':
+            group_field = None
+        elif groupby == 'priority':
+            group_field = 'priority desc'
+        else:
+            group_field = groupby
         order = '%s, %s' % (group_field, sortby) if group_field else sortby
 
         def get_grouped_tasks(pager_offset):
@@ -483,7 +488,7 @@ class ProjectCustomerPortal(CustomerPortal):
         }
 
         # extends filterby criteria with project the customer has access to
-        projects = request.env['project.project'].search(project_domain or [])
+        projects = request.env['project.project'].search(project_domain or [], order="id")
         for project in projects:
             searchbar_filters.update({
                 str(project.id): {'label': project.name, 'domain': [('project_id', '=', project.id)]}
@@ -520,7 +525,7 @@ class ProjectCustomerPortal(CustomerPortal):
             'grouped_tasks': grouped_tasks,
             'show_project': True,
             'pager': pager,
-            'searchbar_filters': OrderedDict(sorted(searchbar_filters.items())),
+            'searchbar_filters': searchbar_filters,
             'filterby': filterby,
         })
         return request.render("project.portal_my_tasks", values)

--- a/addons/project/views/project_portal_project_task_templates.xml
+++ b/addons/project/views/project_portal_project_task_templates.xml
@@ -25,8 +25,8 @@
                         <th t-attf-colspan="{{2 if groupby != 'priority' else 1}}"/>
                         <th>Name</th>
                         <th>Assignees</th>
-                        <th t-if="groupby != 'milestone_id' and allow_milestone" name="project_portal_milestones">Milestone</th>
                         <th t-if="groupby != 'project_id' and multiple_projects">Project</th>
+                        <th t-if="groupby != 'milestone_id' and allow_milestone" name="project_portal_milestones">Milestone</th>
                         <th t-if="groupby != 'state'"/>
                         <th t-if="groupby != 'stage_id'" class="text-end">Stage</th>
                     </tr>
@@ -86,13 +86,13 @@
                                         </span>
                                     </div>
                                 </td>
+                                <td t-if="groupby != 'project_id' and multiple_projects">
+                                    <span title="Current project of the task" t-out="task.project_id.name" />
+                                </td>
                                 <td t-if="groupby != 'milestone_id' and allow_milestone" name="project_portal_milestones">
                                     <t t-if="task.milestone_id and task.allow_milestones">
                                         <span t-esc="task.milestone_id.name" />
                                     </t>
-                                </td>
-                                <td t-if="groupby != 'project_id' and multiple_projects">
-                                    <span title="Current project of the task" t-esc="task.project_id.name" />
                                 </td>
                                 <td t-if="groupby != 'state'" align="right" class="align-middle">
                                     <t t-call="project.portal_my_tasks_state_widget_template">
@@ -206,7 +206,7 @@
                                     <t t-if="task.partner_id">
                                         <t t-call="portal.portal_my_contact">
                                             <t t-set="_contactAvatar" t-value="image_data_uri(task.partner_id.avatar_512)"/>
-                                            <t t-set="_contactName" t-value="task.partner_id.name"/>
+                                            <t t-set="_contactName" t-value="task.partner_id.display_name"/>
                                             <div t-field="task.partner_id" t-options='{"widget": "contact", "fields": ["email", "phone"]}'/>
                                         </t>
                                     </t>


### PR DESCRIPTION
This commit implements the following changes:

 - moved the project field between the name and the assignees for
   improved layout.
 - prioritized high-priority tasks to display first when grouping tasks by
   priority.
 - indicate the name of the customer's company on the portal sidebar.
 - modified the search view:
     moved the 'all' option to the top of the 'filter by' dropdown for easier access.

task-3703029

