### PR TITLE
[FIX] account: different text for discounts and early payment settings

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -3392,7 +3392,7 @@ msgstr ""
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_cash_discount_gain
 #: model:ir.model.fields,field_description:account.field_res_config_settings__account_journal_early_pay_discount_gain_account_id
-msgid "Cash Discount Gain"
+msgid "Early Discount Gain"
 msgstr ""
 
 #. module: account
@@ -3400,7 +3400,7 @@ msgstr ""
 #: code:addons/account/models/chart_template.py:0
 #: model:account.account,name:account.1_cash_discount_loss
 #: model:ir.model.fields,field_description:account.field_res_config_settings__account_journal_early_pay_discount_loss_account_id
-msgid "Cash Discount Loss"
+msgid "Early Discount Loss"
 msgstr ""
 
 #. module: account
@@ -10708,7 +10708,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Post Exchange difference entries in:"
+msgid "Exchange difference entries:"
 msgstr ""
 
 #. module: account
@@ -10718,12 +10718,12 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Post bank transactions and payments in:"
+msgid "Bank transactions and payments:"
 msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Post discounts in:"
+msgid "Early payment discounts:"
 msgstr ""
 
 #. module: account
@@ -11749,7 +11749,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Same Account"
+msgid "Same Account as product"
 msgstr ""
 
 #. module: account
@@ -12149,7 +12149,7 @@ msgstr ""
 
 #. module: account
 #: model_terms:ir.ui.view,arch_db:account.res_config_settings_view_form
-msgid "Separate discount accounts on invoices"
+msgid "Invoice line discounts:"
 msgstr ""
 
 #. module: account

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -181,7 +181,7 @@ class ResConfigSettings(models.TransientModel):
 
     account_journal_early_pay_discount_loss_account_id = fields.Many2one(
         comodel_name='account.account',
-        string='Cash Discount Loss',
+        string='Early Discount Loss',
         help='Account for the difference amount after the expense discount has been granted',
         readonly=False,
         related='company_id.account_journal_early_pay_discount_loss_account_id',
@@ -190,7 +190,7 @@ class ResConfigSettings(models.TransientModel):
     )
     account_journal_early_pay_discount_gain_account_id = fields.Many2one(
         comodel_name='account.account',
-        string='Cash Discount Gain',
+        string='Early Discount Gain',
         help='Account for the difference amount after the income discount has been granted',
         readonly=False,
         check_company=True,

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -250,7 +250,7 @@
 
                         <t groups="account.group_account_user">
                             <block title="Default Accounts" id="default_accounts">
-                                <setting invisible="not group_multi_currency" string="Post Exchange difference entries in:">
+                                <setting invisible="not group_multi_currency" string="Exchange difference entries:">
                                     <div class="content-group">
                                         <div class="row mt8">
                                             <label for="currency_exchange_journal_id" class="col-lg-4 o_light_label" string="Journal" />
@@ -266,7 +266,7 @@
                                         </div>
                                     </div>
                                 </setting>
-                                <setting id="post_bank_transactions_and_payments_setting" string="Post bank transactions and payments in:">
+                                <setting id="post_bank_transactions_and_payments_setting" string="Bank transactions and payments:">
                                     <div class="content-group">
                                         <div class="row mt8">
                                             <label for="account_journal_suspense_account_id" class="col-lg-5 o_light_label"/>
@@ -286,20 +286,20 @@
                                         </div>
                                     </div>
                                 </setting>
-                                <setting string="Separate discount accounts on invoices"
+                                <setting string="Invoice line discounts:"
                                          title="If empty, the discount will be discounted directly on the income/expense account. If set, discount on invoices will be realized in separate accounts.">
                                     <div class="content-group">
                                         <div class="row mt8">
                                             <label for="account_discount_expense_allocation_id" class="col-lg-5 o_light_label" string="Customer Invoices"/>
-                                            <field name="account_discount_expense_allocation_id" placeholder="Same Account"/>
+                                            <field name="account_discount_expense_allocation_id" placeholder="Same Account as product"/>
                                         </div>
                                         <div class="row mt8">
                                             <label for="account_discount_income_allocation_id" class="col-lg-5 o_light_label" string="Vendor Bills"/>
-                                            <field name="account_discount_income_allocation_id" placeholder="Same Account"/>
+                                            <field name="account_discount_income_allocation_id" placeholder="Same Account as product"/>
                                         </div>
                                     </div>
                                 </setting>
-                                <setting string="Post discounts in:">
+                                <setting string="Early payment discounts:">
                                     <div class="content-group">
                                         <div class="row mt8">
                                             <label for="account_journal_early_pay_discount_gain_account_id" class="col-lg-5 o_light_label"/>


### PR DESCRIPTION
We have two settings about discounts that are not linked to the same features (one is line discounts, and the other is Early Payment discounts). They are next to each other but not clear at all. Updating text on settings to differentiate between early payments and discounts.

Enterprise PR: https://github.com/odoo/enterprise/pull/62039

task-3908720



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
