### PR TITLE
[IMP] website: remove URL warning for page deletion and changing URL

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -1283,11 +1283,7 @@ class Website(models.Model):
             url = 'website_url' in record and record.website_url or record.url
             search_criteria.append((url, website.website_domain()))
 
-        # Search the URL in every relevant field
-        html_fields = self._get_html_fields() + [
-            ('website.menu', 'url'),
-        ]
-        for model_name, field_name in html_fields:
+        for model_name, field_name in self._get_html_fields():
             Model = self.env[model_name]
             if not Model.has_access('read'):
                 continue


### PR DESCRIPTION
This PR aims to enhance the user experience by removing the warning message associated with page deletion or URL changes via popover in the website module. The warning, specifically related to the 'url' in the website menu, will no longer be displayed. Additionally, it ensures that menus are appropriately linked with page sharing the same URL, especially those created before the page itself existed.

The reason behind this PR is that the `website.menu` has an ondelete cascade feature that displays unnecessary warnings about website menus. This feature ensures that when changing the URL, all related URLs are automatically updated. Similarly, when deleting pages, associated links are removed. Thus, removing the `url` path from the `search_url_dependencies` eliminates redundant information retrieval from the database. However, when multiple menus share the same URL before the page exists, they are not automatically deleted due to a lack of linkage with page IDs. Therefore, this PR will include page IDs to make sure that when pages are deleted, their related linked menus are also deleted automatically.

![image](https://github.com/odoo/odoo/assets/157009134/ac286c0f-3db8-460a-b74e-c887af074def)

task-3757369