### PR TITLE
[ADD] purchase_{stock}: manually merge rfq

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -652,6 +652,86 @@ class PurchaseOrder(models.Model):
 
         return self.action_view_invoice(moves)
 
+    def action_merge(self):
+        all_origin = []
+        all_vendor_references = []
+        rfq_to_merge = self.filtered(lambda r: r.state in ['draft', 'sent'])
+
+        # Group RFQs by vendor
+        if len(rfq_to_merge) < 2:
+            raise UserError(_("Please select at least two purchase orders with state RFQ and RFQ sent to merge."))
+
+        rfqs_grouped = defaultdict(lambda: self.env['purchase.order'])
+        for rfq in rfq_to_merge:
+            key = self._prepare_grouped_data(rfq)
+            rfqs_grouped[key] += rfq
+
+        bunches_of_rfq_to_be_merge = list(rfqs_grouped.values())
+        if all(len(rfq_bunch) == 1 for rfq_bunch in list(bunches_of_rfq_to_be_merge)):
+            raise UserError(_("In selected purchase order to merge these details must be same\nVendor, currency, destination, dropship address and agreement"))
+        bunches_of_rfq_to_be_merge = [rfqs for rfqs in bunches_of_rfq_to_be_merge if len(rfqs) > 1]
+
+        for rfqs in bunches_of_rfq_to_be_merge:
+            if len(rfqs) <= 1:
+                continue
+            oldest_rfq = min(rfqs, key=lambda r: r.date_order)
+            if oldest_rfq:
+                # Merge RFQs into the oldest purchase order
+                rfqs -= oldest_rfq
+                for rfq_line in rfqs.order_line:
+                    existing_line = oldest_rfq.order_line.filtered(lambda l: l.product_id == rfq_line.product_id and
+                                                                                l.product_uom == rfq_line.product_uom and
+                                                                                l.product_packaging_id == rfq_line.product_packaging_id and
+                                                                                l.product_packaging_qty == rfq_line.product_packaging_qty and
+                                                                                l.analytic_distribution == rfq_line.analytic_distribution and
+                                                                                l.discount == rfq_line.discount and
+                                                                                abs(l.date_planned - rfq_line.date_planned).total_seconds() <= 86400  # 24 hours in seconds
+                                                                        )
+                    if len(existing_line) > 1:
+                        existing_line[0].product_qty += sum(existing_line[1:].mapped('product_qty'))
+                        existing_line[1:].unlink()
+                        existing_line = existing_line[0]
+
+                    if existing_line:
+                        existing_line._merge_po_line(rfq_line)
+                    else:
+                        rfq_line.order_id = oldest_rfq
+
+                # Merge source documents and vendor references
+                all_origin = rfqs.mapped('origin')
+                all_vendor_references = rfqs.mapped('partner_ref')
+
+                oldest_rfq.origin = ', '.join(filter(None, [oldest_rfq.origin, *all_origin]))
+                oldest_rfq.partner_ref = ', '.join(filter(None, [oldest_rfq.partner_ref, *all_vendor_references]))
+
+                rfq_names = rfqs.mapped('name')
+                merged_names = ", ".join(rfq_names)
+                oldest_rfq_message = _("RFQ merged with %(oldest_rfq_name)s and %(cancelled_rfq)s", oldest_rfq_name=oldest_rfq.name, cancelled_rfq=merged_names)
+
+                for rfq in rfqs:
+                    cancelled_rfq_message = _("RFQ merged with %s", oldest_rfq._get_html_link())
+                    rfq.message_post(body=cancelled_rfq_message)
+                oldest_rfq.message_post(body=oldest_rfq_message)
+
+                rfqs.filtered(lambda r: r.state != 'cancel').button_cancel()
+                oldest_rfq._merge_alternative_po(rfqs)
+
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'type': 'success',
+                'message': _('purchase orders merged'),
+                'next': {'type': 'ir.actions.act_window_close'},
+            }
+        }
+
+    def _merge_alternative_po(self, rfqs):
+        pass
+
+    def _prepare_grouped_data(self, rfq):
+        return (rfq.partner_id.id, rfq.currency_id.id, rfq.dest_address_id.id)
+
     def _prepare_invoice(self):
         """Prepare the dict of values to create the new invoice for a purchase order.
         """

--- a/addons/purchase/models/purchase_order_line.py
+++ b/addons/purchase/models/purchase_order_line.py
@@ -685,3 +685,7 @@ class PurchaseOrderLine(models.Model):
             'res_id': self.order_id.id,
             'view_mode': 'form',
         }
+
+    def _merge_po_line(self, rfq_line):
+        self.product_qty += rfq_line.product_qty
+        self.price_unit = min(self.price_unit, rfq_line.price_unit)

--- a/addons/purchase/tests/test_purchase.py
+++ b/addons/purchase/tests/test_purchase.py
@@ -3,6 +3,7 @@
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
 from odoo.tests import tagged, Form
 from odoo import Command, fields
+from odoo.exceptions import UserError
 
 
 from datetime import timedelta
@@ -804,3 +805,60 @@ class TestPurchase(AccountTestInvoicingCommon):
         self.assertEqual(po.order_line.name, '[Vendor B] product_a')
         self.assertEqual(po.order_line.product_qty, 10)
         self.assertEqual(po.order_line.date_planned, fields.Datetime.now() + timedelta(days=6))
+
+    def test_merge_purchase_order(self):
+        PurchaseOrder = self.env['purchase.order']
+        user_1 = self.env['res.users'].search([])[0]
+        user_2 = self.env['res.users'].search([])[1]
+        payment_term_id_1 = self.env['account.payment.term'].search([])[0]
+        payment_term_id_2 = self.env['account.payment.term'].search([])[1]
+        incoterm_id_1 = self.env['account.incoterms'].search([])[0]
+        incoterm_id_2 = self.env['account.incoterms'].search([])[1]
+
+        po_1 = Form(PurchaseOrder)
+        po_1.partner_id = self.partner_a
+        po_1.partner_ref = "azure"
+        po_1.origin = "s0003"
+        po_1.user_id = user_1
+        po_1.payment_term_id = payment_term_id_1
+        po_1.incoterm_id = incoterm_id_1
+        po_1.incoterm_location = "my hub"
+        with po_1.order_line.new() as po_line:
+            po_line.product_id = self.product_a
+            po_line.product_qty = 1
+            po_line.price_unit = 100
+        po_1 = po_1.save()
+
+        po_2 = Form(PurchaseOrder)
+        po_2.partner_id = self.partner_a
+        po_2.partner_ref = "wood corner"
+        po_2.origin = "s0004"
+        po_2.user_id = user_2
+        po_2.payment_term_id = payment_term_id_2
+        po_2.incoterm_id = incoterm_id_2
+        po_2.incoterm_location = "my warehouse"
+
+        with po_2.order_line.new() as po_line_1:
+            po_line_1.product_id = self.product_a
+            po_line_1.product_qty = 5
+            po_line_1.price_unit = 100
+        with po_2.order_line.new() as po_line_2:
+            po_line_2.product_id = self.product_b
+            po_line_2.product_qty = 5
+            po_line_2.price_unit = 500
+        po_2 = po_2.save()
+
+        with self.assertRaises(UserError) as context:
+            PurchaseOrder.browse([po_1.id]).action_merge()
+        self.assertEqual(context.exception.args[0], "Please select at least two purchase orders with state RFQ and RFQ sent to merge.")
+
+        selected_purchase_orders = po_1 | po_2
+        selected_purchase_orders.action_merge()
+        self.assertTrue(po_2.state == 'cancel')
+        self.assertEqual(po_1.order_line[0].product_qty, 6)
+        self.assertEqual(po_1.partner_ref, "azure, wood corner")
+        self.assertEqual(po_1.origin, "s0003, s0004")
+        self.assertEqual(po_1.user_id, user_1)
+        self.assertEqual(po_1.payment_term_id, payment_term_id_1)
+        self.assertEqual(po_1.incoterm_id, incoterm_id_1)
+        self.assertEqual(po_1.incoterm_location, "my hub")

--- a/addons/purchase/views/purchase_views.xml
+++ b/addons/purchase/views/purchase_views.xml
@@ -910,6 +910,19 @@
         <field name="target">new</field>
     </record>
 
+    <record id="action_merger" model="ir.actions.server">
+        <field name="name">Merge</field>
+        <field name="model_id" ref="purchase.model_purchase_order"/>
+        <field name="binding_model_id" ref="purchase.model_purchase_order"/>
+        <field name='groups_id' eval="[(4, ref('account.group_account_invoice'))]"/>
+        <field name="state">code</field>
+        <field name="sequence">1</field>
+        <field name="code">
+            if records:
+                action = records.action_merge()
+        </field>
+    </record>
+
     <record id="action_rfq_form" model="ir.actions.act_window">
         <field name="name">Requests for Quotation</field>
         <field name="res_model">purchase.order</field>

--- a/addons/purchase_requisition/models/purchase.py
+++ b/addons/purchase_requisition/models/purchase.py
@@ -249,6 +249,15 @@ class PurchaseOrder(models.Model):
             best_price_unit_ids.update(lines.ids)
         return list(best_price_ids), list(best_date_ids), list(best_price_unit_ids)
 
+    def _prepare_grouped_data(self, rfq):
+        match_fields = super()._prepare_grouped_data(rfq)
+        return match_fields + (rfq.requisition_id.id,)
+
+    def _merge_alternative_po(self, rfqs):
+        if self.alternative_po_ids:
+            super()._merge_alternative_po(rfqs)
+            self.alternative_po_ids += rfqs.mapped('alternative_po_ids')
+
 
 class PurchaseOrderLine(models.Model):
     _inherit = 'purchase.order.line'

--- a/addons/purchase_stock/models/purchase_order.py
+++ b/addons/purchase_stock/models/purchase_order.py
@@ -119,6 +119,10 @@ class PurchaseOrder(models.Model):
         self._create_picking()
         return result
 
+    def _prepare_grouped_data(self, rfq):
+        match_fields = super()._prepare_grouped_data(rfq)
+        return match_fields + (rfq.picking_type_id.id,)
+
     def button_cancel(self):
         order_lines_ids = OrderedSet()
         pickings_to_cancel_ids = OrderedSet()

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -392,3 +392,7 @@ class PurchaseOrderLine(models.Model):
     def _update_qty_received_method(self):
         """Update qty_received_method for old PO before install this module."""
         self.search(['!', ('state', 'in', ['purchase', 'done'])])._compute_qty_received_method()
+
+    def _merge_po_line(self, rfq_line):
+        super()._merge_po_line(rfq_line)
+        self.move_dest_ids += rfq_line.move_dest_ids


### PR DESCRIPTION
In this commit
===========
Added the new feature that enables manual merging of purchase orders from the same vendor, including draft RFQs and RFQ-sent orders. This streamlines planning and simplifies order management for identical vendors, offering more flexibility for both manual and system-triggered purchase orders.

TaskId: 3577055