### PR TITLE
[FIX] account: bank dashboard misc entry currency

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -396,10 +396,10 @@ class account_journal(models.Model):
       ] + expression.OR(misc_domain)
 
         misc_totals = {
-            account: (balance, count)
-            for account, balance, count in self.env['account.move.line']._read_group(
+            account: (balance, count_lines, currencies)
+            for account, balance, count_lines, currencies in self.env['account.move.line']._read_group(
                 domain=misc_domain,
-                aggregates=['balance:sum', 'id:count'],
+                aggregates=['amount_currency:sum', 'id:count', 'currency_id:recordset'],
                 groupby=['account_id'])
         }
 
@@ -423,8 +423,8 @@ class account_journal(models.Model):
             currency = journal.currency_id or self.env['res.currency'].browse(journal.company_id.sudo().currency_id.id)
             has_outstanding, outstanding_pay_account_balance = outstanding_pay_account_balances[journal.id]
             to_check_balance, number_to_check = to_check.get(journal, (0, 0))
-            misc_balance, number_misc = misc_totals.get(journal.default_account_id, (0, 0))
-            currency_consistent = not journal.currency_id or journal.currency_id == journal.default_account_id.currency_id
+            misc_balance, number_misc, misc_currencies = misc_totals.get(journal.default_account_id, (0, 0, currency))
+            currency_consistent = misc_currencies == currency
             accessible = journal.company_id.id in journal.company_id._accessible_branches().ids
 
             dashboard_data[journal.id].update({
@@ -441,6 +441,7 @@ class account_journal(models.Model):
                 'bank_statements_source': journal.bank_statements_source,
                 'is_sample_data': journal.has_statement_lines,
                 'nb_misc_operations': number_misc,
+                'misc_class': 'text-warning' if not currency_consistent else '',
                 'misc_operations_balance': currency.format(misc_balance) if currency_consistent else None,
             })
 

--- a/addons/account/tests/test_account_journal_dashboard.py
+++ b/addons/account/tests/test_account_journal_dashboard.py
@@ -301,3 +301,51 @@ class TestAccountJournalDashboard(AccountTestInvoicingCommon):
         }).action_post()
         dashboard_data = bank_journal._get_journal_dashboard_data_batched()[bank_journal.id]
         self.assertEqual(0, dashboard_data['nb_misc_operations'])
+
+    def test_bank_journal_different_currency(self):
+        """Test that the misc operations amount on the dashboard is correct
+        for a bank account in another currency."""
+        foreign_currency = self.currency_data['currency']
+        bank_journal = self.company_data['default_journal_bank'].copy({'currency_id': foreign_currency.id})
+
+        self.assertNotEqual(bank_journal.currency_id, bank_journal.company_id.currency_id)
+
+        move = self.env['account.move'].create({
+            'journal_id': self.company_data['default_journal_misc'].id,
+            'line_ids': [
+                Command.create({
+                    'account_id': bank_journal.default_account_id.id,
+                    'currency_id': foreign_currency.id,
+                    'amount_currency': 100,
+                }),
+                Command.create({
+                    'account_id': self.company_data['default_account_assets'].id,
+                    'currency_id': foreign_currency.id,
+                    'amount_currency': -100,
+                })
+            ]
+        })
+        move.action_post()
+
+        dashboard_data = bank_journal._get_journal_dashboard_data_batched()[bank_journal.id]
+        self.assertEqual(dashboard_data.get('misc_operations_balance', 0), foreign_currency.format(100))
+
+        bank_journal.default_account_id.currency_id = False  # not a normal case
+        company_currency_move = self.env['account.move'].create({
+            'journal_id': self.company_data['default_journal_misc'].id,
+            'line_ids': [
+                Command.create({
+                    'account_id': bank_journal.default_account_id.id,
+                    'debit': 100,
+                }),
+                Command.create({
+                    'account_id': self.company_data['default_account_assets'].id,
+                    'credit': 100,
+                })
+            ]
+        })
+        company_currency_move.action_post()
+        dashboard_data = bank_journal._get_journal_dashboard_data_batched()[bank_journal.id]
+
+        self.assertEqual(dashboard_data.get('misc_operations_balance', 0), None)
+        self.assertEqual(dashboard_data.get('misc_class', ''), 'text-warning')

--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -274,7 +274,7 @@
                             </div>
                             <div class="row" t-if="dashboard.nb_misc_operations > 0">
                                 <div id="dashboard_bank_cash_misc_total" class="col text-start">
-                                    <a type="object" name="open_bank_difference_action">Misc. Operations</a>
+                                    <a type="object" name="open_bank_difference_action" t-att-class="dashboard.misc_class">Misc. Operations</a>
                                 </div>
                                 <div class="col-auto text-end">
                                     <span><t t-out="dashboard.misc_operations_balance"/></span>


### PR DESCRIPTION
Problem
--------

https://github.com/odoo/odoo/pull/156655 hides the miscellaneous entry total if there is a discrepancy between the journal currency and journal's default account currency. This fix is not ideal as the total is the sum of the balance field (company currency), while the displayed total uses the journal currency. Since this could be a foreign bank account, the journal currency is correct.

Solution
--------

Sum the `amount_currency` field instead of the `balance` field.

Caveat
-------

Yes, it's possible we are summing apples and oranges as the currencies of the misc move lines may not be the same. In this case, a warning icon is displayed indicating multiple currencies. A module update is required to view this icon.

https://github.com/odoo/odoo/commit/7ef468402d327855ee6323b6a7f82ac6989ee28a#r141889189

opw-3767010