### PR TITLE
[FIX] account: fix cross currency calculation while register payment

### DIFF
--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -557,10 +557,10 @@ class AccountPaymentRegister(models.TransientModel):
             return abs(residual_amount), False
         else:
             # Foreign currency on payment different than the one set on the journal entries.
-            selected_ids  =  self.env.context.get('active_ids',[])
-            invoices  =  self.env['account.move.line'].search([('id','in',selected_ids)])
-            residual_amount  =  invoices[0].move_id.amount_residual
-            return  self.source_currency_id._convert(
+            selected_ids = self.env.context.get('active_ids', [])
+            invoices = self.env['account.move.line'].search([('id', 'in', selected_ids)])
+            residual_amount = invoices[0].move_id.amount_residual
+            return self.source_currency_id._convert(
                 residual_amount,
                 self.currency_id,
                 self.company_id,

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -559,7 +559,7 @@ class AccountPaymentRegister(models.TransientModel):
             # Foreign currency on payment different than the one set on the journal entries.
             selected_ids = self.env.context.get('active_ids', [])
             active_model = self.env.context.get('active_model')
-            if active_model == 'account.move.line':    
+            if active_model == 'account.move.line':
                 invoices = self.env['account.move.line'].search([('id', 'in', selected_ids)])
                 if invoices:
                     residual_amount = invoices[0].move_id.amount_residual

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -558,10 +558,19 @@ class AccountPaymentRegister(models.TransientModel):
         else:
             # Foreign currency on payment different than the one set on the journal entries.
             selected_ids = self.env.context.get('active_ids', [])
-            invoices = self.env['account.move.line'].search([('id', 'in', selected_ids)])
-            residual_amount = invoices[0].move_id.amount_residual
-            return self.source_currency_id._convert(
-                residual_amount,
+            active_model = self.env.context.get('active_model')
+            if active_model == 'account.move.line':    
+                invoices = self.env['account.move.line'].search([('id', 'in', selected_ids)])
+                if invoices:
+                    residual_amount = invoices[0].move_id.amount_residual
+                    return self.source_currency_id._convert(
+                        residual_amount,
+                        self.currency_id,
+                        self.company_id,
+                        self.payment_date,
+                    ), False
+            return comp_curr._convert(
+                self.source_amount,
                 self.currency_id,
                 self.company_id,
                 self.payment_date,

--- a/addons/account/wizard/account_payment_register.py
+++ b/addons/account/wizard/account_payment_register.py
@@ -557,8 +557,11 @@ class AccountPaymentRegister(models.TransientModel):
             return abs(residual_amount), False
         else:
             # Foreign currency on payment different than the one set on the journal entries.
-            return comp_curr._convert(
-                self.source_amount,
+            selected_ids  =  self.env.context.get('active_ids',[])
+            invoices  =  self.env['account.move.line'].search([('id','in',selected_ids)])
+            residual_amount  =  invoices[0].move_id.amount_residual
+            return  self.source_currency_id._convert(
+                residual_amount,
                 self.currency_id,
                 self.company_id,
                 self.payment_date,


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
While registering for Payment in Invoice, if the company currency, the source currency of invoice and the payment currency of invoice; all the three are different, then the currency conversion to the payment currency was not accurate.

Current behavior before PR:
Before this PR, the conversion was directly made between the company currency and the payment currency.

Desired behavior after PR is merged:
This PR targets to change the currency conversion method. It now performs the conversion between the source currency of invoice and the payment currency. This will lead to accurate currency conversion as the exchange rate is correctly calculated now.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
