### PR TITLE
[FIX] sms: prevent error when sending sms

### DIFF
--- a/addons/sms/wizard/sms_composer.py
+++ b/addons/sms/wizard/sms_composer.py
@@ -194,7 +194,7 @@ class SendSMS(models.TransientModel):
         if self.composition_mode == 'numbers':
             return self._action_send_sms_numbers()
         elif self.composition_mode == 'comment':
-            if records is None or not isinstance(records, self.pool['mail.thread']):
+            if not records or not isinstance(records, self.pool['mail.thread']):
                 return self._action_send_sms_numbers()
             if self.comment_single_recipient:
                 return self._action_send_sms_comment_single(records)
@@ -370,6 +370,9 @@ class SendSMS(models.TransientModel):
             records = self.env[self.res_model].browse(self.res_id)
         else:
             records = self.env[self.res_model]
+
+        if not isinstance(records, self.pool['mail.thread']):
+            records = records.mapped('partner_id')
 
         records = records.with_context(mail_notify_author=True)
         return records


### PR DESCRIPTION
This error occurs when the user attempts to send a message using the ``Mitchell Admin`` mobile number after creating a new ``Website Live Chat Channels``.

Steps to reproduce:

- Install the ``im_livechat`` module
- Create new ``Website Live Chat Channels`` > Click on ``Mitchell Admin``
- Add mobile number > Click on the ``SMS`` smart button on the right side of the mobile field
- Add mobile number in ``Recipient`` and add a message in ``Message`` > ``Send SMS``

Traceback : 
``AttributeError 'bool' object has no attribute 'split'``

Here at [1], we're encountering the error because the ``sanitized_numbers`` is getting False and this error is occuring only when we are sending sms message from ``res.users`` because we didn't get records of partner from it due to that we do not have any number in composer at [2] so it will take ``sanitized_numbers`` as False.

This commit will resolve the above error by mapping ``partner_id`` in records.

[1]- https://github.com/odoo/odoo/blob/8780f8d9799eed7188d6577c6bb2690df598196e/addons/sms/wizard/sms_composer.py#L207

[2]- https://github.com/odoo/odoo/blob/b6c82de598f512750ddf80c7b4aade96346207e5/addons/sms/wizard/sms_composer.py#L155

sentry-4681535519

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
