### PR TITLE
[FIX] l10n_sa_edi: prevent weird characters in ZATCA phone

### DIFF
--- a/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
+++ b/addons/l10n_sa_edi/models/account_edi_xml_ubl_21_zatca.py
@@ -99,7 +99,7 @@ class AccountEdiXmlUBL21Zatca(models.AbstractModel):
     def _get_partner_contact_vals(self, partner):
         res = super()._get_partner_contact_vals(partner)
         if res.get('telephone'):
-            res['telephone'] = res['telephone'].replace(' ', '')
+            res['telephone'] = re.sub(r"[^+\d]", '', res['telephone'])
         return res
 
     def _get_partner_party_identification_vals_list(self, partner):

--- a/addons/l10n_sa_edi/tests/common.py
+++ b/addons/l10n_sa_edi/tests/common.py
@@ -49,7 +49,7 @@ class TestSaEdiCommon(AccountEdiTestCommon):
             'country_id': cls.env.ref('base.us').id,
             'state_id': cls.env['res.country.state'].search([('name', '=', 'California')]).id,
             'email': 'azure.Interior24@example.com',
-            'phone': '(870)-931-0505',
+            'phone': '+1 870-931-0505',
             'company_type': 'company',
             'lang': 'en_US',
         })

--- a/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/credit.xml
@@ -139,7 +139,7 @@
             <cac:Contact>
                 <cbc:ID>340</cbc:ID>
                 <cbc:Name>Chichi Lboukla</cbc:Name>
-                <cbc:Telephone>(870)-931-0505</cbc:Telephone>
+                <cbc:Telephone>+18709310505</cbc:Telephone>
                 <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
             </cac:Contact>
         </cac:Party>

--- a/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/debit.xml
@@ -139,7 +139,7 @@
             <cac:Contact>
                 <cbc:ID>550</cbc:ID>
                 <cbc:Name>Chichi Lboukla</cbc:Name>
-                <cbc:Telephone>(870)-931-0505</cbc:Telephone>
+                <cbc:Telephone>+18709310505</cbc:Telephone>
                 <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
             </cac:Contact>
         </cac:Party>

--- a/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
+++ b/addons/l10n_sa_edi/tests/compliance/standard/invoice.xml
@@ -134,7 +134,7 @@
             <cac:Contact>
                 <cbc:ID>42</cbc:ID>
                 <cbc:Name>Chichi Lboukla</cbc:Name>
-                <cbc:Telephone>(870)-931-0505</cbc:Telephone>
+                <cbc:Telephone>+18709310505</cbc:Telephone>
                 <cbc:ElectronicMail>azure.Interior24@example.com</cbc:ElectronicMail>
             </cac:Contact>
         </cac:Party>


### PR DESCRIPTION
Steps to reproduce:
[phonenumbers]
- Create a customer from Malaysia and add a phone number '123456789' -> it will be formatted '+60 12-345 6789'
- Create an invoice
- Confirm
- Click on Process Now

Issue:
There will be a warning "The Buyer’s contact phone number (BT-57) shall start with “0“ or “+”, followed by a maximum of 15 number and minimum 4 character after the “+“ or “0“ , if exist."

Solution:
Only keep digits and the "+" symbol

note:
The test has changed in order to be more realistic. That is, if I have a foreign contact I will:
- or use/set the correct format manually (if not, it should raise an error from the third-party api)
- or install `phonenumbers` to automatically format it (if not on a saas)

`phone_validation` is in 'auto_intsall' whenever `base` and `mail` are installed (and if the library `phonenumbers` is installed) and works as followed:
```
>>> import phonenumbers
>>> raw_phone = '(870)-931-0505'
>>> parsed_number = phonenumbers.parse(raw_phone, "US")
>>> phonenumbers.format_number(parsed_number, phonenumbers.PhoneNumberFormat.INTERNATIONAL)
'+1 870-931-0505'
```

opw-3912128