### PR TITLE
[IMP] survey: improve survey fill finished page

### DIFF
--- a/addons/survey/static/tests/tours/certification_failure.js
+++ b/addons/survey/static/tests/tours/certification_failure.js
@@ -118,10 +118,10 @@ var retrySteps = [{
 }];
 
 var lastSteps = [{
-    trigger: 'h1:contains("Thank you!")',
+    trigger: 'h1:contains("You scored")',
     run: function () {
         if (queryAll('a:contains("Retry")').length === 0) {
-            queryOne('h1:contains("Thank you!")').classList.add("tour_success");
+            queryOne('h1:contains("You scored")').classList.add("tour_success");
         }
     }
 }, {

--- a/addons/survey/static/tests/tours/certification_success.js
+++ b/addons/survey/static/tests/tours/certification_success.js
@@ -109,9 +109,8 @@ registry.category("web_tour.tours").add('test_certification_success', {
         trigger: 'button[type="submit"]',
         run: "click",
     }, {
-        content: "Thank you",
-        trigger: 'h1:contains("Thank you!")',
-        run: "click",
+        content: "You scored",
+        trigger: 'h1:contains("You scored")',
     }, {
         content: "test passed",
         trigger: 'div:contains("Congratulations, you have passed the test!")',

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -289,28 +289,30 @@
     <template id="survey_fill_form_done" name="Survey: finished">
         <div class="wrap">
             <div class="o_survey_finished mt32 mb32">
-                <h1 class="fs-2">Thank you!</h1>
+                <h1 class="fs-2">
+                    <t t-if="survey.scoring_type != 'no_scoring'">
+                        You scored <t t-out="answer.scoring_percentage"/>%
+                    </t>
+                    <t t-else="">Thank you!</t>
+                </h1>
                 <div t-field="survey.description_done" class="oe_no_empty" />
                 <div class="row">
                     <div class="col">
-                        <t t-if="survey.scoring_type != 'no_scoring'">
-                            <div>You scored <t t-esc="answer.scoring_percentage" />%</div>
-                            <t t-if="survey.scoring_success_min">
-                                <t t-if="answer.scoring_success">
-                                    <div>Congratulations, you have passed the test!</div>
+                        <t t-if="survey.scoring_type != 'no_scoring' and survey.scoring_success_min">
+                            <t t-if="answer.scoring_success">
+                                <div>Congratulations, you have passed the test!</div>
 
-                                    <div t-if="survey.certification" class="mt16 mb16">
-                                        <a role="button"
-                                            class="btn btn-primary btn-lg"
-                                            t-att-href="'/survey/%s/get_certification' % survey.id">
-                                            <i class="fa fa-fw fa-trophy" role="img" aria-label="Download certification" title="Download certification"/>
-                                            Download certification
-                                        </a>
-                                    </div>
-                                </t>
-                                <t t-else="">
-                                    <div>Unfortunately, you have failed the test.</div>
-                                </t>
+                                <div t-if="survey.certification" class="mt16 mb16">
+                                    <a role="button"
+                                        class="btn btn-primary btn-lg"
+                                        t-att-href="'/survey/%s/get_certification' % survey.id">
+                                        <i class="fa fa-fw fa-trophy" role="img" aria-label="Download certification" title="Download certification"/>
+                                        Download certification
+                                    </a>
+                                </div>
+                            </t>
+                            <t t-else="">
+                                <div>Unfortunately, you have failed the test.</div>
                             </t>
                         </t>
                         <div class="d-flex gap-3 mt-3">

--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -168,14 +168,14 @@
             <button
                 t-if="survey and survey.users_can_go_back"
                 t-att-disabled="not can_go_back"
-                type="submit" class="btn border-start p-0 shadow-none o_survey_navigation_submit" name="button_submit" value="previous" t-att-data-previous-page-id="previous_page_id">
+                type="submit" class="btn border-0 p-0 shadow-none o_survey_navigation_submit" name="button_submit" value="previous" t-att-data-previous-page-id="previous_page_id">
                 <i class="oi oi-chevron-left p-2" />
             </button>
             <t t-set="can_go_forward"
                 t-value="survey and survey.questions_layout in ['page_per_question', 'page_per_section'] and answer and answer.state != 'done' and not answer.is_session_answer"/>
             <button
                 t-att-disabled="not can_go_forward"
-                type="submit" class="btn border-start p-0 shadow-none o_survey_navigation_submit" t-att-value="'next' if not survey_last else 'finish'">
+                type="submit" class="btn border-0 p-0 shadow-none o_survey_navigation_submit" t-att-value="'next' if not survey_last else 'finish'">
                 <i class="oi oi-chevron-right p-2" />
             </button>
         </div>


### PR DESCRIPTION
This commit makes some visual adjustments to the survey completion page:

1. Remove "Thank you" label when there is a scoring enabled and display "You scored X.XX %"

2. Remove the border on the survey navigation buttons at the bottom right of the page

task-3918542

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
