### PR TITLE
[IMP] *: format hours as hh:mm in the Graph view

### DIFF
--- a/addons/analytic/views/analytic_line_views.xml
+++ b/addons/analytic/views/analytic_line_views.xml
@@ -98,7 +98,7 @@
         <field name="arch" type="xml">
             <graph string="Analytic Items" sample="1">
                 <field name="account_id"/>
-                <field name="unit_amount" type="measure"/>
+                <field name="unit_amount" type="measure" widget="float_time"/>
                 <field name="amount" type="measure"/>
             </graph>
         </field>

--- a/addons/hr_attendance/views/hr_attendance_view.xml
+++ b/addons/hr_attendance/views/hr_attendance_view.xml
@@ -172,6 +172,7 @@
             <graph string="Worked Hours" type="line" stacked="0" sample="1">
                 <field name="employee_id" type="row"/>
                 <field name="check_in" interval="week" type="col"/>
+                <field name="overtime_hours" widget="float_time"/>
                 <field name="worked_hours" type="measure" widget="float_time"/>
             </graph>
         </field>

--- a/addons/hr_holidays/views/hr_leave_views.xml
+++ b/addons/hr_holidays/views/hr_leave_views.xml
@@ -820,6 +820,7 @@
         <field name="arch" type="xml">
             <graph string="Time Off Summary" sample="1">
                 <field name="employee_id"/>
+                <field name="number_of_hours" widget="float_time"/>
                 <field name="number_of_days" type="measure"/>
             </graph>
         </field>

--- a/addons/hr_timesheet/report/project_report_view.xml
+++ b/addons/hr_timesheet/report/project_report_view.xml
@@ -12,6 +12,8 @@
                 <xpath expr="//field[@name='project_id']" position='after'>
                     <field name="allocated_hours" widget="timesheet_uom" type="measure"/>
                     <field name="effective_hours" widget="timesheet_uom" type="measure"/>
+                    <field name="overtime" widget="timesheet_uom"/>
+                    <field name="total_hours_spent" widget="timesheet_uom"/>
                     <field name="remaining_hours" widget="timesheet_uom" type="measure"/>
                 </xpath>
              </field>

--- a/addons/project/report/project_report_views.xml
+++ b/addons/project/report/project_report_views.xml
@@ -23,6 +23,8 @@
                      <field name="project_id"/>
                      <field name="stage_id"/>
                      <field name="nbr" invisible="1"/>
+                     <field name="working_hours_open" widget="float_time"/>
+                     <field name="working_hours_close" widget="float_time"/>
                      <field name="rating_avg" invisible="1"/>
                  </graph>
              </field>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -787,6 +787,8 @@
                 <graph string="Tasks" sample="1" js_class="project_task_graph">
                     <field name="project_id" invisible="context.get('default_project_id', False)"/>
                     <field name="stage_id"/>
+                    <field name="working_hours_open" widget="float_time"/>
+                    <field name="working_hours_close" widget="float_time"/>
                     <field name="color" invisible="1"/>
                     <field name="sequence" invisible="1"/>
                     <field name="rating_last_value" string="Rating (/5)"/>

--- a/addons/web/static/src/views/graph/graph_arch_parser.js
+++ b/addons/web/static/src/views/graph/graph_arch_parser.js
@@ -55,6 +55,13 @@ export class GraphArchParser {
                         }
                         archInfo.fieldAttrs[fieldName].string = string;
                     }
+                    const widget = node.getAttribute("widget");
+                    if (widget) {
+                        if (!archInfo.fieldAttrs[fieldName]) {
+                            archInfo.fieldAttrs[fieldName] = {};
+                        }
+                        archInfo.fieldAttrs[fieldName].widget = widget;
+                    }
                     if (
                         node.getAttribute("invisible") === "True" ||
                         node.getAttribute("invisible") === "1"


### PR DESCRIPTION
`* = {'web', 'project', 'hr_timesheet', 'hr_holidays', 'hr_attendance', 
'analytic'}`

Before this Commit:
The Graph view was not adaptable to the use of widgets, leading to issues with
the representation of time. Specifically, hours were shown as float values in
the graph view. For example, 5 hours and 30 minutes were displayed as 5.50
instead of the more intuitive hh:mm format. Although widgets like "float_time"
or "timesheet_uom" were available to format these values, they were ineffective
in the Graph view due to the architecture parser's limitations. This caused
confusion for users trying to interpret the time accurately.

After this Commit:
The Graph view is now adaptable to the use of widgets. This means that when a
widget is applied to format a field's value, the value will be displayed in the
specified format. For example, hours can now be shown in the hh:mm format
instead of as a float. 

Widget `timesheet_uom` is used at places where the module is related/depended
on `hr_timesheet` otherwise `float_time`.

This improvement also ensures that the formatted values
are reflected in the Y-axis (Ticks/Intervals) of the Graph view, enhancing the
user's ability to interpret the data accurately.

Enterprise PR: https://github.com/odoo/enterprise/pull/66050

Task-3861721
