### PR TITLE
[FIX] expression: prevent an error when using a customized field in domain

### DIFF
--- a/odoo/osv/expression.py
+++ b/odoo/osv/expression.py
@@ -912,7 +912,7 @@ class expression(object):
                     params = (model._name, left)
                     push(('id', inselect_operator, (subselect, params)), model, alias, internal=True)
                 else:
-                    _logger.error("Binary field '%s' stored in attachment: ignore %s %s %s",
+                    _logger.warning("Binary field '%s' stored in attachment: ignore %s %s %s",
                                   field.string, left, operator, reprlib.repr(right))
                     push(TRUE_LEAF, model, alias)
 


### PR DESCRIPTION
Currently, The issue is occurring because of customized field use in the domain.

Steps to reproduce:

- Go to Settings > Technical > Database Structure > Fields.
- And create a new field with Field Label: New Related Field, Model: Attachment, Field Type: Binary.
- Go to Settings > Technical > User Interface > User Defined Filters.
- Create a new filter with Model: Attachment, in the domain, select
'New Related Field' that you have created with '=' operator, and right side of the domain as 'win'.
- Then save it, the error will occur in the backend.

Error Message: Binary field 'Image 1024' stored in attachment: ignore image_1024 != '""'

This error message occurs during the use of customized fields in the Domain condition, And this error message is
not important. So replace a logger error message with a logger warning message at [1] to prevent more error log in terminal.

link [1]: https://github.com/odoo/odoo/blob/85ec121fa1838d6fca3caf3e4c82ec267615dd11/odoo/osv/expression.py#L915-L916

sentry-4551348536
