### PR TITLE
[FIX] web_editor: prevent valueerror for Unsupported file

### DIFF
--- a/addons/web_editor/controllers/main.py
+++ b/addons/web_editor/controllers/main.py
@@ -699,7 +699,10 @@ class Web_Editor(http.Controller):
                     raise werkzeug.exceptions.NotFound()
             svg = attachment.raw.decode('utf-8')
         else:
-            svg = self._get_shape_svg(module, 'shapes', filename)
+            try:
+                svg = self._get_shape_svg(module, 'shapes', filename)
+            except ValueError:
+                raise werkzeug.exceptions.NotFound()
 
         svg, options = self._update_svg_colors(kwargs, svg)
         flip_value = options.get('flip', False)


### PR DESCRIPTION
The error arises because ``file_open`` is called with a file path that includes a ``.css`` extension, which is not supported in this context where a ``.svg`` file is expected.

Error: 
``ValueError: Unsupported file: actuator;/static/shapes/env;.css``

This commit adds a try-catch block to handle a ValueError when an unsupported file is added.

sentry-5163461799

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
