### PR TITLE
[FIX] mrp: update product forcasted qty from unbuild

### DIFF
--- a/addons/mrp/models/mrp_unbuild.py
+++ b/addons/mrp/models/mrp_unbuild.py
@@ -228,7 +228,8 @@ class MrpUnbuild(models.Model):
         for unbuild in self:
             if unbuild.mo_id:
                 finished_moves = unbuild.mo_id.move_finished_ids.filtered(lambda move: move.state == 'done')
-                factor = unbuild.product_qty / unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.product_qty, unbuild.product_uom_id)
+                moved_qty = unbuild.mo_id.product_uom_id._compute_quantity(unbuild.mo_id.qty_produced, unbuild.product_uom_id)
+                factor = unbuild.product_qty / moved_qty if moved_qty else 0
                 for finished_move in finished_moves:
                     moves += unbuild._generate_move_from_existing_move(finished_move, factor, unbuild.location_id, finished_move.location_id)
             else:


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product
- Create a manufacturing order for 20 units of that product
- Confirm the MO update the qty_producing to 20 and mark the MO as done
- Unlock the MO and add set the qty_producing to 30 units
- Unbuild 10 units
- Look at the forcasted quantity of your product

### Expected behavior:

Since we just created 20 additional units of our product, the forecasted qty should be at 20.

### Current behavior:

The forecasted qty is set to 15 as the outgoing qty is at 5 even though it should be at 0.

### Cause of the issue:

Validating the unbuild will update the quantity of our product by creating an outgoing move:
https://github.com/odoo/odoo/blob/eca25fe76001ee5bf17cb799c94bebb5ab07165d/addons/mrp/models/mrp_unbuild.py#L229-L233
However, the denominator of the factor used to create the move is computed from the product_qty rather than the qty_produced by the MO. Therefore, in our case, the factor will be  50 percent (10/20) of the MO's quantity -> 15 units while the unbuild is in fact 33.3 percent (10/20) of the MO's qty -> 10 units.

### Note:

Thanks to [1], the factor is already correctly computed for incoming moves:
https://github.com/odoo/odoo/blob/eca25fe76001ee5bf17cb799c94bebb5ab07165d/addons/mrp/models/mrp_unbuild.py#L248-L251

[1] commit 44f4af1

opw-3903503
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
