### PR TITLE
[FIX] mrp: auto-generate backorder in "always backorder" setup

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -2117,7 +2117,21 @@ class MrpProduction(models.Model):
 
         quantity_issues = self._get_quantity_produced_issues()
         if quantity_issues:
-            return self._action_generate_backorder_wizard(quantity_issues)
+            prods_auto_backorder = [prod for prod in quantity_issues if prod.picking_type_id.create_backorder == "always"]
+            if prods_auto_backorder:
+                auto_backorders = self.env['mrp.production.backorder'].create({
+                    "mrp_production_backorder_line_ids": [Command.create({
+                            'mrp_production_id': prod.id,
+                            'to_backorder': True,
+                        }) for prod in prods_auto_backorder
+                    ],
+                })
+                return auto_backorders.action_backorder()
+            ask_backorder = [prod for prod in quantity_issues if prod.picking_type_id.create_backorder == "ask"]
+            if ask_backorder:
+                return self._action_generate_backorder_wizard(ask_backorder)
+            else:
+                return True
         return True
 
     def _button_mark_done_sanity_checks(self):


### PR DESCRIPTION
### Steps to reproduce:

- Inventory > Configuration > Warehouse Management > Operations types
- Click on Manufacturing and put "Always" on create a backorder
- Create a new MO for 2 units of a product and produce 1 unit

#### > A wizzard appears to ask you if you want to create a backorder

### Cause of the issue:

Clicking on the produce button will call the "button_mark_done" method. However, the parameters of backorder creations are not checked before the wizzard generation:
https://github.com/odoo/odoo/blob/5c2f60ae2b8eb6699bd322bc4ea3d5054c7aea37/addons/mrp/models/mrp_production.py#L2118-L2120 

opw-3890886
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
