### PR TITLE
[IMP] account: Allow selectable reports in Send&Print

### DIFF
--- a/addons/account/__manifest__.py
+++ b/addons/account/__manifest__.py
@@ -54,6 +54,7 @@ You could use this simplified accounting in case you work with an (external) acc
         'views/report_invoice.xml',
         'report/account_invoice_report_view.xml',
         'views/account_cash_rounding_view.xml',
+        'views/ir_actions_views.xml',
         'views/ir_module_views.xml',
         'views/res_config_settings_views.xml',
         'views/partner_view.xml',

--- a/addons/account/models/ir_actions_report.py
+++ b/addons/account/models/ir_actions_report.py
@@ -6,13 +6,18 @@ try:
 except ImportError:
     from PyPDF2.utils import PdfStreamError, PdfReadError
 
-from odoo import api, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.tools import pdf
 
 
 class IrActionsReport(models.Model):
     _inherit = 'ir.actions.report'
+
+    is_invoice_report = fields.Boolean(
+        string="Invoice report",
+        copy=True,
+    )
 
     def _render_qweb_pdf_prepare_streams(self, report_ref, data, res_ids=None):
         # Custom behavior for 'account.report_original_vendor_bill'.
@@ -45,7 +50,7 @@ class IrActionsReport(models.Model):
         return collected_streams
 
     def _is_invoice_report(self, report_ref):
-        return self._get_report(report_ref).report_name in ('account.report_invoice_with_payments', 'account.report_invoice')
+        return self._get_report(report_ref).is_invoice_report
 
     def _pre_render_qweb_pdf(self, report_ref, res_ids=None, data=None):
         # Check for reports only available for invoices.

--- a/addons/account/views/account_report.xml
+++ b/addons/account/views/account_report.xml
@@ -8,6 +8,7 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">account.report_invoice_with_payments</field>
             <field name="report_file">account.report_invoice_with_payments</field>
+            <field name="is_invoice_report">True</field>
             <field name="print_report_name">(object._get_report_base_filename())</field>
             <field name="attachment"/>
             <field name="binding_model_id" ref="model_account_move"/>

--- a/addons/account/views/ir_actions_views.xml
+++ b/addons/account/views/ir_actions_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="ir_actions_report_form_inherit_account" model="ir.ui.view">
+        <field name="name">ir.actions.report.form.inherit.account</field>
+        <field name="model">ir.actions.report</field>
+        <field name="inherit_id" ref="base.act_report_xml_view"/>
+        <field name="arch" type="xml">
+            <field name="paperformat_id" position="after">
+                <field name="is_invoice_report"/>
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/account/wizard/account_move_send_views.xml
+++ b/addons/account/wizard/account_move_send_views.xml
@@ -11,6 +11,7 @@
                 <field name="company_id" invisible="1"/>
                 <field name="move_ids" invisible="1"/>
                 <field name="mode" invisible="1"/>
+                <field name="show_pdf_template_menu" invisible="1"/>
                 <field name="enable_download" invisible="1"/>
                 <field name="enable_send_mail" invisible="1"/>
                 <field name="send_mail_readonly" invisible="1"/>
@@ -27,6 +28,14 @@
                          Sending these invoices will create a gap in the sequence.
                     </div>
                 </div>
+
+                <group>
+                    <field
+                        name="pdf_template_id"
+                        invisible="not show_pdf_template_menu"
+                        class="w-50"
+                        options="{'no_create': True, 'no_edit': True}"/>
+                </group>
 
                 <!-- Options -->
                 <div name="options" class="row">


### PR DESCRIPTION
In invoices send and print wizard, this commit allows the user to select for invoice PDF template. Before this commit, only email template was selectable, and PDF template was hardcoded.

This change was needed to allow some customization when generating an invoice.

Task [link](https://www.odoo.com/web#model=project.task&id=3879033)
task-3879033

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
