### PR TITLE
[FIX] web: handle traceback when user selected attachment and clicks on cancle

### DIFF
--- a/addons/web/static/src/views/widgets/attach_document/attach_document.js
+++ b/addons/web/static/src/views/widgets/attach_document/attach_document.js
@@ -61,7 +61,7 @@ export class AttachDocumentWidget extends Component {
 
     async onFileUploaded(files) {
         const { action, record } = this.props;
-        if (action) {
+        if (action && files.length > 0) {
             const { resId, resModel } = record;
             await this.env.services.orm.call(resModel, action, [resId], {
                 attachment_ids: files.map((file) => file.id),


### PR DESCRIPTION
A traceback is occurring when the user tries to attach a receipt in the expense

To reproduce this issue:

1) Install `hr_expense`
2) Open any existing `my expense` record
3) Click on the `Attach Receipt` button and attach a file 
4) Now again attach a file through the `Attach Receipt` button 
5) This time click on `cancel` while attaching a file through `Attach Receipt`

Error:- 
```
IndexError: list index out of range
```

When the user clicks on the cancel button when trying to attach a file, 
it triggers an `orm` call with `attachments` as an empty list with respected `model` & `action`.

Which leads to the above traceback in the backend.

After applying this commit, will resolve this issue by checking the length of the file before triggering the form.
Which makes code more robust.

sentry-4705156379