### PR TITLE
[FIX] {purchase_,}mrp: display vendor if possible on overview

### DIFF
--- a/addons/mrp/report/mrp_report_bom_structure.py
+++ b/addons/mrp/report/mrp_report_bom_structure.py
@@ -222,7 +222,8 @@ class ReportBomStructure(models.AbstractModel):
 
         key = product.id
         bom_key = bom.id
-        self._update_product_info(product, bom_key, product_info, warehouse, current_quantity, bom=bom, parent_bom=parent_bom)
+        qty_product_uom = bom.product_uom_id._compute_quantity(current_quantity, product.uom_id or bom.product_tmpl_id.uom_id)
+        self._update_product_info(product, bom_key, product_info, warehouse, qty_product_uom, bom=bom, parent_bom=parent_bom)
         route_info = product_info[key].get(bom_key, {})
         quantities_info = {}
         if not ignore_stock:
@@ -236,8 +237,8 @@ class ReportBomStructure(models.AbstractModel):
             'bom_code': bom and bom.code or False,
             'type': 'bom',
             'quantity': current_quantity,
-            'quantity_available': quantities_info.get('free_qty', 0),
-            'quantity_on_hand': quantities_info.get('on_hand_qty', 0),
+            'quantity_available': quantities_info.get('free_qty') or 0,
+            'quantity_on_hand': quantities_info.get('on_hand_qty') or 0,
             'base_bom_line_qty': bom_line.product_qty if bom_line else False,  # bom_line isn't defined only for the top-level product
             'name': product.display_name or bom.product_tmpl_id.display_name,
             'uom': bom.product_uom_id if bom else product.uom_id,
@@ -245,6 +246,7 @@ class ReportBomStructure(models.AbstractModel):
             'route_type': route_info.get('route_type', ''),
             'route_name': route_info.get('route_name', ''),
             'route_detail': route_info.get('route_detail', ''),
+            'route_alert': route_info.get('route_alert', False),
             'lead_time': route_info.get('lead_time', False),
             'currency': company.currency_id,
             'currency_id': company.currency_id.id,
@@ -279,7 +281,8 @@ class ReportBomStructure(models.AbstractModel):
             if not line.child_bom_id:
                 no_bom_lines |= line
                 # Update product_info for all the components before computing closest forecasted.
-                self.with_context(parent_product_id=product.id)._update_product_info(line.product_id, bom.id, product_info, warehouse, line_quantity, bom=False, parent_bom=bom)
+                qty_product_uom = line.product_uom_id._compute_quantity(line_quantity, line.product_id.uom_id)
+                self.with_context(parent_product_id=product.id)._update_product_info(line.product_id, bom.id, product_info, warehouse, qty_product_uom, bom=False, parent_bom=bom)
         components_closest_forecasted = self.with_context(parent_product_id=product.id)._get_components_closest_forecasted(no_bom_lines, line_quantities, bom, product_info, ignore_stock)
         for component_index, line in enumerate(bom.bom_line_ids):
             new_index = f"{index}{component_index}"
@@ -323,7 +326,6 @@ class ReportBomStructure(models.AbstractModel):
 
         key = bom_line.product_id.id
         bom_key = parent_bom.id
-        self._update_product_info(bom_line.product_id, bom_key, product_info, warehouse, line_quantity, bom=False, parent_bom=parent_bom)
         route_info = product_info[key].get(bom_key, {})
 
         quantities_info = {}
@@ -360,6 +362,7 @@ class ReportBomStructure(models.AbstractModel):
             'route_type': route_info.get('route_type', ''),
             'route_name': route_info.get('route_name', ''),
             'route_detail': route_info.get('route_detail', ''),
+            'route_alert': route_info.get('route_alert', False),
             'lead_time': route_info.get('lead_time', False),
             'stock_avail_state': availabilities['stock_avail_state'],
             'resupply_avail_delay': availabilities['resupply_avail_delay'],
@@ -388,6 +391,11 @@ class ReportBomStructure(models.AbstractModel):
             product_info[key][bom_key] = self.with_context(
                 product_info=product_info, parent_bom=parent_bom
             )._get_resupply_route_info(warehouse, product, quantity, bom)
+        elif product_info[key][bom_key].get('route_alert'):
+            # Need more quantity than a single line, might change with additional quantity
+            product_info[key][bom_key] = self.with_context(
+                product_info=product_info, parent_bom=parent_bom
+            )._get_resupply_route_info(warehouse, product, quantity + product_info[key][bom_key].get('qty_checked'), bom)
 
     @api.model
     def _get_byproducts_lines(self, product, bom, bom_quantity, level, total, index):
@@ -500,6 +508,7 @@ class ReportBomStructure(models.AbstractModel):
                 'bom_cost': bom_line['bom_cost'],
                 'route_name': bom_line['route_name'],
                 'route_detail': bom_line['route_detail'],
+                'route_alert': bom_line.get('route_alert', False),
                 'lead_time': bom_line['lead_time'],
                 'level': bom_line['level'],
                 'code': bom_line['code'],
@@ -611,7 +620,7 @@ class ReportBomStructure(models.AbstractModel):
         components = components or []
         route_info = product_info[product.id].get(bom_key)
         resupply_state, resupply_delay = ('unavailable', False)
-        if product.detailed_type != 'product':
+        if product and product.detailed_type != 'product':
             resupply_state, resupply_delay = ('available', 0)
         elif route_info:
             resupply_state, resupply_delay = self._get_resupply_availability(route_info, components)
@@ -642,13 +651,13 @@ class ReportBomStructure(models.AbstractModel):
         if closest_forecasted == date.max:
             return ('unavailable', False)
         date_today = self.env.context.get('from_date', fields.date.today())
-        if product.detailed_type != 'product':
+        if product and product.detailed_type != 'product':
             return ('available', 0)
 
         stock_loc = quantities_info['stock_loc']
         product_info[product.id]['consumptions'][stock_loc] += quantity
         # Check if product is already in stock with enough quantity
-        if float_compare(product_info[product.id]['consumptions'][stock_loc], quantities_info['free_qty'], precision_rounding=product.uom_id.rounding) <= 0:
+        if product and float_compare(product_info[product.id]['consumptions'][stock_loc], quantities_info['free_qty'], precision_rounding=product.uom_id.rounding) <= 0:
             return ('available', 0)
 
         # No need to check forecast if the product isn't located in our stock

--- a/addons/mrp/report/mrp_report_bom_structure.xml
+++ b/addons/mrp/report/mrp_report_bom_structure.xml
@@ -47,7 +47,7 @@
                                 </span>
                             </td>
                             <td>
-                                <span t-if="data['route_name']"><t t-esc="data['route_name']"/>: </span>
+                                <span t-if="data['route_name']" t-attf-class="{{'text-danger' if data.get('route_alert') else ''}}"><t t-esc="data['route_name']"/>: </span>
                                 <span t-esc="data['route_detail']"/>
                             </td>
                             <td t-if="data['show_costs']" class="text-end" t-esc="data['bom_cost']" t-options='{"widget": "monetary", "display_currency": currency}'/>
@@ -127,7 +127,7 @@
                     </span>
                 </td>
                 <td>
-                    <span t-if="l.get('route_name')"><t t-esc="l['route_name']"/>: <t t-esc="l['route_detail']"/></span>
+                    <span t-if="l.get('route_name')" t-attf-class="{{'text-danger' if l.get('route_alert') else ''}}"><t t-esc="l['route_name']"/>: <t t-esc="l['route_detail']"/></span>
                 </td>
                 <td t-if="data['show_costs']" t-attf-class="text-end {{ 'text-muted' if l['type'] == 'component' else '' }}" t-esc="l['bom_cost']" t-options='{"widget": "monetary", "display_currency": currency}'/>
                 <td t-if="data['show_costs']" class="text-end">

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -42,7 +42,7 @@
         </td>
         <td>
             <div t-if="data.route_name">
-                <span><t t-esc="data.route_name"/>: </span>
+                <span t-attf-class="{{ data.route_alert ? 'text-danger' : '' }}"><t t-esc="data.route_name"/>: </span>
                 <a href="#" t-on-click.prevent="() => this.goToRoute(data.route_type)" t-esc="data.route_detail"/>
             </div>
         </td>

--- a/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
@@ -2,6 +2,8 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models, _, fields
+from odoo.tools import float_compare
+
 
 class ReportBomStructure(models.AbstractModel):
     _inherit = 'report.mrp.report_bom_structure'
@@ -73,7 +75,11 @@ class ReportBomStructure(models.AbstractModel):
         subcontract_rules = [rule for rule in rules if rule.action == 'buy' and bom and bom.type == 'subcontract']
         if subcontract_rules:
             supplier = product._select_seller(quantity=quantity, uom_id=product.uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
+            if not supplier:
+                # If no vendor found for the right quantity, we still want to display a vendor for the lead times
+                supplier = product._select_seller(quantity=None, uom_id=product.uom_id, params={'subcontractor_ids': bom.subcontractor_ids})
             if supplier:
+                qty_supplier_uom = product.uom_id._compute_quantity(quantity, supplier.product_uom)
                 return {
                     'route_type': 'subcontract',
                     'route_name': subcontract_rules[0].route_id.display_name,
@@ -82,6 +88,8 @@ class ReportBomStructure(models.AbstractModel):
                     'supplier_delay': supplier.delay + rules_delay,
                     'manufacture_delay': product.produce_delay,
                     'supplier': supplier,
+                    'route_alert': float_compare(qty_supplier_uom, supplier.min_qty, precision_rounding=product.uom_id.rounding) < 0,
+                    'qty_checked': quantity,
                 }
 
         return res

--- a/addons/purchase_mrp/report/mrp_report_bom_structure.py
+++ b/addons/purchase_mrp/report/mrp_report_bom_structure.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import api, models
+from odoo.tools import float_compare
 
 class ReportBomStructure(models.AbstractModel):
     _inherit = 'report.mrp.report_bom_structure'
@@ -12,9 +13,13 @@ class ReportBomStructure(models.AbstractModel):
         if self._is_buy_route(rules, product, bom):
             buy_rules = [rule for rule in rules if rule.action == 'buy']
             supplier = product._select_seller(quantity=quantity, uom_id=product.uom_id)
+            if not supplier:
+                # If no vendor found for the right quantity, we still want to display a vendor for the lead times
+                supplier = product._select_seller(quantity=None, uom_id=product.uom_id)
             parent_bom = self.env.context.get('parent_bom')
             purchase_lead = parent_bom.company_id.days_to_purchase + parent_bom.company_id.po_lead if parent_bom and parent_bom.company_id else 0
             if supplier:
+                qty_supplier_uom = product.uom_id._compute_quantity(quantity, supplier.product_uom)
                 return {
                     'route_type': 'buy',
                     'route_name': buy_rules[0].route_id.display_name,
@@ -22,6 +27,8 @@ class ReportBomStructure(models.AbstractModel):
                     'lead_time': supplier.delay + rules_delay + purchase_lead,
                     'supplier_delay': supplier.delay + rules_delay + purchase_lead,
                     'supplier': supplier,
+                    'route_alert': float_compare(qty_supplier_uom, supplier.min_qty, precision_rounding=product.uom_id.rounding) < 0,
+                    'qty_checked': quantity,
                 }
         return res
 


### PR DESCRIPTION
Previously, if a product had a vendor set with some minimum quantity, it wouldn't be displayed in the BoM Overview if the line quantity didn't match this minimum.
This meant that if that vendor was the only one set for this product, then no resupply route would be displayed and no lead time would be found. This is an issue, as it's inconsistent with how it would actually work when creating a MO from that BoM. (i.e. create the PO to that vendor, but with its default price).

Instead, when no supplier is found for the right quantity, we display the first suitable vendor anyway, but with a different color.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
