### PR TITLE
 [FIX] web_editor: should not cross blocks in getDeepestPosition

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -4175,24 +4175,13 @@ export class OdooEditor extends EventTarget {
         // and the toolbar so we need to fix the selection to be based on the
         // editable children. Calling `getDeepRange` ensure the selection is
         // limited to the editable.
-        const containerSelector = '#wrap>*, .oe_structure>*, [contenteditable]';
-        const container =
-            (selection &&
-                closestElement(selection.anchorNode, containerSelector)) ||
-            // In case a suitable container could not be found then the
-            // selection is restricted inside the editable area.
-            this.editable;
         if (
-            selection.anchorNode === container &&
-            selection.focusNode === container &&
+            selection.anchorNode === this.editable &&
+            selection.focusNode === this.editable &&
             selection.anchorOffset === 0 &&
-            selection.focusOffset === [...container.childNodes].length &&
-            // Checks that the container is not an empty editable structure to
-            // avoid calling "getDeepRange" if it is, otherwise it will be
-            // selected again, creating an infine loop.
-            container.childNodes.length
+            selection.focusOffset === [...this.editable.childNodes].length
         ) {
-            getDeepRange(container, {select: true});
+            getDeepRange(this.editable, {select: true});
             // The selection is changed in `getDeepRange` and will therefore
             // re-trigger the _onSelectionChange.
             return;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -2237,6 +2237,11 @@ export class OdooEditor extends EventTarget {
         }
         // Ensure empty blocks be given a <br> child.
         if (start) {
+            if (start === this.editable && startBlock.textContent === '\u200B') {
+                const p = document.createElement('p');
+                start.appendChild(p);
+                start = p;
+            }
             fillEmpty(closestBlock(start));
         }
         fillEmpty(closestBlock(range.endContainer));

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -289,6 +289,9 @@ export const editorCommands = {
                     }
                 }
             }
+            // Contenteditable false property changes to true after the node is
+            // inserted into DOM.
+            const isNodeToInsertContentEditable = nodeToInsert.isContentEditable;
             if (insertBefore) {
                 currentNode.before(nodeToInsert);
                 insertBefore = false;
@@ -297,6 +300,17 @@ export const editorCommands = {
             }
             if (currentNode.tagName !== 'BR' && isShrunkBlock(currentNode)) {
                 currentNode.remove();
+            }
+            // If the first child of editable is contenteditable false element
+            // a chromium bug prevents selecting the container. Prepend a
+            // zero-width space so it's no longer the first child.
+            if (
+                !isNodeToInsertContentEditable &&
+                editor.editable.firstChild === nodeToInsert &&
+                nodeToInsert.nodeName === 'DIV'
+            ) {
+                const zws = document.createTextNode('\u200B');
+                nodeToInsert.before(zws);
             }
             currentNode = nodeToInsert;
         }

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/commands/commands.js
@@ -53,6 +53,7 @@ import {
     TEXT_STYLE_CLASSES,
     padLinkWithZws,
     isLinkEligibleForZwnbsp,
+    paragraphRelatedElements,
 } from '../utils/utils.js';
 
 const TEXT_CLASSES_REGEX = /\btext-[^\s]*\b/;
@@ -992,10 +993,7 @@ export const editorCommands = {
     insertHorizontalRule(editor) {
         const selection = editor.document.getSelection();
         const range = selection.getRangeAt(0);
-        const element = closestElement(
-            range.startContainer,
-            'P, PRE, H1, H2, H3, H4, H5, H6, BLOCKQUOTE',
-        );
+        const element = closestElement(range.startContainer, paragraphRelatedElements) || closestBlock(range.startContainer);
 
         if (element && ancestors(element).includes(editor.editable)) {
             element.before(editor.document.createElement('hr'));

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1036,13 +1036,17 @@ export function getDeepestPosition(node, offset) {
             // First switch direction to left if offset is at the end.
             direction = offset < node.childNodes.length;
             next = node.childNodes[direction ? offset : offset - 1];
-        } else if (direction && next.nextSibling) {
+        } else if (
+            direction &&
+            next.nextSibling &&
+            closestBlock(node).contains(next.nextSibling)
+        ) {
             // Invalid node: skip to next sibling (without crossing blocks).
             next = next.nextSibling;
         } else {
             // Invalid node: skip to previous sibling (without crossing blocks).
             direction = DIRECTIONS.LEFT;
-            next = !isBlock(next.previousSibling) && next.previousSibling;
+            next = closestBlock(node).contains(next.previousSibling) && next.previousSibling;
         }
         // Avoid too-deep ranges inside self-closing elements like [BR, 0].
         next = !isSelfClosingElement(next) && next;

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1028,7 +1028,7 @@ export function getDeepestPosition(node, offset) {
     let direction = DIRECTIONS.RIGHT;
     let next = node;
     while (next) {
-        if ((isTangible(next) || isZWS(next)) && (!isBlock(next) || next.isContentEditable)) {
+        if (isTangible(next) || isZWS(next)) {
             // Valid node: update position then try to go deeper.
             if (next !== node) {
                 [node, offset] = [next, direction ? 0 : nodeSize(next)];

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
@@ -308,3 +308,26 @@ describe('insert text', () => {
         });
     });
 });
+describe('insert horizontal rule', () => {
+    it('should insert a horizontal rule within a p tag', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<p>[]<br></p>',
+            stepFunction: editor => editor.execCommand('insertHorizontalRule'),
+            contentAfter: '<hr><p>[]<br></p>',
+        });
+    });
+    it('should insert a horizontal rule within a h1 tag', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<h1>[]<br></h1>',
+            stepFunction: editor => editor.execCommand('insertHorizontalRule'),
+            contentAfter: '<hr><h1>[]<br></h1>',
+        });
+    });
+    it('should insert a horizontal rule within a block node', async () => {
+        await testEditor(BasicEditor, {
+            contentBefore: '<div>[]<br></div>',
+            stepFunction: editor => editor.execCommand('insertHorizontalRule'),
+            contentAfter: '<hr><div>[]<br></div>',
+        });
+    });
+});

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/insert.test.js
@@ -72,7 +72,9 @@ describe('insert HTML', () => {
                 stepFunction: async editor => {
                     await editor.execCommand('insert', parseHTML(editor.document, '<div><p>content</p></div>'));
                 },
-                contentAfter: '<div><p>content</p></div><p>[]<br></p>',
+                // Inserts zws to avoid a Chromium bug preventing selection of
+                // contenteditable false element as first child.
+                contentAfter: '\u200b<div><p>content</p></div><p>[]<br></p>',
             });
         });
         it('should not split a pre to insert another pre but just insert the text', async () => {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/utils.test.js
@@ -1845,6 +1845,39 @@ describe('Utils', () => {
                 .expect([node, offset])
                 .to.eql([zwnbsp, 0]);
         });
+        it('should get deepest position for banner element', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                    <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                        <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                        <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                            <p>abc</p>
+                            <p>def</p>
+                        </div>
+                    </div>
+                `),
+                stepFunction: async editor => {
+                    const sel = editor.document.getSelection();
+                    const range = editor.document.createRange();
+                    range.setStart(editor.editable, 0);
+                    range.setEnd(editor.editable, 0);
+                    sel.removeAllRanges();
+                    sel.addRange(range);
+                    await nextTickFrame();
+                },
+                // We end up in the fallback of _fixSelectionOnEditableRoot
+                // which is to remove the selection.
+                contentAfter: unformat(`
+                    <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                        <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                        <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                            <p>abc</p>
+                            <p>def</p>
+                        </div>
+                    </div>
+                `),
+            });
+        });
     });
     // TODO:
     // - getCursors

--- a/addons/web_editor/static/tests/banner_tests.js
+++ b/addons/web_editor/static/tests/banner_tests.js
@@ -123,7 +123,8 @@ QUnit.module(
                 `<p>Test</p><div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
                         <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
                         <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
-                            <p placeholder=\"Type &quot;/&quot; for commands\" class=\"oe-hint oe-command-temporary-hint\"><br></p></div></div><p><br></p>`,
+                            <p placeholder=\"Type &quot;/&quot; for commands\" class=\"oe-hint oe-command-temporary-hint\"><br></p></div>
+                    </div><p><br></p>`,
             );
         });
         QUnit.test("First element of o_editable is not editable", async function (assert) {
@@ -141,15 +142,11 @@ QUnit.module(
             triggerEvent(editor.editable, "keydown", { key: "a", ctrlKey: true });
             await nextTick();
             triggerEvent(editor.editable, "input", { inputType: "deleteContentBackward" });
+            await nextTick();
             assert.strictEqual(
                 editable.innerHTML,
-                `<div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
-                        <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
-                        <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
-                            <p><br></p>
-                        </div>
-                    </div><p placeholder=\"Type &quot;/&quot; for commands\" class=\"oe-hint oe-command-temporary-hint\"><br></p>`,
-                "should not remove banner when ctrl+a and backspace are performed",
+                `<p placeholder=\"Type &quot;/&quot; for commands\" class=\"oe-hint oe-command-temporary-hint\"><br></p>`,
+                "should remove banner when ctrl+a and backspace are performed",
             );
         });
     }


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

- Commit [1] changed `getDeepestPosition` to let it change the selection to its
next block. This commit partially reverts commit [1] and ensures that it only
changes blocks when the node is invisible.

- Commit [2] changed the behavior of Ctrl+A when the first child of an editor was
contenteditable false element, causing it to not select the first element. This
behavior is incorrect, as Ctrl+A should always select all contents. This commit
partially reverts commit [2] and provides an alternative solution to the
original issue.

- Inserting a horizontal rule was only possible on paragraph related
elements. This PR makes sure horizontal rule can be inserted directly to
block elements such as div.

task-3850023

[1]: https://github.com/odoo/odoo/commit/ddc8587f8a712fdddaa714bee2931cb149c03a38
[2]: https://github.com/odoo/odoo/commit/530f102720458e5e1c224bf38073cd763309bf0a

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
