### PR TITLE
[IMP] sale: option to disable 'quotation viewed by customer'

### DIFF
--- a/addons/sale/controllers/portal.py
+++ b/addons/sale/controllers/portal.py
@@ -151,8 +151,7 @@ class CustomerPortal(payment_portal.PaymentPortal):
                     message=msg,
                     token=order_sudo.access_token,
                     message_type="notification",
-                    subtype_xmlid="mail.mt_note",
-                    partner_ids=order_sudo.user_id.sudo().partner_id.ids,
+                    subtype_xmlid="sale.mt_order_viewed",
                 )
 
         backend_url = f'/web#model={order_sudo._name}'\

--- a/addons/sale/data/mail_message_subtype_data.xml
+++ b/addons/sale/data/mail_message_subtype_data.xml
@@ -14,6 +14,12 @@
             <field name="default" eval="False"/>
             <field name="description">Quotation confirmed</field>
         </record>
+        <record id="mt_order_viewed" model="mail.message.subtype">
+            <field name="name">Quotation Viewed</field>
+            <field name="res_model">sale.order</field>
+            <field name="internal" eval="True"/>
+            <field name="default" eval="True"/>
+        </record>
 
         <!-- Salesteam-related subtypes for messaging / Chatter -->
         <record id="mt_salesteam_order_sent" model="mail.message.subtype">
@@ -24,9 +30,17 @@
             <field name="parent_id" ref="sale.mt_order_sent"/>
             <field name="relation_field">team_id</field>
         </record>
+        <record id="mt_salesteam_order_viewed" model="mail.message.subtype">
+            <field name="name">Quotation Viewed</field>
+            <field name="sequence">25</field>
+            <field name="res_model">crm.team</field>
+            <field name="default" eval="True"/>
+            <field name="parent_id" ref="sale.mt_order_viewed"/>
+            <field name="relation_field">team_id</field>
+        </record>
         <record id="mt_salesteam_order_confirmed" model="mail.message.subtype">
             <field name="name">Sales Order Confirmed</field>
-            <field name="sequence">21</field>
+            <field name="sequence">30</field>
             <field name="res_model">crm.team</field>
             <field name="default" eval="True"/>
             <field name="parent_id" ref="sale.mt_order_confirmed"/>
@@ -34,14 +48,14 @@
         </record>
         <record id="mt_salesteam_invoice_created" model="mail.message.subtype">
             <field name="name">Invoice Created</field>
-            <field name="sequence">22</field>
+            <field name="sequence">35</field>
             <field name="res_model">crm.team</field>
             <field name="parent_id" ref="account.mt_invoice_created"/>
             <field name="relation_field">team_id</field>
         </record>
         <record id="mt_salesteam_invoice_confirmed" model="mail.message.subtype">
             <field name="name">Invoice Confirmed</field>
-            <field name="sequence">23</field>
+            <field name="sequence">40</field>
             <field name="res_model">crm.team</field>
             <field name="parent_id" ref="account.mt_invoice_validated"/>
             <field name="relation_field">team_id</field>


### PR DESCRIPTION
Prior this commit:
There is no option available in mail subscriptions to enable users to opt out of receiving notifications when a customer views a quotation.

Post this commit:
A mail subscription has been added for quotation views. This option will allow users to decide if they want to receive notifications when customers view quotations.

Task: 3854195

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
