### PR TITLE
[FIX] web: apply web search read after save

### DIFF
--- a/addons/web/static/src/model/relational_model/dynamic_record_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_record_list.js
@@ -148,16 +148,16 @@ export class DynamicRecordList extends DynamicList {
         );
     }
 
-    _removeRecords(recordIds) {
+    _removeRecords(recordIds, options = {}) {
         const _records = this.records.filter((r) => !recordIds.includes(r.id));
-        if (this.offset && !_records.length) {
+        if (this.offset && !_records.length && !options.noLoad) {
             // we weren't on the first page, and we removed all records of the current page
             const offset = Math.max(this.offset - this.limit, 0);
             return this._load(offset, this.limit, this.orderBy, this.domain);
         }
         const nbRemovedRecords = this.records.length - _records.length;
         if (nbRemovedRecords > 0) {
-            if (this.count > this.offset + this.limit) {
+            if (this.count > this.offset + this.limit && !options.noLoad) {
                 // we removed some records, and there are other pages after the current one
                 return this._load(this.offset, this.limit, this.orderBy, this.domain);
             } else {

--- a/addons/web/static/src/model/relational_model/group.js
+++ b/addons/web/static/src/model/relational_model/group.js
@@ -115,9 +115,9 @@ export class Group extends DataPoint {
         this.count -= records.length;
     }
 
-    async _removeRecords(recordIds) {
+    async _removeRecords(recordIds, options = {}) {
         const idsToRemove = recordIds.filter((id) => this.list.records.some((r) => r.id === id));
-        await this.list._removeRecords(idsToRemove);
+        await this.list._removeRecords(idsToRemove, options);
         this.count -= idsToRemove.length;
     }
 }

--- a/addons/web/static/tests/views/kanban/kanban_view_tests.js
+++ b/addons/web/static/tests/views/kanban/kanban_view_tests.js
@@ -4981,6 +4981,33 @@ QUnit.module("Views", (hooks) => {
         assert.deepEqual(allNames, ["hello", "", "xmo", ""]);
     });
 
+    QUnit.test("drag and drop a record with load more", async (assert) => {
+        await makeView({
+            type: "kanban",
+            resModel: "partner",
+            serverData,
+            arch: `<kanban limit="1">
+                    <templates>
+                        <t t-name="kanban-box">
+                            <div><field name="id"/></div>
+                        </t>
+                    </templates>
+                </kanban>`,
+            groupBy: ["bar"],
+        });
+
+        assert.deepEqual(getCardTexts(target, 0), ["4"], "we should have 1 record shown");
+        assert.deepEqual(getCardTexts(target, 1), ["1"], "we should have 1 record shown");
+
+        await dragAndDrop(
+            getColumn(target, 1).querySelector(".o_kanban_record"),
+            ".o_kanban_group:nth-child(1)"
+        );
+
+        assert.deepEqual(getCardTexts(target, 0), ["4", "1"], "we should have 1 record shown");
+        assert.deepEqual(getCardTexts(target, 1), ["2"], "we should have 1 record shown");
+    });
+
     QUnit.test("can drag and drop a record from one column to the next", async (assert) => {
         await makeView({
             type: "kanban",


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create a project with more than 80 tasks in a stage (see note)
- move the first task to another stage

Issue:
------
THe task appears in the other stage but it still in the previous stage.

Cause:
------
When a record is removed from a stage and has a count greater than the limit, a `web_search_read` is triggered to find the records that should be there. Unfortunately, the record still owns the stage on the server side and is therefore included in the stage (although it has been moved to the other stage).

Solution:
---------
Force the `_load` of the list only when necessary, making sure that it is after the `web_save` to ensure that the changes are applied on the backend.

opw-3891269

Note:
Server action:
```py
project = env['project.project'].create({
    'name': 'test project with 80 tasks',
})
stage = env['project.task.type'].create({
    'name': 'new'
})
env['project.task'].create([
	{
        'name': f'test {i}',
        'project_id': project.id,
        'stage_id': stage.id,
    }
    for i in range(85)
])
```