### PR TITLE
[IMP] hr_holidays: improve time off types with public holiday inclusion

### DIFF
--- a/addons/hr_holidays/models/hr_leave.py
+++ b/addons/hr_holidays/models/hr_leave.py
@@ -534,7 +534,7 @@ class HolidaysRequest(models.Model):
         for leave in employee_leaves:
             if not leave.date_from or not leave.date_to:
                 continue
-            employees_by_dates_calendar[(leave.date_from, leave.date_to, resource_calendar or leave.resource_calendar_id)] += leave.employee_id
+            employees_by_dates_calendar[(leave.date_from, leave.date_to, leave.holiday_status_id.include_public_holidays_in_duration, resource_calendar or leave.resource_calendar_id)] += leave.employee_id
         # We force the company in the domain as we are more than likely in a compute_sudo
         domain = [('time_type', '=', 'leave'),
                   ('company_id', 'in', self.env.companies.ids + self.env.context.get('allowed_company_ids', [])),
@@ -543,12 +543,13 @@ class HolidaysRequest(models.Model):
                   '|', ('holiday_id', '=', False), ('holiday_id', 'not in', employee_leaves.ids)]
         # Precompute values in batch for performance purposes
         work_time_per_day_mapped = {
-            (date_from, date_to, calendar): employees._list_work_time_per_day(date_from, date_to, domain=domain, calendar=calendar)
-            for (date_from, date_to, calendar), employees in employees_by_dates_calendar.items()
+            (date_from, date_to, calendar): employees.with_context(
+                    compute_leaves=not include_public_holidays_in_duration)._list_work_time_per_day(date_from, date_to, domain=domain, calendar=calendar)
+            for (date_from, date_to, include_public_holidays_in_duration, calendar), employees in employees_by_dates_calendar.items()
         }
         work_days_data_mapped = {
-            (date_from, date_to, calendar): employees._get_work_days_data_batch(date_from, date_to, domain=domain, calendar=calendar)
-            for (date_from, date_to, calendar), employees in employees_by_dates_calendar.items()
+            (date_from, date_to, calendar): employees._get_work_days_data_batch(date_from, date_to, compute_leaves=not include_public_holidays_in_duration, domain=domain, calendar=calendar)
+            for (date_from, date_to, include_public_holidays_in_duration, calendar), employees in employees_by_dates_calendar.items()
         }
         for leave in self:
             calendar = resource_calendar or leave.resource_calendar_id
@@ -570,7 +571,7 @@ class HolidaysRequest(models.Model):
                     datetime.combine(leave.date_from.date(), time.min),
                     datetime.combine(leave.date_from.date(), time.max),
                     False)
-                hours = calendar.get_work_hours_count(leave.date_from, leave.date_to)
+                hours = calendar.get_work_hours_count(leave.date_from, leave.date_to, compute_leaves=not leave.holiday_status_id.include_public_holidays_in_duration)
                 days = hours / (today_hours or HOURS_PER_DAY)
             if leave.leave_type_request_unit == 'day' and check_leave_type:
                 days = ceil(days)

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -9,6 +9,7 @@ from collections import defaultdict
 from datetime import time, datetime
 
 from odoo import api, fields, models
+from odoo.exceptions import ValidationError
 from odoo.tools import format_date, frozendict
 from odoo.tools.translate import _
 from odoo.tools.float_utils import float_round
@@ -89,6 +90,7 @@ class HolidaysType(models.Model):
         ('half_day', 'Half Day'),
         ('hour', 'Hours')], default='day', string='Take Time Off in', required=True)
     unpaid = fields.Boolean('Is Unpaid', default=False)
+    include_public_holidays_in_duration = fields.Boolean('Public Holiday Included', default=False, help="Public holidays should be counted in the leave duration when applying for leaves")
     leave_notif_subtype_id = fields.Many2one('mail.message.subtype', string='Time Off Notification Subtype', default=lambda self: self.env.ref('hr_holidays.mt_leave', raise_if_not_found=False))
     allocation_notif_subtype_id = fields.Many2one('mail.message.subtype', string='Allocation Notification Subtype', default=lambda self: self.env.ref('hr_holidays.mt_leave_allocation', raise_if_not_found=False))
     support_document = fields.Boolean(string='Supporting Document')
@@ -137,6 +139,37 @@ class HolidaysType(models.Model):
         ]).holiday_status_id
 
         return [('id', new_operator, leave_types.ids)]
+
+    @api.constrains('include_public_holidays_in_duration')
+    def _check_overlapping_public_holidays(self):
+        public_holidays = self.env['resource.calendar.leaves'].search([
+            ('resource_id', '=', False),
+            '|', ('company_id', 'in', self.company_id.ids),
+                 ('company_id', '=', self.env.company.id),
+        ])
+
+        # Define the date range for the current year
+        min_datetime = fields.Datetime.to_string(datetime.now().replace(month=1, day=1, hour=0, minute=0, second=0, microsecond=0))
+        max_datetime = fields.Datetime.to_string(datetime.now().replace(month=12, day=31, hour=23, minute=59, second=59))
+
+        leaves = self.env['hr.leave'].search([
+            ('holiday_status_id', 'in', self.ids),
+            ('date_from', '>=', min_datetime),
+            ('date_from', '<=', max_datetime),
+            ('state', 'in', ('validate', 'validate1', 'confirm')),
+        ])
+
+        for leave in leaves:
+            leave_from_date = leave.date_from.date()
+            leave_to_date = leave.date_to.date()
+
+            for public_holiday in public_holidays:
+                public_holiday_from_date = public_holiday.date_from.date()
+                public_holiday_to_date = public_holiday.date_to.date()
+
+                if leave_from_date <= public_holiday_to_date and leave_to_date >= public_holiday_from_date:
+                    raise ValidationError(_("You cannot modify the 'Public Holiday Included' setting since one or more leaves for that \
+                        time off type are overlapping with public holidays, meaning that the balance of those employees would be affected by this change."))
 
     @api.depends('requires_allocation', 'max_leaves', 'virtual_remaining_leaves')
     def _compute_valid(self):

--- a/addons/hr_holidays/tests/test_leave_requests.py
+++ b/addons/hr_holidays/tests/test_leave_requests.py
@@ -1112,6 +1112,50 @@ class TestLeaveRequests(TestHrHolidaysCommon):
         self.assertEqual(sick_leave.duration_display, '2 days', msg)
         self.assertEqual(comp_leave.duration_display, '0 hours', msg)
 
+    def test_duration_display_public_leave_include(self):
+        """
+            The purpose is to test whether the duration_display
+            computation considers public holidays when the
+            `include_public_holidays_in_duration` is set to True.
+        """
+        employee = self.employee_emp
+        calendar = employee.resource_calendar_id
+        sick_leave_type = self.env['hr.leave.type'].create({
+            'name': 'Sick Leave (days)',
+            'request_unit': 'day',
+            'leave_validation_type': 'hr',
+        })
+        sick_leave = self.env['hr.leave'].create({
+            'name': 'Sick 3 days',
+            'employee_id': employee.id,
+            'holiday_status_id': sick_leave_type.id,
+            'request_date_from': '2021-11-15',
+            'request_date_to': '2021-11-17',
+        })
+
+        self.assertEqual(sick_leave.duration_display, '3 days')
+
+        calendar.global_leave_ids = [(0, 0, {
+            'name': 'Autumn Holidays',
+            'date_from': '2021-11-16 00:00:00',
+            'date_to': '2021-11-16 23:59:59',
+            'time_type': 'leave',
+        })]
+
+        self.assertEqual(sick_leave.duration_display, '2 days', "hr_holidays: duration_display should not count public holiday")
+
+        sick_leave_type.include_public_holidays_in_duration = True
+        sick_leave.unlink()
+        sick_leave = self.env['hr.leave'].create({
+            'name': 'Sick 3 days',
+            'employee_id': employee.id,
+            'holiday_status_id': sick_leave_type.id,
+            'request_date_from': '2021-11-15',
+            'request_date_to': '2021-11-17',
+        })
+
+        self.assertEqual(sick_leave.duration_display, '3 days', "hr_holidays: duration_display should not update after adding an overlapping holiday")
+
     @freeze_time('2024-01-18')
     def test_undefined_working_hours(self):
         """ Ensure time-off can also be allocated without ResourceCalendar. """

--- a/addons/hr_holidays/views/hr_leave_type_views.xml
+++ b/addons/hr_holidays/views/hr_leave_type_views.xml
@@ -77,6 +77,7 @@
                                 placeholder="Nobody will be notified"
                                 invisible="leave_validation_type in ['no_validation', 'manager'] and (requires_allocation == 'no' or allocation_validation_type != 'officer')"/>
                             <field name="request_unit"/>
+                            <field name="include_public_holidays_in_duration"/>
                             <field name="show_on_dashboard"/>
                             <field name="support_document" string="Allow To Attach Supporting Document" />
                             <field name="time_type" required="1"/>


### PR DESCRIPTION
This PR enhances the functionality of time off types by introducing boolean fields that determine whether public holidays should be counted in the leave duration when applying for leaves.

task-3896017
