### PR TITLE
[IMP] mail: allow non-template editors users to use simple expressions

### DIFF
--- a/addons/html_editor/static/src/fields/html_field.scss
+++ b/addons/html_editor/static/src/fields/html_field.scss
@@ -21,5 +21,9 @@ div.o_field_html {
     .o_field_translate .note-editable {
         padding-right: 40px;
     }
-}
 
+    textarea.o_field_translate:hover + .o_field_text_buttons .o_field_translate,
+    textarea.o_field_translate:focus + .o_field_text_buttons .o_field_translate {
+        visibility: visible;
+    }
+}

--- a/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
+++ b/addons/html_editor/static/src/others/dynamic_placeholder/dynamic_placeholder.js
@@ -24,7 +24,7 @@ export class DynamicPlaceholderPlugin extends Plugin {
         powerboxCategory: { id: "marketing_tools", name: _t("Marketing Tools"), sequence: 60 },
         powerboxItems: {
             name: _t("Dynamic Placeholder"),
-            description: _t("Insert personalized content"),
+            description: _t("Insert a field"),
             category: "marketing_tools",
             fontawesome: "fa-magic",
             action(dispatch) {
@@ -92,11 +92,11 @@ export class DynamicPlaceholderPlugin extends Plugin {
             return;
         }
 
-        let dynamicPlaceholder = "object." + chain;
-        dynamicPlaceholder +=
-            defaultValue && defaultValue !== "" ? ` or '''${defaultValue}'''` : "";
         const t = document.createElement("T");
-        t.setAttribute("t-out", dynamicPlaceholder);
+        t.setAttribute("t-out", `object.${chain}`);
+        if (defaultValue?.length) {
+            t.innerText = defaultValue;
+        }
 
         this.shared.domInsert(t);
         this.editable.focus();

--- a/addons/mail/models/ir_qweb.py
+++ b/addons/mail/models/ir_qweb.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from odoo import api, models
+from odoo import models
 
 
 class IrQweb(models.AbstractModel):
-    """Add ``raise_on_forbidden_code`` option for qweb.
+    """Add ``raise_on_forbidden_code_for_model`` option for qweb.
 
-    When this option is activated, only a whitelist of expressions is allowed.
+    When this option is activated, only a whitelist of expressions
+    is allowed for the given model.
     """
 
     _inherit = "ir.qweb"
@@ -20,47 +21,35 @@ class IrQweb(models.AbstractModel):
     )
 
     def _get_template_cache_keys(self):
-        return super()._get_template_cache_keys() + ["raise_on_forbidden_code"]
+        return super()._get_template_cache_keys() + ["raise_on_forbidden_code_for_model"]
 
     def _compile_directive(self, el, compile_context, directive, level):
         if (
-            compile_context.get("raise_on_forbidden_code")
+            "raise_on_forbidden_code_for_model" in compile_context
             and directive not in self.allowed_directives
         ):
             raise PermissionError("This directive is not allowed for this rendering mode.")
         return super()._compile_directive(el, compile_context, directive, level)
 
     def _compile_directive_att(self, el, compile_context, level):
-        if compile_context.get("raise_on_forbidden_code"):
+        if "raise_on_forbidden_code_for_model" in compile_context:
             if set(el.attrib) - {"t-out", "t-tag-open", "t-tag-close", "t-inner-content"}:
                 raise PermissionError("This directive is not allowed for this rendering mode.")
         return super()._compile_directive_att(el, compile_context, level)
 
     def _compile_expr(self, expr, raise_on_missing=False):
-        if self.env.context.get("raise_on_forbidden_code") and not self._is_expression_allowed(expr):
+        model = self.env.context.get("raise_on_forbidden_code_for_model")
+        if model is not None and not self._is_expression_allowed(expr, model):
             raise PermissionError("This directive is not allowed for this rendering mode.")
         return super()._compile_expr(expr, raise_on_missing)
 
     def _compile_directive_out(self, el, compile_context, level):
-        if compile_context.get("raise_on_forbidden_code"):
+        if "raise_on_forbidden_code_for_model" in compile_context:
             if len(el) != 0:
                 raise PermissionError("No child allowed for t-out.")
             if set(el.attrib) - {'t-out', 't-tag-open', 't-tag-close'}:
                 raise PermissionError("No other attribute allowed for t-out.")
         return super()._compile_directive_out(el, compile_context, level)
 
-    def _is_expression_allowed(self, expression):
-        return expression.strip() in self.allowed_qweb_expressions()
-
-    @api.model
-    def allowed_qweb_expressions(self):
-        # QWeb expressions allowed if we are not template editor
-        return (
-            "object.name",
-            "object.contact_name",
-            "object.partner_id",
-            "object.partner_id.name",
-            "object.user_id",
-            "object.user_id.name",
-            "object.user_id.signature",
-        )
+    def _is_expression_allowed(self, expression, model):
+        return model and expression.strip() in self.env[model].mail_allowed_qweb_expressions()

--- a/addons/mail/models/ir_qweb.py
+++ b/addons/mail/models/ir_qweb.py
@@ -1,16 +1,60 @@
 # -*- coding: utf-8 -*-
-from odoo import models
+
+from odoo import api, models
+
 
 class IrQweb(models.AbstractModel):
-    """ Add ``raise_on_code`` option for qweb. When this option is activated
-    then all directives are prohibited.
+    """Add ``raise_on_forbidden_code`` option for qweb.
+
+    When this option is activated, only a whitelist of expressions is allowed.
     """
-    _inherit = 'ir.qweb'
+
+    _inherit = "ir.qweb"
+
+    allowed_directives = (
+        "esc",
+        "out",
+        "inner-content",
+        "att",
+        "tag-open",
+        "tag-close",
+    )
 
     def _get_template_cache_keys(self):
-        return super()._get_template_cache_keys() + ['raise_on_code']
+        return super()._get_template_cache_keys() + ["raise_on_forbidden_code"]
 
-    def _compile_directives(self, el, compile_context, indent):
-        if compile_context.get('raise_on_code'):
-            raise PermissionError("This rendering mode prohibits the use of directives.")
-        return super()._compile_directives(el, compile_context, indent)
+    def _compile_directive(self, el, compile_context, directive, level):
+        if (
+            compile_context.get("raise_on_forbidden_code")
+            and directive not in self.allowed_directives
+        ):
+            raise PermissionError("This directive is not allowed for this rendering mode.")
+        return super()._compile_directive(el, compile_context, directive, level)
+
+    def _compile_directive_att(self, el, compile_context, level):
+        if compile_context.get("raise_on_forbidden_code"):
+            if set(el.attrib) - {"t-esc", "t-out", "t-tag-open", "t-tag-close"}:
+                raise PermissionError("This directive is not allowed for this rendering mode.")
+
+        return super()._compile_directive_att(el, compile_context, level)
+
+    def _compile_expr(self, expr, raise_on_missing=False):
+        if self.env.context.get("raise_on_forbidden_code") and not self._is_expression_allowed(expr):
+            raise PermissionError("This directive is not allowed for this rendering mode.")
+        return super()._compile_expr(expr, raise_on_missing)
+
+    def _is_expression_allowed(self, expression):
+        return expression.strip() in self.allowed_qweb_expressions()
+
+    @api.model
+    def allowed_qweb_expressions(self):
+        # QWeb expressions allowed if we are not template editor
+        return (
+            "object.name",
+            "object.contact_name",
+            "object.partner_id",
+            "object.partner_id.name",
+            "object.user_id",
+            "object.user_id.name",
+            "object.user_id.signature",
+        )

--- a/addons/mail/models/models.py
+++ b/addons/mail/models/models.py
@@ -117,6 +117,19 @@ class BaseModel(models.AbstractModel):
             return primary_email
         return None
 
+    @api.model
+    def mail_allowed_qweb_expressions(self):
+        # QWeb expressions allowed if we are not template editor
+        return (
+            "object.name",
+            "object.contact_name",
+            "object.partner_id",
+            "object.partner_id.name",
+            "object.user_id",
+            "object.user_id.name",
+            "object.user_id.signature",
+        )
+
     # ------------------------------------------------------------
     # GENERIC MAIL FEATURES
     # ------------------------------------------------------------

--- a/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.scss
+++ b/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.scss
@@ -1,3 +1,7 @@
-.o_field_widget.o_field_char_emojis input {
-    padding-right: 40px; // Avoid overlapping sub
+.o_field_char_emojis input.o_field_placeholder {
+    padding-right: 50px;
+}
+
+.o_field_char_emojis input.o_field_placeholder.o_field_translate {
+    padding-right: 90px;
 }

--- a/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_char_field/emojis_char_field.xml
@@ -5,7 +5,7 @@
         <xpath expr="//span[1]" position="attributes">
             <attribute name="t-ref">targetReadonlyElement</attribute>
         </xpath>
-        <xpath expr="//input" position="after">
+        <xpath expr="//*[hasclass('o_field_char_buttons')]/button" position="before">
             <t t-call="mail.EmojisFieldButton">
                 <t t-set="positionCenter" t-value="true"/>
             </t>

--- a/addons/mail/static/src/views/web/fields/emojis_field_common/emojis_field_common.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_field_common/emojis_field_common.xml
@@ -2,9 +2,9 @@
 
 <templates>
     <t t-name="mail.EmojisFieldButton">
-        <div class="position-relative d-inline">
+        <div class="o_mail_emojis_buttons position-relative d-inline">
             <button
-                class="btn position-absolute end-0"
+                class="btn end-0"
                 t-attf-class="{{positionCenter ? 'pb-0 pt-0' : 'bottom-0'}}"
                 t-ref="emojisButton"
             >

--- a/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
+++ b/addons/mail/static/src/views/web/fields/emojis_text_field/emojis_text_field.xml
@@ -5,7 +5,7 @@
         <xpath expr="//span[1]" position="attributes">
             <attribute name="t-ref">targetReadonlyElement</attribute>
         </xpath>
-        <xpath expr="//textarea" position="after">
+        <xpath expr="//*[hasclass('o_field_text_buttons')]" position="inside">
             <t t-call="mail.EmojisFieldButton"/>
         </xpath>
     </t>

--- a/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
+++ b/addons/mail/static/src/views/web/fields/html_composer_message_field/html_composer_message_field.js
@@ -1,3 +1,4 @@
+import { DYNAMIC_PLACEHOLDER_PLUGINS } from "@html_editor/plugin_sets";
 import { registry } from "@web/core/registry";
 import { HtmlMailField, htmlMailField } from "../html_mail_field/html_mail_field";
 import { MentionPlugin } from "./mention_plugin";
@@ -6,6 +7,11 @@ export class HtmlComposerMessageField extends HtmlMailField {
     getConfig() {
         const config = super.getConfig(...arguments);
         config.Plugins = [...config.Plugins, MentionPlugin];
+        if (!this.props.record.data.composition_batch) {
+            config.Plugins = config.Plugins.filter(
+                (plugin) => !DYNAMIC_PLACEHOLDER_PLUGINS.includes(plugin)
+            );
+        }
         config.onAttachmentChange = (attachment) => {
             // This only needs to happen for the composer for now
             if (

--- a/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
+++ b/addons/mail/static/tests/tours/mail_template_dynamic_placeholder_tour.js
@@ -60,7 +60,7 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
         {
             content: 'Retry insert # inside "Subject" input',
             trigger: 'div[name="subject"] input[type="text"]',
-            run: "edit (yes_model_id ) && press #",
+            run: "edit (yes_model_id) && press #",
         },
         {
             content: "Check if the dynamic placeholder popover is opened",
@@ -73,7 +73,7 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
         },
         {
             content: "Click on the first entry of the dynamic placeholder",
-            trigger: 'div.o_model_field_selector_popover li:first-child button:contains("Name")',
+            trigger: 'div.o_model_field_selector_popover button:contains("Company Name")',
             run: "click",
         },
         {
@@ -83,8 +83,8 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
             run: "edit defValue",
         },
         {
-            content: "Click on the the dynamic placeholder default value",
-            trigger: "div.o_model_field_selector_popover li:first-child button",
+            content: "Click on the insert button",
+            trigger: "div.o_model_field_selector_popover button:first-child",
             run: "click",
         },
         {
@@ -93,11 +93,11 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
             run: "click",
         },
         {
-            content: "Check if subject value was correclty updated",
+            content: "Check if subject value was correctly updated",
             trigger: 'div[name="subject"] input[type="text"]',
             run() {
                 const subjectValue = this.anchor.value;
-                const correctValue = "yes_model_id {{object.name or '''defValue'''}}";
+                const correctValue = "yes_model_id {{object.company_name|||defValue}}";
                 if (subjectValue !== correctValue) {
                     console.error(
                         `Email template should have "${correctValue}" in subject input (actual: ${subjectValue})`
@@ -135,7 +135,7 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
         },
         {
             content: "Click on the first entry of the dynamic placeholder",
-            trigger: 'div.o_model_field_selector_popover li:first-child button:contains("Name")',
+            trigger: 'div.o_model_field_selector_popover button:contains("Company Name")',
             run: "click",
         },
         {
@@ -145,14 +145,13 @@ registry.category("web_tour.tours").add("mail_template_dynamic_placeholder_tour"
             run: "edit defValue",
         },
         {
-            content: "Click on the the dynamic placeholder default value",
-            trigger: "div.o_model_field_selector_popover li:first-child button",
+            content: "Click on the insert button",
+            trigger: "div.o_model_field_selector_popover button:first-child",
             run: "click",
         },
         {
             content: "Ensure the editable contain the dynamic placeholder t tag",
-            trigger:
-                ".note-editable.odoo-editor-editable t[t-out=\"object.name or '''defValue'''\"]",
+            trigger: `.note-editable.odoo-editor-editable t[t-out="object.company_name"]:contains("defValue")`,
             run: "click",
         },
         {

--- a/addons/mail/tests/test_mail_render.py
+++ b/addons/mail/tests/test_mail_render.py
@@ -492,7 +492,7 @@ class TestRegexRendering(common.MailCommon):
             with patch('odoo.tools.safe_eval.unsafe_eval', side_effect=eval) as unsafe_eval:
                 self.assertEqual(render(template), expected)
                 self.assertFalse(unsafe_eval.called)
-                self.assertFalse(self.env['mail.render.mixin']._has_unsafe_expression_template_inline_template(template))
+                self.assertFalse(self.env['mail.render.mixin']._has_unsafe_expression_template_inline_template(template, 'res.partner'))
 
         non_static_templates = (
             ('''{{''}}''', ''),
@@ -503,7 +503,7 @@ class TestRegexRendering(common.MailCommon):
             with patch('odoo.tools.safe_eval.unsafe_eval', side_effect=eval) as unsafe_eval:
                 self.assertEqual(render(template), expected)
                 self.assertTrue(unsafe_eval.called)
-                self.assertTrue(self.env['mail.render.mixin']._has_unsafe_expression_template_inline_template(template))
+                self.assertTrue(self.env['mail.render.mixin']._has_unsafe_expression_template_inline_template(template, 'res.partner'))
 
 
 @tagged('mail_render')

--- a/addons/mail/wizard/mail_compose_message_views.xml
+++ b/addons/mail/wizard/mail_compose_message_views.xml
@@ -45,7 +45,9 @@
                     </group>
                     <field name="can_edit_body" invisible="1"/>
                     <div invisible="composition_mode == 'mass_mail'">
-                        <field name="body" widget="html_composer_message" class="oe-bordered-editor" placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"/>
+                        <field name="body" widget="html_composer_message" class="oe-bordered-editor"
+                            placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'render_model'}"/>
                         <group>
                             <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1"/>
                         </group>
@@ -57,7 +59,9 @@
                     <notebook invisible="composition_mode != 'mass_mail'">
                         <page string="Content" name="page_content">
                             <div>
-                                <field name="body" widget="html_composer_message" class="oe-bordered-editor" placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"/>
+                                <field name="body" widget="html_composer_message" class="oe-bordered-editor"
+                                    placeholder="Write your message here..." readonly="not can_edit_body" force_save="1"
+                                    options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'render_model'}"/>
                                 <group>
                                     <field name="attachment_ids" widget="many2many_binary" string="Attach a file" nolabel="1"/>
                                 </group>
@@ -101,7 +105,10 @@
             <field name="arch" type="xml">
                 <form string="Templates">
                     <group>
-                        <field name="subject" placeholder="e.g. &quot;Welcome to MyCompany&quot; or &quot;Nice to meet you, {{ object.name }}&quot;"/>
+                        <field name="subject"
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'model'}"
+                            placeholder="e.g. &quot;Welcome to MyCompany&quot; or &quot;Nice to meet you, {{ object.name }}&quot;"/>
+                        <field name="model" invisible="1"/>
                     </group>
                     <footer>
                         <button name="create_mail_template" type="object" class="btn btn-primary" string="Save"/>

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -26,23 +26,15 @@
 }
 
 .o_form_view.o_mass_mailing_mailing_form .o_form_renderer {
-    &.o_form_readonly .o_mass_mailing_subject {
+    .o_mass_mailing_subject {
         // Place the favorite button without breaking the emoji widget
-        padding-right: 50px;
-        .o_mass_mailing_favorite {
-            margin-right: -50px;
-        }
-        .o_mail_emojis_dropdown {
-            margin-left: -40px;
-            bottom: 0;
-        }
-        div.o_field_char_emojis {
-            // Override widget CSS attributes to place
-            // the favorite button next to the subject
-            margin-right: 1rem;
-            min-width: 0;
-            width: auto!important;
-            max-width: calc(100vw - 300px);
+        .o_field_char_emojis {
+            .o_field_char_buttons {
+                right: 30px;
+            }
+            input {
+                padding-right: 65px;
+            }
         }
     }
     .o_mass_mailing_subject {

--- a/addons/mass_mailing/static/src/scss/mass_mailing.scss
+++ b/addons/mass_mailing/static/src/scss/mass_mailing.scss
@@ -26,22 +26,6 @@
 }
 
 .o_form_view.o_mass_mailing_mailing_form .o_form_renderer {
-    .o_mass_mailing_subject {
-        // Place the favorite button without breaking the emoji widget
-        .o_field_char_emojis {
-            .o_field_char_buttons {
-                right: 30px;
-            }
-            input {
-                padding-right: 65px;
-            }
-        }
-    }
-    .o_mass_mailing_subject {
-        .fa-star {
-            color: $o-main-favorite-color;
-        }
-    }
     // Align the model / domain container with subject field in large devices
     // and provide better tap area to the filter
     @include media-breakpoint-up(md) {
@@ -57,14 +41,6 @@
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;
-        }
-    }
-}
-
-.o_xxs_form_view.o_mass_mailing_mailing_form {
-    .o_mass_mailing_subject {
-        span.o_field_char {
-            max-width: 90vw!important;
         }
     }
 }

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -215,12 +215,12 @@
                                     widget="char_emojis" placeholder="e.g. New Sale on all T-shirts"/>
                                 <field name="favorite" invisible="1"/>
                                 <button type="object" name="action_set_favorite"
-                                    class="o_mass_mailing_favorite p-0"
+                                    class="o_mass_mailing_favorite px-2 py-0"
                                     icon="fa-star-o"
                                     invisible="favorite"
                                     title="Add to Templates"/>
                                 <button type="object" name="action_remove_favorite"
-                                    class="o_mass_mailing_favorite p-0"
+                                    class="o_mass_mailing_favorite px-2 py-0"
                                     icon="fa-star"
                                     invisible="not favorite"
                                     title="Remove from Templates"/>

--- a/addons/mass_mailing/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing/views/mailing_mailing_views.xml
@@ -72,7 +72,16 @@
                         <button name="action_test" type="object" class="btn-secondary" string="Test" data-hotkey="k"/>
                         <button name="action_cancel" type="object" invisible="state != 'in_queue'" class="btn-secondary" string="Cancel" data-hotkey="x"/>
                         <button name="action_retry_failed" type="object" invisible="state != 'done' or failed == 0" class="oe_highlight" string="Retry" data-hotkey="y"/>
-
+                        <button type="object"
+                            name="action_set_favorite"
+                            class="btn-secondary"
+                            invisible="favorite"
+                            string="Add to Templates"/>
+                        <button type="object"
+                            name="action_remove_favorite"
+                            class="btn-secondary"
+                            invisible="not favorite"
+                            string="Remove from Templates"/>
                         <field name="state" readonly="1" widget="statusbar" statusbar_visible="draft,in_queue,sending,done"/>
                     </header>
                     <div class="alert alert-info" role="alert"
@@ -207,24 +216,10 @@
                             <field name="mailing_type" widget="radio" options="{'horizontal': true}"
                                 invisible="1"
                                 readonly="state != 'draft'" force_save="1"/>
-                            <label for="subject">Subject</label>
-                            <div class="o_mass_mailing_subject d-flex flex-row align-items-baseline">
-                                <field class="text-break" name="subject" string="Subject"
-                                    options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
-                                    readonly="state in ('sending', 'done')"
-                                    widget="char_emojis" placeholder="e.g. New Sale on all T-shirts"/>
-                                <field name="favorite" invisible="1"/>
-                                <button type="object" name="action_set_favorite"
-                                    class="o_mass_mailing_favorite px-2 py-0"
-                                    icon="fa-star-o"
-                                    invisible="favorite"
-                                    title="Add to Templates"/>
-                                <button type="object" name="action_remove_favorite"
-                                    class="o_mass_mailing_favorite px-2 py-0"
-                                    icon="fa-star"
-                                    invisible="not favorite"
-                                    title="Remove from Templates"/>
-                            </div>
+                            <field class="text-break" name="subject"
+                                options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
+                                readonly="state in ('sending', 'done')"
+                                widget="char_emojis" placeholder="e.g. New Sale on all T-shirts"/>
                             <label for="mailing_model_id" string="Recipients"/>
                             <div name="mailing_model_id_container">
                                 <div class="row">

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -138,7 +138,8 @@
                     <field name="body_plaintext" widget="sms_widget"
                         readonly="state in ('sending', 'done')"
                         required="mailing_type == 'sms'"
-                        options="{'dynamic_placeholder': true}" enable_emojis="true"/>
+                        options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'mailing_model_real'}"
+                        enable_emojis="true"/>
                 </page>
             </xpath>
             <xpath expr="//page[@name='settings']/group/group[@name='email_content']" position="after">

--- a/addons/mass_mailing_sms/views/mailing_mailing_views.xml
+++ b/addons/mass_mailing_sms/views/mailing_mailing_views.xml
@@ -103,11 +103,8 @@
                 <attribute name="invisible">mailing_type != 'mail' or state in ('draft', 'test')</attribute>
             </xpath>
             <!-- Form -->
-            <xpath expr="//label[@for='subject']" position="attributes">
+            <xpath expr="//field[@name='subject']" position="attributes">
                 <attribute name="invisible">mailing_type != 'mail'</attribute>
-            </xpath>
-            <xpath expr="//label[@for='subject']" position="after">
-                <label for="sms_subject" invisible="mailing_type != 'sms'"/>
             </xpath>
             <xpath expr="//field[@name='subject']" position="attributes">
                 <attribute name="invisible">mailing_type != 'mail'</attribute>

--- a/addons/sms/static/src/components/sms_widget/fields_sms_widget.js
+++ b/addons/sms/static/src/components/sms_widget/fields_sms_widget.js
@@ -79,6 +79,7 @@ export class SmsWidget extends EmojisTextField {
      * @private
      */
     async onBlur() {
+        await super.onBlur();
         var content = this.props.record.data[this.props.name] || '';
         if( !content.trim().length && content.length > 0) {
             this.notification.add(

--- a/addons/sms/static/src/components/sms_widget/fields_sms_widget.xml
+++ b/addons/sms/static/src/components/sms_widget/fields_sms_widget.xml
@@ -2,9 +2,6 @@
 
 <templates xml:space="preserve">
     <t t-name="sms.SmsWidget" t-inherit="mail.EmojisTextField" t-inherit-mode="primary">
-        <xpath expr="//textarea[1]" position="attributes">
-            <attribute name="t-on-blur">onBlur</attribute>
-        </xpath>
         <xpath expr="/*[last()]/*[last()]" position="after">
             <div class="o_sms_container">
                 <span class="text-muted o_sms_count">

--- a/addons/sms/wizard/sms_composer_views.xml
+++ b/addons/sms/wizard/sms_composer_views.xml
@@ -46,8 +46,11 @@
                             <field name="recipient_single_description" class="oe_inline" invisible="not recipient_single_description"/>
                             <field name="recipient_single_number_itf" class="oe_inline" nolabel="1" onchange_on_keydown="True" placeholder="e.g. +1 415 555 0100"/>
                         </div>
-                        <field name="body" widget="sms_widget" invisible="not comment_single_recipient or recipient_single_valid"/>
-                        <field name="body" widget="sms_widget" invisible="comment_single_recipient and not recipient_single_valid" default_focus="1"/>
+                        <field name="body" widget="sms_widget" invisible="comment_single_recipient or recipient_single_valid"
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"/>
+                        <field name="body" widget="sms_widget" invisible="comment_single_recipient or not recipient_single_valid" default_focus="1"
+                            options="{'dynamic_placeholder': true, 'dynamic_placeholder_model_reference_field': 'res_model'}"/>
+                        <field name="body" widget="sms_widget" invisible="not comment_single_recipient"/>
                         <field name="mass_keep_log" invisible="1"/>
                     </group>
                 </sheet>

--- a/addons/test_marketing_card/tests/test_card_campaign.py
+++ b/addons/test_marketing_card/tests/test_card_campaign.py
@@ -73,7 +73,7 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
         with self.mock_image_renderer(), self.mock_mail_gateway(), self.assertQueryCount(243):
             mailing = self.env['mailing.mailing'].create({
                 'name': 'Test Marketing Card Mailing',
-                'body_html': f'<a href="/cards/{self.campaign.id}/preview"><img src="/web/image/card.campaign/{self.campaign.id}/image_preview"/></a>',
+                'body_html': f'<a href="/cards/{self.campaign.id}/preview"><img src="/web/image/card.campaign/{self.campaign.id}/image_preview"></a>',
                 'mailing_domain': repr([('partner_id.email', 'like', 'partn')]),
                 'mailing_model_id': self.env['ir.model']._get_id(performances._name),
                 'subject': 'The show is about to start!',
@@ -87,7 +87,7 @@ class TestMarketingCardMail(MailCase, MarketingCardCommon):
             record_id = int(sent_mail['object_id'].split('-')[0])
             preview_url = f"{self.campaign.get_base_url()}/cards/{self.campaign.id}/{record_id}/{self.campaign._generate_card_hash_token(record_id)}/preview"
             image_url = f"{self.campaign.get_base_url()}/cards/{self.campaign.id}/{record_id}/{self.campaign._generate_card_hash_token(record_id)}/card.jpg"
-            self.assertIn(f'<a href="{preview_url}"><img src="{image_url}"/></a>', sent_mail['body'])
+            self.assertIn(f'<a href="{preview_url}"><img src="{image_url}"></a>', sent_mail['body'])
 
 
 class TestMarketingCardRender(MarketingCardCommon):

--- a/addons/web/static/src/core/model_field_selector/model_field_selector.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector.js
@@ -56,7 +56,7 @@ export class ModelFieldSelector extends Component {
         this.popover.open(currentTarget, {
             resModel: this.props.resModel,
             path: this.props.path,
-            update: (path, debug = false) => {
+            update: (path, _fieldInfo, debug = false) => {
                 this.newPath = path;
                 if (!debug) {
                     this.updateState({ ...this.props, path }, true);

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.js
@@ -1,5 +1,6 @@
 import { Component, onWillStart, useEffect, useRef, useState } from "@odoo/owl";
 import { debounce } from "@web/core/utils/timing";
+import { _t } from "@web/core/l10n/translation";
 import { fuzzyLookup } from "@web/core/utils/search";
 import { KeepLast } from "@web/core/utils/concurrency";
 import { sortBy } from "@web/core/utils/arrays";
@@ -39,7 +40,10 @@ class Page {
     get title() {
         const prefix = this.previousPage?.previousPage ? "... > " : "";
         const title = this.previousPage?.selectedField.string || "";
-        return `${prefix}${title}`;
+        if (prefix.length || title.length) {
+            return `${prefix}${title}`;
+        }
+        return _t("Select a field");
     }
 
     focus(direction) {
@@ -223,7 +227,7 @@ export class ModelFieldSelectorPopover extends Component {
         }
         this.keepLast.add(Promise.resolve());
         this.state.page.selectedName = field.name;
-        this.props.update(this.state.page.path);
+        this.props.update(this.state.page.path, field);
         this.props.close();
     }
 

--- a/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
+++ b/addons/web/static/src/core/model_field_selector/model_field_selector_popover.xml
@@ -54,7 +54,11 @@
             </div>
             <t t-if="showDebugInput">
                 <div class="o_model_field_selector_popover_footer border-top py-1 px-2">
-                    <input type="text" class="o_model_field_selector_debug o_input" t-att-value="state.page.path" t-on-change="(ev) => this.loadNewPath(ev.target.value)" t-on-keydown="onDebugInputKeydown" t-on-input="(ev) => this.props.update(ev.target.value, true)"/>
+                    <input type="text" class="o_model_field_selector_debug o_input"
+                        t-att-value="state.page.path"
+                        t-on-change="(ev) => this.loadNewPath(ev.target.value)"
+                        t-on-keydown="onDebugInputKeydown"
+                        t-on-input="(ev) => this.props.update(ev.target.value, null, true)"/>
                 </div>
             </t>
         </div>

--- a/addons/web/static/src/views/fields/char/char_field.scss
+++ b/addons/web/static/src/views/fields/char/char_field.scss
@@ -5,3 +5,21 @@
         width: inherit;
     }
 }
+
+.o_field_char_buttons {
+    right: 0;
+    margin-left: -35px;
+    margin-right: 20px;
+
+    .o_field_translate {
+        margin-left: 0 !important;
+    }
+}
+
+.o_field_char input.o_field_placeholder {
+    padding-right: 40px;
+}
+
+.o_field_char input.o_field_placeholder.o_field_translate {
+    padding-right: 70px;
+}

--- a/addons/web/static/src/views/fields/char/char_field.xml
+++ b/addons/web/static/src/views/fields/char/char_field.xml
@@ -8,20 +8,31 @@
         <t t-else="">
             <input
                 class="o_input"
-                t-att-class="{'o_field_translate': isTranslatable}"
+                t-att-class="{
+                    'o_field_translate': isTranslatable,
+                    'o_field_placeholder': hasDynamicPlaceholder
+                }"
                 t-att-id="props.id"
                 t-att-type="props.isPassword ? 'password' : 'text'"
                 t-att-autocomplete="props.autocomplete or (props.isPassword ? 'new-password' : 'off')"
                 t-att-maxlength="maxLength > 0 and maxLength"
                 t-att-placeholder="props.placeholder"
+                t-on-blur="onBlur"
                 t-ref="input"
             />
-            <t t-if="isTranslatable">
-                <TranslationButton
-                    fieldName="props.name"
-                    record="props.record"
+            <div class="o_field_char_buttons position-absolute d-inline">
+                <t t-if="isTranslatable">
+                    <TranslationButton
+                        fieldName="props.name"
+                        record="props.record"
+                    />
+                </t>
+                <button t-if="hasDynamicPlaceholder"
+                    class="btn m-0 py-0 px-2 fa fa-magic"
+                    title="Insert Field"
+                    t-on-click="onDynamicPlaceholderOpen"
                 />
-            </t>
+            </div>
         </t>
     </t>
 

--- a/addons/web/static/src/views/fields/dynamic_placeholder_hook.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_hook.js
@@ -26,10 +26,10 @@ export function useDynamicPlaceholder(elementRef) {
         let rangeIndex = parseInt(element.getAttribute("data-oe-dynamic-placeholder-range-index"));
         // When the user cancel/close the popover, the path is empty.
         if (path) {
-            let dynamicPlaceholder = "{{object." + path;
-            dynamicPlaceholder +=
-                defaultValue && defaultValue !== "" ? ` or '''${defaultValue}'''}}` : "}}";
-
+            defaultValue = defaultValue.replace("|||", "");
+            const dynamicPlaceholder = ` {{object.${path}${
+                defaultValue?.length ? ` ||| ${defaultValue}` : ""
+            }}}`;
             const baseValue = element.value;
             const splitedValue = [baseValue.slice(0, rangeIndex), baseValue.slice(rangeIndex)];
             const newValue =

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -4,8 +4,8 @@ import { ModelFieldSelectorPopover } from "@web/core/model_field_selector/model_
 import { Component, onWillStart, useState } from "@odoo/owl";
 import { user } from "@web/core/user";
 
-const allowedQwebExpressions = memoize(async (_null, orm) => {
-    return await orm.call("ir.qweb", "allowed_qweb_expressions");
+const allowedQwebExpressions = memoize(async (model, orm) => {
+    return await orm.call(model, "mail_allowed_qweb_expressions");
 });
 
 export class DynamicPlaceholderPopover extends Component {
@@ -28,7 +28,7 @@ export class DynamicPlaceholderPopover extends Component {
             [this.isTemplateEditor, this.allowedQwebExpressions] = await Promise.all([
                 user.hasGroup("mail.group_mail_template_editor"),
                 // (only the first element is the cache key)
-                allowedQwebExpressions(null, this.orm),
+                allowedQwebExpressions(this.props.resModel, this.orm),
             ]);
         });
     }

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.js
@@ -1,6 +1,12 @@
-import { useAutofocus } from "@web/core/utils/hooks";
+import { memoize } from "@web/core/utils/functions";
+import { useAutofocus, useService } from "@web/core/utils/hooks";
 import { ModelFieldSelectorPopover } from "@web/core/model_field_selector/model_field_selector_popover";
-import { Component, useState } from "@odoo/owl";
+import { Component, onWillStart, useState } from "@odoo/owl";
+import { user } from "@web/core/user";
+
+const allowedQwebExpressions = memoize(async (_null, orm) => {
+    return await orm.call("ir.qweb", "allowed_qweb_expressions");
+});
 
 export class DynamicPlaceholderPopover extends Component {
     static template = "web.DynamicPlaceholderPopover";
@@ -16,9 +22,22 @@ export class DynamicPlaceholderPopover extends Component {
             isPathSelected: false,
             defaultValue: "",
         });
+        this.orm = useService("orm");
+
+        onWillStart(async () => {
+            [this.isTemplateEditor, this.allowedQwebExpressions] = await Promise.all([
+                user.hasGroup("mail.group_mail_template_editor"),
+                // (only the first element is the cache key)
+                allowedQwebExpressions(null, this.orm),
+            ]);
+        });
     }
 
-    filter(fieldDef) {
+    filter(fieldDef, path) {
+        const fullPath = `object${path ? `.${path}` : ""}.${fieldDef.name}`;
+        if (!this.isTemplateEditor && !this.allowedQwebExpressions.includes(fullPath)) {
+            return false;
+        }
         return !["one2many", "boolean", "many2many"].includes(fieldDef.type) && fieldDef.searchable;
     }
     closeFieldSelector() {
@@ -28,8 +47,9 @@ export class DynamicPlaceholderPopover extends Component {
         }
         this.props.close();
     }
-    setPath(path) {
+    setPath(path, fieldInfo) {
         this.state.path = path;
+        this.state.fieldName = fieldInfo?.string;
     }
     setDefaultValue(value) {
         this.state.defaultValue = value;
@@ -37,6 +57,12 @@ export class DynamicPlaceholderPopover extends Component {
     validate() {
         this.props.close();
         this.props.validate(this.state.path, this.state.defaultValue);
+    }
+
+    onBack() {
+        this.state.defaultValue = "";
+        this.state.isPathSelected = false;
+        this.state.path = "";
     }
 
     // @TODO should rework this to use hotkeys

--- a/addons/web/static/src/views/fields/dynamic_placeholder_popover.xml
+++ b/addons/web/static/src/views/fields/dynamic_placeholder_popover.xml
@@ -4,9 +4,15 @@
     <t t-name="web.DynamicPlaceholderPopover">
         <t t-if="state.isPathSelected">
             <div class="o_model_field_selector_popover" t-on-keydown="onInputKeydown" tabindex="-1">
-                <div class="border-bottom p-2 text-dark fw-bolder">
-                    <div class="d-flex justify-content-between align-items-center">
-                        <div class="o_model_field_selector_popover_title">Default value</div>
+                <div class="border-bottom p-2">
+                    <div class="d-flex justify-content-between align-items-center text-dark fw-bolder">
+                        <i class="btn btn-link me-n2 fa fa-arrow-left text-dark"
+                           title="Back"
+                           role="img"
+                           aria-label="Back"
+                           t-on-click="onBack"
+                        />
+                        <div class="o_model_field_selector_popover_title">Enter a default value</div>
                         <i class="o_model_field_selector_popover_close btn btn-link me-n2 fa fa-times text-dark"
                            title="Close"
                            role="img"
@@ -14,31 +20,31 @@
                            t-on-click="props.close"
                         />
                     </div>
+                    <t t-if="state.fieldName">
+                        <span t-out="state.fieldName"/>
+                        <br/>
+                        <span>or</span>
+                    </t>
                     <div class="o_model_field_selector_default_value_input mt-2">
                         <input type="text"
-                               placeholder='Type a default text or press ENTER'
-                               class="o_input"
-                               t-att-value="state.defaultValue"
-                               t-on-input="(ev) => this.setDefaultValue(ev.target.value)"
-                               t-ref="autofocus"/>
+                            placeholder="What should we write if the field is empty"
+                            class="o_input"
+                            t-att-value="state.defaultValue"
+                            t-on-input="(ev) => this.setDefaultValue(ev.target.value)"
+                            t-ref="autofocus"/>
                     </div>
                 </div>
-                <div class="o_model_field_selector_popover_body">
-                    <ul class="o_model_field_selector_popover_page list-unstyled mb-0 overflow-auto">
-                        <li t-attf-class="o_model_field_selector_popover_item border-bottom #{state.defaultValue === '' and 'active'}">
-                            <button class="o_model_field_selector_popover_item_name btn flex-fill border-0 rounded-0 text-start"  t-on-click="() => this.validate()">
-                                <t t-if="state.defaultValue === ''">
-                                    <div class="text-muted o_model_field_selector_item_title">Default text is used when no values are set</div>
-                                </t>
-                                <t t-else="">
-                                    <div class="text-muted o_model_field_selector_item_title">As a default text when no value are set</div>
-                                </t>
-                            </button>
-                        </li>
-                    </ul>
+                <div class="o_model_field_selector_popover_footer border-top py-1 my-2 px-2">
+                    <input type="text" class="o_input o_model_field_selector_debug"
+                        disabled="disabled" t-att-value="state.path" />
                 </div>
-                <div class="o_model_field_selector_popover_footer border-top py-1 px-2">
-                    <input type="text" class="o_input o_model_field_selector_debug" disabled="disabled" t-att-value="state.path" />
+                <div class="d-flex flex-row justify-content-around py-2">
+                    <button class="btn btn-primary" t-on-click="validate">
+                        Insert
+                    </button>
+                    <button class="btn btn-secondary" t-on-click="() => this.props.close()">
+                        Discard
+                    </button>
                 </div>
             </div>
         </t>

--- a/addons/web/static/src/views/fields/text/text_field.scss
+++ b/addons/web/static/src/views/fields/text/text_field.scss
@@ -5,3 +5,20 @@
         overflow-y: hidden;
     }
 }
+.o_field_text_buttons {
+    float: right;
+    margin-left: -35px;
+    margin-right: 10px;
+    margin-top: -40px;
+
+    .o_field_translate {
+        margin-left: 0 !important;
+    }
+}
+
+.o_field_text {
+    textarea.o_field_translate:hover + .o_field_text_buttons .o_field_translate,
+    textarea.o_field_translate:focus + .o_field_text_buttons .o_field_translate {
+        visibility: visible;
+    }
+}

--- a/addons/web/static/src/views/fields/text/text_field.xml
+++ b/addons/web/static/src/views/fields/text/text_field.xml
@@ -14,13 +14,20 @@
                     t-att-placeholder="props.placeholder"
                     t-att-rows="rowCount"
                     t-ref="textarea"
+                    t-on-blur="onBlur"
                 />
-                <t t-if="isTranslatable">
+                <div class="o_field_text_buttons d-flex flex-row align-items-baseline">
                     <TranslationButton
+                        t-if="isTranslatable"
                         fieldName="props.name"
                         record="props.record"
                     />
-                </t>
+                    <button t-if="props.dynamicPlaceholder"
+                        class="btn m-0 py-0 px-2 fa fa-magic position-relative"
+                        title="Insert Field"
+                        t-on-click="onDynamicPlaceholderOpen"
+                    />
+                </div>
             </div>
         </t>
     </t>

--- a/addons/web/static/src/views/form/form_controller.scss
+++ b/addons/web/static/src/views/form/form_controller.scss
@@ -637,7 +637,15 @@
     }
 
     div {
-        div:focus-within > span.o_field_translate, div:hover > span.o_field_translate {
+        div:focus-within > div.o_field_char_buttons > span.o_field_translate,
+        div:hover > div.o_field_char_buttons > span.o_field_translate {
+            visibility: visible !important;
+        }
+    }
+
+    div {
+        div:focus-within > span.o_field_translate,
+        div:hover > span.o_field_translate {
             visibility: visible !important;
         }
     }

--- a/addons/web/static/tests/core/model_field_selector.test.js
+++ b/addons/web/static/tests/core/model_field_selector.test.js
@@ -483,7 +483,7 @@ test("title on first four pages", async () => {
         },
     });
     await openModelFieldSelectorPopover();
-    expect(getTitle()).toBe("");
+    expect(getTitle()).toBe("Select a field");
 
     await followRelation();
     expect(getTitle()).toBe("Mother");
@@ -544,7 +544,7 @@ test("start on complex path and click prev", async () => {
 
     // go back to first page. Nothing has changed.
     await clickPrev();
-    expect(getTitle()).toBe("");
+    expect(getTitle()).toBe("Select a field");
     expect(getFocusedFieldName()).toBe("Mother");
     expect(getModelFieldSelectorValues()).toEqual(["Mother"]);
     expect(".o_model_field_selector_popover_prev_page").toHaveCount(0);
@@ -744,7 +744,7 @@ test("support properties", async () => {
 
     await mountWithCleanup(Parent);
     await openModelFieldSelectorPopover();
-    expect(getTitle()).toBe("");
+    expect(getTitle()).toBe("Select a field");
     expect('.o_model_field_selector_popover_item[data-name="properties"]').toHaveCount(1);
     expect(
         '.o_model_field_selector_popover_item[data-name="properties"] .o_model_field_selector_popover_relation_icon'
@@ -760,7 +760,7 @@ test("support properties", async () => {
     expect.verifySteps([]);
 
     await clickPrev();
-    expect(getTitle()).toBe("");
+    expect(getTitle()).toBe("Select a field");
     await contains(
         '.o_model_field_selector_popover_item[data-name="properties"] .o_model_field_selector_popover_item_name'
     ).click();

--- a/addons/web/static/tests/views/fields/text_field.test.js
+++ b/addons/web/static/tests/views/fields/text_field.test.js
@@ -183,6 +183,8 @@ test("in editable list view", async () => {
 });
 
 test.tags("desktop")("with dynamic placeholder", async () => {
+    onRpc("allowed_qweb_expressions", () => []);
+
     Product._fields.placeholder = fields.Char({ default: "product" });
     await mountView({
         type: "form",
@@ -210,6 +212,8 @@ test.tags("desktop")("with dynamic placeholder", async () => {
 });
 
 test.tags("mobile")("with dynamic placeholder in mobile", async () => {
+    onRpc("allowed_qweb_expressions", () => []);
+
     Product._fields.placeholder = fields.Char({ default: "product" });
     await mountView({
         type: "form",

--- a/addons/web/static/tests/views/fields/text_field.test.js
+++ b/addons/web/static/tests/views/fields/text_field.test.js
@@ -183,7 +183,7 @@ test("in editable list view", async () => {
 });
 
 test.tags("desktop")("with dynamic placeholder", async () => {
-    onRpc("allowed_qweb_expressions", () => []);
+    onRpc("mail_allowed_qweb_expressions", () => []);
 
     Product._fields.placeholder = fields.Char({ default: "product" });
     await mountView({
@@ -212,7 +212,7 @@ test.tags("desktop")("with dynamic placeholder", async () => {
 });
 
 test.tags("mobile")("with dynamic placeholder in mobile", async () => {
-    onRpc("allowed_qweb_expressions", () => []);
+    onRpc("mail_allowed_qweb_expressions", () => []);
 
     Product._fields.placeholder = fields.Char({ default: "product" });
     await mountView({

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -8267,7 +8267,7 @@ test(`can save without any dirty translatable fields`, async () => {
     expect.verifySteps(["get_views", "web_read"]);
     expect(`.o_form_editable`).toHaveCount(1);
     // o_field_translate is on the input and on the translate button
-    expect(`div[name='name'] > .o_field_translate`).toHaveCount(2);
+    expect(`div[name='name'] .o_field_translate`).toHaveCount(2);
 
     await contains(`.o_form_button_save`, { visible: false }).click();
     expect(`.alert .o_field_translate`).toHaveCount(0);

--- a/addons/web_editor/static/src/js/backend/html_field.js
+++ b/addons/web_editor/static/src/js/backend/html_field.js
@@ -191,7 +191,7 @@ export class HtmlField extends Component {
                         category: _t('Marketing Tools'),
                         name: _t('Dynamic Placeholder'),
                         priority: 10,
-                        description: _t('Insert personalized content'),
+                        description: _t('Insert a field'),
                         fontawesome: 'fa-magic',
                         callback: () => {
                             this.wysiwygRangePosition = getRangePosition(document.createElement('x'), this.wysiwyg.options.document || document);
@@ -348,9 +348,9 @@ export class HtmlField extends Component {
             // before inserting the <t> element.
             this.wysiwyg.focus();
             let dynamicPlaceholder = "object." + chain;
-            dynamicPlaceholder += defaultValue && defaultValue !== '' ? ` or '''${defaultValue}'''` : '';
             const t = document.createElement('T');
             t.setAttribute('t-out', dynamicPlaceholder);
+            t.innerText = defaultValue;
             this.wysiwyg.odooEditor.execCommand('insert', t);
             // Ensure the dynamic placeholder <t> element is sanitized.
             this.wysiwyg.odooEditor.sanitize(t);


### PR DESCRIPTION
Purpose
=======
Allow the non-template editor users to write simple expression
(e.g. object.name...) in mass-mailing but also in mail templates.

The mail composer in mass-mode is still in readonly mode if we are not
template editor, and we selected a template, because it might contain
complex code (conditions, loops, etc).

Task-3877116