### PR TITLE
[FIX] mail: allow bypassing message attachments check

### DIFF
--- a/addons/mail/i18n/mail.pot
+++ b/addons/mail/i18n/mail.pot
@@ -7667,7 +7667,7 @@ msgstr ""
 #. module: mail
 #: code:addons/mail/models/ir_attachment.py:0
 #, python-format
-msgid "You may not unlink attachments from other people's messages"
+msgid "You may not unlink or modify attachments from other people's messages"
 msgstr ""
 
 #. module: mail

--- a/addons/mail/static/src/models/attachment/attachment.js
+++ b/addons/mail/static/src/models/attachment/attachment.js
@@ -4,6 +4,8 @@ import { registerNewModel } from '@mail/model/model_core';
 import { attr, many2many, many2one, one2many } from '@mail/model/model_field';
 import { clear, insert } from '@mail/model/model_field_command';
 
+import { session } from '@web/session';
+
 function factory(dependencies) {
 
     class Attachment extends dependencies['mail.model'] {
@@ -197,7 +199,13 @@ function factory(dependencies) {
             if (!this.messaging) {
                 return;
             }
-
+            // for chatter messages, being an admin is sufficient
+            if (
+                session.is_admin &&
+                (!this.originThread || this.originThread.model !== "mail.channel")
+            ) {
+                return true;
+            }
             if (this.messages.length) {
                 return this.messages.some(message => (
                     message.canBeDeleted ||


### PR DESCRIPTION
In some cases it may be necessary to bypass the check for attachments on other users messages
if the attachment from the message is used for another purpose without being copied.

We add a method to filter out the attachments for that check.

Additional changes:
- Admins can delete attachments from message in the UI again
- Check returns `True` instead of `None` when it succeeds, to match its parent
- AccessError is raised with a cause so that we can detect if it was raised because of the message check

issue introduced in odoo/odoo#4c4e63f01aefa01c2377f15f2020485cb0f7e4da

task-3519815
