### PR TITLE
[IMP] base_sparse_field: add sql json searching and improve constraints

### DIFF
--- a/addons/base_sparse_field/models/fields.py
+++ b/addons/base_sparse_field/models/fields.py
@@ -3,7 +3,9 @@
 import json
 
 from odoo import fields
-
+from odoo import tools
+from odoo.tools.query import Query
+from odoo.osv import expression
 
 def monkey_patch(cls):
     """ Return a method decorator to monkey-patch the given class. """
@@ -42,6 +44,7 @@ def _get_attrs(self, model_class, name):
         attrs['store'] = False
         attrs['copy'] = attrs.get('copy', False)
         attrs['compute'] = self._compute_sparse
+        attrs['search'] = self._search_sparse
         if not attrs.get('readonly'):
             attrs['inverse'] = self._inverse_sparse
     return attrs
@@ -70,6 +73,18 @@ def _inverse_sparse(self, records):
                 record[self.sparse] = values
 
 
+@monkey_patch(fields.Field)
+def _search_sparse(self, records, operator, value):
+    """ Determine the domain to search on field ``self``. """
+    if isinstance(value, Query):
+        value = list(value)
+    model = records.env[self.model_name]
+    cast_type = self.column_type[0]
+    sql_op = expression.SQL_OPERATORS[operator].code
+
+    base_query = f"SELECT id FROM {model._table} WHERE ({self.sparse} ->> %s)::{cast_type} {sql_op} %s"
+    return [("id", "inselect", (base_query, [self.name, value]))]
+
 #
 # Definition and implementation of serialized fields
 #
@@ -77,7 +92,7 @@ def _inverse_sparse(self, records):
 class Serialized(fields.Field):
     """ Serialized fields provide the storage for sparse fields. """
     type = 'serialized'
-    column_type = ('text', 'text')
+    column_type = ('jsonb', 'jsonb')
 
     prefetch = False                    # not prefetched by default
 
@@ -90,6 +105,26 @@ class Serialized(fields.Field):
 
     def convert_to_record(self, value, record):
         return json.loads(value or "{}")
+
+    def update_db(self, model, columns):
+        res = super().update_db(model, columns)
+        if self.store:
+            constraint_name = f"{model._table}_{self.name}_jsonobject"
+            definition = f"CHECK (jsonb_typeof({self.name}) = 'object')"
+            current_definition = tools.constraint_definition(
+                model._cr, model._table, constraint_name
+            )
+            if current_definition != definition:
+                if current_definition:
+                    tools.drop_constraint(model._cr, model._table, constraint_name)
+                model.pool.post_constraint(
+                    tools.add_constraint,
+                    model._cr,
+                    model._table,
+                    constraint_name,
+                    definition,
+                )
+        return res
 
 
 fields.Serialized = Serialized

--- a/addons/base_sparse_field/tests/test_sparse_fields.py
+++ b/addons/base_sparse_field/tests/test_sparse_fields.py
@@ -7,7 +7,8 @@ class TestSparseFields(common.TransactionCase):
 
     def test_sparse(self):
         """ test sparse fields. """
-        record = self.env['sparse_fields.test'].create({})
+        SparseFieldTest = self.env['sparse_fields.test']
+        record = SparseFieldTest.create({})
         self.assertFalse(record.data)
 
         partner = self.env.ref('base.main_partner')
@@ -23,9 +24,18 @@ class TestSparseFields(common.TransactionCase):
             record.write({key: val})
             self.assertEqual(record.data, dict(values[:n+1]))
 
+        # Flush records so they can be searched
+        self.env.flush_all()
+        self.env.cr.flush()
+
         for key, val in values[:-1]:
             self.assertEqual(record[key], val)
         self.assertEqual(record.partner, partner)
+
+        for n, (key, val) in enumerate(values):
+            with self.subTest(field_value=key):
+                self.assertEqual(record, SparseFieldTest.search([(key, '=', val)]))
+                self.assertNotEqual(record, SparseFieldTest.search([(key, '!=', val)]))
 
         for n, (key, _val) in enumerate(values):
             record.write({key: False})

--- a/doc/cla/individual/psevertson.md
+++ b/doc/cla/individual/psevertson.md
@@ -1,0 +1,11 @@
+United States, 2024-05-15
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Porter Severtson portersevertson@gmail.com https://github.com/psevertson


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
- Adds the ability to search by sparse fields
- Adds constraints to serialized fields so they are always json object type (to make searching possible)

Current behavior before PR:
- Sparse fields are not searchable. While sparse fields are useful to prevent bloat of extra columns & foreign keys, it would be useful to be able to search by them when needed
- Serialized fields can be any text in SQL. This means you can write non-jsonobject data to the field, which is not the intention, can would break trying to read from the field

Desired behavior after PR is merged:
- Sparse fields become searchable by normal domains.
- Serialized fields are constrained to SQL type JSONB, and get a check constraint to make sure it's a json_object



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
