### PR TITLE
[FIX] point_of_sale: restrict close pop-up

### DIFF
--- a/addons/point_of_sale/static/src/app/popup/popup_controller.xml
+++ b/addons/point_of_sale/static/src/app/popup/popup_controller.xml
@@ -4,7 +4,7 @@
     <t t-name="point_of_sale.PopupContainer">
         <div t-if="Object.keys(props.popups).length > 0" class="popups">
             <t t-foreach="props.popups" t-as="popup" t-key="popup">
-                <div t-if="popup_last || popup_value.props.keepBehind" role="dialog" 
+                <div t-att-class="{ 'd-none': !(popup_last || popup_value.props.keepBehind) }" role="dialog" 
                     class="modal-dialog position-absolute start-0 top-0 d-flex align-items-center justify-content-center h-100 w-100 mw-100 m-0 p-0 pe-auto bg-dark bg-opacity-50">
                     <t t-component="popup_value.component" t-props="popup_value.props" isActive="popup_last" />
                 </div>

--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -184,7 +184,7 @@ export class Product extends PosModel {
         if (this.combo_ids.length) {
             const { confirmed, payload } = await this.env.services.popup.add(
                 ComboConfiguratorPopup,
-                { product: this, keepBehind: true }
+                { product: this }
             );
             if (!confirmed) {
                 return;
@@ -752,9 +752,17 @@ export class Orderline extends PosModel {
             orderline.compute_fixed_price(order_line_price),
             this.pos.currency.decimal_places
         );
-        let hasSameAttributes = Object.keys(Object(orderline.attribute_value_ids)).length === Object.keys(Object(this.attribute_value_ids)).length;
-        if(hasSameAttributes && Object(orderline.attribute_value_ids)?.length && Object(this.attribute_value_ids)?.length) {
-            hasSameAttributes = orderline.attribute_value_ids.every((value, index) => value === this.attribute_value_ids[index]);
+        let hasSameAttributes =
+            Object.keys(Object(orderline.attribute_value_ids)).length ===
+            Object.keys(Object(this.attribute_value_ids)).length;
+        if (
+            hasSameAttributes &&
+            Object(orderline.attribute_value_ids)?.length &&
+            Object(this.attribute_value_ids)?.length
+        ) {
+            hasSameAttributes = orderline.attribute_value_ids.every(
+                (value, index) => value === this.attribute_value_ids[index]
+            );
         }
         return (
             !this.skipChange &&
@@ -1097,19 +1105,24 @@ export class Orderline extends PosModel {
     findAttribute(values, customAttributes) {
         const listOfAttributes = [];
         const addedPtal_id = [];
-        for (const value of values){
-            for (const ptal_id of this.pos.ptal_ids_by_ptav_id[value]){
-                if (addedPtal_id.includes(ptal_id)){
+        for (const value of values) {
+            for (const ptal_id of this.pos.ptal_ids_by_ptav_id[value]) {
+                if (addedPtal_id.includes(ptal_id)) {
                     continue;
                 }
-                const attribute = this.pos.attributes_by_ptal_id[ptal_id]
-                const attFound = attribute.values.filter((target) => {
-                    return Object.values(values).includes(target.id);
-                }).map(att => ({...att})); // make a copy
+                const attribute = this.pos.attributes_by_ptal_id[ptal_id];
+                const attFound = attribute.values
+                    .filter((target) => {
+                        return Object.values(values).includes(target.id);
+                    })
+                    .map((att) => ({ ...att })); // make a copy
                 attFound.forEach((att) => {
                     if (att.is_custom) {
                         customAttributes.forEach((customAttribute) => {
-                            if (att.id === customAttribute.custom_product_template_attribute_value_id) {
+                            if (
+                                att.id ===
+                                customAttribute.custom_product_template_attribute_value_id
+                            ) {
                                 att.name = customAttribute.value;
                             }
                         });
@@ -1595,7 +1608,8 @@ export class Order extends PosModel {
                 qrCodeSrc(
                     `${this.pos.base_url}/pos/ticket/validate?access_token=${this.access_token}`
                 ),
-            ticket_code: this.pos.company.point_of_sale_ticket_unique_code &&
+            ticket_code:
+                this.pos.company.point_of_sale_ticket_unique_code &&
                 this.finalized &&
                 this.ticketCode,
             base_url: this.pos.base_url,

--- a/addons/point_of_sale/static/tests/unit/popup_controller_tests.js
+++ b/addons/point_of_sale/static/tests/unit/popup_controller_tests.js
@@ -82,9 +82,7 @@ QUnit.test("allow multiple popups at the same time", async function (assert) {
     const popup2Promise = root.popup.add(CustomPopup2, {});
     await nextTick();
 
-    assert.containsOnce(fixture, ".popup", "only one popup is displayed");
     assert.containsOnce(fixture, ".custom-popup-2", "second popup is displayed");
-    assert.containsNone(fixture, ".custom-popup-1", "first popup is not displayed");
 
     await click(fixture.querySelector(".modal-dialog .custom-popup-2 .confirm"));
 
@@ -118,10 +116,9 @@ QUnit.test("pressing cancel/confirm key should only close the top popup", async 
         cancelKey: "Escape",
     });
     await nextTick();
-    assert.containsNone(fixture, ".custom-popup-1", "first popup no longer displayed");
     assert.containsOnce(fixture, ".custom-popup-2", "second popup is open");
 
-    await triggerEvent(fixture, ".popup", "keyup", { key: "Escape" });
+    await triggerEvent(fixture, ".custom-popup-2", "keyup", { key: "Escape" });
     assert.containsNone(fixture, ".custom-popup-2", "second popup no longer displayed");
     assert.containsOnce(fixture, ".custom-popup-1", "first popup is displayed again");
 
@@ -132,7 +129,7 @@ QUnit.test("pressing cancel/confirm key should only close the top popup", async 
         "canceling the popup with escape resolved the promise with confirmed: false"
     );
 
-    await triggerEvent(fixture, ".popup", "keyup", { key: "Enter" });
+    await triggerEvent(fixture, ".custom-popup-1", "keyup", { key: "Enter" });
     assert.containsNone(fixture, ".popup", "no popups remain");
 
     const result1 = await popup1Promise;


### PR DESCRIPTION
Steps:
===
- Install point_of_sale with demo data.
- Select Office combo product .
- Select Desk organizer from pop-up.
- Another pop-up will appear.
- Click on the discard button of the first pop-up.

Issue:
===
- Closing of the first popup breaks the sequence of the combo product.

Cause:
===
- There is no condition to hide the first popup when the second one is displayed

Fix:
===
- Add the d-none class based on condition.

task-3897933