### PR TITLE
[FIX] hr_expense : traceback instead of error message when creating report

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -649,7 +649,7 @@ class HrExpense(models.Model):
         expenses_with_amount = self.filtered(lambda expense: not (
             expense.currency_id.is_zero(expense.total_amount_currency)
             or expense.company_currency_id.is_zero(expense.total_amount)
-            or not float_round(expense.quantity, precision_rounding=expense.product_uom_id.rounding)
+            or (expense.product_id and not float_round(expense.quantity, precision_rounding=expense.product_uom_id.rounding))
         ))
 
         if any(expense.state != 'draft' or expense.sheet_id for expense in expenses_with_amount):

--- a/addons/hr_expense/tests/test_expenses_mail_import.py
+++ b/addons/hr_expense/tests/test_expenses_mail_import.py
@@ -1,6 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo.addons.hr_expense.tests.common import TestExpenseCommon
 from odoo.tests import tagged
+from odoo.exceptions import UserError
 
 
 @tagged('-at_install', 'post_install')
@@ -212,3 +213,17 @@ class TestExpensesMailImport(TestExpenseCommon):
             self.product_a,
             self.company_data['currency'],
         )
+
+    def test_import_expense_from_mail_get_default_expense_sheet_values_errors(self):
+        # Make sure we get the expected UserError when trying to validate an expense with no product
+        message = {
+            'message_id': "the-world-is-a-ghetto",
+            'subject': 'no product code 800',
+            'email_from': self.expense_user_employee.email,
+            'to': 'catchall@yourcompany.com',
+            'body': "Don't you know, that for me, and for you",
+            'attachments': [],
+        }
+
+        expense = self.env['hr.expense'].message_new(message)
+        self.assertRaisesRegex(UserError, r"You can not create report without category\.", expense._get_default_expense_sheet_values)


### PR DESCRIPTION
Before commit:
When creating an expense through an email alias, it can sometimes have no product_id set.  This usually causes a clean error message to pop up, but here there was a traceback due to the use of product_uom_id.rounding before we get to show the error message

After commit:
The traceback is solved and the correct error message is shown

opw-3921278

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
