### PR TITLE
[FIX] account: display ValidationError upon empty company on SO

### DIFF
--- a/addons/sale/i18n/sale.pot
+++ b/addons/sale/i18n/sale.pot
@@ -716,6 +716,13 @@ msgid "Accept & Sign Quotation"
 msgstr ""
 
 #. module: sale
+#. odoo-python
+#: code:addons/sale/models/sale_order.py:0
+#, python-format
+msgid "The company is required, please select one before making any other changes to the sale order."
+msgstr ""
+
+#. module: sale
 #: model_terms:ir.ui.view,arch_db:sale.sale_order_portal_template
 msgid "Accept &amp; Pay"
 msgstr ""

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -742,6 +742,14 @@ class SaleOrder(models.Model):
                 }
             }
 
+    @api.onchange('company_id')
+    def _onchange_company_id(self):
+        for order in self:
+            # This can't be caught by a python constraint as it is only triggered at save
+            # and a compute methodd needs this data to be set correctly before saving
+            if not order.company_id:
+                raise ValidationError(_("The company is required, please select one before making any other changes to the sale order."))
+
     @api.onchange('fiscal_position_id')
     def _onchange_fpos_id_show_update_fpos(self):
         if self.order_line and (

--- a/addons/sale/tests/test_sale_order.py
+++ b/addons/sale/tests/test_sale_order.py
@@ -511,7 +511,8 @@ class TestSaleOrder(SaleCommon):
         })
         self.env.companies = [self.env.company, company_2]
         so_form = Form(self.env['sale.order'])
-        so_form.company_id = self.env['res.company']
+        with self.assertRaises(ValidationError):
+            so_form.company_id = self.env['res.company']
 
     def test_so_is_not_invoiceable_if_only_discount_line_is_to_invoice(self):
         self.sale_order.order_line.product_id.invoice_policy = 'delivery'

--- a/addons/sale_management/models/sale_order.py
+++ b/addons/sale_management/models/sale_order.py
@@ -95,6 +95,7 @@ class SaleOrder(models.Model):
     @api.onchange('company_id')
     def _onchange_company_id(self):
         """Trigger quotation template recomputation on unsaved records company change"""
+        super()._onchange_company_id()
         if self._origin.id:
             return
         self._compute_sale_order_template_id()


### PR DESCRIPTION
Problem: In a multi-company environment, deselecting a company
on the sales order throws a traceback error that no company can
be found.

Purpose: No traceback error should occur. Instead,
a ValidationError should display requiring the user
to set a company.


Steps to Reproduce on Runbot:
1. Install Sales and Invoice
2. Create a sale orders with a company and save.
3. Deselect the company to be empty and try to save
4. Traceback error occurs

opw-3915943

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
