### PR TITLE
[IMP] account: register payment difference in multiple coa

### DIFF
--- a/addons/account/security/ir.model.access.csv
+++ b/addons/account/security/ir.model.access.csv
@@ -134,3 +134,4 @@ access_account_report_column_ac_user,account.report.column.ac.user,model_account
 
 access_account_report_external_value_readonly,account.report.external.value.readonly,model_account_report_external_value,account.group_account_readonly,1,0,0,0
 access_account_report_external_value_ac_user,account.report.external.value.ac.user,model_account_report_external_value,account.group_account_manager,1,1,1,1
+account.access_account_payment_register_dif_line,access_account_payment_register_dif_line,account.model_account_payment_register_dif_line,base.group_user,1,1,1,1

--- a/addons/account/tests/test_account_move_reconcile.py
+++ b/addons/account/tests/test_account_move_reconcile.py
@@ -4837,7 +4837,13 @@ class TestAccountMoveReconcile(AccountTestInvoicingCommon):
         payment_vals = {
             'currency_id': self.other_currency.id,
             'payment_difference_handling': 'reconcile',
-            'writeoff_account_id': self.env.company.expense_currency_exchange_account_id.id,
+            'account_payment_register_dif_ids': [
+                Command.create({
+                    'writeoff_account_id': self.env.company.expense_currency_exchange_account_id.id,
+                    'writeoff_label': 'Writeoff Label',
+                    'writeoff_amount': 0.0,
+                })
+            ],
         }
 
         # Check that a payment can be created if no exchange difference entry is generated.

--- a/addons/account/tests/test_account_payment_register.py
+++ b/addons/account/tests/test_account_payment_register.py
@@ -188,8 +188,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'amount': 800.0,
             'group_payment': True,
             'payment_difference_handling': 'reconcile',
-            'writeoff_account_id': self.company_data['default_account_revenue'].id,
-            'writeoff_label': 'writeoff',
+            'account_payment_register_dif_ids': [
+                Command.create({
+                    'writeoff_account_id': self.company_data['default_account_revenue'].id,
+                    'writeoff_label': 'Writeoff Label',
+                    'writeoff_amount': 2200.0,
+                })
+            ],
             'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
@@ -231,8 +236,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'amount': 3100.0,
             'group_payment': True,
             'payment_difference_handling': 'reconcile',
-            'writeoff_account_id': self.company_data['default_account_revenue'].id,
-            'writeoff_label': 'writeoff',
+            'account_payment_register_dif_ids': [
+                Command.create({
+                    'writeoff_account_id': self.company_data['default_account_revenue'].id,
+                    'writeoff_label': 'Writeoff Label',
+                    'writeoff_amount': -100.0,
+                })
+            ],
             'payment_method_line_id': self.inbound_payment_method_line.id,
         })._create_payments()
 
@@ -274,8 +284,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'amount': 800.0,
             'group_payment': True,
             'payment_difference_handling': 'reconcile',
-            'writeoff_account_id': self.company_data['default_account_revenue'].id,
-            'writeoff_label': 'writeoff',
+            'account_payment_register_dif_ids': [
+                Command.create({
+                    'writeoff_account_id': self.company_data['default_account_revenue'].id,
+                    'writeoff_label': 'Writeoff Label',
+                    'writeoff_amount': 2200.0,
+                })
+            ],
             'payment_method_line_id': self.outbound_payment_method_line.id,
         })._create_payments()
 
@@ -317,8 +332,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
             'amount': 3100.0,
             'group_payment': True,
             'payment_difference_handling': 'reconcile',
-            'writeoff_account_id': self.company_data['default_account_revenue'].id,
-            'writeoff_label': 'writeoff',
+            'account_payment_register_dif_ids': [
+                Command.create({
+                    'writeoff_account_id': self.company_data['default_account_revenue'].id,
+                    'writeoff_label': 'Writeoff Label',
+                    'writeoff_amount': -100.0,
+                })
+            ],
             'payment_method_line_id': self.outbound_payment_method_line.id,
         })._create_payments()
 
@@ -854,8 +874,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'currency_id': self.other_currency_2.id,
                 'amount': 0.08,
                 'payment_difference_handling': 'reconcile',
-                'writeoff_account_id': self.company_data['default_account_revenue'].id,
-                'writeoff_label': 'writeoff',
+                'account_payment_register_dif_ids': [
+                    Command.create({
+                        'writeoff_account_id': self.company_data['default_account_revenue'].id,
+                        'writeoff_label': 'Writeoff Label',
+                        'writeoff_amount': 0.04,
+                    })
+                ],
             })\
             ._create_payments()
 
@@ -893,8 +918,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'currency_id': self.other_currency_2.id,
                 'amount': 0.08,
                 'payment_difference_handling': 'reconcile',
-                'writeoff_account_id': self.company_data['default_account_revenue'].id,
-                'writeoff_label': 'writeoff',
+                'account_payment_register_dif_ids': [
+                    Command.create({
+                        'writeoff_account_id': self.company_data['default_account_revenue'].id,
+                        'writeoff_label': 'Writeoff Label',
+                        'writeoff_amount': 0.04,
+                    })
+                ],
             })\
             ._create_payments()
 
@@ -932,8 +962,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'currency_id': self.other_currency_2.id,
                 'amount': 0.16,
                 'payment_difference_handling': 'reconcile',
-                'writeoff_account_id': self.company_data['default_account_revenue'].id,
-                'writeoff_label': 'writeoff',
+                'account_payment_register_dif_ids': [
+                    Command.create({
+                        'writeoff_account_id': self.company_data['default_account_revenue'].id,
+                        'writeoff_label': 'Writeoff Label',
+                        'writeoff_amount': -0.04,
+                    })
+                ],
             })\
             ._create_payments()
 
@@ -971,8 +1006,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'currency_id': self.other_currency_2.id,
                 'amount': 0.16,
                 'payment_difference_handling': 'reconcile',
-                'writeoff_account_id': self.company_data['default_account_revenue'].id,
-                'writeoff_label': 'writeoff',
+                'account_payment_register_dif_ids': [
+                    Command.create({
+                        'writeoff_account_id': self.company_data['default_account_revenue'].id,
+                        'writeoff_label': 'Writeoff Label',
+                        'writeoff_amount': -0.04,
+                    })
+                ],
             })\
             ._create_payments()
 
@@ -1019,7 +1059,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'currency_id': self.other_currency.id,
                 'amount': 1998,
                 'payment_difference_handling': 'reconcile',
-                'writeoff_account_id': self.env.company.expense_currency_exchange_account_id.id,
+                'account_payment_register_dif_ids': [
+                    Command.create({
+                        'writeoff_account_id': self.env.company.expense_currency_exchange_account_id.id,
+                        'writeoff_label': 'Writeoff Label',
+                        'writeoff_amount': 1.0,
+                    })
+                ],
             })\
             ._create_payments()
 
@@ -1082,7 +1128,13 @@ class TestAccountPaymentRegister(AccountTestInvoicingCommon):
                 'amount': 370.0,
                 'payment_date': '2016-01-01',
                 'payment_difference_handling': 'reconcile',
-                'writeoff_account_id': self.env.company.expense_currency_exchange_account_id.id,
+                'account_payment_register_dif_ids': [
+                    Command.create({
+                        'writeoff_account_id': self.env.company.expense_currency_exchange_account_id.id,
+                        'writeoff_label': 'Writeoff Label',
+                        'writeoff_amount': 1.0,
+                    })
+                ],
             })\
             ._create_payments()
 

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -29,7 +29,6 @@
                     <field name="available_partner_bank_ids" invisible="1"/>
                     <field name="company_currency_id" invisible="1"/>
                     <field name="hide_writeoff_section" invisible="1"/>
-                    <field name="writeoff_is_exchange_account" invisible="1"/>
                     <field name="untrusted_bank_ids" invisible="1"/>
                     <field name="missing_account_partners" invisible="1"/>
 
@@ -70,31 +69,31 @@
                             <field name="communication"
                                    invisible="not can_edit_wizard or (can_group_payments and not group_payment)"/>
                         </group>
-                        <group name="group3"
-                               invisible="payment_difference == 0.0 or not can_edit_wizard or can_group_payments and not group_payment">
-                            <label for="payment_difference"/>
-                            <div>
-                                <field name="payment_difference"/>
-                                <field name="payment_difference_handling" widget="radio" nolabel="1"/>
-                                <div invisible="hide_writeoff_section or payment_difference_handling == 'open'">
-                                    <label for="writeoff_account_id" string="Post Difference In" class="oe_edit_only"/>
-                                    <field name="writeoff_account_id"
-                                           string="Post Difference In"
-                                           options="{'no_create': True}"
-                                           required="payment_difference_handling == 'reconcile' and not early_payment_discount_mode"/>
-                                    <label for="writeoff_label"
-                                           class="oe_edit_only"
-                                           string="Label"
-                                           invisible="writeoff_is_exchange_account"/>
-                                    <field name="writeoff_label"
-                                           required="payment_difference_handling == 'reconcile'"
-                                           invisible="writeoff_is_exchange_account"/>
-                                </div>
-                            </div>
-                        </group>
                         <field name="qr_code" invisible="1"/>
                         <div invisible="not qr_code" colspan="2" class="text-center">
                             <field name="qr_code"/>
+                        </div>
+                    </group>
+                    <group invisible="payment_difference == 0.0 or not can_edit_wizard or can_group_payments and not group_payment">
+                        <label for="payment_difference"/>
+                        <div>
+                            <field name="payment_difference"/>
+                            <field name="payment_difference_handling" widget="radio" nolabel="1"/>
+                            <div invisible="hide_writeoff_section or payment_difference_handling == 'open'">
+                                <field name="account_payment_register_dif_ids">
+                                    <tree string="Difference Lines" editable="bottom">
+                                        <!-- Invisible fields -->
+                                        <field name="currency_id" invisible="1" column_invisible="1"/>
+                                        <field name='source_currency_id' invisible="1" column_invisible="1"/>
+                                        <field name='can_edit_wizard' invisible="1" column_invisible="1"/>
+                                        <field name="writeoff_is_exchange_account" invisible="1" column_invisible="1"/>
+
+                                        <field name="writeoff_account_id" string="Post Difference In" modifiers="{'required':true}" options="{'no_create': True}"/>
+                                        <field name="writeoff_label" placeholder="eg. Writeoff label..." modifiers="{'required':true}"/>
+                                        <field name="writeoff_amount" string="Amount" modifiers="{'required':true}"/>
+                                    </tree>
+                                </field>
+                            </div>
                         </div>
                     </group>
                     <footer>


### PR DESCRIPTION
- Currently, during the posting of partial payments, users are limited to selecting only one Chart of Accounts (COA) for posting the entire difference. This restriction prevents users from allocating the difference across multiple COAs. The received amount against a customer invoice may be lower for various reasons, sometimes involving multiple factors such as TDS and Cash Discount both

- For that, Introduce an editable field against the Chart of Accounts (COA) to register difference amount in multiple accounts.

task - 3707383

Community PR - https://github.com/odoo/odoo/pull/165077
Enterprise PR - https://github.com/odoo/enterprise/pull/62442
Upgrade PR - https://github.com/odoo/upgrade/pull/6014
