### PR TITLE
[FIX]account/saas-16.2: Chart Template es_common

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -924,7 +924,7 @@ class AccountChartTemplate(models.AbstractModel):
     def _get_tag_mapper(self, template_code):
         tags = {x.name: x.id for x in self.env['account.account.tag'].with_context(active_test=False).search([
             ('applicability', '=', 'taxes'),
-            ('country_id', '=', self._get_chart_template_mapping()[template_code]['country_id']),
+            ('country_id', '=', self._get_chart_template_mapping(get_all=True)[template_code]['country_id']),
         ])}
 
         def mapping_getter(*args):
@@ -957,7 +957,7 @@ class AccountChartTemplate(models.AbstractModel):
         model_fields = Model._fields
 
         if module is None:
-            module = self._get_chart_template_mapping().get(template_code)['module']
+            module = self._get_chart_template_mapping(get_all=True).get(template_code)['module']
         assert re.fullmatch(r"[a-z0-9_]+", module)
 
         res = {}


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:

Steps To Reproduce:
1. Create fresh database in version 16.0.
2. Install the module `l10n_es`.
3. Migrate the database to version 17.0 or saas-16.2 by setting the chart_template_id of res_company to `es_common` which is 
 id = 1.
4. Finally, the error will be reproduced.

When the module `l10n_es` is installed and if the Chart Template is set to `es_common` before saas-16.2 then it will raise a TypeError as "TypeError: 'NoneType' object is not subscriptable" when migrating to version 17.0 or saas-16.2. It is just because the changes in this [PR](https://github.com/odoo/odoo/blob/saas-16.2/addons/l10n_es/models/template_es_common.py#L13) here the chart template has made invisible ('visible':0). So, when it tries to fetch the template with the [template_code](https://github.com/odoo/odoo/blob/saas-16.2/addons/account/models/chart_template.py#L960) `es_common` it will get a None value because it has made invisible. Finally, it will surely raise a TypeError if the chart template is set to `es_common`.

Desired behavior after PR is merged:

The TypeError which is raising while migrating to version saas-16.2 or more will be handled with this PR just by setting the value **True** for the default parameter **get_all** of the method **_get_chart_template_mapping()** .
 
Proof: [Link](https://pad.odoo.com/p/piWY3u0RCGJlSDLg60Om)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
