### PR TITLE
[FIX] sale: date_order field in dubug mode only

### DIFF
--- a/addons/sale/views/sale_views.xml
+++ b/addons/sale/views/sale_views.xml
@@ -323,10 +323,10 @@
                         </group>
                         <group name="order_details">
                             <field name="validity_date" attrs="{'invisible': [('state', 'in', ['sale', 'done'])]}"/>
-                            <div class="o_td_label" groups="base.group_no_one" attrs="{'invisible': [('state', 'in', ['sale', 'done', 'cancel'])]}">
+                            <div class="o_td_label" attrs="{'invisible': [('state', 'in', ['sale', 'done', 'cancel'])]}">
                                 <label for="date_order" string="Quotation Date"/>
                             </div>
-                            <field name="date_order" nolabel="1" groups="base.group_no_one" attrs="{'invisible': [('state', 'in', ['sale', 'done', 'cancel'])]}"/>
+                            <field name="date_order" nolabel="1" attrs="{'invisible': [('state', 'in', ['sale', 'done', 'cancel'])]}"/>
                             <div class="o_td_label" attrs="{'invisible': [('state', 'in', ['draft', 'sent'])]}">
                                 <label for="date_order" string="Order Date"/>
                             </div>


### PR DESCRIPTION
`date_order`was visible in debug-mode only for seemingly no reasons, causing difficulties for our sales team when creating sales orders.

Other fields that were displayed only in debug mode
for no clear reason have been fixed by https://github.com/odoo/odoo/pull/45816.

@qrtl QT4545

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
