### PR TITLE
[IMP] stock_picking_batch:  detailed operations in batch

### DIFF
--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -92,6 +92,14 @@ class StockPicking(models.Model):
         help='Batch associated to this transfer', index=True, copy=False)
     batch_sequence = fields.Integer(string='Sequence')
 
+    @api.depends('partner_id')
+    def _compute_display_name(self):
+        for picking in self:
+            if self.env.context.get('show_partner_name_in_display') and picking.partner_id:
+                picking.display_name = f"{picking.name} - {picking.partner_id.name}"
+            else:
+                picking.display_name = picking.name
+
     @api.model_create_multi
     def create(self, vals_list):
         pickings = super().create(vals_list)
@@ -310,5 +318,6 @@ class StockPicking(models.Model):
             'type': 'ir.actions.act_window',
             'res_model': 'stock.picking.batch',
             'res_id': self.batch_id.id,
-            'view_mode': 'form'
+            'view_mode': 'form',
+            'context': {'show_partner_name_in_display': True}
         }

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -67,6 +67,7 @@ class StockPickingBatch(models.Model):
     estimated_shipping_volume = fields.Float(
         "shipping_volume", compute='_compute_estimated_shipping_capacity', digits='Product Unit of Measure')
     properties = fields.Properties('Properties', definition='picking_type_id.batch_properties_definition', copy=True)
+    has_package = fields.Boolean(string='Has Package', compute='_compute_has_package')
 
     @api.depends('description')
     @api.depends_context('add_to_existing_batch')
@@ -144,6 +145,11 @@ class StockPickingBatch(models.Model):
     def _compute_scheduled_date(self):
         for rec in self:
             rec.scheduled_date = min(rec.picking_ids.filtered('scheduled_date').mapped('scheduled_date'), default=False)
+
+    def _compute_has_package(self):
+        for batch in self:
+            # Check if there is any picking that has a result_package_id
+            batch.has_package = any(batch.picking_ids.move_line_ids.mapped('result_package_id'))
 
     @api.onchange('scheduled_date')
     def onchange_scheduled_date(self):
@@ -301,6 +307,26 @@ class StockPickingBatch(models.Model):
                 'default_move_ids': self.move_ids.ids,
                 'default_move_quantity': 'move'},
         }
+
+    def action_batch_detailed_operations(self):
+        view_id = self.env.ref('stock_picking_batch.view_move_line_tree').id
+        return {
+            'name': _('Detailed Operations'),
+            'view_mode': 'list',
+            'type': 'ir.actions.act_window',
+            'res_model': 'stock.move.line',
+            'views': [(view_id, 'list')],
+            'domain': [('id', 'in', self.move_line_ids.ids)],
+            'context': {'show_lots_text': self.show_lots_text},
+        }
+
+    def action_see_packages(self):
+        self.ensure_one()
+        action = self.env["ir.actions.actions"]._for_xml_id("stock.action_package_view")
+        packages = self.move_line_ids.mapped('result_package_id')
+        action['domain'] = [('id', 'in', packages.ids)]
+        action['context'] = {'picking_id': self.picking_ids.ids}
+        return action
 
     # -------------------------------------------------------------------------
     # Miscellaneous

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -763,17 +763,17 @@ class TestBatchPicking02(TransactionCase):
         batch_form.picking_ids.add(picking)
         batch = batch_form.save()
         batch.action_confirm()
-        confirmed_form = Form(batch)
+        batch.action_see_packages()
         # Adding a new line should not raise an error
-        confirmed_form.move_line_ids.new()
+        batch.move_line_ids.new()
         # Adding a line should work also for users in multi_locations (former storage categories) group
         self.env.user.groups_id += self.env.ref('stock.group_stock_multi_locations')
         batch_form = Form(self.env['stock.picking.batch'])
         batch_form.picking_ids.add(picking)
         batch = batch_form.save()
         batch.action_confirm()
-        confirmed_form = Form(batch)
-        confirmed_form.move_line_ids.new()
+        batch.action_see_packages()
+        batch.move_line_ids.new()
 
     def test_batch_validation_without_backorder(self):
         loc1, loc2 = self.stock_location.child_ids

--- a/addons/stock_picking_batch/views/stock_picking_batch_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_batch_views.xml
@@ -12,28 +12,20 @@
                     <field name="state" widget="statusbar" statusbar_visible="draft,confirmed,assigned,done"/>
                 </header>
             </xpath>
+             <xpath expr="//chatter" position="replace"/>
         </field>
     </record>
 
-    <record id="view_picking_move_tree_inherited" model="ir.ui.view">
-        <field name="name">stock_picking_batch.picking.move.list</field>
+    <record id="view_stock_move_operations" model="ir.ui.view">
+        <field name="name">stock.move.operations.stock_picking_batch</field>
         <field name="model">stock.move</field>
-        <field name="inherit_id" ref="stock.view_picking_move_tree"/>
-        <field name="mode">primary</field>
-        <field name="priority" eval="1000"/>
+        <field name="inherit_id" ref="stock.view_stock_move_operations"/>
         <field name="arch" type="xml">
-            <xpath expr="//list" position="attributes">
-                <attribute name="delete">0</attribute>
+            <xpath expr="//group/group[1]/field[@name='product_id']" position="before">
+                <field name="picking_id" string="Transfer" readonly="True"/>
             </xpath>
-            <xpath expr="//field[@name='product_id']" position="after">
-                <field name="picking_id"
-                    required="1"
-                    readonly="id"
-                    domain="[('id', 'in', parent.picking_ids)]"
-                    options="{'no_create_edit': True}"/>
-            </xpath>
-            <xpath expr="//field[@name='quantity']" position="attributes">
-                <attribute name="readonly">1</attribute>
+            <xpath expr="//field[@name='show_lots_m2o']" position="after">
+                <field name="quantity" invisible="1"/>
             </xpath>
         </field>
     </record>
@@ -42,15 +34,15 @@
         <field name="name">stock_picking_batch.move.line.list</field>
         <field name="model">stock.move.line</field>
         <field name="arch" type="xml">
-            <list editable="top" decoration-muted="state == 'cancel'" string="Move Lines" default_order="location_id">
+            <list editable="top" decoration-muted="state == 'cancel'" string="Move Lines" default_order="result_package_id desc, location_id asc, location_dest_id asc, picking_id asc, id">
                 <field name="tracking" column_invisible="True"/>
                 <field name="state" column_invisible="True"/>
                 <field name="company_id" column_invisible="True"/>
                 <field name="product_id" context="{'default_is_storable': True}" required="1" readonly="id"/>
                 <field name="picking_id" required="1" readonly="id"
                     options="{'no_create_edit': True}" domain="[('id', 'in', parent.picking_ids)]"/>
-                <field name="lot_id"   groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="parent.show_lots_text" />
-                <field name="lot_name" groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="not parent.show_lots_text"/>
+                <field name="lot_id"   groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="not context.get('show_lots_text', False)" />
+                <field name="lot_name" groups="stock.group_production_lot" readonly="tracking not in ['lot', 'serial']" column_invisible="context.get('show_lots_text', False)"/>
                 <field name="location_id"/>
                 <field name="location_dest_id"/>
                 <field name="package_id" groups="stock.group_tracking_lot"/>
@@ -95,6 +87,18 @@
                             class="oe_stat_button" icon="fa-list"
                             invisible="not show_allocation"
                             groups="stock.group_reception_report"/>
+                        <button name="action_see_packages" string="Packages" type="object"
+                            class="oe_stat_button" icon="fa-cubes"
+                            invisible="not has_package"/>
+                        <button name="action_batch_detailed_operations"
+                            class="oe_stat_button"
+                            icon="fa-bars"
+                            type="object"
+                            help="List view of batch detailed operations">
+                            <div class="o_form_field o_stat_info">
+                                <span class="o_stat_text">Detailed Operations</span>
+                            </div>
+                        </button>
                     </div>
                     <div class="oe_title">
                         <h1><field name="name" class="oe_inline"/></h1>
@@ -110,12 +114,25 @@
                         <field name="properties" nolabel="1" columns="2" hideAddButton="1"/>
                     </group>
                     <notebook>
-                        <page string="Detailed Operations" name="page_detailed_operations" invisible="state == 'draft'">
-                            <field name="move_line_ids" context="{'list_view_ref': 'stock_picking_batch.view_move_line_tree'}" readonly="state not in ['draft', 'in_progress']"/>
-                            <button class="oe_highlight" name="action_put_in_pack" type="object" string="Put in Pack" invisible="state in ('draft', 'done', 'cancel')" groups="stock.group_tracking_lot"/>
-                        </page>
                         <page string="Operations" name="page_operations" invisible="state == 'draft'">
-                            <field name="move_ids" context="{'list_view_ref': 'stock_picking_batch.view_picking_move_tree_inherited'}"/>
+                            <field name="move_ids" readonly="state == 'cancel' or state == 'done'"
+                                widget="stock_move_one2many"
+                                context="{'form_view_ref': 'stock.view_stock_move_operations'}">
+                                <list delete="0" create="0" editable="bottom">
+                                    <field name="show_details_visible" column_invisible="True"/>
+                                    <field name="product_id" context="{'default_detailed_type': 'product'}" required="1" readonly="(state != 'draft' and not additional) or move_lines_count &gt; 0" force_save="1"/>
+                                    <field name="product_packaging_id" groups="product.group_stock_packaging"
+                                        context="{'default_product_id': product_id}"
+                                        readonly="not product_id"/>
+                                    <field name="picking_id" required="1" readonly="id" domain="[('id', 'in', parent.picking_ids)]" options="{'no_create_edit': True}"/>
+                                    <field name="product_uom_qty" string="Demand" readonly="not is_initial_demand_editable"/>
+                                    <field name="quantity" string="Quantity" readonly="1" column_invisible="parent.state=='draft'" decoration-danger="product_uom_qty and quantity > product_uom_qty and parent.state not in ['done', 'cancel']"/>
+                                    <field name="picked" column_invisible="parent.state=='draft'" readonly="1"/>
+                                    <field name="product_uom" readonly="state != 'draft' and not additional" options="{'no_open': True, 'no_create': True}" string="Unit of Measue" groups="uom.group_uom"/>
+                                </list>
+                            </field>
+                            <button class="btn-primary float-end" name="action_put_in_pack" type="object" string="Put in Pack" invisible="state in ('draft', 'done', 'cancel') or has_package" groups="stock.group_tracking_lot" data-hotkey="shift+g"/>
+                            <button class="btn-secondary float-end" name="action_put_in_pack" type="object" string="Put in Pack" invisible="state in ('draft', 'done', 'cancel') or not has_package" groups="stock.group_tracking_lot" data-hotkey="shift+g"/>
                         </page>
                         <page string="Transfers" name="page_transfers">
                             <field name="allowed_picking_ids" invisible="1"/>
@@ -219,7 +236,7 @@
         <field name="res_model">stock.picking.batch</field>
         <field name="view_mode">list,kanban,form</field>
         <field name="domain">[('is_wave', '=', False)]</field>
-        <field name="context">{'search_default_draft': True, 'search_default_in_progress': True}</field>
+        <field name="context">{'search_default_draft': True, 'search_default_in_progress': True, 'show_partner_name_in_display': True}</field>
         <field name="search_view_id" ref="stock_picking_batch_filter"/>
         <field name="help" type="html">
             <div class="container mt-5">

--- a/addons/stock_picking_batch/wizard/stock_picking_to_batch.py
+++ b/addons/stock_picking_batch/wizard/stock_picking_to_batch.py
@@ -41,4 +41,5 @@ class StockPickingToBatch(models.TransientModel):
             'res_model': 'stock.picking.batch',
             'type': 'ir.actions.act_window',
             'res_id': batch.id,
+            'context': {'show_partner_name_in_display': True},
         }


### PR DESCRIPTION
In this commit:
===================
- Added below things in stock picking batch:
   - detailed operations in the smart button
   - details icon on the move
   - concatenated picking id and partner id detail stock move view.

task-3866855
