### PR TITLE
[IMP] hr_expense: expenses back2basics

### DIFF
--- a/addons/hr_expense/__manifest__.py
+++ b/addons/hr_expense/__manifest__.py
@@ -67,6 +67,7 @@ This module also uses analytic accounting and is compatible with the invoice on 
         'web.assets_tests': [
             'hr_expense/static/tests/tours/expense_upload_tours.js',
             'hr_expense/static/tests/tours/expense_form_tours.js',
+            'hr_expense/static/tests/tours/expense_form_in_sheet_tours.js',
         ],
         'web.report_assets_common': [
             'hr_expense/static/src/scss/hr_expense.scss',

--- a/addons/hr_expense/data/hr_expense_data.xml
+++ b/addons/hr_expense/data/hr_expense_data.xml
@@ -67,7 +67,7 @@
             <field name="image_1920" type="base64" file="hr_expense/static/img/communication.svg"/>
         </record>
         <record id="product_product_no_cost" model="product.product">
-            <field name="name">Others</field>
+            <field name="name">Expenses</field>
             <field name="standard_price">0.0</field>
             <field name="type">service</field>
             <field name="default_code">EXP_GEN</field>

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -6,7 +6,6 @@ import werkzeug
 
 from odoo import api, fields, Command, models, _
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools.misc import format_date
 from odoo.tools import email_split, float_repr, float_round, is_html_empty
 
 
@@ -607,15 +606,7 @@ class HrExpense(models.Model):
                 raise UserError(_('You are not authorized to edit this expense report.'))
 
         if enforced_non_zero_expenses:
-            error_msgs = []
-            if 'total_amount' in vals:
-                if any(expense.company_currency_id.is_zero(vals['total_amount']) for expense in enforced_non_zero_expenses):
-                    error_msgs.append(_("You cannot set the expense total to 0 if it's linked to a report."))
-            if 'total_amount_currency' in vals:
-                if any(expense.currency_id.is_zero(vals['total_amount_currency']) for expense in enforced_non_zero_expenses):
-                    error_msgs.append(_("You cannot set the expense total in currency to 0 if it's linked to a report."))
-            if error_msgs:
-                raise UserError("\n".join(error_msgs))
+            enforced_non_zero_expenses.check_amount_not_zero(vals)
 
         res = super().write(vals)
 
@@ -650,6 +641,14 @@ class HrExpense(models.Model):
             attachments_to_unlink.with_context(sync_attachment=False).unlink()
         return res
 
+    @api.model_create_multi
+    def create(self, vals_list):
+        expenses = super().create(vals_list)
+        if self.env.context.get('check_total_amount_not_zero'):
+            for expense, vals in zip(expenses, vals_list):
+                expense.check_amount_not_zero(vals)
+        return expenses
+
     def unlink(self):
         attachments_to_unlink = self.env['ir.attachment']
         for sheet in self.sheet_id:
@@ -680,6 +679,17 @@ class HrExpense(models.Model):
 
     def get_expense_attachments(self):
         return self.attachment_ids.mapped('image_src')
+
+    def check_amount_not_zero(self, vals):
+        error_msgs = []
+        if 'total_amount' in vals:
+            if any(expense.company_currency_id.is_zero(vals['total_amount']) for expense in self):
+                error_msgs.append(_("You cannot set the expense total to 0 if it's linked to a report."))
+        if 'total_amount_currency' in vals:
+            if any(expense.currency_id.is_zero(vals['total_amount_currency']) for expense in self):
+                error_msgs.append(_("You cannot set the expense total in currency to 0 if it's linked to a report."))
+        if error_msgs:
+            raise UserError("\n".join(error_msgs))
 
     # ----------------------------------------
     # Actions
@@ -733,19 +743,9 @@ class HrExpense(models.Model):
         # else we use the form view required name to force the user to set a name
         for todo in sheets:
             paid_by = 'company' if todo[0].payment_mode == 'company_account' else 'employee'
-            sheet_name = _("New Expense Report, paid by %(paid_by)s", paid_by=paid_by) if len(sheets) > 1 else False
-            if len(todo) == 1:
-                sheet_name = todo.name
-            else:
-                dates = todo.mapped('date')
-                if False not in dates:  # If at least one date isn't set, we don't set a default name
-                    min_date = format_date(self.env, min(dates))
-                    max_date = format_date(self.env, max(dates))
-                    if min_date == max_date:
-                        sheet_name = min_date
-                    else:
-                        sheet_name = _("%(date_from)s - %(date_to)s", date_from=min_date, date_to=max_date)
-
+            sheet_name = self.env['hr.expense.sheet']._get_default_sheet_name(todo)
+            if not sheet_name and len(sheets) > 1:
+                sheet_name = _("New Expense Report, paid by %(paid_by)s", paid_by=paid_by)
             values.append({
                 'company_id': self.company_id.id,
                 'employee_id': self[0].employee_id.id,
@@ -981,19 +981,16 @@ class HrExpense(models.Model):
             'to_submit': {
                 'description': _('to submit'),
                 'amount': 0.0,
-                'tooltip': _("Expenses that need to be submitted to the approver."),
                 'currency': self.env.company.currency_id.id,
             },
             'submitted': {
                 'description': _('under validation'),
                 'amount': 0.0,
-                'tooltip': _("Expenses from which the report has been submitted to the approver and is waiting for approval."),
                 'currency': self.env.company.currency_id.id,
             },
             'approved': {
                 'description': _('to be reimbursed'),
                 'amount': 0.0,
-                'tooltip': _("Expenses paid by employee that are approved but not paid yet."),
                 'currency': self.env.company.currency_id.id,
             }
         }

--- a/addons/hr_expense/static/src/components/nb_attachment.xml
+++ b/addons/hr_expense/static/src/components/nb_attachment.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates>
-    <t t-name="hr_expense.AttachmentNumber">
+    <t t-if="nb_attachment > 0" t-name="hr_expense.AttachmentNumber" >
         <div>
             <span class="fa fa-paperclip pe-1 align-middle"/>
-            <t t-if="nb_attachment > 0" class="text-center" t-out="nb_attachment"/>
+            <t class="text-center" t-out="nb_attachment"/>
         </div>
     </t>
 </templates>

--- a/addons/hr_expense/static/src/js/tours/hr_expense.js
+++ b/addons/hr_expense/static/src/js/tours/hr_expense.js
@@ -12,13 +12,13 @@ registry.category("web_tour.tours").add('hr_expense_tour' , {
     steps: () => [stepUtils.showAppsMenuItem(), {
     isActive: ["community"],
     trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',
-    content: _t("Wasting time recording your receipts? Let’s try a better way."),
+    content: markup(_t("<b>Wasting time recording your receipts?</b> Let’s try a better way.")),
     position: 'right',
     run: "click",
 }, {
     isActive: ["enterprise"],
     trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',
-    content: _t("Wasting time recording your receipts? Let’s try a better way."),
+    content: markup(_t("<b>Wasting time recording your receipts?</b> Let’s try a better way.")),
     position: 'bottom',
     run: "click",
 },

--- a/addons/hr_expense/static/src/views/list.xml
+++ b/addons/hr_expense/static/src/views/list.xml
@@ -26,10 +26,10 @@
 
     <t t-name="hr_expense.ListView" t-inherit="web.ListView" t-inherit-mode="primary">
         <xpath expr="//button[hasclass('o_list_button_add')]" position="before">
-            <button type="button" class="d-none d-md-inline o_button_upload_expense btn btn-primary" t-on-click.prevent="uploadDocument">
+            <button t-if="!isExpenseSheet" type="button" class="d-none d-md-inline o_button_upload_expense btn btn-primary" t-on-click.prevent="uploadDocument">
                 Upload
             </button>
-            <button type="button" class="d-inline d-md-none o_button_upload_expense btn btn-primary me-1" t-on-click.prevent="uploadDocument">
+            <button t-if="!isExpenseSheet" type="button" class="d-inline d-md-none o_button_upload_expense btn btn-primary me-1" t-on-click.prevent="uploadDocument">
                 Scan
             </button>
         </xpath>

--- a/addons/hr_expense/static/tests/tours/expense_form_in_sheet_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_form_in_sheet_tours.js
@@ -1,0 +1,74 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+import { stepUtils } from "@web_tour/tour_service/tour_utils";
+
+registry.category("web_tour.tours").add('do_not_create_zero_amount_expense_in_sheet', {
+    test: true,
+    url: '/web',
+    steps: () => [
+        ...stepUtils.goToAppSteps('hr_expense.menu_hr_expense_root', "Go to the Expenses app"),
+        {
+            content: "Go to Expense Reports",
+            trigger: '.dropdown-item[data-menu-xmlid="hr_expense.menu_hr_expense_report"]',
+            run: "click",
+        },
+        {
+            content: "Go to a report",
+            trigger: '.o_data_row .o_data_cell[data-tooltip="report_for_tour"]',
+            run: "click",
+        },
+        {
+            content: "Add an expense line",
+            trigger: 'div[name="expense_line_ids"] .o_field_x2many_list_row_add a',
+            run: "click",
+        },
+        {
+            content: "Create new expense line",
+            trigger: '.modal-footer .o_create_button',
+            run: "click",
+        },
+        {
+            content: "Add expense name",
+            trigger: '.modal-body .o_field_widget[name=name] input',
+            run: "edit expense_for_tour",
+        },
+        {
+            content: "Set total amount to zero",
+            trigger: '.modal-body .o_field_widget[name=total_amount_currency] input',
+            run: "edit 0.0",
+        },
+        {
+            content: "Select category to Expense",
+            trigger: '.modal-body .o_field_widget[name=product_id] input',
+            run: "click",
+        },
+        {
+            content: "Choose category to Expense",
+            trigger: '.o_field_widget[name=product_id] .o-autocomplete--dropdown-menu li:contains([EXP_GEN])',
+            run: "click",
+        },
+        {
+            content: "Click Save",
+            trigger: '.modal-footer .o_form_button_save',
+            run: 'click',
+        },
+        {
+            content: "Close the displayed user error indicating that the expense total cannot be set to zero if it is linked to a report.",
+            trigger: '.modal-footer .btn-primary.o-default-button',
+            run: 'click',
+        },
+        {
+            content: "Set total amount to ten",
+            trigger: '.modal-body .o_field_widget[name=total_amount_currency] input',
+            run: "edit 10.0",
+        },
+        {
+            content: "Click Save",
+            trigger: '.modal-footer .o_form_button_save',
+            run: 'click',
+        },
+        // Save the report
+        ...stepUtils.saveForm(),
+    ],
+});

--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -230,7 +230,7 @@
                                        readonly="not is_editable"/>
                                 <field name="employee_id" groups="hr.group_hr_user"
                                        context="{'default_company_id': company_id}" widget="many2one_avatar_employee"
-                                       options="{'relation': 'hr.employee', 'no_create': True}"
+                                       options="{'relation': 'hr.employee'}"
                                    readonly="not is_editable"/>
                             </t>
                             <label id="lo" for="payment_mode"/>
@@ -239,7 +239,7 @@
                             </div>
                         </group>
                         <group>
-                            <field name="date" readonly="not is_editable"/>
+                            <field name="date" readonly="not is_editable" class="w-50"/>
                             <field name="vendor_id" invisible="payment_mode != 'company_account'"/>
                             <field name="accounting_date"
                                    invisible="not accounting_date or state not in ['approved', 'done']"
@@ -635,10 +635,11 @@
             <field name="arch" type="xml">
                 <tree class="o_expense_categories">
                     <field name="name" readonly="1"/>
-                    <field name="default_code" optional="show" readonly="1"/>
-                    <field name="description" widget="html" string="Internal Note" optional="show" readonly="1"/>
-                    <field name="lst_price" optional="show" string="Sales Price"/>
-                    <field name="standard_price" optional="show"/>
+                    <field name="currency_id" column_invisible="True"/>
+                    <field name="default_code" optional="show" string="Reference" readonly="1"/>
+                    <field name="description" string="Note" optional="show" readonly="1"/>
+                    <field name="lst_price" widget='monetary' options="{'currency_field': 'currency_id', 'field_digits': True}" optional="show" string="Sales Price"/>
+                    <field name="standard_price" widget='monetary' options="{'currency_field': 'currency_id', 'field_digits': True}" optional="show"/>
                     <field name="supplier_taxes_id" widget="many2many_tags" optional="show"/>
                 </tree>
             </field>
@@ -794,7 +795,7 @@
                     <div class="oe_button_box" name="button_box">
                         <button name="action_open_account_moves"
                             class="oe_stat_button"
-                            icon="fa-file-text-o"
+                            icon="fa-bars"
                             type="object"
                             invisible="state not in ['approve', 'post', 'done'] or nb_account_move == 0"
                             groups="account.group_account_invoice">
@@ -868,6 +869,7 @@
                                         'default_company_id': company_id,
                                         'default_employee_id': employee_id,
                                         'default_payment_mode': payment_mode or 'own_account',
+                                        'check_total_amount_not_zero': True,
                                     }"
                                     readonly="not is_editable"
                                     force_save="1">
@@ -1210,7 +1212,7 @@
                    groups="account.group_account_user,hr_expense.group_hr_expense_team_approver"/>
 
         <menuitem id="menu_hr_expense_reports" name="Reporting" sequence="4" parent="menu_hr_expense_root"
-                  groups="hr_expense.group_hr_expense_manager"/>
+                  groups="hr_expense.group_hr_expense_team_approver"/>
         <menuitem id="menu_hr_expense_all_expenses" name="Expenses Analysis" sequence="0"
                   parent="menu_hr_expense_reports" action="hr_expense_actions_all"/>
 

--- a/addons/hr_expense/views/res_config_settings_views.xml
+++ b/addons/hr_expense/views/res_config_settings_views.xml
@@ -30,7 +30,7 @@
                                     </div>
                                 </div>
                             </setting>
-                            <setting string="Reimburse in Payslip" help="Reimburse expenses in payslips" id="hr_payroll_accountant">
+                            <setting string="Reimburse in Payslip" help="Refund employees via their payslips." id="hr_payroll_accountant">
                                 <field name="module_hr_payroll_expense" widget="upgrade_boolean"/>
                             </setting>
                             <setting id="expense_extract_settings" string="Expense Digitalization (OCR)" company_dependent="1"

--- a/addons/hr_expense/wizard/hr_expense_refuse_reason_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_refuse_reason_views.xml
@@ -5,9 +5,10 @@
         <field name="model">hr.expense.refuse.wizard</field>
         <field name="arch" type="xml">
             <form string="Expense refuse reason">
-                <separator string="Reason to refuse Expense"/>
                 <field name="sheet_ids" invisible="1"/>
-                <field name="reason" class="w-100"/>
+                <group>
+                    <field string="Reason" name="reason" class="w-100"/>
+                </group>
                 <footer>
                     <button string='Refuse' name="action_refuse" type="object" class="oe_highlight" data-hotkey="q"/>
                     <button string="Cancel" class="oe_link" special="cancel" data-hotkey="x"/>
@@ -22,5 +23,6 @@
         <field name="view_mode">form</field>
         <field name="view_id" ref="hr_expense_refuse_wizard_view_form"/>
         <field name="target">new</field>
+        <field name="context">{'dialog_size': 'medium'}</field>
     </record>
 </odoo>

--- a/addons/hr_expense/wizard/hr_expense_split_wizard.py
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard.py
@@ -1,7 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api, _
-from odoo.tools import float_compare
 
 
 class HrExpenseSplitWizard(models.TransientModel):

--- a/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
+++ b/addons/hr_expense/wizard/hr_expense_split_wizard_views.xml
@@ -6,6 +6,10 @@
             <field name="model">hr.expense.split.wizard</field>
             <field name="arch" type="xml">
                 <form>
+                    <div class="alert alert-warning w-100 d-flex align-items-center gap-1" 
+                        invisible="split_possible"  role="alert">
+                        <span>The total amount doesn't match the original amount.</span>
+                    </div>
                     <field name="total_amount_currency_original" invisible="1"/>
                     <field name="expense_id" invisible="1"/>
                     <field name="expense_split_line_ids" widget="one2many" context="{'default_expense_id': expense_id}">
@@ -17,13 +21,13 @@
                             <field name="product_has_cost" column_invisible="True"/>
                             <field name="name"/>
                             <field name="product_id"/>
-                            <field name="total_amount_currency" force_save="1" readonly="product_has_cost"/>
+                            <field name="employee_id" widget="many2one_avatar_user"/>
                             <field name="tax_ids" widget="many2many_tags" readonly="not product_has_tax"/>
                             <field name="tax_amount_currency"/>
                             <field name="analytic_distribution" widget="analytic_distribution"
                                 optional="show"
                                 groups="analytic.group_analytic_accounting"/>
-                            <field name="employee_id" widget="many2one_avatar_user"/>
+                            <field name="total_amount_currency" force_save="1" readonly="product_has_cost"/>
                         </tree>
                     </field>
                     <field name="currency_id" invisible="1"/>
@@ -36,8 +40,7 @@
                     </group>
                     <field name="split_possible" invisible="1"/>
                     <footer>
-                        <button name="action_split_expense" invisible="split_possible" string="Split Expense" type="object" class="oe_highlight disabled"  data-hotkey="q"/>
-                        <button name="action_split_expense" string="Split Expense" invisible="not split_possible" type="object" class="oe_highlight"  data-hotkey="q"/>
+                        <button name="action_split_expense" string="Split Expense" type="object" class="oe_highlight"  data-hotkey="q"/>
                         <button string="Cancel" class="btn-secondary" special="cancel" data-hotkey="x"/>
                     </footer>
                 </form>


### PR DESCRIPTION
Changes to hr_expense module:
* Remove helpers for states in statebar.
* Make Reporting menu accessible for team approver and all approver access rights.
* Add currency symbols to sales price and cost in expense categories.
* In the Expenses page, hide the `Create Report` button if there are no expenses to report.
* When creating the report, automatically fill the name based on expenses if no name was specified before.
* Add Validation check that no expenses can have zero amount.
* In Expenses list view, hide paper clip icon if there's no attachments.

task-3859580
Enterprise PR: https://github.com/odoo/enterprise/pull/61963


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
