### PR TITLE
[IMP] base, l10n_jp: titles on contact.

### DIFF
--- a/addons/l10n_jp/__manifest__.py
+++ b/addons/l10n_jp/__manifest__.py
@@ -29,6 +29,8 @@ Note:
     'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml',
+        'data/res_partner_title_data.xml',
+        'views/res_partner_views.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_jp/data/res_partner_title_data.xml
+++ b/addons/l10n_jp/data/res_partner_title_data.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo noupdate="True">
+    <!-- These are set directly in japanese, are you cannot really translate english in all cases. -->
+    <record id="res_partner_title_sama" model="res.partner.title">
+        <field name="name">様</field>
+        <field name="position">after</field>
+    </record>
+    <record id="res_partner_title_sensei" model="res.partner.title">
+        <field name="name">先生</field>
+        <field name="position">after</field>
+    </record>
+    <record id="res_partner_title_hakase" model="res.partner.title">
+        <field name="name">博士</field>
+        <field name="position">after</field>
+    </record>
+    <record id="res_partner_title_onchu" model="res.partner.title">
+        <field name="name">御中</field>
+        <field name="position">after</field>
+    </record>
+</odoo>

--- a/addons/l10n_jp/views/res_partner_views.xml
+++ b/addons/l10n_jp/views/res_partner_views.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+        <record id="res_partner_view_form" model="ir.ui.view">
+            <field name="name">res.partner.form</field>
+            <field name="model">res.partner</field>
+            <field name="inherit_id" ref="account.view_partner_property_form"/>
+            <field name="arch" type="xml">
+                <!-- in Japan, honorifics should also be added to companies. -->
+                <field name="title" position="attributes">
+                    <attribute name="invisible">is_company and country_code != 'JP'</attribute>
+                </field>
+            </field>
+        </record>
+</odoo>

--- a/odoo/addons/base/models/ir_qweb_fields.py
+++ b/odoo/addons/base/models/ir_qweb_fields.py
@@ -778,6 +778,7 @@ class Contact(models.AbstractModel):
             no_tag_br=dict(type='boolean', string=_('Use comma'), description=_("Use comma instead of the <br> tag to display the address")),
             phone_icons=dict(type='boolean', string=_('Display phone icons'), description=_("Display the phone icons even if no_marker is True")),
             country_image=dict(type='boolean', string=_('Display country image'), description=_("Display the country image if the field is present on the record")),
+            no_title=dict(type='boolean', string=_('Hide title'), description=_("Hide the title when the field is present on the record"), default_value=False),
         )
         return options
 
@@ -803,6 +804,9 @@ class Contact(models.AbstractModel):
             opsep = Markup('<br/>')
 
         value = value.sudo().with_context(show_address=True)
+        if not options.get('no_title'):
+            value = value.with_context(show_title=True)
+
         display_name = value.display_name or ''
         # Avoid having something like:
         # display_name = 'Foo\n  \n' -> This is a res.partner with a name and no address

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -10,6 +10,7 @@
                 <tree string="Partner Titles" editable="bottom">
                     <field name="name"/>
                     <field name="shortcut"/>
+                    <field name="position"/>
                 </tree>
             </field>
         </record>
@@ -22,6 +23,7 @@
                         <group col="4">
                             <field name="name"/>
                             <field name="shortcut"/>
+                            <field name="position"/>
                         </group>
                     </sheet>
                 </form>


### PR DESCRIPTION
In multiple countries, adding honorifics near the names of your customer/vendor/… is seen as basic politeness and not doing so is considered rude. One well-known example is Japan, Korea is another country with similar needs.

As of today, Odoo has no way to do that easily, and users have no choice but to use Studio to customize the reports manually.

This feature aim to improve that by providing a standard way of providing titles when sending documents to your contacts.

This is done by adding the title to the contact qweb widget by default if it is set on the contact record.
This also adds a new field on the title model in order to define whether the title should be a prefix or a suffix.

Note that this is a simple, naive approach that may not fit all scenarios perfectly.

task id # 3272592

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
