### PR TITLE
[FIX] purchase{,_stock}: don't round price unit

### DIFF
--- a/addons/purchase/models/purchase.py
+++ b/addons/purchase/models/purchase.py
@@ -1365,7 +1365,7 @@ class PurchaseOrderLine(models.Model):
             qty = self.product_qty or 1
             price_unit_prec = self.env['decimal.precision'].precision_get('Product Price')
             price_unit = self.taxes_id.with_context(round=False).compute_all(price_unit, currency=self.order_id.currency_id, quantity=qty, product=self.product_id)['total_void']
-            price_unit = float_round(price_unit / qty, precision_digits=price_unit_prec)
+            price_unit = price_unit / qty
         if self.product_uom.id != self.product_id.uom_id.id:
             price_unit *= self.product_uom.factor / self.product_id.uom_id.factor
         return price_unit

--- a/addons/purchase_stock/tests/test_average_price.py
+++ b/addons/purchase_stock/tests/test_average_price.py
@@ -254,3 +254,51 @@ class TestAveragePrice(ValuationReconciliationTestCommon):
         picking.button_validate()
 
         self.assertEqual(avco_product.avg_cost, 300)
+
+    def test_no_compensatory_svl_from_asymmetrical_rounding(self):
+        """ Ensure that a purchase order for a high quantity of some product using avg costing does
+        not calculate the price unit asymmetrically for the order(line) and the invoice AML.
+        """
+        self.stock_account_product_categ.property_cost_method = 'average'
+        avco_product = self.env['product.product'].create({
+            'name': 'test_rounding_in_valuation product',
+            'type': 'product',
+            'categ_id': self.stock_account_product_categ.id,
+            'purchase_method': 'purchase',
+            'standard_price': 2.0,
+        })
+
+        incl_tax = self.env['account.tax'].create({
+            'name': 'test_rounding_in_valuation tax',
+            'type_tax_use': 'purchase',
+            'amount_type': 'percent',
+            'amount': 10,
+            'price_include': True,
+            'invoice_repartition_line_ids': [
+                (0, 0, {'repartition_type': 'base'}),
+                (0, 0, {
+                    'repartition_type': 'tax',
+                    'factor_percent': 100,
+                    'account_id': self.env['account.account'].search([('name', '=', 'Tax Paid')], limit=1).id,
+                }),
+            ],
+            'include_base_amount': False,
+        })
+
+        po = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [(0, 0, {
+                'product_id': avco_product.id,
+                'product_qty': 999,
+                'taxes_id': [(6, 0, [incl_tax.id])],
+            })],
+        })
+        po.button_confirm()
+
+        po.picking_ids.move_ids.quantity_done = 999
+        po.picking_ids.button_validate()
+        po.action_create_invoice()
+        po.invoice_ids[0].invoice_date = time.strftime('%Y-%m-%d')
+        po.invoice_ids[0].action_post()
+
+        self.assertFalse(po.picking_ids.move_ids.stock_valuation_layer_ids.stock_valuation_layer_ids)


### PR DESCRIPTION
**Current behavior:**
Creating a purchase order for >1000 units of a product with a
tax that is included in the base price, there will be rounding
issues and a corrective SVL will be created with the creation of
the invoice which makes it impossible to reset the bill to
draft.

**Expected behavior:**
The SVL value will reflect the true value of the associated
moves, no corrective SVL will be created on invoice generation.

**Steps to reproduce:**
1. Make a storable product with a category having 'average'
     costing method

2. Make a purchase tax of 10% with:
     `price_include: True`
     `repartition_type: tax = {factor_percent: 100, account_id=Tax Paid}`
     `include_base_amount': False`

3. Create a purchase order for the product with the new tax,
     with a quantity of 1000

4. Confirm the order, validate the picking, create a bill and
     confirm it as well

5. Observe that 2 SVL are created (corrective one after the
     creation of the invoice)

**Cause of the issue:**
The price unit calculation for the purchase order line's price
unit value is rounded, while the price unit calculation for the
associated account move line is not. The valuation system
compensates for this difference by creating another SVL record.

**Fix:**
Don't round when calculating the price unit for the purchase
order line. We should keep the max amount of precision until
there is an explicit need to round.

opw-3757684