### PR TITLE
[FIX] account: bypass exchange journal check for non-forex transactions

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -2622,7 +2622,7 @@ class AccountMoveLine(models.Model):
             return
 
         journal = company.currency_exchange_journal_id
-        if not journal:
+        if not journal and amounts_list:
             raise UserError(_(
                     "You have to configure the 'Exchange Gain or Loss Journal' in your company settings, to manage"
                     " automatically the booking of accounting entries related to differences between exchange rates."


### PR DESCRIPTION
When attempting to register a payment in the company's currency for an invoice also in company currency (where no currency exchange occurs), the system incorrectly prompts for an exchange journal configuration. This behavior is observed even when no exchange difference exists, leading to an unnecessary error message.

### Steps to Reproduce

1. Install `account_accountant`.
2. Ensure no default exchange journal is defined in the settings.
3. Create and confirm an invoice in the company currency.
4. Attempt to register a payment for that invoice in the same currency.

Result: A user error is triggered, incorrectly requiring an exchange journal.

### Cause

This issue was introduced in commit 2d2a7729a77f8004aa046998ce75cd85280b3a6e, which enforced a check for the exchange journal without considering whether there was an actual exchange difference.

opw-3901083