### PR TITLE
[FIX] event_sale: compute sale_status upon registration

### DIFF
--- a/addons/event_sale/models/event_registration.py
+++ b/addons/event_sale/models/event_registration.py
@@ -131,6 +131,8 @@ class EventRegistration(models.Model):
 
     def _get_registration_summary(self):
         res = super(EventRegistration, self)._get_registration_summary()
+        if not self.sale_status:
+            self._compute_registration_status()
         res.update({
             'sale_status': self.sale_status,
             'sale_status_value': dict(self._fields['sale_status']._description_selection(self.env))[self.sale_status],


### PR DESCRIPTION
Problem: The user is unable to scan the attendee's ticket barcode because a traceback error occurs, detailing that sale_status is False.

Purpose: Calling the compute on sale_status when registering the
attendee restores the functionality of successfully
scanning an attendee's ticket.

Steps to Reproduce on Runbot17:
1. Installe event_sale, event, sale
2. Create an ongoing event that sells tickets
3. Manually register a new attendee for the event
4. After the registration is completed, the sale_status is False.
5. Attempt to scan the attendee's ticket barcode
6. Traceback Error: 'sale_status_value': dict(self._fields['sale_status']._description_selection(self.env))[self.sale_status], KeyError: False

opw-3870685



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
