### PR TITLE
[IMP] sale: hide activity_ids when there are no activities

### DIFF
--- a/addons/sale/views/sale_order_views.xml
+++ b/addons/sale/views/sale_order_views.xml
@@ -35,7 +35,7 @@
             <calendar string="Sales Orders" create="0" mode="month" date_start="activity_date_deadline" color="state" event_limit="5" quick_create="0">
                 <field name="currency_id" invisible="1"/>
                 <field name="state" filters="1" invisible="1"/>
-                <field name="activity_ids" options="{'icon': 'fa fa-clock-o'}"/>
+                <field name="activity_ids" options="{'icon': 'fa fa-clock-o'}" invisible="not activity_ids"/>
                 <field name="partner_id" avatar_field="avatar_128" options="{'icon': 'fa fa-users'}"/>
                 <field name="amount_total" widget="monetary"/>
                 <field name="payment_term_id"/>

--- a/addons/web/static/src/views/calendar/calendar_arch_parser.js
+++ b/addons/web/static/src/views/calendar/calendar_arch_parser.js
@@ -29,6 +29,7 @@ export class CalendarArchParser {
         let scale = sessionScale || "week";
         let canCreate = true;
         let canDelete = true;
+        let canEdit = true;
         let quickCreate = true;
         let quickCreateViewId = null;
         let hasEditDialog = false;
@@ -83,6 +84,9 @@ export class CalendarArchParser {
                     }
                     if (node.hasAttribute("delete")) {
                         canDelete = exprToBoolean(node.getAttribute("delete"), true);
+                    }
+                    if (node.hasAttribute("edit")) {
+                        canEdit = exprToBoolean(node.getAttribute("edit"), true);
                     }
                     if (node.hasAttribute("quick_create")) {
                         quickCreate = exprToBoolean(node.getAttribute("quick_create"), true);
@@ -184,6 +188,7 @@ export class CalendarArchParser {
         return {
             canCreate,
             canDelete,
+            canEdit,
             eventLimit,
             fieldMapping,
             fieldNames: [...fieldNames],

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -72,7 +72,7 @@ export class CalendarModel extends Model {
         return this.meta.canDelete;
     }
     get canEdit() {
-        return !this.meta.fields[this.meta.fieldMapping.date_start].readonly;
+        return this.meta.canEdit && !this.meta.fields[this.meta.fieldMapping.date_start].readonly;
     }
     get eventLimit() {
         return this.meta.eventLimit;

--- a/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_arch_parser.test.js
@@ -9,6 +9,7 @@ const parser = new CalendarArchParser();
 const DEFAULT_ARCH_RESULTS = {
     canCreate: true,
     canDelete: true,
+    canEdit: true,
     eventLimit: 5,
     fieldMapping: {
         date_start: "start_date",
@@ -70,6 +71,18 @@ test("canDelete", () => {
     expect(parseWith({ delete: "false" }).canDelete).toBe(false);
     expect(parseWith({ delete: "False" }).canDelete).toBe(false);
     expect(parseWith({ delete: "0" }).canDelete).toBe(false);
+});
+
+test("canEdit", () => {
+    expect(parseWith({ edit: "" }).canEdit).toBe(true);
+
+    expect(parseWith({ edit: "true" }).canEdit).toBe(true);
+    expect(parseWith({ edit: "True" }).canEdit).toBe(true);
+    expect(parseWith({ edit: "1" }).canEdit).toBe(true);
+
+    expect(parseWith({ edit: "false" }).canEdit).toBe(false);
+    expect(parseWith({ edit: "False" }).canEdit).toBe(false);
+    expect(parseWith({ edit: "0" }).canEdit).toBe(false);
 });
 
 test("eventLimit", () => {

--- a/odoo/addons/base/rng/calendar_view.rng
+++ b/odoo/addons/base/rng/calendar_view.rng
@@ -26,6 +26,7 @@
             <rng:optional><rng:attribute name="hide_date"/></rng:optional>
             <rng:optional><rng:attribute name="create"/></rng:optional>
             <rng:optional><rng:attribute name="delete"/></rng:optional>
+            <rng:optional><rng:attribute name="edit"/></rng:optional>
             <rng:optional><rng:attribute name="scales"/></rng:optional>
             <rng:optional><rng:attribute name="banner_route"/></rng:optional>
             <rng:optional>


### PR DESCRIPTION
Before:
The calendar view pop-up displayed an empty activity line when no activities
were scheduled for a rental order, which was not visually appealing.

After:
If no activities are scheduled for a particular rental order, the activity_ids
field is now hidden from the calendar view pop-up.

task-3893588