### PR TITLE
[PERF] *: update index from `True` -> `btree_not_null`

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -277,13 +277,13 @@ class AccountMove(models.Model):
     # === Date fields === #
     invoice_date = fields.Date(
         string='Invoice/Bill Date',
-        index=True,
+        index='btree_not_null',
         copy=False,
     )
     invoice_date_due = fields.Date(
         string='Due Date',
         compute='_compute_invoice_date_due', store=True, readonly=False,
-        index=True,
+        index='btree_not_null',
         copy=False,
     )
     delivery_date = fields.Date(

--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -261,7 +261,7 @@ class AccountMoveLine(models.Model):
     matching_number = fields.Char(
         string="Matching #",
         copy=False,
-        index='btree',
+        index='btree_not_null',
         help="Matching number for this line, 'P' if it is only partially reconcile, or the name of "
              "the full reconcile if it exists.",
     )  # can also start with `I` for imports: see `_reconcile_marked`
@@ -328,7 +328,7 @@ class AccountMoveLine(models.Model):
     )
     date_maturity = fields.Date(
         string='Due Date',
-        index=True,
+        index='btree_not_null',
         tracking=True,
         help="This field is used for payable and receivable journal entries. "
              "You can put the limit date for the payment of this line.",

--- a/addons/crm/models/calendar.py
+++ b/addons/crm/models/calendar.py
@@ -25,7 +25,7 @@ class CalendarEvent(models.Model):
 
     opportunity_id = fields.Many2one(
         'crm.lead', 'Opportunity', domain="[('type', '=', 'opportunity')]",
-        index=True, ondelete='set null')
+        index='btree_not_null', ondelete='set null')
 
     def _compute_is_highlighted(self):
         super(CalendarEvent, self)._compute_is_highlighted()

--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -111,7 +111,7 @@ class Lead(models.Model):
     user_id = fields.Many2one(
         'res.users', string='Salesperson', default=lambda self: self.env.user,
         domain="[('share', '=', False)]",
-        check_company=True, index=True, tracking=True)
+        check_company=True, index='btree_not_null', tracking=True)
     user_company_ids = fields.Many2many(
         'res.company', compute='_compute_user_company_ids',
         help='UX: Limit to lead company or all if no company')
@@ -123,7 +123,7 @@ class Lead(models.Model):
         copy=True)
     company_id = fields.Many2one(
         'res.company', string='Company', index=True,
-        compute='_compute_company_id', readonly=False, store=True)
+        compute='_compute_company_id', readonly=False, store='btree_not_null')
     referred = fields.Char('Referred By')
     description = fields.Html('Notes')
     active = fields.Boolean('Active', default=True, tracking=True)
@@ -173,7 +173,7 @@ class Lead(models.Model):
     date_deadline = fields.Date('Expected Closing', help="Estimate of the date on which the opportunity will be won.")
     # Customer / contact
     partner_id = fields.Many2one(
-        'res.partner', string='Customer', check_company=True, index=True, tracking=10,
+        'res.partner', string='Customer', check_company=True, index='btree_not_null', tracking=10,
         help="Linked partner (optional). Usually created when converting the lead. You can find a partner by its Name, TIN, Email or Internal Reference.")
     partner_is_blacklisted = fields.Boolean('Partner is blacklisted', related='partner_id.is_blacklisted', readonly=True)
     contact_name = fields.Char(
@@ -234,7 +234,7 @@ class Lead(models.Model):
     # Won/Lost
     lost_reason_id = fields.Many2one(
         'crm.lost.reason', string='Lost Reason',
-        index=True, ondelete='restrict', tracking=True)
+        index='btree_not_null', ondelete='restrict', tracking=True)
     # Statistics
     calendar_event_ids = fields.One2many('calendar.event', 'opportunity_id', string='Meetings')
     duplicate_lead_ids = fields.Many2many("crm.lead", compute="_compute_potential_lead_duplicates", string="Potential Duplicate Lead", context={"active_test": False})

--- a/addons/event/models/event_registration.py
+++ b/addons/event/models/event_registration.py
@@ -38,9 +38,9 @@ class EventRegistration(models.Model):
     active = fields.Boolean(default=True)
     barcode = fields.Char(string='Barcode', default=lambda self: self._get_random_barcode(), readonly=True, copy=False)
     # utm informations
-    utm_campaign_id = fields.Many2one('utm.campaign', 'Campaign', index=True, ondelete='set null')
-    utm_source_id = fields.Many2one('utm.source', 'Source', index=True, ondelete='set null')
-    utm_medium_id = fields.Many2one('utm.medium', 'Medium', index=True, ondelete='set null')
+    utm_campaign_id = fields.Many2one('utm.campaign', 'Campaign', index='btree_not_null', ondelete='set null')
+    utm_source_id = fields.Many2one('utm.source', 'Source', index='btree_not_null', ondelete='set null')
+    utm_medium_id = fields.Many2one('utm.medium', 'Medium', index='btree_not_null', ondelete='set null')
     # attendee
     partner_id = fields.Many2one('res.partner', string='Booked by', tracking=1)
     name = fields.Char(

--- a/addons/hr_gamification/models/gamification.py
+++ b/addons/hr_gamification/models/gamification.py
@@ -9,7 +9,7 @@ class GamificationBadgeUser(models.Model):
     """User having received a badge"""
     _inherit = 'gamification.badge.user'
 
-    employee_id = fields.Many2one('hr.employee', string='Employee', index=True)
+    employee_id = fields.Many2one('hr.employee', string='Employee', index='btree_not_null')
 
     @api.constrains('employee_id')
     def _check_employee_related_user(self):

--- a/addons/mail/models/mail_notification.py
+++ b/addons/mail/models/mail_notification.py
@@ -18,7 +18,7 @@ class MailNotification(models.Model):
     # origin
     author_id = fields.Many2one('res.partner', 'Author', ondelete='set null')
     mail_message_id = fields.Many2one('mail.message', 'Message', index=True, ondelete='cascade', required=True)
-    mail_mail_id = fields.Many2one('mail.mail', 'Mail', index=True, help='Optional mail_mail ID. Used mainly to optimize searches.')
+    mail_mail_id = fields.Many2one('mail.mail', 'Mail', index='btree_not_null', help='Optional mail_mail ID. Used mainly to optimize searches.')
     # recipient
     res_partner_id = fields.Many2one('res.partner', 'Recipient', index=True, ondelete='cascade')
     # status

--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -120,7 +120,7 @@ class MassMailing(models.Model):
         'ir.attachment', 'mass_mailing_ir_attachments_rel',
         'mass_mailing_id', 'attachment_id', string='Attachments')
     keep_archives = fields.Boolean(string='Keep Archives')
-    campaign_id = fields.Many2one('utm.campaign', string='UTM Campaign', index=True, ondelete='set null')
+    campaign_id = fields.Many2one('utm.campaign', string='UTM Campaign', index='btree_not_null', ondelete='set null')
     medium_id = fields.Many2one(
         'utm.medium', string='Medium',
         compute='_compute_medium_id', readonly=False, store=True,

--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -165,7 +165,7 @@ class Project(models.Model):
     access_instruction_message = fields.Char('Access Instruction Message', compute='_compute_access_instruction_message')
     doc_count = fields.Integer(compute='_compute_attached_docs_count', string="Number of documents attached")
     date_start = fields.Date(string='Start Date')
-    date = fields.Date(string='Expiration Date', index=True, tracking=True,
+    date = fields.Date(string='Expiration Date', index='btree_not_null', tracking=True,
         help="Date on which this project ends. The timeframe defined on the project is taken into account when viewing its planning.")
     allow_task_dependencies = fields.Boolean('Task Dependencies', default=lambda self: self.env.user.has_group('project.group_project_task_dependencies'))
     allow_milestones = fields.Boolean('Milestones', default=lambda self: self.env.user.has_group('project.group_project_milestone'))

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -147,10 +147,10 @@ class Task(models.Model):
 
     create_date = fields.Datetime("Created On", readonly=True, index=True)
     write_date = fields.Datetime("Last Updated On", readonly=True)
-    date_end = fields.Datetime(string='Ending Date', index=True, copy=False)
+    date_end = fields.Datetime(string='Ending Date', index='btree_not_null', copy=False)
     date_assign = fields.Datetime(string='Assigning Date', copy=False, readonly=True,
         help="Date on which this task was last assigned (or unassigned). Based on this, you can get statistics on the time it usually takes to assign tasks.")
-    date_deadline = fields.Datetime(string='Deadline', index=True, tracking=True)
+    date_deadline = fields.Datetime(string='Deadline', index='btree_not_null', tracking=True)
 
     date_last_stage_update = fields.Datetime(string='Last Stage Update',
         index=True,
@@ -197,7 +197,7 @@ class Task(models.Model):
     # In the domain of displayed_image_id, we couln't use attachment_ids because a one2many is represented as a list of commands so we used res_model & res_id
     displayed_image_id = fields.Many2one('ir.attachment', domain="[('res_model', '=', 'project.task'), ('res_id', '=', id), ('mimetype', 'ilike', 'image')]", string='Cover Image')
 
-    parent_id = fields.Many2one('project.task', string='Parent Task', index=True, domain="['!', ('id', 'child_of', id)]", tracking=True)
+    parent_id = fields.Many2one('project.task', string='Parent Task', index='btree_not_null', domain="['!', ('id', 'child_of', id)]", tracking=True)
     child_ids = fields.One2many('project.task', 'parent_id', string="Sub-tasks", domain="[('recurring_task', '=', False)]")
     subtask_count = fields.Integer("Sub-task Count", compute='_compute_subtask_count')
     closed_subtask_count = fields.Integer("Closed Sub-tasks Count", compute='_compute_subtask_count')

--- a/addons/rating/models/rating.py
+++ b/addons/rating/models/rating.py
@@ -47,7 +47,7 @@ class Rating(models.Model):
     feedback = fields.Text('Comment')
     message_id = fields.Many2one(
         'mail.message', string="Message",
-        index=True, ondelete='cascade')
+        index='btree_not_null', ondelete='cascade')
     is_internal = fields.Boolean('Visible Internally Only', readonly=False, related='message_id.is_internal', store=True)
     access_token = fields.Char('Security Token', default=_default_access_token)
     consumed = fields.Boolean(string="Filled Rating")

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -15,10 +15,10 @@ class SaleOrderLine(models.Model):
     qty_delivered_method = fields.Selection(selection_add=[('milestones', 'Milestones')])
     project_id = fields.Many2one(
         'project.project', 'Generated Project',
-        index=True, copy=False)
+        index='btree_not_null', copy=False)
     task_id = fields.Many2one(
         'project.task', 'Generated Task',
-        index=True, copy=False)
+        index='btree_not_null', copy=False)
     # used to know if generate a task and/or a project, depending on the product settings
     reached_milestones_ids = fields.One2many('project.milestone', 'sale_line_id', string='Reached Milestones', domain=[('is_reached', '=', True)])
 

--- a/addons/sale_timesheet/models/account.py
+++ b/addons/sale_timesheet/models/account.py
@@ -35,7 +35,7 @@ class AccountAnalyticLine(models.Model):
         ]""",
         help="Sales order item to which the time spent will be added in order to be invoiced to your customer. Remove the sales order item for the timesheet entry to be non-billable.")
     # we needed to store it only in order to be able to groupby in the portal
-    order_id = fields.Many2one(related='so_line.order_id', store=True, readonly=True, index=True)
+    order_id = fields.Many2one(related='so_line.order_id', store=True, readonly=True, index='btree_not_null')
     is_so_line_edited = fields.Boolean("Is Sales Order Item Manually Edited")
     allow_billable = fields.Boolean(related="project_id.allow_billable")
 

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -42,7 +42,7 @@ class SmsSms(models.Model):
     number = fields.Char('Number')
     body = fields.Text()
     partner_id = fields.Many2one('res.partner', 'Customer')
-    mail_message_id = fields.Many2one('mail.message', index=True)
+    mail_message_id = fields.Many2one('mail.message', index='btree_not_null')
     state = fields.Selection([
         ('outgoing', 'In Queue'),
         ('process', 'Processing'),

--- a/addons/website/models/website_visitor.py
+++ b/addons/website/models/website_visitor.py
@@ -24,7 +24,7 @@ class WebsiteTrack(models.Model):
     _log_access = False
 
     visitor_id = fields.Many2one('website.visitor', ondelete="cascade", index=True, required=True, readonly=True)
-    page_id = fields.Many2one('website.page', index=True, ondelete='cascade', readonly=True)
+    page_id = fields.Many2one('website.page', index='btree_not_null', ondelete='cascade', readonly=True)
     url = fields.Text('Url', index=True)
     visit_datetime = fields.Datetime('Visit Date', default=fields.Datetime.now, required=True, readonly=True)
 

--- a/addons/website_event_track/models/event_track_visitor.py
+++ b/addons/website_event_track/models/event_track_visitor.py
@@ -14,7 +14,7 @@ class TrackVisitor(models.Model):
 
     partner_id = fields.Many2one(
         'res.partner', string='Partner', compute='_compute_partner_id',
-        index=True, ondelete='set null', readonly=False, store=True)
+        index='btree_not_null', ondelete='set null', readonly=False, store=True)
     visitor_id = fields.Many2one(
         'website.visitor', string='Visitor', index=True, ondelete='cascade')
     track_id = fields.Many2one(

--- a/odoo/addons/base/models/ir_model.py
+++ b/odoo/addons/base/models/ir_model.py
@@ -503,7 +503,7 @@ class IrModelFields(models.Model):
     _allow_sudo_commands = False
 
     name = fields.Char(string='Field Name', default='x_', required=True, index=True)
-    complete_name = fields.Char(index=True)
+    complete_name = fields.Char()
     model = fields.Char(string='Model Name', required=True, index=True,
                         help="The technical name of the model this field belongs to")
     relation = fields.Char(string='Related Model',

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -196,10 +196,10 @@ class Partner(models.Model):
     complete_name = fields.Char(compute='_compute_complete_name', store=True, index=True)
     date = fields.Date(index=True)
     title = fields.Many2one('res.partner.title')
-    parent_id = fields.Many2one('res.partner', string='Related Company', index=True)
+    parent_id = fields.Many2one('res.partner', string='Related Company', index='btree_not_null')
     parent_name = fields.Char(related='parent_id.name', readonly=True, string='Parent name')
     child_ids = fields.One2many('res.partner', 'parent_id', string='Contact', domain=[('active', '=', True)])
-    ref = fields.Char(string='Reference', index=True)
+    ref = fields.Char(string='Reference', index='btree_not_null')
     lang = fields.Selection(_lang_get, string='Language',
                             help="All the emails and documents sent to this contact will be translated in this language.")
     active_lang_count = fields.Integer(compute='_compute_active_lang_count')
@@ -215,7 +215,7 @@ class Partner(models.Model):
         precompute=True,  # avoid queries post-create
         readonly=False, store=True,
         help='The internal user in charge of this contact.')
-    vat = fields.Char(string='Tax ID', index=True, help="The Tax Identification Number. Values here will be validated based on the country format. You can use '/' to indicate that the partner is not subject to tax.")
+    vat = fields.Char(string='Tax ID', index='btree_not_null', help="The Tax Identification Number. Values here will be validated based on the country format. You can use '/' to indicate that the partner is not subject to tax.")
     same_vat_partner_id = fields.Many2one('res.partner', string='Partner with same Tax ID', compute='_compute_same_vat_partner_id', store=False)
     same_company_registry_partner_id = fields.Many2one('res.partner', string='Partner with same Company Registry', compute='_compute_same_vat_partner_id', store=False)
     company_registry = fields.Char(string="Company ID", compute='_compute_company_registry', store=True, readonly=False,


### PR DESCRIPTION
## Description
Update indexes that have a large `null_frac` (the % of NULL value in the column) into `btree_not_null` to save some disk space. Fields who had lookups based on their `False` value weren't converted, unless it's a model we use often and its `null_frac` was `>0.4` which is often the threshold when Postgres will estimate doing a `Seq.Scan` instead.

## Reference
task-3875080

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
