### PR TITLE
[REF] mrp: BOM explode

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -360,6 +360,7 @@ class MrpBom(models.Model):
             Quantity describes the number of times you need the BoM: so the quantity divided by the number created by the BoM
             and converted into its UoM
         """
+        self.ensure_one()
         product_ids = set()
         product_boms = {}
         def update_product_boms():
@@ -369,8 +370,8 @@ class MrpBom(models.Model):
             # Set missing keys to default value
             for product in products:
                 product_boms.setdefault(product, self.env['mrp.bom'])
-
-        boms_done = [(self, {'qty': quantity, 'product': product, 'original_qty': quantity, 'parent_line': False})]
+        quantity = quantity / self.product_qty
+        boms_done = [(self, {'qty': quantity, 'product': product, 'parent_line': False})]
         lines_done = []
 
         bom_lines = []
@@ -398,13 +399,13 @@ class MrpBom(models.Model):
                 for bom_line in bom.bom_line_ids:
                     if not bom_line.product_id in product_boms:
                         product_ids.add(bom_line.product_id.id)
-                boms_done.append((bom, {'qty': converted_line_quantity, 'product': current_product, 'original_qty': quantity, 'parent_line': current_line}))
+                boms_done.append((bom, {'qty': converted_line_quantity, 'product': current_product, 'parent_line': current_line}))
             else:
                 # We round up here because the user expects that if he has to consume a little more, the whole UOM unit
                 # should be consumed.
                 rounding = current_line.product_uom_id.rounding
                 line_quantity = float_round(line_quantity, precision_rounding=rounding, rounding_method='UP')
-                lines_done.append((current_line, {'qty': line_quantity, 'product': current_product, 'original_qty': quantity, 'parent_line': parent_line}))
+                lines_done.append((current_line, {'qty': line_quantity, 'product': current_product, 'parent_line': parent_line}))
 
         return boms_done, lines_done
 

--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -560,7 +560,7 @@ class MrpProduction(models.Model):
                 # keep manual entries
                 workorders_values = []
                 product_qty = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
-                exploded_boms, dummy = production.bom_id.explode(production.product_id, product_qty / production.bom_id.product_qty, picking_type=production.bom_id.picking_type_id)
+                exploded_boms, _dummy = production.bom_id.explode(production.product_id, product_qty, picking_type=production.bom_id.picking_type_id)
 
                 for bom, bom_data in exploded_boms:
                     # If the operations of the parent BoM and phantom BoM are the same, don't recreate work orders.
@@ -1153,8 +1153,8 @@ class MrpProduction(models.Model):
         for production in self:
             if not production.bom_id:
                 continue
-            factor = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id) / production.bom_id.product_qty
-            boms, lines = production.bom_id.explode(production.product_id, factor, picking_type=production.bom_id.picking_type_id)
+            product_qty = production.product_uom_id._compute_quantity(production.product_qty, production.bom_id.product_uom_id)
+            _boms, lines = production.bom_id.explode(production.product_id, product_qty, picking_type=production.bom_id.picking_type_id)
             for bom_line, line_data in lines:
                 if bom_line.child_bom_id and bom_line.child_bom_id.type == 'phantom' or\
                         bom_line.product_id.type != 'consu':

--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -263,8 +263,8 @@ class MrpUnbuild(models.Model):
                 for raw_move in raw_moves:
                     moves += unbuild._generate_move_from_existing_move(raw_move, factor, raw_move.location_dest_id, self.location_dest_id)
             else:
-                factor = unbuild.product_uom_id._compute_quantity(unbuild.product_qty, unbuild.bom_id.product_uom_id) / unbuild.bom_id.product_qty
-                boms, lines = unbuild.bom_id.explode(unbuild.product_id, factor, picking_type=unbuild.bom_id.picking_type_id)
+                product_qty = unbuild.product_uom_id._compute_quantity(unbuild.product_qty, unbuild.bom_id.product_uom_id)
+                _boms, lines = unbuild.bom_id.explode(unbuild.product_id, product_qty, picking_type=unbuild.bom_id.picking_type_id)
                 for line, line_data in lines:
                     moves += unbuild._generate_move_from_bom_line(line.product_id, line.product_uom_id, line_data['qty'], bom_line_id=line.id)
         return moves

--- a/addons/mrp/models/stock_orderpoint.py
+++ b/addons/mrp/models/stock_orderpoint.py
@@ -79,7 +79,7 @@ class StockWarehouseOrderpoint(models.Model):
         orderpoints_without_kit = self - self.env['stock.warehouse.orderpoint'].concat(*bom_kit_orderpoints.keys())
         res = super(StockWarehouseOrderpoint, orderpoints_without_kit)._quantity_in_progress()
         for orderpoint in bom_kit_orderpoints:
-            dummy, bom_sub_lines = bom_kit_orderpoints[orderpoint].explode(orderpoint.product_id, 1)
+            _dummy, bom_sub_lines = bom_kit_orderpoints[orderpoint].explode(orderpoint.product_id, 1)
             ratios_qty_available = []
             # total = qty_available + in_progress
             ratios_total = []
@@ -87,7 +87,7 @@ class StockWarehouseOrderpoint(models.Model):
                 component = bom_line.product_id
                 if not component.is_storable or float_is_zero(bom_line_data['qty'], precision_rounding=bom_line.product_uom_id.rounding):
                     continue
-                uom_qty_per_kit = bom_line_data['qty'] / bom_line_data['original_qty']
+                uom_qty_per_kit = bom_line_data['qty']
                 qty_per_kit = bom_line.product_uom_id._compute_quantity(uom_qty_per_kit, bom_line.product_id.uom_id, raise_if_failure=False)
                 if not qty_per_kit:
                     continue

--- a/addons/mrp/models/stock_rule.py
+++ b/addons/mrp/models/stock_rule.py
@@ -263,8 +263,7 @@ class ProcurementGroup(models.Model):
             bom_kit = kits_by_company[procurement.company_id].get(procurement.product_id)
             if bom_kit:
                 order_qty = procurement.product_uom._compute_quantity(procurement.product_qty, bom_kit.product_uom_id, round=False)
-                qty_to_produce = (order_qty / bom_kit.product_qty)
-                boms, bom_sub_lines = bom_kit.explode(procurement.product_id, qty_to_produce)
+                _boms, bom_sub_lines = bom_kit.explode(procurement.product_id, order_qty)
                 for bom_line, bom_line_data in bom_sub_lines:
                     bom_line_uom = bom_line.product_uom_id
                     quant_uom = bom_line.product_id.uom_id

--- a/addons/mrp_account/models/account_move.py
+++ b/addons/mrp_account/models/account_move.py
@@ -19,8 +19,7 @@ class AccountMoveLine(models.Model):
             bom_kit = bom_kits[product]
             if bom_kit:
                 invoiced_qty = product.uom_id._compute_quantity(qty, bom_kit.product_uom_id, round=False)
-                factor = invoiced_qty / bom_kit.product_qty
-                dummy, bom_sub_lines = bom_kit.explode(product, factor)
+                _dummy, bom_sub_lines = bom_kit.explode(product, invoiced_qty)
                 for bom_line, bom_line_data in bom_sub_lines:
                     qties[bom_line.product_id] += bom_line.product_uom_id._compute_quantity(bom_line_data['qty'], bom_line.product_id.uom_id)
             else:

--- a/addons/mrp_repair/models/repair.py
+++ b/addons/mrp_repair/models/repair.py
@@ -24,8 +24,8 @@ class Repair(models.Model):
             bom = self.env['mrp.bom'].sudo()._bom_find(op.product_id, company_id=op.company_id.id, bom_type='phantom')[op.product_id]
             if not bom:
                 continue
-            factor = op.product_uom._compute_quantity(op.product_uom_qty, bom.product_uom_id) / bom.product_qty
-            _boms, lines = bom.sudo().explode(op.product_id, factor, picking_type=bom.picking_type_id)
+            product_qty = op.product_uom._compute_quantity(op.product_uom_qty, bom.product_uom_id)
+            _boms, lines = bom.sudo().explode(op.product_id, product_qty, picking_type=bom.picking_type_id)
             for bom_line, line_data in lines:
                 if bom_line.product_id.type != 'service':
                     line_vals_list.append(op._prepare_phantom_line_vals(bom_line, line_data['qty']))

--- a/addons/sale_mrp/models/account_move.py
+++ b/addons/sale_mrp/models/account_move.py
@@ -36,6 +36,6 @@ class AccountMoveLine(models.Model):
                     prod_qty_to_invoice = factor * qty_to_invoice
                     product = product.with_company(self.company_id)
                     average_price_unit += factor * product._compute_average_price(prod_qty_invoiced, prod_qty_to_invoice, prod_moves, is_returned=is_line_reversing)
-                price_unit = average_price_unit / bom.product_qty or price_unit
+                price_unit = average_price_unit or price_unit
                 price_unit = self.product_id.uom_id._compute_price(price_unit, self.product_uom_id)
         return price_unit

--- a/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
+++ b/addons/sale_mrp/tests/test_sale_mrp_anglo_saxon_valuation.py
@@ -106,9 +106,9 @@ class TestSaleMRPAngloSaxonValuation(ValuationReconciliationTestCommon):
         self.assertEqual(len(amls), 4)
         stock_out_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_stock_out'])
         self.assertEqual(stock_out_aml.debit, 0)
-        self.assertAlmostEqual(stock_out_aml.credit, 1.53, "Should not include the value of consumable component")
+        self.assertAlmostEqual(stock_out_aml.credit, 1.58, 2, "Should not include the value of consumable component")
         cogs_aml = amls.filtered(lambda aml: aml.account_id == self.company_data['default_account_expense'])
-        self.assertAlmostEqual(cogs_aml.debit, 1.53, "Should not include the value of consumable component")
+        self.assertAlmostEqual(cogs_aml.debit, 1.58, 2, "Should not include the value of consumable component")
         self.assertEqual(cogs_aml.credit, 0)
 
     def test_sale_mrp_anglo_saxon_variant(self):


### PR DESCRIPTION
Product qty of the bom is already known from inside the BOM explode it's less error-prone and more convenient to take that amount into consideration in the function rather than dividing and multiplying before and after the call

Also removed 'original_qty' which is taken as an argument and needlessly dupliacted on each line

