### PR TITLE
[FIX] spreadsheet: missing context in navigateTo

### DIFF
--- a/addons/spreadsheet/static/src/actions/helpers.js
+++ b/addons/spreadsheet/static/src/actions/helpers.js
@@ -15,7 +15,7 @@ export async function navigateTo(env, actionXmlId, actionDescription, options) {
     let navigateActionDescription;
     const { views, view_mode, domain, context, name, res_model, res_id } = actionDescription;
     try {
-        navigateActionDescription = await actionService.loadAction(actionXmlId);
+        navigateActionDescription = await actionService.loadAction(actionXmlId, context);
         const filteredViews = views.map(
             ([v, viewType]) =>
                 navigateActionDescription.views.find(([, type]) => viewType === type) || [

--- a/addons/spreadsheet/static/src/list/list_actions.js
+++ b/addons/spreadsheet/static/src/list/list_actions.js
@@ -21,7 +21,7 @@ export const SEE_RECORD_LIST = async (position, env) => {
         .map(astToFormula)
         .map((arg) => env.model.getters.evaluateFormula(sheetId, arg));
     const listId = env.model.getters.getListIdFromPosition(position);
-    const { model, actionXmlId } = env.model.getters.getListDefinition(listId);
+    const { model, actionXmlId, context } = env.model.getters.getListDefinition(listId);
     const dataSource = await env.model.getters.getAsyncListDataSource(listId);
     const index = evaluatedArgs[1];
     if (typeof index !== "number") {
@@ -39,6 +39,7 @@ export const SEE_RECORD_LIST = async (position, env) => {
             res_model: model,
             res_id: recordId,
             views: [[false, "form"]],
+            context,
         },
         { viewType: "form" }
     );

--- a/addons/spreadsheet/static/src/pivot/pivot_actions.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_actions.js
@@ -13,8 +13,8 @@ export const SEE_RECORDS_PIVOT = async (position, env) => {
     const pivot = env.model.getters.getPivot(pivotId);
     await pivot.load();
     const { model } = pivot.definition;
-    const { actionXmlId } = env.model.getters.getPivotDefinition(pivotId);
     const argsDomain = env.model.getters.getPivotDomainArgsFromPosition(position)?.domainArgs;
+    const { actionXmlId, context } = env.model.getters.getPivotDefinition(pivotId);
     const domain = pivot.getPivotCellDomain(argsDomain);
     const name = await pivot.getModelLabel();
     await navigateTo(
@@ -30,6 +30,7 @@ export const SEE_RECORDS_PIVOT = async (position, env) => {
             ],
             target: "current",
             domain,
+            context,
         },
         { viewType: "list" }
     );
@@ -49,7 +50,7 @@ export const SEE_RECORDS_PIVOT_VISIBLE = (position, env) => {
         return false;
     }
     const dataSource = env.model.getters.getPivot(pivotId);
-    const loadingError = dataSource.assertIsValid({ throwOnError: false })
+    const loadingError = dataSource.assertIsValid({ throwOnError: false });
     return (
         !loadingError &&
         evaluatedCell.type !== "empty" &&

--- a/addons/spreadsheet/static/tests/pivots/pivot_see_records_test.js
+++ b/addons/spreadsheet/static/tests/pivots/pivot_see_records_test.js
@@ -24,6 +24,7 @@ const basicListAction = {
     ],
     target: "current",
     domain: [],
+    context: {},
 };
 
 QUnit.test("Can open see records on headers col", async function (assert) {
@@ -188,7 +189,10 @@ QUnit.test("Can see records on ODOO.PIVOT.TABLE cells", async function (assert) 
 
 QUnit.test("Cannot see records of pivot formula without value", async function (assert) {
     const { env, model } = await createSpreadsheetWithPivot();
-    assert.strictEqual(getCellFormula(model, "B3"), `=ODOO.PIVOT(1,"probability","bar","false","foo",1)`);
+    assert.strictEqual(
+        getCellFormula(model, "B3"),
+        `=ODOO.PIVOT(1,"probability","bar","false","foo",1)`
+    );
     assert.strictEqual(getCellValue(model, "B3"), "", "B3 is empty");
     selectCell(model, "B3");
     const action = await getActionMenu(cellMenuRegistry, ["pivot_see_records"], env);


### PR DESCRIPTION
## Description:

navigateTo helper function in helpers.js was not passing the context to the action.

This commit resolves the problem by ensuring the context is properly passed to the action.

task-3880304

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
