### PR TITLE
[FIX] base: remove real person's phone number

### DIFF
--- a/odoo/addons/base/data/res_users_demo.xml
+++ b/odoo/addons/base/data/res_users_demo.xml
@@ -24,7 +24,7 @@
             <field name="zip">94134</field>
             <field name='country_id' ref='base.us'/>
             <field name='state_id' ref='state_us_5'/>
-            <field name="phone">+1 (650) 555-0111 </field>
+            <field name="phone">+5 555-555-5555</field>
             <field name="email">info@yourcompany.example.com</field>
             <field name="website">www.example.com</field>
         </record>


### PR DESCRIPTION
Issue
----

Demo company data contains a phone number of a real person, who receives phone calls from
peolple asking to buy stuff :)

Steps
----

Number is available on website footer.

Cause
----

A real number is used in demo data.

opw-3853066
