### PR TITLE
[IMP] web_tour: Fix drag and drop event

### DIFF
--- a/addons/web_tour/static/src/tour_service/tour_utils.js
+++ b/addons/web_tour/static/src/tour_service/tour_utils.js
@@ -92,7 +92,8 @@ export function getConsumeEventType(element, runCommand) {
         }
         if (
             (/^drag_and_drop_native/.test(runCommand) && classList.contains("o_draggable")) ||
-            element.closest(".o_draggable")
+            element.closest(".o_draggable") ||
+            element.draggable
         ) {
             return "pointerdown";
         }


### PR DESCRIPTION
Before this commit:
When using the drag and drop event of the tour for elements containing the 'draggable' attribute set to true, the tour step does not progress to the next step.

After this commit:
Now, even if the element contains the 'draggable' attribute, we ensure that the pointer moves to the next step.

task-3925591


