### PR TITLE
[FIX] web: Avoid reading undefined element

### DIFF
--- a/addons/web/static/src/legacy/js/core/menu.js
+++ b/addons/web/static/src/legacy/js/core/menu.js
@@ -130,8 +130,8 @@ export async function initAutoMoreMenu(el, options) {
             maxWidth -= (parseFloat(style.paddingLeft) + parseFloat(style.paddingRight) + parseFloat(style.borderLeftWidth) + parseFloat(style.borderRightWidth));
             maxWidth -= unfoldableItems.reduce((sum, el) => sum + computeFloatOuterWidthWithMargins(el, true, true, false), 0);
         }
-        // Ignore if there is no overflow.
-        if (maxWidth - menuItemsWidth >= -0.001) {
+        // Ignore if there is no overflow - or no items
+        if ((nbItems == 0) || (maxWidth - menuItemsWidth >= -0.001)) {
             return _endAutoMoreMenu();
         }
 


### PR DESCRIPTION
This is an experimental fix!

Got this error in a case with no elements in "items": Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'nextElementSibling')

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
