### PR TITLE
[FIX] website: prevent file icon from becoming invisible

### DIFF
--- a/addons/website/static/src/components/translator/translator.js
+++ b/addons/website/static/src/components/translator/translator.js
@@ -266,9 +266,9 @@ export class WebsiteTranslator extends WebsiteEditorComponent {
         const toTranslateColor = window.getComputedStyle(document.documentElement).getPropertyValue('--o-we-content-to-translate-color');
         const translatedColor = window.getComputedStyle(document.documentElement).getPropertyValue('--o-we-translated-content-color');
 
-        styleEl.sheet.insertRule(`[data-oe-translation-state].o_dirty {background: ${translatedColor} !important;}`);
-        styleEl.sheet.insertRule(`[data-oe-translation-state="translated"] {background: ${translatedColor} !important;}`);
-        styleEl.sheet.insertRule(`[data-oe-translation-state] {background: ${toTranslateColor} !important;}`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state].o_dirty { background-color: ${translatedColor} !important; }`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state="translated"] { background-color: ${translatedColor} !important; }`);
+        styleEl.sheet.insertRule(`[data-oe-translation-state] { background-color: ${toTranslateColor} !important; }`);
 
         const showNotification = ev => {
             let message = _t('This translation is not editable.');

--- a/addons/website/static/src/components/translator/translator.scss
+++ b/addons/website/static/src/components/translator/translator.scss
@@ -4,10 +4,10 @@
         padding: 4px;
 
         &[data-oe-translation-state] {
-            background: $o-we-translated-content-color;
+            background-color: $o-we-translated-content-color;
         }
         &[data-oe-translation-state="to_translate"] {
-            background: $o-we-content-to-translate-color;
+            background-color: $o-we-content-to-translate-color;
         }
     }
 }

--- a/addons/website/static/src/scss/website.wysiwyg.scss
+++ b/addons/website/static/src/scss/website.wysiwyg.scss
@@ -10,20 +10,20 @@
 
 html[lang] > body.editor_enable [data-oe-translation-state] {
     &, .o_translation_select_option, &[data-oe-field="mega_menu_content"] * {
-        background: rgba($o-we-content-to-translate-color, 0.5) !important;
+        background-color: rgba($o-we-content-to-translate-color, 0.5) !important;
     }
 
     &[data-oe-translation-state="translated"] {
         &, .o_translation_select_option, &[data-oe-field="mega_menu_content"] * {
-            background: rgba($o-we-translated-content-color, 0.5) !important;
+            background-color: rgba($o-we-translated-content-color, 0.5) !important;
         }
     }
 
     &.o_dirty, &.oe_translated, .oe_translated {
-        background: rgba($o-we-translated-content-color, 0.25) !important;
+        background-color: rgba($o-we-translated-content-color, 0.25) !important;
 
         &[data-oe-field="mega_menu_content"] * {
-            background: rgba($o-we-translated-content-color, 0.25) !important;
+            background-color: rgba($o-we-translated-content-color, 0.25) !important;
         }
     }
 }


### PR DESCRIPTION
This commit permits to keep document icon visible during the translation of a website page.

Steps to reproduce the issue:
- Have a website in English (main) and French
- Edit the website in the main lang (English)
- Drop Image text block
- Change the image to a document
- Save
- Edit the translation in French

=> The document logo becomes invisible.

This commit fixes this issue.

task-3626918