### PR TITLE
[FIX] website_sale: retain rental period on attribute

### DIFF
--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -265,7 +265,7 @@ class WebsiteSale(http.Controller):
             'order': order,
         }
 
-    def _get_additional_shop_values(self, values):
+    def _get_additional_shop_values(self, values, **post):
         """ Hook to update values used for rendering website_sale.products template """
         return {}
 
@@ -452,7 +452,7 @@ class WebsiteSale(http.Controller):
             values['available_max_price'] = tools.float_round(available_max_price, 2)
         if category:
             values['main_object'] = category
-        values.update(self._get_additional_shop_values(values))
+        values.update(self._get_additional_shop_values(values, **post))
         return request.render("website_sale.products", values)
 
     @http.route(['/shop/<model("product.template"):product>'], type='http', auth="public", website=True, sitemap=True)


### PR DESCRIPTION
version - 16.0

Steps:
-Install rental app.
-Activate the date picker from the web-editor.
-Add the start date and end date from that.
-Select some attribute of the product.

Issue:
-When any user adds the start date and end date from the date picker and 
after that, the user adds the other attribute(filter) of the product, that s>

Cause:
-The selected rental period (start and end dates) is not persisted when the
 page refreshes or updates due to attribute selection.

Fix:
Get the value of 'start_date' and 'end_date'.
Update the hidden input fields for 'start_date' and 'end_date' with the 
values before applying the attribute changes.

opw-3774060