### PR TITLE
[FIX] point_of_sale: prevent opening Product popup without options

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -148,11 +148,22 @@ export class Product extends PosModel {
         const attributes = this.attribute_line_ids
             .map((id) => this.pos.attributes_by_ptal_id[id])
             .filter((attr) => attr !== undefined);
-        return await this.env.services.popup.add(ProductConfiguratorPopup, {
-            product: this,
-            attributes: attributes,
-            quantity: initQuantity,
-        });
+        if (attributes.some((attribute) => attribute.values.length > 1 || attribute.values[0].is_custom)) {
+            return await this.env.services.popup.add(ProductConfiguratorPopup, {
+                product: this,
+                attributes: attributes,
+                quantity: initQuantity,
+            });
+        }
+        return {
+            confirmed: true,
+            payload: {
+                attribute_value_ids: attributes.map((attr) => attr.values[0].id),
+                attribute_custom_values: [],
+                price_extra: attributes.reduce((acc, attr) => acc + attr.values[0].price_extra, 0),
+                quantity: 1,
+            }
+        };
     }
 
     isConfigurable() {


### PR DESCRIPTION
This commit addresses the issue where the Product Configurator Popup was displayed unnecessarily when there was only one value for each attribute of a product. The implementation now includes a check to ensure that the popup is shown only when there are more that one choices available. This enhancement improves the user experience by avoiding the display of a redundant popup without viable options.

opw-3903425

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
