### PR TITLE
[IMP] hr_timesheet: remove total section when timesheets are not grouped

### DIFF
--- a/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_portal_templates.xml
@@ -88,16 +88,6 @@
                                     </t>
                                 </th>
                             </tr>
-                            <tr t-else="">
-                                <div style="text-align: right;" class="me-2 mb-1 text-muted">
-                                    <t t-if="is_uom_day">
-                                        Total: <span t-esc="timesheets._convert_hours_to_days(hours_spent)" t-options='{"widget": "timesheet_uom"}'/>
-                                    </t>
-                                    <t t-else="">
-                                        Total: <span t-esc="hours_spent" t-options='{"widget": "float_time"}'/>
-                                    </t>
-                                </div>
-                            </tr>
                         </tbody>
                         <tbody style="font-size: 0.8rem">
                             <t t-foreach="timesheets" t-as="timesheet">


### PR DESCRIPTION
-In this PR, we remove the total label in the portal view, if the
 timesheets are not grouped.

task-3908815