### PR TITLE
[IMP] base_import_module: add translations in data module

### DIFF
--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -7,7 +7,6 @@ import lxml
 import os
 import requests
 import sys
-import tempfile
 import zipfile
 from collections import defaultdict
 from io import BytesIO
@@ -20,6 +19,7 @@ from odoo.osv.expression import is_leaf
 from odoo.release import major_version
 from odoo.tools import convert_csv_import, convert_sql_import, convert_xml_import, exception_to_unicode
 from odoo.tools import file_open, file_open_temporary_directory, ormcache
+from odoo.tools.translate import get_po_paths_env, TranslationImporter
 
 _logger = logging.getLogger(__name__)
 
@@ -194,6 +194,17 @@ class IrModule(models.Model):
             'res_id': asset.id,
         } for asset in created_assets])
 
+        translation_importer = TranslationImporter(self.env.cr, verbose=False)
+        for lang_ in self.env['res.lang'].get_installed():
+            lang = lang_[0]
+            is_lang_imported = False
+            for po_path in get_po_paths_env(module, lang, env=self.env):
+                translation_importer.load_file(po_path, lang)
+                is_lang_imported = True
+            if lang != 'en_US' and not is_lang_imported:
+                _logger.info('module %s: no translation for language %s', module, lang)
+        translation_importer.save(overwrite=True)
+
         mod._update_from_terp(terp)
         _logger.info("Successfully imported module '%s'", module)
         return True
@@ -241,7 +252,8 @@ class IrModule(models.Model):
                     mod_name = filename.split('/')[0]
                     is_data_file = filename in module_data_files[mod_name]
                     is_static = filename.startswith('%s/static' % mod_name)
-                    if is_data_file or is_static:
+                    is_translation = filename.startswith('%s/i18n' % mod_name) and filename.endswith('.po')
+                    if is_data_file or is_static or is_translation:
                         z.extract(file, module_dir)
 
                 dirs = [d for d in os.listdir(module_dir) if os.path.isdir(opj(module_dir, d))]

--- a/addons/base_import_module/tests/test_import_module.py
+++ b/addons/base_import_module/tests/test_import_module.py
@@ -56,8 +56,17 @@ class TestImportModule(odoo.tests.TransactionCase):
                     </record>
                 </data>
             """),
+            ('bar/i18n/fr_FR.po', b"""
+                #. module: bar
+                #: model:res.country,name:bar.foo
+                msgid "foo"
+                msgstr "dumb"
+            """),
         ]
-        self.import_zipfile(files)
+        self.env['res.lang']._activate_lang('fr_FR')
+        with self.assertLogs('odoo.addons.base_import_module.models.ir_module') as log_catcher:
+            self.import_zipfile(files)
+            self.assertIn('module foo: no translation for language fr_FR', log_catcher.output[5])
         self.assertEqual(self.env.ref('foo.foo')._name, 'res.partner')
         self.assertEqual(self.env.ref('foo.foo').name, 'foo')
         self.assertEqual(self.env.ref('foo.bar')._name, 'res.partner')
@@ -66,6 +75,11 @@ class TestImportModule(odoo.tests.TransactionCase):
 
         self.assertEqual(self.env.ref('bar.foo')._name, 'res.country')
         self.assertEqual(self.env.ref('bar.foo').name, 'foo')
+        self.assertEqual(self.env.ref('bar.foo').with_context(lang="fr_FR").name, 'dumb')
+
+        # Check that activating a non-loaded language does not crash the code
+        self.env['res.lang']._activate_lang('es')
+        self.assertEqual(self.env.ref('bar.foo').with_context(lang="es").name, 'foo')
 
         for path, data in files:
             if path.split('/')[1] == 'static':

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -928,11 +928,12 @@ class Module(models.Model):
             if not modpath:
                 continue
             for lang in langs:
-                po_paths = get_po_paths(module_name, lang)
-                for po_path in po_paths:
+                is_lang_imported = False
+                for po_path in get_po_paths(module_name, lang):
                     _logger.info('module %s: loading translation file %s for language %s', module_name, po_path, lang)
                     translation_importer.load_file(po_path, lang)
-                if lang != 'en_US' and not po_paths:
+                    is_lang_imported = True
+                if lang != 'en_US' and not is_lang_imported:
                     _logger.info('module %s: no translation for language %s', module_name, lang)
 
         translation_importer.save(overwrite=overwrite)

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from __future__ import annotations
+
 import codecs
 import fnmatch
 import functools
@@ -1373,7 +1376,7 @@ class TranslationImporter:
                      the language must be present and activated in the database
         :param xmlids: if given, only translations for records with xmlid in xmlids will be loaded
         """
-        with suppress(FileNotFoundError), file_open(filepath, mode='rb') as fileobj:
+        with suppress(FileNotFoundError), file_open(filepath, mode='rb', env=self.env) as fileobj:
             _logger.info('loading base translation file %s for language %s', filepath, lang)
             fileformat = os.path.splitext(filepath)[-1][1:].lower()
             self.load(fileobj, fileformat, lang, xmlids=xmlids)
@@ -1612,8 +1615,11 @@ def load_language(cr, lang):
     installer.lang_install()
 
 
-
 def get_po_paths(module_name: str, lang: str):
+    return get_po_paths_env(module_name, lang)
+
+
+def get_po_paths_env(module_name: str, lang: str, env: odoo.api.Environment | None = None):
     lang_base = lang.split('_')[0]
     # Load the base as a fallback in case a translation is missing:
     po_names = [lang_base, lang]
@@ -1627,7 +1633,7 @@ def get_po_paths(module_name: str, lang: str):
     ]
     for path in po_paths:
         with suppress(FileNotFoundError):
-            yield file_path(path)
+            yield file_path(path, env=env)
 
 
 class CodeTranslations:

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -1621,10 +1621,9 @@ def get_po_paths(module_name: str, lang: str):
     if lang_base == 'es' and lang not in ('es_ES', 'es_419'):
         po_names.insert(1, 'es_419')
     po_paths = [
-        path
+        join(module_name, dir_, filename + '.po')
         for filename in po_names
         for dir_ in ('i18n', 'i18n_extra')
-        if (path := join(module_name, dir_, filename + '.po'))
     ]
     for path in po_paths:
         with suppress(FileNotFoundError):


### PR DESCRIPTION
Before this commit, translations in data modules were not taken into account as there were not extracted nor loaded. This commit adds the possibility to add a i18n folder that contains the translations for the imported module

task-3734243

To-do in master:
- Merge `get_po_paths` and `get_po_paths_env`
- Add an argument `env` to `_load_module_terms` so that `_import_module` (in base_import_module) calls `_load_module_terms` directly.
