### PR TITLE
[FIX] onboarding: Correcting breaking translation bug Sweden.

### DIFF
--- a/addons/onboarding/i18n/sv.po
+++ b/addons/onboarding/i18n/sv.po
@@ -444,4 +444,4 @@ msgstr "o_onboarding_confetti"
 #. module: onboarding
 #: model_terms:ir.ui.view,arch_db:onboarding.onboarding_panel
 msgid "onboarding.onboarding.step"
-msgstr "onboarding.onboarding.steg"
+msgstr "onboarding.onboarding.step"


### PR DESCRIPTION
Because of translation of code. Odoo doesn't work if language is set to Swedish before doing the installation. The problem is in the translation in onboarding module.
