### PR TITLE
[IMP] repair: create&Use lot/serial for Repairs

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -404,6 +404,20 @@ class RepairOrder(models.Model):
         repairs_to_cancel = self.filtered(lambda ro: ro.state not in ('draft', 'cancel'))
         repairs_to_cancel.action_repair_cancel()
 
+    def action_generate_serial(self):
+        self.ensure_one()
+        name = self.env['ir.sequence'].next_by_code('stock.lot.serial')
+        exist_lot = not name or self.env['stock.lot'].search([
+            ('product_id', '=', self.product_id.id),
+            '|', ('company_id', '=', False), ('company_id', '=', self.company_id.id),
+            ('name', '=', name),
+        ], limit=1)
+        if exist_lot:
+            name = self.env['stock.lot']._get_next_serial(self.company_id, self.product_id)
+        if not name:
+            raise UserError(_("Please set the first Serial Number or a default sequence"))
+        self.lot_id = self.env['stock.lot'].create({'product_id': self.product_id.id, 'name': name})
+
     def action_assign(self):
         return self.move_ids._action_assign()
 

--- a/addons/repair/models/stock_lot.py
+++ b/addons/repair/models/stock_lot.py
@@ -2,6 +2,7 @@
 
 from collections import defaultdict
 from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class StockLot(models.Model):
@@ -70,3 +71,11 @@ class StockLot(models.Model):
                 'view_mode': 'list,form'
             })
         return action
+
+    def _check_create(self):
+        active_repair_id = self.env.context.get('active_repair_id')
+        if active_repair_id:
+            active_repair = self.env['repair.order'].browse(active_repair_id)
+            if active_repair and not active_repair.picking_type_id.use_create_lots:
+                raise UserError(_('You are not allowed to create a lot or serial number with this operation type. To change this, go on the operation type and tick the box "Create New Lots/Serial Numbers".'))
+        return super()._check_create()

--- a/addons/repair/models/stock_warehouse.py
+++ b/addons/repair/models/stock_warehouse.py
@@ -39,6 +39,8 @@ class StockWarehouse(models.Model):
                 'sequence': next_sequence + 1,
                 'sequence_code': 'RO',
                 'company_id': self.company_id.id,
+                'use_create_lots': True,
+                'use_existing_lots': True,
             },
         })
         return data, max_sequence + 2

--- a/addons/repair/tests/test_repair.py
+++ b/addons/repair/tests/test_repair.py
@@ -780,3 +780,27 @@ class TestRepair(common.TransactionCase):
         repair_order.move_ids[1].quantity = 4.0
         self.assertFalse(repair_order.has_uncomplete_moves)
         repair_order.action_repair_end()
+
+    def test_repair_final_product_generate_lot_and_serial(self):
+        """
+        This test checks that the product lot_id value generate on the fly.
+        """
+        self.stock_warehouse.repair_type_id.use_create_lots = True
+        repair_order = self.env['repair.order'].create({
+            'product_id': self.product_storable_lot.id,
+            'product_uom': self.product_storable_lot.uom_id.id,
+            'partner_id': self.res_partner_1.id,
+            'move_ids': [
+                Command.create({
+                    'product_id': self.product_product_5.id,
+                    'product_uom_qty': 3.0,
+                    'state': 'draft',
+                    'repair_line_type': 'add',
+                }),
+            ],
+        })
+        repair_order.action_validate()
+        repair_order.action_repair_start()
+        self.assertFalse(repair_order.lot_id.name)
+        repair_order.action_generate_serial()
+        self.assertTrue(repair_order.lot_id.name)

--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -106,7 +106,11 @@
                             <field name="repair_request" invisible="not sale_order_line_id"/>
                             <field name="partner_id" widget="res_partner_many2one" context="{'res_partner_search_mode': 'customer', 'show_vat': True}" readonly="sale_order_id"/>
                             <field name="product_id" readonly="state in ['cancel', 'done']"/>
-                            <field name="lot_id" context="{'default_product_id': product_id}" groups="stock.group_production_lot" options="{'no_create': True, 'no_create_edit': True}" invisible="tracking not in ['serial', 'lot']" readonly="state == 'done'" required="tracking in ['serial', 'lot']"/>
+                            <label for="lot_id" invisible="tracking not in ['serial', 'lot']"/>
+                            <div class="o_row" invisible="tracking not in ['serial', 'lot']">
+                                <field name="lot_id" context="{'default_product_id': product_id}" groups="stock.group_production_lot" invisible="tracking not in ['serial', 'lot']" readonly="state == 'done'" required="state=='done' and tracking in ['serial', 'lot']"/>
+                                <button name="action_generate_serial" type="object" class="btn btn-primary fa fa-plus-square-o" aria-label="Creates a new serial/lot number" title="Creates a new serial/lot number" role="img" invisible="lot_id"/>
+                            </div>
                             <field name="product_uom_category_id" invisible="1"/>
                             <label for="product_qty" invisible="not product_id"/>
                             <div class="o_row" invisible="not product_id">
@@ -133,7 +137,7 @@
                 <notebook>
                     <page string="Parts" name="parts">
                         <field name="move_ids" readonly="state == 'cancel' or state == 'done'"
-                        context="{'default_repair_id': id, 'default_product_uom_qty': 1, 'default_company_id': company_id, 'default_date': schedule_date, 'default_repair_line_type': 'add'}">
+                        context="{'default_repair_id': id, 'default_product_uom_qty': 1, 'default_company_id': company_id, 'default_date': schedule_date, 'default_repair_line_type': 'add', 'active_repair_id': id}">
                             <list string="Operations" editable="bottom">
                                 <control>
                                     <create string="Add a line"/>

--- a/addons/repair/views/stock_picking_views.xml
+++ b/addons/repair/views/stock_picking_views.xml
@@ -27,6 +27,9 @@
                     <field name="is_repairable"/>
                 </group>
             </xpath>
+            <xpath expr="//group[@name='stock_picking_type_lot']" position="attributes">
+                <attribute name="invisible">code not in ['incoming', 'outgoing', 'internal', 'repair_operation']</attribute>
+            </xpath>
             <field name="create_backorder" position="attributes">
                 <attribute name="invisible">code == 'repair_operation'</attribute>
             </field>


### PR DESCRIPTION
Before this commit:
==================
- Before this commit option to select create new lot/serial, use the existing lot/serial not visible on the repair operation type.
- User  not able to create a new lot/serial from the repair-order form view

After this commit:
==================
- create new lot/serial, use the existing lot/serial option visible in repair operation type (set to be true as of now both).
- user can create lot/serial of choice and also create using a button.

task  3915019
