### PR TITLE
[FIX] stock: do not auto apply snoozed reordering rules

### DIFF
--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from odoo import Command
+from odoo.fields import Date
+from odoo.tools.date_utils import add
 from odoo.tests.common import TransactionCase, Form
 
 
@@ -83,3 +86,59 @@ class TestSalePurchaseStockFlow(TransactionCase):
 
         sm.move_line_ids.qty_done = 10
         self.assertEqual(so.order_line.qty_delivered, 10)
+
+    def test_auto_trigger_snoozed_orderpoint(self):
+        """ Check that reordering rules are auto triggerred unless they are snoozed """
+
+        seller = self.env['product.supplierinfo'].create({
+            'partner_id': self.vendor.id,
+            'price': 10,
+        })
+        product = self.env['product.product'].create({
+            'name': 'Super product 1',
+            'type': 'product',
+            'seller_ids': [Command.set(seller.ids)],
+            'route_ids': [Command.set(self.buy_route.ids)],
+        })
+        orderpoint = self.env['stock.warehouse.orderpoint'].create({
+            'name': 'Super product RR',
+            'route_id': self.buy_route.id,
+            'product_id': product.id,
+            'product_min_qty': 0,
+            'product_max_qty': 5,
+        })
+        so_1, so_2 = self.env['sale.order'].create([
+            {
+                'partner_id': self.customer.id,
+                'order_line': [Command.create({
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_uom_qty': 1,
+                    'product_uom': product.uom_id.id,
+                    'price_unit': product.list_price,
+                })]
+            },
+            {
+                'partner_id': self.customer.id,
+                'order_line': [Command.create({
+                    'name': product.name,
+                    'product_id': product.id,
+                    'product_uom_qty': 2,
+                    'product_uom': product.uom_id.id,
+                    'price_unit': product.list_price,
+                })]
+            },
+        ])
+
+        # we check that the first so triggers the RR
+        so_1.action_confirm()
+        po = self.env['purchase.order'].search([('partner_id', '=', self.vendor.id)], limit=1)
+        self.assertEqual(po.order_line.product_qty, 6.0)
+        po.button_cancel()
+        self.assertEqual(po.state, "cancel")
+
+        # we snooze the RR and check that the second so does not trigger it
+        orderpoint.snoozed_until = add(Date.today(), days=1)
+        so_2.action_confirm()
+        po = self.env['purchase.order'].search([('partner_id', '=', self.vendor.id), ('state', '!=', 'cancel')], limit=1)
+        self.assertFalse(po)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2135,6 +2135,8 @@ Please change the quantity done or the rounding precision of your unit of measur
                 ('location_id', 'parent_of', move.location_id.id),
                 ('company_id', '=', move.company_id.id),
                 '!', ('location_id', 'parent_of', move.location_dest_id.id),
+                '|', ('snoozed_until', '=', False),
+                ('snoozed_until', '<=', fields.Date.today()),
             ], limit=1)
             if orderpoint:
                 orderpoints_by_company[orderpoint.company_id] |= orderpoint


### PR DESCRIPTION
### Steps to reproduce:

- Create a storable product with a vendor (in the pruchase tab)
- Create a buy reordering rule with that vendor for that product
- Select the reordering rule line and snooze it for one day
- Create a sale order for

#### > the snoozed reordering rule is triggered

### Cause of the issue:

The `snoozed_untill` field of the orderpoint is not taken into account by the `_trigger_scheduler` to determine which auto-trigger orderpoint should be applied:
https://github.com/odoo/odoo/blob/4f43eb2e69224c9cb271b6e2ca7533d929333985/addons/stock/models/stock_move.py#L2132-L2138

opw-3901613
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
