### PR TITLE
[FIX] hr_expense: prevent value error

### DIFF
--- a/addons/hr_expense/views/hr_expense_views.xml
+++ b/addons/hr_expense/views/hr_expense_views.xml
@@ -216,11 +216,7 @@
                                 <field name="tax_amount"/>
                             </div>
                             <t groups="hr_expense.group_hr_expense_team_approver">
-                                <field name="employee_id" groups="!hr.group_hr_user"
-                                       context="{'default_company_id': company_id}" widget="many2one_avatar_employee"
-                                       options="{'relation': 'hr.employee.public', 'no_create': True}"
-                                       readonly="not is_editable"/>
-                                <field name="employee_id" groups="hr.group_hr_user"
+                                <field name="employee_id"
                                        context="{'default_company_id': company_id}" widget="many2one_avatar_employee"
                                        options="{'relation': 'hr.employee', 'no_create': True}"
                                    readonly="not is_editable"/>


### PR DESCRIPTION
Steps to reproduce:
- Go to user settings, select Marc Demo
- Set hr.employee with no right
- Set hr.expense with administrator rights
- Go to expense
- Select an expense and try to change the employee

Issue:
Value Error:  Invalid field hr.employee.public.filter_for_expense in leaf ('filter_for_expense', '=', True)

Cause:
Because of the widget, we fetch data from hr.employee.public https://github.com/odoo/odoo/blob/43122b3efc9fca3532eff36a35c15e35aa2aa125/addons/hr/static/src/views/fields/employee_field_relation_mixin.js#L30

Since `filter_expense` is not stored
https://github.com/odoo/odoo/blob/68fbdc964038ef6a1cf0d3df773db101ca81794a/addons/hr_expense/models/hr_employee.py#L28

It won't be 'copied' in hr.employee.public
https://github.com/odoo/odoo/blob/753a5d5d99407b84b30b5ba48d549cea0b9d2f75/addons/hr/models/hr_employee_public.py#L84-L85

All of that added to the domain restriction defined in: https://github.com/odoo/odoo/blob/ecedbeb7c90ffbf83b8c5742af6376f7d8ceb245/addons/hr_expense/models/hr_expense.py#L34-L41

will trigger the Value Error.

Solution:
We revert the fix added in 16.0: https://github.com/odoo/odoo/pull/138069 The error in the commit message does not appear as from 17.0

opw-3862083