### PR TITLE
[IMP] project: improve project share wizard

### DIFF
--- a/addons/project/wizard/project_share_collaborator_wizard.py
+++ b/addons/project/wizard/project_share_collaborator_wizard.py
@@ -17,10 +17,10 @@ class ProjectSharingCollaboratorWizard(models.TransientModel):
         required=True,
     )
     access_mode = fields.Selection(
-        [('read', 'Read-only'), ('edit_limited', 'Edit with limited access'), ('edit', 'Edit')],
+        [('read', 'Read'), ('edit_limited', 'Edit with limited access'), ('edit', 'Edit')],
         default='read',
         required=True,
-        help="Read-only: collaborators can view tasks but cannot edit them.\n"
+        help="Read: collaborators can view tasks but cannot edit them.\n"
             "Edit with limited access: collaborators can view and edit tasks they follow in the Kanban view.\n"
             "Edit: collaborators can view and edit all tasks in the Kanban view. Additionally, they can choose which tasks they want to follow."
     )

--- a/addons/project/wizard/project_share_wizard.py
+++ b/addons/project/wizard/project_share_wizard.py
@@ -52,7 +52,7 @@ class ProjectShareWizard(models.TransientModel):
         project_model = self.env['ir.model']._get('project.project')
         return [(project_model.model, project_model.name)]
 
-    share_link = fields.Char("Public Link", help="Anyone with this link can access the project in read-only mode.")
+    share_link = fields.Char("Public Link", help="Anyone with this link can access the project in read mode.")
     collaborator_ids = fields.One2many('project.share.collaborator.wizard', 'parent_wizard_id', string='Collaborators')
     existing_partner_ids = fields.Many2many('res.partner', compute='_compute_existing_partner_ids', export_string_translation=False)
 

--- a/addons/project/wizard/project_share_wizard_views.xml
+++ b/addons/project/wizard/project_share_wizard_views.xml
@@ -23,7 +23,7 @@
                 </field>
                 <p class="text-muted">Choose one of the following access modes for your collaborators:</p>
                 <ul class="text-muted">
-                    <li>Read-only: collaborators can view tasks but cannot edit them.</li>
+                    <li>Read: collaborators can view tasks but cannot edit them.</li>
                     <li>Edit with limited access: collaborators can view and edit tasks they follow in the Kanban view.</li>
                     <li>Edit: collaborators can view and edit all tasks in the Kanban view. Additionally, they can choose which tasks they want to follow.</li>
                 </ul>
@@ -41,7 +41,7 @@
         <field name="arch" type="xml">
             <form string="Confirmation">
                 <p>People invited to collaborate on the project will have portal access rights.</p>
-                <p>They can edit shared project tasks and view specific documents in read-only mode on your website. This includes leads/opportunities, quotations/sales orders, purchase orders, invoices and bills, timesheets, and tickets.</p>
+                <p>They can edit shared project tasks and view specific documents in read mode on your website. This includes leads/opportunities, quotations/sales orders, purchase orders, invoices and bills, timesheets, and tickets.</p>
                 <p>You have full control and can revoke portal access anytime. Are you ready to proceed?</p>
                 <footer>
                     <button string="Grant Portal Access" name="action_send_mail" type="object" class="btn-primary" data-hotkey="q"/>
@@ -52,7 +52,7 @@
     </record>
 
     <record id="project_share_wizard_action" model="ir.actions.act_window">
-        <field name="name">Share a Project</field>
+        <field name="name">Share Project</field>
         <field name="res_model">project.share.wizard</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>


### PR DESCRIPTION

We did the following in this commit:
   - Renamed access_mode label (Read-only -> Read)
   - If access_mode is "Read" and "Send by Email" is not selected, then both
     "Send Invitation" and "Discard" buttons are hidden and "Close" appears
     instead.
   - Renamed project share action (Share a Project -> Share Project)

task-3919304