### PR TITLE
[FIX] hr_attendance: fix kiosk kanban view issue with unset job position

### DIFF
--- a/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
+++ b/addons/hr_attendance/static/src/components/manual_selection/manual_selection.xml
@@ -74,7 +74,7 @@
                                 <strong><span><t t-esc="employee.name"/></span></strong>
                             </div>
                             <ul>
-                                <li><span><t t-esc="employee.job"/></span></li>
+                                <li t-if="employee.job"><span><t t-esc="employee.job"/></span></li>
                             </ul>
                         </div>
                     </div>


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
This PR addresses an issue in the attendance module. When an employee's job position is not set, the kiosk mode displays `false` in the employee kanban view when manually identified.

Cause
The issue arises when the job position is not set in the employee profile.

Fix:
This PR resolves the issue by modifying the kanban view template of employees in kiosk mode.if condition is added to ensure that the job position is displayed only if it is set for the employee.

task-3892580
