### PR TITLE
[FIX] web: Keep single company mode when logging into a company

### DIFF
--- a/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/mobile/mobile_switch_company_menu_tests.js
@@ -19,6 +19,10 @@ import { session } from "@web/session";
 const serviceRegistry = registry.category("services");
 let target;
 
+function toCIDS(...ids) {
+    return `cids=${ids.join("%2C")}`;
+}
+
 const ORIGINAL_TOGGLE_DELAY = MobileSwitchCompanyMenu.toggleDelay;
 async function createSwitchCompanyMenu(routerParams = {}, toggleDelay = 0) {
     patchWithCleanup(MobileSwitchCompanyMenu, { toggleDelay });
@@ -249,11 +253,11 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
 
         /**
          *   [x] Company 1
-         *   [ ] Company 2      -> log into
-         *   [x] **Company 3**
+         *   [x] **Company 2**    -> log into
+         *   [x] Company 3
          */
         await click(scMenuEl.querySelectorAll(".log_into")[1]);
-        assert.verifySteps(["cids=2"]);
+        assert.verifySteps([toCIDS(2, 3, 1)]);
     });
 
     QUnit.test("multi company mode: log into an already selected company", async (assert) => {
@@ -279,11 +283,11 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
 
         /**
          *   [ ] Company 1
-         *   [x] **Company 2**
-         *   [x] Company 3      -> log into
+         *   [x] Company 2
+         *   [x] **Company 3**      -> log into
          */
         await click(scMenuEl.querySelectorAll(".log_into")[2]);
-        assert.verifySteps(["cids=3"]);
+        assert.verifySteps([toCIDS(3, 2)]);
     });
 
     QUnit.test("companies can be logged in even if some toggled within delay", async (assert) => {
@@ -307,13 +311,16 @@ QUnit.module("MobileSwitchCompanyMenu", (hooks) => {
         assert.containsN(scMenuEl, "[data-company-id] .fa-square-o", 2);
 
         /**
-         *   [ ] **Company 1**  -> toggled
-         *   [ ] Company 2      -> logged in
-         *   [ ] Company 3      -> toggled
+         *   [ ] **Company 1**  -> 2) toggled
+         *   [x] Company 2      -> 3) logged in
+         *   [ ] Company 3      -> 1) toggled
          */
         await click(scMenuEl.querySelectorAll(".toggle_company")[2]);
         await click(scMenuEl.querySelectorAll(".toggle_company")[0]);
         await click(scMenuEl.querySelectorAll(".log_into")[1]);
-        assert.verifySteps(["cids=2"]);
+
+        // When "Company 2" is logged into, only one company is currently selected
+        // so we treat it as single company mode
+        assert.verifySteps([toCIDS(2)]);
     });
 });

--- a/addons/web/static/tests/webclient/switch_company_menu_tests.js
+++ b/addons/web/static/tests/webclient/switch_company_menu_tests.js
@@ -35,6 +35,10 @@ async function createSwitchCompanyMenu(routerParams = {}, toggleDelay = 0) {
     return scMenu;
 }
 
+function toCIDS(...ids) {
+    return `cids=${ids.join("%2C")}`;
+}
+
 QUnit.module("SwitchCompanyMenu", (hooks) => {
     hooks.beforeEach(() => {
         patchWithCleanup(session.user_companies, {
@@ -253,7 +257,103 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
          */
         await click(target.querySelectorAll(".log_into")[1]);
         assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
-        assert.verifySteps(["cids=2"]);
+        assert.verifySteps([toCIDS(2)]);
+    });
+
+    QUnit.test("single company mode: from company loginto branch", async (assert) => {
+        assert.expect(8);
+        const scMenu = await createSwitchCompanyMenu({ onPushState: (url) => assert.step(url.split("#")[1]) });
+
+        /**
+         *   [x] **Hermit**
+         *   [ ] Herman's
+         *   [ ] Heroes TM
+         *   [ ]    Hercules
+         *   [ ]    Hulk
+         */
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [3]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 3);
+        await click(target.querySelector(".dropdown-toggle"));
+        assert.containsN(target, "[data-company-id]", 5);
+        assert.containsN(target, "[data-company-id] .fa-check-square", 1);
+        assert.containsN(target, "[data-company-id] .fa-square-o", 4);
+
+        /**
+         *   [ ] Hermit
+         *   [ ] Herman's
+         *   [x] **Heroes TM** -> log into
+         *   [x]    Hercules
+         *   [x]    Hulk
+         */
+        await click(target.querySelectorAll(".log_into")[2]);
+        assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
+        assert.verifySteps([toCIDS(1, 4, 5)]);
+    });
+
+    QUnit.test("single company mode: from branch loginto company", async (assert) => {
+        assert.expect(8);
+        Object.assign(browser.location, { hash: toCIDS(1, 4, 5) });
+        const scMenu = await createSwitchCompanyMenu({ onPushState: (url) => assert.step(url.split("#")[1]) });
+
+        /**
+         *   [ ] Hermit
+         *   [ ] Herman's
+         *   [x] **Heroes TM**
+         *   [x]    Hercules
+         *   [x]    Hulk
+         */
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1, 4, 5]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        await click(target.querySelector(".dropdown-toggle"));
+        assert.containsN(target, "[data-company-id]", 5);
+        assert.containsN(target, "[data-company-id] .fa-check-square", 3);
+        assert.containsN(target, "[data-company-id] .fa-square-o", 2);
+
+        /**
+         *   [x] Hermit    -> log into
+         *   [ ] Herman's
+         *   [ ] Heroes TM
+         *   [ ]    Hercules
+         *   [ ]    Hulk
+         */
+        await click(target.querySelectorAll(".log_into")[0]);
+        assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
+        assert.verifySteps([toCIDS(3)]);
+    });
+
+    QUnit.test("single company mode: from leaf (only one company in branch selected) loginto company", async (assert) => {
+        assert.expect(8);
+        Object.assign(browser.location, { hash: toCIDS(1) });
+
+        function onPushState(url) {
+            assert.step(url.split("#")[1]);
+        }
+        const scMenu = await createSwitchCompanyMenu({ onPushState });
+
+        /**
+         *   [ ] Hermit
+         *   [ ] Herman's
+         *   [x] **Heroes TM**
+         *   [ ]    Hercules
+         *   [ ]    Hulk
+         */
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        await click(target.querySelector(".dropdown-toggle"));
+        assert.containsN(target, "[data-company-id]", 5);
+        assert.containsN(target, "[data-company-id] .fa-check-square", 1);
+        assert.containsN(target, "[data-company-id] .fa-square-o", 4);
+
+        /**
+         *   [ ] Hermit
+         *   [x] **Herman's**     -> log into
+         *   [ ] Heroes TM
+         *   [ ]    Hercules
+         *   [ ]    Hulk
+         */
+        await click(target.querySelectorAll(".log_into")[1]);
+        assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
+        assert.verifySteps([toCIDS(2)]);
     });
 
     QUnit.test("multi company mode: log into a non selected company", async (assert) => {
@@ -262,7 +362,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         function onPushState(url) {
             assert.step(url.split("#")[1]);
         }
-        Object.assign(browser.location, { hash: "cids=3%2C1" });
+        Object.assign(browser.location, { hash: toCIDS(3, 1) });
         const scMenu = await createSwitchCompanyMenu({ onPushState });
 
         /**
@@ -280,15 +380,15 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         assert.containsN(target, "[data-company-id] .fa-square-o", 3);
 
         /**
-         *   [ ] Hermit
+         *   [x] Hermit
          *   [x] **Herman's**    -> log into
-         *   [ ] Heroes TM
+         *   [x] Heroes TM
          *   [ ]    Hercules
          *   [ ]    Hulk
          */
         await click(target.querySelectorAll(".log_into")[1]);
         assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
-        assert.verifySteps(["cids=2"]);
+        assert.verifySteps([toCIDS(2, 3, 1)]);
     });
 
     QUnit.test("multi company mode: log into an already selected company", async (assert) => {
@@ -297,7 +397,7 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         function onPushState(url) {
             assert.step(url.split("#")[1]);
         }
-        Object.assign(browser.location, { hash: "cids=2%2C1" });
+        Object.assign(browser.location, { hash: toCIDS(2, 1) });
         const scMenu = await createSwitchCompanyMenu({ onPushState });
 
         /**
@@ -316,14 +416,45 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
 
         /**
          *   [ ] Hermit
-         *   [ ] Herman's
+         *   [x] Herman's
          *   [x] **Heroes TM**    -> log into
          *   [x]    Hercules
          *   [x]    Hulk
          */
         await click(target.querySelectorAll(".log_into")[2]);
         assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
-        assert.verifySteps(["cids=1%2C4%2C5"]);
+        assert.verifySteps([toCIDS(1, 2, 4, 5)]);
+    });
+
+    QUnit.test("multi company mode: switching company doesn't deselect already selected ones", async (assert) => {
+        assert.expect(8);
+        Object.assign(browser.location, { hash: toCIDS(1, 2, 4, 5) });
+        const scMenu = await createSwitchCompanyMenu({ onPushState: (url) => assert.step(url.split("#")[1]) });
+
+        /**
+         *   [ ] Hermit
+         *   [x] Herman's
+         *   [x] **Heroes TM**
+         *   [x]    Hercules
+         *   [x]    Hulk
+         */
+        assert.deepEqual(scMenu.env.services.company.allowedCompanyIds, [1, 2, 4, 5]);
+        assert.strictEqual(scMenu.env.services.company.currentCompany.id, 1);
+        await click(target.querySelector(".dropdown-toggle"));
+        assert.containsN(target, "[data-company-id]", 5);
+        assert.containsN(target, "[data-company-id] .fa-check-square", 4);
+        assert.containsN(target, "[data-company-id] .fa-square-o", 1);
+
+        /**
+         *   [ ] Hermit
+         *   [x] **Herman's** -> log into
+         *   [x] Heroes TM
+         *   [x]    Hercules
+         *   [x]    Hulk
+         */
+        await click(target.querySelectorAll(".log_into")[1]);
+        assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
+        assert.verifySteps([toCIDS(2, 1, 4, 5)]);
     });
 
     QUnit.test("companies can be logged in even if some toggled within delay", async (assert) => {
@@ -349,9 +480,9 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         assert.containsN(target, "[data-company-id] .fa-square-o", 4);
 
         /**
-         *   [ ] Hermit         -> toggled
-         *   [x] **Herman's**   -> logged in
-         *   [ ] Heroes TM      -> toggled
+         *   [ ] Hermit         -> 2) toggled
+         *   [x] **Herman's**   -> 3) logged in
+         *   [ ] Heroes TM      -> 1) toggled
          *   [ ]    Hercules
          *   [ ]    Hulk
          */
@@ -359,6 +490,9 @@ QUnit.module("SwitchCompanyMenu", (hooks) => {
         await click(target.querySelectorAll(".toggle_company")[0]);
         await click(target.querySelectorAll(".log_into")[1]);
         assert.containsNone(target, ".dropdown-menu", "dropdown is directly closed");
-        assert.verifySteps(["cids=2"]);
+
+        // When "Herman's" is logged into, only one company is currently selected
+        // so we treat it as single company mode
+        assert.verifySteps([toCIDS(2)]);
     });
 });


### PR DESCRIPTION
Before this PR:
When loggin into a company, it would simply add the new company in the
list of the currently selected/active companies, this made it harder
to use or stay in single-company mode.

After this PR:
Logging into a company will now switch companies if we are in single-company
mode, essentially making the user stay in single-company mode. The user
can still toggle companies to enter multi-company mode.

*This behaviour got lost when adding the branches system in the company service.*

Task ID: 3927141

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
