### PR TITLE
[IMP] marketing_automation: whatsappp integration

### DIFF
--- a/addons/link_tracker/models/link_tracker.py
+++ b/addons/link_tracker/models/link_tracker.py
@@ -316,7 +316,7 @@ class LinkTrackerClick(models.Model):
 
     campaign_id = fields.Many2one(
         'utm.campaign', 'UTM Campaign', index='btree_not_null',
-        related="link_id.campaign_id", store=True, ondelete="set null")
+        default="link_id.campaign_id", store=True, ondelete="set null")
     link_id = fields.Many2one(
         'link.tracker', 'Link',
         index=True, required=True, ondelete='cascade')


### PR DESCRIPTION
Whatsapp was added as an activity type in marketing automation. Whatsapp addition caused the addition of certain trigger types, as well as integrating whatsapp with link tracker.

task-3595515

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
