### PR TITLE
[FIX] utm: fix utm automatic unique name generation

### DIFF
--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -464,9 +464,8 @@ class TestMassMailUTM(MassMailCommon):
 
         # should generate same name (coming from same subject)
         mailing_0.subject = 'First subject'
-        with self.subTest(reason="FIXME: receives First subject (Mass Mailing created on 2022-01-02) [4], always incrementing"):
-            self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)',
-                msg='The name should not be updated')
+        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)',
+            msg='The name should not be updated')
 
         # take a (long) existing name -> should increment
         mailing_0.name = 'Second subject (Mass Mailing created on 2022-01-02)'
@@ -475,9 +474,8 @@ class TestMassMailUTM(MassMailCommon):
 
         # back to first subject: not linked to any record so should take it back
         mailing_0.subject = 'First subject'
-        with self.subTest(reason="FIXME: should take first available, instead receives First subject (Mass Mailing created on 2022-01-02) [4]"):
-            self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)',
-                msg='The name should be back to first one')
+        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)',
+            msg='The name should be back to first one')
 
 
 @tagged('mass_mailing')

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -21,7 +21,7 @@ from odoo.tools import mute_logger
 BASE_64_STRING = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII='
 
 
-@tagged('mass_mailing')
+@tagged("mass_mailing")
 class TestMassMailValues(MassMailCommon):
 
     @classmethod
@@ -421,6 +421,10 @@ class TestMassMailValues(MassMailCommon):
             activity.write({'res_id': 0})
             self.env.flush_all()
 
+
+@tagged("mass_mailing", "utm")
+class TestMassMailUTM(MassMailCommon):
+
     @freeze_time('2022-01-02')
     @patch.object(Cursor, 'now', lambda *args, **kwargs: datetime(2022, 1, 2))
     @users('user_marketing')
@@ -431,6 +435,7 @@ class TestMassMailValues(MassMailCommon):
         that this generated name is unique.
         """
         mailing_0 = self.env['mailing.mailing'].create({'subject': 'First subject'})
+        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)')
 
         mailing_1, mailing_2, mailing_3, mailing_4, mailing_5, mailing_6 = self.env['mailing.mailing'].create([{
             'subject': 'First subject',
@@ -457,13 +462,22 @@ class TestMassMailValues(MassMailCommon):
         self.assertEqual(mailing_5.name, 'Mailing [2]')
         self.assertEqual(mailing_6.name, 'Second subject (Mass Mailing created on 2022-01-02)')
 
+        # should generate same name (coming from same subject)
         mailing_0.subject = 'First subject'
-        self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02) [4]',
-            msg='The name must have been re-generated')
+        with self.subTest(reason="FIXME: receives First subject (Mass Mailing created on 2022-01-02) [4], always incrementing"):
+            self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)',
+                msg='The name should not be updated')
 
+        # take a (long) existing name -> should increment
         mailing_0.name = 'Second subject (Mass Mailing created on 2022-01-02)'
         self.assertEqual(mailing_0.name, 'Second subject (Mass Mailing created on 2022-01-02) [2]',
             msg='The name must be unique')
+
+        # back to first subject: not linked to any record so should take it back
+        mailing_0.subject = 'First subject'
+        with self.subTest(reason="FIXME: should take first available, instead receives First subject (Mass Mailing created on 2022-01-02) [4]"):
+            self.assertEqual(mailing_0.name, 'First subject (Mass Mailing created on 2022-01-02)',
+                msg='The name should be back to first one')
 
 
 @tagged('mass_mailing')

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -471,7 +471,7 @@ class TestMassMailUTM(MassMailCommon):
         # take a (long) existing name -> should increment
         mailing_0.name = 'Second subject (Mass Mailing created on 2022-01-02)'
         self.assertEqual(mailing_0.name, 'Second subject (Mass Mailing created on 2022-01-02) [2]',
-            msg='The name must be unique')
+            msg='The name must be unique, it was already taken')
 
         # back to first subject: not linked to any record so should take it back
         mailing_0.subject = 'First subject'

--- a/addons/test_mass_mailing/models/__init__.py
+++ b/addons/test_mass_mailing/models/__init__.py
@@ -2,4 +2,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import mailing_models
+from . import mailing_models_utm
 from . import mailing_models_cornercase

--- a/addons/test_mass_mailing/models/mailing_models_utm.py
+++ b/addons/test_mass_mailing/models/mailing_models_utm.py
@@ -1,0 +1,33 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class UtmTestSourceMixin(models.Model):
+    """ Test utm.source.mixin """
+    _description = "UTM Source Mixin Test Model"
+    _name = "utm.test.source.mixin"
+    _order = "id DESC"
+    _rec_name = "title"
+    _inherit = [
+        "utm.source.mixin",
+    ]
+
+    name = fields.Char(inherited=True)
+    title = fields.Char()
+
+
+class UtmTestSourceMixinOther(models.Model):
+    """ Test utm.source.mixin, similar to the other one, allowing also to test
+    cross model uniqueness check """
+    _description = "UTM Source Mixin Test Model (another)"
+    _name = "utm.test.source.mixin.other"
+    _order = "id DESC"
+    _rec_name = "title"
+    _inherit = [
+        "mail.thread",
+        "utm.source.mixin",
+    ]
+
+    name = fields.Char(inherited=True)
+    title = fields.Char()

--- a/addons/test_mass_mailing/security/ir.model.access.csv
+++ b/addons/test_mass_mailing/security/ir.model.access.csv
@@ -17,3 +17,5 @@ access_mailing_test_partner_unstored_all,access.mailing.test.partner.unstored.al
 access_mailing_test_partner_unstored_user,access.mailing.test.partner.unstored.user,model_mailing_test_partner_unstored,base.group_user,1,1,1,1
 access_mailing_test_utm_all,access.mailing.test.utm.all,model_mailing_test_utm,,0,0,0,0
 access_mailing_test_utm_user,access.mailing.test.utm.user,model_mailing_test_utm,base.group_user,1,1,1,1
+access_utm_test_source_mixin_user,access.utm.test.source.mixin.user,model_utm_test_source_mixin,base.group_user,1,1,1,1
+access_utm_test_source_mixin_other_user,access.utm.test.source.mixin.other.user,model_utm_test_source_mixin_other,base.group_user,1,1,1,1

--- a/addons/test_mass_mailing/tests/__init__.py
+++ b/addons/test_mass_mailing/tests/__init__.py
@@ -13,3 +13,4 @@ from . import test_mailing_statistics
 from . import test_mailing_statistics_sms
 from . import test_mailing_test
 from . import test_performance
+from . import test_utm

--- a/addons/test_mass_mailing/tests/test_utm.py
+++ b/addons/test_mass_mailing/tests/test_utm.py
@@ -11,18 +11,17 @@ class TestUTM(common.TestMassMailCommon):
     def test_utm_source_mixin_name(self):
         """ Test name management with source mixin, as name should be unique
         and automatically incremented """
-        with self.subTest(test="Automatic increment at create"):
-            sources = self.env["utm.test.source.mixin"].create([
-                {
-                    'name': 'Test',
-                    'title': 'Test',
-                }
-                for idx in range(5)]
-            )
-            self.assertListEqual(
-                sources.mapped('name'),
-                ["Test", "Test [2]", "Test [3]", "Test [4]", "Test [5]"]
-            )
+        sources = self.env["utm.test.source.mixin"].create([
+            {
+                'name': 'Test',
+                'title': 'Test',
+            }
+            for idx in range(5)]
+        )
+        self.assertListEqual(
+            sources.mapped('name'),
+            ["Test", "Test [2]", "Test [3]", "Test [4]", "Test [5]"]
+        )
 
     @users("employee")
     def test_utm_source_mixin_name_brackets(self):

--- a/addons/test_mass_mailing/tests/test_utm.py
+++ b/addons/test_mass_mailing/tests/test_utm.py
@@ -78,12 +78,10 @@ class TestUTM(common.TestMassMailCommon):
         self.assertEqual(source_other_2.name, "New")
         self.assertEqual(source_other_2.title, "New")
 
-        with self.subTest(reason="FIXME: cross model uniqueness crashes, wrong model used"):
-            source_other_2.write({"name": "Test"})
-            self.assertEqual(source_other_2.name, "Test [3]")
-            self.assertEqual(source_other_2.title, "New")
+        source_other_2.write({"name": "Test"})
+        self.assertEqual(source_other_2.name, "Test [3]")
+        self.assertEqual(source_other_2.title, "New")
 
-        with self.subTest(reason="FIXME: cross model uniqueness crashes, wrong model used"):
-            source_2 = source_1.copy()
-            self.assertEqual(source_2.name, "Test [4]")
-            self.assertEqual(source_2.title, "Test")
+        source_2 = source_1.copy()
+        self.assertEqual(source_2.name, "Test [4]")
+        self.assertEqual(source_2.title, "Test")

--- a/addons/test_mass_mailing/tests/test_utm.py
+++ b/addons/test_mass_mailing/tests/test_utm.py
@@ -26,25 +26,24 @@ class TestUTM(common.TestMassMailCommon):
     @users("employee")
     def test_utm_source_mixin_name_brackets(self):
         """ Test with brackets """
-        with self.subTest(test="Brackets should not prevent numbering"):
-            false_dupes = self.env["utm.test.source.mixin"].create([
-                {
-                    'name': 'NewTest [2]',
-                    'title': 'NewTest',
-                }
-                for idx in range(3)] + [
-                {
-                    'name': 'NewTest [3]',
-                    'title': 'NewTest',
-                }, {
-                    'name': 'NewTest',
-                    'title': 'NewTest',
-                }]
-            )
-            self.assertListEqual(
-                false_dupes.mapped('name'),
-                ["NewTest", "NewTest [2]", "NewTest [3]", "NewTest [4]", "NewTest [5]"]
-            )
+        false_dupes = self.env["utm.test.source.mixin"].create([
+            {
+                'name': 'NewTest [2]',
+                'title': 'NewTest',
+            }
+            for idx in range(3)] + [
+            {
+                'name': 'NewTest [3]',
+                'title': 'NewTest',
+            }, {
+                'name': 'NewTest',
+                'title': 'NewTest',
+            }]
+        )
+        self.assertListEqual(
+            false_dupes.mapped('name'),
+            ["NewTest [2]", "NewTest", "NewTest [3]", "NewTest [4]", "NewTest [5]"]
+        )
 
         new_source = self.env["utm.test.source.mixin"].create({
             "name": "OtherTest [2]",

--- a/addons/test_mass_mailing/tests/test_utm.py
+++ b/addons/test_mass_mailing/tests/test_utm.py
@@ -1,0 +1,89 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.addons.test_mass_mailing.tests import common
+from odoo.tests import tagged, users
+
+
+@tagged("utm")
+class TestUTM(common.TestMassMailCommon):
+
+    @users("employee")
+    def test_utm_source_mixin_name(self):
+        """ Test name management with source mixin, as name should be unique
+        and automatically incremented """
+        with self.subTest(test="Automatic increment at create"):
+            sources = self.env["utm.test.source.mixin"].create([
+                {
+                    'name': 'Test',
+                    'title': 'Test',
+                }
+                for idx in range(5)]
+            )
+            self.assertListEqual(
+                sources.mapped('name'),
+                ["Test", "Test [2]", "Test [3]", "Test [4]", "Test [5]"]
+            )
+
+    @users("employee")
+    def test_utm_source_mixin_name_brackets(self):
+        """ Test with brackets """
+        with self.subTest(test="Brackets should not prevent numbering"):
+            false_dupes = self.env["utm.test.source.mixin"].create([
+                {
+                    'name': 'NewTest [2]',
+                    'title': 'NewTest',
+                }
+                for idx in range(3)] + [
+                {
+                    'name': 'NewTest [3]',
+                    'title': 'NewTest',
+                }, {
+                    'name': 'NewTest',
+                    'title': 'NewTest',
+                }]
+            )
+            self.assertListEqual(
+                false_dupes.mapped('name'),
+                ["NewTest", "NewTest [2]", "NewTest [3]", "NewTest [4]", "NewTest [5]"]
+            )
+
+        new_source = self.env["utm.test.source.mixin"].create({
+            "name": "OtherTest [2]",
+        })
+        self.assertEqual(new_source.name, "OtherTest [2]")
+
+    @users("employee")
+    def test_utm_source_mixin_name_cross_model(self):
+        """ Uniqueness of source should be ensured cross models. For this purpose
+        we use two models using the utm.source.mixin, allowing to check conflict
+        management between models. """
+        source_1 = self.env["utm.test.source.mixin"].create({
+            "name": "Test",
+            "title": "Test",
+        })
+        self.assertEqual(source_1.name, "Test")
+        self.assertEqual(source_1.title, "Test")
+
+        source_other_1 = self.env["utm.test.source.mixin.other"].create({
+            "name": "Test",
+            "title": "Test",
+        })
+        self.assertEqual(source_other_1.name, "Test [2]")
+        self.assertEqual(source_other_1.title, "Test")
+
+        source_other_2 = self.env["utm.test.source.mixin.other"].create({
+            "name": "New",
+            "title": "New",
+        })
+        self.assertEqual(source_other_2.name, "New")
+        self.assertEqual(source_other_2.title, "New")
+
+        with self.subTest(reason="FIXME: cross model uniqueness crashes, wrong model used"):
+            source_other_2.write({"name": "Test"})
+            self.assertEqual(source_other_2.name, "Test [3]")
+            self.assertEqual(source_other_2.title, "New")
+
+        with self.subTest(reason="FIXME: cross model uniqueness crashes, wrong model used"):
+            source_2 = source_1.copy()
+            self.assertEqual(source_2.name, "Test [4]")
+            self.assertEqual(source_2.title, "Test")

--- a/addons/utm/models/utm_campaign.py
+++ b/addons/utm/models/utm_campaign.py
@@ -33,7 +33,9 @@ class UtmCampaign(models.Model):
 
     @api.depends('title')
     def _compute_name(self):
-        new_names = self.env['utm.mixin']._get_unique_names(self._name, [c.title for c in self])
+        new_names = self.env['utm.mixin'].with_context(
+            utm_check_skip_record_ids=self.ids
+        )._get_unique_names(self._name, [c.title for c in self])
         for campaign, new_name in zip(self, new_names):
             campaign.name = new_name
 

--- a/addons/utm/models/utm_mixin.py
+++ b/addons/utm/models/utm_mixin.py
@@ -124,12 +124,17 @@ class UtmMixin(models.AbstractModel):
                 result.append(False)
                 continue
 
-            name_without_counter = self._split_name_and_count(name)[0]
-            # keep going until the count is not already used
-            for count in current_counter_per_name[name_without_counter]:
-                if count not in used_counters_per_name.get(name_without_counter, set()):
-                    break
-            result.append(f'{name_without_counter} [{count}]' if count > 1 else name)
+            name_without_counter, asked_counter = self._split_name_and_count(name)
+            existing = used_counters_per_name.get(name_without_counter, set())
+            if asked_counter and asked_counter not in existing:
+                count = asked_counter
+            else:
+                # keep going until the count is not already used
+                for count in current_counter_per_name[name_without_counter]:
+                    if count not in existing:
+                        break
+            existing.add(count)
+            result.append(f'{name_without_counter} [{count}]' if count > 1 else name_without_counter)
 
         return result
 

--- a/addons/utm/models/utm_source.py
+++ b/addons/utm/models/utm_source.py
@@ -75,12 +75,12 @@ class UtmSourceMixin(models.AbstractModel):
         if values.get(self._rec_name) and not values.get('name'):
             values['name'] = self.env['utm.source']._generate_name(self, values[self._rec_name])
         if values.get('name'):
-            values['name'] = self.env['utm.mixin']._get_unique_names(self._name, [values['name']])[0]
+            values['name'] = self.env['utm.mixin']._get_unique_names("utm.source", [values['name']])[0]
 
         super().write(values)
 
     def copy(self, default=None):
         """Increment the counter when duplicating the source."""
         default = default or {}
-        default['name'] = self.env['utm.mixin']._get_unique_names(self._name, [self.name])[0]
+        default['name'] = self.env['utm.mixin']._get_unique_names("utm.source", [self.name])[0]
         return super().copy(default)

--- a/addons/utm/models/utm_source.py
+++ b/addons/utm/models/utm_source.py
@@ -72,10 +72,17 @@ class UtmSourceMixin(models.AbstractModel):
         return super().create(vals_list)
 
     def write(self, values):
+        if (values.get(self._rec_name) or values.get('name')) and len(self) > 1:
+            raise ValueError(
+                _('You cannot update multiple records with the same name. The name should be unique!')
+            )
+
         if values.get(self._rec_name) and not values.get('name'):
             values['name'] = self.env['utm.source']._generate_name(self, values[self._rec_name])
         if values.get('name'):
-            values['name'] = self.env['utm.mixin']._get_unique_names("utm.source", [values['name']])[0]
+            values['name'] = self.env['utm.mixin'].with_context(
+                utm_check_skip_record_ids=self.source_id.ids
+            )._get_unique_names("utm.source", [values['name']])[0]
 
         super().write(values)
 

--- a/addons/utm/tests/test_utm.py
+++ b/addons/utm/tests/test_utm.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo.addons.utm.models.utm_mixin import UtmMixin
 from odoo.addons.utm.tests.common import TestUTMCommon
 from odoo.tests import tagged
 
@@ -158,3 +159,15 @@ class TestUtm(TestUTMCommon):
                 utm_batch_nodup.mapped("name"),
                 ["NoDupBatch [2]", "NoDupBatch [4]", "NoDupBatch [6]", "Margoulin"]
             )
+
+    def test_split_name_and_count(self):
+        """ Test for tool '_split_name_and_count' """
+        for name, (expected_name, expected_count) in [
+            ("medium", ("medium", 1)),
+            ("medium [0]", ("medium", 0)),
+            ("medium [1]", ("medium", 1)),
+            ("medium [x]", ("medium [x]", 1)),  # not integer -> do not care
+            ("medium [0", ("medium [0", 1)),  # unrecognized -> do not crash
+        ]:
+            with self.subTest(name=name):
+                self.assertEqual(UtmMixin._split_name_and_count(name), (expected_name, expected_count))

--- a/addons/utm/tests/test_utm.py
+++ b/addons/utm/tests/test_utm.py
@@ -50,6 +50,8 @@ class TestUtm(TestUTMCommon):
         source_4_2 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 4 [2]')
         self.assertNotIn(source_4_2, source_1 | source_2 | source_3 | source_3_2)
         self.assertEqual(source_4_2.name, 'Source 4 [2]')
+        source_4_2_bis = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 4 [2]')
+        self.assertEqual(source_4_2_bis, source_4_2)
         # ... then basic without duplicate mark
         source_4 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 4')
         self.assertNotIn(source_4, source_1 | source_2 | source_3 | source_3_2 | source_4_2)

--- a/addons/utm/tests/test_utm.py
+++ b/addons/utm/tests/test_utm.py
@@ -20,8 +20,7 @@ class TestUtm(TestUTMCommon):
 
         campaigns[0].title = "ForcedName"
         self.assertEqual(campaigns[0].name, "ForcedName [2]")
-        with self.subTest(reason="FIXME: same name should not trigger auto increment, received ForcedName [3]"):
-            self.assertEqual(campaigns[0].name, "ForcedName [2]")
+        self.assertEqual(campaigns[0].name, "ForcedName [2]")
 
     def test_find_or_create_record(self):
         """ Tests for '_find_or_create_record' """

--- a/addons/utm/tests/test_utm.py
+++ b/addons/utm/tests/test_utm.py
@@ -53,8 +53,7 @@ class TestUtm(TestUTMCommon):
         # ... then basic without duplicate mark
         source_4 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 4')
         self.assertNotIn(source_4, source_1 | source_2 | source_3 | source_3_2 | source_4_2)
-        with self.subTest(reason="FIXME: should not increment automatically, should be 'Source 4', instead receives 'Source 4 [3]'"):
-            self.assertEqual(source_4.name, 'Source 4')
+        self.assertEqual(source_4.name, 'Source 4')
 
     def test_name_generation(self):
         """Test that the name is always unique. A counter must be added at the
@@ -90,12 +89,10 @@ class TestUtm(TestUTMCommon):
             (utm_0 | utm_3 | utm_4).unlink()
 
             utm_new_multi = self.env[utm_model].create([{'name': 'UTM new'} for _ in range(4)])
-            with self.subTest(reason="FIXME: Duplicate counters should be filled in order of missing, not continuing after max"):
-                # receives 'UTM new [5]', 'UTM new [6]', 'UTM new [7]', 'UTM new [8]'
-                self.assertListEqual(
-                    utm_new_multi.mapped('name'),
-                    ['UTM new', 'UTM new [2]', 'UTM new [3]', 'UTM new [5]'],
-                    'Duplicate counters should be filled in order of missing.')
+            self.assertListEqual(
+                utm_new_multi.mapped('name'),
+                ['UTM new', 'UTM new [2]', 'UTM new [3]', 'UTM new [5]'],
+                'Duplicate counters should be filled in order of missing.')
 
             # no ilike-based duplicate
             utm_7 = self.env[utm_model].create({'name': 'UTM ne'})

--- a/addons/utm/tests/test_utm.py
+++ b/addons/utm/tests/test_utm.py
@@ -2,10 +2,28 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.addons.utm.tests.common import TestUTMCommon
+from odoo.tests import tagged
 
 
+@tagged("utm", "post_install", "-at_install")
 class TestUtm(TestUTMCommon):
+
+    def test_campaign_automatic_name(self):
+        """ Test automatic naming of campaigns based on title """
+        campaigns = self.env["utm.campaign"].create([
+            {"title": "Title"},
+            {"name": "ForcedName", "title": "WithTitle"}
+        ])
+        self.assertEqual(campaigns[0].name, "Title")
+        self.assertEqual(campaigns[1].name, "ForcedName")
+
+        campaigns[0].title = "ForcedName"
+        self.assertEqual(campaigns[0].name, "ForcedName [2]")
+        with self.subTest(reason="FIXME: same name should not trigger auto increment, received ForcedName [3]"):
+            self.assertEqual(campaigns[0].name, "ForcedName [2]")
+
     def test_find_or_create_record(self):
+        """ Tests for '_find_or_create_record' """
         source_1, source_2 = self.env['utm.source'].create([{
             'name': 'Source 1',
         }, {
@@ -15,53 +33,128 @@ class TestUtm(TestUTMCommon):
         # Find the record based on the given name
         source = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 1')
         self.assertEqual(source, source_1)
+        source = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 2')
+        self.assertEqual(source, source_2)
 
         # Create a new record
-        source_4 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 3')
-        self.assertNotIn(source_4, source_1 | source_2)
-        self.assertEqual(source_4.name, 'Source 3')
+        source_3 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 3')
+        self.assertNotIn(source_3, source_1 | source_2)
+        self.assertEqual(source_3.name, 'Source 3')
+
+        # Duplicate mark: valid new record
+        source_3_2 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 3 [2]')
+        self.assertNotIn(source_3_2, source_1 | source_2 | source_3)
+        self.assertEqual(source_3_2.name, 'Source 3 [2]')
+
+        # New source with duplicate mark ...
+        source_4_2 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 4 [2]')
+        self.assertNotIn(source_4_2, source_1 | source_2 | source_3 | source_3_2)
+        self.assertEqual(source_4_2.name, 'Source 4 [2]')
+        # ... then basic without duplicate mark
+        source_4 = self.env['utm.mixin']._find_or_create_record('utm.source', 'Source 4')
+        self.assertNotIn(source_4, source_1 | source_2 | source_3 | source_3_2 | source_4_2)
+        with self.subTest(reason="FIXME: should not increment automatically, should be 'Source 4', instead receives 'Source 4 [3]'"):
+            self.assertEqual(source_4.name, 'Source 4')
 
     def test_name_generation(self):
-        """Test that the name is always unique.
-
-        A counter must be added at the end of the name if it's not the case.
-        """
+        """Test that the name is always unique. A counter must be added at the
+        end of the name if it's not the case."""
         for utm_model in ('utm.source', 'utm.medium', 'utm.campaign'):
-            utm_0 = self.env[utm_model].create({'name': 'UTM dup'})
+            utm_0 = self.env[utm_model].create({'name': 'UTM new'})
 
-            utm_1, utm_2, utm_3, utm_4, utm_5 = self.env[utm_model].create([{
-                'name': 'UTM 1',
-            }, {
-                'name': 'UTM 2',
-            }, {
-                'name': 'UTM dup',
-            }, {
-                # UTM record 4 has the same name of the previous UTM record
-                'name': 'UTM dup',
-            }, {
-                # UTM record 5 has the same name of the previous UTM record
-                # but with a wrong counter part, it will be removed and updated
-                'name': 'UTM dup [0]',
-            }])
+            utm_1, utm_2, utm_3, utm_4, utm_5 = self.env[utm_model].create([
+                {
+                    'name': 'UTM 1',
+                }, {
+                    'name': 'UTM 2',
+                }, {
+                    # UTM record 3 has the same name of the previous UTM record
+                    'name': 'UTM new',
+                }, {
+                    # UTM record 4 has the same name of the previous UTM record
+                    'name': 'UTM new',
+                }, {
+                    # UTM record 5 has the same name of the previous UTM record
+                    # but with a wrong counter part, it should be removed and updated
+                    'name': 'UTM new [0]',
+                },
+            ])
 
-            self.assertEqual(utm_0.name, 'UTM dup', msg='The first "UTM dup" should be left unchanged since it is unique')
+            self.assertEqual(utm_0.name, 'UTM new', msg='The first "UTM dup" should be left unchanged since it is unique')
             self.assertEqual(utm_1.name, 'UTM 1', msg='This name is already unique')
             self.assertEqual(utm_2.name, 'UTM 2', msg='This name is already unique')
-            self.assertEqual(utm_3.name, 'UTM dup [2]', msg='Must add a counter as suffix to ensure uniqueness')
-            self.assertEqual(utm_4.name, 'UTM dup [3]', msg='Must add a counter as suffix to ensure uniqueness')
-            self.assertEqual(utm_5.name, 'UTM dup [4]', msg='Must add a counter as suffix to ensure uniqueness')
+            self.assertEqual(utm_3.name, 'UTM new [2]', msg='Must add a counter as suffix to ensure uniqueness')
+            self.assertEqual(utm_4.name, 'UTM new [3]', msg='Must add a counter as suffix to ensure uniqueness')
+            self.assertEqual(utm_5.name, 'UTM new [4]', msg='Must add a counter as suffix to ensure uniqueness')
 
             (utm_0 | utm_3 | utm_4).unlink()
 
-            utm_6 = self.env[utm_model].create({'name': 'UTM dup'})
-            self.assertEqual(utm_6.name, 'UTM dup [5]')
+            utm_new_multi = self.env[utm_model].create([{'name': 'UTM new'} for _ in range(4)])
+            with self.subTest(reason="FIXME: Duplicate counters should be filled in order of missing, not continuing after max"):
+                # receives 'UTM new [5]', 'UTM new [6]', 'UTM new [7]', 'UTM new [8]'
+                self.assertListEqual(
+                    utm_new_multi.mapped('name'),
+                    ['UTM new', 'UTM new [2]', 'UTM new [3]', 'UTM new [5]'],
+                    'Duplicate counters should be filled in order of missing.')
 
-            utm_7 = self.env[utm_model].create({'name': 'UTM d'})
-            self.assertEqual(utm_7.name, 'UTM d', msg='Even if this name has the same prefix as the other, it is still unique')
+            # no ilike-based duplicate
+            utm_7 = self.env[utm_model].create({'name': 'UTM ne'})
+            self.assertEqual(
+                utm_7.name, 'UTM ne',
+                msg='Even if this name has the same prefix as the other, it is still unique')
 
+            # copy should avoid uniqueness issues
             utm_8 = utm_7.copy()
-            self.assertEqual(utm_8.name, 'UTM d [2]', msg='Must add a counter as suffix to ensure uniqueness')
+            self.assertEqual(
+                utm_8.name, 'UTM ne [2]',
+                msg='Must add a counter as suffix to ensure uniqueness')
 
         # Test name uniqueness when creating a campaign using a title (quick creation)
-        utm_9 = self.env['utm.campaign'].create({'title': 'UTM dup'})
-        self.assertEqual(utm_9.name, 'UTM dup [6]', msg='Even if the record has been created using a title, the name must be unique')
+        utm_9 = self.env['utm.campaign'].create({'title': 'UTM ne'})
+        self.assertEqual(
+            utm_9.name, 'UTM ne [3]',
+            msg='Even if the record has been created using a title, the name must be unique')
+
+    def test_name_generation_duplicate_marks(self):
+        """ Check corner cases when giving duplicate marks directly in name """
+        for utm_model in ('utm.source', 'utm.medium', 'utm.campaign'):
+            utm = self.env[utm_model].create({"name": "MarkTest [2]"})
+            self.assertEqual(
+                utm.name, "MarkTest [2]",
+                "Should respect creation value")
+
+            utm.write({"name": "MarkTest [2]"})
+            self.assertEqual(
+                utm.name, "MarkTest [2]",
+                "Writing same value: should not auto increment")
+
+            utm.write({"name": "MarkTest"})
+            self.assertEqual(
+                utm.name, "MarkTest",
+                "First available counter")
+
+            utm.write({"name": "MarkTest [8]"})
+            self.assertEqual(
+                utm.name, "MarkTest [8]",
+                "Should respect given values")
+
+            utm_batch = self.env[utm_model].create([
+                {"name": "BatchTest [2]"}
+                for x in range(4)
+            ])
+            self.assertEqual(
+                utm_batch.mapped("name"),
+                ["BatchTest [2]", "BatchTest", "BatchTest [3]", "BatchTest [4]"],
+                "Accept input if possible, otherwise increment"
+            )
+
+            utm_batch_nodup = self.env[utm_model].create([
+                {"name": "NoDupBatch [2]"},
+                {"name": "NoDupBatch [4]"},
+                {"name": "NoDupBatch [6]"},
+                {"name": "Margoulin"},
+            ])
+            self.assertEqual(
+                utm_batch_nodup.mapped("name"),
+                ["NoDupBatch [2]", "NoDupBatch [4]", "NoDupBatch [6]", "Margoulin"]
+            )

--- a/addons/utm/tests/test_utm_consistency.py
+++ b/addons/utm/tests/test_utm_consistency.py
@@ -6,8 +6,8 @@ from odoo.exceptions import UserError
 from odoo.tests.common import tagged, users
 
 
-@tagged('post_install', '-at_install', 'utm_consistency')
-class TestUTMSecurity(TestUTMCommon):
+@tagged('post_install', '-at_install', 'utm', 'utm_consistency')
+class TestUTMConsistency(TestUTMCommon):
 
     @users('__system__')
     def test_utm_consistency(self):

--- a/addons/utm/tests/test_utm_security.py
+++ b/addons/utm/tests/test_utm_security.py
@@ -6,7 +6,7 @@ from odoo.exceptions import AccessError
 from odoo.tests.common import tagged, users
 
 
-@tagged('post_install', '-at_install', 'security')
+@tagged('post_install', '-at_install', 'security', 'utm')
 class TestUTMSecurity(TestUTMCommon):
 
     @users('__system__')


### PR DESCRIPTION
PURPOSE

Fix various issues related to automatic source creation and naming involving
auto increment to avoid uniqueness constraint issues.

Notably
  * avoid always incrementing (e.g. same name should not increment);
  * do not fail to start counters at 0 when possible;
  * improve write / batch bad support;
  * correctly check uniqueness in utm.source.mixin currently done on wrong
    model;
  * fill holes in counter sequence instead of continuing above higher found
    counter;

See sub commits for more details.

LINKS

Task-3874538 (odoo/odoo#162229) Do not create endless copies
Task-3837272 (odoo/odoo#159699) Incorrect UTM source enumeration
