### PR TITLE
[FIX] website_sale_loyalty: multi products reward

### DIFF
--- a/addons/website/tools.py
+++ b/addons/website/tools.py
@@ -89,7 +89,8 @@ def MockRequest(
         match.side_effect = NotFound
 
     def update_context(**overrides):
-        request.context = dict(request.context, **overrides)
+        request.env = request.env(context=dict(request.context, **overrides))
+        request.context = request.env.context
 
     request.update_context = update_context
 

--- a/addons/website_sale_loyalty/controllers/main.py
+++ b/addons/website_sale_loyalty/controllers/main.py
@@ -90,8 +90,13 @@ class WebsiteSale(main.WebsiteSale):
             if reward_id in rewards:
                 coupon_id = coupon
         redirect = post.get('r', '/shop/cart')
-        if not coupon_id or not reward_id.exists() or reward_id.multi_product:
+        if not coupon_id or not reward_id.exists():
             return request.redirect(redirect)
+        if reward_id.multi_product and 'product_id' in post:
+            request.update_context(product_id=int(post['product_id']))
+        else:
+            request.redirect(redirect)
+
         self._apply_reward(order, reward_id, coupon_id)
         return request.redirect(redirect)
 
@@ -101,8 +106,10 @@ class WebsiteSale(main.WebsiteSale):
         :returns: whether the reward was successfully applied
         :rtype: bool
         """
+        product_id = request.env.context.get('product_id')
+        product = product_id and request.env['product.product'].sudo().browse(product_id)
         try:
-            reward_status = order._apply_program_reward(reward, coupon)
+            reward_status = order._apply_program_reward(reward, coupon, product=product)
         except UserError as e:
             request.session['error_promo_code'] = str(e)
             return False

--- a/addons/website_sale_loyalty/tests/__init__.py
+++ b/addons/website_sale_loyalty/tests/__init__.py
@@ -2,3 +2,4 @@ from . import test_apply_pending_coupon
 from . import test_sale_coupon_multiwebsite
 from . import test_shop_sale_coupon
 from . import test_free_product_reward
+from . import test_shop_multi_reward

--- a/addons/website_sale_loyalty/tests/test_shop_multi_reward.py
+++ b/addons/website_sale_loyalty/tests/test_shop_multi_reward.py
@@ -1,0 +1,69 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details
+
+from odoo.fields import Command
+from odoo.tests import TransactionCase, tagged
+
+from odoo.addons.website.tools import MockRequest
+from odoo.addons.website_sale_loyalty.controllers.main import WebsiteSale
+
+
+@tagged('post_install', '-at_install')
+class TestClaimReward(TransactionCase):
+
+    def test_claim_reward_with_multi_product(self):
+        WebsiteSaleController = WebsiteSale()
+
+        tag = self.env['product.tag'].create({
+            'name': 'multi reward',
+        })
+
+        product1, product2 = self.env['product.product'].create([
+            {
+            'name': 'Test Product',
+            'list_price': 10.0,
+            'product_tag_ids': tag,
+        }, {
+            'name': 'Test Product 2',
+            'list_price': 20.0,
+            'product_tag_ids': tag,
+        }])
+
+        partner = self.env['res.partner'].create({
+            'name': 'Test Customer',
+            'email': 'test@example.com',
+        })
+
+        promo_program = self.env['loyalty.program'].create({
+            'name': 'Free Products',
+            'program_type': 'promotion',
+            'applies_on': 'current',
+            'trigger': 'auto',
+            'rule_ids': [Command.create({
+                'minimum_qty': 1,
+                'minimum_amount': 0.00,
+                'reward_point_amount': 3,
+            })],
+            'reward_ids': [Command.create({
+                'reward_type': 'product',
+                'reward_product_tag_id': tag.id,
+                'reward_product_qty': 1,
+                'required_points': 1,
+            })]
+        })
+
+        website = self.env['website'].browse(1)
+        order = self.env['sale.order'].create({
+            'website_id': website.id,
+            'partner_id': partner.id,
+            'order_line': [Command.create({
+                'product_id': product1.id,
+                'product_uom_qty': 1,
+            })],
+        })
+        order._update_programs_and_rewards()
+        with MockRequest(self.env, website=website, sale_order_id=order.id):
+
+            WebsiteSaleController.claim_reward(promo_program.reward_ids[:1].id, product_id=str(product2.id))
+
+            self.assertEqual(len(order.order_line), 2, 'reward line should be added to order')
+            self.assertEqual(order.order_line[1].product_id, product2, 'added reward line should should contain product 2')

--- a/addons/website_sale_loyalty/views/website_sale_templates.xml
+++ b/addons/website_sale_loyalty/views/website_sale_templates.xml
@@ -36,8 +36,28 @@
                                         <input type="hidden" name="reward" t-att-value="reward.id"/>
                                         <div class="alert alert-success text-start mt16" role="alert">
                                             <div class="d-flex flex-row">
-                                                <div class="flex-grow-1">
+                                                <div class="flex-grow-1 text-break">
                                                     <strong t-esc="reward.description"/>
+                                                    <div t-if="reward.reward_type == 'product'"
+                                                        class="mt-1 pe-3"
+                                                    >
+                                                        <select
+                                                            t-if="reward.multi_product"
+                                                            class="o_select w-100 form-select form-select-sm css_attribute_select"
+                                                            name="product_id"
+                                                        >
+                                                            <option
+                                                                t-foreach="reward.reward_product_ids"
+                                                                t-as="product"
+                                                                t-att-value="product.id"
+                                                            >
+                                                                <t t-out="product.display_name"/>
+                                                            </option>
+                                                        </select>
+                                                        <t t-else="">
+                                                            <t t-esc="reward.reward_product_ids.display_name"/>
+                                                        </t>
+                                                    </div>
                                                     <div t-if="reward.program_id.portal_visible">
                                                         <t t-set="coupon" t-value="coupon_reward[0]"/>
                                                         <t t-if="not reward.program_id.is_nominative">


### PR DESCRIPTION
Steps to reproduce:
    Create 2 products with a product tag (ex. '3+1')
    Create Buy X Get Y reward.
    In the conditional rules choose:
    - in the 'among' section the product tag '3+1',
    - in the 'grant' 1 point per unit paid
    In the rewards choose:
    - reward type as 'Free product'
    - in exchage of 3 points
    - in the 'among' section the product tag '3+1'
    Go to /shop page and add 3 products with the tag '3+1'
    Try to click on the button 'Free product'
    The reward is not applied

Reason:
In the claim_reward function a reward is not applied if it is a multi_product one.

Fix:
added a dropdown on template that will allow user to select product. the selected product will be sent to backend and processed in claim_reward function

Task : 3774033

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
