### PR TITLE
[FIX] {website_,}sale: remove attribute in name of sol if useless

### DIFF
--- a/addons/sale/models/sale_order_line.py
+++ b/addons/sale/models/sale_order_line.py
@@ -860,13 +860,13 @@ class SaleOrderLine(models.Model):
         :return: the description related to special variant attributes/values
         :rtype: string
         """
-        if not self.product_custom_attribute_value_ids and not self.product_no_variant_attribute_value_ids:
-            return ""
-
-        name = "\n"
-
         custom_ptavs = self.product_custom_attribute_value_ids.custom_product_template_attribute_value_id
         no_variant_ptavs = self.product_no_variant_attribute_value_ids._origin
+        if not self.product_custom_attribute_value_ids and len(no_variant_ptavs - custom_ptavs) <= 1:
+            return ""
+        no_variant_ptavs = no_variant_ptavs[:0] if len(no_variant_ptavs - custom_ptavs) <= 1 else no_variant_ptavs
+
+        name = "\n"
 
         # display the no_variant attributes, except those that are also
         # displayed by a custom (avoid duplicate description)

--- a/addons/sale_product_matrix/static/tests/tours/sale_product_matrix_tour.js
+++ b/addons/sale_product_matrix/static/tests/tours/sale_product_matrix_tour.js
@@ -51,7 +51,7 @@ tour.register('sale_matrix_tour', {
     // wait for qty to be 1 => check the total to be sure all qties are set to 1
     extra_trigger: '.oe_subtotal_footer_separator:contains("248.40")',
 }, {
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
+    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)")',
     extra_trigger: '.o_form_editable',
 }, {
     trigger: '.o_edit_product_configuration',  // edit the matrix
@@ -80,7 +80,7 @@ tour.register('sale_matrix_tour', {
     // wait for qty to be changed => check the total to be sure all qties are set to 3
     extra_trigger: '.oe_subtotal_footer_separator:contains("745.20")',
 }, {
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
+    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)")',
     extra_trigger: '.o_form_editable',
 }, {
     trigger: '.o_edit_product_configuration',
@@ -103,7 +103,7 @@ tour.register('sale_matrix_tour', {
 {
     trigger: '.o_form_button_edit:contains("Edit")',   // Edit Sales Order.
 }, {
-    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)\n\nPA4: PAV41")',
+    trigger: 'span:contains("Matrix (PAV11, PAV22, PAV31)")',
     extra_trigger: '.o_form_editable',
 }, {
     trigger: '.o_edit_product_configuration',  // edit the matrix

--- a/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
+++ b/addons/website_sale/static/tests/tours/website_sale_shop_no_variant_attribute.js
@@ -25,12 +25,6 @@ tour.register('tour_shop_no_variant_attribute', {
     },
         tourUtils.goToCart(),
     {
-        content: "check no_variant value is present",
-        trigger: '.td-product_name:contains(No Variant Attribute: No Variant Value)',
-        extra_trigger: '#cart_products',
-        run: function () {},
-    },
-    {
         content: "check price is correct",
         trigger: '.td-price:contains(11.0)',
         run: function () {},

--- a/addons/website_sale_product_configurator/static/tests/tours/website_sale_variants_modal_window.js
+++ b/addons/website_sale_product_configurator/static/tests/tours/website_sale_variants_modal_window.js
@@ -58,10 +58,6 @@ odoo.define('website_sale.tour_variants_modal_window', function (require) {
             trigger: 'td.td-product_name:contains(M dynamic)',
         },
         {
-            content: "Check never variant",
-            trigger: 'td.td-product_name:contains(Never attribute size: M never)',
-        },
-        {
             content: "Check never custom variant",
             trigger: 'td.td-product_name:contains(Never attribute size custom: Yes never custom: TEST)',
         }

--- a/addons/website_sale_product_configurator/tests/test_website_sale_configurator.py
+++ b/addons/website_sale_product_configurator/tests/test_website_sale_configurator.py
@@ -142,4 +142,4 @@ class TestWebsiteSaleProductConfigurator(TestProductConfiguratorCommon, HttpCase
         # Check the name of the created sale order line
         new_sale_order = self.env['sale.order'].search([]) - old_sale_order
         new_order_line = new_sale_order.order_line
-        self.assertEqual(new_order_line.name, 'Short (TEST) (M always, M dynamic)\n\nNever attribute size: M never\nNever attribute size custom: Yes never custom: TEST')
+        self.assertEqual(new_order_line.name, 'Short (TEST) (M always, M dynamic)\n\nNever attribute size custom: Yes never custom: TEST')


### PR DESCRIPTION
Steps to reproduce:
- Install eCommerce
- Make a product
- Make an attribute for that product, 'Variants Creation Mode' should be 'Never'
- Order the product through the website and print the invoice

Issues:
The description contains the variant even though this information isn't needed since the product has one variant. This reproduce the behaviour which is observed in the sales app.
POs were consulted to confirm that this is the wanted behaviour

opw-3864115