### PR TITLE
[FIX] website: link a new page to existing menus having same page url

### DIFF
--- a/addons/website/models/website.py
+++ b/addons/website/models/website.py
@@ -757,6 +757,10 @@ class Website(models.Model):
             view.arch_fs = False
 
         website = self.get_current_website()
+        menu = self.env['website.menu'].search([
+            ('url', 'in', [page_url, page_url.lstrip("/")]),
+            ('website_id', '=', website.id),
+        ], limit=1)
         if ispage:
             default_page_values = {
                 'url': page_url,
@@ -764,6 +768,11 @@ class Website(models.Model):
                 'view_id': view.id,
                 'track': True,
             }
+            # To link the page with the menus having the same URL as the the page
+            if menu.exists():
+                default_page_values.update({'menu_ids': menu.ids})
+                result['menu_id'] = menu.id
+                add_menu = False
             if page_values:
                 default_page_values.update(page_values)
             page = self.env['website.page'].create(default_page_values)


### PR DESCRIPTION
This PR resolves an issue where menus created before a corresponding page existed wouldn't automatically delete when the page was removed. Previously, these menus were linked to the page's URL as a string instead of its pageID, preventing the automatic deletion through the ondelete cascade feature.

Steps to reproduce:
1. Create a menu from the menu editor. E.g:
         Menu: test_menu ​
         URL: /test (right now we don't have any page for this URL).
2. Create page with the same URL using the New Page option:
         Page title: test (let 'ADD to menu' button check)
3. Delete this page:
         You will find test_menu is not deleted while its page gets deleted.

Expected Behavior: The test_menu should also be deleted automatically, along with the associated page.

To address this issue, this PR ensures that pageID are linked to menus that share the same URL at the time of the creation of a new page.

Task-3757369