### PR TITLE
[IMP] base, fields, tools, website: stop sanitizing supported videos

### DIFF
--- a/addons/website/static/src/js/content/snippets.animation.js
+++ b/addons/website/static/src/js/content/snippets.animation.js
@@ -711,15 +711,15 @@ registry.mediaVideo = publicWidget.Widget.extend(MobileYoutubeAutoplayMixin, {
      * @override
      */
     start: function () {
-        // TODO: this code should be refactored to make more sense and be better
-        // integrated with Odoo (this refactoring should be done in master).
-
         const proms = [this._super.apply(this, arguments)];
         let iframeEl = this.$target[0].querySelector(':scope > iframe');
 
         // The following code is only there to ensure compatibility with
         // videos added before bug fixes or new Odoo versions where the
-        // <iframe/> element is properly saved.
+        // <iframe/> element is properly saved in the DOM. Previous versions
+        // could sanitize those depending on the editor user access rights or
+        // the type of content that was edited. Now those are never sanitized.
+        // TODO: remove this code once a proper migration script is done.
         if (!iframeEl) {
             iframeEl = this._generateIframe();
         }
@@ -769,6 +769,7 @@ registry.mediaVideo = publicWidget.Widget.extend(MobileYoutubeAutoplayMixin, {
             return;
         }
         var domain = m[1].replace(/^www\./, '');
+        // See host_whitelist on the python side
         var supportedDomains = ['youtu.be', 'youtube.com', 'youtube-nocookie.com', 'instagram.com', 'vine.co', 'player.vimeo.com', 'vimeo.com', 'dailymotion.com', 'player.youku.com', 'youku.com'];
         if (!_.contains(supportedDomains, domain)) {
             // Unsupported domain, don't inject iframe

--- a/odoo/addons/base/tests/test_mail.py
+++ b/odoo/addons/base/tests/test_mail.py
@@ -333,6 +333,47 @@ class TestSanitizer(BaseCase):
     #     for ext in test_mail_examples.MSOFFICE_1_OUT:
     #         self.assertNotIn(ext, new_html)
 
+    def test_video_support(self):
+        cases = [
+            (
+                '<iframe src="//www.youtube.com/embed/_yzUhaL7RYw?rel=0&autoplay=1&mute=1&enablejsapi=1"></iframe>',
+                '<iframe src="//www.youtube.com/embed/_yzUhaL7RYw?rel=0&amp;autoplay=1&amp;mute=1&amp;enablejsapi=1"></iframe>',
+                "Protocol-relative Youtube video should not be sanitized"
+            ),
+            (
+                '<iframe src="//youtube.com/embed/_yzUhaL7RYw?rel=0&autoplay=1&mute=1&enablejsapi=1"></iframe>',
+                '<iframe src="//youtube.com/embed/_yzUhaL7RYw?rel=0&amp;autoplay=1&amp;mute=1&amp;enablejsapi=1"></iframe>',
+                "Protocol-relative no-www Youtube video should not be sanitized"
+            ),
+            (
+                '<iframe src="https://www.youtube.com/embed/_yzUhaL7RYw"></iframe>',
+                '<iframe src="https://www.youtube.com/embed/_yzUhaL7RYw"></iframe>',
+                "Full protocol Youtube video should not be sanitized"
+            ),
+            (
+                '<iframe src="https://youtube.com/embed/_yzUhaL7RYw"></iframe>',
+                '<iframe src="https://youtube.com/embed/_yzUhaL7RYw"></iframe>',
+                "Full protocol no-www Youtube video should not be sanitized"
+            ),
+            (
+                '<iframe src="https://player.vimeo.com"></iframe>',
+                '<iframe src="https://player.vimeo.com"></iframe>',
+                "Random vimeo video should not be sanitized"
+            ),
+            (
+                '<iframe src="https://www.youtube.malicious"></iframe>',
+                '',
+                "Random iframe should be sanitized (1)"
+            ),
+            (
+                '<iframe src="/foo/bar"></iframe>',
+                '',
+                "Random iframe should be sanitized (2)"
+            ),
+        ]
+        for content, expected, message in cases:
+            self.assertEqual(html_sanitize(content), expected, message)
+
 
 class TestHtmlTools(BaseCase):
     """ Test some of our generic utility functions about html """

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -2005,8 +2005,8 @@ class Html(_String):
             original_value = record[self.name]
             if original_value:
                 # Note that sanitize also normalize
-                original_value_normalized = html_normalize(original_value, self._filter_acceptable_sanitization_loss)
-                original_value_sanitized = html_sanitize(original_value_normalized, **sanitize_vals)
+                original_value_sanitized = html_sanitize(original_value, **sanitize_vals)
+                original_value_normalized = html_normalize(original_value)
 
                 if (
                     not original_value_sanitized  # sanitizer could empty it
@@ -2025,56 +2025,6 @@ class Html(_String):
                     ))
 
         return html_sanitize(value, **sanitize_vals)
-
-    def _filter_acceptable_sanitization_loss(self, doc):
-        # FIXME this should be done only for some specific fields of some
-        # specific models. However, given the state of the codebase and the
-        # functional flows, doing it always should be the same. Facts:
-        #
-        # - "media_iframe_video" is a concept introduced by the web_editor app
-        #
-        # - Not considering "media_iframe_video" elements (so considering them
-        #   as an acceptable sanitization loss) is only ok for "fields that can
-        #   only be seen *and* modified through a website screen. Indeed, on
-        #   website loading, the iframe is rebuilt from the "media_iframe_video"
-        #   element dataset information if it was previously sanitized.
-        #
-        # - Some fields are sanitized_overridable despite the fact they do not
-        #   depend on the website model... but in that case, media_iframe_video
-        #   simply cannot appear in the field through user flows (the ability to
-        #   add videos is disabled since the field is sanitized).
-        #
-        # Special award to the survey.question description field though, which:
-        # - Does not depend on website
-        # - Is sanitize=True and sanitize_overridable=True
-        # - Contains "media_iframe_video" in some demo data although the only
-        #   way to get some in there by yourself is to:
-        #    1. Install website.
-        #    2. Fill in the survey.question with some content through the
-        #       backend form view.
-        #    3. Somehow reach the related survey from the website and enter edit
-        #       mode when reaching the question.
-        #    4. Add a video in the previously created content.
-        #
-        # => In that case, not considering media_iframe_video element here is
-        #    wrong as it allows non-admin users to save, have the video that was
-        #    added by an admin sanitized and thus not see it anymore... except
-        #    through website screens. This is unlikely though: first getting the
-        #    video in there is unlikely but re-editing it from the backend after
-        #    is probably not common either... and in the end, at worst, the user
-        #    sees the video disappear while it is still there in the actual
-        #    survey (from website screens).
-        #
-        # Ideally, this should be implemented per model/field. Probably with a
-        # mixin used by all relevant models (probably all except this survey app
-        # one).
-        #
-        # An even more ideal solution would be to get rid of this concept of
-        # acceptable sanitization loss and instead make it so safe videos are
-        # simply not sanitized at all in the first place.
-        for el in doc.xpath('//div[hasclass("media_iframe_video")]'):
-            el.getparent().remove(el)
-        return doc
 
     def convert_to_record(self, value, record):
         r = super().convert_to_record(value, record)

--- a/odoo/tools/mail.py
+++ b/odoo/tools/mail.py
@@ -46,6 +46,18 @@ SANITIZE_TAGS = {
     'kill_tags': ['base', 'embed', 'frame', 'head', 'iframe', 'link', 'meta',
                   'noscript', 'object', 'script', 'style', 'title'],
     'remove_tags': ['html', 'body'],
+    'whitelist_tags': ['iframe'],
+    'host_whitelist': [
+        # TODO probably some of those can be removed but kept in stable for now
+        'youtu.be', 'www.youtu.be',
+        'youtube.com', 'www.youtube.com',
+        'youtube-nocookie.com', 'www.youtube-nocookie.com',
+        'instagram.com', 'www.instagram.com',
+        'vine.co', 'www.vine.co',
+        'player.vimeo.com', 'vimeo.com', 'www.vimeo.com',
+        'dailymotion.com', 'www.dailymotion.com',
+        'player.youku.com', 'youku.com', 'www.youku.com',
+    ],
 }
 
 
@@ -105,6 +117,13 @@ class _Cleaner(clean.Cleaner):
                 el.attrib['style'] = '; '.join('%s:%s' % (key, val) for (key, val) in valid_styles.items())
             else:
                 del el.attrib['style']
+
+    def allow_embedded_url(self, el, url):
+        # Fix the lib implementation: protocol relative URLs should be
+        # considered as http(s) URLs.
+        if url.startswith('//'):
+            url = f'https:{url}'
+        return super().allow_embedded_url(el, url)
 
 
 def tag_quote(el):


### PR DESCRIPTION
- First commit: trying to solve the problem going into the right direction IMO
- Second commit: revert previous one
- Third commit: what should be done IMO ->

With the multiple commits made at [1], we allowed a sanitization or not
depending on the *user access rights* instead of the *type of content*.
To do so, all relevant fields were still marked as to be sanitized (or
not) but we also allowed to mark the fields as "sanitize overridable",
meaning you could skip sanitization if you have enough access rights.

In the process, users without sufficient access rights are prevented to
edit a content which already contains elements that would be sanitized
(i.e. content that an user with enough access rights added previously).

This is nice... as long as an administrator user adds a video in such
fields. Indeed, video elements suffered from a bad but acceptable
behavior since a while:
- We prefer the actual `<iframe>` element to be saved as content,
  starting their loading as the browsers see fit instead of rebuilding
  them after page load.
- We still allowed non-admin users to add videos: the `<iframe>` is
  wrapped into an `<div>` holding the video source. In that case, on
  save, the `<iframe>` element is sanitized. But on page load, we simply
  rebuild the actual `<iframe>` element, provided the video source is
  from a supported domain (**).

That second part actually holds much history that will not be detailed
again here.

That ok-ish behavior is now broken as an user without sufficient access
rights to by-pass sanitization is now prohibited to edit a content
containing a video as the system detects that some elements (the
`<iframe>` elements) would be lost after save.

Steps to reproduce:
- Make it so demo user cannot by-pass sanitization and is a restricted
  editor user with admin rights on products.
- Go to a product as an admin user.
- Add a video in the website description.
- Save
- Go to that product as the demo user.
- Add some more content => You cannot (a dialog informs you that you
  cannot edit the content because an admin edited it previously).

In fact, the solution is kinda obvious and should have been what was
done when implementing (**) (even if (**) would still have been needed
in stable): as we already process videos on page load to build iframe
for the domains we support, we can just prevent sanitizing those in the
first place if they do use the domains we support. The sanitization lib
we use actually allows to do that out-of-the-box, although it needed
some patching to make it fully work.

[1]: https://github.com/odoo/odoo/pull/97398

task-3757205