### PR TITLE
[IMP] survey: improve session code generation

### DIFF
--- a/addons/survey/tests/test_survey.py
+++ b/addons/survey/tests/test_survey.py
@@ -17,8 +17,8 @@ class TestSurveyInternals(common.TestSurveyCommon, MailCase):
     def test_allowed_triggering_question_ids(self):
         # Create 2 surveys, each with 3 questions, each with 2 suggested answers
         survey_1, survey_2 = self.env['survey.survey'].create([
-            {'title': 'Test Survey 1', 'session_code': '10000'},
-            {'title': 'Test Survey 2', 'session_code': '10001'}
+            {'title': 'Test Survey 1'},
+            {'title': 'Test Survey 2'}
         ])
         self.env['survey.question'].create([
             {
@@ -265,6 +265,20 @@ class TestSurveyInternals(common.TestSurveyCommon, MailCase):
         # Check that scoring is correct and survey is passed
         self.assertEqual(user_input.scoring_percentage, 100)
         self.assertTrue(user_input.scoring_success)
+
+    def test_session_code_generation(self):
+        surveys = self.env['survey.survey'].create([{
+            'title': f'Survey {i}'
+        } for i in range(30)])
+        survey_codes = surveys.mapped('session_code')
+        self.assertEqual(len(survey_codes), 30)
+        for code in survey_codes:
+            self.assertTrue(bool(code))
+            self.assertEqual(
+                len(surveys.filtered(lambda survey: survey.session_code == code)),
+                1,
+                f"Each code should be unique, found multiple occurrences of: {code}"
+            )
 
     def test_simple_choice_question_answer_result(self):
         test_survey = self.env['survey.survey'].create({

--- a/addons/survey/tests/test_survey_invite.py
+++ b/addons/survey/tests/test_survey_invite.py
@@ -41,12 +41,10 @@ class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
             {},  # empty
             {   # no question
                 'question_and_page_ids': [Command.create({'is_page': True, 'question_type': False, 'title': 'P0', 'sequence': 1})],
-                'session_code': '100000',
             }, {
                 # scored without positive score obtainable
                 'scoring_type': 'scoring_with_answers',
                 'question_and_page_ids': [Command.create({'question_type': 'numerical_box', 'title': 'Q0', 'sequence': 1})],
-                'session_code': '100001',
             }, {
                 # scored without positive score obtainable from simple choice
                 'scoring_type': 'scoring_with_answers',
@@ -58,7 +56,6 @@ class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
                         Command.create({'value': '2', 'answer_score': 0}),
                     ],
                 })],
-                'session_code': '100002',
             }, {
                 # closed
                 'active': False,
@@ -66,7 +63,6 @@ class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
                     Command.create({'is_page': True, 'question_type': False, 'title': 'P0', 'sequence': 1}),
                     Command.create({'title': 'Q0', 'sequence': 2, 'question_type': 'text_box'})
                 ],
-                'session_code': '100003',
              },
         ]
         good_cases = [
@@ -76,7 +72,6 @@ class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
                 'question_and_page_ids': [
                     Command.create({'question_type': 'numerical_box', 'title': 'Q0', 'sequence': 1, 'answer_score': 1}),
                 ],
-                'session_code': '100004',
             }, {
                 # scored with positive score obtainable from simple choice
                 'scoring_type': 'scoring_with_answers',
@@ -98,7 +93,6 @@ class TestSurveyInvite(common.TestSurveyCommon, MailCommon):
                         ],
                     }),
                 ],
-                'session_code': '100005',
             },
         ]
         surveys = self.env['survey.survey'].with_user(self.survey_manager).create([

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -175,6 +175,7 @@
                                     </div>
                                 </group>
                                 <group string="Live Session" name="live_session" invisible="not session_available">
+                                    <field name="access_token" invisible="1"/>  <!-- dependency of 'session_code' -->
                                     <field name="session_code" />
                                     <field name="session_link" widget="CopyClipboardChar" />
                                     <field name="session_speed_rating" invisible="scoring_type == 'no_scoring'" />


### PR DESCRIPTION
The current session code generation for surveys is a bit messy:
- It runs multiple times for a create-multi syntax
- It has poor performance with a search within a loop
- It can fail non-deterministically

This commit reworks the code generation in favor of a precomputed stored field with the compute method generating all the necessary codes at once.

Task-3916147
Runbot-error-57541
