### PR TITLE
[FIX] mail: public channel non joined user mentioned channel access

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -435,6 +435,8 @@ class Channel(models.Model):
                 if current_channel_member and current_channel_member.rtc_session_ids:
                     current_channel_member._rtc_invite_members(member_ids=new_members.ids)
         self.env['bus.bus']._sendmany(notifications)
+        members = new_members + existing_members
+        return members
 
     def _can_invite(self, partner_id):
         """Return True if the current user can invite the partner to the channel.

--- a/addons/mail/static/src/discuss/typing/composer_patch.js
+++ b/addons/mail/static/src/discuss/typing/composer_patch.js
@@ -31,7 +31,7 @@ patch(Composer.prototype, "discuss/typing", {
      * @param {boolean} [is_typing=true]
      */
     notifyIsTyping(is_typing = true) {
-        if (["chat", "channel", "group"].includes(this.thread?.type)) {
+        if (this.thread?.model === "discuss.channel") {
             this.messaging.rpc(
                 "/discuss/channel/notify_typing",
                 {


### PR DESCRIPTION
**Current behavior before PR:**

Non joined users were not able to access public channel's chat window
through channel mentions

**Desired behavior after PR is merged:**

Non joined users can access public channel's chat window through
channel mentions

**task-id: 3899453**


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
