### PR TITLE
[FIX] hr_holidays: absent employees of department

### DIFF
--- a/addons/hr_holidays/views/hr_views.xml
+++ b/addons/hr_holidays/views/hr_views.xml
@@ -4,10 +4,10 @@
    <record id="hr_employee_action_from_department" model="ir.actions.act_window">
        <field name="name">Absent Employees</field>
        <field name="res_model">hr.employee</field>
-       <field name="view_mode">kanban,tree,form</field>
+       <field name="view_mode">tree,kanban,form</field>
        <field name="context">{
            'search_default_is_absent': 1,
-           'search_default_department_id': active_id,
+           'searchpanel_default_department_id': active_id,
            'default_department_id': active_id}
        </field>
        <field name="search_view_id" ref="hr.view_employee_filter"/>


### PR DESCRIPTION
Before this commit, clicking on absence button of any department shows all the absent employees for all the department instead of that department.

This commit brings,  the list view of absent employees of that department after clicking on absence button of any department.

task-3919504