### PR TITLE
ORM optimizations + clean

### DIFF
--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -964,7 +964,7 @@ class IrModelFields(models.Model):
 
         # discard the removed fields from fields to compute
         for field in fields:
-            self.env.all.tocompute.pop(field, None)
+            self.env.transaction.tocompute.pop(field, None)
 
         model_names = self.mapped('model')
         self._drop_column()

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -212,7 +212,7 @@ class Partner(models.Model):
     title = fields.Many2one('res.partner.title')
     parent_id = fields.Many2one('res.partner', string='Related Company', index=True)
     parent_name = fields.Char(related='parent_id.name', readonly=True, string='Parent name')
-    child_ids = fields.One2many('res.partner', 'parent_id', string='Contact', domain=[('active', '=', True)])
+    child_ids = fields.One2many('res.partner', 'parent_id', string='Contact', domain=[('active', '=', True)], context={'active_test': False})
     ref = fields.Char(string='Reference', index=True)
     lang = fields.Selection(_lang_get, string='Language',
                             help="All the emails and documents sent to this contact will be translated in this language.")
@@ -655,8 +655,12 @@ class Partner(models.Model):
         was meant to be company address """
         parent = self.parent_id
         address_fields = self._address_fields()
-        if (parent.is_company or not parent.parent_id) and len(parent.child_ids) == 1 and \
-            any(self[f] for f in address_fields) and not any(parent[f] for f in address_fields):
+        if (
+            (parent.is_company or not parent.parent_id)
+            and any(self[f] for f in address_fields)
+            and not any(parent[f] for f in address_fields)
+            and len(parent.child_ids) == 1
+        ):
             addr_vals = self._update_fields_values(address_fields)
             parent.update_address(addr_vals)
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1385,7 +1385,7 @@ class Field(MetaField('DummyField', (object,), {})):
         """ Process the pending computations of ``self`` on ``records``. This
         should be called only if ``self`` is computed and stored.
         """
-        to_compute_ids = records.env.all.tocompute.get(self)
+        to_compute_ids = records.env.transaction.tocompute.get(self)
         if not to_compute_ids:
             return
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1187,7 +1187,7 @@ class Field(MetaField('DummyField', (object,), {})):
     # Descriptor methods
     #
 
-    def __get__(self, record, owner):
+    def __get__(self, record, owner=None):
         """ return the value of field ``self`` on ``record`` """
         if record is None:
             return self         # the field is accessed through the owner class
@@ -1333,7 +1333,7 @@ class Field(MetaField('DummyField', (object,), {})):
             # [rec.line_ids.mapped('name') for rec in recs] would generate one
             # query per record in `recs`!
             remaining = records.__class__(records.env, records._ids[len(vals):], records._prefetch_ids)
-            self.__get__(first(remaining), type(remaining))
+            self.__get__(first(remaining))
             vals += records.env.cache.get_until_miss(remaining, self)
 
         return self.convert_to_record_multi(vals, records)
@@ -2949,7 +2949,7 @@ class _Relational(Field):
     context = {}                        # context for searching values
     check_company = False
 
-    def __get__(self, records, owner):
+    def __get__(self, records, owner=None):
         # base case: do the regular access
         if records is None or len(records._ids) <= 1:
             return super().__get__(records, owner)
@@ -4477,7 +4477,7 @@ class One2many(_RelationalMulti):
             domain = domain + [(inverse_field.model_field, '=', records._name)]
         return domain
 
-    def __get__(self, records, owner):
+    def __get__(self, records, owner=None):
         if records is not None and self.inverse_name is not None:
             # force the computation of the inverse field to ensure that the
             # cache value of self is consistent
@@ -5180,7 +5180,7 @@ class Id(Field):
     def update_db(self, model, columns):
         pass                            # this column is created with the table
 
-    def __get__(self, record, owner):
+    def __get__(self, record, owner=None):
         if record is None:
             return self         # the field is accessed through the class owner
 

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6662,7 +6662,7 @@ class BaseModel(metaclass=MetaModel):
         """
         if isinstance(key, str):
             # important: one must call the field's getter
-            return self._fields[key].__get__(self, self.env.registry[self._name])
+            return self._fields[key].__get__(self)
         elif isinstance(key, slice):
             return self.browse(self._ids[key])
         else:

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6168,9 +6168,11 @@ class BaseModel(metaclass=MetaModel):
             records.filtered("partner_id.is_company")
         """
         if isinstance(func, str):
-            name = func
-            func = lambda rec: any(rec.mapped(name))
-        return self.browse([rec.id for rec in self if func(rec)])
+            if '.' in func:
+                return self.browse(rec.id for rec in self if any(rec.mapped(func)))
+            else:  # Avoid costly mapped
+                return self.browse(rec.id for rec in self if rec[func])
+        return self.browse(rec.id for rec in self if func(rec))
 
     def grouped(self, key):
         """Eagerly groups the records of ``self`` by the ``key``, returning a

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6489,8 +6489,6 @@ class BaseModel(metaclass=MetaModel):
         """ Test whether ``self`` is nonempty. """
         return True if self._ids else False  # fast version of bool(self._ids)
 
-    __nonzero__ = __bool__
-
     def __len__(self):
         """ Return the size of ``self``. """
         return len(self._ids)

--- a/odoo/models.py
+++ b/odoo/models.py
@@ -6779,15 +6779,15 @@ class BaseModel(metaclass=MetaModel):
             # currently depends on self, and it should not be recomputed before
             # the modification.  So we only collect what should be marked for
             # recomputation.
-            marked = self.env.all.tocompute     # {field: ids}
-            tomark = defaultdict(OrderedSet)    # {field: ids}
+            marked = self.env.transaction.tocompute     # {field: ids}
+            tomark = defaultdict(OrderedSet)            # {field: ids}
         else:
             # When called after modification, one should traverse backwards
             # dependencies by taking into account all fields already known to
             # be recomputed.  In that case, we mark fieds to compute as soon as
             # possible.
             marked = {}
-            tomark = self.env.all.tocompute
+            tomark = self.env.transaction.tocompute
 
         # determine what to trigger (with iterators)
         todo = [self._modified([self._fields[fname] for fname in fnames], create)]
@@ -6933,7 +6933,7 @@ class BaseModel(metaclass=MetaModel):
                 self._recompute_field(field, self._ids)
 
     def _recompute_field(self, field, ids=None):
-        ids_to_compute = self.env.all.tocompute.get(field, ())
+        ids_to_compute = self.env.transaction.tocompute.get(field, ())
         if ids is None:
             ids = ids_to_compute
         else:

--- a/odoo/sql_db.py
+++ b/odoo/sql_db.py
@@ -776,7 +776,6 @@ class Connection(object):
 
     def __bool__(self):
         raise NotImplementedError()
-    __nonzero__ = __bool__
 
 def connection_info_for(db_or_uri, readonly=False):
     """ parse the given `db_or_uri` and return a 2-tuple (dbname, connection_params)

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -838,7 +838,7 @@ class TransactionCase(BaseCase):
 
         # restore environments after the test to avoid invoking flush() with an
         # invalid environment (inexistent user id) from another test
-        envs = self.env.all.envs
+        envs = self.env.transaction.envs
         for env in list(envs):
             self.addCleanup(env.clear)
         # restore the set of known environments as it was at setUp


### PR DESCRIPTION
#### [REM] core: remove `BaseModel/Connection.__nonzero__`

`__nonzero__` is only used by Python 2. Time to remove them.

#### [IMP] base: improve performance of res.partner.child_ids field

Reading res.partner.child_ids is slower than necessary and slows down `_handle_first_contact_creation` (useful in the populate tool) and `address_get`. In fact, the domain `[('active', '=', True)]` on the field already filters out inactive records during the `One2many.read`, but the ORM does the same job (in Python) every time the field is accessed (see `One2many.convert_to_record`).

Avoid this extra filter by adding `context={'active_test': False}` in the field. Also, reorder the condition in `_handle_first_contact_creation` to avoid reading child_ids most of the time (much more expensive than the other conditions).

#### [IMP] core: improve performance of `BaseModel.__getitem__`

Improve the performance of `BaseModel.__getitem__` (heavily used by the ORM) and avoid an useless lookups on self.env.registry. The owner attribute is not used in `Field.__get__`. The Python documentation mentions that the 'owner' (objtype) attribute should have a default value of None, which allows us to omit it entirely when calling from
`BaseModel.__getitem__` (see https://docs.python.org/3.9/howto/descriptor.html#descriptor-protocol).

Before `self['id']` took taking 183 ns ± 0.142 ns and now it's taking 121 ns ± 0.396 ns. Note that `self.id` took 74.1 ns ± 0.0983 ns, then the extra cost of `BaseModel.__getitem__` is reduced from 109 ns to 47 ns.

#### [IMP] core: improve performance of `BaseModel.filtered`

Improve the performance of BaseModel.filtered() when the func attribute is a string. This is especially important for _RelationalMulti.convert_to_record(), which uses filtered('active') every time an X2Many is accessed. Avoid the extra work done by BaseModel.mapped() for simple filtering, which is called on each single record.

Performance Test (cache full):
```
records_239 = self.env['ir.ui.view'].with_context(active_test=False).search([])
records_10 = records_239[:10]
record = records_239[0]
```

Before:
```
record.filtered('active'):        2.29 µs ±  42.2 ns
records_10.filtered('active'):   18    µs ±  45.3 ns
records_239.filtered('active'): 402    µs ± 610   ns
```
Now:
```
record.filtered('active'):        1.37 µs ±   1.2 ns
records_10.filtered('active'):    8.74 µs ±  41.4 ns
records_239.filtered('active'): 193    µs ± 415   ns
```
#### [IMP] core: slightly improve performance of the Cache fields

Slightly improve the performance of the field cache to improve the performance of Odoo in general:

- Add `__slots__` to the Cache class.
- Change all conditions `model.pool.field_depends_context[field]` to `field in model.pool.field_depends_context` to avoid extra calls to `get` done in `Collector.__getitem__` and because the Collector doesn't hold empty tuples.

Before `self.login` took 445 ns ± 0.868 ns and with the improvement, it takes 405 ns ± 0.437 ns.

#### [REF] core: refactor env attributes

- Remove the Environment.all attribute, it was a duplicate of Environment.transaction (which is more verbose).
- Remove Environment.args, not used anymore, and don't bring it back for its original purpose, because a quick test shows that it was mostly useless.
- Remove the useless assert on context in `Environment.__new__`, it will be checked when transforming to `frozendict`.




Futher improvements can be done for `Field.__get__`: https://github.com/odoo/odoo/pull/168646/files