### PR TITLE
[FIX] web: adapt `FormStatusIndicator` alignment

### DIFF
--- a/addons/web/static/src/search/control_panel/control_panel.xml
+++ b/addons/web/static/src/search/control_panel/control_panel.xml
@@ -131,7 +131,7 @@
             <t t-call="web.Breadcrumb.Actions"/>
         </div>
 
-        <t t-slot="control-panel-status-indicator" />
+        <t t-slot="control-panel-status-indicator" t-props="breadcrumbs"/>
     </t>
 
     <t t-name="web.Breadcrumb.Actions">

--- a/addons/web/static/src/views/form/form_controller.xml
+++ b/addons/web/static/src/views/form/form_controller.xml
@@ -41,9 +41,11 @@
                         />
                     </t>
 
-                    <t t-set-slot="control-panel-status-indicator">
+                    <t t-set-slot="control-panel-status-indicator" t-slot-scope="breadcrumbs">
                         <t t-if="canEdit">
-                            <FormStatusIndicator model="model" discard.bind="discard" save.bind="saveButtonClicked" />
+                            <t t-set="collapsedBreadcrumbs" t-value="Object.keys(breadcrumbs).slice(-3, -1)"/>
+                            <t t-set="visiblePathBreadcrumbs" t-value="Object.keys(breadcrumbs).slice(0, -3).reverse()"/>
+                            <FormStatusIndicator model="model" discard.bind="discard" save.bind="saveButtonClicked" breadcrumb="collapsedBreadcrumbs.length || visiblePathBreadcrumbs.length"/>
                         </t>
                     </t>
                     <t t-set-slot="control-panel-create-button">

--- a/addons/web/static/src/views/form/form_status_indicator/form_status_indicator.js
+++ b/addons/web/static/src/views/form/form_status_indicator/form_status_indicator.js
@@ -7,6 +7,7 @@ export class FormStatusIndicator extends Component {
         model: Object,
         save: Function,
         discard: Function,
+        breadcrumb: { type: Number, optional: true },
     };
 
     setup() {

--- a/addons/web/static/src/views/form/form_status_indicator/form_status_indicator.xml
+++ b/addons/web/static/src/views/form/form_status_indicator/form_status_indicator.xml
@@ -2,11 +2,11 @@
 <templates xml:space="preserve">
 
     <t t-name="web.FormStatusIndicator">
-        <div class="o_form_status_indicator d-md-flex align-items-center align-self-md-end me-auto" t-att-class="{ o_form_status_indicator_new_record: props.model.root.isNew }">
+        <div class="o_form_status_indicator d-md-flex align-items-center me-auto" t-att-class="{ 'o_form_status_indicator_new_record': props.model.root.isNew, 'align-self-md-end': props.breadcrumb }">
             <div class="o_form_status_indicator_buttons d-flex" t-att-class="{ invisible: !(props.model.root.isNew or displayButtons) }">
                 <button
                     type="button"
-                    class="o_form_button_save btn btn-light px-1 py-0 lh-sm"
+                    class="o_form_button_save btn btn-light border-0 px-1 py-0 lh-sm"
                     data-hotkey="s"
                     t-on-click.stop="save"
                     data-tooltip="Save manually"
@@ -16,7 +16,7 @@
                 </button>
                 <button
                     type="button"
-                    class="o_form_button_cancel btn btn-light px-1 py-0 lh-sm"
+                    class="o_form_button_cancel btn btn-light border-0 px-1 py-0 lh-sm"
                     data-hotkey="j"
                     t-on-click.stop="discard"
                     data-tooltip="Discard all changes"


### PR DESCRIPTION
Prior to this commit, the `FormStatusIndicator` buttons were not properly aligned with the content of the breadcrumb in the control panel.

This commit adjusts the alignment of `FormStatusIndicator` correctly according to the content of the breadcrumb.

Also, to align the cog menu perfectly with the "save" and "cancel" buttons, we've removed the border around the latter two.

task-3874495

| Before | After |
|--------|--------|
| ![Capture d’écran 2024-05-13 à 16 04 53](https://github.com/odoo/odoo/assets/80679690/8699c6c2-be00-4ed9-b193-01fad2445de1) | ![Capture d’écran 2024-05-13 à 16 04 45](https://github.com/odoo/odoo/assets/80679690/9dc09cb2-bdf8-401c-8f48-978eb022f7ef) |
|  ![Capture d’écran 2024-05-13 à 16 07 33](https://github.com/odoo/odoo/assets/80679690/97f02e22-06b4-42c1-9e02-b0bb57c5c972) | ![Capture d’écran 2024-05-13 à 16 07 20](https://github.com/odoo/odoo/assets/80679690/f031a83a-ae60-4459-bbb8-80f1c2ad6fab) |




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
