### PR TITLE
[FIX] website_partner: fix website description field

### DIFF
--- a/addons/website_partner/models/res_partner.py
+++ b/addons/website_partner/models/res_partner.py
@@ -9,7 +9,7 @@ class WebsiteResPartner(models.Model):
     _name = 'res.partner'
     _inherit = ['res.partner', 'website.seo.metadata']
 
-    website_description = fields.Html('Website Partner Full Description', strip_style=True, translate=html_translate)
+    website_description = fields.Html('Website Partner Full Description', strip_style=True, sanitize_overridable=True, translate=html_translate)
     website_short_description = fields.Text('Website Partner Short Description', translate=True)
 
     def _compute_website_url(self):


### PR DESCRIPTION
Steps to reproduce the bug:

- Go to the "/partners" page.
- Click on the first partner to go to their page.
- Enter "edit mode".
- Drag and drop a "Dynamic products" snippet into the right column of
the page.
- Save the page.
- Bug: the "Dynamic products" snippet is not visible on the page.

The problem is not specific to the "Dynamic products" snippet. The issue
occurs with all snippets. When the "website description" field is saved,
all HTML attributes are removed (except the "class" attribute). This
causes many bugs, which vary depending on the snippets dropped into the
field.

This commit adds the parameter "sanitize_overridable=True" to the
"website_description" field of "website_partner". It means that the
description can now be properly edited as an user with enough rights,
while keeping the same level of protection for other users editing this
field. Still buggy, below version 15.0, for a restricted editor editing
that description but should be rare.

opw-3908218
