### PR TITLE
[FIX] pos_loyalty: load product fields in the reward product domain

### DIFF
--- a/addons/pos_loyalty/tests/test_frontend.py
+++ b/addons/pos_loyalty/tests/test_frontend.py
@@ -1175,7 +1175,7 @@ class TestUi(TestPointOfSaleHttpCommon):
                 'discount': 50,
                 'discount_mode': 'percent',
                 'discount_applicability': 'specific',
-                'discount_product_domain': '[("categ_id", "ilike", "office")]',
+                'discount_product_domain': '["&", ("categ_id", "ilike", "office"), ("name", "ilike", "Product B")]',
             })],
             'pos_config_ids': [Command.link(self.main_pos_config.id)],
         })


### PR DESCRIPTION
Prior to this commit, if a reward product domain contained a field that was not loaded into the Point of Sale (PoS), the promotion would not function correctly. This commit resolves this issue by adding the missing fields, ensuring that the promotion operates as expected.

opw-3896038

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
