### PR TITLE
[IMP] portal: filename consistency

### DIFF
--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -507,7 +507,7 @@ class CustomerPortal(Controller):
             'Content-Length': len(report),
         }
         if report_type == 'pdf' and download:
-            filename = "%s.pdf" % (re.sub(r'\W+', '-', model._get_report_base_filename()))
+            filename = "%s.pdf" % (re.sub(r'\W+', '_', model._get_report_base_filename()))
             headers['Content-Disposition'] = content_disposition(filename)
         return headers
 


### PR DESCRIPTION
In the get_http_headers we have a regex that will match one or more
occurrences of any character that is not a word character (i.e., not
alphanumeric or underscore) and replace it with '-'.
To be consistent with other module like accounting, we changed the '-' into an
'_'

task: 3925645



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
