### PR TITLE
[IMP] hr, {resource_}mail: open partners avatar card on click of @mentions

### DIFF
--- a/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
+++ b/addons/hr/static/src/components/avatar_card/avatar_card_popover_patch.js
@@ -7,16 +7,19 @@ export const patchAvatarCardPopover = {
         this.userInfoTemplate = "hr.avatarCardUserInfos";
     },
     get fieldNames() {
-        const fields = super.fieldNames;
-        return fields.concat([
-            "work_phone",
-            "work_email",
-            "work_location_name",
-            "work_location_type",
-            "job_title",
-            "department_id",
-            this.props.recordModel ? "employee_id" : "employee_ids",
-        ]);
+        if (this.props.res_model == "res.users") {
+            const fields = super.fieldNames;
+            return fields.concat([
+                "work_phone",
+                "work_email",
+                "work_location_name",
+                "work_location_type",
+                "job_title",
+                "department_id",
+                this.props.recordModel ? "employee_id" : "employee_ids",
+            ]);
+        }
+        return super.fieldNames;
     },
     get email() {
         return this.user.work_email || this.user.email;

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -938,7 +938,7 @@ class MailMessage(models.Model):
             # sudo: mail.message - reading reactions on accessible message is allowed
             Store.Many("reaction_ids", rename="reactions", sudo=True),
             # sudo: res.partner: reading limited data of recipients is acceptable
-            Store.Many("partner_ids", ["avatar_128", "name"], rename="recipients", sudo=True),
+            Store.Many("partner_ids", ["avatar_128", "name", "user"], rename="recipients", sudo=True),
             "res_id",  # keep for iOS app
             "subject",
             # sudo: mail.message.subtype - reading description on accessible message is allowed

--- a/addons/mail/static/src/core/web/message_patch.js
+++ b/addons/mail/static/src/core/web/message_patch.js
@@ -61,6 +61,23 @@ patch(Message.prototype, {
             }
         }
     },
+    onClick(ev) {
+        if (ev.target.closest(".o_mail_redirect")) {
+            ev.preventDefault();
+            let id = Number(ev.target.dataset.oeId);
+            const Partner = this.store.Persona.get({ type: "partner", id: id });
+            if (Partner.userId) {
+                id = Partner.userId;
+            }
+            const remodel = Partner.userId ? "res.users" : "res.partner";
+            this.avatarCard.open(ev.target, {
+                id: id,
+                res_model: remodel,
+            });
+            return true;
+        }
+        return super.onClick(ev);
+    },
     openRecord() {
         this.message.thread.open({ focus: true });
     },

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.js
@@ -8,6 +8,7 @@ export class AvatarCardPopover extends Component {
     static props = {
         id: { type: Number, required: true },
         close: { type: Function, required: true },
+        res_model: { type: String, optional: true },
     };
 
     setup() {
@@ -15,11 +16,20 @@ export class AvatarCardPopover extends Component {
         this.orm = useService("orm");
         this.openChat = useOpenChat("res.users");
         onWillStart(async () => {
-            [this.user] = await this.orm.read("res.users", [this.props.id], this.fieldNames);
+            [this.user] = await this.orm.read(
+                this.props.res_model,
+                [this.props.id],
+                this.fieldNames
+            );
         });
     }
 
+    static defaultProps = { res_model: "res.users" };
+
     get fieldNames() {
+        if (this.props.res_model == "res.partner") {
+            return ["name", "email", "phone", "im_status"];
+        }
         return ["name", "email", "phone", "im_status", "share", "partner_id"];
     }
 
@@ -37,7 +47,7 @@ export class AvatarCardPopover extends Component {
 
     async getProfileAction() {
         return {
-            res_id: this.user.partner_id[0],
+            res_id: this.props.res_model == "res.users" ? this.user.partner_id[0] : this.user.id,
             res_model: "res.partner",
             type: "ir.actions.act_window",
             views: [[false, "form"]],

--- a/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
+++ b/addons/mail/static/src/discuss/web/avatar_card/avatar_card_popover.xml
@@ -31,7 +31,7 @@
                 <div class="flex-wrap gap-2 mt-2">
                     <div class="justify-content-end d-flex align-items-baseline">
                         <div class="d-flex gap-2 o_avatar_card_buttons">
-                            <button t-if="!user.share" class="btn btn-secondary btn-sm" t-on-click.stop="onSendClick">Send message</button>
+                            <button t-if="!user.share  and props.res_model =='res.users'" class="btn btn-secondary btn-sm" t-on-click.stop="onSendClick">Send message</button>
                             <button t-if="showViewProfileBtn" class="btn btn-secondary btn-sm" t-custom-click.stop="(ev, isMiddleClick) => this.onClickViewProfile(isMiddleClick)" t-ref="viewProfileBtn">View Profile</button>
                         </div>
                     </div>

--- a/addons/mail/static/tests/activity/activity.test.js
+++ b/addons/mail/static/tests/activity/activity.test.js
@@ -598,22 +598,6 @@ test("activity with a link to a record", async () => {
     await contains(".o_form_view input", { value: "Partner 2" });
 });
 
-test("activity with a user mention", async () => {
-    const pyEnv = await startServer();
-    const partnerId1 = pyEnv["res.partner"].create({ name: "Partner 1" });
-    const partnerId2 = pyEnv["res.partner"].create({ name: "Partner 2" });
-    pyEnv["res.users"].create({ partner_id: partnerId2 });
-    pyEnv["mail.activity"].create({
-        note: `<p>How are you, <a class="o_mail_redirect" href="#" data-oe-model="res.partner" data-oe-id="${partnerId2}">@Partner 2</a>?</p>`,
-        res_id: partnerId1,
-        res_model: "res.partner",
-    });
-    await start();
-    await openFormView("res.partner", partnerId1);
-    await click(".o-mail-Activity-note a", { text: "@Partner 2" });
-    await contains(".o-mail-ChatWindow-header", { text: "Partner 2" });
-});
-
 test("activity with a channel mention", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "Partner" });

--- a/addons/mail/static/tests/message/message.test.js
+++ b/addons/mail/static/tests/message/message.test.js
@@ -1445,7 +1445,7 @@ test("data-oe-id & data-oe-model link redirection on click", async () => {
     await waitForSteps(["do-action:openFormView_some.model_250"]);
 });
 
-test("Chat with partner should be opened after clicking on their mention", async () => {
+test("Avatar card of the partner should be opened after clicking on their mention", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({
         name: "Test Partner",
@@ -1460,8 +1460,9 @@ test("Chat with partner should be opened after clicking on their mention", async
     await contains(".o-mail-Composer-input", { value: "@Test Partner " });
     await click(".o-mail-Composer-send:enabled");
     await click(".o_mail_redirect");
-    await contains(".o-mail-ChatWindow .o-mail-Thread");
-    await contains(".o-mail-ChatWindow", { text: "Test Partner" });
+    await contains(".o_avatar_card");
+    await contains(".o_card_user_infos", { text: "Test Partner" });
+    await contains(".o_card_user_infos", { text: "testpartner@odoo.com" });
 });
 
 test("Channel should be opened after clicking on its mention", async () => {


### PR DESCRIPTION
**Prior to this commit:**
Clicking on a partner's @mention in the chat interface would directly 
open the corresponding chat thread.

**Following this commit:**
Upon clicking a partner's @mention, the system now presents an avatar 
card containing pertinent information about the mentioned partner. 
Additionally, if the partner has a userId then display the 'Send Message'.
The increase in the querycount is due to additional information of user added
in the message.


Related Enterprise PR: https://github.com/odoo/enterprise/pull/61950

**task-3816952**