### PR TITLE
[FIX] phone_validation: Support french mobile numbers starting with 7

### DIFF
--- a/addons/phone_validation/lib/phonenumbers_patch/__init__.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/__init__.py
@@ -38,6 +38,9 @@ else:
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.12.32/python/phonenumbers/data/region_CI.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('CI', _local_load_region)
 
+    # Altered version of https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.36/python/phonenumbers/data/region_FR.py
+    phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('FR', _local_load_region)
+
     if parse_version(phonenumbers.__version__) < parse_version('8.13.32'):
         # https://github.com/daviddrysdale/python-phonenumbers/blob/v8.13.32/python/phonenumbers/data/region_MA.py
         phonenumbers.phonemetadata.PhoneMetadata.register_region_loader('MA', _local_load_region)

--- a/addons/phone_validation/lib/phonenumbers_patch/region_FR.py
+++ b/addons/phone_validation/lib/phonenumbers_patch/region_FR.py
@@ -1,0 +1,21 @@
+"""Auto-generated file, do not edit by hand. FR metadata"""
+from ..phonemetadata import NumberFormat, PhoneNumberDesc, PhoneMetadata
+
+PHONE_METADATA_FR = PhoneMetadata(id='FR', country_code=33, international_prefix='00',
+    general_desc=PhoneNumberDesc(national_number_pattern='[1-9]\\d{8}', possible_length=(9,)),
+    fixed_line=PhoneNumberDesc(national_number_pattern='(?:26[013-9]|59[1-35-9])\\d{6}|(?:[13]\\d|2[0-57-9]|4[1-9]|5[0-8])\\d{7}', example_number='123456789', possible_length=(9,)),
+    mobile=PhoneNumberDesc(national_number_pattern='(?:[67](?:[0-24-8]\\d|3[0-8]|9[589])|7[3-9]\\d)\\d{6}', example_number='612345678', possible_length=(9,)),
+    toll_free=PhoneNumberDesc(national_number_pattern='80[0-5]\\d{6}', example_number='801234567', possible_length=(9,)),
+    premium_rate=PhoneNumberDesc(national_number_pattern='836(?:0[0-36-9]|[1-9]\\d)\\d{4}|8(?:1[2-9]|2[2-47-9]|3[0-57-9]|[569]\\d|8[0-35-9])\\d{6}', example_number='891123456', possible_length=(9,)),
+    shared_cost=PhoneNumberDesc(national_number_pattern='8(?:1[01]|2[0156]|4[02]|84)\\d{6}', example_number='884012345', possible_length=(9,)),
+    voip=PhoneNumberDesc(national_number_pattern='9\\d{8}', example_number='912345678', possible_length=(9,)),
+    uan=PhoneNumberDesc(national_number_pattern='80[6-9]\\d{6}', example_number='806123456', possible_length=(9,)),
+    national_prefix='0',
+    national_prefix_for_parsing='0',
+    number_format=[NumberFormat(pattern='(\\d{4})', format='\\1', leading_digits_pattern=['10']),
+        NumberFormat(pattern='(\\d{3})(\\d{3})', format='\\1 \\2', leading_digits_pattern=['1']),
+        NumberFormat(pattern='(\\d{3})(\\d{2})(\\d{2})(\\d{2})', format='\\1 \\2 \\3 \\4', leading_digits_pattern=['8'], national_prefix_formatting_rule='0 \\1'),
+        NumberFormat(pattern='(\\d)(\\d{2})(\\d{2})(\\d{2})(\\d{2})', format='\\1 \\2 \\3 \\4 \\5', leading_digits_pattern=['[1-79]'], national_prefix_formatting_rule='0\\1')],
+    intl_number_format=[NumberFormat(pattern='(\\d{3})(\\d{2})(\\d{2})(\\d{2})', format='\\1 \\2 \\3 \\4', leading_digits_pattern=['8']),
+        NumberFormat(pattern='(\\d)(\\d{2})(\\d{2})(\\d{2})(\\d{2})', format='\\1 \\2 \\3 \\4 \\5', leading_digits_pattern=['[1-79]'])],
+    mobile_number_portable_region=True)

--- a/addons/phone_validation/tests/test_phonenumbers_patch.py
+++ b/addons/phone_validation/tests/test_phonenumbers_patch.py
@@ -95,6 +95,13 @@ class TestPhonenumbersPatch(BaseCase):
         )
         self._assert_parsing_phonenumbers(parse_test_lines_CO)
 
+    def test_region_FR_monkey_patch(self):
+        """Makes sure that patch for French phone numbers work"""
+        parse_test_lines_FR = (
+            self.PhoneInputOutputLine("07 01 43 78 61", region="FR", gt_national_number=701437861, gt_country_code=33),
+        )
+        self._assert_parsing_phonenumbers(parse_test_lines_FR)
+
     def test_region_MA_monkey_patch(self):
         """Makes sure that patch for Morocco phone numbers work"""
         parse_test_lines_MU = (


### PR DESCRIPTION
[FIX] phone_validation: Support french mobile numbers starting with 7

Mobile numbers in France start with 06 or 07 (ref1, ref2)
Currently used phonenumbers library (8.12.1) doesn't support numbers starting with 07,
neither the (currently) newest version of the phonenumbers library (8.13.36)

This commit modifies the new version of the phonenumbers metadata for French
mobile numbers adding support for mobile numbers starting with 7.

[Reproduce]
- Install phone_validation,contacts
- Set company country to France
- Add contact with correct French NATIONAL number starting with 07
- BUG: +33 is not added in front of the number

(ref.1)
https://en.wikipedia.org/wiki/Telephone_numbers_in_France

(ref.2)
https://www.itu.int/oth/T020200004A/en

opw-3860059