### PR TITLE
[FIX] l10n_ee: add "erikord" tax groups

### DIFF
--- a/addons/l10n_ee/data/account_tax_group_data.xml
+++ b/addons/l10n_ee/data/account_tax_group_data.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <data noupdate="1">
-        <record id="tax_group_vat_20" model="account.tax.group">
-            <field name="name">VAT 20%</field>
+        <record id="tax_group_vat_22" model="account.tax.group">
+            <field name="name">VAT 22%</field>
             <field name="country_id" ref="base.ee"/>
         </record>
 
-        <record id="tax_group_vat_22" model="account.tax.group">
-            <field name="name">VAT 22%</field>
+        <record id="tax_group_vat_20" model="account.tax.group">
+            <field name="name">VAT 20%</field>
             <field name="country_id" ref="base.ee"/>
         </record>
 
@@ -23,6 +23,26 @@
 
         <record id="tax_group_vat_0" model="account.tax.group">
             <field name="name">VAT 0%</field>
+            <field name="country_id" ref="base.ee"/>
+        </record>
+
+        <record id="tax_group_vat_22erikord" model="account.tax.group">
+            <field name="name">VAT 22% (KMS §41/§42)</field>
+            <field name="country_id" ref="base.ee"/>
+        </record>
+
+        <record id="tax_group_vat_20erikord" model="account.tax.group">
+            <field name="name">VAT 20% (KMS §41/§42)</field>
+            <field name="country_id" ref="base.ee"/>
+        </record>
+
+        <record id="tax_group_vat_9erikord" model="account.tax.group">
+            <field name="name">VAT 9% (KMS §41/§42)</field>
+            <field name="country_id" ref="base.ee"/>
+        </record>
+
+        <record id="tax_group_vat_5erikord" model="account.tax.group">
+            <field name="name">VAT 5% (KMS §41/§42)</field>
             <field name="country_id" ref="base.ee"/>
         </record>
     </data>

--- a/addons/l10n_ee/data/account_tax_template_data.xml
+++ b/addons/l10n_ee/data/account_tax_template_data.xml
@@ -1134,6 +1134,7 @@
         <field name="description">20%</field>
         <field name="active" eval="False"/>
         <field name="tax_group_id" ref="tax_group_vat_20"/>
+        <field name="l10n_ee_kmd_inf_code">11</field>
         <field name="chart_template_id" ref="l10nee_chart_template"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, { 'repartition_type': 'base' }),
@@ -1209,6 +1210,7 @@
         <field name="description">22%</field>
         <field name="active" eval="False"/>
         <field name="tax_group_id" ref="tax_group_vat_22"/>
+        <field name="l10n_ee_kmd_inf_code">11</field>
         <field name="chart_template_id" ref="l10nee_chart_template"/>
         <field name="invoice_repartition_line_ids" eval="[(5, 0, 0),
             (0,0, { 'repartition_type': 'base' }),


### PR DESCRIPTION
It's not convenient to define new tax groups, which is needed when wanting to use "erikord" taxes. To easy the process, we add the tax groups in the module data.

task-3859431