### PR TITLE
[FIX] stock_account: handle neg. quant valuation

### DIFF
--- a/addons/stock_account/i18n/stock_account.pot
+++ b/addons/stock_account/i18n/stock_account.pot
@@ -847,6 +847,14 @@ msgid ""
 msgstr ""
 
 #. module: stock_account
+#: code:addons/stock_account/models/product.py:0
+#, python-format
+msgid ""
+"You don't have any output valuation account defined on your product "
+"category. You must define one before processing this operation."
+msgstr ""
+
+#. module: stock_account
 #: code:addons/stock_account/models/stock_move.py:0
 #, python-format
 msgid ""

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -681,9 +681,20 @@ class ProductProduct(models.Model):
                 raise UserError(_('You don\'t have any input valuation account defined on your product category. You must define one before processing this operation.'))
             if not product_accounts[product.id].get('stock_valuation'):
                 raise UserError(_('You don\'t have any stock valuation account defined on your product category. You must define one before processing this operation.'))
+            if not product_accounts[product.id].get('stock_output'):
+                raise UserError(
+                    _('You don\'t have any output valuation account defined on your product '
+                      'category. You must define one before processing this operation.')
+                )
 
-            debit_account_id = product_accounts[product.id]['stock_valuation'].id
-            credit_account_id = product_accounts[product.id]['stock_input'].id
+            precision = self.env['decimal.precision'].precision_get('Product Unit of Measure')
+            if float_compare(out_stock_valuation_layer.quantity, 0, precision_digits=precision) == 1:
+                debit_account_id = product_accounts[product.id]['stock_valuation'].id
+                credit_account_id = product_accounts[product.id]['stock_input'].id
+            else:
+                debit_account_id = product_accounts[product.id]['stock_output'].id
+                credit_account_id = product_accounts[product.id]['stock_valuation'].id
+
             value = out_stock_valuation_layer.value
             move_vals = {
                 'journal_id': product_accounts[product.id]['stock_journal'].id,

--- a/addons/stock_account/tests/test_account_move.py
+++ b/addons/stock_account/tests/test_account_move.py
@@ -152,3 +152,70 @@ class TestAccountMove(AccountTestInvoicingCommon):
 
             product_accounts = basic_product.product_tmpl_id.with_company(company.id).get_product_accounts()
             self.assertEqual(bill.invoice_line_ids.account_id, product_accounts['expense'])
+
+    def test_product_valuation_method_change_to_automated_negative_on_hand_qty(self):
+        """
+        We have a product whose category has manual valuation and on-hand quantity is negative:
+            Upon switching to an automated valuation method for the product category, the following
+            entries should be generated in the stock journal:
+                1. CREDIT to valuation account
+                2. DEBIT to stock output account
+        """
+        stock_location = self.env['stock.warehouse'].search([
+            ('company_id', '=', self.env.company.id),
+        ], limit=1).lot_stock_id
+        categ = self.env['product.category'].create({'name': 'categ'})
+        product = self.product_a
+        product.write({
+            'type': 'product',
+            'categ_id': categ.id,
+        })
+
+        out_picking = self.env['stock.picking'].create({
+            'location_id': stock_location.id,
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'picking_type_id': stock_location.warehouse_id.out_type_id.id,
+        })
+        sm = self.env['stock.move'].create({
+            'name': product.name,
+            'product_id': product.id,
+            'product_uom_qty': 1,
+            'product_uom': product.uom_id.id,
+            'location_id': out_picking.location_id.id,
+            'location_dest_id': out_picking.location_dest_id.id,
+            'picking_id': out_picking.id,
+        })
+        out_picking.action_confirm()
+        sm.quantity_done = 1
+        out_picking.button_validate()
+
+        categ.write({
+            'property_valuation': 'real_time',
+            'property_stock_account_input_categ_id': self.stock_input_account.id,
+            'property_stock_account_output_categ_id': self.stock_output_account.id,
+            'property_stock_valuation_account_id': self.stock_valuation_account.id,
+            'property_stock_journal': self.stock_journal.id,
+        })
+
+        amls = self.env['account.move.line'].search([('product_id', '=', product.id)])
+        if amls[0].account_id == self.stock_valuation_account:
+            stock_valuation_line = amls[0]
+            output_line = amls[1]
+        else:
+            output_line = amls[0]
+            stock_valuation_line = amls[1]
+
+        expected_valuation_line = {
+            'account_id': self.stock_valuation_account.id,
+            'credit': product.standard_price,
+            'debit': 0,
+        }
+        expected_output_line = {
+            'account_id': self.stock_output_account.id,
+            'credit': 0,
+            'debit': product.standard_price,
+        }
+        self.assertRecordValues(
+            [stock_valuation_line, output_line],
+            [expected_valuation_line, expected_output_line]
+        )


### PR DESCRIPTION
**Current behavior:**
Switching from manual to automated valuation on a product that has a negative quantity will create entries in the valuation journal with incorrect debit/credit figures.

**Expected behavior:**
The lines generated in this manner should look like ones created when the valuation is generated for a product that was already valuated with the automated option.

**Steps to reproduce:**
1. Create a product category with the default manual valuation method, create a storable product that belongs to it

2. Sell some quantity of the new product without adding any on-hand quantity (so that the qty is negative), confirm the order and generate the invoice

3. Swap to automated valuation in the product category that was created in step 1

4. In the entries for the stock valuation journal, observe that:
     A) the stock valuation account is getting *debited* instead of credited, and

     B) the other entry generated is for the stock input account
          instead of stock output, and

     C) the debit/credit amounts should be swapped here as well

**Cause of the issue:**
The negative quantity case is not considered when we do the empty/replenish sequence on valuation method change.

**Fix:**
Add an explicit check for negative quantity in the replenish step of changing valuation method.

opw-3810779