### PR TITLE
[FIX] loyalty : Prevent archiving product when archive discount program

### DIFF
--- a/addons/loyalty/models/loyalty_reward.py
+++ b/addons/loyalty/models/loyalty_reward.py
@@ -232,9 +232,9 @@ class LoyaltyReward(models.Model):
                 reward.discount_line_product_id.write({'name': reward.description})
         if 'active' in vals:
             if vals['active']:
-                self.reward_product_id.action_unarchive()
+                self.discount_line_product_id.action_unarchive()
             else:
-                self.reward_product_id.action_archive()
+                self.discount_line_product_id.action_archive()
         return res
 
     def unlink(self):

--- a/addons/loyalty/tests/test_loyalty.py
+++ b/addons/loyalty/tests/test_loyalty.py
@@ -157,3 +157,30 @@ class TestLoyalty(TransactionCase):
             product.action_archive()
         self.program.action_archive()
         product.action_archive()
+
+    def test_prevent_archiving_product_when_archiving_program(self):
+        """
+        Test prevent archiving a product when archiving a "Buy X Get Y" program.
+        We just have to archive the free product that has been created while creating
+        the program itself not the product we already had before.
+        """
+        product = self.env['product.product'].with_context(default_taxes_id=False).create({
+            'name': 'Test Product',
+            'detailed_type': 'consu',
+            'list_price': 20.0,
+        })
+
+        loyalty_program = self.env['loyalty.program'].create({
+            'name': 'Test Program',
+            'program_type': 'buy_x_get_y',
+            'reward_ids': [
+                Command.create({
+                    'description': 'Test Product',
+                    'reward_product_id': product.id,
+                    'reward_type': 'product'
+                }),
+            ],
+        })
+        loyalty_program.action_archive()
+        # Make sure that the main product didn't get archived
+        self.assertTrue(product.active)


### PR DESCRIPTION
Steps to reproduce:
	- Install Sales and Loyalty modules
	- Create a discount & loyalty program with type of 'Buy X get Y' and a reward product that has a quantity on-hand
	- Archive the discount & loyalty program
	- Check the quantity of the product you put as reward

Current behavior before PR:
The reward product lose its quantity when archiving the corresponding discount & loyalty program. This is happening because when archiving the program we archive the reward product too.
https://github.com/odoo/odoo/blob/17.0/addons/loyalty/models/loyalty_reward.py#L239

Desired behavior after PR is merged:
We are now archiving just the free product that got created when we were creating the discount & loyalty program not the main product. This is happening
only when the reward type is 'Product'

opw-3909184
