### PR TITLE
[IMP] survey: display score for informative quiz

### DIFF
--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -287,22 +287,24 @@
                 <div t-field="survey.description_done" class="oe_no_empty" />
                 <div class="row">
                     <div class="col">
-                        <t t-if="survey.scoring_type != 'no_scoring' and survey.scoring_success_min">
+                        <t t-if="survey.scoring_type != 'no_scoring'">
                             <div>You scored <t t-esc="answer.scoring_percentage" />%</div>
-                            <t t-if="answer.scoring_success">
-                                <div>Congratulations, you have passed the test!</div>
+                            <t t-if="survey.scoring_success_min">
+                                <t t-if="answer.scoring_success">
+                                    <div>Congratulations, you have passed the test!</div>
 
-                                <div t-if="survey.certification" class="mt16 mb16">
-                                    <a role="button"
-                                        class="btn btn-primary btn-lg"
-                                        t-att-href="'/survey/%s/get_certification' % survey.id">
-                                        <i class="fa fa-fw fa-trophy" role="img" aria-label="Download certification" title="Download certification"/>
-                                        Download certification
-                                    </a>
-                                </div>
-                            </t>
-                            <t t-else="">
-                                <div>Unfortunately, you have failed the test.</div>
+                                    <div t-if="survey.certification" class="mt16 mb16">
+                                        <a role="button"
+                                            class="btn btn-primary btn-lg"
+                                            t-att-href="'/survey/%s/get_certification' % survey.id">
+                                            <i class="fa fa-fw fa-trophy" role="img" aria-label="Download certification" title="Download certification"/>
+                                            Download certification
+                                        </a>
+                                    </div>
+                                </t>
+                                <t t-else="">
+                                    <div>Unfortunately, you have failed the test.</div>
+                                </t>
                             </t>
                         </t>
                         <div class="d-flex gap-3 mt-3">


### PR DESCRIPTION
Description of the issue/feature this PR addresses:

Current behavior before PR:
No score was displayed if the required score is set to 0.00% On survey finish screen

Desired behavior after PR is merged:
Score will be displayed if scoring is enabled regardless of the value set in required score.

Task - 3918859

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
