### PR TITLE
[IMP] project: calculate margin based on profit/revenue in project updates

### DIFF
--- a/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
+++ b/addons/project/static/src/components/project_right_side_panel/components/project_profitability.xml
@@ -80,20 +80,21 @@
                         <th>Margin</th>
                         <th class="text-end" t-att-class="margin.invoiced_billed &lt; 0 ? 'text-danger' : 'text-success'">
                             <t t-esc="props.formatMonetary(margin.invoiced_billed)"/><br/>
-                            <t t-if="costs.total.billed != 0">
-                                <t t-esc="margin.invoiced_billed > 0 ? '+' : ''"/><t t-esc="(margin.invoiced_billed / (-costs.total.billed) * 100).toFixed(0)"/>%
+                            <t t-if="revenues.total.invoiced != 0">
+                                <t t-out="margin.invoiced_billed > 0 ? '+' : ''"/><t t-out="(margin.invoiced_billed / revenues.total.invoiced * 100).toFixed(0)"/>%
                             </t>
                         </th>
                         <th class="text-end" t-att-class="margin.to_invoice_to_bill &lt; 0 ? 'text-danger' : 'text-success'">
                             <t t-esc="props.formatMonetary(margin.to_invoice_to_bill)"/><br/>
-                            <t t-if="costs.total.to_bill != 0">
-                                <t t-esc="margin.to_invoice_to_bill > 0 ? '+' : ''"/><t t-esc="(margin.to_invoice_to_bill / (-costs.total.to_bill) * 100).toFixed(0)"/>%
+                            <t t-if="revenues.total.to_invoice != 0">
+                                <t t-out="margin.to_invoice_to_bill > 0 ? '+' : ''"/><t t-out="(margin.to_invoice_to_bill / revenues.total.to_invoice * 100).toFixed(0)"/>%
                             </t>
                         </th>
                         <th class="text-end" t-att-class="margin.total &lt; 0 ? 'text-danger' : 'text-success'">
                             <t t-esc="props.formatMonetary(margin.total)"/><br/>
-                            <t t-if="(costs.total.billed + costs.total.to_bill) != 0">
-                                <t t-esc="margin.total > 0 ? '+' : ''"/><t t-esc="(margin.total / (-costs.total.billed - costs.total.to_bill) * 100).toFixed(0)"/>%
+                            <t t-set="revenue" t-value="revenues.total.invoiced + revenues.total.to_invoice"/>
+                            <t t-if="revenue != 0">
+                                <t t-out="margin.total > 0 ? '+' : ''"/><t t-out="(margin.total / revenue * 100).toFixed(0)"/>%
                             </t>
                         </th>
                     </tr>


### PR DESCRIPTION
Steps to reproduce:
 - Enable Analytical Accounting.
 - Create a service product priced at 50 Rs and one normal product with the type "Consumable" priced at 10 Rs.
 - Set the service product to "Create a project on order."
 - Create a Sales Order (SO) with this service product. This will create a project (as per the settings on the product form).
 - Generate a Purchase Order (PO) for the test consumable product and specify the same analytical account used in the generated project.

As per general business conventions, profitability is calculated based on revenue. While calculating profitability based on cost (Profit/Cost) is correct, it applies to a very limited number of business flows. The majority of businesses/industries calculate
profitability using the formula Profit/Revenue.

task-3911923