### PR TITLE
[FIX] {sale_,}stock: allow negative procurements again

### DIFF
--- a/addons/mrp/tests/test_procurement.py
+++ b/addons/mrp/tests/test_procurement.py
@@ -128,6 +128,76 @@ class TestProcurement(TestMrpCommon):
             production_product_4 = production_form.save()
             production_product_4.action_confirm()
 
+    def test_procurement_3(self):
+        warehouse = self.env['stock.warehouse'].search([], limit=1)
+        warehouse.write({'reception_steps': 'three_steps'})
+        warehouse.mto_pull_id.route_id.active = True
+        self.env['stock.location']._parent_store_compute()
+        warehouse.reception_route_id.rule_ids.filtered(
+            lambda p: p.location_src_id == warehouse.wh_input_stock_loc_id and
+            p.location_dest_id == warehouse.wh_qc_stock_loc_id).write({
+                'action': 'pull',
+                'location_dest_from_rule': True,
+                'procure_method': 'make_to_stock',
+            })
+        warehouse.reception_route_id.rule_ids.filtered(
+            lambda p: p.location_src_id == warehouse.wh_qc_stock_loc_id and
+            p.location_dest_id == warehouse.lot_stock_id).write({
+                'action': 'pull',
+                'location_dest_from_rule': True,
+            })
+
+        finished_product = self.env['product.product'].create({
+            'name': 'Finished Product',
+            'type': 'product',
+        })
+        component = self.env['product.product'].create({
+            'name': 'Component',
+            'type': 'product',
+            'route_ids': [(4, warehouse.mto_pull_id.route_id.id)]
+        })
+        self.env['stock.quant']._update_available_quantity(component, warehouse.wh_input_stock_loc_id, 100)
+        bom = self.env['mrp.bom'].create({
+            'product_id': finished_product.id,
+            'product_tmpl_id': finished_product.product_tmpl_id.id,
+            'product_uom_id': self.uom_unit.id,
+            'product_qty': 1.0,
+            'type': 'normal',
+            'bom_line_ids': [
+                (0, 0, {'product_id': component.id, 'product_qty': 1.0})
+            ]})
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = finished_product
+        mo_form.bom_id = bom
+        mo_form.product_qty = 5
+        mo_form.product_uom_id = finished_product.uom_id
+        mo_form.location_src_id = warehouse.lot_stock_id
+        mo = mo_form.save()
+        mo.action_confirm()
+        pickings = self.env['stock.picking'].search([('product_id', '=', component.id)])
+        self.assertEqual(len(pickings), 2.0)
+        picking_input_to_qc = pickings.filtered(lambda p: p.location_id == warehouse.wh_input_stock_loc_id)
+        picking_qc_to_stock = pickings - picking_input_to_qc
+        self.assertTrue(picking_input_to_qc)
+        self.assertTrue(picking_qc_to_stock)
+        picking_input_to_qc.action_assign()
+        self.assertEqual(picking_input_to_qc.state, 'assigned')
+        picking_input_to_qc.move_ids.write({'quantity': 5.0, 'picked': True})
+        picking_input_to_qc._action_done()
+        picking_qc_to_stock.action_assign()
+        self.assertEqual(picking_qc_to_stock.state, 'assigned')
+        picking_qc_to_stock.move_ids.write({'quantity': 3.0, 'picked': True})
+        picking_qc_to_stock.with_context(skip_backorder=True, picking_ids_not_to_backorder=picking_qc_to_stock.ids).button_validate()
+        self.assertEqual(picking_qc_to_stock.state, 'done')
+        mo.action_assign()
+        self.assertEqual(mo.move_raw_ids.quantity, 3.0)
+        produce_form = Form(mo)
+        produce_form.qty_producing = 3.0
+        mo = produce_form.save()
+        self.assertEqual(mo.move_raw_ids.quantity, 3.0)
+        picking_qc_to_stock.move_line_ids.quantity = 5.0
+        self.assertEqual(mo.move_raw_ids.quantity, 3.0)
+
     def test_link_date_mo_moves(self):
         """ Check link of shedule date for manufaturing with date stock move."""
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -978,13 +978,6 @@ Please change the quantity done or the rounding precision of your unit of measur
         new_moves = self.env['stock.move'].concat(*new_moves)
         new_moves = new_moves.sudo()._action_confirm()
 
-        # Remaining from action_confirm to adapt
-        # if new_push_moves:
-        #     neg_push_moves = new_push_moves.filtered(lambda sm: float_compare(sm.product_uom_qty, 0, precision_rounding=sm.product_uom.rounding) < 0)
-        #     (new_push_moves - neg_push_moves).sudo()._action_confirm()
-        #     # Negative moves do not have any picking, so we should try to merge it with their siblings
-        #     neg_push_moves._action_confirm(merge_into=neg_push_moves.move_orig_ids.move_dest_ids)
-
         return new_moves
 
     def _merge_moves_fields(self):
@@ -1412,17 +1405,34 @@ Please change the quantity done or the rounding precision of your unit of measur
         if merge:
             moves = self._merge_moves(merge_into=merge_into)
 
-        # Transform remaining move in return in case of negative initial demand
         neg_r_moves = moves.filtered(lambda move: float_compare(
             move.product_uom_qty, 0, precision_rounding=move.product_uom.rounding) < 0)
 
-        # TODO for next version: rethink negative procurement. For now do nothing if initial move is processed
-        neg_r_moves.write({
-            'move_orig_ids': [Command.clear()],
-            'move_dest_ids': [Command.clear()],
-        })
-        moves -= neg_r_moves
-        neg_r_moves.unlink()
+        # Push remaining quantities to next step
+        neg_to_push = neg_r_moves.filtered(lambda move: move.location_final_id and move.location_dest_id != move.location_final_id)
+        new_push_moves = self.env['stock.move']
+        if neg_to_push:
+            new_push_moves = neg_to_push._push_apply()
+
+        # Transform remaining move in returns in case of negative initial demand
+        for move in neg_r_moves:
+            move.location_id, move.location_dest_id, move.location_final_id = move.location_dest_id, move.location_id, move.location_id
+            orig_move_ids, dest_move_ids = [], []
+            for m in move.move_orig_ids | move.move_dest_ids:
+                from_loc, to_loc = m.location_id, m.location_dest_id
+                if float_compare(m.product_uom_qty, 0, precision_rounding=m.product_uom.rounding) < 0:
+                    from_loc, to_loc = to_loc, from_loc
+                if to_loc == move.location_id:
+                    orig_move_ids += m.ids
+                elif move.location_dest_id == from_loc:
+                    dest_move_ids += m.ids
+            move.move_orig_ids, move.move_dest_ids = [Command.set(orig_move_ids)], [Command.set(dest_move_ids)]
+            move.product_uom_qty *= -1
+            if move.picking_type_id.return_picking_type_id:
+                move.picking_type_id = move.picking_type_id.return_picking_type_id
+            # We are returning some products, we must take them in the source location
+            move.procure_method = 'make_to_stock'
+        neg_r_moves._assign_picking()
 
         # call `_action_assign` on every confirmed move which location_id bypasses the reservation + those expected to be auto-assigned
         moves.filtered(lambda move: move.state in ('confirmed', 'partially_available')
@@ -1430,6 +1440,12 @@ Please change the quantity done or the rounding precision of your unit of measur
                             or move.picking_type_id.reservation_method == 'at_confirm'
                             or (move.reservation_date and move.reservation_date <= fields.Date.today())))\
              ._action_assign()
+
+        if new_push_moves:
+            neg_push_moves = new_push_moves.filtered(lambda sm: float_compare(sm.product_uom_qty, 0, precision_rounding=sm.product_uom.rounding) < 0)
+            (new_push_moves - neg_push_moves).sudo()._action_confirm()
+            # Negative moves do not have any picking, so we should try to merge it with their siblings
+            neg_push_moves._action_confirm(merge_into=neg_push_moves.move_orig_ids.move_dest_ids)
         return moves
 
     def _prepare_procurement_origin(self):
@@ -1963,9 +1979,10 @@ Please change the quantity done or the rounding precision of your unit of measur
                 moves_state_to_write['assigned'].add(move.id)
             elif move.quantity and float_compare(move.quantity, move.product_uom_qty, precision_rounding=rounding) <= 0:
                 moves_state_to_write['partially_available'].add(move.id)
-            elif move.procure_method == 'make_to_order' and not move.move_orig_ids:
-                moves_state_to_write['waiting'].add(move.id)
-            elif move.move_orig_ids and any(orig.state not in ('done', 'cancel') for orig in move.move_orig_ids):
+            elif (move.procure_method == 'make_to_order' and not move.move_orig_ids) or\
+                 (move.move_orig_ids and any(float_compare(orig.product_uom_qty, 0, precision_rounding=orig.product_uom.rounding) > 0
+                                             and orig.state not in ('done', 'cancel') for orig in move.move_orig_ids)):
+                # In the process of merging a negative move, we may still have a negative move in the move_orig_ids at that point.
                 moves_state_to_write['waiting'].add(move.id)
             else:
                 moves_state_to_write['confirmed'].add(move.id)

--- a/addons/stock/models/stock_rule.py
+++ b/addons/stock/models/stock_rule.py
@@ -219,10 +219,13 @@ class StockRule(models.Model):
 
     def _push_prepare_move_copy_values(self, move_to_copy, new_date):
         company_id = self.company_id.id
+        copied_quantity = move_to_copy.quantity
+        if float_compare(move_to_copy.product_uom_qty, 0, precision_rounding=move_to_copy.product_uom.rounding) < 0:
+            copied_quantity = move_to_copy.product_uom_qty
         if not company_id:
             company_id = self.sudo().warehouse_id and self.sudo().warehouse_id.company_id.id or self.sudo().picking_type_id.warehouse_id.company_id.id
         new_move_vals = {
-            'product_uom_qty': move_to_copy.quantity,
+            'product_uom_qty': copied_quantity,
             'origin': move_to_copy.origin or move_to_copy.picking_id.name or "/",
             'location_id': move_to_copy.location_dest_id.id,
             'location_dest_id': self.location_dest_id.id,

--- a/addons/stock/tests/test_old_rules.py
+++ b/addons/stock/tests/test_old_rules.py
@@ -587,3 +587,63 @@ class TestOldRules(TestStockCommon):
         report = self.env['report.stock.report_reception']
         report_values = report._get_report_values(docids=[receipt.id])
         self.assertEqual(len(report_values['sources_to_lines']), 1, "There should only be 1 line (pick move)")
+
+    def test_pick_ship_1(self):
+        """ Enable the pick ship route, force a procurement group on the
+        pick. When a second move is added, make sure the `partner_id` and
+        `origin` fields are erased.
+        """
+        pick_ship_route = self.warehouse_2_steps.delivery_route_id
+        # create a procurement group and set in on the pick stock rule
+        procurement_group0 = self.env['procurement.group'].create({})
+        pick_rule = pick_ship_route.rule_ids.filtered(lambda rule: 'Stock → Output' in rule.name)
+        push_rule = pick_ship_route.rule_ids - pick_rule
+        pick_rule.write({
+            'group_propagation_option': 'fixed',
+            'group_id': procurement_group0.id,
+        })
+
+        ship_location = pick_rule.location_dest_id
+        customer_location = push_rule.location_dest_id
+        partners = self.env['res.partner'].search([], limit=2)
+        partner0 = partners[0]
+        partner1 = partners[1]
+        procurement_group1 = self.env['procurement.group'].create({'partner_id': partner0.id})
+        procurement_group2 = self.env['procurement.group'].create({'partner_id': partner1.id})
+
+        move1 = self.env['stock.move'].create({
+            'name': 'first out move',
+            'procure_method': 'make_to_order',
+            'location_id': ship_location.id,
+            'location_dest_id': customer_location.id,
+            'product_id': self.productA.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+            'warehouse_id': self.warehouse_2_steps.id,
+            'group_id': procurement_group1.id,
+            'origin': 'origin1',
+        })
+
+        move2 = self.env['stock.move'].create({
+            'name': 'second out move',
+            'procure_method': 'make_to_order',
+            'location_id': ship_location.id,
+            'location_dest_id': customer_location.id,
+            'product_id': self.productA.id,
+            'product_uom': self.uom_unit.id,
+            'product_uom_qty': 1.0,
+            'warehouse_id': self.warehouse_2_steps.id,
+            'group_id': procurement_group2.id,
+            'origin': 'origin2',
+        })
+
+        # first out move, the "pick" picking should have a partner and an origin
+        move1._action_confirm()
+        picking_pick = move1.move_orig_ids.picking_id
+        self.assertEqual(picking_pick.partner_id.id, procurement_group1.partner_id.id)
+        self.assertEqual(picking_pick.origin, move1.group_id.name)
+
+        # second out move, the "pick" picking should have lost its partner and origin
+        move2._action_confirm()
+        self.assertEqual(picking_pick.partner_id.id, False)
+        self.assertEqual(picking_pick.origin, False)


### PR DESCRIPTION
Following #156437, the mechanism to handle negative procurements was removed as it wasn't applicable with the new push flow. This was a mistakes, as :
- The old pull flow is still available, so we still need to be able to propagate a negative quantity.
- Even with the new push flow, this introduced a regression as we couldn't process negative quantity PO/SO anymore.

The main issue was that with the new push flow, the whole picking chain might not exist yet by the time a negative quantity procurement is generated.
Let's take the following case, in 3 step delivery
- Stock -> Packing: qty = 5, status = 'done'
- Packing -> Output: qty = 5, status = 'assigned'

Here, we have the first step that was already processed, so the move from Packing -> Output has been created, while the one from Output -> Customer isn't yet (i.e. it will be when Packing -> Output is done). That means that if we were to create a procurement of -1 qty, we'd want:
- New: Packing -> Stock: qty = 1 (move back the excess qty)
- Packing -> Output: qty = 4 (merge the quantity into the existing move)
- NO Customer -> Output move, as the delivery move hasn't yet been created.

To achieve this, in the case of negative procurements, we instead generate the whole push chain of negative move then try to merge them. Then, we remove moves that shouldn't have been created.

Note: Also restores some tests that were disabled by the pull&push refactor now that it works again :roll_eyes: 

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
