### PR TITLE
[FIX] account_fleet: unlink log services when bill in draft

### DIFF
--- a/addons/account_fleet/models/fleet_vehicle_log_services.py
+++ b/addons/account_fleet/models/fleet_vehicle_log_services.py
@@ -40,5 +40,6 @@ class FleetVehicleLogServices(models.Model):
 
     @api.ondelete(at_uninstall=False)
     def _unlink_if_no_linked_bill(self):
-        if any(log_service.account_move_line_id for log_service in self):
-            raise UserError(_("You cannot delete log services records because one or more of them were bill created."))
+        for log_service in self:
+            if log_service.account_move_line_id and log_service.account_move_state == 'posted':
+                raise UserError(_("You cannot delete log services records because one or more of them were bill created."))

--- a/addons/account_fleet/tests/test_fleet_vehicle_log_services.py
+++ b/addons/account_fleet/tests/test_fleet_vehicle_log_services.py
@@ -73,11 +73,9 @@ class TestFleetVehicleLogServices(AccountTestInvoicingCommon):
         self.assertEqual(self.car_2.log_services[0].amount, service_line_2.price_subtotal)
 
         self.bill.button_draft()
-        self.service_line.unlink()
 
         self.assertFalse(self.car_1.log_services)
-        self.assertEqual(self.car_2.log_services[0].account_move_line_id.move_id, self.bill)
-        self.assertEqual(self.car_2.log_services[0].amount, service_line_2.price_subtotal)
+        self.assertFalse(self.car_2.log_services)
 
     def test_service_log_deletion(self):
         self.bill.action_post()


### PR DESCRIPTION
Create a bill
Add a vehicle on the line
Post the bill
Reset to draft
Remove the vehicle from the line
Save the bill

An error will block the action
"""
Validation Error

The operation cannot be completed:
- Create/update: a mandatory field is not set.
- Delete: another model requires the record being deleted. If possible, archive it instead.

Model: Services for vehicles (fleet.vehicle.log.services) Field: Vehicle (vehicle_id)
"""

This occurs because when the bill is posted we create an associated log service. Then when we reset the bill to draft, log services records are not deleted and the vehicle cannot be removed from the bill line.

opw-3790136