### PR TITLE
[FIX] web_editor: fix the tolltip appearance for draggable snippets

### DIFF
--- a/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
+++ b/addons/web_editor/static/src/scss/wysiwyg_snippets.scss
@@ -385,6 +385,10 @@
                     @include o-position-absolute(8px, 6px, auto, auto);
                 }
 
+                &.o_disabled {
+                    pointer-events: initial;
+                }
+
                 &.o_snippet_install {
                     .btn.o_install_btn {
                         @include o-position-absolute($top: 10px);
@@ -396,6 +400,7 @@
                 }
 
                 &.o_disabled, &.o_snippet_install {
+                    cursor: default;
                     background-color: rgba($o-we-sidebar-blocks-content-snippet-bg, .2);
 
                     .oe_snippet_thumbnail_img {

--- a/addons/web_editor/static/src/xml/snippets.xml
+++ b/addons/web_editor/static/src/xml/snippets.xml
@@ -161,6 +161,7 @@
             </div>
 
             <div id="o_scroll" t-ref="snippets-area" t-att-class="{ 'd-none': state.currentTab !== constructor.tabs.BLOCKS }">
+                <t t-set="disabledTooltip">This block cannot be dropped anywhere on this page.</t>
                 <t t-foreach="getSnippetsByCategories()" t-as="category" t-key="category.id">
                     <div t-att-id="category.id" t-if="category_value.length > 0" class="o_panel">
                         <div class="o_panel_header">
@@ -175,7 +176,8 @@
                                     t-att-data-oe-snippet-id="snippet.id"
                                     t-att-data-module-id="snippet.moduleId"
                                     t-on-click="_onSnippetClick"
-                                    data-tooltip="This block cannot be dropped anywhere on this page.">
+                                    data-tooltip="This block cannot be dropped anywhere on this page."
+                                    t-att-data-tooltip="snippet.disabled ? disabledTooltip : false">
                                     <t t-if="snippet.disabled">
                                         <img src="/web_editor/static/src/img/snippet_disabled.svg" class="o_snippet_undroppable"/>
                                     </t>


### PR DESCRIPTION
Since [1], a tooltip indicating "This block cannot be dropped anywhere
on this page." appears each time you hover a draggable snippet.

This commit addresses the issue by only showing this tooltip in the
right circumstances, when a snippet is not draggable (disabled or
installable...).

[1]: https://github.com/odoo/odoo/commit/91293fe4a8125f65cd7e5f487aacbc62c35c0f74#diff-c971e01f28cfbdec366b6a712c516e3427887fde8a39674e5bb3b5a056cedad0R178

task-3893159
