### PR TITLE
[FIX] stock: validate a scrap picking without backorder

### DIFF
--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1179,12 +1179,12 @@ class Picking(models.Model):
             has_quantity = False
             has_pick = False
             for move in picking.move_ids:
+                if move.quantity:
+                    has_quantity = True
                 if move.scrapped:
                     continue
                 if move.picked:
                     has_pick = True
-                if move.quantity:
-                    has_quantity = True
                 if has_quantity and has_pick:
                     break
             if has_quantity and not has_pick:

--- a/addons/stock/tests/test_move.py
+++ b/addons/stock/tests/test_move.py
@@ -5010,6 +5010,30 @@ class StockMove(TransactionCase):
         picking.button_validate()
         self.assertEqual(picking.state, 'done')
 
+    def test_scrap_10(self):
+        """Create a picking with a scrap destination location and attempt to validate it."""
+        # 10 units are available in stock
+        self.env['stock.quant']._update_available_quantity(self.product, self.stock_location, 10)
+        scrap_location = self.env['stock.location'].search([('company_id', '=', self.env.company.id), ('scrap_location', '=', True)], limit=1)
+        picking = self.env['stock.picking'].create({
+            'name': 'A single picking with one move to scrap',
+            'location_id': self.stock_location.id,
+            'location_dest_id': scrap_location.id,
+            'picking_type_id': self.env.ref('stock.picking_type_out').id,
+        })
+        move1 = self.env['stock.move'].create({
+            'name': 'A move to confirm and scrap its product',
+            'location_id': self.stock_location.id,
+            'location_dest_id': scrap_location.id,
+            'product_id': self.product.id,
+            'product_uom_qty': 10.0,
+            'picking_id': picking.id,
+        })
+        move1._action_confirm()
+        self.assertEqual(move1.quantity, 10)
+        picking.button_validate()
+        self.assertEqual(picking.state, 'done')
+
     def test_in_date_1(self):
         """ Check that moving a tracked quant keeps the incoming date.
         """


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product “P1” and update its quantity to 10.
- Create a picking:
    - Source location: Wh/Stock
    - Destination location: Virtual Locations/Scrap
    - Product: 10 units of P1.

- Mark as to-do.
- Try to validate the picking.

**Problem:**
A wizard asking to create a backorder is triggered. This occurs because when validating the picking, we check if all the moves are picked and the quantity is set. However, for the scrap moves that are ignored, we'll consider the move as not picked and no quantity done is set, hence the creation of a backorder is proposed.

**Solution:**
For the scrap moves, ignore the check of "picked" but check if a quantity done is set when validating the picking.

opw-3900082
