### PR TITLE
[FIX] {sale,pos}_loyalty: compute points including discount lines

### DIFF
--- a/addons/pos_loyalty/static/src/js/Loyalty.js
+++ b/addons/pos_loyalty/static/src/js/Loyalty.js
@@ -905,10 +905,9 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                     if (((!line.reward_product_id && (rule.any_product || rule.valid_product_ids.has(line.get_product().id))) ||
                         (line.reward_product_id && (rule.any_product || rule.valid_product_ids.has(line.reward_product_id)))) &&
                         !line.ignoreLoyaltyPoints({ program })){
-                        // We only count reward products from the same program to avoid unwanted feedback loops
-                        if (line.reward_product_id) {
+                        if (line.is_reward_line) {
                             const reward = this.pos.reward_by_id[line.reward_id];
-                            if (program.id !== reward.program_id) {
+                            if ((program.id === reward.program_id.id) || ['gift_card', 'ewallet'].includes(reward.program_id.program_type)) {
                                 continue;
                             }
                         }
@@ -918,8 +917,8 @@ const PosLoyaltyOrder = (Order) => class PosLoyaltyOrder extends Order {
                         } else {
                             qtyPerProduct[line.reward_product_id || line.get_product().id] = lineQty;
                         }
+                        orderedProductPaid += line.get_price_with_tax();
                         if(!line.is_reward_line){
-                            orderedProductPaid += line.get_price_with_tax();
                             totalProductQty += lineQty;
                         }
                     }

--- a/addons/pos_loyalty/static/src/tours/EWalletProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/EWalletProgramTours.js
@@ -122,3 +122,16 @@ ErrorPopup.do.clickConfirm();
 Tour.register('ExpiredEWalletProgramTour', { test: true, url: '/pos/web' }, getSteps());
 
 //#endregion
+
+startSteps();
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer("partner_a");
+PosLoyalty.check.eWalletButtonState({ highlighted: false });
+ProductScreen.exec.addOrderline("product_a", "1");
+PosLoyalty.check.eWalletButtonState({ highlighted: true, text: getEWalletText("Pay") });
+PosLoyalty.do.clickEWalletButton(getEWalletText("Pay"));
+PosLoyalty.check.pointsAwardedAre("100"),
+PosLoyalty.exec.finalizeOrder("Cash", "90.00");
+Tour.register("PosLoyaltyPointsEwallet", { test: true, url: "/pos/web" }, getSteps());

--- a/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
+++ b/addons/pos_loyalty/static/src/tours/GiftCardProgramTours.js
@@ -49,3 +49,21 @@ PosLoyalty.check.orderTotalIs('35.00');
 PosLoyalty.exec.finalizeOrder('Cash', '35');
 Tour.register('GiftCardProgramScanUseTour', { test: true, url: '/pos/web' }, getSteps());
 //#endregion
+
+startSteps();
+ProductScreen.do.confirmOpeningPopup();
+ProductScreen.do.clickHomeCategory();
+ProductScreen.do.clickDisplayedProduct('Gift Card');
+TextInputPopup.check.isShown();
+TextInputPopup.do.inputText('044123456');
+TextInputPopup.do.clickConfirm();
+PosLoyalty.check.orderTotalIs('50.00');
+PosLoyalty.exec.finalizeOrder('Cash', '50');
+ProductScreen.do.clickPartnerButton();
+ProductScreen.do.clickCustomer("partner_a");
+ProductScreen.exec.addOrderline("product_a", "1");
+PosLoyalty.do.enterCode("044123456");
+PosLoyalty.check.orderTotalIs("50.00");
+PosLoyalty.check.pointsAwardedAre("100"),
+PosLoyalty.exec.finalizeOrder("Cash", "50");
+Tour.register("PosLoyaltyPointsGiftcard", { test: true, url: "/pos/web" }, getSteps());

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTour.js
@@ -359,3 +359,43 @@ ProductScreen.check.selectedOrderlineHas('Product A', '2.00', '40.00');
 PosLoyalty.check.orderTotalIs('66.00');
 
 Tour.register('PosLoyaltyMinAmountAndSpecificProductTour', {test: true, url: '/pos/web'}, getSteps());
+
+function createOrderCoupon(totalAmount, couponName, couponAmount, loyaltyPoints) {
+    return [
+        ProductScreen.do.confirmOpeningPopup(),
+        ProductScreen.do.clickHomeCategory(),
+        ProductScreen.do.clickPartnerButton(),
+        ProductScreen.do.clickCustomer("partner_a"),
+        ProductScreen.exec.addOrderline("product_a", "1"),
+        ProductScreen.exec.addOrderline("product_b", "1"),
+        PosLoyalty.do.enterCode("promocode"),
+        PosLoyalty.check.hasRewardLine(`${couponName}`, `${couponAmount}`),
+        PosLoyalty.check.orderTotalIs(`${totalAmount}`),
+        PosLoyalty.check.pointsAwardedAre(`${loyaltyPoints}`),
+        PosLoyalty.exec.finalizeOrder("Cash", `${totalAmount}`),
+    ];
+}
+
+startSteps();
+createOrderCoupon("135.00", "10% on your order", "-15.00", "135");
+Tour.register("PosLoyaltyPointsDiscountNoDomainProgramNoDomain", { test: true, url: "/pos/web" }, getSteps());
+
+startSteps();
+createOrderCoupon("135.00", "10% on your order", "-15.00", "100");
+Tour.register("PosLoyaltyPointsDiscountNoDomainProgramDomain", { test: true, url: "/pos/web" }, getSteps());
+
+startSteps();
+createOrderCoupon("140.00", "10% on food", "-10.00", "90");
+Tour.register("PosLoyaltyPointsDiscountWithDomainProgramDomain", { test: true, url: "/pos/web" }, getSteps());
+
+startSteps();
+ProductScreen.do.confirmOpeningPopup(),
+ProductScreen.do.clickHomeCategory(),
+ProductScreen.do.clickPartnerButton(),
+ProductScreen.do.clickCustomer("partner_a"),
+ProductScreen.exec.addOrderline("product_a", "1"),
+PosLoyalty.check.hasRewardLine('10% on your order', '-10.00');
+PosLoyalty.check.orderTotalIs('90'),
+PosLoyalty.check.pointsAwardedAre("90"),
+PosLoyalty.exec.finalizeOrder("Cash", "90"),
+Tour.register("PosLoyaltyPointsGlobalDiscountProgramNoDomain", { test: true, url: "/pos/web" }, getSteps());

--- a/addons/pos_loyalty/static/src/tours/PosLoyaltyTourMethods.js
+++ b/addons/pos_loyalty/static/src/tours/PosLoyaltyTourMethods.js
@@ -165,6 +165,15 @@ odoo.define('pos_loyalty.tour.PosCouponTourMethods', function (require) {
                 }
             ]
         }
+        pointsAwardedAre(points_str) {
+            return [
+                {
+                    content: 'loyalty points awarded ' + points_str,
+                    trigger: '.loyalty-points-won .value:contains("' + points_str + '")',
+                    run: function () {}, // it's a check
+                },
+            ];
+        }
     }
 
     class Execute {

--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1643,3 +1643,275 @@ class TestUi(TestPointOfSaleHttpCommon):
 
         self.assertTrue(loyalty_card)
         self.assertFalse(loyalty_card.points)
+
+    def test_points_awarded_global_discount_code_no_domain_program(self):
+        """
+        Check the calculation for points awarded when there is a global discount applied and the
+        loyalty program applies on all product (no domain).
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.product_a.write({
+            'list_price': 100,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        self.auto_promo_program_next.applies_on = 'current'
+        self.auto_promo_program_next.active = True
+
+        loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': self.partner_a.id,
+            'points': 0,
+        })
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyPointsGlobalDiscountProgramNoDomain",
+            login="accountman",
+        )
+        self.assertEqual(loyalty_card.points, 90)
+
+    def test_points_awarded_discount_code_no_domain_program(self):
+        """
+        Check the calculation for points awarded when there is a discount coupon applied and the
+        loyalty program applies on all product (no domain).
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.product_a.write({
+            'list_price': 100,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+        self.product_b.write({
+            'list_price': 50,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+        loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        loyalty_program.pos_config_ids = [Command.link(self.main_pos_config.id)]
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': self.partner_a.id,
+            'points': 0,
+        })
+
+        self.code_promo_program.active = True
+        self.code_promo_program.reward_ids.write(
+            {
+                'description': '10% on your order',
+                'discount': 10,
+                'discount_applicability': 'order',
+                'discount_product_ids': None
+            })
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyPointsDiscountNoDomainProgramNoDomain",
+            login="accountman",
+        )
+        self.assertEqual(loyalty_card.points, 135)
+
+    def test_points_awarded_general_discount_code_specific_domain_program(self):
+        """
+        Check the calculation for points awarded when there is a discount coupon applied and the
+        loyalty program applies on a sepcific domain. The discount code has no domain. The product
+        related to that discount is not in the domain of the loyalty program.
+        Expected behavior: The discount is not included in the computation of points
+        """
+        product_category_base = self.env.ref('product.product_category_1')
+        product_category_food = self.env['product.category'].create({
+            'name': 'Food',
+            'parent_id': product_category_base.id
+        })
+
+        self.env['loyalty.program'].search([]).write({'active': False})
+
+        self.product_a.write({
+            'list_price': 100,
+            'available_in_pos': True,
+            'taxes_id': False,
+            'categ_id': product_category_food.id,
+        })
+        self.product_b.write({
+            'list_price': 50,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        loyalty_program.rule_ids.product_category_id = product_category_food.id
+        loyalty_program.pos_config_ids = [Command.link(self.main_pos_config.id)]
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': self.partner_a.id,
+            'points': 0,
+        })
+
+        self.code_promo_program.active = True
+        self.code_promo_program.reward_ids.write(
+            {
+                'description': '10% on your order',
+                'discount': 10,
+                'discount_applicability': 'order',
+                'discount_product_ids': None
+            })
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyPointsDiscountNoDomainProgramDomain",
+            login="accountman",
+        )
+        self.assertEqual(loyalty_card.points, 100)
+
+    def test_points_awarded_specific_discount_code_specific_domain_program(self):
+        """
+        Check the calculation for points awarded when there is a discount coupon applied and the
+        loyalty program applies on a sepcific domain. The discount code has the same domain as the
+        loyalty program. The product related to that discount code is set up to be included in the
+        domain of the loyalty program.
+        """
+        product_category_base = self.env.ref('product.product_category_1')
+        product_category_food = self.env['product.category'].create({
+            'name': 'Food',
+            'parent_id': product_category_base.id
+        })
+
+        self.env['loyalty.program'].search([]).write({'active': False})
+
+        self.product_a.write({
+            'list_price': 100,
+            'available_in_pos': True,
+            'taxes_id': False,
+            'categ_id': product_category_food.id,
+        })
+        self.product_b.write({
+            'list_price': 50,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        loyalty_program.rule_ids.product_category_id = product_category_food.id
+        loyalty_program.pos_config_ids = [Command.link(self.main_pos_config.id)]
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': self.partner_a.id,
+            'points': 0,
+        })
+
+        self.code_promo_program.active = True
+        self.code_promo_program.reward_ids.write(
+            {
+                'description': '10% on your order',
+                'discount': 10,
+                'discount_product_ids': None,
+                'discount_product_category_id': product_category_food.id,
+            })
+
+        discount_product = self.env['product.product'].search([('id', '=', self.code_promo_program.reward_ids.discount_line_product_id.id)])
+        discount_product.categ_id = product_category_food.id
+        discount_product.name = "10% on food"
+        discount_product.available_in_pos = True
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyPointsDiscountWithDomainProgramDomain",
+            login="accountman",
+        )
+        self.assertEqual(loyalty_card.points, 90)
+
+    def test_points_awarded_ewallet(self):
+        """
+        Check the calculation for point awarded when using ewallet
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.product_a.write({
+            'list_price': 100,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        loyalty_program.pos_config_ids = [Command.link(self.main_pos_config.id)]
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': self.partner_a.id,
+            'points': 0,
+        })
+
+        ewallet_program = self.env['loyalty.program'].create({
+            'name': 'eWallet Program',
+            'program_type': 'ewallet',
+            'trigger': 'auto',
+            'applies_on': 'future',
+            'reward_ids': [Command.create({
+                'reward_type': 'discount',
+                'discount_mode': 'per_point',
+                'discount': 1,
+            })],
+            'rule_ids': [Command.create({
+                'reward_point_amount': '1',
+                'reward_point_mode': 'money',
+                'product_ids': self.env.ref('loyalty.ewallet_product_50'),
+            })],
+            'trigger_product_ids': self.env.ref('loyalty.ewallet_product_50'),
+        })
+
+        self.env['loyalty.card'].create({
+            'program_id': ewallet_program.id,
+            'partner_id': self.partner_a.id,
+            'points': 10,
+        })
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyPointsEwallet",
+            login="accountman",
+        )
+        self.assertEqual(loyalty_card.points, 100)
+
+    def test_points_awarded_giftcard(self):
+        """
+        Check the calculation for point awarded when using a gift card
+        """
+        self.env['loyalty.program'].search([]).write({'active': False})
+        self.env.ref('loyalty.gift_card_product_50').write({'active': True})
+        # Create gift card program
+        gift_card_program = self.create_programs([('arbitrary_name', 'gift_card')])['arbitrary_name']
+        # Change the gift card program settings
+        self.main_pos_config.write({'gift_card_settings': 'scan_use'})
+        # Generate 50$ gift card.
+        self.env["loyalty.generate.wizard"].with_context(
+            {"active_id": gift_card_program.id}
+        ).create({"coupon_qty": 1, 'points_granted': 50}).generate_coupons()
+        # Change the code of the gift card.
+        gift_card_program.coupon_ids.code = '044123456'
+
+        self.product_a.write({
+            'list_price': 100,
+            'available_in_pos': True,
+            'taxes_id': False,
+        })
+
+        loyalty_program = self.create_programs([('Loyalty P', 'loyalty')])['Loyalty P']
+        loyalty_program.pos_config_ids = [Command.link(self.main_pos_config.id)]
+        loyalty_card = self.env['loyalty.card'].create({
+            'program_id': loyalty_program.id,
+            'partner_id': self.partner_a.id,
+            'points': 0,
+        })
+
+        self.main_pos_config.open_ui()
+        self.start_tour(
+            "/pos/web?config_id=%d" % self.main_pos_config.id,
+            "PosLoyaltyPointsGiftcard",
+            login="accountman",
+        )
+        self.assertEqual(loyalty_card.points, 100)

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -942,8 +942,17 @@ class SaleOrder(models.Model):
                         points += rule.reward_point_amount
                     elif rule.reward_point_mode == 'money':
                         # Compute amount paid for rule
-                        # NOTE: this does not account for discounts -> 1 point per $ * (100$ - 30%) will result in 100 points
-                        amount_paid = sum(max(0, line.price_total) for line in order_lines if line.product_id in rule_products)
+                        # NOTE: this accounts for discounts -> 1 point per $ * (100$ - 30%) will
+                        # result in 70 points
+                        amount_paid = 0.0
+                        rule_products = so_products_per_rule.get(rule, [])
+                        for line in self.order_line - self._get_no_effect_on_threshold_lines():
+                            if line.reward_id.program_id.program_type in [
+                                'ewallet', 'gift_card', program.program_type
+                            ]:
+                                continue
+                            amount_paid += line.price_total if line.product_id in rule_products else 0.0
+
                         points += float_round(rule.reward_point_amount * amount_paid, precision_digits=2, rounding_method='DOWN')
                     elif rule.reward_point_mode == 'unit':
                         points += rule.reward_point_amount * ordered_rule_products_qty


### PR DESCRIPTION
Currently when applying a coupon for 10% on the order on the current order, the points awarded are 100% of the points instead of 90%. The loyalty program rewarding x points per $ spent.

The same behavior is also observed in the sale worflow.

Steps to reproduce:
-------------------
* Go to the **Point of Sale** App
* Open shop session
* Select a customer
* Add a product (ex. Office chair 70$)
* Select **Enter Code**
* Enter the code `10pc`
> Observation: The order will grant 700 points instead of 630. The amount paid is 63$ with the code for 10% on the order.

Settings of the **Discount & Loyalties**:
* **Code for 10% on orders**
  * Rule: 
    * `Among` -> no restriction set 
    * `Minimum quantity`: 1 
    * `Minimum Purchase`: 0
  * Reward:
    * `Discount`: 10% `on` order
* **Loyalty Program**
  * `Use points on`: Current & Future orders
  * Rule:
    * `Among` -> no restriction set
    * `Minimum quantity`: 1 
    * `Minimum Purchase`: 0 
    * `Grant` 10 loyalty poins per $ spent

Idea of the fix
---------------
As discussed with DALA, discount should count toward points awarded. Here is how it should apply:
* If program_rule has no domain, all lines should count (except ewallet & gift cards)
* If program_rule has a domain, we should use all the lines where the product matches the domain (except ewallet & gift cards)

This applies for the computation of points based on the money spent.

Why the fix:
------------
https://github.com/odoo/odoo/blob/2f6f8014f79e1db53d6c4c27e0cc60ccd48fd301/addons/sale_loyalty/models/sale_order.py#L917

Sale-wise, we replace `rule_products` with `so_products_per_rule.get(rule, [])`. We also replace `order_lines` by `lines_per_rule`.
* `rule_products` don't include discounts as they are computed on `order_lines` (all lines that are not reward lines). https://github.com/odoo/odoo/blob/2f6f8014f79e1db53d6c4c27e0cc60ccd48fd301/addons/sale_loyalty/models/sale_order.py#L834-L841 https://github.com/odoo/odoo/blob/2f6f8014f79e1db53d6c4c27e0cc60ccd48fd301/addons/sale_loyalty/models/sale_order.py#L889
* `so_products_per_rule` will include the discounts if they match with the program's domain.
https://github.com/odoo/odoo/blob/2f6f8014f79e1db53d6c4c27e0cc60ccd48fd301/addons/sale_loyalty/models/sale_order.py#L844
* We don't need to exclude the free product reward lines from `lines_for_points` as the price is 0 on the SO. Shipping lines and free shipping rewards are not counted.

In pos, the fix is a bit different.

https://github.com/odoo/odoo/blob/4b9dee8fbe9aefde798c8543fef89c661cc85c57/addons/pos_loyalty/static/src/js/Loyalty.js#L908-L914

We first notice that this piece of code is never triggered as the structure of `program.id` is a number and `reward.program_id` is the following thus the last if statement is never true. A `.id` is added.
```
Proxy(Object) {id: 1, name: 'Code for 10% on orders', trigger: 'with_code', applies_on: 'current', program_type: 'promo_code', …}
```

This now means that we only count reward lines if they are from the same program. 

With the following if statement, it means that only the lines that are not reward lines are counted (which excludes discounts).

https://github.com/odoo/odoo/blob/eadfa4ee290a8b62956097aa66989eacff230275/addons/pos_loyalty/static/src/js/Loyalty.js#L921-L924

We conclude that those two ifs must be changed as we want a similar behavior as the workflow in sales.

We remove `orderedProductPaid` out of the if statement since it can be impacted by reward lines. We change the first if to excludes the reward lines only from the current program or from ewallet and giftcards. With this, `orderedProductPaid` now counts the discount lines from other program. (Similar to sales, where `amount_paid` is computed with `lines_per_rule`)

`totalProductQty` still applies only on non reward lines. (Same as sales)

opw-3858286