### PR TITLE
[FIX] mail: Allow users to use pager with activity view

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -674,7 +674,7 @@ class MailActivity(models.Model):
         activity_domain = [('res_model', '=', res_model)]
         is_filtered = domain or limit or offset
         if is_filtered:
-            activity_domain.append(('res_id', 'in', DocModel._search(domain or [], offset, limit) if is_filtered else []))
+            activity_domain.append(('res_id', 'in', DocModel._search(domain or [], offset, limit, DocModel._order) if is_filtered else []))
         all_activities = Activity.with_context(active_test=not fetch_done).search(
             activity_domain, order='date_done DESC, date_deadline ASC')
         all_ongoing = all_activities.filtered('active')

--- a/addons/mail/static/src/views/web/activity/activity_controller.js
+++ b/addons/mail/static/src/views/web/activity/activity_controller.js
@@ -38,6 +38,9 @@ export class ActivityController extends Component {
                 limit: limit,
                 total: count,
                 onUpdate: async (params) => {
+                    // Ensure that only (active) records with at least one activity, "done" (archived) or not, are fetched.
+                    // We don't use active_test=false in the context because otherwise we would also get archived records.
+                    params.domain = [...(this.model.originalDomain || []), ["activity_ids.active", "in", [true, false]]];
                     await Promise.all([this.model.root.load(params), this.model.fetchActivityData(params)]);
                 },
                 updateTotal: hasLimitedCount ? () => this.model.root.fetchCount() : undefined,

--- a/addons/test_mail/__manifest__.py
+++ b/addons/test_mail/__manifest__.py
@@ -30,6 +30,9 @@ tests independently to functional aspects of other models. """,
         'web.tests_assets': [
             'test_mail/static/tests/helpers/*',
         ],
+        'web.assets_tests': [
+            'test_mail/static/tests/tours/*',
+        ],
     },
     'installable': True,
     'license': 'LGPL-3',

--- a/addons/test_mail/static/tests/tours/mail_activity_view_tour.js
+++ b/addons/test_mail/static/tests/tours/mail_activity_view_tour.js
@@ -1,0 +1,68 @@
+/* @odoo-module */
+
+import { registry } from "@web/core/registry";
+
+const setPager = value => [
+    {
+        content: "Click Pager",
+        trigger: ".o_pager_value:first()",
+    },
+    {
+        content: "Change pager to display lines " + value,
+        trigger: "input.o_pager_value",
+        run: "text " + value,
+    },
+    {
+        trigger: `.o_pager_value:contains('${value}')`,
+        isCheck: true,
+    },
+]
+
+
+const checkRows = values => {
+    return {
+        trigger: '.o_activity_view',
+        run: () => {
+            const dataRow = document.querySelectorAll('.o_activity_view tbody .o_data_row .o_activity_record');
+            if (dataRow.length !== values.length) {
+                throw Error(`There should be ${values.length} activities`);
+            }
+            values.forEach((value, index) => {
+                if (dataRow[index].textContent !== value) {
+                    throw Error(`Record does not match ${value} != ${dataRow[index]}`);
+                }
+            });
+        }
+    }
+}
+
+registry.category("web_tour.tours").add("mail_activity_view", {
+    test: true,
+    steps: () => [
+        {
+            content: "Open the debug menu",
+            trigger: ".o_debug_manager button",
+        },
+        {
+            content: "Click the Set Defaults menu",
+            trigger: ".o_debug_manager .dropdown-item:contains(Open View)",
+        },
+        {
+            trigger: ".o_searchview_input",
+            run: "text Test Activity View"
+        },
+        {
+            trigger: ".o_menu_item.focus",
+            content: "Validate search",
+        },
+        {
+            content: "Select Test Activity View",
+            trigger: `.o_data_row td:contains("Test Activity View")`,
+        },
+        checkRows(["Task 1", "Task 2", "Task 3"]),
+        ...setPager("1-2"),
+        checkRows(["Task 2", "Task 3"]),
+        ...setPager("3"),
+        checkRows(["Task 1"]),
+    ],
+})


### PR DESCRIPTION
Since 17.0 activity view now has a pager, which is not working at all.

Actually there are two problems fixed in this commit
    - Frontend problem fixed in activity_controller.js
    - Backend problem fixed in mail_activity.py

# First problem:

Steps:
    - Install a module with activity view (`sale_management` for example)
    - Open activity view

Let's say we have 4 records, at the loading of the view a request to
`get_activity_data` with the following domain in the payload
```json
{
   "domain": [
      ["user_id", "=", 2],
      ["activity_ids.active", "in", [true, false]]
   ]
}
```
the response contains for example
```json
{
    "activity_res_ids": [
        3,
        19,
        4,
        7
    ]
}
```
This is correct, the problem comes if we try to "refresh" the view
with the pager, by clicking in the pager's input and press enter
(without changing anything).
Normally it will be exactly the same request as the one above.
But the domain is not the same this time
```json
{
    "domain": [["user_id", "=", 2]]
}
```
Because of this `get_activity_data` returns incorrect data.

To fix this issue we have to do the same thing as here in the pager onUpdate()

https://github.com/odoo/odoo/blob/e11e3ca447fa2997b51a39cefc3457ae411ccb3c/addons/mail/static/src/views/web/activity/activity_model.js#L12

# Second problem:

When the model contains a different order than 'id' `get_activity_data`
can returns incorrect data since we don't specify `order` in `_search`

opw-[3862389](https://www.odoo.com/web#id=3862389&view_type=form&model=project.task)