### PR TITLE
[PERF] stock: improve stock.move name_get memory usage

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -569,7 +569,7 @@ class StockMove(models.Model):
 
     def name_get(self):
         res = []
-        for move in self:
+        for move in self.with_context(prefetch_fields=False):
             res.append((move.id, '%s%s%s>%s' % (
                 move.picking_id.origin and '%s/' % move.picking_id.origin or '',
                 move.product_id.code and '%s: ' % move.product_id.code or '',


### PR DESCRIPTION
In the context of an export with a lot of records containing a 'stock.move' field (ex: stock.valuation.layer.stock_move_id):
 - Only the picking_id.origin, product_id.code and location(_dest)_id.name are needed.
 - Most of the data of picking_id, product_id and location(_dest)_id will be fetch and put in cache. This can result in a memory error as multiple thousands of records values (at the very least) will be stored in the cache.

Customer cases:
STOCK.MOVE: 350_000

BEFORE:     994 MB
![image](https://github.com/odoo/odoo/assets/29302288/161b0ba5-a3b2-4e66-86b5-c141e96632ca)

AFTER:      105 MB
![image](https://github.com/odoo/odoo/assets/29302288/01e5a36f-f741-48ff-829e-ed65dfce5a17)

OPW-3911127

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
