### PR TITLE
[FIX] Spanish certificate not been submitted

### DIFF
--- a/doc/cla/corporate/nersis.md
+++ b/doc/cla/corporate/nersis.md
@@ -1,0 +1,15 @@
+Spain, 2024-05-09
+
+Nersis Solutions agrees to the terms of the Odoo Corporate Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Alejandro avaltierra@nersis.es https://github.com/avaltierrab
+
+List of contributors:
+
+Alejandro avaltierra@nersis.es https://github.com/avaltierrab


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Fix the error None field by checking the certificates field

Current behavior before PR: Using an spanish certificate in res.company (field -> l10n_es_edi_facturae_certificate_id) returns error none field. When trying to save the changes you get the error:
RPC_ERROR Odoo Server Error Traceback (most recent call last): File "/home/odoo/src/odoo/17.0/odoo/http.py", line 1765, in _serve_db return service_model.retrying(self._serve_ir_http, self.env) File "/home/odoo/src/odoo/17.0/odoo/service/model.py", line 133, in retrying result = func() File "/home/odoo/src/odoo/17.0/odoo/http.py", line 1792, in _serve_ir_http response = self.dispatcher.dispatch(rule.endpoint, args) File "/home/odoo/src/odoo/17.0/odoo/http.py", line 1996, in dispatch result = self.request.registry['ir.http']._dispatch(endpoint) File "/home/odoo/src/odoo/17.0/odoo/addons/base/models/ir_http.py", line 222, in _dispatch result = endpoint(**request.params) File "/home/odoo/src/odoo/17.0/odoo/http.py", line 722, in route_wrapper result = endpoint(self, *args, **params_ok) File "/home/odoo/src/odoo/17.0/addons/web/controllers/dataset.py", line 24, in call_kw return self._call_kw(model, method, args, kwargs) File "/home/odoo/src/odoo/17.0/addons/web/controllers/dataset.py", line 20, in _call_kw return call_kw(request.env[model], method, args, kwargs) File "/home/odoo/src/odoo/17.0/odoo/api.py", line 468, in call_kw result = _call_kw_multi(method, model, args, kwargs) File "/home/odoo/src/odoo/17.0/odoo/api.py", line 453, in _call_kw_multi result = method(recs, *args, **kwargs) File "/home/odoo/src/odoo/17.0/addons/web/models/models.py", line 73, in web_save self = self.create(vals) File "", line 2, in create File "/home/odoo/src/odoo/17.0/odoo/api.py", line 414, in _model_create_multi return create(self, [arg]) File "/home/odoo/src/odoo/17.0/addons/l10n_es_edi_facturae/models/l10n_es_edi_facturae_certificate.py", line 54, in create if fields.datetime.now() > certif.not_valid_after: AttributeError: 'NoneType' object has no attribute 'not_valid_after'

Desired behavior after PR is merged: Save the certificate.



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
