### PR TITLE
[FIX] stock: print the delivery address on slip when using packages

### DIFF
--- a/addons/stock/models/stock_package_level.py
+++ b/addons/stock/models/stock_package_level.py
@@ -146,6 +146,7 @@ class StockPackageLevel(models.Model):
                         'location_dest_id': package_level.location_dest_id.id,
                         'package_level_id': package_level.id,
                         'company_id': package_level.company_id.id,
+                        'partner_id': package_level.picking_id.partner_id.id,
                     })
 
     @api.model

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -1612,6 +1612,31 @@ class TestPacking(TestPackingCommon):
             {'package_id': pack2.id, 'state': 'assigned', 'is_done': False},
         ])
 
+    def test_should_print_delivery_address_with_package(self):
+        """Test that should_print_delivery_address in stock_picking returns true if a delivery contains only a package."""
+        pack = self.env['stock.quant.package'].create({'name': 'New Package'})
+        self.env['stock.quant']._update_available_quantity(self.productA, self.stock_location, 5, package_id=pack)
+
+        picking = self.env['stock.picking'].create({
+            'location_id': self.stock_location.id,
+            'location_dest_id': self.ref('stock.stock_location_customers'),
+            'picking_type_id': self.ref('stock.picking_type_out'),
+            'partner_id': self.env['res.partner'].create({'name': 'Test Partner'}).id,
+        })
+
+        package_level = self.env['stock.package_level'].create({
+            'package_id': pack.id,
+            'picking_id': picking.id,
+            'location_dest_id': picking.location_dest_id.id,
+            'company_id': picking.company_id.id,
+        })
+
+        picking.action_confirm()
+        package_level.is_done = True
+        picking.button_validate()
+
+        self.assertTrue(picking.should_print_delivery_address())
+
 @odoo.tests.tagged('post_install', '-at_install')
 class TestPackagePropagation(TestPackingCommon):
 


### PR DESCRIPTION
### Issue
The delivery slip of a picking with a package doesn't print the delivery address of the partner.

### Steps to reproduce:
1. Go to Settings > Inventory > Operations and enable 'Packages'
2. Go to Inventory > Configuration > Warehouse Management > Operations Types
3. Open operation type 'Delivery Orders' and enable 'Show Detailed Operations' and 'Move Entire Packages'
4. Create a package: in Purchase, new RFQ, select products, confirm order, receive products, click on 'Put in Pack' and validate
5. In Inventory create a new Delivery Order, select a Delivery Address and the package you just created
6. Mark it as Done, validate and print the delivery slip
7. The delivery address is not the right one (the one selected on step 5)

### Cause:
When creating the moves for the items in the package, the partner_id is not given. So the moves don't have the field partner_id. When the method should_print_delivery_address() of stock_picking is called, it returns False as self.move_ids[0].partner_id is undefined, and the delivery address is not printed.
This bug does not occur if action_confirm is called before setting the partner because when setting the partner the write method will change the partner_id attribute of the moves.

### Solution:
Add the partner_id in _generate_moves() of stock_package_level to create the moves with the selected partner_id.

opw-3901104

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
