### PR TITLE
[FIX] web_tour: fixed tour pointer overlay sequence

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_service.js
+++ b/addons/web_tour/static/src/tour_service/tour_service.js
@@ -146,7 +146,7 @@ export const tourService = {
                         component: TourPointer,
                         props: { pointerState, ...config },
                     };
-                    remove = overlay.add(pointers[tourName].component, pointers[tourName].props);
+                    remove = overlay.add(pointers[tourName].component, pointers[tourName].props, { sequence: 60 });
                 },
                 stop() {
                     remove?.();


### PR DESCRIPTION
Steps to Reproduce:

- Run the project tour
- Click on new button kanban view
- In the Quick Project Create view you cant see the tour pointer
- Move the Dialog aside you can see the pointer below the form.

Issue:

- The issue is that the tour pointer is displayed beneath the dialog

Cause:

- After this PR https://github.com/odoo/odoo/pull/153068
- Every overlay item is wrapped in a div.
- All the div have same z-index and are sorted by using sequence(passed by the user).

Fix:

- Increase the sequence of tour pointer to 60 (default is 50),

task-3906723

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
