### PR TITLE
[FIX] website: prevent valueerror for NUL characters

### DIFF
--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -47,7 +47,7 @@ class WebsiteForm(http.Controller):
                     kwargs.pop('model_name')
                     return self._handle_website_form(model_name, **kwargs)
             error = _("Suspicious activity detected by Google reCaptcha.")
-        except (ValidationError, UserError) as e:
+        except (ValidationError, UserError, ValueError) as e:
             error = e.args[0]
         return json.dumps({
             'error': error,


### PR DESCRIPTION
This error often occurs when the data submitted through forms contains NUL characters.

Error: 
``ValueError: A string literal cannot contain NUL (0x00) characters.``

This commit will catch ValueError when the data with NUL characters is submitted through forms.

sentry-5049576227

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
