### PR TITLE
[FIX] web: fix traceback when clicks on the statusbar of followup reports

### DIFF
--- a/addons/web/models/models.py
+++ b/addons/web/models/models.py
@@ -117,6 +117,8 @@ class Base(models.AbstractModel):
                     vals['id']: cleanup(vals)
                     for vals in co_records.web_read(extra_fields)
                 }
+                if not many2one_data:
+                    continue
 
                 if 'display_name' in field_spec['fields']:
                     for rec in co_records.sudo():


### PR DESCRIPTION
This traceback occurs when the user clicks on the `statusbar` of `followup reports`
 by excluding all `aml's`.

To reproduce this issue:-

1) Install `Accounting`
2) Open the `Follow-up-report` from `dropdown menu` of
  `Customer Invoices` in `accounting onboarding dashboard`.
3) Open any one record by removing the default filter 
4) Enable the `Exclude from follow-ups` for all `aml's` 
5) Now click on the `status bar`

Error:- 
```
KeyError: 1
  File "odoo/http.py", line 2256, in __call__
    response = request._serve_db()
  File "odoo/http.py", line 1832, in _serve_db
    return self._transactioning(_serve_ir_http, readonly=ro)
  File "odoo/http.py", line 1852, in _transactioning
    return service_model.retrying(func, env=self.env)
  File "odoo/service/model.py", line 134, in retrying
    result = func()
  File "odoo/http.py", line 1830, in _serve_ir_http
    return self._serve_ir_http(rule, args)
  File "odoo/http.py", line 1837, in _serve_ir_http
    response = self.dispatcher.dispatch(rule.endpoint, args)
  File "odoo/http.py", line 2062, in dispatch
    result = self.request.registry['ir.http']._dispatch(endpoint)
  File "odoo/addons/base/models/ir_http.py", line 220, in _dispatch
    result = endpoint(**request.params)
  File "odoo/http.py", line 742, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "addons/web/controllers/dataset.py", line 38, in call_kw
    return self._call_kw(model, method, args, kwargs)
  File "addons/web/controllers/dataset.py", line 34, in _call_kw
    return call_kw(request.env[model], method, args, kwargs)
  File "odoo/api.py", line 458, in call_kw
    result = getattr(recs, name)(*args, **kwargs)
  File "addons/web/models/models.py", line 76, in web_save
    return self.with_context(bin_size=True).web_read(specification)
  File "addons/web/models/models.py", line 129, in web_read
    vals = many2one_data[values[field_name]]
```

When the user `Excludes` all the `Followups` and clicks on the `status-bar`,
the `web_read` method triggers with a record of `res.partner` having no `followup_line_id`.

Because of that, there will be no `many2one_data` as `extra_fields` are `{}` 
values_list is also empty for the recursive call of many2one_data as `co_records` is also
having no recordsets.

Which leads to an exception from the below line (128).

https://github.com/odoo/odoo/blob/0d1399d06bd5ab30918b1a84abccb0f44504a508/addons/web/models/models.py#L116-L128

After applying this commit, it will resolve this issue by adding an extra check of "many2one_data" before assigning the value from many2one_data. Which makes the code more robust.

sentry-4982604710