### PR TITLE
[IMP] mail: header buttons for acitivity view

### DIFF
--- a/addons/mail/models/mail_activity.py
+++ b/addons/mail/models/mail_activity.py
@@ -428,7 +428,7 @@ class MailActivity(models.Model):
     def action_done(self):
         """ Wrapper without feedback because web button add context as
         parameter, therefore setting context to feedback """
-        return self.action_feedback()
+        return self.filtered(lambda r: r.active).action_feedback()
 
     def action_done_redirect_to_other(self):
         """ Mark activity as done and return action mail.mail_activity_without_access_action.
@@ -581,7 +581,13 @@ class MailActivity(models.Model):
     def action_snooze(self):
         today = date.today()
         for activity in self:
-            activity.date_deadline = max(activity.date_deadline, today) + timedelta(days=7)
+            if activity.active:
+                activity.date_deadline = max(activity.date_deadline, today) + timedelta(days=7)
+
+    def action_cancel(self):
+        for activity in self:
+            if activity.active:
+                activity.unlink()
 
     def activity_format(self):
         return Store(self).get_result()

--- a/addons/mail/views/mail_activity_views.xml
+++ b/addons/mail/views/mail_activity_views.xml
@@ -295,19 +295,24 @@
         <field name="model">mail.activity</field>
         <field name="arch" type="xml">
             <tree string="Next Activities"
-                    decoration-danger="date_deadline &lt; current_date"
-                    decoration-warning="date_deadline == current_date"
-                    decoration-success="date_deadline &gt; current_date"
+                    decoration-danger="date_deadline &lt; current_date and active == True"
+                    decoration-warning="date_deadline == current_date and active == True"
+                    decoration-success="date_deadline &gt; current_date and active == True"
                     default_order="date_deadline" create="false">
+                <header>
+                    <button name="action_done" type="object" string="Done" icon="fa-check"/>
+                    <button name="action_cancel" type="object" string="Cancel" icon="fa-times"/>
+                    <button name="action_snooze" type="object" string="Snooze 7d" icon="fa-bell-slash"/>
+                </header>
                 <field name="res_name"/>
                 <field name="activity_type_id"/>
                 <field name="user_id" widget="many2one_avatar_user"/>
                 <field name="summary"/>
                 <field name="date_deadline" widget="remaining_days"/>
                 <field name="date_done" string="Done Date" optional="hide"/>
-                <button name="action_done" type="object" string="Done" icon="fa-check"/>
-                <button name="unlink" type="object" string="Cancel" icon="fa-times" class="text-danger"/>
-                <button name="action_snooze" class="text-warning" type="object" string="Snooze 7d" icon="fa-bell-slash"/>
+                <button name="action_done" type="object" string="Done" icon="fa-check" invisible="active == False"/>
+                <button name="unlink" type="object" string="Cancel" icon="fa-times" class="text-danger" invisible="active == False"/>
+                <button name="action_snooze" class="text-warning" type="object" string="Snooze 7d" icon="fa-bell-slash" invisible="active == False"/>
             </tree>
         </field>
     </record>

--- a/addons/web/static/src/views/fields/remaining_days/remaining_days_field.xml
+++ b/addons/web/static/src/views/fields/remaining_days/remaining_days_field.xml
@@ -6,9 +6,9 @@
             <t t-set="formatted" t-value="formattedValue" />
             <div
                 t-att-class="{
-                    'fw-bold': days !== null and days lte 0,
-                    'text-danger': days !== null and days lt 0,
-                    'text-warning': days !== null and days === 0,
+                    'fw-bold': days !== null and days lte 0 and props.record.isActive,
+                    'text-danger': days !== null and days lt 0 and props.record.isActive,
+                    'text-warning': days !== null and days === 0 and props.record.isActive,
                 }"
                 t-att-title="formatted"
             >


### PR DESCRIPTION
Purpose:
- In all activity view, there were no header buttons to mark multiple
activities as done/cancel/snooze
- Activity marked and stored as done, still showed inline buttons to
mark it as done, cancel or snooze.
- Once an activity was marked as done, it was still showing special
color decoration in view.

Specs:
- Added header buttons for done/cancel/snooze in all activities tree view.
- Once activity marked as done, inline buttons for done, cancel and
snooze will not be displayed anymore.
- Once activity marked as done, it will not show special color decoration.
- Action methods are reconfigured in such a way that it applies to only active
activities, and disregard the archived ones since those activities are already
marked as done.

Task - 3911396