### PR TITLE
[FIX] website_event_sale: pricelist dropdown visible on mobile

### DIFF
--- a/addons/website_event_sale/views/website_event_templates.xml
+++ b/addons/website_event_sale/views/website_event_templates.xml
@@ -8,7 +8,7 @@
             <t t-set="website_sale_pricelists" t-value="website.get_pricelist_available(show_visible=True)" />
             <t t-set="hasPricelistDropdown" t-value="website_sale_pricelists and len(website_sale_pricelists)&gt;1"/>
             <t t-call="website_sale.pricelist_list">
-                <t t-set="_classes" t-valuef="d-none d-lg-inline p-0 ms-2 my-1"/>
+                <t t-set="_classes" t-valuef="d-inline p-0 ms-2 my-1"/>
             </t>
         </div>
     </xpath>


### PR DESCRIPTION
Make the pricelist dropdown for events tickets visible on smaller screens, if not, users will be stuck with the default pricelist and won't be able to change to the one they need to use.

## Steps to reproduce:

1. Create an event with selling tickets.
2. Make sure you have more than 1 pricelist available.
3. Go to order a ticket, and in the dialog, make sure our screen size is below 992px.
4. The dropdown to select pricelist is no longer visible.

opw-3889376