### PR TITLE
[ADD]Belarusian language support

### DIFF
--- a/doc/cla/individual/skiby.md
+++ b/doc/cla/individual/skiby.md
@@ -1,0 +1,7 @@
+Poland, 2024-05-03
+
+I hereby agree to the terms of the Odoo Individual Contributor License Agreement v1.0.
+I declare that I am authorized and able to make this agreement and sign this declaration.
+
+Signed,
+Sergei Ruzki sergei.ruzki@gmail.com https://github.com/skiby

--- a/odoo/addons/base/data/res.lang.csv
+++ b/odoo/addons/base/data/res.lang.csv
@@ -5,6 +5,7 @@
 "base.lang_ar_SY","Arabic (Syria) / الْعَرَبيّة","ar_SY","ar_SY","Right-to-Left","[3,0]",".",",","%d %b, %Y","%I:%M:%S","6"
 "base.lang_az","Azerbaijani / Azərbaycanca","az_AZ","az","Left-to-Right","[3,0]",","," ","%d.%m.%Y","%H:%M:%S","1"
 "base.lang_eu_ES","Basque / Euskara","eu_ES","eu_ES","Left-to-Right","[]",",",,"%a, %Y.eko %bren %da","%H:%M:%S","1"
+"base.lang_be","Belarusian / Беларуская мова","be_BY","be","Left-to-Right","[3,0]",","," ","%d.%m.%Y","%H:%M:%S","1"
 "base.lang_bn_IN","Bengali / বাংলা","bn_IN","bn_IN","Left-to-Right","[]",",",,"%A %d %b %Y","%I:%M:%S","1"
 "base.lang_bs_BA","Bosnian / bosanski jezik","bs_BA","bs","Left-to-Right","[3,0]",",",".","%d.%m.%Y","%H:%M:%S","1"
 "base.lang_bg","Bulgarian / български език","bg_BG","bg","Left-to-Right","[3,0]",",",,"%d.%m.%Y","%H,%M,%S","1"


### PR DESCRIPTION
Belarusian language support for Odoo

Description of the issue/feature this PR addresses:
Odoo still doesn't support Belarusian language.
We started the translation to belarusian, but have no place, we could upload it.

Current behavior before PR:
No lang_be_BY

Desired behavior after PR is merged:
lang_be_BY will be added to Odoo core



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
