### PR TITLE
[FIX] l10n_es_pos: don't generate pdf for simplified invoices

### DIFF
--- a/addons/l10n_es_pos/static/src/overrides/models/pos_store.js
+++ b/addons/l10n_es_pos/static/src/overrides/models/pos_store.js
@@ -14,4 +14,17 @@ patch(PosStore.prototype, {
         }
         return result;
     },
+
+    _getCreateOrderContext(orders, options) {
+        let context = super._getCreateOrderContext(...arguments);
+        if (this.config.is_spanish) {
+            const noOrderRequiresInvoicePrinting = orders.every(
+                (order) => !order.to_invoice && order.data.is_l10n_es_simplified_invoice
+            );
+            if (noOrderRequiresInvoicePrinting) {
+                context = { ...context, generate_pdf: false };
+            }
+        }
+        return context;
+    },
 });


### PR DESCRIPTION
## Analysis
In case it's a simplified invoice, the 'to_invoice' is automatically set to True if a corresponding journal is set. Simplified invoices then generates a PDF which takes a few seconds to generate (using wkhtmltopdf) and slow downs the user experience. 

## Fix
This commit avoids generating the PDF in case no orders explicitly require an invoice. It mostly works the same as this commit for the Chilean localization: https://github.com/odoo/enterprise/pull/53655 which introduced a new context parameter (in the related commit: https://github.com/odoo/odoo/pull/148159).


### References
opw-3875944

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr