### PR TITLE
[IMP] utm: improve website medium robustness

### DIFF
--- a/addons/hr_recruitment/models/hr_recruitment_source.py
+++ b/addons/hr_recruitment/models/hr_recruitment_source.py
@@ -13,7 +13,7 @@ class RecruitmentSource(models.Model):
     has_domain = fields.Char(compute='_compute_has_domain')
     job_id = fields.Many2one('hr.job', "Job", ondelete='cascade')
     alias_id = fields.Many2one('mail.alias', "Alias ID", ondelete='restrict')
-    medium_id = fields.Many2one('utm.medium', default=lambda self: self.env.ref('utm.utm_medium_website'))
+    medium_id = fields.Many2one('utm.medium', default=lambda self: self.env['utm.medium']._fetch_or_create_utm_medium('website'))
 
     def _compute_has_domain(self):
         for source in self:
@@ -25,7 +25,7 @@ class RecruitmentSource(models.Model):
 
     def create_alias(self):
         campaign = self.env.ref('hr_recruitment.utm_campaign_job')
-        medium = self.env.ref('utm.utm_medium_email')
+        medium = self.env['utm.medium']._fetch_or_create_utm_medium('email')
         for source in self.filtered(lambda s: not s.alias_id):
             vals = {
                 'alias_defaults': {

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -390,7 +390,7 @@ class MassMailing(models.Model):
     def _compute_medium_id(self):
         for mailing in self:
             if mailing.mailing_type == 'mail' and not mailing.medium_id:
-                mailing.medium_id = self.env.ref('utm.utm_medium_email').id
+                mailing.medium_id = self.env['utm.medium']._fetch_or_create_utm_medium('email').id
 
     @api.depends('mailing_model_id')
     def _compute_reply_to_mode(self):

--- a/addons/mass_mailing_sms/models/mailing_mailing.py
+++ b/addons/mass_mailing_sms/models/mailing_mailing.py
@@ -58,10 +58,10 @@ class Mailing(models.Model):
     def _compute_medium_id(self):
         super(Mailing, self)._compute_medium_id()
         for mailing in self:
-            if mailing.mailing_type == 'sms' and (not mailing.medium_id or mailing.medium_id == self.env.ref('utm.utm_medium_email')):
-                mailing.medium_id = self.env.ref('mass_mailing_sms.utm_medium_sms').id
-            elif mailing.mailing_type == 'mail' and (not mailing.medium_id or mailing.medium_id == self.env.ref('mass_mailing_sms.utm_medium_sms')):
-                mailing.medium_id = self.env.ref('utm.utm_medium_email').id
+            if mailing.mailing_type == 'sms' and (not mailing.medium_id or mailing.medium_id == self.env['utm.medium']._fetch_or_create_utm_medium('email')):
+                mailing.medium_id = self.env['utm.medium']._fetch_or_create_utm_medium("sms", module="mass_mailing_sms").id
+            elif mailing.mailing_type == 'mail' and (not mailing.medium_id or mailing.medium_id == self.env['utm.medium']._fetch_or_create_utm_medium("sms", module="mass_mailing_sms")):
+                mailing.medium_id = self.env['utm.medium']._fetch_or_create_utm_medium('email').id
 
     @api.depends('sms_template_id', 'mailing_type')
     def _compute_body_plaintext(self):

--- a/addons/mass_mailing_sms/models/utm.py
+++ b/addons/mass_mailing_sms/models/utm.py
@@ -89,3 +89,7 @@ class UtmMedium(models.Model):
                 "functional flows, such as the SMS Marketing.",
                 utm_medium_sms.name
             ))
+
+    @property
+    def SELF_REQUIRED_UTM_MEDIUMS_REF(self):
+        return super().SELF_REQUIRED_UTM_MEDIUMS_REF | {"mass_mailing_sms.utm_medium_sms": "SMS"}

--- a/addons/website_crm/models/crm_lead.py
+++ b/addons/website_crm/models/crm_lead.py
@@ -47,7 +47,7 @@ class Lead(models.Model):
     def website_form_input_filter(self, request, values):
         values['medium_id'] = values.get('medium_id') or \
                               self.sudo().default_get(['medium_id']).get('medium_id') or \
-                              self.sudo().env.ref('utm.utm_medium_website').id
+                              self.env['utm.medium']._fetch_or_create_utm_medium('website').id
         values['team_id'] = values.get('team_id') or \
                             request.website.crm_default_team_id.id
         values['user_id'] = values.get('user_id') or \

--- a/addons/website_hr_recruitment/models/hr_recruitment_source.py
+++ b/addons/website_hr_recruitment/models/hr_recruitment_source.py
@@ -18,7 +18,7 @@ class RecruitmentSource(models.Model):
                 source.job_id.website_url,
                 urls.url_encode({
                     'utm_campaign': self.env.ref('hr_recruitment.utm_campaign_job').name,
-                    'utm_medium': source.medium_id.name or self.env.ref('utm.utm_medium_website').name,
+                    'utm_medium': source.medium_id.name or self.env['utm.medium']._fetch_or_create_utm_medium('website').name,
                     'utm_source': source.source_id.name
                 })
             ))


### PR DESCRIPTION
This commit improves the robustness of all utm mediums.
When a user deletes an essential medium, e.g. Website or Email, this has
consequences as this action also deletes the associated ref.
This means that each time ref is called on a deleted Medium, there is an error
that is raised.

To fix this, a check `ondelete` is done to verify that the user does not delete an
essential medium.
If those mediums are already deleted then, thanks to the new
`_fetch_or_create_utm_medium` method, the medium is recreated with its reference.

This way there should be no error raised in the future.

task-3901146

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
