### PR TITLE
[FIX] website_sale: prevent attributeerror when paying by Demo

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1426,7 +1426,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             #in order to not override shippig address, it's checked separately from shipping option
             self._include_country_and_state_in_address(shipping_address)
 
-            if order_sudo.partner_shipping_id.name.endswith(order_sudo.name):
+            shipping_name = order_sudo.partner_shipping_id.name
+            if shipping_name and shipping_name.endswith(order_sudo.name):
                 # The existing partner was created by `process_express_checkout_delivery_choice`, it
                 # means that the partner is missing information, so we update it.
                 order_sudo.partner_shipping_id = self._create_or_edit_partner(


### PR DESCRIPTION
If the user's contact have delivery address without contact name and
the user pays for an order by the Demo payment provider,
a traceback will appear.

Steps to reproduce the error:
- Install "website_sale" and "contacts" module
- Activate Demo payment provider
- Go to Contacts > Open Mitchell Admin > Contacts & Addresses >
  Add Delivery Address without Contact Name > Save
- Go to Website >  Shop > Add a product to cart > Proceed to Checkout >
  Pay with Demo > Pay

Traceback:
```
AttributeError: 'bool' object has no attribute 'endswith'
  File "odoo/http.py", line 2256, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1832, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1852, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1830, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1837, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2062, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 742, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/website_sale/controllers/main.py", line 1365, in process_express_checkout
    if order_sudo.partner_shipping_id.name.endswith(order_sudo.name):
```

https://github.com/odoo/odoo/blob/97d13089ba320ab20e564a45fcd2a6f8b33d8e9b/addons/website_sale/controllers/main.py#L1429
When the delivery address does not have a contact name,
Here, order_sudo.partner_shipping_id.name will be False,
So it will lead to the above traceback.

sentry-4664052401

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
