### PR TITLE
[FIX] web: hide field overriden by view in `SetDefaultDialog`

### DIFF
--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -230,14 +230,17 @@ class SetDefaultDialog extends Component {
                 const valueDisplayed = this.display(fieldInfo, this.fieldsValues[fieldName]);
                 const value = valueDisplayed[0];
                 const displayed = valueDisplayed[1];
-                // ignore fields which are empty, invisible, readonly, o2m or m2m
+                const { context } = this.props.component.props;
+                // ignore fields which are empty, invisible, readonly, o2m, m2m
+                // or whose default value is set from the action's context
                 if (
-                    !value ||
+                    (fieldInfo.type !== "boolean" && !value) ||
                     invisibleOrReadOnly ||
                     fieldInfo.type === "one2many" ||
                     fieldInfo.type === "many2many" ||
                     fieldInfo.type === "binary" ||
-                    this.fieldsInfo[fieldName].options.isPassword
+                    this.fieldsInfo[fieldName].options.isPassword ||
+                    `default_${fieldInfo.name}` in context
                 ) {
                     return false;
                 }


### PR DESCRIPTION
Problem
---
In debug mode, when setting items from the debug items menu, it is possible to set a default for field which is overridden in an action by having `default_<fieldname>=_` in the `context` prop.

But the default value which was just set will be ignored, because the override from the view takes priority.

Fix
---
Check for fields which are overriden in the view before displaying the dialog, and do not offer the option to set them.

Justification
---
I think it's the only viable "fix" in stable because trying to change the context prop only works if we want the set default to be global, so it breaks the option to set them by user/company when saving them to `ir.default`s

and I don't think there is a way to check if an `ir.default` was set via the debug item without adding a field to the model.

Side-Fix
---
A small bug occuring in the same condition we're changing was that: we check which fields are set to know if it makes sense to set their default value by a `!value` check, but `false` is a valid value for `boolean`s.
We can fix this by:
```diff
- !value ||
+ (fieldInfo.type !== 'boolean' && !value) ||
```

opw-3858753

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
