### PR TITLE
[FIX] website: Search only related attachments

### DIFF
--- a/addons/website/models/ir_module_module.py
+++ b/addons/website/models/ir_module_module.py
@@ -157,7 +157,14 @@ class IrModuleModule(models.Model):
                 if not find and model_name == 'ir.attachment':
                     # In master, a unique constraint over (theme_template_id, website_id)
                     # will be introduced, thus ensuring unicity of 'find'
-                    find = rec.copy_ids.search([('key', '=', rec.key), ('website_id', '=', website.id), ("original_id", "=", False)])
+                    find = rec.copy_ids.search(
+                        [
+                            ('theme_template_id', '=', rec.id),
+                            ('key', '=', rec.key),
+                            ('website_id', '=', website.id),
+                            ("original_id", "=", False),
+                        ]
+                    )
 
                 if find:
                     imd = self.env['ir.model.data'].search([('model', '=', find._name), ('res_id', '=', find.id)])


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**

The current code searches for attachments without taking into account the relationship through `theme_template_id`. This can cause that a wrong record is retrieved or that more than one record is, triggering an error later on:

```
File "/home/odoo/src/odoo/saas-17.1/addons/website/models/ir_module_module.py", line 165, in _update_records
    imd = self.env['ir.model.data'].search([('model', '=', find._name), ('res_id', '=', find.id)])
File "/home/odoo/src/odoo/saas-17.1/odoo/fields.py", line 5110, in __get__
    raise ValueError("Expected singleton: %s" % record)
```



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
