### PR TITLE
[FIX] stock: handle multi-step warehouse resupply

### DIFF
--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -334,6 +334,9 @@ class StockWarehouseOrderpoint(models.Model):
 
         return replenish report ir.actions.act_window
         """
+        def is_parent_path_in(resupply_loc, path_dict, record_loc):
+            return record_loc and resupply_loc.parent_path in path_dict.get(record_loc, '')
+
         action = self.env["ir.actions.actions"]._for_xml_id("stock.action_orderpoint_replenish")
         action['context'] = self.env.context
         # Search also with archived ones to avoid to trigger product_location_check SQL constraints later
@@ -362,8 +365,8 @@ class StockWarehouseOrderpoint(models.Model):
         domain_move_out = expression.AND([domain_product, domain_state, domain_move_out_loc])
 
         moves_in = defaultdict(list)
-        for item in Move._read_group(domain_move_in, ['product_id', 'location_dest_id'], ['product_qty:sum']):
-            moves_in[item[0]].append((item[1], item[2]))
+        for item in Move._read_group(domain_move_in, ['product_id', 'location_dest_id', 'location_final_id'], ['product_qty:sum']):
+            moves_in[item[0]].append((item[1], item[2], item[3]))
 
         moves_out = defaultdict(list)
         for item in Move._read_group(domain_move_out, ['product_id', 'location_id'], ['product_qty:sum']):
@@ -377,9 +380,9 @@ class StockWarehouseOrderpoint(models.Model):
         path = {loc: loc.parent_path for loc in self.env['stock.location'].with_context(active_test=False).search([('id', 'child_of', all_replenish_location_ids.ids)])}
         for loc in all_replenish_location_ids:
             for product in all_product_ids:
-                qty_available = sum(q[1] for q in quants.get(product, [(0, 0)]) if q[0] and loc.parent_path in path[q[0]])
-                incoming_qty = sum(m[1] for m in moves_in.get(product, [(0, 0)]) if m[0] and loc.parent_path in path[m[0]])
-                outgoing_qty = sum(m[1] for m in moves_out.get(product, [(0, 0)]) if m[0] and loc.parent_path in path[m[0]])
+                qty_available = sum(q[1] for q in quants.get(product, [(0, 0)]) if is_parent_path_in(loc, path, q[0]))
+                incoming_qty = sum(m[2] for m in moves_in.get(product, [(0, 0, 0)]) if is_parent_path_in(loc, path, m[0]) or is_parent_path_in(loc, path, m[1]))
+                outgoing_qty = sum(m[1] for m in moves_out.get(product, [(0, 0)]) if is_parent_path_in(loc, path, m[0]))
                 if float_compare(qty_available + incoming_qty - outgoing_qty, 0, precision_rounding=rounding[product.id]) < 0:
                     # group product by lead_days and location in order to read virtual_available
                     # in batch

--- a/addons/stock/models/stock_warehouse.py
+++ b/addons/stock/models/stock_warehouse.py
@@ -719,6 +719,11 @@ class Warehouse(models.Model):
             pull_rules_list = supplier_wh._get_supply_pull_rules_values(
                 [self.Routing(output_location, transit_location, supplier_wh.out_type_id, 'pull')],
                 values={'route_id': inter_wh_route.id, 'location_dest_from_rule': True})
+            if supplier_wh.delivery_steps != 'ship_only':
+                # Replenish from Output location
+                pull_rules_list += supplier_wh._get_supply_pull_rules_values(
+                    [self.Routing(supplier_wh.lot_stock_id, output_location, supplier_wh.pick_type_id, 'pull')],
+                    values={'route_id': inter_wh_route.id})
             pull_rules_list += self._get_supply_pull_rules_values(
                 [self.Routing(transit_location, self.lot_stock_id, self.in_type_id, 'pull')],
                 values={'route_id': inter_wh_route.id, 'propagate_warehouse_id': supplier_wh.id})
@@ -870,6 +875,12 @@ class Warehouse(models.Model):
             'location_src_id': new_location.id,
             'procure_method': change_to_multiple and "make_to_order" or "make_to_stock"})
         if not change_to_multiple:
+            # Remove the extra rule to resupply Output from Stock
+            rules_to_archive = Rule.search([('route_id', 'in', routes.ids), ('action', '!=', 'push'),
+                                           ('location_dest_id', '=', self.wh_output_stock_loc_id.id),
+                                           ('picking_type_id', '=', self.pick_type_id.id)])
+            rules_to_archive.active = False
+
             # If single delivery we should create the necessary MTO rules for the resupply
             routings = [self.Routing(self.lot_stock_id, location, self.out_type_id, 'pull') for location in rules.location_dest_id]
             mto_vals = self._get_global_route_rules_values().get('mto_pull_id')
@@ -879,6 +890,21 @@ class Warehouse(models.Model):
             for mto_rule_val in mto_rule_vals:
                 Rule.create(mto_rule_val)
         else:
+            # Add the missing rules to resupply Output from Stock
+            rules_to_unarchive = Rule.with_context(active_test=False).search([
+                ('route_id', 'in', routes.ids), ('action', '!=', 'push'),
+                ('location_dest_id', '=', self.wh_output_stock_loc_id.id),
+                ('picking_type_id', '=', self.pick_type_id.id)])
+            rules_to_unarchive.active = True
+            found_routes = rules_to_unarchive.route_id
+
+            missing_rule_vals = []
+            for route in (routes - found_routes):
+                missing_rule_vals += self._get_supply_pull_rules_values(
+                    [self.Routing(self.lot_stock_id, new_location, self.pick_type_id, 'pull')],
+                    values={'route_id': route.id})
+            Rule.create(missing_rule_vals)
+
             # We need to delete all the MTO stock rules, otherwise they risk to be used in the system
             Rule.search([
                 '&', ('route_id', '=', self._find_global_route('stock.route_warehouse0_mto', _('Replenish on Order (MTO)')).id),

--- a/addons/stock/tests/test_warehouse.py
+++ b/addons/stock/tests/test_warehouse.py
@@ -513,6 +513,109 @@ class TestWarehouse(TestStockCommon):
         self.assertEqual(warehouse_B.resupply_route_ids, resupply_route)
         self.assertTrue(resupply_route.active, 'Route should now be active')
 
+    def test_muti_step_resupply_warehouse(self):
+        """ Simulate the following situation:
+        - First warehouse has a 3-steps delivery
+        - Second warehouse has a 3-steps reception
+        - Second warehouse is resupplied by the first warehouse
+        - A product has some stock in the first warehouse
+        - A reordering rule is set on the product to fill the second warehouse
+        Ensure that the product can move all the way from the first to the second warehouse.
+        """
+        warehouse_A = self.env['stock.warehouse'].create({
+            'name': 'Warehouse A',
+            'code': 'WH_A',
+            'delivery_steps': 'pick_pack_ship',
+        })
+        warehouse_B = self.env['stock.warehouse'].create({
+            'name': 'Warehouse B',
+            'code': 'WH_B',
+            'reception_steps': 'three_steps',
+            'resupply_wh_ids': [Command.link(warehouse_A.id)],
+        })
+        self.product_3.write({
+            'type': 'product',
+            'route_ids': [Command.link(warehouse_B.resupply_route_ids.id)],
+        })
+        self.env['stock.quant']._update_available_quantity(self.product_3, warehouse_A.lot_stock_id, 1.0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_3, warehouse_A.lot_stock_id), 1)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_3, warehouse_B.lot_stock_id), 0)
+
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'location_id': warehouse_B.lot_stock_id.id,
+            'product_id': self.product_3.id,
+            'qty_to_order': 1.0,
+        })
+        orderpoint.action_replenish()
+        # Check that the orderpoint generated the source move from the furthest location.
+        move = self.env['stock.move'].search([('location_id', '=', warehouse_A.lot_stock_id.id), ('origin', '=', orderpoint.name)])
+        self.assertTrue(move, 'No move created from WH_A/Stock')
+
+        # Validate each intermediate transfers towards resupply of WH_B/Stock
+        inter_wh_loc = self.env.company.internal_transit_location_id
+        step_location_ids = [
+            (warehouse_A.lot_stock_id.id, warehouse_A.wh_pack_stock_loc_id.id),             # WH_A/Stock -> WH_A/Packing Zone
+            (warehouse_A.wh_pack_stock_loc_id.id, warehouse_A.wh_output_stock_loc_id.id),   # WH_A/Packing Zone -> WH_A/Output
+            (warehouse_A.wh_output_stock_loc_id.id, inter_wh_loc.id),                       # WH_A/Output -> Inter-warehouse transit
+            (inter_wh_loc.id, warehouse_B.wh_input_stock_loc_id.id),                        # Inter-warehouse transit -> WH_B/Input
+            (warehouse_B.wh_input_stock_loc_id.id, warehouse_B.wh_qc_stock_loc_id.id),      # WH_B/Input -> WH_B/Quality Control
+            (warehouse_B.wh_qc_stock_loc_id.id, warehouse_B.lot_stock_id.id),               # WH_B/Quality Control -> WH_B/Stock
+        ]
+        for loc_src_id, loc_dest_id in step_location_ids:
+            self.assertEqual(move.location_id.id, loc_src_id)
+            self.assertEqual(move.location_dest_id.id, loc_dest_id)
+            move.picked = True
+            move._action_done()
+            self.assertEqual(move.state, 'done')
+            move = move.move_dest_ids
+        # Verify that the quantity has been properly transfered from WH_A/Stock to WH_B/Stock
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_3, warehouse_A.lot_stock_id), 0)
+        self.assertEqual(self.env['stock.quant']._get_available_quantity(self.product_3, warehouse_B.lot_stock_id), 1)
+
+    def test_change_delivery_step_resupply_warehouse(self):
+        """ Verifies that when changing the delivery steps of a warehouse, it correctly adds/removes the extra rule
+        that is required to resupply the Output location.
+        """
+        warehouse_A = self.env['stock.warehouse'].create({
+            'name': 'Warehouse X',
+            'code': 'WH_X',
+        })
+        warehouse_B = self.env['stock.warehouse'].create({
+            'name': 'Warehouse Y',
+            'code': 'WH_Y',
+            'resupply_wh_ids': [Command.link(warehouse_A.id)],
+        })
+        resupply_rules = warehouse_B.resupply_route_ids.rule_ids
+        self.assertEqual(len(resupply_rules), 2)
+        stock_A_to_transit = resupply_rules.filtered(lambda r: r.location_dest_id == self.env.company.internal_transit_location_id)
+        self.assertEqual(stock_A_to_transit.location_src_id, warehouse_A.lot_stock_id)
+
+        # Set Warehouse A to 3 steps, a new rule should be created to resupply Output.
+        warehouse_A.delivery_steps = 'pick_pack_ship'
+        new_resupply_rules = warehouse_B.resupply_route_ids.rule_ids
+        self.assertEqual(len(new_resupply_rules), 3)
+        self.assertEqual(stock_A_to_transit.location_src_id, warehouse_A.wh_output_stock_loc_id)
+        stock_to_output = new_resupply_rules - resupply_rules
+        self.assertEqual(stock_to_output.location_src_id, warehouse_A.lot_stock_id)
+        self.assertEqual(stock_to_output.location_dest_id, warehouse_A.wh_output_stock_loc_id)
+
+        # Set Warehouse A to 2 steps, no change should have been made.
+        warehouse_A.delivery_steps = 'pick_ship'
+        self.assertEqual(warehouse_B.resupply_route_ids.rule_ids, new_resupply_rules)
+        self.assertEqual(stock_A_to_transit.location_src_id, warehouse_A.wh_output_stock_loc_id)
+        self.assertEqual(stock_to_output.location_dest_id, warehouse_A.wh_output_stock_loc_id)
+
+        # Set Warehouse A to 1 step, the rule to resupply Output should be archived.
+        warehouse_A.delivery_steps = 'ship_only'
+        self.assertEqual(warehouse_B.resupply_route_ids.rule_ids, resupply_rules)
+        self.assertEqual(stock_A_to_transit.location_src_id, warehouse_A.lot_stock_id)
+        self.assertFalse(stock_to_output.active, "The intermediate rule should have been archived.")
+
+        # Set Warehouse A back to 2 steps, the rule to resupply Output should be unarchived.
+        warehouse_A.delivery_steps = 'pick_ship'
+        self.assertTrue(stock_to_output.active, "The intermediate rule should have been unarchived.")
+        self.assertEqual(warehouse_B.resupply_route_ids.rule_ids, new_resupply_rules, "No new rule should have been created.")
+
     def test_noleak(self):
         # non-regression test to avoid company_id leaking to other warehouses (see blame)
         partner = self.env['res.partner'].create({'name': 'Chicago partner'})


### PR DESCRIPTION
Steps to reproduce:
- Have two separate warehouses A & B
- Enable 3-step delivery on warehouse A
- Enable 'Resupply from warehouse A' in warehouse B
- Set a product using that resupply route and trigger its ressuply (e.g. through a reordering rule)

Issue:
An error message pops up indicating that there are no rules could be found to resupply A/Output.

Following the pull&push refactor in #156437, we changed the way the default 3-step delivery would work (with now a mix of pull & push rules). This means that there are no longer any default pull rules to resupply the Output location.

To avoid this, we add the missing rule, pulling from Stock -> Output, using the standard delivery rules for the eventual pack operation.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
