### PR TITLE
[FIX] loyalty: impossible to delete rewards

### DIFF
--- a/addons/pos_loyalty/models/loyalty_reward.py
+++ b/addons/pos_loyalty/models/loyalty_reward.py
@@ -11,3 +11,8 @@ class LoyaltyReward(models.Model):
         for vals in res:
             vals.update({'taxes_id': False})
         return res
+
+    def unlink(self):
+        if len(self) == 1 and self.env['pos.order.line'].search_count([('reward_id', 'in', self.ids)], limit=1):
+            return self.action_archive()
+        return super().unlink()

--- a/addons/pos_loyalty/tests/__init__.py
+++ b/addons/pos_loyalty/tests/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import test_frontend
+from . import test_unlink_reward

--- a/addons/pos_loyalty/tests/test_unlink_reward.py
+++ b/addons/pos_loyalty/tests/test_unlink_reward.py
@@ -1,0 +1,62 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.addons.point_of_sale.tests.common import TestPointOfSaleCommon
+from odoo.tests.common import tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestUnlinkReward(TestPointOfSaleCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        # Create a loyalty program
+        cls.loyalty_program = cls.env['loyalty.program'].create({
+            'name': 'Buy 4 whiteboard_pen, Take 1 whiteboard_pen',
+            'program_type': 'loyalty',
+            'trigger': 'auto',
+            'applies_on': 'both',
+            'rule_ids': [Command.create({
+                'product_ids': cls.whiteboard_pen.ids,
+                'reward_point_mode': 'unit',
+                'minimum_qty': 1,
+            })],
+        })
+
+        # Create a reward
+        cls.reward = cls.env['loyalty.reward'].create({
+            'program_id': cls.loyalty_program.id,
+            'reward_type': 'product',
+            'reward_product_id': cls.whiteboard_pen.id,
+            'reward_product_qty': 1,
+            'required_points': 4,
+        })
+
+    def test_pos_unlink_reward(self):
+        self.pos_config.open_ui()
+        current_session = self.pos_config.current_session_id
+        self.PosOrder.create({
+            'company_id': self.env.company.id,
+            'session_id': current_session.id,
+            'partner_id': self.partner1.id,
+            'pricelist_id': self.partner1.property_product_pricelist.id,
+            'lines': [
+                Command.create({
+                    'product_id': self.whiteboard_pen.id,
+                    'qty': 5,
+                    'price_subtotal': 12.0,
+                    'price_subtotal_incl': 12.0,
+                    'reward_id': self.reward.id,
+                })
+            ],
+            'amount_tax': 0.0,
+            'amount_total': 134.38,
+            'amount_paid': 0.0,
+            'amount_return': 0.0,
+        })
+        # Attempt to delete the reward
+        self.reward.unlink()
+
+        # Ensure the reward is archived and not deleted
+        self.assertTrue(self.reward.exists())
+        self.assertFalse(self.reward.active)

--- a/addons/sale_loyalty/models/loyalty_reward.py
+++ b/addons/sale_loyalty/models/loyalty_reward.py
@@ -15,3 +15,8 @@ class LoyaltyReward(models.Model):
                 'invoice_policy': 'order',
             })
         return res
+
+    def unlink(self):
+        if len(self) == 1 and self.env['sale.order.line'].search_count([('reward_id', 'in', self.ids)], limit=1):
+            return self.action_archive()
+        return super().unlink()

--- a/addons/sale_loyalty/tests/__init__.py
+++ b/addons/sale_loyalty/tests/__init__.py
@@ -10,3 +10,4 @@ from . import test_program_rules
 from . import test_program_with_code_operations
 from . import test_program_without_code_operations
 from . import test_sale_invoicing
+from . import test_unlink_reward

--- a/addons/sale_loyalty/tests/test_unlink_reward.py
+++ b/addons/sale_loyalty/tests/test_unlink_reward.py
@@ -1,0 +1,55 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+
+from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
+from odoo.tests.common import tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestUnlinkReward(TestSaleCouponCommon):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.promotion_program = cls.env['loyalty.program'].create({
+            'name': 'Buy A + 1 B, 1 B are free',
+            'program_type': 'promotion',
+            'applies_on': 'current',
+            'company_id': cls.env.company.id,
+            'trigger': 'auto',
+            'rule_ids': [Command.create({
+                'product_ids': cls.product_A,
+                'reward_point_amount': 1,
+                'reward_point_mode': 'order',
+                'minimum_qty': 1,
+            })],
+        })
+        cls.reward = cls.env['loyalty.reward'].create({
+            'program_id': cls.promotion_program.id,
+            'reward_type': 'discount',
+        })
+
+    def test_sale_unlink_reward(self):
+        order = self.empty_order
+        order.write({'order_line': [
+            Command.create({
+                'product_id': self.product_A.id,
+                'name': 'Ordinary Product A',
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 1.0,
+            }),
+            Command.create({
+                'product_id': self.product_B.id,
+                'name': '2 Product B',
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 1.0,
+            }),
+        ]})
+        order._update_programs_and_rewards()
+        self._claim_reward(order, self.promotion_program)
+        self.reward.unlink()
+
+        # Check that the reward is archived and not deleted
+        self.assertTrue(self.reward.exists())
+        self.assertFalse(self.reward.active)


### PR DESCRIPTION
Steps :
* Create a loyalty program of any type
* Create 2 or more rewards
* Create a sale order and use the loyalty program and reward we just created
* Go back to the loyalty program and try to delete that reward

Issue :
The record cannot be deleted as another model  requires the record being deleted

Fix :
Changed the unlink method to delete the record if this record id is not required by another model and archive the record if it is required

opw : 3879031

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
