### PR TITLE
[IMP] payment: enhance user experience when no payment method

### DIFF
--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -95,7 +95,6 @@
                     <h4 class="fs-6 small text-uppercase fw-bolder">
                         <t t-if="not collapse_payment_methods">Choose a payment method</t>
                         <t t-else="">Other payment methods</t>
-                        <!-- === Availability report button (for debug) === -->
                         <t t-call="payment.availability_report_button"/>
                     </h4>
                     <!-- === Body === -->
@@ -128,7 +127,7 @@
                 <!-- === Submit button === -->
                 <t t-if="display_submit_button" t-call="payment.submit_button"/>
             </div>
-            <!-- === Availability report (for debug) === -->
+            <!-- === Availability report === -->
             <t t-call="payment.availability_report"/>
         </form>
         <t t-else="" t-call="payment.no_pms_available_warning"/>
@@ -408,37 +407,65 @@
 
     <template id="payment.no_pms_available_warning">
         <div class="alert alert-warning mt-2">
-            <strong>No suitable payment option could be found.</strong>
-            <!-- === Availability report button (for debug) === -->
-            <t t-call="payment.availability_report_button"/>
-            <br/>
-            If you believe that it is an error, please contact the website administrator.
-            <div class="mt-2" groups="base.group_system">
+            <div>
+                <strong>No payment method available</strong>
+            </div>
+            <div t-if="request.env.is_system()" class="mt-2">
+                <p t-if="providers_sudo">
+                    None is configured for:
+                    <t t-out="request.env.company.country_id.name"/>,
+                    <t t-out="request.env.company.currency_id.name"/>.
+                </p>
+                <p t-else="">
+                    No payment providers are configured.
+                </p>
                 <a
-                    t-if="request.env.company.country_id.is_stripe_supported_country"
+                    t-if="request.env.company.country_id.is_stripe_supported_country
+                          and not providers_sudo"
                     name="activate_stripe"
                     href="/odoo/action-payment.action_activate_stripe"
                     role="button"
-                    class="btn btn-primary"
+                    class="btn btn-primary me-2"
                 > ACTIVATE STRIPE </a>
                 <a
+                    t-if="availability_report"
+                    role="button"
+                    class="btn-link alert-warning me-2"
+                    data-bs-toggle="collapse"
+                    href="#payment_availability_report"
+                >
+                    <strong><i class="fa fa-file-text"/> Show availability report</strong>
+                </a>
+                <a
+                    t-if="not providers_sudo"
                     role="button"
                     type="action"
-                    class="btn-link alert-warning ps-2"
+                    class="btn-link alert-warning me-2"
                     href="/odoo/action-payment.action_payment_provider"
                 >
-                    <strong><i class="oi oi-arrow-right"></i> View alternatives </strong>
+                    <strong><i class="oi oi-arrow-right"/> Payment Providers</strong>
+                </a>
+                <a
+                    t-else=""
+                    role="button"
+                    type="action"
+                    class="btn-link alert-warning"
+                    href="/web#action=payment.action_payment_method"
+                >
+                    <strong><i class="oi oi-arrow-right"/> Payment Methods</strong>
                 </a>
             </div>
+            <div t-else="" class="mt-2">
+                If you believe that it is an error, please contact the website administrator.
+            </div>
         </div>
-        <!-- === Availability report (for debug) === -->
+        <!-- === Availability report === -->
         <t t-call="payment.availability_report"/>
     </template>
 
     <template id="payment.availability_report_button">
         <a
             t-if="request.env.user._is_system() and availability_report"
-            groups="base.group_no_one"
             role="button"
             data-bs-toggle="collapse"
             href="#payment_availability_report"
@@ -453,7 +480,6 @@
         <div
             t-if="request.env.user._is_system() and availability_report"
             id="payment_availability_report"
-            groups="base.group_no_one"
             class="collapse"
         >
             <h4 class="fs-6 text-uppercase fw-bolder"> Availability report </h4>


### PR DESCRIPTION
Before these commit:
When debug mode is on, if there are no payment methods available but some payment provider is configured, the user receives a suggestion to show the debug
report. However, the user can't access the debug report when the
debug mode is off.

After these commit:
-> Users now receive the suggestion for the debug report even when the debug mode is off.
-> Added a button for accessing payment methods.
-> Renamed the button "View alternatives" to "View all Providers".

task-3775279