### PR TITLE
[IMP] stock: multi transfers validation improvement

### DIFF
--- a/addons/stock/wizard/stock_backorder_confirmation_views.xml
+++ b/addons/stock/wizard/stock_backorder_confirmation_views.xml
@@ -33,7 +33,7 @@
                 <field name="show_transfers" invisible="1"/>
                 <field name="backorder_confirmation_line_ids" nolabel="1" invisible="not show_transfers">
                     <list create="0" delete="0" editable="top">
-                        <field name="picking_id"/>
+                        <field name="picking_id" force_save="1" readonly="1"/>
                         <field name="to_backorder" widget="boolean_toggle"/>
                     </list>
                 </field>


### PR DESCRIPTION
Before this PR :
------------------------------------------------
- During multi-transfer validation, the back-order creation popup displayed all transfers.
- If the quality app was installed, there was no filter to exclude transfers requiring quality checks.
- Multi-transfer validation only displayed quality checks for one transfer and did not validate any transfers.

After this PR:
------------------------------------------------
- Restructured the back-order popup to display only selected transfers in a dropdown menu.
- Implemented a filter to exclude transfers requiring quality checks, visible only when the quality module is installed.
- Enhanced the display and validation of all quality checks popups.

Task-id : 3790406