### PR TITLE
[FIX] hr: print multiple badges

### DIFF
--- a/addons/hr/__manifest__.py
+++ b/addons/hr/__manifest__.py
@@ -20,6 +20,7 @@
     'data': [
         'security/hr_security.xml',
         'security/ir.model.access.csv',
+        'data/report_paperformat.xml',
         'wizard/hr_departure_wizard_views.xml',
         'wizard/mail_activity_schedule_views.xml',
         'views/mail_activity_plan_views.xml',

--- a/addons/hr/data/report_paperformat.xml
+++ b/addons/hr/data/report_paperformat.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="paperformat_hr_employee_badge" model="report.paperformat">
+        <field name="name">Badge(s)</field>
+        <field name="default" eval="True"/>
+        <field name="disable_shrinking" eval="True"/>
+        <field name="dpi">96</field>
+        <field name="format">A4</field>
+        <field name="orientation">Portrait</field>
+        <field name="margin_top">5</field>
+        <field name="margin_bottom">0</field>
+        <field name="margin_left">0</field>
+        <field name="margin_right">0</field>
+    </record>
+</odoo>

--- a/addons/hr/report/hr_employee_badge.xml
+++ b/addons/hr/report/hr_employee_badge.xml
@@ -6,6 +6,7 @@
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">hr.print_employee_badge</field>
         <field name="report_file">hr.print_employee_badge</field>
+        <field name="paperformat_id" ref="hr.paperformat_hr_employee_badge"/>
         <field name="print_report_name">'Badge - %s' % (object.name).replace('/', '')</field>
         <field name="binding_model_id" ref="model_hr_employee"/>
         <field name="binding_type">report</field>
@@ -16,32 +17,40 @@
             <div class="page">
                 <div class="oe_structure"></div>
                 <t t-foreach="docs" t-as="employee">
-                    <div class="col-md-6">
+                    <div style="display: inline-block; page-break-inside: avoid; width: 243pt; height: 153pt; border: 1pt solid black; border-radius:8pt; margin:5pt; padding: 2pt;">
                         <div class="oe_structure"></div>
-                        <table style="width:243pt; height:153pt; border: 1pt solid black; border-collapse:separate; border-radius:8pt; margin:5pt">
-                            <td style="width:33%;" valign="center">
-                                <table style="width:77pt; height:150pt" class="table-borderless">
-                                    <tr style="height:30%">
-                                        <td align="center" valign="center">
-                                            <span t-if="employee.company_id.logo">
-                                                <img t-att-src="image_data_uri(employee.company_id.logo)" style="max-height:45pt;max-width:90%" alt="Company Logo"/>
-                                            </span>
-                                        </td>
-                                    </tr>
-                                    <tr style="height:70%;">
-                                        <td align="center" valign="center">
-                                            <img t-att-src="image_data_uri(employee.avatar_1920)" style="max-height:85pt;max-width:90%" alt="Employee Image"/>
-                                        </td>
-                                    </tr>
-                                </table>
-                            </td>
-                            <td style="width:67%" valign="center">
-                                <table style="width:155pt; height:85pt" class="table-borderless">
-                                    <tr><th><div style="font-size:15pt; margin-bottom:0pt;margin-top:0pt;" align="center"><span t-out="employee.name">Marc Demo</span></div></th></tr>
-                                    <tr><td><div align="center" style="font-size:10pt;margin-bottom:5pt;"><span t-out="employee.job_id.name">Software Developer</span></div></td></tr>
-                                    <tr><td><div t-if="employee.barcode" t-field="employee.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 120, 'img_style': 'max-height:50pt;max-width:100%;', 'img_align': 'center'}">12345678901</div></td></tr>
-                                </table>
-                            </td>
+                        <table style="width: 100%; height: 100%; border-spacing: 4pt; border-collapse: separate;" class="table-borderless">
+                            <tr>
+                                <td style="width: 33%;">
+                                    <table style="width: 100%; height: 100%; text-align: center;" class="table-borderless">
+                                        <t t-if="employee.company_id.logo">
+                                            <tr style="height:30%; padding-top: 4pt; padding-bottom: 2pt">
+                                                <td>
+                                                    <img t-att-src="image_data_uri(employee.company_id.logo)" style="max-height: 40pt; max-width: 100%;" alt="Company Logo"/>
+                                                </td>
+                                            </tr>
+                                        </t>
+                                        <tr style="height:70%;">
+                                            <td style="height: 100%; width: 100%; padding-top: 2pt; padding-bottom: 4pt;">
+                                                <img t-att-src="image_data_uri(employee.avatar_1920)" style="max-height: 100pt; max-width: 100%;" alt="Employee Image"/>
+                                            </td> 
+                                        </tr>
+                                    </table>
+                                </td>
+                                <td style="width:67%; height:100%; vertical-align: top;">
+                                    <table style="width: 100%; height: 100%; text-align: center;" class="table-borderless">
+                                        <tr><th><span style="font-size: 15pt;" t-out="employee.name">Marc Demo</span></th></tr>
+                                        <tr><td><span style="font-size: 10pt;" t-out="employee.job_id.name">Software Developer</span></td></tr>
+                                        <tr style="height: 100%;">
+                                            <td style="vertical-align: bottom; padding-bottom: 4pt;">
+                                                <div t-if="employee.barcode" t-field="employee.barcode" t-options="{'widget': 'barcode', 'width': 600, 'height': 120, 'img_style': 'max-width:100%;', 'img_align': 'center'}">
+                                                    12345678901
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    </table>
+                                </td>
+                            </tr>
                         </table>
                         <div class="oe_structure"></div>
                     </div>


### PR DESCRIPTION
The PDF that is generated when printing multiple badges used to display the badges in one long column and a single badge would sometimes span two pages, making it unusable as a badge. A fix was implemented to have badges fill out as much as possible of a single A4 page by displaying the badges in two columns. Badges are also now prevented from spanning two pages. 

The task also describes adding a little spacing above the person's name, which was also solved by restructuring the XML and implementing a consistent spacing around and between all elements, hopefully making the badges look a bit nicer. 

It also came to light during the implementation of this fix that the badges were too small, in physical dimension, which was also fixed.

task-3910959

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
