### PR TITLE
[FIX] web: signature sign submit buttons disabled when no sign

### DIFF
--- a/addons/web/static/src/core/signature/name_and_signature.js
+++ b/addons/web/static/src/core/signature/name_and_signature.js
@@ -56,6 +56,7 @@ export class NameAndSignature extends Component {
                     this.$signatureField = $(".o_web_sign_signature");
                     this.$signatureField.on("change", () => {
                         this.props.signature.isSignatureEmpty = this.isSignatureEmpty;
+                        this.props.onSignatureChange(this.state.signMode);
                     });
                     this.jSignature();
                     this.resetSignature();
@@ -253,6 +254,7 @@ export class NameAndSignature extends Component {
                 );
                 Object.assign(context, ignoredContext);
                 this.props.signature.isSignatureEmpty = this.isSignatureEmpty;
+                this.props.onSignatureChange(this.state.signMode);
                 return this.isSignatureEmpty;
             }, 0);
         };
@@ -361,6 +363,7 @@ NameAndSignature.props = {
     signatureType: { type: String, optional: true },
     noInputName: { type: Boolean, optional: true },
     mode: { type: String, optional: true },
+    onSignatureChange: { type: Function, optional: true },
 };
 NameAndSignature.defaultProps = {
     defaultFont: "",
@@ -368,4 +371,5 @@ NameAndSignature.defaultProps = {
     fontColor: "DarkBlue",
     signatureType: "signature",
     noInputName: false,
+    onSignatureChange: () => {},
 };

--- a/addons/web/static/tests/core/name_and_signature_tests.js
+++ b/addons/web/static/tests/core/name_and_signature_tests.js
@@ -127,4 +127,25 @@ QUnit.module("Components", ({ beforeEach }) => {
             );
         }
     );
+
+    QUnit.test(
+        "test name_and_signature widget update signmode with onSignatureChange prop",
+        async function (assert) {
+            const defaultName = "Noi dea";
+            let currentSignMode = "";
+            props = {
+                ...props,
+                onSignatureChange: function (signMode) {
+                    if (currentSignMode !== signMode) {
+                        currentSignMode = signMode;
+                        assert.step(signMode);
+                    }
+                },
+            };
+            props.signature.name = defaultName;
+            await mount(NameAndSignature, target, { env, props });
+            await click(target, ".o_web_sign_draw_button");
+            assert.verifySteps(["auto", "draw"], "should be draw");
+        }
+    );
 });


### PR DESCRIPTION
## Issue: 
After the changes we have made to sign in 17.0 we stop properly handling the state of the buttons for submit our sign after signing, the problem then is that in Draw mode for example, we are able to submit the sign even before drawing anything, which will allow us to send the document "unsigned", since there will not be any sign.

## Steps to reproduce:
1. Get Sign module.
2. Upload any document to sign.
3. Add sign box and go to sign the document.
4. Now change from Auto to Draw.

## Solution: 
We should take into account that it makes sense that everytime we update if our signature is empty, we update the state of the buttons accordingly avoiding this way to be able to sign without an actual sing. The solution address a similar approach at what was already being done with the onChangeName, we move this logic to be handled by a specific function for this buttons 'handleButtonStateChange'.

The fix is part of > [#61981](https://github.com/odoo/enterprise/pull/61981)

opw-3874034
