### PR TITLE
[FIX] stock: fix inconsistency on onhand qty on product

### DIFF
--- a/addons/stock/models/product.py
+++ b/addons/stock/models/product.py
@@ -97,7 +97,7 @@ class Product(models.Model):
     @api.depends('stock_move_ids.product_qty', 'stock_move_ids.state')
     @api.depends_context(
         'lot_id', 'owner_id', 'package_id', 'from_date', 'to_date',
-        'location', 'warehouse',
+        'location', 'warehouse', 'allowed_company_ids'
     )
     def _compute_quantities(self):
         products = self.filtered(lambda p: p.type != 'service')
@@ -251,7 +251,9 @@ class Product(models.Model):
             if location:
                 location_ids = _search_ids('stock.location', location)
             else:
-                location_ids = set(Warehouse.search([]).mapped('view_location_id').ids)
+                location_ids = set(Warehouse.search(
+                    [('company_id', 'in', self.env.companies.ids)]
+                ).mapped('view_location_id').ids)
 
         return self._get_domain_locations_new(location_ids, compute_child=self.env.context.get('compute_child', True))
 

--- a/addons/stock/tests/test_product.py
+++ b/addons/stock/tests/test_product.py
@@ -295,3 +295,28 @@ class TestVirtualAvailable(TestStockCommon):
         product_form.type = 'service'
         product = product_form.save()
         self.assertEqual(product.tracking, 'none')
+
+    def test_domain_locations_only_considers_selected_companies(self):
+        product = self.env['product.product'].create({'name': 'Product', 'type': 'product'})
+        company_a = self.env['res.company'].create({'name': 'Company A'})
+        company_b = self.env['res.company'].create({'name': 'Company B'})
+        warehouse_a = self.env['stock.warehouse'].create({
+            'code': 'WHA', 'company_id': company_a.id
+        })
+        warehouse_b = self.env['stock.warehouse'].create({
+            'code': 'WHB', 'company_id': company_b.id
+        })
+        self.env['stock.quant'].create([
+            {'product_id': product.id, 'location_id': warehouse_a.lot_stock_id.id, 'quantity': 1},
+            {'product_id': product.id, 'location_id': warehouse_b.lot_stock_id.id, 'quantity': 2},
+        ])
+
+        self.assertEqual(product.sudo().with_context(
+            allowed_company_ids=[company_a.id]
+        ).qty_available, 1)
+        self.assertEqual(product.sudo().with_context(
+            allowed_company_ids=[company_b.id]
+        ).qty_available, 2)
+        self.assertEqual(product.sudo().with_context(
+            allowed_company_ids=[company_a.id, company_b.id]
+        ).qty_available, 3)


### PR DESCRIPTION
after this pr:
odoo[#164196](https://github.com/odoo/odoo/pull/164196)
It will create inconsistency during upgrade
specially when we are upgrading from 14.0 to 17.0
because when it's try to compute
```qty_available```, it's call ``` _compute_quantities_dict```, on that function, to find quant domain, using ```get_domain_location``` and on that function will find those warehouses which has ```company_id = self.env.companies.ids``` and then related virtual location of that warehouses. but in 14.0
will find all the warehouses as that code does
not exist in 14.0 so it will find
all the warehouses's virtual location before upgrade and that will raise exception.

```
Traceback (most recent call last):
  File /tmp/tmpok8tnqc4/migrations/testing.py, line 211, in test_check
    self.check(value)
  File /tmp/tmpok8tnqc4/migrations/stock/tests/test_on_hand_quantity.py, line 58, in check
    self.assertEqual(before_results, self.convert_check(after_results), self.message)
AssertionError: Lists differ: [[17430, '1'], [17505, '1'], [17510, '1'], [1[59512 chars]'1']] != [[17985, '1'], [17986, '21'], [18063, '9'], [[23100 chars]'1']]

First differing element 0:
[17430, '1']
[17985, '1']

First list contains 2566 additional elements.
First extra element 1629:
[23315, '25']

Diff is 107124 characters long. Set self.maxDiff to None to see it. : Invariant check fail
```
- Customer have been facing the same issue during the migration in this request [id](https://upgrade.odoo.com/web?debug=1#id=1542548&menu_id=107&cids=1&action=150&model=upgrade.request&view_type=form)
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
