### PR TITLE
[FIX] website_sale: prevent error when no order find during delivery

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1817,6 +1817,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
             order = request.env['sale.order'].sudo().browse(sale_order_id)
             assert order.id == request.session.get('sale_last_order_id')
 
+        if not order:
+            return request.redirect('/shop')
+
         errors = self._get_shop_payment_errors(order)
         if errors:
             first_error = errors[0]  # only display first error


### PR DESCRIPTION
This error occurs when there is no record of a sales order available for the ongoing order with a payment status of ``Canceled/Error``, and an attempt is made to deliver that order.

Steps to reproduce:
- Install the ``website_sale`` module
- Invoicing > Configuration > Online Payments > Payment Providers
- Activate ``Demo`` payment provider
- Add any product to the cart > View Cart > Checkout
- Choose payment method > Payment Status: ``Canceled/Error`` > Pay Now
- Now duplicate the tab > Go to the first tab
- eCommerce > orders > remove the ``Confirmed`` filter and delete the order that you have created
- Go to the second tab > click on ``Skip``

Traceback:
``ValueError: Expected singleton: sale.order()``

When deleting an order during delivery because of payment status in ``Canceled/Error``, we encounter an issue at line [1] where the order appears empty. This leads to an error being raised due to the order's emptiness.

This commit will resolve the above error by verifying if the order exists during delivery. If it doesn't, the system will redirect back to the shop.

[1]: https://github.com/odoo/odoo/blob/0ed79a4cbd705daf3690bcc602c31cb3f6099bec/addons/delivery/models/delivery_carrier.py#L133

sentry-4961963900

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
