### PR TITLE
[IMP] web, *: review z-index utilities

### DIFF
--- a/addons/mail/static/src/core/common/chat_window.xml
+++ b/addons/mail/static/src/core/common/chat_window.xml
@@ -13,7 +13,7 @@
         t-on-keydown="onKeydown"
         tabindex="1"
     >
-        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 border-bottom z-index-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall, 'o-folded': props.chatWindow.folded }">
+        <div class="o-mail-ChatWindow-header d-flex align-items-center flex-shrink-0 bg-100 border-bottom z-1" t-on-click="onClickHeader" t-att-class="{ 'cursor-pointer': !ui.isSmall, 'o-folded': props.chatWindow.folded }">
             <t t-if="threadActions.actions.length > 3">
                 <div class="d-flex text-truncate">
                     <Dropdown position="'left-start'" onStateChanged="isOpen => this.onActionsMenuStateChanged(isOpen)" menuClass="'d-flex flex-column py-0'">

--- a/addons/mail/static/src/core/common/date_section.xml
+++ b/addons/mail/static/src/core/common/date_section.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
 <t t-name="mail.DateSection">
-    <div class="o-mail-DateSection d-flex align-items-center w-100 fw-bold z-index-1" t-attf-class="{{ props.className }}">
+    <div class="o-mail-DateSection d-flex align-items-center w-100 fw-bold z-1" t-attf-class="{{ props.className }}">
         <hr class="o-discuss-separator flex-grow-1"/>
         <span class="px-3 opacity-75 small text-muted"><t t-esc="props.date"/></span>
         <hr class="o-discuss-separator flex-grow-1"/>

--- a/addons/mail/static/src/core/common/discuss.xml
+++ b/addons/mail/static/src/core/common/discuss.xml
@@ -5,13 +5,13 @@
     <div class="o-mail-Discuss d-flex h-100 flex-grow-1" t-att-class="{ 'flex-column align-items-center bg-view': ui.isSmall }" t-ref="root">
         <div t-if="ui.isSmall and store.discuss.activeTab === 'main'" class="w-100 border-bottom" t-call="mail.Discuss.mobileTopbar" t-ref="mobileTopbar"/>
         <div t-if="store.inPublicPage or !(ui.isSmall and store.discuss.activeTab !== 'main')" class="o-mail-Discuss-content d-flex flex-column h-100 w-100 overflow-auto" t-ref="content">
-            <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom z-index-1" t-att-class="{ 'flex-grow-1': !ui.isSmall }" t-ref="header">
+            <div class="o-mail-Discuss-header px-3 bg-view d-flex flex-shrink-0 align-items-center border-bottom z-1" t-att-class="{ 'flex-grow-1': !ui.isSmall }" t-ref="header">
                 <t t-if="thread">
                     <div t-if="['channel', 'group', 'chat'].includes(thread.channel_type)" class="o-mail-Discuss-threadAvatar position-relative align-self-center align-items-center mt-2 mb-2 me-2">
                         <img class="rounded" t-att-src="thread.avatarUrl" alt="Thread Image"/>
                         <FileUploader t-if="thread.is_editable" acceptedFileExtensions="'.bmp, .jpg, .jpeg, .png, .svg'" showUploadingText="false" multiUpload="false" onUploaded.bind="(data) => this.onFileUploaded(data)">
                             <t t-set-slot="toggler">
-                                <a href="#" class="position-absolute z-index-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">
+                                <a href="#" class="position-absolute z-1 h-100 w-100 rounded start-0 bottom-0" title="Upload Avatar">
                                     <i class="position-absolute top-50 start-50 fa fa-sm fa-pencil text-white"/>
                                 </a>
                             </t>

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -21,7 +21,7 @@
                         <DateSection date="msg.dateDay" className="'pt-2'"/>
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
-                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-index-1">
+                    <div t-if="msg.threadAsFirstUnread?.eq(props.thread)" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-1">
                         <hr class="ms-2 flex-grow-1 border border-danger opacity-50"/><span class="px-2 text-danger">New messages</span><hr class="me-2 flex-grow-1 border border-danger opacity-50"/>
                     </div>
                     <t t-if="msg.isNotification">

--- a/addons/mail/static/src/core/web/discuss_sidebar.xml
+++ b/addons/mail/static/src/core/web/discuss_sidebar.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.DiscussSidebar">
-        <div class="o-mail-DiscussSidebar d-flex flex-column overflow-auto flex-shrink-0 h-100 pt-3 border-end z-index-1 o-mail-discussSidebarBgColor">
+        <div class="o-mail-DiscussSidebar d-flex flex-column overflow-auto flex-shrink-0 h-100 pt-3 border-end z-1 o-mail-discussSidebarBgColor">
             <t t-foreach="discussSidebarItems" t-as="item" t-key="item_index" t-component="item"/>
         </div>
     </t>

--- a/addons/mail/static/src/discuss/call/common/call_participant_card.xml
+++ b/addons/mail/static/src/discuss/call/common/call_participant_card.xml
@@ -33,7 +33,7 @@
             </div>
             <t t-if="rtcSession">
                 <!-- overlay -->
-                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-index-1 position-absolute bottom-0 start-0 d-flex overflow-hidden">
+                <span class="o-discuss-CallParticipantCard-overlay o-discuss-CallParticipantCard-overlayBottom z-1 position-absolute bottom-0 start-0 d-flex overflow-hidden">
                     <span t-if="!props.minimized and !props.inset" class="p-1 rounded-1 text-truncate" t-esc="name"/>
                     <small t-if="rtcSession.isScreenSharingOn and props.minimized and !isOfActiveCall" class="user-select-none o-minimized rounded-pill text-bg-danger d-flex align-items-center fw-bolder" title="live" aria-label="live">
                         LIVE

--- a/addons/mail/static/src/discuss/core/web/channel_selector.xml
+++ b/addons/mail/static/src/discuss/core/web/channel_selector.xml
@@ -15,7 +15,7 @@
             maxlength="100"
         />
     </div>
-    <NavigableList class="'o-discuss-ChannelSelector-list z-index-1'" t-props="state.navigableListProps"/>
+    <NavigableList class="'o-discuss-ChannelSelector-list z-1'" t-props="state.navigableListProps"/>
 </t>
 
 <t t-name="discuss.ChannelSelector.channel">

--- a/addons/onboarding/views/onboarding_templates.xml
+++ b/addons/onboarding/views/onboarding_templates.xml
@@ -70,7 +70,7 @@
 
             <div class="o_onboarding_line position-absolute"/>
             <div class="o_onboarding_step_side d-flex">
-                <img class="z-index-1" t-attf-src="#{image}" t-attf-alt="#{alt}"/>
+                <img class="z-1" t-attf-src="#{image}" t-attf-alt="#{alt}"/>
             </div>
 
             <div class="o_onboarding_step_content position-relative pt-2 flex-grow-1 d-flex flex-column align-items-center justify-content-around">

--- a/addons/payment/views/payment_form_templates.xml
+++ b/addons/payment/views/payment_form_templates.xml
@@ -149,7 +149,7 @@
             <!-- === Delete button === -->
             <button t-if="allow_token_deletion"
                     name="o_payment_delete_token"
-                    t-att-class="'btn btn-link px-2 py-0 lh-lg z-index-1'
+                    t-att-class="'btn btn-link px-2 py-0 lh-lg z-1'
                                  + (' d-none' if mode != 'validation' else '')"
                     t-attf-data-linked-radio="o_payment_token_{{token_sudo.id}}"
             >
@@ -371,7 +371,7 @@
             - color_name: The class name of the color (`warning`, `danger`...).
             - title: The title to display on hover.
         -->
-        <i t-attf-class="fa fa-{{icon_name}} text-{{color_name}} position-relative z-index-1"
+        <i t-attf-class="fa fa-{{icon_name}} text-{{color_name}} position-relative z-1"
            t-att-title="title"
            data-bs-toggle="tooltip"
            data-bs-placement="top"
@@ -386,7 +386,7 @@
         -->
         <span t-field="logo_pm_sudo.image_payment_form"
               t-options="{'widget': 'image', 'alt-field': 'name'}"
-              class="position-relative d-block rounded overflow-hidden z-index-1 shadow-sm"
+              class="position-relative d-block rounded overflow-hidden z-1 shadow-sm"
               t-att-title="logo_pm_sudo.name"
               data-bs-toggle="tooltip"
               data-bs-placement="top"

--- a/addons/pos_self_order/static/src/app/components/order_widget/order_widget.xml
+++ b/addons/pos_self_order/static/src/app/components/order_widget/order_widget.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.OrderWidget">
         <div
-            class="page-buttons d-flex flex-nowrap justify-content-between py-2 px-3 gap-2 gap-md-3 bg-view z-index-1"
+            class="page-buttons d-flex flex-nowrap justify-content-between py-2 px-3 gap-2 gap-md-3 bg-view z-1"
             t-att-class="{
                 'shadow-lg border-top' : !props.removeTopClasses
             }">

--- a/addons/pos_self_order/static/src/app/components/product_card/product_card.js
+++ b/addons/pos_self_order/static/src/app/components/product_card/product_card.js
@@ -39,13 +39,7 @@ export class ProductCard extends Component {
         const toOrderRect = toOrder.getBoundingClientRect();
 
         clonedPic.classList.remove("w-100", "h-100");
-        clonedPic.classList.add(
-            "position-fixed",
-            "border",
-            "border-white",
-            "border-4",
-            "z-index-1"
-        );
+        clonedPic.classList.add("position-fixed", "border", "border-white", "border-4", "z-1");
         clonedPic.style.top = `${picRect.top}px`;
         clonedPic.style.left = `${picRect.left}px`;
         clonedPic.style.width = `${picRect.width}px`;

--- a/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/cart_page/cart_page.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.CartPage">
         <div class="order-cart-content d-flex flex-column flex-grow-1 justify-content-between overflow-y-auto">
-            <div class="d-flex align-items-center flex-shrink-0 justify-content-between gap-3 p-3 w-100 bg-view border-bottom overflow-x-auto z-index-1">
+            <div class="d-flex align-items-center flex-shrink-0 justify-content-between gap-3 p-3 w-100 bg-view border-bottom overflow-x-auto z-1">
                 <h1 class="mb-0 fw-bolder text-nowrap">Your Order</h1>
             </div>
             <div class="order-content flex-grow-1 overflow-auto pb-4">

--- a/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/combo_page/combo_page.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ComboPage">
-        <div class="d-flex align-items-center flex-shrink-0 justify-content-between gap-3 px-3 py-2 w-100 bg-view border-bottom overflow-x-auto z-index-1">
+        <div class="d-flex align-items-center flex-shrink-0 justify-content-between gap-3 px-3 py-2 w-100 bg-view border-bottom overflow-x-auto z-1">
             <button class="btn btn-secondary btn-lg px-3 text-nowrap" t-on-click="() => this.router.back()">
                 <i class="oi oi-chevron-left" aria-hidden="true"/><span class="ms-2 d-none d-md-inline">Discard</span>
             </button>
@@ -25,7 +25,7 @@
                             t-attf-style="width: calc(100vw / {{props.product.combo_ids.length}})"/>
                         <div class="pos_self_order_breadcrumb_pill d-flex align-items-center justify-content-center ratio ratio-1x1 mx-md-auto">
                             <span
-                                class="rounded-pill d-flex justify-content-center align-items-center border border-2 z-index-1"
+                                class="rounded-pill d-flex justify-content-center align-items-center border border-2 z-1"
                                 t-att-class="{
                                     'text-bg-primary border-primary' : isComboCurrent,
                                     'bg-view' : !isComboCurrent,

--- a/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_list_page/product_list_page.xml
@@ -3,7 +3,7 @@
     <t t-name="pos_self_order.ProductListPage">
         <div class="d-flex flex-column vh-100 overflow-hidden">
             <!-- Categories selector + Search -->
-            <div class="navbar-container position-relative d-flex flex-nowrap w-100 bg-view border-bottom z-index-1">
+            <div class="navbar-container position-relative d-flex flex-nowrap w-100 bg-view border-bottom z-1">
                 <nav id="listgroup-categories" class="category-list d-flex flex-grow-1 py-2 px-3 gap-2 gap-md-3 overflow-x-auto" t-ref="categoryList">
                     <a
                         t-foreach="selfOrder.availableCategories"

--- a/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
+++ b/addons/pos_self_order/static/src/app/pages/product_page/product_page.xml
@@ -2,7 +2,7 @@
 <templates id="template" xml:space="preserve">
     <t t-name="pos_self_order.ProductPage">
         <div class="d-flex flex-column bg-view flex-grow-1 h-100">
-            <div class="d-flex align-items-center flex-shrink-0 justify-content-between gap-3 px-3 py-2 w-100 bg-view border-bottom overflow-x-auto z-index-1">
+            <div class="d-flex align-items-center flex-shrink-0 justify-content-between gap-3 px-3 py-2 w-100 bg-view border-bottom overflow-x-auto z-1">
                 <button class="btn btn-secondary btn-lg px-3 text-nowrap" t-on-click="() => router.back()">
                     <i class="oi oi-chevron-left" aria-hidden="true"/><span class="ms-2 d-none d-md-inline">Discard</span>
                 </button>

--- a/addons/sale/static/src/js/sale_action_helper/sale_action_helper.xml
+++ b/addons/sale/static/src/js/sale_action_helper/sale_action_helper.xml
@@ -11,7 +11,7 @@
                             role="button"
                             t-on-click="this.openVideoPreview"
                         >
-                            <i class="position-absolute top-50 start-50 translate-middle w-auto h-auto z-index-1 fa fa-4x fa-play-circle"/>
+                            <i class="position-absolute top-50 start-50 translate-middle w-auto h-auto z-1 fa fa-4x fa-play-circle"/>
                             <div class="position-absolute top-0 end-0 w-100 h-100"/>
                             <img src="/sale/static/src/img/sales_quotation_thumbnail.webp" class="img w-100"/>
                         </a>

--- a/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
+++ b/addons/spreadsheet_dashboard/static/src/bundle/dashboard_action/dashboard_action.xml
@@ -67,7 +67,7 @@
 
     <t t-name="spreadsheet_dashboard.DashboardAction.Expanded">
         <div class="o_spreadsheet_dashboard_search_panel o_search_panel flex-grow-0 border-end flex-shrink-0 pe-2 pb-5 ps-4 h-100 bg-view overflow-auto position-relative">
-            <button t-if="!env.isSmall and state.activeDashboard" class="btn btn-light btn-sm end-0 m-1 mb-2 position-absolute px-2 py-1 top-0 z-index-1" t-on-click="toggleSidebar">
+            <button t-if="!env.isSmall and state.activeDashboard" class="btn btn-light btn-sm end-0 m-1 mb-2 position-absolute px-2 py-1 top-0 z-1" t-on-click="toggleSidebar">
                 <i class="fa fa-fw fa-angle-double-left"/>
             </button>
             <div class="mt-2"/>

--- a/addons/web/static/src/core/datetime/datetime_picker.xml
+++ b/addons/web/static/src/core/datetime/datetime_picker.xml
@@ -44,7 +44,7 @@
                                 t-on-pointerenter="() => (state.hoveredDate = itemInfo.range[0])"
                                 t-on-click="() => this.zoomOrSelect(itemInfo)"
                             >
-                                <span t-esc="itemInfo.label" class="z-index-1" />
+                                <span t-esc="itemInfo.label" class="z-1" />
                             </button>
                         </t>
                     </t>
@@ -115,7 +115,7 @@
                     t-att-disabled="!itemInfo.isValid"
                     t-on-click="() => this.zoomOrSelect(itemInfo)"
                 >
-                    <span t-esc="itemInfo.label" class="z-index-1" />
+                    <span t-esc="itemInfo.label" class="z-1" />
                 </button>
             </t>
         </div>

--- a/addons/web/static/src/core/signature/name_and_signature.xml
+++ b/addons/web/static/src/core/signature/name_and_signature.xml
@@ -97,7 +97,7 @@
 
                 <div class="o_signature_stroke position-absolute"/>
 
-                <canvas t-if="state.showSignatureArea" t-ref="signature" class="o_web_sign_signature z-index-1"/>
+                <canvas t-if="state.showSignatureArea" t-ref="signature" class="o_web_sign_signature z-1"/>
 
                 <div t-if="loadIsInvalid" t-attf-class="o_web_sign_load_invalid card-footer d-none">
                     <div class="alert alert-danger mb-0" role="alert">

--- a/addons/web/static/src/scss/utilities_custom.scss
+++ b/addons/web/static/src/scss/utilities_custom.scss
@@ -166,10 +166,6 @@ $utilities: map-merge(
             property: flex-basis,
             values: $utilities-sizes,
         ),
-        "z-index": (
-            property: z-index,
-            values: 0 1,
-        ),
         "transition": (
             property: transition,
             values: (

--- a/addons/web/static/src/search/search_panel/search_panel.xml
+++ b/addons/web/static/src/search/search_panel/search_panel.xml
@@ -53,7 +53,7 @@
          t-att-class="env.searchModel.searchPanelInfo.className"
          t-attf-class="#{env.isSmall ? 'px-3' : 'pe-1 ps-3'}"
          t-ref="root">
-        <button t-if="!env.isSmall" class="btn btn-light btn-sm end-0 m-2 position-absolute px-2 py-1 top-0 z-index-1" t-on-click="toggleSidebar">
+        <button t-if="!env.isSmall" class="btn btn-light btn-sm end-0 m-2 position-absolute px-2 py-1 top-0 z-1" t-on-click="toggleSidebar">
             <i class="fa fa-fw fa-angle-double-left"/>
         </button>
         <div t-if="!sections or sections.length === 0" class="o_search_panel_empty_state me-3">

--- a/addons/web/static/src/views/fields/properties/property_definition.xml
+++ b/addons/web/static/src/views/fields/properties/property_definition.xml
@@ -57,7 +57,7 @@
                             <button class="btn btn-link d-flex p-0 w-100" t-att-title="state.typeLabel">
                                 <div class="o_input_dropdown w-100 o_field_property_dropdown">
                                     <img t-attf-src="/web/static/src/views/fields/properties/icons/{{state.propertyDefinition.type}}.png"
-                                        class="position-relative z-index-1 me-n4"/>
+                                        class="position-relative z-1 me-n4"/>
                                     <input type="text" class="dropdown text-start w-100 o_input py-1 align-middle"
                                         t-att-id="getUniqueDomID('type')"
                                         t-att-value="state.typeLabel" readonly=""/>

--- a/addons/web/static/src/views/form/form_compiler.js
+++ b/addons/web/static/src/views/form/form_compiler.js
@@ -161,7 +161,7 @@ export class FormCompiler extends ViewCompiler {
                 );
             }
             if (child.tagName === "field") {
-                child.classList.add("d-inline-block", "mb-0", "z-index-0");
+                child.classList.add("d-inline-block", "mb-0", "z-0");
             }
             append(mainSlot, this.compileNode(child, params, false));
             append(buttonBox, mainSlot);

--- a/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
+++ b/addons/web/static/src/views/kanban/kanban_column_quick_create.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.KanbanColumnQuickCreate">
         <div class="o_column_quick_create flex-shrink-0 flex-grow-1 flex-md-grow-0" t-ref="root">
-            <div t-if="props.folded" class="o_quick_create_folded position-sticky z-index-1 my-3 text-nowrap" t-on-click="unfold">
+            <div t-if="props.folded" class="o_quick_create_folded position-sticky z-1 my-3 text-nowrap" t-on-click="unfold">
                 <button class="o_kanban_add_column btn btn-light w-100" aria-label="Add column" data-tooltip="Add column">
                     <i class="fa fa-plus me-2" role="img"/><t t-out="relatedFieldName"/>
                 </button>

--- a/addons/web/static/src/views/kanban/kanban_header.xml
+++ b/addons/web/static/src/views/kanban/kanban_header.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.KanbanHeader">
-        <div class="o_kanban_header position-sticky top-0 z-index-1" t-ref="root" t-attf-class="{{ !env.isSmall and group.isFolded ? 'pt-2' : 'py-2' }}">
+        <div class="o_kanban_header position-sticky top-0 z-1" t-ref="root" t-attf-class="{{ !env.isSmall and group.isFolded ? 'pt-2' : 'py-2' }}">
             <div class="o_kanban_header_title position-relative d-flex lh-lg">
                 <div t-if="group.isFolded" class="o_column_title d-flex align-items-center pt-1 fs-4 lh-1 text-nowrap opacity-50 opacity-100-hover flex-grow-1"
                      t-on-mouseenter="onTitleMouseEnter" t-on-mouseleave="onTitleMouseLeave">

--- a/addons/web/static/src/views/list/list_renderer.xml
+++ b/addons/web/static/src/views/list/list_renderer.xml
@@ -36,7 +36,7 @@
                                         <i t-att-class="getSortableIconClass(column)"/>
                                     </div>
                                     <span
-                                          class="o_resize position-absolute top-0 end-0 bottom-0 ps-1 bg-black-25 opacity-0 opacity-50-hover z-index-1"
+                                          class="o_resize position-absolute top-0 end-0 bottom-0 ps-1 bg-black-25 opacity-0 opacity-50-hover z-1"
                                           t-on-pointerdown.stop.prevent="onStartResize"/>
                                 </t>
                             </th>

--- a/addons/web/static/src/webclient/settings_form_view/settings/settings_page.xml
+++ b/addons/web/static/src/webclient/settings_form_view/settings/settings_page.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
     <t t-name="web.SettingsPage">
         <div class="o_setting_container">
-            <div class="position-sticky top-0 flex-grow-0 z-index-1">
+            <div class="position-sticky top-0 flex-grow-0 z-1">
                 <div class="settings_tab h-100 border-end" t-if="!env.isSmall or state.search.value.length === 0" t-ref="settings_tab">
                     <t t-foreach="props.modules" t-as="module" t-key="module.key">
                         <div class="tab" t-if="!module.isVisible"

--- a/addons/web_editor/static/src/components/media_dialog/file_selector.js
+++ b/addons/web_editor/static/src/components/media_dialog/file_selector.js
@@ -15,7 +15,7 @@ export const IMAGE_MIMETYPES = ['image/jpg', 'image/jpeg', 'image/jpe', 'image/p
 export const IMAGE_EXTENSIONS = ['.jpg', '.jpeg', '.jpe', '.png', '.svg', '.gif', '.webp'];
 
 class RemoveButton extends Component {
-    static template = xml`<i class="fa fa-trash o_existing_attachment_remove position-absolute top-0 end-0 p-2 bg-white-25 cursor-pointer opacity-0 opacity-100-hover z-index-1 transition-base" t-att-title="removeTitle" role="img" t-att-aria-label="removeTitle" t-on-click="this.remove"/>`;
+    static template = xml`<i class="fa fa-trash o_existing_attachment_remove position-absolute top-0 end-0 p-2 bg-white-25 cursor-pointer opacity-0 opacity-100-hover z-1 transition-base" t-att-title="removeTitle" role="img" t-att-aria-label="removeTitle" t-on-click="this.remove"/>`;
     static props = ["model?", "remove"];
     setup() {
         this.removeTitle = _t("This file is attached to the current record.");

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2707,7 +2707,7 @@ const SelectPagerUserValueWidget = SelectUserValueWidget.extend({
         const _super = this._super.bind(this);
 
         await _super(...arguments);
-        this.menuEl.classList.add('o_we_has_pager', 'position-fixed', 'top-0', 'end-0', 'z-index-1', 'rounded-0');
+        this.menuEl.classList.add('o_we_has_pager', 'position-fixed', 'top-0', 'end-0', 'z-1', 'rounded-0');
         this.menuTogglerEl.classList.add('o_we_toggler_pager');
 
         this.pagerContainerEl = this.el.querySelector('.o_pager_container');

--- a/addons/website/data/website_demo.xml
+++ b/addons/website/data/website_demo.xml
@@ -332,7 +332,7 @@
                                         <div class="row mt-4">
                                             <div class="col-6">
                                                 <h2 class="mt-4">Modal</h2>
-                                                <div class="modal position-relative d-block p-5 h-auto rounded-3 z-index-0">
+                                                <div class="modal position-relative d-block p-5 h-auto rounded-3 z-0">
                                                     <div class="modal-dialog p-0">
                                                         <div class="modal-content">
                                                             <div class="modal-header">

--- a/addons/website/views/website_templates.xml
+++ b/addons/website/views/website_templates.xml
@@ -675,7 +675,7 @@
                     <t t-call="website.placeholder_header_search_box">
                         <t t-set="_input_classes" t-valuef="o_header_stretch_search_input border-0 rounded-0 bg-transparent text-reset"/>
                         <t t-set="_submit_classes" t-valuef="o_navlink_background_hover rounded-0 text-reset"/>
-                        <t t-set="_form_classes" t-valuef="h-100 z-index-0"/>
+                        <t t-set="_form_classes" t-valuef="h-100 z-0"/>
                         <t t-set="_classes" t-valuef="h-100 border-start o_border_contrast"/>
                     </t>
                     <!-- Social -->
@@ -1105,7 +1105,7 @@
 
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" t-if="is_view_active('website.header_text_element') or is_view_active('website.header_social_links') or is_view_active('website.header_search_box') or is_view_active('website.header_call_to_action')"
-                     class="o_header_sales_three_top o_header_hide_on_scroll position-relative border-bottom z-index-1 o_border_contrast">
+                     class="o_header_sales_three_top o_header_hide_on_scroll position-relative border-bottom z-1 o_border_contrast">
                     <div class="container d-flex justify-content-between gap-3 h-100">
                         <ul class="navbar-nav align-items-center gap-3 py-1">
                             <!-- Social -->
@@ -1122,7 +1122,7 @@
                             <t t-call="website.placeholder_header_search_box">
                                 <t t-set="_input_classes" t-valuef="border-0 border-start rounded-0"/>
                                 <t t-set="_submit_classes" t-valuef="rounded-0 bg-o-color-4"/>
-                                <t t-set="_form_classes" t-valuef="h-100 z-index-0"/>
+                                <t t-set="_form_classes" t-valuef="h-100 z-0"/>
                                 <t t-set="_classes" t-valuef="h-100"/>
                             </t>
                             <!-- Call To Action -->
@@ -1186,7 +1186,7 @@
 <template id="template_header_sales_four" inherit_id="website.layout" name="Template Header Sale 4" active="False">
     <xpath expr="//header//nav" position="replace">
         <t t-call="website.navbar">
-            <t t-set="_navbar_classes" t-valuef="o_header_sales_four_top o_header_force_no_radius d-none d-lg-block p-0 shadow-sm z-index-1"/>
+            <t t-set="_navbar_classes" t-valuef="o_header_sales_four_top o_header_force_no_radius d-none d-lg-block p-0 shadow-sm z-1"/>
 
             <div id="o_main_nav" class="o_main_nav">
                 <div aria-label="Top" class="container d-flex">
@@ -1236,7 +1236,7 @@
                         </t>
                     </ul>
                 </div>
-                <div aria-label="Bottom" class="o_header_sales_four_bot o_header_hide_on_scroll z-index-0">
+                <div aria-label="Bottom" class="o_header_sales_four_bot o_header_hide_on_scroll z-0">
                     <div class="container">
                         <ul class="navbar-nav d-grid align-items-center py-2 o_grid_header_3_cols">
                             <!-- Search bar -->
@@ -2814,10 +2814,10 @@ Sitemap: <t t-esc="url_root"/>sitemap.xml
         </div>
         <div class="o_wizard_circle_progress progress d-md-none position-relative rounded-circle ms-3 bg-transparent"
                 t-attf-style="--rightProgress:{{'180' if _steps_in_deg >= 180 else _steps_in_deg}}deg; --leftProgress:{{_steps_in_deg-180 if _steps_in_deg >= 180 else 0}}deg;">
-            <span class="o_wizard_circle_progress_left position-absolute start-0 top-0 z-index-1 overflow-hidden w-50 h-100 ">
+            <span class="o_wizard_circle_progress_left position-absolute start-0 top-0 z-1 overflow-hidden w-50 h-100 ">
                 <span class="progress-bar position-absolute start-100 top-0 w-100 h-100 border border-5 border-start-0 border-primary bg-transparent"/>
             </span>
-            <span class="o_wizard_circle_progress_right position-absolute top-0 end-0 z-index-1 overflow-hidden w-50 h-100">
+            <span class="o_wizard_circle_progress_right position-absolute top-0 end-0 z-1 overflow-hidden w-50 h-100">
                 <span class="progress-bar position-absolute top-0 end-100 w-100 h-100 border border-5 border-end-0 border-primary bg-transparent"/>
             </span>
             <p class="mx-auto fw-bold">

--- a/addons/website_event_track/views/event_track_templates_agenda.xml
+++ b/addons/website_event_track/views/event_track_templates_agenda.xml
@@ -165,7 +165,7 @@
                     </t>
                 </table>
             </div>
-            <span class="o_we_online_agenda_overlay py-5 px-3 pe-none z-index-1"/>
+            <span class="o_we_online_agenda_overlay py-5 px-3 pe-none z-1"/>
         </div>
     </section>
 </template>

--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -231,7 +231,7 @@
 
 <!-- User sidebar -->
 <template id="user_sidebar">
-    <aside class="o_wforum_sidebar col-3 d-none d-lg-flex flex-column z-index-1">
+    <aside class="o_wforum_sidebar col-3 d-none d-lg-flex flex-column z-1">
         <div class="flex-grow-1 px-2">
             <t t-call="website_forum.user_sidebar_header"/>
             <t t-call="website_forum.user_sidebar_body"/>

--- a/addons/website_forum/views/forum_forum_templates_post.xml
+++ b/addons/website_forum/views/forum_forum_templates_post.xml
@@ -40,7 +40,7 @@
                 t-value="'/forum/' + slug(question_tag.forum_id) + '/tag/' + slug(question_tag) + '/questions?' + keep_query( 'search', 'sorting', 'my', 'create_uid', filters='tag')"/>
 
             <a t-att-href="click_action"
-                t-attf-class="badge position-relative z-index-1 #{ 'text-bg-primary' if tag and tag.name == question_tag.name else 'text-bg-secondary' } fw-normal"
+                t-attf-class="badge position-relative z-1 #{ 'text-bg-primary' if tag and tag.name == question_tag.name else 'text-bg-secondary' } fw-normal"
                 t-field="question_tag.name"/>
         </t>
     </div>
@@ -53,7 +53,7 @@
     <div t-if="is_profile" class="card">
         <div class="card-body">
             <t t-call="website_forum.display_post_question_block"/>
-            <div class="d-inline-flex gap-2 position-relative z-index-1 me-1">
+            <div class="d-inline-flex gap-2 position-relative z-1 me-1">
                 <t t-if="answer" t-call="website_forum.author_box">
                     <t t-set="object" t-value="question"/>
                     <t t-set="_image_classes" t-value="'rounded-circle'"/>
@@ -80,11 +80,11 @@
             </t>
         </td>
         <td class="o_wforum_posters order-1 order-lg-2">
-            <div class="position-relative z-index-1 d-flex flex-row-reverse">
+            <div class="position-relative z-1 d-flex flex-row-reverse">
                 <div class="d-none d-lg-flex flex-row-reverse" t-foreach="question.child_ids.filtered(lambda a: a.create_uid != question.create_uid)[-4:]" t-as="post_answer">
                     <t t-call="website_forum.author_box">
                         <t t-set="object" t-value="post_answer"/>
-                        <t t-if="post_answer.is_correct" t-set="_box_classes" t-valuef="z-index-1 order-1"/>
+                        <t t-if="post_answer.is_correct" t-set="_box_classes" t-valuef="z-1 order-1"/>
                         <t t-set="_image_classes" t-value="'me-n2'"/>
                         <t t-set="show_image" t-value="True"/>
                         <t t-set="allow_biography" t-value="True"/>
@@ -92,7 +92,7 @@
                 </div>
                 <t t-call="website_forum.author_box">
                     <t t-set="object" t-value="question"/>
-                    <t t-set="_box_classes" t-value="'z-index-1'"/>
+                    <t t-set="_box_classes" t-value="'z-1'"/>
                     <t t-set="_image_classes" t-value="'me-lg-n2'"/>
                     <t t-set="show_image" t-value="True"/>
                     <t t-set="allow_biography" t-value="True"/>
@@ -115,7 +115,7 @@
             <span t-out="question.views" t-attf-class="#{ 'opacity-50' if question.views == 0 else '' }" />
         </td>
         <td class="o_wforum_last_activity d-none d-lg-table-cell order-4 text-center" t-att-data-last-activity="question.last_activity_date">
-            <span class="o_wforum_relative_datetime position-relative z-index-1" t-att-title="question.last_activity_date"/>
+            <span class="o_wforum_relative_datetime position-relative z-1" t-att-title="question.last_activity_date"/>
         </td>
     </tr>
 </template>

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -1561,7 +1561,7 @@
                                        class="js_add_cart_json btn btn-link d-inline-block border-end-0"
                                        aria-label="Remove one"
                                        title="Remove one">
-                                        <i class="position-relative z-index-1 fa fa-minus"/>
+                                        <i class="position-relative z-1 fa fa-minus"/>
                                     </a>
                                     <input type="text"
                                            class="js_quantity quantity form-control border-start-0 border-end-0"
@@ -1581,7 +1581,7 @@
                                        class="js_add_cart_json d-inline-block float_left btn btn-link border-start-0"
                                        aria-label="Add one"
                                        title="Add one">
-                                        <i class="fa fa-plus position-relative z-index-1"/>
+                                        <i class="fa fa-plus position-relative z-1"/>
                                     </a>
                                 </t>
                                 <t t-else="">
@@ -2590,7 +2590,7 @@
         <div t-elif="len(product_images) == 1 and website.product_page_image_layout != 'grid'"
              class="position-relative d-inline-flex overflow-hidden m-auto h-100"
         >
-            <span t-attf-class="o_ribbon #{ribbon._get_position_class()} z-index-1"
+            <span t-attf-class="o_ribbon #{ribbon._get_position_class()} z-1"
                   t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
                   t-out="ribbon['name'] or ''"
             />
@@ -2609,7 +2609,7 @@
         <div id="o-carousel-product" class="carousel slide position-sticky mb-3 overflow-hidden" data-bs-ride="true" t-att-data-name="product_carousel_block_name">
             <div class="o_carousel_product_outer carousel-outer position-relative flex-grow-1 overflow-hidden">
                 <span t-if="len(product_images) > 1"
-                      t-attf-class="o_ribbon #{ribbon._get_position_class()} z-index-1"
+                      t-attf-class="o_ribbon #{ribbon._get_position_class()} z-1"
                       t-attf-style="#{text_color and ('color: %s; ' % text_color)}#{bg_color and 'background-color:' + bg_color}"
                       t-out="ribbon['name'] or ''"
                 />


### PR DESCRIPTION
task-3930430
- requires https://github.com/odoo/enterprise/pull/62524

-------------
This PR removes the custom `z-index` utilities in favor of Bootstrap default allowing us to choose value from a wider range.

Prior to this PR, we were using custom utilities to handle the z-index of our elements. This approach allowed us to use `z-index-0` and `z-index-1` classes but it was sometimes not enough, leading to the use of `z-index` CSS properties.

With the migration to Bootstrap 5.3 achieved in Commit[1], we now have access to a wider range of `z-index` which are defined inside the `$zindex-levels` map and go from `-1` to `3`. Unfortunately, these new utilities were being overridden by our custom one.

To unlock these utilities and allow more flexibility in our code, this PR removes the custom utilities in favor of Bootstrap default.

Commit[1]: [6e90b00](https://github.com/odoo/odoo/pull/158560/commits/6e90b0033ed19f2496d0e8816e431cc34dafef6e)