### PR TITLE
[IMP] website: remove conditional rendering and change redirect message

### DIFF
--- a/addons/website/static/src/components/dialog/page_properties.js
+++ b/addons/website/static/src/components/dialog/page_properties.js
@@ -42,7 +42,6 @@ export class PageDependencies extends Component {
         );
         this.state = useState({
             dependencies: {},
-            depText: "...",
         });
     }
 
@@ -52,11 +51,6 @@ export class PageDependencies extends Component {
             'search_url_dependencies',
             [this.props.resModel, this.props.resIds],
         );
-        if (this.props.mode === 'popover') {
-            this.state.depText = Object.entries(this.state.dependencies)
-                .map(dependency => `${dependency[1].length} ${dependency[0].toLowerCase()}`)
-                .join(', ');
-        }
     }
 
     showDependencies() {

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -20,18 +20,9 @@
             <t t-set="depTemplate">
                 <t t-call="{{ constructor.popoverTemplate }}"/>
             </t>
-            <t t-if="props.type === 'key'">
-                <div t-att-data-bs-template="depTemplate" data-bs-html="true" title="Dependencies" t-ref="action">
-                    It looks like your file is being called by
-                    <a href="#" t-on-click="showDependencies"><t t-esc="depText" /></a>.
-                    Changing its name will break these calls.
-                </div>
-            </t>
-            <t t-else="">
-                <div t-att-data-bs-template="depTemplate" data-bs-html="true" title="Dependencies" t-ref="action">
-                    (could be used in <a href="#" t-on-click="showDependencies"><t t-esc="state.depText" /></a>)
-                </div>
-            </t>
+            <div t-att-data-bs-template="depTemplate" data-bs-html="true" title="Dependencies" t-ref="action">
+                (could be used in <a href="#" t-on-click="showDependencies"><t t-esc="state.depText" /></a>)
+            </div>
         </t>
         <t t-else="">
             <p class="text-warning">We found these ones:</p>

--- a/addons/website/static/src/components/dialog/page_properties.xml
+++ b/addons/website/static/src/components/dialog/page_properties.xml
@@ -21,7 +21,7 @@
                 <t t-call="{{ constructor.popoverTemplate }}"/>
             </t>
             <div t-att-data-bs-template="depTemplate" data-bs-html="true" title="Dependencies" t-ref="action">
-                (could be used in <a href="#" t-on-click="showDependencies"><t t-esc="state.depText" /></a>)
+                Could be used in many places, see here: <a href="#" t-on-click="showDependencies">Dependencies</a>
             </div>
         </t>
         <t t-else="">


### PR DESCRIPTION
Previously, the redirect message was conditionally rendered based on the "type" prop of PageDependencies. However, in commit [1] the "type" prop and its related code were removed, causing the if condition to be useless. This commit [2] removes the if condition and directly renders the redirect message, removing unnecessary code.

Also, the redirect message used to occupy too much space displaying comma-separated dependencies. in commit [3] we have replaced the comma-separated dependencies with the "Dependencies" keyword. we have also removed the associated code responsible for making the comma-separated dependencies from the codebase entirely.

[1]: https://github.com/odoo/odoo/commit/6a60a62372e0fe4170055e5b4b794310c02b346e
[2]: https://github.com/odoo-dev/odoo/commit/893e3c1aa5452fec865743125612947ed2ad1cdc
[3]: https://github.com/odoo-dev/odoo/commit/dcac7e3f56013c95a7147a53262e602e8887d9c6
task-3889951