### PR TITLE
[FIX] web_editor: preserve table selection on formatting commands

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js
@@ -1832,6 +1832,7 @@ export class OdooEditor extends EventTarget {
                 if (sel.anchorNode && ancestors(sel.anchorNode).includes(this.editable)) {
                     this.execCommand(buttonEl.dataset.call, buttonEl.dataset.arg1);
 
+                    this.historyResetLatestComputedSelection(true);
                     ev.preventDefault();
                     this._updateToolbar();
                 }
@@ -3837,21 +3838,25 @@ export class OdooEditor extends EventTarget {
             ev.preventDefault();
             ev.stopPropagation();
             this.execCommand('bold');
+            this.historyResetLatestComputedSelection(true);
         } else if (IS_KEYBOARD_EVENT_ITALIC(ev)) {
             // Ctrl-I
             ev.preventDefault();
             ev.stopPropagation();
             this.execCommand('italic');
+            this.historyResetLatestComputedSelection(true);
         } else if (IS_KEYBOARD_EVENT_UNDERLINE(ev)) {
             // Ctrl-U
             ev.preventDefault();
             ev.stopPropagation();
             this.execCommand('underline');
+            this.historyResetLatestComputedSelection(true);
         } else if (IS_KEYBOARD_EVENT_STRIKETHROUGH(ev)) {
             // Ctrl-5 / Ctrl-shift-(
             ev.preventDefault();
             ev.stopPropagation();
             this.execCommand('strikeThrough');
+            this.historyResetLatestComputedSelection(true);
         } else if (IS_KEYBOARD_EVENT_LEFT_ARROW(ev) || IS_KEYBOARD_EVENT_RIGHT_ARROW(ev)) {
             // Move selection if adjacent character is zero-width space.
             const side = ev.key === 'ArrowLeft' ? 'previous' : 'next';

--- a/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/src/utils/utils.js
@@ -1218,19 +1218,14 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
         getDeepRange(editor.editable, { splitText: true, select: true, correctTripleClick: true });
     }
 
-    // Get selected nodes within td to handle non-p elements like h1, h2...
-    // Targeting <br> to ensure span stays inside its corresponding block node.
-    const selectedNodesInTds = [...editor.editable.querySelectorAll('.o_selected_td')]
-        .map(node => closestElement(node).querySelector('br'));
     const selectedNodes = getSelectedNodes(editor.editable)
-        .filter(n => n.nodeType === Node.TEXT_NODE && closestElement(n).isContentEditable && isVisibleTextNode(n));
-    const selectedTextNodes = selectedNodes.length ? selectedNodes : selectedNodesInTds;
+        .filter(n => ((n.nodeType === Node.TEXT_NODE && isVisibleTextNode(n)) || n.nodeName === 'BR') && closestElement(n).isContentEditable);
 
     const formatSpec = formatsSpecs[formatName];
-    for (const selectedTextNode of selectedTextNodes) {
+    for (const node of selectedNodes) {
         const inlineAncestors = [];
-        let currentNode = selectedTextNode;
-        let parentNode = selectedTextNode.parentElement;
+        let currentNode = node;
+        let parentNode = node.parentElement;
 
         // Remove the format on all inline ancestors until a block or an element
         // with a class (in case the formating comes from the class).
@@ -1259,20 +1254,20 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
 
         const firstBlockOrClassHasFormat = formatSpec.isFormatted(parentNode, formatProps);
         if (firstBlockOrClassHasFormat && !applyStyle) {
-            formatSpec.addNeutralStyle && formatSpec.addNeutralStyle(getOrCreateSpan(selectedTextNode, inlineAncestors));
+            formatSpec.addNeutralStyle && formatSpec.addNeutralStyle(getOrCreateSpan(node, inlineAncestors));
         } else if (!firstBlockOrClassHasFormat && applyStyle) {
             const tag = formatSpec.tagName && document.createElement(formatSpec.tagName);
             if (tag) {
-                selectedTextNode.after(tag);
-                tag.append(selectedTextNode);
+                node.after(tag);
+                tag.append(node);
 
                 if (!formatSpec.isFormatted(tag, formatProps)) {
-                    tag.after(selectedTextNode);
+                    tag.after(node);
                     tag.remove();
-                    formatSpec.addStyle(getOrCreateSpan(selectedTextNode, inlineAncestors), formatProps);
+                    formatSpec.addStyle(getOrCreateSpan(node, inlineAncestors), formatProps);
                 }
             } else if (formatName !== 'fontSize' || formatProps.size !== undefined) {
-                formatSpec.addStyle(getOrCreateSpan(selectedTextNode, inlineAncestors), formatProps);
+                formatSpec.addStyle(getOrCreateSpan(node, inlineAncestors), formatProps);
             }
         }
     }
@@ -1281,8 +1276,8 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
         const siblings = [...zws.parentElement.childNodes];
         if (
             !isBlock(zws.parentElement) &&
-            selectedTextNodes.includes(siblings[0]) &&
-            selectedTextNodes.includes(siblings[siblings.length - 1])
+            selectedNodes.includes(siblings[0]) &&
+            selectedNodes.includes(siblings[siblings.length - 1])
         ) {
             zws.parentElement.setAttribute('data-oe-zws-empty-inline', '');
         } else {
@@ -1292,12 +1287,11 @@ export const formatSelection = (editor, formatName, {applyStyle, formatProps} = 
             span.append(zws);
         }
     }
-
-    if (selectedTextNodes[0] && selectedTextNodes[0].textContent === '\u200B') {
-        setSelection(selectedTextNodes[0], 0);
-    } else if (selectedTextNodes.length) {
-        const firstNode = selectedTextNodes[0];
-        const lastNode = selectedTextNodes[selectedTextNodes.length - 1];
+    if (selectedNodes.length === 1 && selectedNodes[0].textContent === '\u200B') {
+        setSelection(selectedNodes[0], 0);
+    } else if (selectedNodes.length) {
+        const firstNode = selectedNodes[0];
+        const lastNode = selectedNodes[selectedNodes.length - 1];
         if (direction === DIRECTIONS.RIGHT) {
             setSelection(firstNode, 0, lastNode, lastNode.length, false);
         } else {

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/format.test.js
@@ -1,5 +1,5 @@
 import { isSelectionFormat } from '../../src/utils/utils.js';
-import { BasicEditor, testEditor, setTestSelection, Direction, unformat, insertText } from '../utils.js';
+import { BasicEditor, testEditor, setTestSelection, Direction, unformat, insertText, triggerEvent } from '../utils.js';
 
 const bold = async editor => {
     await editor.execCommand('bold');
@@ -52,6 +52,55 @@ describe('Format', () => {
                 contentBefore: '<p>ab[cde]fg</p>',
                 stepFunction: bold,
                 contentAfter: `<p>ab${strong(`[cde]`)}fg</p>`,
+            });
+        });
+        it('should make a few characters bold inside table', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                    <table class="table table-bordered o_table o_selected_table">
+                        <tbody>
+                            <tr>
+                                <td class="o_selected_td"><p>[abc</p></td>
+                                <td class="o_selected_td"><p>def</p></td>
+                                <td class="o_selected_td"><p>]<br></p></td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>`
+                ),
+                stepFunction: async editor => {
+                    await triggerEvent(editor.editable, 'keydown', { key: 'b', ctrlKey: true });
+                },
+                contentAfterEdit: unformat(`
+                    <table class="table table-bordered o_table o_selected_table">
+                        <tbody>
+                            <tr>
+                                <td class="o_selected_td"><p>${strong(`[abc`)}</p></td>
+                                <td class="o_selected_td"><p>${strong(`def`)}</p></td>
+                                <td class="o_selected_td"><p>${strong(`]<br>`)}</p></td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>`
+                ),
             });
         });
         it('should make a few characters not bold', async () => {
@@ -228,6 +277,55 @@ describe('Format', () => {
                 contentAfter: `<p>ab${em(`[cde]`)}fg</p>`,
             });
         });
+        it('should make a few characters italic inside table', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                    <table class="table table-bordered o_table o_selected_table">
+                        <tbody>
+                            <tr>
+                                <td class="o_selected_td"><p>[abc</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p>def</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p>]<br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>`
+                ),
+                stepFunction: async editor => {
+                    await triggerEvent(editor.editable, 'keydown', { key: 'i', ctrlKey: true });
+                },
+                contentAfterEdit: unformat(`
+                    <table class="table table-bordered o_table o_selected_table">
+                        <tbody>
+                            <tr>
+                                <td class="o_selected_td"><p>${em(`[abc`)}</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p>${em(`def`)}</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p>${em(`]<br>`)}</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>`
+                ),
+            });
+        });
         it('should make a few characters not italic', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p>${em(`ab[cde]fg`)}</p>`,
@@ -316,6 +414,55 @@ describe('Format', () => {
                 contentAfter: `<p>ab${u(`[cde]`)}fg</p>`,
             });
         });
+        it('should make a few characters underline inside table', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                    <table class="table table-bordered o_table o_selected_table">
+                        <tbody>
+                            <tr>
+                                <td class="o_selected_td"><p>[abc</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p>def</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p>]<br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>`
+                ),
+                stepFunction: async editor => {
+                    await triggerEvent(editor.editable, 'keydown', { key: 'u', ctrlKey: true });
+                },
+                contentAfterEdit: unformat(`
+                    <table class="table table-bordered o_table o_selected_table">
+                        <tbody>
+                            <tr>
+                                <td class="o_selected_td"><p>${u(`[abc`)}</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p>${u(`def`)}</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td class="o_selected_td"><p>${u(`]<br>`)}</p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>`
+                ),
+            });
+        });
         it('should make a few characters not underline', async () => {
             await testEditor(BasicEditor, {
                 contentBefore: `<p>${u(`ab[cde]fg`)}</p>`,
@@ -402,6 +549,55 @@ describe('Format', () => {
                 contentBefore: `<p>ab[cde]fg</p>`,
                 stepFunction: strikeThrough,
                 contentAfter: `<p>ab${s(`[cde]`)}fg</p>`,
+            });
+        });
+        it('should make a few characters strikeThrough inside table', async () => {
+            await testEditor(BasicEditor, {
+                contentBefore: unformat(`
+                    <table class="table table-bordered o_table o_selected_table">
+                        <tbody>
+                            <tr>
+                                <td class="o_selected_td"><p>[abc</p></td>
+                                <td class="o_selected_td"><p>def</p></td>
+                                <td class="o_selected_td"><p>]<br></p></td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>`
+                ),
+                stepFunction: async editor => {
+                    await triggerEvent(editor.editable, 'keydown', { key: '5', ctrlKey: true });
+                },
+                contentAfterEdit: unformat(`
+                    <table class="table table-bordered o_table o_selected_table">
+                        <tbody>
+                            <tr>
+                                <td class="o_selected_td"><p>${s(`[abc`)}</p></td>
+                                <td class="o_selected_td"><p>${s(`def`)}</p></td>
+                                <td class="o_selected_td"><p>${s(`]<br>`)}</p></td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                            <tr>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                                <td><p><br></p></td>
+                            </tr>
+                        </tbody>
+                    </table>`
+                ),
             });
         });
         it('should make a few characters not strikeThrough', async () => {

--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1657,8 +1657,8 @@ const Wysiwyg = Widget.extend({
                         // Deselect tables so the applied color can be seen
                         // without using `!important` (otherwise the selection
                         // hides it).
-                        if (this.odooEditor.deselectTable() && hasValidSelection(this.odooEditor.editable)) {
-                            this.odooEditor.document.getSelection().collapseToStart();
+                        if (hasValidSelection(this.odooEditor.editable)) {
+                            this.odooEditor.deselectTable();
                         }
                         this._updateEditorUI(this.lastMediaClicked && { target: this.lastMediaClicked });
                         colorpicker.off('color_leave');


### PR DESCRIPTION
### Description of the issue/feature this PR addresses:

On selecting multiple cells in a table and applying formatting commands like (Bold, Italic, Underline, and Strikethrough) resulted in the loss of selection. The root cause of this issue was identified in the `cleanForSave()` function, which triggered `deselectTable()` during command execution, removing the entire selection from the table results in collapsing the selection to start.

### Approach:

This PR addresses the issue by restoring selection using `historyResetLatestComputedSelection()` after executing the command, ensuring that the selection is preserved as intended. Additionally, a specific issue related to applying heading tags was encountered, stemming from the call to `getDeepRange()` within the `formatSelection()` function, disrupting proper selection restoration, particularly in the case of headings.

### Desired behavior after PR is merged:

We maintain the selection after applying formatting commands (Bold, Italic, Underline, and Strikethrough) in table.

task-3822527