### PR TITLE
[FIX] ir_sequence: prevent an error when producing a manufacturing order

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -230,7 +230,7 @@ class IrSequence(models.Model):
         try:
             interpolated_prefix = _interpolate(self.prefix, d)
             interpolated_suffix = _interpolate(self.suffix, d)
-        except ValueError:
+        except (ValueError, TypeError):
             raise UserError(_('Invalid prefix or suffix for sequence \'%s\'') % self.name)
         return interpolated_prefix, interpolated_suffix
 

--- a/odoo/addons/base/tests/test_ir_sequence.py
+++ b/odoo/addons/base/tests/test_ir_sequence.py
@@ -7,6 +7,7 @@ import psycopg2
 import psycopg2.errorcodes
 
 import odoo
+from odoo.exceptions import UserError
 from odoo.tests import common
 from odoo.tests.common import BaseCase
 
@@ -173,6 +174,22 @@ class TestIrSequenceGenerate(BaseCase):
             for i in range(1, 10):
                 n = env['ir.sequence'].next_by_code('test_sequence_type_6')
                 self.assertEqual(n, str(i))
+
+    def test_ir_sequence_prefix(self):
+        """ test whether the raise a user error for an invalid sequence """
+
+        # try to create a sequence with invalid prefix
+        with environment() as env:
+            seq = env['ir.sequence'].create({
+                'code': 'test_sequence_type_7',
+                'name': 'Test sequence',
+                'prefix': '%u',
+                'suffix': '',
+            })
+            self.assertTrue(seq)
+
+            with self.assertRaises(UserError):
+                env['ir.sequence'].next_by_code('test_sequence_type_7')
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Currently, an error occurs when producing a manufacturing order for a product whose tracking is by lot.

Step to produce:

- Install the 'mrp' module (ensure developer mode is enabled).
- Go to Settings / Technical / Sequences & Identifiers / Sequences, Open 'stock.lot.serial' and add ''%default_code-%(month)s%(y)s-' as a prefix.
- Create a new product by lots, Open 'Manufacturing Orders'  and create an order with that new product.
- Confirm this order, And then click on mark as done and apply immediate production

```TypeError: %d format: a real number is required, not dict```

An error occurs when attempting to produce a manufacturing order of a product which have lot by serial numbers because the system tries to generate an invalid serial number at [1].

link [1]: https://github.com/odoo/odoo/blob/c7d420b077490108794f513e9ff21b0d850f57af/addons/stock/models/stock_production_lot.py#L89

To resolve the issue, raise a user error for an invalid sequence.

sentry-5343084412

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
