### PR TITLE
[FIX] website: fix website form editable test

### DIFF
--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -858,13 +858,15 @@
         },
         {
             content: "Click on the text inside the dropped form column",
+            extra_trigger: "iframe section.s_website_form .col-lg-4[contenteditable=true]",
             trigger: "iframe section.s_website_form h3.card-title",
             run: "dblclick",
         },
-        {   // Simulate a user interaction with the editable content.
+        {
+            // Simulate a user interaction with the editable content.
             content: "Update the text inside the form column",
             trigger: "iframe section.s_website_form h3.card-title",
-            run: "keydown 65 66 67",
+            run: "text ABC",
         },
         {
             content: "Check that the new text value was correctly set",


### PR DESCRIPTION
When an editable content is dropped in the website form, the editable
elements identification and adaptation happens on `start()` (async).

In a normal user interaction context, the dropped content would be set
as editable in time, but when doing automated testing, we need to make
sure the dropped content has `[contenteditable=true]` before editing
its content.

Remark: This commit also removes the `_keydown()` test function from
the tour (since it still uses the deprecated `execCommand()`) and
replaces it with a simple `run: "text ..."`.

runbot-64816