### PR TITLE
[FIX] hr_expense: Broken access rights

### DIFF
--- a/addons/hr_expense/i18n/hr_expense.pot
+++ b/addons/hr_expense/i18n/hr_expense.pot
@@ -1941,6 +1941,18 @@ msgstr ""
 #. module: hr_expense
 #: code:addons/hr_expense/models/hr_expense.py:0
 #, python-format
+msgid "You don't have the rights to bypass the validation process of this expense."
+msgstr ""
+
+#. module: hr_expense
+#: code:addons/hr_expense/models/hr_expense.py:0
+#, python-format
+msgid "You don't have the rights to bypass the validation process of this expense report."
+msgstr ""
+
+#. module: hr_expense
+#: code:addons/hr_expense/models/hr_expense.py:0
+#, python-format
 msgid "You are not authorized to edit the reference of this expense report."
 msgstr ""
 

--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -376,6 +376,9 @@ class HrExpense(models.Model):
         if 'reference' in vals:
             if any(not expense.is_ref_editable for expense in self):
                 raise UserError(_('You are not authorized to edit the reference of this expense report.'))
+        if 'state' in vals and (not self.user_has_groups('hr_expense.group_hr_expense_manager') and vals['state'] != 'submit' and
+        any(expense.state == 'draft' for expense in self)):
+            raise UserError(_("You don't have the rights to bypass the validation process of this expense."))
         return super(HrExpense, self).write(vals)
 
     @api.model
@@ -1031,6 +1034,17 @@ class HrExpenseSheet(models.Model):
         sheet.activity_update()
         return sheet
 
+    def write(self, vals):
+        if 'state' in vals:
+            # Avoid user with write access on expense sheet in draft state to bypass the validation process
+            if not self.user_has_groups('hr_expense.group_hr_expense_manager') and self.state == 'draft' and vals['state'] != 'submit':
+                raise UserError(_("You don't have the rights to bypass the validation process of this expense report."))
+            elif vals['state'] == 'approve':
+                self._check_can_approve()
+            elif vals['state'] == 'cancel':
+                self._check_can_refuse()
+        return super().write(vals)
+
     @api.ondelete(at_uninstall=False)
     def _unlink_except_posted_or_paid(self):
         for expense in self:
@@ -1130,7 +1144,7 @@ class HrExpenseSheet(models.Model):
 
     def action_submit_sheet(self):
         self.write({'state': 'submit'})
-        self.activity_update()
+        self.sudo().activity_update()
 
     def _check_can_approve(self):
         if not self.user_has_groups('hr_expense.group_hr_expense_team_approver'):
@@ -1188,9 +1202,10 @@ class HrExpenseSheet(models.Model):
     def paid_expense_sheets(self):
         self.write({'state': 'done'})
 
-    def refuse_sheet(self, reason):
+    # TODO in master could be aggregated with _check_can_accept
+    def _check_can_refuse(self):
         if not self.user_has_groups('hr_expense.group_hr_expense_team_approver'):
-            raise UserError(_("Only Managers and HR Officers can approve expenses"))
+            raise UserError(_("Only Managers and HR Officers can refuse expenses"))
         elif not self.user_has_groups('hr_expense.group_hr_expense_manager'):
             current_managers = self.employee_id.expense_manager_id | self.employee_id.parent_id.user_id | self.employee_id.department_id.manager_id.user_id
 
@@ -1200,6 +1215,8 @@ class HrExpenseSheet(models.Model):
             if not self.env.user in current_managers and not self.user_has_groups('hr_expense.group_hr_expense_user') and self.employee_id.expense_manager_id != self.env.user:
                 raise UserError(_("You can only refuse your department expenses"))
 
+    def refuse_sheet(self, reason):
+        self._check_can_refuse()
         self.write({'state': 'cancel'})
         for sheet in self:
             sheet.message_post_with_view('hr_expense.hr_expense_template_refuse_reason', values={'reason': reason, 'is_sheet': True, 'name': sheet.name})
@@ -1208,8 +1225,8 @@ class HrExpenseSheet(models.Model):
     def reset_expense_sheets(self):
         if not self.can_reset:
             raise UserError(_("Only HR Officers or the concerned employee can reset to draft."))
+        self.sudo().write({'state': 'draft', 'approval_date': False})
         self.mapped('expense_line_ids').write({'is_refused': False})
-        self.write({'state': 'draft', 'approval_date': False})
         self.activity_update()
         return True
 

--- a/addons/hr_expense/security/ir_rule.xml
+++ b/addons/hr_expense/security/ir_rule.xml
@@ -22,8 +22,17 @@
         <record id="ir_rule_hr_expense_employee" model="ir.rule">
             <field name="name">Employee Expense</field>
             <field name="model_id" ref="model_hr_expense"/>
-            <field name="domain_force">[('employee_id.user_id', '=', user.id)]</field>
+            <field name="domain_force">[('employee_id.user_id', '=', user.id), ('state', '=', 'draft')]</field>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        </record>
+        <record id="ir_rule_hr_expense_employee_not_draft" model="ir.rule">
+            <field name="name">Employee can't modify expense that is not in draft state</field>
+            <field name="model_id" ref="model_hr_expense"/>
+            <field name="domain_force">[('employee_id.user_id', '=', user.id), ('state', '!=', 'draft')]</field>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
 
         <record id="ir_rule_hr_expense_sheet_manager" model="ir.rule">
@@ -47,8 +56,17 @@
         <record id="ir_rule_hr_expense_sheet_employee" model="ir.rule">
             <field name="name">Employee Expense Sheet</field>
             <field name="model_id" ref="model_hr_expense_sheet"/>
-            <field name="domain_force">[('employee_id.user_id', '=', user.id)]</field>
+            <field name="domain_force">[('employee_id.user_id', '=', user.id), ('state', '=', 'draft')]</field>
             <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+        </record>
+        <record id="ir_rule_hr_expense_sheet_employee_not_draft" model="ir.rule">
+            <field name="name">Employee can't modify expense sheet that is not in draft state</field>
+            <field name="model_id" ref="model_hr_expense_sheet"/>
+            <field name="domain_force">[('employee_id.user_id', '=', user.id), ('state', '!=', 'draft')]</field>
+            <field name="groups" eval="[(4, ref('base.group_user'))]"/>
+            <field name="perm_create" eval="False"/>
+            <field name="perm_write" eval="False"/>
+            <field name="perm_unlink" eval="False"/>
         </record>
 
         <record id="hr_expense_comp_rule" model="ir.rule">

--- a/addons/hr_expense/tests/test_expenses_access_rights.py
+++ b/addons/hr_expense/tests/test_expenses_access_rights.py
@@ -27,6 +27,31 @@ class TestExpensesAccessRights(TestExpenseCommon):
                 'unit_amount': 1,
             })
 
+        expense = self.env['hr.expense'].with_user(self.expense_user_employee).create({
+            'name': 'expense_1',
+            'date': '2016-01-01',
+            'product_id': self.product_a.id,
+            'unit_amount': 10.0,
+            'employee_id': self.expense_employee.id,
+        })
+
+        # The expense employee shouldn't be able to bypass the submit state.
+        with self.assertRaises(UserError):
+            expense.with_user(self.expense_user_employee).state = 'approve'
+
+        # Employee can report & submit their expense
+        expense_sheet = self.env['hr.expense.sheet'].with_user(self.expense_user_employee).create({
+            'name': 'expense sheet for employee',
+            'expense_line_ids': expense,
+            'payment_mode': expense.payment_mode,
+        })
+        expense_sheet.with_user(self.expense_user_employee).action_submit_sheet()
+        self.assertEqual(expense.state, 'reported')  # Todo change in 17.0+
+
+        # Employee can also revert from the submitted state to a draft state
+        expense_sheet.with_user(self.expense_user_employee).reset_expense_sheets()
+        self.assertEqual(expense.state, 'draft')  # Todo change in 17.0+
+
     def test_expense_sheet_access_rights_approve(self):
 
         # The expense employee is able to a create an expense sheet.
@@ -49,6 +74,10 @@ class TestExpensesAccessRights(TestExpenseCommon):
         })
         self.assertRecordValues(expense_sheet, [{'state': 'draft'}])
 
+        # The expense employee shouldn't be able to bypass the submit state.
+        with self.assertRaises(UserError):
+            expense_sheet.with_user(self.expense_user_employee).state = 'approve'
+
         # The expense employee is able to submit the expense sheet.
 
         expense_sheet.with_user(self.expense_user_employee).action_submit_sheet()
@@ -64,6 +93,10 @@ class TestExpensesAccessRights(TestExpenseCommon):
 
         expense_sheet.with_user(self.expense_user_manager).approve_expense_sheets()
         self.assertRecordValues(expense_sheet, [{'state': 'approve'}])
+
+        # The expense employee shouldn't be able to modify an approved expense.
+        with self.assertRaises(UserError):
+            expense_sheet.expense_line_ids[0].with_user(self.expense_user_employee).total_amount = 1000.0
 
         # An expense manager is not able to create the journal entry.
 


### PR DESCRIPTION
The state changes right check was only done on specific method but it
wasn't check at write level. Which allowed to bypass it.

The record rule on hr_expense_user without a check on the state is in
draft allow to change data on approved expense sheets.