### PR TITLE
[IMP] sale: show correct price on product configurator

### DIFF
--- a/addons/sale/controllers/product_configurator.py
+++ b/addons/sale/controllers/product_configurator.py
@@ -19,6 +19,7 @@ class ProductConfiguratorController(Controller):
         pricelist_id=None,
         ptav_ids=None,
         only_main_product=False,
+        **kwargs,
     ):
         """ Return all product information needed for the product configurator.
 
@@ -68,6 +69,7 @@ class ProductConfiguratorController(Controller):
                         quantity=quantity,
                         product_uom_id=product_uom_id,
                         pricelist_id=pricelist_id,
+                        **kwargs,
                     ),
                     parent_product_tmpl_ids=[],
                 )
@@ -85,6 +87,7 @@ class ProductConfiguratorController(Controller):
                         parent_combination=product_template.attribute_line_ids.\
                             product_template_value_ids,
                         pricelist_id=pricelist_id,
+                        **kwargs,
                     ),
                     parent_product_tmpl_ids=[product_template.id],
                 ) for optional_product_template in product_template.optional_product_ids
@@ -118,6 +121,7 @@ class ProductConfiguratorController(Controller):
         product_uom_id=None,
         company_id=None,
         pricelist_id=None,
+        **kwargs
     ):
         """ Return the updated combination information.
 
@@ -152,6 +156,7 @@ class ProductConfiguratorController(Controller):
             uom=product_uom,
             currency=currency,
             date=datetime.fromisoformat(so_date),
+            **kwargs,
         )
 
     @route('/sale_product_configurator/get_optional_products', type='json', auth='user')
@@ -213,6 +218,7 @@ class ProductConfiguratorController(Controller):
         product_uom_id=None,
         pricelist_id=None,
         parent_combination=None,
+        **kwargs
     ):
         """ Return complete information about a product.
 
@@ -277,6 +283,7 @@ class ProductConfiguratorController(Controller):
                 uom=product_uom,
                 currency=currency,
                 date=datetime.fromisoformat(so_date),
+                **kwargs,
             ),
             quantity=quantity,
             attribute_lines=[dict(

--- a/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
+++ b/addons/sale/static/src/js/product_configurator_dialog/product_configurator_dialog.js
@@ -72,8 +72,8 @@ export class ProductConfiguratorDialog extends Component {
     // Data Exchanges
     //--------------------------------------------------------------------------
 
-    async _loadData(onlyMainProduct) {
-        return rpc('/sale_product_configurator/get_values', {
+    _loadDataValues(onlyMainProduct) {
+        return {
             product_template_id: this.props.productTemplateId,
             quantity: this.props.quantity,
             currency_id: this.props.currencyId,
@@ -83,7 +83,11 @@ export class ProductConfiguratorDialog extends Component {
             pricelist_id: this.props.pricelistId,
             ptav_ids: this.props.ptavIds,
             only_main_product: onlyMainProduct,
-        });
+        };
+    }
+
+    async _loadData(onlyMainProduct) {
+        return rpc('/sale_product_configurator/get_values', this._loadDataValues(onlyMainProduct));
     }
 
     async _createProduct(product) {
@@ -94,7 +98,11 @@ export class ProductConfiguratorDialog extends Component {
     }
 
     async _updateCombination(product, quantity) {
-        return rpc('/sale_product_configurator/update_combination', {
+        return rpc('/sale_product_configurator/update_combination', this._updateCombinationValues(product, quantity));
+    }
+
+    _updateCombinationValues(product, quantity) {
+        return {
             product_template_id: product.product_tmpl_id,
             combination: this._getCombination(product),
             currency_id: this.props.currencyId,
@@ -103,7 +111,7 @@ export class ProductConfiguratorDialog extends Component {
             product_uom_id: this.props.productUOMId,
             company_id: this.props.companyId,
             pricelist_id: this.props.pricelistId,
-        });
+        };
     }
 
     async _getOptionalProducts(product) {

--- a/addons/sale/static/src/js/sale_product_field.js
+++ b/addons/sale/static/src/js/sale_product_field.js
@@ -185,7 +185,7 @@ export class SaleOrderLineProductField extends Many2OneField {
         }
     }
 
-    async _openProductConfigurator(edit=false) {
+    async ProductConfiguratorDialogValues(edit=false) {
         const saleOrderRecord = this.props.record.model.root;
         let ptavIds = this.props.record.data.product_template_attribute_value_ids.records.map(
             record => record.resId
@@ -216,8 +216,7 @@ export class SaleOrderLineProductField extends Many2OneField {
                     ["custom_product_template_attribute_value_id", "custom_value"]
                 )
         }
-
-        this.dialog.add(ProductConfiguratorDialog, {
+        return {
             productTemplateId: this.props.record.data.product_template_id[0],
             ptavIds: ptavIds,
             customAttributeValues: customAttributeValues.map(
@@ -251,7 +250,11 @@ export class SaleOrderLineProductField extends Many2OneField {
             discard: () => {
                 saleOrderRecord.data.order_line.delete(this.props.record);
             },
-        });
+        };
+    }
+
+    async _openProductConfigurator(edit=false) {
+        this.dialog.add(ProductConfiguratorDialog, await this.ProductConfiguratorDialogValues(edit));
     }
 }
 


### PR DESCRIPTION
Before this commit
---------
When opening a product configurator for a subscription product in a sale order line, only the sale price of the product was displayed, missing any associated subscription price.

After this commit
----------
Updated product configurator to display correct prices for subscription products. Implemented logic to fetch and display subscription prices based on the recurring period set for the sale order.

task-2879576

I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
