### PR TITLE
[FIX] models: do no allow voiding a required fields

### DIFF
--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -643,6 +643,8 @@ class ResPartner(models.Model):
 
     @api.model
     def _commercial_fields(self):
+        if not self.env['ir.property']._get('property_account_payable_id', 'res.partner'):
+            return super()._commercial_fields()  # Not using accounting on current company
         return super(ResPartner, self)._commercial_fields() + \
             ['debit_limit', 'property_account_payable_id', 'property_account_receivable_id', 'property_account_position_id',
              'property_payment_term_id', 'property_supplier_payment_term_id', 'last_time_entries_checked', 'credit_limit']

--- a/addons/account/tests/test_account_account.py
+++ b/addons/account/tests/test_account_account.py
@@ -3,8 +3,6 @@ from odoo import Command
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import Form, tagged
 from odoo.exceptions import UserError, ValidationError
-from odoo.tools import mute_logger
-import psycopg2
 from freezegun import freeze_time
 
 @tagged('post_install', '-at_install')
@@ -172,7 +170,7 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         with self.assertRaises(UserError):
             self.env['account.account'].name_create('550003 Existing Account')
         # account code is mandatory and providing a name without a code should raise an error
-        with self.assertRaises(psycopg2.DatabaseError), mute_logger('odoo.sql_db'):
+        with self.assertRaisesRegex(ValidationError, "must have a value"):
             self.env['account.account'].with_context(import_file=True).name_create('Existing Account')
         account_id = self.env['account.account'].with_context(import_file=True).name_create('550003 Existing Account')[0]
         account = self.env['account.account'].browse(account_id)
@@ -328,7 +326,7 @@ class TestAccountAccount(AccountTestInvoicingCommon):
         self.assertEqual(account.name, "A new account")
 
         # name split is only possible through name_create, so an error should be raised
-        with self.assertRaises(psycopg2.DatabaseError), mute_logger('odoo.sql_db'):
+        with self.assertRaisesRegex(ValidationError, "must have a value"):
             account = self.env['account.account'].create({
                 'name': '314159 A new account',
                 'account_type': 'expense',

--- a/addons/fleet/views/fleet_vehicle_views.xml
+++ b/addons/fleet/views/fleet_vehicle_views.xml
@@ -177,7 +177,7 @@
         <field name="name">fleet.vehicle.tree</field>
         <field name="model">fleet.vehicle</field>
         <field name="arch" type="xml">
-            <tree string="Vehicle" 
+            <tree string="Vehicle"
                 decoration-warning="contract_renewal_due_soon and not contract_renewal_overdue"
                 decoration-danger="contract_renewal_overdue"
                 multi_edit="1"
@@ -465,7 +465,6 @@
         <field name="name">Odometers</field>
         <field name="res_model">fleet.vehicle.odometer</field>
         <field name="view_mode">tree,kanban,form,graph</field>
-        <field name="context"></field>
         <field name="help" type="html">
           <p class="o_view_nocontent_smiling_face">
             Create a new odometer log

--- a/addons/mail/models/mail_alias_domain.py
+++ b/addons/mail/models/mail_alias_domain.py
@@ -166,11 +166,11 @@ class AliasDomain(models.Model):
     @api.model
     def _sanitize_configuration(self, config_values):
         """ Tool sanitizing configuration values for domains """
-        if config_values.get('bounce_alias'):
+        if 'bounce_alias' in config_values:
             config_values['bounce_alias'] = self.env['mail.alias']._sanitize_alias_name(config_values['bounce_alias'])
-        if config_values.get('catchall_alias'):
+        if 'catchall_alias' in config_values:
             config_values['catchall_alias'] = self.env['mail.alias']._sanitize_alias_name(config_values['catchall_alias'])
-        if config_values.get('default_from'):
+        if 'default_from' in config_values:
             config_values['default_from'] = self.env['mail.alias']._sanitize_alias_name(
                 config_values['default_from'], is_email=True
             )

--- a/addons/mass_mailing/tests/test_mailing_internals.py
+++ b/addons/mass_mailing/tests/test_mailing_internals.py
@@ -411,7 +411,7 @@ class TestMassMailValues(MassMailCommon):
             'model': recipient._name,
             'res_id': recipient.id,
         })
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValidationError):
             activity.write({'model': False})
             self.env.flush_all()
         with self.assertRaises(IntegrityError):

--- a/addons/payment/data/payment_method_data.xml
+++ b/addons/payment/data/payment_method_data.xml
@@ -8,6 +8,7 @@
         <field name="code">7eleven</field>
         <field name="sequence">1000</field>
         <field name="active">False</field>
+        <field name="image" type="base64" file="payment/static/img/payment-methods.svg"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
         <field name="support_refund">partial</field>
@@ -860,6 +861,7 @@
         <field name="code">cashalo</field>
         <field name="sequence">1000</field>
         <field name="active">False</field>
+        <field name="image" type="base64" file="payment/static/img/payment-methods.svg"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
         <field name="support_refund">partial</field>
@@ -880,6 +882,7 @@
         <field name="code">cebuana</field>
         <field name="sequence">1000</field>
         <field name="active">False</field>
+        <field name="image" type="base64" file="payment/static/img/payment-methods.svg"/>
         <field name="support_tokenization">False</field>
         <field name="support_express_checkout">False</field>
         <field name="support_refund">partial</field>

--- a/addons/test_mail/tests/test_mail_activity.py
+++ b/addons/test_mail/tests/test_mail_activity.py
@@ -14,6 +14,7 @@ import random
 from odoo import fields, exceptions, tests
 from odoo.addons.mail.tests.common import mail_new_test_user, MailCommon
 from odoo.addons.test_mail.models.test_mail_models import MailTestActivity
+from odoo.exceptions import ValidationError
 from odoo.tests import Form, HttpCase, users
 from odoo.tools import mute_logger
 
@@ -275,7 +276,7 @@ class TestActivityFlow(TestActivityCommon):
             'res_id': test_record.id,
             'res_model_id': self.env['ir.model']._get_id(test_record._name),
         })
-        with self.assertRaises(IntegrityError):
+        with self.assertRaises(ValidationError):
             activity.write({'res_model_id': False})
             self.env.flush_all()
         with self.assertRaises(IntegrityError):

--- a/addons/test_mail/tests/test_mail_alias.py
+++ b/addons/test_mail/tests/test_mail_alias.py
@@ -681,10 +681,10 @@ class TestMailAliasDomain(TestMailAliasCommon):
         # falsy values
         for config_value in [False, None, '', ' ']:
             with self.subTest(config_value=config_value):
-                alias_domain.write({'bounce_alias': config_value})
-                self.assertFalse(alias_domain.bounce_alias)
-                alias_domain.write({'catchall_alias': config_value})
-                self.assertFalse(alias_domain.catchall_alias)
+                with self.assertRaises(exceptions.ValidationError):
+                    alias_domain.write({'bounce_alias': config_value})
+                with self.assertRaises(exceptions.ValidationError):
+                    alias_domain.write({'catchall_alias': config_value})
                 alias_domain.write({'default_from': config_value})
                 self.assertFalse(alias_domain.default_from)
 

--- a/addons/test_mail/tests/test_mail_mail.py
+++ b/addons/test_mail/tests/test_mail_mail.py
@@ -313,11 +313,10 @@ class TestMailMail(MailCommon):
             self.assertEqual(notification.notification_status, 'exception')
 
         # MailServer.send_email(): _prepare_email_message: unexpected ASCII / Malformed 'Return-Path' or 'From' address
-        # Force bounce alias to void, will force usage of email_from
-        self.mail_alias_domain.bounce_alias = False
-        self.env.company.invalidate_recordset(fnames={'bounce_email', 'bounce_formatted'})
         for email_from in ['strange@example¢¡.com', 'robert']:
             self._reset_data()
+            # Force bounce alias to same_value as email_from to disable default bounce
+            mail = mail.with_context(domain_bounce_address=email_from)
             mail.write({'email_from': email_from})
             with self.mock_mail_gateway():
                 mail.send(raise_exception=False)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -3019,7 +3019,7 @@ class BaseModel(metaclass=MetaModel):
                     params = [it for it in (True, False) if it in value]
                     check_null = False in value
                 else:
-                    params = [it for it in value if it is not False and it is not None]
+                    params = [it for it in value if it]
                     check_null = len(params) < len(value)
 
                 if params:
@@ -3046,10 +3046,10 @@ class BaseModel(metaclass=MetaModel):
             else:
                 return SQL("(%s IS NULL OR %s = FALSE)", sql_field, sql_field)
 
-        if operator == '=' and (value is False or value is None):
+        if operator == '=' and not value:
             return SQL("%s IS NULL", sql_field)
 
-        if operator == '!=' and (value is False or value is None):
+        if operator == '!=' and not value:
             return SQL("%s IS NOT NULL", sql_field)
 
         # general case
@@ -4671,8 +4671,8 @@ class BaseModel(metaclass=MetaModel):
                     raise ValueError("Invalid field %r on model %r" % (key, self._name))
                 if field.company_dependent:
                     irprop_def = self.env['ir.property']._get(key, self._name)
-                    cached_def = field.convert_to_cache(irprop_def, self)
-                    cached_val = field.convert_to_cache(val, self)
+                    cached_def = field.convert_to_cache(irprop_def, self, validate=False)
+                    cached_val = field.convert_to_cache(val, self, validate=False)
                     if cached_val == cached_def:
                         # val is the same as the default value defined in
                         # 'ir.property'; by design, 'ir.property' will not

--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -1452,7 +1452,7 @@ class expression(object):
                     model_raw_trans = model.with_context(prefetch_langs=True)
                     sql_field = model_raw_trans._field_to_sql(alias, field.name, self.query)
                     sql_operator = SQL_OPERATORS[operator]
-                    params = [it for it in right if it is not False and it is not None]
+                    params = [it for it in right if it]
                     check_null = len(params) < len(right)
                     if params:
                         params = [field.convert_to_column(p, model, validate=False).adapted['en_US'] for p in params]


### PR DESCRIPTION
Display a nice error instead of a SQL error
It could make sense in some cases to be able to void a field in order to recompute the the default value, but that should only happen in `onchange`
