### PR TITLE
[FIX] point_of_sale, l10n_fr_pos_cert: fix the line correction

### DIFF
--- a/addons/l10n_fr_pos_cert/static/src/js/pos.js
+++ b/addons/l10n_fr_pos_cert/static/src/js/pos.js
@@ -1,7 +1,7 @@
 /** @odoo-module */
 
 import { PosStore } from "@point_of_sale/app/store/pos_store";
-import { Order, Orderline } from "@point_of_sale/app/store/models";
+import { Order } from "@point_of_sale/app/store/models";
 import { _t } from "@web/core/l10n/translation";
 import { patch } from "@web/core/utils/patch";
 import { ErrorPopup } from "@point_of_sale/app/errors/popups/error_popup";
@@ -17,16 +17,6 @@ patch(PosStore.prototype, {
             return false;
         }
         return french_countries.includes(this.company.country?.code);
-    },
-    disallowLineQuantityChange() {
-        const result = super.disallowLineQuantityChange(...arguments);
-        let selectedOrderLine = this.selectedOrder.get_selected_orderline();
-        //Note: is_reward_line is a field in the pos_loyalty module
-        if (selectedOrderLine?.is_reward_line) {
-            //Always allow quantity change for reward lines
-            return false || result;
-        }
-        return this.is_french_country() || result;
     },
 });
 
@@ -54,22 +44,5 @@ patch(Order.prototype, {
         var result = super.wait_for_push_order(...arguments);
         result = Boolean(result || this.pos.is_french_country());
         return result;
-    },
-});
-
-patch(Orderline.prototype, {
-    can_be_merged_with(orderline) {
-        if (!this.pos.is_french_country()) {
-            return super.can_be_merged_with(...arguments);
-        }
-        const order = this.pos.get_order();
-        const orderlines = order.orderlines;
-        const lastOrderline = order.orderlines.at(orderlines.length - 1);
-
-        if (lastOrderline.product.id !== orderline.product.id || lastOrderline.quantity < 0) {
-            return false;
-        } else {
-            return super.can_be_merged_with(...arguments);
-        }
     },
 });


### PR DESCRIPTION
Currently, when using a company with french localization, if you try deleting lines on a draft order in the session, a new line is created to make the correction.

Steps to reproduce:
-------------------
* Switch to a company with french localisation
* Open Pos shop session
* Add products to the cart
* Go to the backend
* Go back to the session
* Try deleting a line
> Observations: A new line is added with negative quantity to cancel out the line we wanted to delete. Instead of just removing the first line.

Why the fix:
------------
The line correction of the POS certification for the French localization is too restrictive. The law says that correction on validated orders should be made on new lines. For the order that are not validated, the lines can be changed normally.

This is a backport of what will be merged in master as it is a compatible change in stable versions.

This should not break the inalterability chain as you only pass through the functions `disallowLineQuantityChange()` and
`can_be_merged_with()` with orders that are not locked (i.e. they have not been paid yet).

Related ongoing task-id: 3874373

opw-3865724
