### PR TITLE
[FIX] delivery: fix order weight estimation for shipping providers

### DIFF
--- a/addons/delivery/models/sale_order.py
+++ b/addons/delivery/models/sale_order.py
@@ -155,8 +155,6 @@ class SaleOrder(models.Model):
 
     def _get_estimated_weight(self):
         self.ensure_one()
-        if self.delivery_set:
-            return self.shipping_weight
         weight = 0.0
         for order_line in self.order_line.filtered(lambda l: l.product_id.type in ['product', 'consu'] and not l.is_delivery and not l.display_type and l.product_uom_qty > 0):
             weight += order_line.product_qty * order_line.product_id.weight


### PR DESCRIPTION
Steps to reproduce:
- Create a 'Based on Rules' shipping method.
- Configure it to have different prices based on weight. For example, $10 if <= 1KG and $20 if > 1KG.
- Create a product whose weight is 1KG.
- Create a quotation with one unit of this product.
- Add shipping to this quotation using the created shipping method.
- Increase the quantity of the product and update the shipping cost.

Expected behavior:
Cost increases since the total weight increased and matched the higher price rule.

Current behavior:
Cost remains as it is and doesn't increase.

This was because `_get_estimated_weight` method checks first for the value of `shipping_weight` field on `sale.order`, which is in turn, a computed field that gets its value from the same method: `_get_estimated_weight`. Therefore, once the value of `shipping_weight` is set for the first time. `_get_estimated_weight` will keep returning the same value forever.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
