### PR TITLE
[FIX] web: hotkeys will ignore IME

### DIFF
--- a/addons/web/static/src/core/hotkeys/hotkey_service.js
+++ b/addons/web/static/src/core/hotkeys/hotkey_service.js
@@ -60,6 +60,10 @@ export function getActiveHotkey(ev) {
         // See https://stackoverflow.com/questions/59534586/google-chrome-fires-keydown-event-when-form-autocomplete
         return "";
     }
+    if (ev.isComposing) {
+        // This case happens with an IME for example: we let it handle all key events.
+        return "";
+    }
     const hotkey = [];
 
     // ------- Modifiers -------

--- a/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
+++ b/addons/web/static/tests/core/hotkeys/hotkey_service_tests.js
@@ -54,6 +54,20 @@ QUnit.test("register / unregister", async (assert) => {
     assert.verifySteps([key]);
 });
 
+QUnit.test("should ignore when IME is composing", async (assert) => {
+    const key = "enter";
+    env.services.hotkey.add(key, () => assert.step(key));
+    await nextTick();
+
+    triggerHotkey(key);
+    await nextTick();
+    assert.verifySteps([key]);
+
+    triggerHotkey(key, false, { isComposing: true });
+    await nextTick();
+    assert.verifySteps([]);
+});
+
 QUnit.test("hotkey handles wrongly formed KeyboardEvent", async (assert) => {
     // This test's aim is to assert that Chrome's autofill bug is handled.
     // When filling a form with the autofill feature of Chrome, a keyboard event without any


### PR DESCRIPTION
- Before this commit One using an Input Method Editor (i.e. for writing hiraganas) could potentially trigger an hotkey, which does not make any sense.

- After this commit While an IME is still composing, the hotkey service will ignore.

opw-3633735
