### PR TITLE
[FIX] base, *: ensure arch_updated set to false when hard reset a view

### DIFF
--- a/addons/test_website/tests/test_reset_views.py
+++ b/addons/test_website/tests/test_reset_views.py
@@ -109,3 +109,5 @@ class TestWebsiteResetViews(odoo.tests.HttpCase):
             # version is also broken
             self.fix_it('/test_page_view')
         self.fix_it('/test_page_view', 'hard')
+        # hard reset should set arch_updated to false
+        self.assertFalse(self.test_page_view.arch_updated)

--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -367,11 +367,13 @@ actual arch.
             arch = False
             if mode == 'soft':
                 arch = view.arch_prev
+                write_dict = {'arch_db': arch}
             elif mode == 'hard' and view.arch_fs:
                 arch = view.with_context(read_arch_from_file=True, lang=None).arch
+                write_dict = {'arch_db': arch, 'arch_prev': False, 'arch_updated': False}
             if arch:
                 # Don't save current arch in previous since we reset, this arch is probably broken
-                view.with_context(no_save_prev=True, lang=None).write({'arch_db': arch})
+                view.with_context(no_save_prev=True, lang=None).write(write_dict)
 
     @api.depends('write_date')
     def _compute_model_data_id(self):


### PR DESCRIPTION
*: test_website

Since [1], the code responsible for resetting broken view failed to
consider that during a "hard" reset, the 'arch_updated' field should be
set to False.

Steps to reproduce (on a local server):

- Activate the developer mode
- Navigate to Website and click on "Go to Website"
- Click on the menu "Pages" > "Manage Pages"
- At the /contactus line, click on the "bug" button to access the view
- Click on "Edit" to be able to change the architecture
- Add something that breaks the view in the template (i.e :
  ```<p t-field="no_field.exists"></p>```)
- Click on "Save" and after "Go to Page Manager"
- Click on the /contactus url link
- An internal server error page appears with the possibility to restore
  the previous version of the view (soft reset) or to reset to initial
  version (hard reset). Click on "Hard Reset"
- With your DB manager, search in the table ir.ui.view, the record with
  the key website.contactus. Observe that the field arch_updated is
  still True while the view is reset and shouldn't be in an updated
  state.

This commit ensures consistent updating of this field. 
A "Hard" reset of a broken view will remove its previous architecture
used for "Soft" reset, since there is no real usage where a "Previous"
reset is needed after a "Hard" one.

[1]: https://github.com/odoo/odoo/commit/479585140caca9fdc758709f043da500297e8046

task-3743850