### PR TITLE
[IMP] mass_mailing: add a generic /view route

### DIFF
--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -322,6 +322,11 @@ class MassMailController(http.Controller):
         """Dummy route so placeholder is not prefixed by language, MUST have multilang=False"""
         return request.redirect('/mailing/my', code=301, local=True)
 
+    @http.route('/view', type='http', auth='user', website=True, sitemap=False)
+    def mailing_view_in_browser_placeholder_link(self):
+        """Route used to give an example of what would be when the user follows the placeholder links in the mailing editor."""
+        return request.render('mass_mailing.mailing_view_generic')
+
     # ------------------------------------------------------------
     # TRACKING
     # ------------------------------------------------------------

--- a/addons/mass_mailing/views/mailing_templates_portal_management.xml
+++ b/addons/mass_mailing/views/mailing_templates_portal_management.xml
@@ -24,6 +24,31 @@
         </t>
     </template>
 
+    <!-- Template used for '/view' generic dummy placeholder -->
+    <template id="mailing_view_generic" name="View in Browser">
+        <t t-call="web.frontend_layout">
+            <body class="bg-white o_mailing_portal_body">
+                <header>
+                    <title>Odoo</title>
+                </header>
+                <div id="wrap" class="oe_structure oe_empty"/>
+                <main class="h-100 align-content-center">
+                    <div class="o_view_nocontent">
+                        <div class="justify-content-center o_nocontent_help col-6">
+                            <img src="/web/static/img/smiling_face.svg"/>
+                            <p class="o_view_nocontent_smiling_face row justify-content-center col-6 offset-3 pt-3">
+                                Nothing to see yet!
+                            </p>
+                            <div class="row justify-content-center col-6 offset-3 pb-5">
+                                Send a test version of your mailing to preview its design
+                            </div>
+                        </div>
+                    </div>
+                </main>
+            </body>
+         </t>
+    </template>
+
     <!-- Dummy layout to "view" a template content (html) -->
     <template id="mailing_view" name="Browser View">
 &lt;!DOCTYPE html&gt;


### PR DESCRIPTION
This commit adds a new generic view to the /view route. This view is created so that users that click on the `View in browser` while still in the mailing editor.

This view is intended to only inform users that the template is not already rendered. They should send a test to see it in action.

task-3869575

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
