### PR TITLE
[IMP] website: Squaring image before application of some shapes

### DIFF
--- a/addons/web_editor/i18n/web_editor.pot
+++ b/addons/web_editor/i18n/web_editor.pot
@@ -2698,6 +2698,11 @@ msgid "Start"
 msgstr ""
 
 #. module: web_editor
+#: model_terms:ir.ui.view,arch_db:web_editor.snippet_options
+msgid "Stretch"
+msgstr ""
+
+#. module: web_editor
 #. odoo-javascript
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0
 #: code:addons/web_editor/static/src/js/editor/odoo-editor/src/OdooEditor.js:0

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -6619,6 +6619,46 @@ registry.ImageTools = ImageHandlerOption.extend({
     //--------------------------------------------------------------------------
 
     /**
+     * Toggles the ratio of the image between 0:0 (no crop) and 1:1, in order to
+     * make it appear squared when needed (with `data-unstretch=true` shapes).
+     *
+     * @see this.selectClass for parameters
+     */
+    async removeStretch(previewMode, widgetValue, params) {
+        this.options.wysiwyg.odooEditor.historyPauseSteps();
+        this.trigger_up("disable_loading_effect");
+        // Preserve the cursor to be able to replace the image afterwards.
+        const restoreCursor = preserveCursor(this.$target[0].ownerDocument);
+        const img = this._getImg();
+        const document = this.el.ownerDocument;
+        const imageCropWrapperElement = document.createElement("div");
+        imageCropWrapperElement.classList.add("d-none"); // Hiding the cropper.
+        document.body.append(imageCropWrapperElement);
+        const imageCropWrapper = await attachComponent(this, imageCropWrapperElement, ImageCrop, {
+            activeOnStart: true,
+            media: img,
+            mimetype: this._getImageMimetype(img),
+        });
+        await imageCropWrapper.component.mountedPromise;
+        if (widgetValue) {
+            await imageCropWrapper.component.reset();
+        } else {
+            await imageCropWrapper.component.cropSquare(false);
+            if (isGif(this._getImageMimetype(img))) {
+                img.dataset[img.dataset.shape ? "originalMimetype" : "mimetype"] = "image/png";
+            }
+        }
+        await this._reapplyCurrentShape();
+        imageCropWrapper.destroy();
+        imageCropWrapperElement.remove();
+        restoreCursor();
+        this.trigger_up("enable_loading_effect");
+        if (!widgetValue) {
+            this._onImageCropped();
+        }
+        this.options.wysiwyg.odooEditor.historyUnpauseSteps();
+    },
+    /**
      * Displays the image cropping tools
      *
      * @see this.selectClass for parameters
@@ -6701,6 +6741,7 @@ registry.ImageTools = ImageHandlerOption.extend({
         // the component to be mounted before calling reset, mount it
         // temporarily into the body.
         const imageCropWrapperElement = document.createElement('div');
+        imageCropWrapperElement.classList.add("d-none"); // Hiding the cropper.
         document.body.append(imageCropWrapperElement);
         const imageCropWrapper = await attachComponent(this, imageCropWrapperElement, ImageCrop, {
             activeOnStart: true,
@@ -6728,7 +6769,57 @@ registry.ImageTools = ImageHandlerOption.extend({
      * @see this.selectClass for parameters
      */
     async setImgShape(previewMode, widgetValue, params) {
+        this.trigger_up("disable_loading_effect");
         const img = this._getImg();
+        let clonedImgEl;
+
+        // If the shape needs the image to be square (1:1 ratio) and if not
+        // already the case, crop the image before applying the shape.
+        const isCropRequired = params.unstretch;
+        if ((isCropRequired && img.dataset.aspectRatio !== "1/1" && previewMode !== "reset")
+                || this.hasCroppedPreview) {
+            // Preserve the cursor to be able to replace the image afterwards.
+            const restoreCursor = preserveCursor(this.$target[0].ownerDocument);
+            // Replace the image by its clone to avoid flickering.
+            clonedImgEl = img.cloneNode(true);
+            img.insertAdjacentElement("afterend", clonedImgEl);
+            img.classList.add("d-none");
+
+            const document = this.el.ownerDocument;
+            const imageCropWrapperElement = document.createElement("div");
+            imageCropWrapperElement.classList.add("d-none"); // Hiding the cropper.
+            document.body.append(imageCropWrapperElement);
+            const imageCropWrapper = await attachComponent(this, imageCropWrapperElement, ImageCrop, {
+                activeOnStart: true,
+                media: img,
+                mimetype: this._getImageMimetype(img),
+            });
+            await imageCropWrapper.component.mountedPromise;
+            await imageCropWrapper.component.cropSquare(previewMode);
+            if (previewMode === false) {
+                if (isGif(this._getImageMimetype(img))) {
+                    img.dataset[img.dataset.shape ? "originalMimetype" : "mimetype"] = "image/png";
+                }
+                this.isImageCropped = true;
+            }
+            await this._reapplyCurrentShape();
+            imageCropWrapper.destroy();
+            imageCropWrapperElement.remove();
+
+            restoreCursor();
+
+            if (previewMode === true) {
+                this.hasCroppedPreview = true;
+            } else {
+                delete this.hasCroppedPreview;
+            }
+        }
+        // Re-rendering the options after selecting a "cropping" shape.
+        if (this.isImageCropped && previewMode === "reset") {
+            delete this.isImageCropped;
+            this._onImageCropped();
+        }
+
         const saveData = previewMode === false;
         if (img.dataset.hoverEffect && !widgetValue) {
             // When a shape is removed and there is a hover effect on the
@@ -6787,6 +6878,12 @@ registry.ImageTools = ImageHandlerOption.extend({
             weUtils.forwardToThumbnail(img);
         }
         img.classList.add('o_modified_image_to_save');
+        // Remove the image clone, if any.
+        if (clonedImgEl) {
+            clonedImgEl.remove();
+            img.classList.remove("d-none");
+        }
+        this.trigger_up("enable_loading_effect");
     },
     /**
      * Handles color assignment on the shape. Widget is a color picker.
@@ -7326,6 +7423,9 @@ registry.ImageTools = ImageHandlerOption.extend({
             const shapeImgSquareWidget = this._requestUserValueWidgets("shape_img_square_opt")[0];
             return !shapeImgSquareWidget.isActive();
         }
+        if (widgetName === "toggle_stretch_opt") {
+            return this._isCropRequired();
+        }
         return this._super(...arguments);
     },
     /**
@@ -7370,6 +7470,10 @@ registry.ImageTools = ImageHandlerOption.extend({
             case 'setHoverEffectColor': {
                 const imgEl = this._getImg();
                 return imgEl.dataset.hoverEffectColor || "";
+            }
+            case "removeStretch": {
+                const imgEl = this._getImg();
+                return imgEl.dataset.aspectRatio !== "1/1";
             }
         }
         return this._super(...arguments);
@@ -7596,6 +7700,16 @@ registry.ImageTools = ImageHandlerOption.extend({
     _isAnimatedShape() {
         const shapeImgWidget = this._requestUserValueWidgets("shape_img_opt")[0];
         return shapeImgWidget?.getMethodsParams().animated;
+    },
+    /**
+     * Checks if squaring of image is required before application of shape.
+     *
+     * @private
+     * @returns {boolean}
+     */
+    _isCropRequired() {
+        const shapeImgWidget = this._requestUserValueWidgets("shape_img_opt")[0];
+        return shapeImgWidget?.getMethodsParams().unstretch;
     },
     /**
      * Checks if the shape can have a hover effect.

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -93,7 +93,7 @@ export class ImageCrop extends Component {
                 this.aspectRatio = '0/0';
                 this.$cropperImage.cropper('setAspectRatio', this.aspectRatios[this.aspectRatio].value);
             }
-            await this._save(false);
+            await this._save();
         }
     }
 
@@ -192,7 +192,7 @@ export class ImageCrop extends Component {
      * @private
      * @param {boolean} [cropped=true]
      */
-    async _save(cropped = true) {
+    async _save() {
         // Mark the media for later creation of cropped attachment
         this.media.classList.add('o_modified_image_to_save');
 
@@ -205,6 +205,7 @@ export class ImageCrop extends Component {
         });
         delete this.media.dataset.resizeWidth;
         this.initialSrc = await applyModifications(this.media, {forceModification: true, mimetype: this.mimetype});
+        const cropped = this.aspectRatio !== "0/0";
         this.media.classList.toggle('o_we_image_cropped', cropped);
         this.$media.trigger('image_cropped');
         this._closeCropper();

--- a/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
+++ b/addons/web_editor/static/src/js/wysiwyg/widgets/image_crop.js
@@ -97,6 +97,30 @@ export class ImageCrop extends Component {
         }
     }
 
+    /**
+     * Crops the image into a 1:1 ratio or resets the crop, depending on the
+     * preview mode.
+     *
+     *  @param {boolean} previewMode "reset", true or false.
+     */
+    async cropSquare(previewMode) {
+        if(previewMode === "reset"){
+            if (this.$cropperImage) {
+                this.$cropperImage.cropper("setAspectRatio", this.aspectRatios[this.aspectRatio].value);
+                await this._save(false);
+            }
+        } else {
+            const ratio = "1/1";
+            if (this.$cropperImage) {
+                if (this.aspectRatio !== ratio) {
+                    this.aspectRatio = previewMode ? this.aspectRatio : ratio;
+                    this.$cropperImage.cropper("setAspectRatio", this.aspectRatios[ratio].value);
+                }
+                await this._save(false);
+            }
+        }
+    }
+
     //--------------------------------------------------------------------------
     // Private
     //--------------------------------------------------------------------------
@@ -190,9 +214,9 @@ export class ImageCrop extends Component {
      * attachments will be created).
      *
      * @private
-     * @param {boolean} [cropped=true]
+     * @param {boolean} [refreshOptions=true]
      */
-    async _save() {
+    async _save(refreshOptions = true) {
         // Mark the media for later creation of cropped attachment
         this.media.classList.add('o_modified_image_to_save');
 
@@ -207,7 +231,9 @@ export class ImageCrop extends Component {
         this.initialSrc = await applyModifications(this.media, {forceModification: true, mimetype: this.mimetype});
         const cropped = this.aspectRatio !== "0/0";
         this.media.classList.toggle('o_we_image_cropped', cropped);
-        this.$media.trigger('image_cropped');
+        if(refreshOptions){
+            this.$media.trigger('image_cropped');
+        }
         this._closeCropper();
     }
     /**

--- a/addons/web_editor/views/snippets.xml
+++ b/addons/web_editor/views/snippets.xml
@@ -484,24 +484,24 @@
                             <we-title class="">Geometrics</we-title>
                             <we-select-page string="Geometrics">
                                 <we-button data-set-img-shape="web_editor/geometric/geo_square" data-no-transform="true" data-name="shape_img_square_opt"/> <!-- hidden and only used for hover effects -->
-                                <we-button data-set-img-shape="web_editor/geometric/geo_shuriken" data-select-label="Shuriken" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_diamond" data-select-label="Diamond" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_triangle" data-select-label="Triangle"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_cornered_triangle" data-select-label="Corner Triangle"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_pentagon" data-select-label="Pentagon"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_hexagon" data-select-label="Hexagon"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_heptagon" data-select-label="Heptagon"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_star" data-select-label="Star 1"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_star_8pin" data-select-label="Star 2" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_star_16pin" data-select-label="Star 3" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_slanted" data-select-label="Slanted"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_emerald" data-select-label="Emerald"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_tetris" data-select-label="Tetris"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_kayak" data-select-label="Kayak"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_tear" data-select-label="Tear"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_gem" data-select-label="Gem"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_sonar" data-select-label="Sonar"/>
-                                <we-button data-set-img-shape="web_editor/geometric/geo_door" data-select-label="Door"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_shuriken" data-select-label="Shuriken" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_diamond" data-select-label="Diamond" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_triangle" data-select-label="Triangle" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_cornered_triangle" data-select-label="Corner Triangle" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_pentagon" data-select-label="Pentagon" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_hexagon" data-select-label="Hexagon" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_heptagon" data-select-label="Heptagon" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_star" data-select-label="Star 1" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_star_8pin" data-select-label="Star 2" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_star_16pin" data-select-label="Star 3" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_slanted" data-select-label="Slanted" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_emerald" data-select-label="Emerald" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_tetris" data-select-label="Tetris" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_kayak" data-select-label="Kayak" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_tear" data-select-label="Tear" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_gem" data-select-label="Gem" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_sonar" data-select-label="Sonar" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric/geo_door" data-select-label="Door" data-unstretch="true"/>
                                 <t t-if="not no_animations">
                                     <we-button data-set-img-shape="web_editor/geometric/geo_square_1" data-select-label="Square 1" data-animated="true"/>
                                     <we-button data-set-img-shape="web_editor/geometric/geo_square_2" data-select-label="Square 2" data-animated="true"/>
@@ -514,28 +514,28 @@
 
                             <we-title>Geometrics Rounded</we-title>
                             <we-select-page string="Geometrics Rounded">
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_circle" data-select-label="Circle" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_square" data-select-label="Square (R)" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_diamond" data-select-label="Diamond (R)" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_shuriken" data-select-label="Shuriken (R)" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_triangle" data-select-label="Triangle (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_pentagon" data-select-label="Pentagon (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_hexagon" data-select-label="Hexagon (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_heptagon" data-select-label="Heptagon (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star" data-select-label="Star 1 (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_7pin" data-select-label="Star 2 (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_8pin" data-select-label="Star 3 (R)" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_16pin" data-select-label="Star 4 (R)" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_emerald" data-select-label="Emerald (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_lemon" data-select-label="Lemon (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_tear" data-select-label="Tear (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_pill" data-select-label="Pill (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_gem" data-select-label="Gem (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_cornered" data-select-label="Cornered"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_door" data-select-label="Door (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_sonar" data-select-label="Sonar (R)"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_clover" data-select-label="Clover (R)" data-no-transform="true"/>
-                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_bread" data-select-label="Bread (R)" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_circle" data-select-label="Circle" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_square" data-select-label="Square (R)" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_diamond" data-select-label="Diamond (R)" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_shuriken" data-select-label="Shuriken (R)" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_triangle" data-select-label="Triangle (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_pentagon" data-select-label="Pentagon (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_hexagon" data-select-label="Hexagon (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_heptagon" data-select-label="Heptagon (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star" data-select-label="Star 1 (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_7pin" data-select-label="Star 2 (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_8pin" data-select-label="Star 3 (R)" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_star_16pin" data-select-label="Star 4 (R)" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_emerald" data-select-label="Emerald (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_lemon" data-select-label="Lemon (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_tear" data-select-label="Tear (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_pill" data-select-label="Pill (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_gem" data-select-label="Gem (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_cornered" data-select-label="Cornered" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_door" data-select-label="Door (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_sonar" data-select-label="Sonar (R)" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_clover" data-select-label="Clover (R)" data-no-transform="true" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/geometric_round/geo_round_bread" data-select-label="Bread (R)" data-no-transform="true" data-unstretch="true"/>
                                 <t t-if="not no_animations">
                                     <we-button data-set-img-shape="web_editor/geometric_round/geo_round_square_1" data-select-label="Square 1 (R)" data-animated="true"/>
                                     <we-button data-set-img-shape="web_editor/geometric_round/geo_round_square_2" data-select-label="Square 2 (R)" data-animated="true"/>
@@ -553,7 +553,7 @@
                                 <we-button data-set-img-shape="web_editor/panel/panel_duo_step_pill" data-select-label="Duo Step Pill"/>
                                 <we-button data-set-img-shape="web_editor/panel/panel_trio_in_r" data-select-label="Trio In (R)"/>
                                 <we-button data-set-img-shape="web_editor/panel/panel_trio_out_r" data-select-label="Trio Out (R)"/>
-                                <we-button data-set-img-shape="web_editor/panel/panel_window" data-select-label="Window" data-no-transform="true"/>
+                                <we-button data-set-img-shape="web_editor/panel/panel_window" data-select-label="Window" data-no-transform="true" data-unstretch="true"/>
                             </we-select-page>
 
                             <we-title>Composites</we-title>
@@ -568,9 +568,9 @@
                         <div class="o_scroll_shapes_decorative">
                             <we-title>Brushed</we-title>
                             <we-select-page string="Brushed">
-                                <we-button data-set-img-shape="web_editor/brushed/brush_1" data-select-label="Brush 1"/>
-                                <we-button data-set-img-shape="web_editor/brushed/brush_2" data-select-label="Brush 2"/>
-                                <we-button data-set-img-shape="web_editor/brushed/brush_3" data-select-label="Brush 3"/>
+                                <we-button data-set-img-shape="web_editor/brushed/brush_1" data-select-label="Brush 1" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/brushed/brush_2" data-select-label="Brush 2" data-unstretch="true"/>
+                                <we-button data-set-img-shape="web_editor/brushed/brush_3" data-select-label="Brush 3" data-unstretch="true"/>
                                 <we-button data-set-img-shape="web_editor/brushed/brush_4" data-select-label="Brush 4"/>
                             </we-select-page>
 
@@ -705,6 +705,9 @@
                     data-min="-2"
                     data-step="0.1"
                     data-to-ratio="true"/>
+            </we-row>
+            <we-row string="Stretch" class="o_we_sublevel_1">
+                <we-checkbox data-remove-stretch="true" data-dependencies="shape_img_opt" data-no-preview="true" data-name="toggle_stretch_opt"/>
             </we-row>
         </div>
         <we-input string="Description" class="o_we_large"


### PR DESCRIPTION
Specification:
- Upon applying the first set of shapes to an image, the image ratio
defaults to 1:1.
- When a second set of shapes is applied, the image ratio reverts to
its original dimensions (0:0).
- A toggle button named "Stretch" should be present to switch between
the 1:1 and 0:0 ratios.
- The "Stretch" toggle button should only be visible when the first set
of shapes has been applied.

Before this PR:
All shapes were applied maintaining the current ratio of the image.

After this PR:
Before the application of shapes, the image ratio is processed
according to the specified default, and the "Stretch" toggle button
is displayed as required.

task-3678061