### PR TITLE
[FIX] stock.landed.cost: Use invoice date currency exchange rate for landed cost computation

### DIFF
--- a/addons/stock_landed_costs/models/account_move.py
+++ b/addons/stock_landed_costs/models/account_move.py
@@ -31,7 +31,7 @@ class AccountMove(models.Model):
                 'product_id': l.product_id.id,
                 'name': l.product_id.name,
                 'account_id': l.product_id.product_tmpl_id.get_product_accounts()['stock_input'].id,
-                'price_unit': l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, l.move_id.date),
+                'price_unit': l.currency_id._convert(l.price_subtotal, l.company_currency_id, l.company_id, self.invoice_date),
                 'split_method': l.product_id.split_method_landed_cost or 'equal',
             }) for l in landed_costs_lines],
         })

--- a/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
+++ b/addons/stock_landed_costs/tests/test_stockvaluationlayer.py
@@ -584,3 +584,74 @@ class TestStockValuationLCFIFOVB(TestStockValuationLCCommon):
 
         self.assertEqual(self.product1.quantity_svl, 10)
         self.assertEqual(self.product1.value_svl, 150)
+
+    def test_create_landed_cost_from_bill_multi_currencies(self):
+        # create a vendor bill in EUR where base currency in USD
+        company = self.env.user.company_id
+        usd_currency = self.env.ref('base.USD')
+        eur_currency = self.env.ref('base.EUR')
+
+        company.currency_id = usd_currency
+
+        invoice_date = '2023-01-01'
+        accounting_date = '2024-01-31'
+
+        self.cr.execute("UPDATE res_company SET currency_id = %s WHERE id = %s", (usd_currency.id, company.id))
+        self.env['res.currency.rate'].search([]).unlink()
+        self.env['res.currency.rate'].create({
+            'name': invoice_date,
+            'rate': 1.0,
+            'currency_id': usd_currency.id,
+            'company_id': company.id,
+        })
+
+        self.env['res.currency.rate'].create({
+            'name': invoice_date,
+            'rate': 0.5,
+            'currency_id': eur_currency.id,
+            'company_id': company.id,
+        })
+
+        self.env['res.currency.rate'].create({
+            'name': accounting_date,
+            'rate': 0.25,
+            'currency_id': eur_currency.id,
+            'company_id': company.id,
+        })
+
+        po_form = Form(self.env['purchase.order'])
+        po_form.partner_id = self.vendor1
+        with po_form.order_line.new() as po_line:
+            po_line.product_id = self.product1
+            po_line.product_qty = 1
+            po_line.price_unit = 10
+            po_line.taxes_id.clear()
+        po = po_form.save()
+        po.button_confirm()
+
+        receipt = po.picking_ids
+        receipt.move_line_ids.qty_done = 1
+        receipt.button_validate()
+
+        action = po.action_create_invoice()
+        bill = self.env['account.move'].browse(action['res_id'])
+        bill_form = Form(bill)
+        bill_form.invoice_date = invoice_date
+        bill_form.date = accounting_date
+        bill_form.currency_id = eur_currency
+
+        with bill_form.invoice_line_ids.new() as inv_line:
+            inv_line.product_id = self.productlc1
+            inv_line.price_unit = 5
+            inv_line.currency_id = eur_currency
+
+        bill = bill_form.save()
+        bill.action_post()
+
+        action = bill.button_create_landed_costs()
+        lc_form = Form(self.env[action['res_model']].browse(action['res_id']))
+        lc_form.picking_ids.add(receipt)
+        lc = lc_form.save()
+        lc.button_validate()
+
+        self.assertEqual(lc.cost_lines.price_unit, 10)


### PR DESCRIPTION
[FIX] stock.landed.cost: Use invoice date currency exchange rate for landed cost computation
    
Fixes an issue where the landed cost computation was based on the exchange rate of the accounting date instead of the invoice date, causing discrepancies in valuation and vendor bill. Now, the exchange rate of the invoice date is correctly utilized for accurate landed cost calculation.
    
To reproduce the issue:
    
1. Create a purchase order
2. Receive the product
3. Create a vendor bill for landed cost product in a different currency
4. Click on the "Create Landed Cost" button in the vendor bill

Error: The landed cost is computed using the exchange rate of the accounting date, while the total on the invoice is calculated using the invoice date's exchange rate. This results in a discrepancy between the bill price and the valuation.

The fix ensures that the exchange rate of the invoice date is used for computing the total for the landed cost.

opw-3862915

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
