### PR TITLE
[FIX] web: Wrong width on media-breakpoint-only mixin used with custom breakpoints

### DIFF
--- a/addons/web/static/lib/bootstrap/scss/mixins/_breakpoints.scss
+++ b/addons/web/static/lib/bootstrap/scss/mixins/_breakpoints.scss
@@ -109,7 +109,7 @@
 @mixin media-breakpoint-only($name, $breakpoints: $grid-breakpoints) {
   $min:  breakpoint-min($name, $breakpoints);
   $next: breakpoint-next($name, $breakpoints);
-  $max:  breakpoint-max($next);
+  $max:  breakpoint-max($next, $breakpoints);
 
   @if $min != null and $max != null {
     @media (min-width: $min) and (max-width: $max) {

--- a/doc/cla/individual/Axel-Gohier.md
+++ b/doc/cla/individual/Axel-Gohier.md
@@ -1,0 +1,11 @@
+France, 2024-05-14
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+GOHIER Axel gohier-axel119@orange.fr https://github.com/Axel-Gohier


### PR DESCRIPTION
## Wrong width on media-breakpoint-only mixin used with custom breakpoints

Same issue from bootstrap : [github.com/twbs/bootstrap/issues/35084](https://github.com/twbs/bootstrap/issues/35084)

### Impacted versions:
 - 17.0
 - 16.0

### Code: 
*addons/web/static/lib/bootstrap/scss/mixins/_breakpoints.scss:*
```scss
// Media between the breakpoint's minimum and maximum widths.
// No minimum for the smallest breakpoint, and no maximum for the largest one.
// Makes the @content apply only to the given breakpoint, not viewports any wider or narrower.
@mixin media-breakpoint-only($name, $breakpoints: $grid-breakpoints) {
  $min:  breakpoint-min($name, $breakpoints);
  $next: breakpoint-next($name, $breakpoints);
  $max:  breakpoint-max($next);

  @if $min != null and $max != null {
    @media (min-width: $min) and (max-width: $max) {
      @content;
    }
  } @else if $max == null {
    @include media-breakpoint-up($name, $breakpoints) {
      @content;
    }
  } @else if $min == null {
    @include media-breakpoint-down($next, $breakpoints) {
      @content;
    }
  }
}
```
The `$max` doesn't pass the custom breakpoints, so it return the max of the default `$grid-breakpoints`.

### Steps to reproduce:
1. Create a new custom breakpoints
    ```scss
    $custom-breakpoints: (
      xs: 0,
      sm: 580px,
      md: 772px,
      lg: 996px,
      xl: 1205px,
      xxl: 1604px,
    );
    ```
2. Create scss rules to apply only on one breakpoint.
    ```scss
    @include media-breakpoint-only(md, $custom-breakpoints) {
        ...
    }
    ```

#### Current behavior:
 
 - The rules are applied on the wrong range of pixel : 
     ```scss
     @media (min-width: 772px) and (max-width: 991.98px) {
      ...
     }
    ```
 
#### Expected behavior:
 
 - ```scss
    @media (min-width: 772px) and (max-width: 995.98px) {
      ...
    }
    ```
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
