### PR TITLE
[FIX] l10n_cl: fix to allow credit notes code 61 over purchase vendor bills code 46

### DIFF
--- a/addons/l10n_cl/models/account_move.py
+++ b/addons/l10n_cl/models/account_move.py
@@ -58,6 +58,10 @@ class AccountMove(models.Model):
             vat = rec.partner_id.vat
             country_id = rec.partner_id.country_id
             latam_document_type_code = rec.l10n_latam_document_type_id.code
+            if (rec.journal_id.type == 'purchase' and tax_payer_type == '4' and country_id.code != 'CL' and
+                latam_document_type_code == '61' and
+               '46' in rec.l10n_cl_reference_ids.mapped('l10n_cl_reference_doc_type_selection')):
+                continue
             if (not tax_payer_type or not vat) and (country_id.code == "CL" and latam_document_type_code
                                                   and latam_document_type_code not in ['35', '38', '39', '41']):
                 raise ValidationError(_('Tax payer type and vat number are mandatory for this type of '


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Before this fix, It was not possible to issue a credit note code 61 to be applied to an invoice of type '46' when the vendor was foreign. Typically, credit notes for foreign vendors are code 112; however, code 61 is necessary to reverse a type 46 invoice.

After this PR:
In the validation included in this PR, we allow this credit note type 61, provided there is a reference to a code '46' invoice, included in the document reference model.

This PR corresponds to the odoo/enterprise PR enabling the issuance of type 46 invoices referenced below:

https://github.com/odoo/enterprise/pull/59876















---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
