### PR TITLE
[FIX] loyalty: Correct duplicate view rendering

### DIFF
--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -114,7 +114,7 @@ class TestLoyalty(TransactionCase):
         self.assertTrue(all(r.reward_type == 'product' for r in self.program.reward_ids))
 
     def test_loyalty_program_preserve_reward_with_always_edit(self):
-        with Form(self.env['loyalty.program']) as program_form:
+        with Form(self.env['loyalty.program'], 'loyalty.loyalty_program_view_form') as program_form:
             program_form.name = 'Test'
             program_form.program_type = 'buy_x_get_y'
             program_form.reward_ids.remove(0)

--- a/addons/loyalty/views/loyalty_program_views.xml
+++ b/addons/loyalty/views/loyalty_program_views.xml
@@ -111,21 +111,13 @@
                         </group>
                     </group>
                     <notebook>
-                        <page string="Rules &amp; Rewards" name="rules_rewards" attrs="{'invisible': [('program_type', 'in', ('gift_card', 'ewallet'))]}">
+                        <page string="Rules &amp; Rewards" name="rules_rewards">
                             <group>
                                 <group>
                                     <field name="rule_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a rule"
                                         class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol, 'program_type': program_type}"/>
                                 </group>
                                 <group>
-                                    <field name="reward_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a reward"
-                                      class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol, 'program_type': program_type}"/>
-                                </group>
-                            </group>
-                        </page>
-                        <page string="Rewards" name="rewards" groups="base.group_no_one" attrs="{'invisible': [('program_type', 'not in', ('gift_card', 'ewallet'))]}">
-                            <group>
-                                <group groups="base.group_no_one">
                                     <field name="reward_ids" colspan="2" mode="kanban" nolabel="1" add-label="Add a reward"
                                       class="o_loyalty_kanban_inline" widget="loyalty_one2many" context="{'currency_symbol': currency_symbol, 'program_type': program_type}"/>
                                 </group>
@@ -200,6 +192,12 @@
         <field name="inherit_id" ref="loyalty_program_view_form"/>
         <field name="mode">primary</field>
         <field name="arch" type="xml">
+            <notebook position="attributes">
+                <attribute name="groups">base.group_no_one</attribute>
+            </notebook>
+            <xpath expr="//field[@name='rule_ids']/.." position="attributes">
+                <attribute name="attrs">{'invisible': [('program_type', 'in', ('gift_card', 'ewallet'))]}</attribute>
+            </xpath>
             <form position="attributes">
                 <attribute name="string">Gift &amp; Ewallet</attribute>
             </form>


### PR DESCRIPTION
To display rewards for gift cards and e-wallets in debug mode (where rules and rewards were hidden by default), a kanban view for rewards was duplicated in a previous bugfix (related to Commit 3e1b12961d1a2c4bd83863a151ac1bb780e3abf1) inside `loyalty_program_view_form`. This led to an error when trying to render the rewards kanban view a second time in debug mode.

To solve this, the kanban view for rewards has been moved directly into the `loyalty_program_gift_ewallet_view_form`, replacing both rules and rewards by just rewards (in debug mode only).
This prevents duplication and rendering errors.

opw-3903363