### PR TITLE
[FIX] website: fix dynamic snippets behaviour on destroy

### DIFF
--- a/addons/website/static/src/js/content/website_root.js
+++ b/addons/website/static/src/js/content/website_root.js
@@ -108,7 +108,7 @@ export const WebsiteRoot = publicRootData.PublicRoot.extend({
                 const key = await this._getGMapAPIKey(refetch);
 
                 window.odoo_gmap_api_post_load = (async function odoo_gmap_api_post_load() {
-                    await this._startWidgets(undefined, {editableMode: editableMode});
+                    await this._startWidgets($("section.s_google_map"), {editableMode: editableMode});
                     resolve(key);
                 }).bind(this);
 

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -258,6 +258,7 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
             }
             onClickSave() {
                 this.props.confirm(this.modalRef, this.state.apiKey);
+                this.props.close();
             }
         };
 

--- a/addons/website/static/src/snippets/s_dynamic_snippet/000.js
+++ b/addons/website/static/src/snippets/s_dynamic_snippet/000.js
@@ -211,7 +211,7 @@ const DynamicSnippet = publicWidget.Widget.extend({
     _setupSizeChangedManagement: function (enable) {
         if (enable === true) {
             this.removeSizeListener = listenSizeChange(this._onSizeChanged.bind(this));
-        } else {
+        } else if (this.removeSizeListener) {
             this.removeSizeListener();
             delete this.removeSizeListener;
         }


### PR DESCRIPTION
Steps to reproduce:

1- For the "Google Map" Block:

- Go to a website page (in "edit" mode) > Drop a "Google Map" block.

- Set the Google project API key and click on "Save" > The dialog is
still visible with the "Save" button disabled > We have to reload the
page manually to be able to add the snippet.

- Add a dynamic snippet (product block, event, etc) right after the map.

- Save > Traceback shown and we cannot edit the page anymore.

2- For the "Tab" block:

- Go to a website page (in "edit" mode) > Drop a "Tabs" block.

- Set its Style to "Tabs" > Insert a dynamic content products block
inside each of the tabs block.

- When trying to add a new tab to the tabs block, there is an uncaught
promise error.

Technical explanation:

On "Google Maps" block:

[A]: The Google Maps script has an `odoo_gmap_api_post_load()` function
as a callback when the library is loaded. This function will
automatically call `_startWidgets()` for all widgets in the DOM (which
is a very strange behaviour).

[B]: If one of the blocks in the DOM is a dynamic snippet, the
`DynamicSnippet` public widget that handles the block will set a
"resize" handler on `start()` and remove it on `destroy()`. But with the
behaviour from [A], the external `_startWidgets()` will destroy the
widget even if its `start()` process is not fully completed, and the
code will try to call a "resize listener removal" function that is not
initialized yet. Which explains the traceback.

On "Tabs" block:

[C]: The fix from [1] was added to restore the handling of event for
cloned snippets that were lost after moving the event handling to the
`wysiwyg_adapter`. One of these listeners notifies stops the public
widgets inside the snippet that is about to be cloned. This behaviour
triggers the same issue as [B] when the block contains a dynamic
snippet.

On Google Maps API key dialog:

[D]: After [2], website legacy dialogs (including `s_google_map_modal`)
were replaced with OWL dialogs… In this new code, the dialog needs to be
closed when the API key is valid to prevent the blocked UI and allow the
dialog promise to be resolved when setting the Google Maps key.

The goal of this commit is to prevent the behaviour from [B] & [C] by
only restarting the map widgets when the Gmap library is loaded (an
extra check was added on the `DynamicSnippet` to prevent triggering the
same behaviour by another external `_startWidgets()`).

Also, the `GoogleMapAPIKeyDialog` will be closed in `onClickSave()` to
fix the behaviour from [D].

[1]: https://github.com/odoo/odoo/commit/24ca4ae3fbe9b25eb502e0a293a3dcab31ce8857
[2]: https://github.com/odoo/odoo/commit/57ed8bc0bf9d1ae2b7542d677a4d7e8fd1899ea2

opw-3879971
opw-3895730