### PR TITLE
[FIX] stock_account: handle neg. quant valuation

### DIFF
--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -682,8 +682,12 @@ class ProductProduct(models.Model):
             if not product_accounts[product.id].get('stock_valuation'):
                 raise UserError(_('You don\'t have any stock valuation account defined on your product category. You must define one before processing this operation.'))
 
-            debit_account_id = product_accounts[product.id]['stock_valuation'].id
-            credit_account_id = product_accounts[product.id]['stock_input'].id
+            if out_stock_valuation_layer.quantity > 0:
+                debit_account_id = product_accounts[product.id]['stock_valuation'].id
+                credit_account_id = product_accounts[product.id]['stock_input'].id
+            else:
+                debit_account_id = product_accounts[product.id]['stock_output'].id
+                credit_account_id = product_accounts[product.id]['stock_valuation'].id
             value = out_stock_valuation_layer.value
             move_vals = {
                 'journal_id': product_accounts[product.id]['stock_journal'].id,


### PR DESCRIPTION
**Current behavior:**
Switching from manual to automated valuation on a product that has a negative quantity will create entries in the valuation journal with incorrect debit/credit figures.

**Expected behavior:**
The lines generated in this manner should look like ones created when the valuation is generated for a product that was already valuated with the automated option.

**Steps to reproduce:**
1. Create a producy category with the default manual valuation method, create a storable product that belongs to it

2. Sell some quantity of the new product without adding any on-hand quantity (so that the qty is negative), confirm the order and generate the invoice

3. Swap to automated valuation in the product category that was created in step 1

4. In the entries for the stock valuation journal, observe that:
     A) the stock valuation account is getting *debited* instead of credited, and

     B) the other entry generated is for the stock input account
          instead of stock output, and

     C) the debit/credit amounts should be swapped here as well

**Cause of the issue:**
The negative quantity case is not considered when we do the empty/replenish sequence on valuation method change.

**Fix:**
Add an explicit check for negative quantity in the replenish step of changing valuation method.

opw-3810779