### PR TITLE
[IMP] account{,_accountant}: allow grouping by Product (Category) in Deferred reports

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -281,6 +281,7 @@ class AccountMoveLine(models.Model):
         string="Account Root",
         store=True,
     )
+    product_category_id = fields.Many2one(related='product_id.product_tmpl_id.categ_id')
 
     # ==============================================================================================
     #                                          INVOICE

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -322,6 +322,8 @@
                     <field name="account_type"/>
                     <field name="partner_id"/>
                     <field name="journal_id"/>
+                    <field name="product_id"/>
+                    <field name="product_category_id"/>
                     <field name="move_id" string="Journal Entry" filter_domain="[
                         '|', ('move_id.name', 'ilike', self), ('move_id.ref', 'ilike', self)]"/>
                     <field name="tax_ids" />


### PR DESCRIPTION
We now allow grouping by other fields that account_id in the report, namely product_id, and product_category_id. However, for the deferral generation, we continue grouping by account_id.

task-id 3925943

https://github.com/odoo/enterprise/pull/62534