### PR TITLE
[FIX] sale_loyalty: taxes on gift cards

### DIFF
--- a/addons/sale_loyalty/tests/test_pay_with_gift_card.py
+++ b/addons/sale_loyalty/tests/test_pay_with_gift_card.py
@@ -1,9 +1,10 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import Command
+from odoo.fields import Command
+from odoo.tests import tagged
+
 from odoo.addons.sale_loyalty.tests.common import TestSaleCouponCommon
-from odoo.tests.common import tagged
+
 
 @tagged('-at_install', 'post_install')
 class TestPayWithGiftCard(TestSaleCouponCommon):
@@ -151,3 +152,82 @@ class TestPayWithGiftCard(TestSaleCouponCommon):
         # real flows also have to update the programs and rewards
         order._update_programs_and_rewards()
         self.assertEqual(order.amount_total, 0) # 100 - 10% - 90
+
+    def test_gift_card_product_has_no_taxes_on_creation(self):
+        gift_card_program = self.env['loyalty.program'].create({
+            'name': 'Gift Cards',
+            'applies_on': 'future',
+            'program_type': 'gift_card',
+            'trigger': 'auto',
+            'rule_ids': [Command.create({
+                'product_ids': self.product_gift_card,
+                'reward_point_amount': 1,
+                'reward_point_mode': 'money',
+                'reward_point_split': True,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount': 1,
+                'discount_mode': 'per_point',
+                'discount_applicability': 'order',
+            })]
+        })
+        self.assertFalse(gift_card_program.reward_ids.discount_line_product_id.taxes_id)
+
+    def test_paying_with_gift_card_uses_gift_card_product_taxes(self):
+        order = self.empty_order
+        order.order_line = [
+            Command.create({
+                'product_id': self.product_B.id,
+                'name': 'Ordinary Product b',
+                'product_uom': self.uom_unit.id,
+                'product_uom_qty': 1.0,
+                'price_unit': 200.0,
+            })
+        ]
+        sol = order.order_line
+        before_gift_card_payment = order.amount_total
+        self.assertNotEqual(before_gift_card_payment, 0)
+
+        self.env['loyalty.generate.wizard'].with_context(active_id=self.program_gift_card.id).create({
+            'coupon_qty': 1,
+            'points_granted': 100,
+        }).generate_coupons()
+        gift_card = self.program_gift_card.coupon_ids[0]
+
+        # TODO check amount total of gift_card_line
+
+        # TAX EXCL
+        self.program_gift_card.reward_ids.discount_line_product_id.taxes_id = [
+            Command.link(self.tax_15pc_excl.id)
+        ]
+        self._apply_promo_code(order, gift_card.code)
+        gift_card_line = order.order_line - sol
+        self.assertAlmostEqual(gift_card_line.price_total, -100.0)
+        self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
+        self.assertTrue(all(line.tax_id for line in order.order_line))
+        self.assertEqual(order.order_line.tax_id, self.tax_15pc_excl)
+
+        # TAX INCL
+        gift_card_line.unlink()  # Remove gift card
+        self.program_gift_card.reward_ids.discount_line_product_id.taxes_id = [
+            Command.set(self.tax_10pc_incl.ids)
+        ]
+        self._apply_promo_code(order, gift_card.code)
+        gift_card_line = order.order_line - sol
+        self.assertAlmostEqual(gift_card_line.price_total, -100.0)
+        self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
+        self.assertTrue(all(line.tax_id for line in order.order_line))
+        self.assertEqual(gift_card_line.tax_id, self.tax_10pc_incl)
+
+        # TAX INCL + TAX EXCL
+        gift_card_line.unlink()  # Remove gift card
+        self.program_gift_card.reward_ids.discount_line_product_id.taxes_id = [
+            Command.link(self.tax_15pc_excl.id)
+        ]
+        self._apply_promo_code(order, gift_card.code)
+        gift_card_line = order.order_line - sol
+        self.assertAlmostEqual(gift_card_line.price_total, -100.0)
+        self.assertAlmostEqual(order.amount_total, before_gift_card_payment - 100.0)
+        self.assertTrue(all(line.tax_id for line in order.order_line))
+        self.assertEqual(gift_card_line.tax_id, self.tax_10pc_incl + self.tax_15pc_excl)


### PR DESCRIPTION
VAT should be accounted for on gift card rewards (when necessary). To allow that, we will start considering the taxes set on the reward product. As it is enforced that no taxes are set on that product on creation, we are sure that if a tax is set on the product, it can safely be applied on the reward line.

opw-3817604


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
