### PR TITLE
[IMP] account*,l10n*: add named i18n parameters and escape strings

### DIFF
--- a/addons/account/models/account_bank_statement_line.py
+++ b/addons/account/models/account_bank_statement_line.py
@@ -745,8 +745,9 @@ class AccountBankStatementLine(models.Model):
 
                 if len(suspense_lines) > 1:
                     raise UserError(_(
-                        "%s reached an invalid state regarding its related statement line.\n"
-                        "To be consistent, the journal entry must always have exactly one suspense line.", st_line.move_id.display_name
+                        "%(move)s reached an invalid state regarding its related statement line.\n"
+                        "To be consistent, the journal entry must always have exactly one suspense line.",
+                        move=st_line.move_id.display_name,
                     ))
                 elif len(suspense_lines) == 1:
                     if journal_currency and suspense_lines.currency_id == journal_currency:

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2347,7 +2347,7 @@ class AccountMove(models.Model):
                     return
 
                 rounding_line_vals.update({
-                    'name': _('%s (rounding)', biggest_tax_line.name),
+                    'name': _("%(tax_name)s (rounding)", tax_name=biggest_tax_line.name),
                     'account_id': biggest_tax_line.account_id.id,
                     'tax_repartition_line_id': biggest_tax_line.tax_repartition_line_id.id,
                     'tax_tag_ids': [(6, 0, biggest_tax_line.tax_tag_ids.ids)],
@@ -4218,7 +4218,7 @@ class AccountMove(models.Model):
                 validation_msgs.add(_('You need to add a line before posting.'))
             if not soft and move.auto_post != 'no' and move.date > fields.Date.context_today(self):
                 date_msg = move.date.strftime(get_lang(self.env).date_format)
-                validation_msgs.add(_("This move is configured to be auto-posted on %s", date_msg))
+                validation_msgs.add(_("This move is configured to be auto-posted on %(date)s", date=date_msg))
             if not move.journal_id.active:
                 validation_msgs.add(_(
                     "You cannot post an entry in an archived journal (%(journal)s)",

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -1019,7 +1019,10 @@ class AccountPayment(models.Model):
         # Do not allow to post if the account is required but not trusted
         for payment in self:
             if payment.require_partner_bank_account and not payment.partner_bank_id.allow_out_payment:
-                raise UserError(_('To record payments with %s, the recipient bank account must be manually validated. You should go on the partner bank account in order to validate it.', self.payment_method_line_id.name))
+                raise UserError(_(
+                    "To record payments with %(method_name)s, the recipient bank account must be manually validated. You should go on the partner bank account in order to validate it.",
+                    method_name=self.payment_method_line_id.name,
+                ))
 
         self.move_id._post(soft=False)
 

--- a/addons/account/models/product.py
+++ b/addons/account/models/product.py
@@ -93,10 +93,10 @@ class ProductTemplate(models.Model):
         joined = []
         included = res['total_included']
         if currency.compare_amounts(included, price):
-            joined.append(_('%s Incl. Taxes', format_amount(self.env, included, currency)))
+            joined.append(_('%(amount)s Incl. Taxes', amount=format_amount(self.env, included, currency)))
         excluded = res['total_excluded']
         if currency.compare_amounts(excluded, price):
-            joined.append(_('%s Excl. Taxes', format_amount(self.env, excluded, currency)))
+            joined.append(_('%(amount)s Excl. Taxes', amount=format_amount(self.env, excluded, currency)))
         if joined:
             tax_string = f"(= {', '.join(joined)})"
         else:

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -946,7 +946,10 @@ class AccountPaymentRegister(models.TransientModel):
             batches.append(batch)
 
         if not batches:
-            raise UserError(_('To record payments with %s, the recipient bank account must be manually validated. You should go on the partner bank account in order to validate it.', self.payment_method_line_id.name))
+            raise UserError(_(
+                "To record payments with %(payment_method)s, the recipient bank account must be manually validated. You should go on the partner bank account in order to validate it.",
+                payment_method=self.payment_method_line_id.name,
+            ))
 
         first_batch_result = batches[0]
         edit_mode = self.can_edit_wizard and (len(first_batch_result['lines']) == 1 or self.group_payment)

--- a/addons/account/wizard/account_resequence.py
+++ b/addons/account/wizard/account_resequence.py
@@ -74,7 +74,13 @@ class ReSequenceWizard(models.TransientModel):
                  or (self.sequence_number_reset == 'year_range' and line['server-year-start-date'][0:4] != previous_line['server-year-start-date'][0:4])\
                  or (self.sequence_number_reset == 'month' and line['server-date'][0:7] != previous_line['server-date'][0:7]):
                     if in_elipsis:
-                        changeLines.append({'id': 'other_' + str(line['id']), 'current_name': _('... (%s other)', in_elipsis), 'new_by_name': '...', 'new_by_date': '...', 'date': '...'})
+                        changeLines.append({
+                            'id': 'other_' + str(line['id']),
+                            'current_name': _('... (%(nb_of_values)s other)', nb_of_values=in_elipsis),
+                            'new_by_name': '...',
+                            'new_by_date': '...',
+                            'date': '...',
+                        })
                         in_elipsis = 0
                     changeLines.append(line)
                 else:

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -159,7 +159,7 @@ class AccountEdiFormat(models.Model):
                     "blocking_level": "error",
                 }}
             elif error:
-                error_message = "<br/>".join(["[%s] %s" % (e.get("code"), html_escape(e.get("message"))) for e in error])
+                error_message = "<br/>".join([html_escape("[%s] %s" % (e.get("code"), e.get("message"))) for e in error])
                 return {invoice: {
                     "success": False,
                     "error": error_message,
@@ -215,7 +215,7 @@ class AccountEdiFormat(models.Model):
                     "blocking_level": "error",
                 }}
             if error:
-                error_message = "<br/>".join(["[%s] %s" % (e.get("code"), html_escape(e.get("message"))) for e in error])
+                error_message = "<br/>".join([html_escape("[%s] %s" % (e.get("code"), e.get("message"))) for e in error])
                 return {invoice: {
                     "success": False,
                     "error": error_message,

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -153,7 +153,7 @@ class AccountEdiFormat(models.Model):
             if "312" in error_codes:
                 # E-waybill is already canceled
                 # this happens when timeout from the Government portal but IRN is generated
-                error_message = "<br/>".join(["[%s] %s" % (e.get("code"), html_escape(e.get("message"))) for e in error])
+                error_message = "<br/>".join([html_escape("[%s] %s" % (e.get("code"), e.get("message"))) for e in error])
                 error = []
                 response = {"data": ""}
                 odoobot = self.env.ref("base.partner_root")
@@ -171,7 +171,7 @@ class AccountEdiFormat(models.Model):
                     "blocking_level": "error",
                 }
             elif error:
-                error_message = "<br/>".join(["[%s] %s" % (e.get("code"), html_escape(e.get("message"))) for e in error])
+                error_message = "<br/>".join([html_escape("[%s] %s" % (e.get("code"), e.get("message"))) for e in error])
                 blocking_level = "error"
                 if "404" in error_codes:
                     blocking_level = "warning"
@@ -230,7 +230,7 @@ class AccountEdiFormat(models.Model):
                     "blocking_level": "error",
                 }
             elif error:
-                error_message = "<br/>".join(["[%s] %s" % (e.get("code"), html_escape(e.get("message"))) for e in error])
+                error_message = "<br/>".join([html_escape("[%s] %s" % (e.get("code"), e.get("message"))) for e in error])
                 blocking_level = "error"
                 if "404" in error_codes or "waiting" in error_codes:
                     blocking_level = "warning"
@@ -329,7 +329,7 @@ class AccountEdiFormat(models.Model):
                     "blocking_level": "error",
                 }
             elif error:
-                error_message = "<br/>".join(["[%s] %s" % (e.get("code"), html_escape(e.get("message"))) for e in error])
+                error_message = "<br/>".join([html_escape("[%s] %s" % (e.get("code"), e.get("message"))) for e in error])
                 blocking_level = "error"
                 if "404" in error_codes:
                     blocking_level = "warning"

--- a/addons/l10n_in_edi_ewaybill/models/res_config_settings.py
+++ b/addons/l10n_in_edi_ewaybill/models/res_config_settings.py
@@ -20,7 +20,7 @@ class ResConfigSettings(models.TransientModel):
         if response.get("error") or not self.company_id.sudo()._l10n_in_edi_ewaybill_token_is_valid():
             error_message = _("Incorrect username or password, or the GST number on company does not match.")
             if response.get("error"):
-                error_message = "\n".join(["[%s] %s" % (e.get("code"), html_escape(e.get("message"))) for e in response["error"]])
+                error_message = "\n".join([html_escape("[%s] %s" % (e.get("code"), e.get("message"))) for e in response["error"]])
             raise UserError(error_message)
         return {
               'type': 'ir.actions.client',


### PR DESCRIPTION
- Name translated string parameters to make it possible to move them around in translations and make the translators' job a bit nicer
- Make sure all rendered strings go through Markup or html_escape

In general, if a named parameter isn't useful to translators then it won't be added here (e.g. strings that already provide enough context with one parameter)

task-3884350

**Enterprise PR:** odoo/enterprise#62348