### PR TITLE
[FIX] account: prevent error when opening accrued revenue entry

### DIFF
--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -167,7 +167,9 @@ class AccruedExpenseRevenue(models.TransientModel):
                     o.order_line.with_context(accrual_entry_date=self.date)._compute_untaxed_amount_invoiced()
                     o.order_line.with_context(accrual_entry_date=self.date)._compute_qty_to_invoice()
                 lines = o.order_line.filtered(
-                    lambda l: l.display_type not in ['line_section', 'line_note'] and
+                    # We only want lines that are not sections or notes and include all lines
+                    # for purchase orders but exclude downpayment lines for sales orders.
+                    lambda l: l.display_type not in ['line_section', 'line_note'] and (is_purchase or not l.is_downpayment) and
                     fields.Float.compare(
                         l.qty_to_invoice,
                         0,

--- a/addons/sale/tests/test_accrued_sale_orders.py
+++ b/addons/sale/tests/test_accrued_sale_orders.py
@@ -137,3 +137,35 @@ class TestAccruedSaleOrders(AccountTestInvoicingCommon):
             {'account_id': self.account_expense.id, 'debit': 12000.0, 'credit': 0.0, 'analytic_distribution': {str(self.analytic_account_a.id): 66.67, str(self.analytic_account_b.id): 33.33, str(self.analytic_account_c.id): 100.0}},
 
         ])
+
+    def test_product_name_in_accrued_revenue_entry(self):
+        self.sale_order.order_line.qty_delivered = 5
+
+        so_context = {
+            'active_model': 'sale.order',
+            'active_ids': self.sale_order.ids,
+            'active_id': self.sale_order.id,
+            'default_journal_id': self.company_data['default_journal_sale'].id,
+        }
+        payment_params = {
+            'advance_payment_method': 'percentage',
+            'amount': 50.0,
+        }
+        downpayment = self.env['sale.advance.payment.inv'].with_context(so_context).create(payment_params)
+        invoice = downpayment._create_invoices({
+            'sale_orders': so_context,
+        })
+        invoice.invoice_date = self.wizard.date
+        invoice.action_post()
+        self.wizard.create_entries()
+        self.assertFalse(self.wizard.display_amount)
+        self.assertRecordValues(self.env['account.move'].search(self.wizard.create_entries()['domain']).line_ids, [
+            # reverse move lines
+            {'account_id': self.account_revenue.id, 'debit': 5000, 'credit': 0},
+            {'account_id': self.alt_inc_account.id, 'debit': 1000, 'credit': 0},
+            {'account_id': self.wizard.account_id.id, 'debit': 0, 'credit': 6000},
+            # move lines
+            {'account_id': self.account_revenue.id, 'debit': 0, 'credit': 5000},
+            {'account_id': self.alt_inc_account.id, 'debit': 0, 'credit': 1000},
+            {'account_id': self.wizard.account_id.id, 'debit': 6000, 'credit': 0},
+        ])


### PR DESCRIPTION
This error occurs when we create a new sales order, then proceed to create an
invoice within that sales order, and finally attempt to open the
``Accrued Revenue Entry`` from the action button.

Steps to reproduce:

- Install the ``sale_management`` and ``account_accountant`` modules
- Create new sales orders > ``Confirm`` > ``Create Invoice`` button >
  Down Payment in % > ``Confirm`` > ``Sale Order`` smart button
- Go to action button > ``Accrued Revenue Entry``

Traceback : 
``AssertionError precision_rounding must be positive, got 0.0``

At [1] within ``o.order_line``, we are encountering an issue where
``precision_rounding`` is being retrieved as zero. This is leading to an error.

This commit will fix the above error by implementing a check for the 
``is_downpayment`` in the order line.

[1]: https://github.com/odoo/odoo/blob/34b651de35b986db404a3950866bed7bc7e1fae2/addons/account/wizard/accrued_orders.py#L174

sentry-4857910663
