### PR TITLE
[IMP] mrp: Bom overview lazy loading

### DIFF
--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -296,7 +296,7 @@ class MrpBom(models.Model):
         company_id = self.env.context.get('default_company_id', self.env.company.id)
         warehouse = self.env['stock.warehouse'].search([('company_id', '=', company_id)], limit=1)
         for bom in self:
-            bom_data = self.env['report.mrp.report_bom_structure'].with_context(minimized=True)._get_bom_data(bom, warehouse, bom.product_id, ignore_stock=True)
+            bom_data = self.env['report.mrp.report_bom_structure'].with_context(minimized=True)._get_bom_data(bom, warehouse, bom.product_id, ignore_stock=True, max_depth=False)
             bom.days_to_prepare_mo = self.env['report.mrp.report_bom_structure']._get_max_component_delay(bom_data['components'])
 
     @api.constrains('product_tmpl_id', 'product_id', 'type')

--- a/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.xml
+++ b/addons/mrp/static/src/components/bom_overview/mrp_bom_overview.xml
@@ -17,6 +17,7 @@
             changeBomQuantity.bind="onChangeBomQuantity"
             changeDisplay.bind="onChangeDisplay"
             precision="state.precision"
+            unfoldFetchData.bind="unfold"
             />
 
         <BomOverviewTable
@@ -25,7 +26,9 @@
             currentWarehouseId="state.currentWarehouse.id"
             data="state.bomData"
             precision="state.precision"
-            changeFolded.bind="onChangeFolded"/>
+            changeFolded.bind="onChangeFolded"
+            getChildBomData.bind="getChildBomData"
+            />
     </div>
 
 </templates>

--- a/addons/mrp/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.xml
+++ b/addons/mrp/static/src/components/bom_overview_components_block/mrp_bom_overview_components_block.xml
@@ -5,7 +5,7 @@
         <t name="components" t-if="hasComponents">
             <t t-foreach="data.components" t-as="line" t-key="line.index">
                 <BomOverviewLine
-                    isFolded="state[getIdentifier(line)]"
+                    state="state"
                     showOptions="props.showOptions"
                     data="line"
                     precision="props.precision"
@@ -18,7 +18,9 @@
                         currentWarehouseId="props.currentWarehouseId"
                         data="line"
                         precision="props.precision"
-                        changeFolded.bind="props.changeFolded"/>
+                        changeFolded.bind="props.changeFolded"
+                        getChildBomData="props.getChildBomData"
+                    />
                 </t>
             </t>
         </t>

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.js
@@ -5,7 +5,7 @@ import { BomOverviewDisplayFilter } from "../bom_overview_display_filter/mrp_bom
 import { Dropdown } from "@web/core/dropdown/dropdown";
 import { DropdownItem } from "@web/core/dropdown/dropdown_item";
 import { Many2XAutocomplete } from "@web/views/fields/relational_utils";
-import { Component } from "@odoo/owl";
+import { Component, useState } from "@odoo/owl";
 import { useService } from "@web/core/utils/hooks";
 
 export class BomOverviewControlPanel extends Component {
@@ -33,6 +33,7 @@ export class BomOverviewControlPanel extends Component {
         changeBomQuantity: Function,
         changeDisplay: Function,
         precision: Number,
+        unfoldFetchData: Function,
     };
     static defaultProps = {
         variants: {},
@@ -42,6 +43,9 @@ export class BomOverviewControlPanel extends Component {
     setup() {
         this.action = useService("action");
         this.controlPanelDisplay = {};
+        this.state = useState({
+            isLoading: false,
+        });
     }
 
     //---- Handlers ----
@@ -58,7 +62,10 @@ export class BomOverviewControlPanel extends Component {
         }
     }
 
-    clickUnfold() {
+    async clickUnfold() {
+        this.state.isLoading = true;
+        await this.props.unfoldFetchData();
+        this.state.isLoading = false;
         this.env.overviewBus.trigger("unfold-all");
     }
 

--- a/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
+++ b/addons/mrp/static/src/components/bom_overview_control_panel/mrp_bom_overview_control_panel.xml
@@ -12,7 +12,7 @@
                         <t t-if="props.showVariants">
                             <button t-on-click="() => this.props.print(true)" type="button" class="btn btn-secondary text-nowrap">Print All Variants</button>
                         </t>
-                        <button t-on-click="clickUnfold" type="button" class="btn btn-secondary">Unfold</button>
+                        <button t-on-click="clickUnfold" type="button" class="btn btn-secondary">Unfold<i t-if="state.isLoading" class='fa fa-spinner fa-spin'/></button>
                     </div>
                 </div>
             </t>

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.js
@@ -8,7 +8,7 @@ import { Component } from "@odoo/owl";
 export class BomOverviewLine extends Component {
     static template = "mrp.BomOverviewLine";
     static props = {
-        isFolded: { type: Boolean, optional: true },
+        state: { type: Object, optional: true },
         showOptions: {
             type: Object,
             shape: {
@@ -100,6 +100,14 @@ export class BomOverviewLine extends Component {
         return this.props.data;
     }
 
+    get isLoading() {
+        return this.props.state.isLoading.find((e) => e === this.data.index);
+    }
+
+    get isFolded() {
+        return this.props.state[this.identifier];
+    }
+
     get precision() {
         return this.props.precision;
     }
@@ -108,8 +116,8 @@ export class BomOverviewLine extends Component {
         return `${this.data.type}_${this.data.index}`;
     }
 
-    get hasComponents() {
-        return this.data.components && this.data.components.length > 0;
+    get bomId() {
+        return this.data.bom_id ? true : false;
     }
 
     get hasQuantity() {
@@ -121,7 +129,7 @@ export class BomOverviewLine extends Component {
     }
 
     get hasFoldButton() {
-        return this.data.level > 0 && this.hasComponents;
+        return this.data.level > 0 && this.bomId;
     }
 
     get marginMultiplicator() {

--- a/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
+++ b/addons/mrp/static/src/components/bom_overview_line/mrp_bom_overview_line.xml
@@ -4,9 +4,14 @@
     <tr t-name="mrp.BomOverviewLine" t-on-click="() => this.props.toggleFolded(identifier)">
         <td name="td_mrp_bom">
             <div class="text-truncate" t-attf-style="margin-left: {{ marginMultiplicator * 20 }}px">
-                <t t-if="data.level > 0 &amp;&amp; hasComponents">
+                <t t-if="data.level > 0 &amp;&amp; bomId">
                     <span class="o_mrp_bom_unfoldable btn btn-light p-0" t-attf-aria-label="{{ props.isFolded ? 'Unfold' : 'Fold' }}" t-attf-title="{{ props.isFolded ? 'Unfold' : 'Fold' }}" style="margin-right: 1px">
-                        <i t-attf-class="fa fa-fw fa-caret-{{ props.isFolded ? 'right' : 'down' }}" role="img"/>
+                        <t t-if="!isLoading">
+                            <i t-attf-class="fa fa-fw fa-caret-{{ isFolded ? 'right' : 'down' }}" role="img"/>
+                        </t>
+                        <t t-else="">
+                            <i class='fa fa-spinner fa-spin'/>
+                        </t>
                     </span>
                 </t>
                 <a href="#" t-on-click.prevent="() => this.goToAction(data.link_id, data.link_model)" t-esc="data.name"/>

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.js
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.js
@@ -29,6 +29,7 @@ export class BomOverviewTable extends Component {
         data: Object,
         precision: Number,
         changeFolded: Function,
+        getChildBomData: Function,
     };
 
     setup() {

--- a/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
+++ b/addons/mrp/static/src/components/bom_overview_table/mrp_bom_overview_table.xml
@@ -51,7 +51,9 @@
                             currentWarehouseId="props.currentWarehouseId"
                             data="data"
                             precision="props.precision"
-                            changeFolded.bind="props.changeFolded"/>
+                            changeFolded.bind="props.changeFolded"
+                            getChildBomData.bind="props.getChildBomData"
+                            />
                     </tbody>
                     <tfoot t-if="showCosts">
                         <tr>

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -639,7 +639,7 @@ class TestBoM(TestMrpCommon):
                 operation.time_cycle_manual = 5
 
         # TEST BOM STRUCTURE VALUE WITH BOM QUANTITY
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_crumble.id, searchQty=11, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_crumble.id, searchQty=11, searchVariant=False)
         # 5 min 'Prepare biscuits' + 3 min 'Prepare butter' + 5 min 'Mix manually' = 13 minutes for 1 biscuits so 13 * 11 = 143 minutes
         self.assertEqual(report_values['lines']['operations_time'], 143.0, 'Operation time should be the same for 1 unit or for the batch')
         # Operation cost is the sum of operation line.
@@ -658,7 +658,7 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(float_compare(report_values['lines']['bom_cost'] / 11.0, 6.17, precision_digits=2), 0, 'Product Unit Bom Price is not correct')
 
         # TEST BOM STRUCTURE VALUE BY UNIT
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_crumble.id, searchQty=1, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_crumble.id, searchQty=1, searchVariant=False)
         # 5 min 'Prepare biscuits' + 3 min 'Prepare butter' + 5 min 'Mix manually' = 13 minutes
         self.assertEqual(report_values['lines']['operations_time'], 13.0, 'Operation time should be the same for 1 unit or for the batch')
         # Operation cost is the sum of operation line.
@@ -677,8 +677,7 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(float_compare(report_values['lines']['bom_cost'], 6.17, precision_digits=2), 0, 'Product Unit Bom Price is not correct')
 
         # TEST OPERATION COST WHEN PRODUCED QTY > BOM QUANTITY
-        report_values_12 = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_crumble.id, searchQty=12, searchVariant=False)
-        report_values_22 = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_crumble.id, searchQty=22, searchVariant=False)
+        report_values_22 = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_crumble.id, searchQty=22, searchVariant=False)
 
         #Operation cost = 47.66 € = 256 (min) * 10€/h
         self.assertEqual(float_compare(report_values_22['lines']['operations_cost'], 47.66, precision_digits=2), 0, 'Operation cost is not correct')
@@ -734,7 +733,7 @@ class TestBoM(TestMrpCommon):
                 operation.time_cycle_manual = 5
 
         # TEST CHEESE BOM STRUCTURE VALUE WITH BOM QUANTITY
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_cheese_cake.id, searchQty=60, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_cheese_cake.id, searchQty=60, searchVariant=False)
         # Operation time = 15 min * 60 + capacity_time_start + capacity_time_stop = 928
         self.assertEqual(report_values['lines']['operations_time'], 928.0, 'Operation time should be the same for 1 unit or for the batch')
         # Operation cost is the sum of operation line : (60 * 10)/60 * 10€ + (10 + 15 + 60 * 5)/60 * 20€ + (1 + 2)/60 * 20€ = 209,33€
@@ -747,7 +746,7 @@ class TestBoM(TestMrpCommon):
                 self.assertEqual(float_compare(component_line['bom_cost'], (3 * 5.17), precision_digits=2), 0)
             if component_line['product'].id == crumble.id:
                 # 5.4 kg of crumble at the cost of a batch.
-                crumble_cost = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_crumble.id, searchQty=5.4, searchVariant=False)['lines']['bom_cost']
+                crumble_cost = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_crumble.id, searchQty=5.4, searchVariant=False)['lines']['bom_cost']
                 self.assertEqual(float_compare(component_line['bom_cost'], crumble_cost, precision_digits=2), 0)
         # total price = Cream (15.51€) + crumble_cost (34.63 €) + operation_cost(209,33) = 259.47€
         self.assertEqual(float_compare(report_values['lines']['bom_cost'], 259.47, precision_digits=2), 0, 'Product Bom Price is not correct')
@@ -795,7 +794,7 @@ class TestBoM(TestMrpCommon):
                 operation.time_cycle_manual = 5
 
         # TEST BOM STRUCTURE VALUE WITH BOM QUANTITY
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_drawer.id, searchQty=11, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_drawer.id, searchQty=11, searchVariant=False)
         # 5 min 'Prepare biscuits' + 3 min 'Prepare butter' + 5 min 'Mix manually' = 13 minutes
         self.assertEqual(report_values['lines']['operations_time'], 660.0, 'Operation time should be the same for 1 unit or for the batch')
 
@@ -969,7 +968,7 @@ class TestBoM(TestMrpCommon):
 
         blue_car_with_gps = self.car._get_variant_for_combination(self.car_color_blue + self.car_gps_yes)
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_car.id, searchQty=1, searchVariant=blue_car_with_gps.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_car.id, searchQty=1, searchVariant=blue_car_with_gps.id, max_depth=False)
         # Two lines. blue dashboard with gps and blue paint.
         self.assertEqual(len(report_values['lines']['components']), 2)
 
@@ -1002,7 +1001,7 @@ class TestBoM(TestMrpCommon):
 
         red_car_without_gps = self.car._get_variant_for_combination(self.car_color_red + self.car_gps_no)
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_car.id, searchQty=1, searchVariant=red_car_without_gps.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_car.id, searchQty=1, searchVariant=red_car_without_gps.id)
         # Same math than before but without GPS
         self.assertEqual(report_values['lines']['bom_cost'], 210)
 
@@ -1023,7 +1022,7 @@ class TestBoM(TestMrpCommon):
         quantity = 5 dozens
         - Raw Material 4 litres (product.product 5$/litre)
 
-        Check the Price for 80 units of Finished -> 2.92$:
+        Check the Price for 80 units of Finished -> 2.91$:
         """
         # Create a products templates
         uom_unit = self.env.ref('uom.product_uom_unit')
@@ -1088,9 +1087,9 @@ class TestBoM(TestMrpCommon):
             line.product_qty = 4
         bom_assembly = bom_assembly.save()
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_finished.id, searchQty=80)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_finished.id, searchQty=80)
 
-        self.assertAlmostEqual(report_values['lines']['bom_cost'], 2.92)
+        self.assertAlmostEqual(report_values['lines']['bom_cost'], 2.91)
 
     def test_bom_report_capacity_with_quantity_of_0(self):
         uom_unit = self.env.ref('uom.product_uom_unit')
@@ -1132,7 +1131,7 @@ class TestBoM(TestMrpCommon):
             ]
         })
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom.id)
 
         # The first product shouldn't affect the producible quantity because the target needs none of it
         # So with 4 of the second product available, we can produce 40 items
@@ -1156,7 +1155,7 @@ class TestBoM(TestMrpCommon):
             ]
         })
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom.id)
         # Total quantity of components is 4, so shouldn't be able to produce a single one.
         self.assertEqual(report_values['lines']['producible_qty'], 0)
 
@@ -1189,7 +1188,7 @@ class TestBoM(TestMrpCommon):
             ]
         })
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom.id)
         line_values = report_values['lines']['components'][0]
         self.assertEqual(line_values['availability_state'], 'unavailable', 'The merged components should be unavailable')
 
@@ -1202,7 +1201,7 @@ class TestBoM(TestMrpCommon):
             'product_qty': 1.0,
         })]
         self.bom_4.bom_line_ids.product_qty = 0
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=self.bom_4.id, searchQty=1, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=self.bom_4.id, searchQty=1, searchVariant=False)
 
         self.assertEqual(sum([value['quantity'] for value in report_values['lines']['components'][:2]]), 0, 'The quantity should be set to 0 for all components of the bom.')
 
@@ -2195,7 +2194,7 @@ class TestBoM(TestMrpCommon):
                 }),
             ]
         })
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_normal.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_normal.id)
         line_values = report_values['lines']
         self.assertEqual(line_values['availability_state'], 'unavailable')
 
@@ -2211,7 +2210,7 @@ class TestBoM(TestMrpCommon):
                 }),
             ]
         })
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom_kit.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom_kit.id)
         line_values = report_values['lines']
         self.assertEqual(line_values['availability_state'], 'available')
 

--- a/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
+++ b/addons/mrp_subcontracting/report/mrp_report_bom_structure.py
@@ -19,8 +19,8 @@ class ReportBomStructure(models.AbstractModel):
             'level': level or 0
         }
 
-    def _get_bom_data(self, bom, warehouse, product=False, line_qty=False, bom_line=False, level=0, parent_bom=False, parent_product=False, index=0, product_info=False, ignore_stock=False):
-        res = super()._get_bom_data(bom, warehouse, product, line_qty, bom_line, level, parent_bom, parent_product, index, product_info, ignore_stock)
+    def _get_bom_data(self, bom, warehouse, product=False, line_qty=False, bom_line=False, level=0, parent_bom=False, parent_product=False, index=0, product_info=False, ignore_stock=False, depth=1, max_depth=1):
+        res = super()._get_bom_data(bom, warehouse, product, line_qty, bom_line, level, parent_bom, parent_product, index, product_info, ignore_stock, depth, max_depth)
         if bom.type == 'subcontract' and not self.env.context.get('minimized', False):
             if not res['product']:
                 seller = bom.product_tmpl_id.seller_ids.filtered(lambda s: s.partner_id in bom.subcontractor_ids)[:1]

--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -645,7 +645,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         })
         self.assertTrue(supplier.is_subcontractor)
         self.comp1.standard_price = 5
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, searchQty=1, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(self.bom.id, searchQty=1, searchVariant=False, max_depth=False)
         subcontracting_values = report_values['lines']['subcontracting']
         self.assertEqual(subcontracting_values['name'], self.subcontractor_partner1.display_name)
         self.assertEqual(report_values['lines']['bom_cost'], 20)  # 10 For subcontracting + 5 for comp1 + 5 for subcontracting of comp2_bom
@@ -653,14 +653,14 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         self.assertEqual(subcontracting_values['prod_cost'], 10)
         self.assertEqual(report_values['lines']['components'][0]['bom_cost'], 5)
         self.assertEqual(report_values['lines']['components'][1]['bom_cost'], 5)
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, searchQty=3, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(self.bom.id, searchQty=3, searchVariant=False, max_depth=False)
         subcontracting_values = report_values['lines']['subcontracting']
         self.assertEqual(report_values['lines']['bom_cost'], 60)  # 30 for subcontracting + 15 for comp1 + 15 for subcontracting of comp2_bom
         self.assertEqual(subcontracting_values['bom_cost'], 30)
         self.assertEqual(subcontracting_values['prod_cost'], 30)
         self.assertEqual(report_values['lines']['components'][0]['bom_cost'], 15)
         self.assertEqual(report_values['lines']['components'][1]['bom_cost'], 15)
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, searchQty=5, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(self.bom.id, searchQty=5, searchVariant=False, max_depth=False)
         subcontracting_values = report_values['lines']['subcontracting']
         self.assertEqual(report_values['lines']['bom_cost'], 80)  # 50 for subcontracting + 25 for comp1 + 5 for subcontracting of comp2_bom
         self.assertEqual(subcontracting_values['bom_cost'], 50)
@@ -1045,7 +1045,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         self.env['stock.quant']._update_available_quantity(self.comp2, subcontractor_location, 4)
 
         # Generate a report for 3 products: all products should be ready for production
-        bom_data = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, 3)
+        bom_data = self.env['report.mrp.report_bom_structure'].get_report_data(self.bom.id, 3)
 
         self.assertTrue(bom_data['lines']['components_available'])
         for component in bom_data['lines']['components']:
@@ -1057,7 +1057,7 @@ class TestSubcontractingFlows(TestMrpSubcontractingCommon):
         self.assertTrue('leftover_date' not in bom_data['lines']['earliest_date'])
 
         # Generate a report for 5 products: only 4 products should be ready for production
-        bom_data = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, 5)
+        bom_data = self.env['report.mrp.report_bom_structure'].get_report_data(self.bom.id, 5)
 
         self.assertFalse(bom_data['lines']['components_available'])
         for component in bom_data['lines']['components']:
@@ -1742,5 +1742,5 @@ class TestSubcontractingSerialMassReceipt(TransactionCase):
             'type': 'subcontract',
             'subcontractor_ids': [Command.set([self.subcontractor.id])],
         })
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom.id, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom.id, searchVariant=False)
         self.assertTrue(report_values)

--- a/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_purchase_subcontracting.py
@@ -449,14 +449,14 @@ class TestSubcontractingDropshippingFlows(TestMrpSubcontractingCommon):
         # Need to add the subcontractor as Vendor to have the bom read as subcontracted.
         self.comp1.write({'seller_ids': [Command.create({'partner_id': self.subcontractor_partner1.id})]})
 
-        report = self.env['report.mrp.report_bom_structure'].with_context(warehouse_id=warehouse.id)._get_report_data(bom_subcontract.id)
+        report = self.env['report.mrp.report_bom_structure'].with_context(warehouse_id=warehouse.id).get_report_data(bom_subcontract.id)
         component_lines = report.get('lines', []).get('components', [])
         self.assertEqual(component_lines[0]['product_id'], compo_drop.id)
         self.assertEqual(component_lines[0]['route_name'], 'Dropship Subcontractor on Order')
         self.assertEqual(component_lines[1]['product_id'], compo_rr.id)
         self.assertEqual(component_lines[1]['route_name'], 'Buy', 'Despite the RR linked to it, it should still display the Buy route')
 
-        report = self.env['report.mrp.report_bom_structure'].with_context(warehouse_id=warehouse.id)._get_report_data(bom_local.id)
+        report = self.env['report.mrp.report_bom_structure'].with_context(warehouse_id=warehouse.id).get_report_data(bom_local.id)
         component_lines = report.get('lines', []).get('components', [])
         self.assertEqual(component_lines[0]['product_id'], compo_drop.id)
         self.assertEqual(component_lines[0]['route_name'], 'Buy', 'Outside of the subcontracted context, it should try to resupply stock.')

--- a/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
+++ b/addons/mrp_subcontracting_purchase/tests/test_mrp_subcontracting_purchase.py
@@ -764,7 +764,7 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         quantity_after_move = self.env['stock.quant']._get_available_quantity(component, self.subcontractor_partner1.property_stock_subcontractor, allow_negative=True)
         self.assertEqual(quantity_after_move, quantity_before_move + moved_quantity_to_subcontractor)
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom.id, searchQty=search_qty_less_than_or_equal_moved, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom.id, searchQty=search_qty_less_than_or_equal_moved, searchVariant=False)
         self.assertEqual(report_values['lines']['components'][0]['quantity_available'], total_component_quantity)
         self.assertEqual(report_values['lines']['components'][0]['quantity_on_hand'], total_component_quantity)
         self.assertEqual(report_values['lines']['quantity_available'], 0)
@@ -774,10 +774,10 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
 
         self.assertEqual(report_values['lines']['components'][0]['stock_avail_state'], 'available')
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom.id, searchQty=search_qty_less_than_or_equal_total, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom.id, searchQty=search_qty_less_than_or_equal_total, searchVariant=False)
         self.assertEqual(report_values['lines']['components'][0]['stock_avail_state'], 'available')
 
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom.id, searchQty=search_qty_more_than_total, searchVariant=False)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom.id, searchQty=search_qty_more_than_total, searchVariant=False)
         self.assertEqual(report_values['lines']['components'][0]['stock_avail_state'], 'unavailable')
 
     @freeze_time('2024-01-01')
@@ -810,7 +810,7 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         self.env['stock.quant']._update_available_quantity(self.comp2, subcontractor_location, 4)
 
         # Generate a report for 3 products: all products should be ready for production
-        bom_data = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, 3)
+        bom_data = self.env['report.mrp.report_bom_structure'].get_report_data(self.bom.id, 3)
 
         self.assertTrue(bom_data['lines']['components_available'])
         for component in bom_data['lines']['components']:
@@ -823,7 +823,7 @@ class MrpSubcontractingPurchaseTest(TestMrpSubcontractingCommon):
         self.assertTrue('leftover_date' not in bom_data['lines']['earliest_date'])
 
         # Generate a report for 5 products: only 4 products should be ready for production
-        bom_data = self.env['report.mrp.report_bom_structure']._get_report_data(self.bom.id, 5)
+        bom_data = self.env['report.mrp.report_bom_structure'].get_report_data(self.bom.id, 5)
 
         self.assertFalse(bom_data['lines']['components_available'])
         for component in bom_data['lines']['components']:

--- a/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
+++ b/addons/purchase_mrp/tests/test_purchase_mrp_flow.py
@@ -877,7 +877,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
 
         po_today.button_confirm()
         po_5days.button_confirm()
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom.id)
         line_values = report_values['lines']['components'][0]
         self.assertEqual(line_values['availability_state'], 'estimated', 'The merged components should be estimated.')
 
@@ -918,7 +918,7 @@ class TestPurchaseMrpFlow(AccountTestInvoicingCommon):
             line.price_unit = 10
         po_today = f.save()
         po_today.button_confirm()
-        report_values = self.env['report.mrp.report_bom_structure']._get_report_data(bom_id=bom.id)
+        report_values = self.env['report.mrp.report_bom_structure'].get_report_data(bom_id=bom.id)
         line_values = report_values['lines']['components'][0]
         self.assertEqual(line_values['availability_state'], 'expected', 'The first component should be expected as there is an incoming PO.')
 


### PR DESCRIPTION
The BoM overview report loading time could be very long due to a lot of recursive
function calls (mainly stock related).

These calls could be limited to the information we want to display on the report
(basically the first layer of the bom), making the loading of the BoM overview lazy.

However, we still need to compute the price of the bom and components/sub-boms,
so loading the BoM overview will still go through all of them, but will not
take the stock part of the components/sub-boms into account, which was the most
time-consuming part of the loading.

Time gain speaking, this pr will loose some time when unfolding all at once
because it will recompute every bom data, but the time lost is significally lower than
the time gained at loading if the bom has a lot of sub-boms.

Displaying the time gained does not really make sense as it greatly depends on
the number of components/bom and the depth of the boms but we can almost approximate
the loading time to the time to load the components of the first BoM.

task-id: 3422605
enterprise: https://github.com/odoo/enterprise/pull/63165
