### PR TITLE
[FIX] hr_expense: create expenses without employee access rights

### DIFF
--- a/addons/hr_expense/__manifest__.py
+++ b/addons/hr_expense/__manifest__.py
@@ -65,6 +65,7 @@ This module also uses analytic accounting and is compatible with the invoice on 
         ],
         'web.assets_tests': [
             'hr_expense/static/tests/tours/expense_upload_tours.js',
+            'hr_expense/static/tests/tours/expense_form_tours.js',
         ],
         'web.report_assets_common': [
             'hr_expense/static/src/scss/hr_expense.scss',

--- a/addons/hr_expense/static/tests/tours/expense_form_tours.js
+++ b/addons/hr_expense/static/tests/tours/expense_form_tours.js
@@ -1,0 +1,50 @@
+/** @odoo-module **/
+
+import { registry } from "@web/core/registry";
+
+registry.category("web_tour.tours").add('create_expense_no_employee_access_tour', {
+    test: true,
+    url: "/web",
+    steps: () => [
+    {
+        content: "Go to Expense",
+        trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',
+    },
+    {
+        content: "Remove filter for own expenses",
+        trigger: '.o_facet_value:contains(My Expense) + button[title="Remove"]',
+    },
+    {
+        content: "Go to form view of pre-prepared record",
+        trigger: '.o_data_cell:contains(expense_for_tour_0)'
+    },
+    {
+        content: "Click employee selection dropdown",
+        trigger: 'input#employee_id_0',
+    },
+    {
+        content: "Delete default search",
+        trigger: 'input#employee_id_0',
+        run() {
+            const dropdown = document.querySelector('input#employee_id_0');
+            dropdown.value = '';
+        }
+    },
+    {
+        content: "Select test expense employee",
+        trigger: 'a.dropdown-item:contains(expense_employee)',
+    },
+    {
+        content: "Save",
+        trigger: '.o_form_button_save',
+    },
+    {
+        content: "Exit form",
+        trigger: '.o_menu_brand',
+    },
+    {
+        content: "Check",
+        trigger: '.o_app[data-menu-xmlid="hr_expense.menu_hr_expense_root"]',
+        isCheck: true,
+    },
+]});

--- a/addons/hr_expense/tests/test_ui.py
+++ b/addons/hr_expense/tests/test_ui.py
@@ -60,3 +60,18 @@ class TestUi(TestExpenseCommon, HttpCase):
         })
 
         self.start_tour('/web', 'show_expense_receipt_tour', login=self.env.user.login)
+
+    def test_expense_manager_can_always_set_employee(self):
+        """Test that users with access rights to `hr.expense` can set the employee on them
+        by using the usual form view, even if they do not have access rights to `hr.employee`
+        """
+        employee_1 = self.expense_employee
+        employee_2 = self.env['hr.employee'].create({'name': 'employee2'})
+        expense = self.env['hr.expense'].create({
+            'name': 'expense_for_tour_0',
+            'employee_id': employee_2.id,
+            'product_id': self.product_a.id,
+            'total_amount': 1,
+        })
+        self.start_tour('/web', 'create_expense_no_employee_access_tour', login=self.expense_user_manager.login)
+        self.assertEqual(expense.employee_id.id, employee_1.id, "Employee should have been changed by tour")


### PR DESCRIPTION
Problem
---
When creating/editing expenses, if the user doesn't have any access rights to
employee, a ValueError is thrown when clicking the employee field.

The Error happens because the model used for employees for users
without access is `hr.employee.public` instead of the usual
`hr.employee` and `hr.employee.public` does not define the
`filter_for_expense` field, which is used for searching / filtering
employees to set.

Fix
---
`hr.employee` and `hr.employee.public` both inherit from
`hr.employee.base`, therefore we can put the search field and method,
into an `hr.expense` child model of `hr.employee.base`.

Note that (as far as I understand) this will not break stable because
the `filter_for_expense` field is `store=False`.

opw-3858951