### PR TITLE
[FIX] project: group tasks by personal stage in the list view

### DIFF
--- a/addons/project/models/project.py
+++ b/addons/project/models/project.py
@@ -1957,6 +1957,10 @@ class Task(models.Model):
     def _search(self, args, offset=0, limit=None, order=None, count=False, access_rights_uid=None):
         fields_list = {term[0] for term in args if isinstance(term, (tuple, list)) and term not in [expression.TRUE_LEAF, expression.FALSE_LEAF]}
         self._ensure_fields_are_accessible(fields_list)
+        for index, leaf in enumerate(args):
+            if leaf[0] == 'personal_stage_type_ids' and leaf[1] == '=' and not leaf[2]:
+                types = self.env['project.task.type']._search([('user_id', '=', self.env.uid)])
+                args[index] = ('personal_stage_type_ids', 'not in', types)
         return super(Task, self)._search(args, offset=offset, limit=limit, order=order, count=count, access_rights_uid=access_rights_uid)
 
     def mapped(self, func):

--- a/addons/project/tests/test_project_task_type.py
+++ b/addons/project/tests/test_project_task_type.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
 from odoo.exceptions import UserError
 from odoo.addons.project.tests.test_project_base import TestProjectCommon
 
@@ -57,3 +58,93 @@ class TestProjectTaskType(TestProjectCommon):
             self.stage_created.write({
                 'user_id': self.uid,
             })
+
+    def test_group_by_personal_stage(self):
+        """
+        Check the consistence of search_read and read_group when one groups project.tasks by personal stages.
+
+        Supose we have a user and his manager. Group all tasks by personal stage in the "list view".
+        A `web_read_group` is performed to classify the tasks and a `web_search_read` is performed to display the lines.
+        We check the consitency of both operations for tasks that are not linked to a personal stage of the current user.
+        """
+
+        if 'hr.employee' not in self.env:
+            self.skipTest("This test requires to set a manager")
+        project = self.project_goats
+        user = self.user_projectmanager
+        manager_user = self.env['res.users'].create({
+            'name': 'Roger Employee',
+            'login': 'Roger',
+            'email': 'rog.projectmanager@example.com',
+            'groups_id': [Command.set([self.ref('base.group_user'), self.ref('project.group_project_manager')])],
+        })
+        manager = self.env['hr.employee'].create({
+            'user_id': manager_user.id,
+            'image_1920': False,
+        })
+        (user | manager_user).employee_id.write({'parent_id': manager.id})
+        user_personal_stages = self.env['project.task.type'].search([('user_id', '=', user.id)])
+        # we create tasks for the user with different types of assignement
+        self.env['project.task'].with_user(user).create([
+            {
+                'name': f"Task: {stage.id}",
+                'project_id': project.id,
+                'personal_stage_type_id': stage.id,
+                'user_ids': [Command.link(user.id)],
+            }
+            for stage in user_personal_stages],
+        )
+        self.env['project.task'].with_user(user).create([
+            {
+                'name': f"Task: {stage.id}",
+                'project_id': project.id,
+                'personal_stage_type_id': stage.id,
+                'user_ids': [Command.link(user.id), Command.link(manager_user.id)],
+            }
+            for stage in user_personal_stages],
+        )
+        # this task is created to create the default personal stages of manager user
+        self.env['project.task'].with_user(manager_user).create({
+            'name': "Manager's task",
+            'project_id': project.id,
+            'user_ids': [Command.link(manager_user.id)],
+        })
+        manager_user_personal_stages = self.env['project.task.type'].search([('user_id', '=', manager_user.id)])
+        self.env['project.task'].with_user(manager_user).create([
+            {
+                'name': f"Task : {stage.id}",
+                'project_id': project.id,
+                'stage_id': stage.id,
+                'user_ids': [Command.link(manager_user.id)],
+            }
+            for stage in manager_user_personal_stages],
+        )
+
+        self.env.uid = user.id
+        base_domain = [("user_ids.employee_parent_id.user_id", "=", manager_user.id)]
+        tasks = self.env['project.task'].with_user(user.id).search(base_domain)
+        tasks_with_personal_stage = tasks.filtered(lambda t: user in t.personal_stage_type_id.user_id)
+        tasks_without_personal_stage = tasks - tasks_with_personal_stage
+        fields = [
+            "id",
+            "name",
+            "project_id",
+            "milestone_id",
+            "partner_id",
+            "user_ids",
+            "activity_ids",
+            "stage_id",
+            "personal_stage_type_ids",
+            "tag_ids",
+            "priority",
+            "company_id",
+        ]
+        groupby = ["personal_stage_type_ids"]
+        user_read_group = self.env['project.task'].with_user(user).read_group(domain=base_domain, fields=fields, groupby=groupby)
+        number_of_tasks_in_groups = sum(gr['personal_stage_type_ids_count'] if gr['personal_stage_type_ids'] and gr['personal_stage_type_ids'][0] in user_personal_stages.ids else 0 for gr in user_read_group)
+        self.assertEqual(len(tasks_with_personal_stage), number_of_tasks_in_groups)
+        tasks_found_for_user = [task['id'] for task in self.env['project.task'].with_user(user.id).search_read(domain=base_domain, fields=fields)]
+        self.assertEqual(tasks.ids, tasks_found_for_user)
+        domain = ["&", ("personal_stage_type_ids", "=", False), ("user_ids.employee_parent_id.user_id", "=", manager_user.id)]
+        tasks_diplayed_without_personal_stage = [task['id'] for task in self.env['project.task'].with_user(user.id).search_read(domain=domain, fields=fields)]
+        self.assertEqual(tasks_without_personal_stage.ids, tasks_diplayed_without_personal_stage)


### PR DESCRIPTION
### Issue:

Suppose that we group all tasks by personal stage in the "list view". A `web_read_group` is performed to classify the tasks and a `web_search_read` is performed to display the lines. The result of both operations is not consistent for tasks that do not belong to a personal stage of the current user.

### Cause of the issue:

The "Personal stage" field of the project.task model correspond actually to the field personal_stage_type_ids wich represents the set of all personal stages linked to the task for a user (but does not take the current user into account). When performing a group by "Personal stage", the "None" group will correspond to all tasks that do not have a personal stage linked to our current user. However, the lines diplayed by the `web_search_read` for that group will correspond to all tasks that do not have a personal stage for any user. This is due to the fact that the condition used in the domain of this group is `("personal_stage_type_ids", "=", False)`

### Fix:

Since the personal_stage_type_ids is a store related field, any implementation of a search method will not be taken into account for that field. We therefore decided to modify manually the search_read method for that particular condition.

opw-3877522
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
