### PR TITLE
[FIX] pos_sale: cancel all transfers after settling order

### DIFF
--- a/addons/pos_sale/models/pos_order.py
+++ b/addons/pos_sale/models/pos_order.py
@@ -95,7 +95,7 @@ class PosOrder(models.Model):
                     new_qty = 0
                 stock_move.product_uom_qty = so_line.compute_uom_qty(new_qty, stock_move, False)
                 # If the product is delivered with more than one step, we need to update the quantity of the other steps
-                for move in so_line_stock_move_ids.filtered(lambda m: m.state in ['waiting', 'confirmed'] and m.product_id == stock_move.product_id):
+                for move in so_line_stock_move_ids.filtered(lambda m: m.state in ['waiting', 'confirmed', 'assigned'] and m.product_id == stock_move.product_id):
                     move.product_uom_qty = stock_move.product_uom_qty
                     waiting_picking_ids.add(move.picking_id.id)
                 waiting_picking_ids.add(picking.id)

--- a/addons/pos_sale/tests/test_pos_sale_flow.py
+++ b/addons/pos_sale/tests/test_pos_sale_flow.py
@@ -276,6 +276,8 @@ class TestPoSSale(TestPointOfSaleHttpCommon):
             'type': 'product',
             'lst_price': 10.0,
         })
+        self.env['stock.quant']._update_available_quantity(product_a, warehouse.lot_stock_id, 1)
+
         #create a sale order with 2 lines
         sale_order = self.env['sale.order'].create({
             'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,


### PR DESCRIPTION
## Steps to reproduce:
- Install POS app
- Change the warehouse to a 2-step delivery method
- Create a sales order for a product and confirm
- Ensure the product is reserved for the picking transfer **as** the issue doesn't exist (all transfers are successfully cancelled) if there are no products reserved
- Go to POS and settle the sales order
- The delivery transfer is cancelled but the picking transfer (with product reserved) is not cancelled. although all transfers should be cancelled if the order is fully delivered!

## Investigation:
- When the product is already reserved, the picking transfer is in the **Ready/assigned** state
- When updating the steps, the **Ready/assigned** state is not taken into consideration and so the picking transfer is not updated to be **cancelled**

opw-3474929