### PR TITLE
[IMP] point_of_sale: add blur bg to product images

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/blurry_fill_image/blurry_fill_image.js
+++ b/addons/point_of_sale/static/src/app/generic_components/blurry_fill_image/blurry_fill_image.js
@@ -1,0 +1,17 @@
+import { Component, xml } from "@odoo/owl";
+
+export class BlurryFillImage extends Component {
+    static props = {
+        imageUrl: String,
+        style: { type: String, optional: true },
+    };
+    static defaultProps = {
+        style: "min-height: 6rem; max-height: 6rem;",
+    };
+    static template = xml`
+        <div t-if="props.imageUrl" t-att-style="props.style" class="blurry-fill-image-frame">
+            <div class="blur" t-attf-style="background-image: url('{{props.imageUrl}}')" />
+            <img t-att-src="props.imageUrl"/>
+        </div>
+    `;
+}

--- a/addons/point_of_sale/static/src/app/generic_components/blurry_fill_image/blurry_fill_image.scss
+++ b/addons/point_of_sale/static/src/app/generic_components/blurry_fill_image/blurry_fill_image.scss
@@ -1,0 +1,24 @@
+.blurry-fill-image-frame {
+  position: relative;
+}
+
+.blurry-fill-image-frame .blur {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  top: 0;
+  left: 0;
+  background-size: cover;
+  background-position: center;
+}
+
+.blurry-fill-image-frame img {
+  position: relative;
+  z-index: 1;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  object-position: center;
+  backdrop-filter: blur(10px);
+  -webkit-backdrop-filter: blur(10px);
+}

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.js
@@ -1,6 +1,8 @@
 import { Component } from "@odoo/owl";
+import { BlurryFillImage } from "@point_of_sale/app/generic_components/blurry_fill_image/blurry_fill_image";
 
 export class ProductCard extends Component {
+    static components = { BlurryFillImage };
     static template = "point_of_sale.ProductCard";
     static props = {
         class: { String, optional: true },

--- a/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/product_card/product_card.xml
@@ -8,12 +8,10 @@
             t-on-click="props.onClick"
             t-att-data-product-id="props.productId"
             t-attf-aria-labelledby="article_product_{{props.productId}}">
-            <div t-if="props.productInfo" class="product-information-tag" t-on-click.stop="props.onProductInfoClick">
+            <div t-if="props.productInfo" class="product-information-tag" t-on-click.stop="props.onProductInfoClick" style="z-index: 2;">
                 <i class="product-information-tag-logo fa fa-info" role="img" aria-label="Product Information" title="Product Information" />
             </div>
-            <div t-if="props.imageUrl" class="product-img">
-                <img class="w-100" t-att-src="props.imageUrl" t-att-alt="props.name" />
-            </div>
+            <BlurryFillImage imageUrl="props.imageUrl" />
             <div class="product-content d-flex flex-column justify-content-between h-100 mx-2 py-1">
                 <div class="overflow-hidden lh-sm product-name"
                     t-att-class="{'no-image': !props.imageUrl}"


### PR DESCRIPTION
The product images in pos used to have the `object-fit: cover` css property, but because this was cutting off parts of the images in certain cases, it was recently changed to `object-fit: contain`.

This makes it such that the images now have empty space around them.

In this commit we create a generic component `BlurryFillImage` that displays the image from the url provided as prop with a blurry background and use this component in the product screen to improve the design.

Task: 3930953

Description of the issue/feature this PR addresses:

before:
![image](https://github.com/odoo/odoo/assets/118446179/0e118b4a-8c66-4c62-bc30-471722dad0b4)


after:
![image](https://github.com/odoo/odoo/assets/118446179/a0c4d36a-d540-40dc-9d87-7d190048bcc8)





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
