### PR TITLE
[FIX] base_vat: block wrong vat number in frontend

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -180,7 +180,7 @@ class ResPartner(models.Model):
 
         # Get check function: either simple syntactic check or call to VIES service
         eu_countries = self.env.ref('base.europe').country_ids
-        if company.vat_check_vies and default_country in eu_countries and partner_is_company:
+        if company.vat_check_vies and default_country in eu_countries and (partner_is_company or self.env.context.get('website_id')):
             check_func = self.vies_vat_check
         else:
             check_func = self.simple_vat_check


### PR DESCRIPTION
When creating a user from the frontend, we don't
perform the check with VIES service, even if the option
is enabled.

- Install ecommerce
- With a Belgian Company, enable the option `vat_check_vies`
- From the eshop, create a user from Portugal with
  VAT number PT123456789
-> The form is validated even if the vies check fails, it should be
   blocked.

opw-3806961
