### PR TITLE
[FIX] stock: prevent an error  when creating a stock quant

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -264,7 +264,7 @@
                         domain="[('product_id', '=', product_id), ('location_id', 'child_of', picking_location_id)]"
                         context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'tree_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
                         widget="pick_from"
-                        options="{'no_open': True}"/>
+                        options="{'no_open': True, 'no_create': True}"/>
                     <field name="lot_id" column_invisible="context.get('show_lots_text')" groups="stock.group_production_lot" invisible="not lots_visible" context="{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id}" optional="show"/>
                     <field name="lot_name" column_invisible="not context.get('show_lots_text')"  groups="stock.group_production_lot" invisible="not lots_visible" context="{'default_product_id': product_id}"/>
                     <field name="location_dest_id" options="{'no_create': True}" column_invisible="context.get('picking_code') == 'outgoing'" groups="stock.group_stock_multi_locations" domain="[('id', 'child_of', picking_location_dest_id), '|', ('company_id', '=', False), ('company_id', '=', company_id), ('usage', '!=', 'view')]"/>


### PR DESCRIPTION
Currently, an error occurs when creating a stock quant (Pick From) in the 'Detailed Operations' list view.

Step to produce:

- Install the 'stock' module.
- Go to Inventory / Operations / Transfers / Receipts and create a receipt, add 'Receive From', and also add 'Product' and 'Demand' in Operations.
- Click on 'Validate' then click on 'Return', and open 'Detailed Operations'.
- Now try to create a new stock quant (Pick From) from a list view.

```ValueError: Wrong container value 'WH/Stock'```

An error occurs when attempting to create or edit a 'picked'(Pick From) in the list view of 'Detailed Operations' and the system raises a value error at [1] as 'product_id takes a string instead of an integer' in default values.

link[1]: https://github.com/odoo/odoo/blob/259cba71690c500c335a4a2c43e4c606697bc817/odoo/fields.py#L3582-L3583

To resolve the issue, restricted to creating a stock quant from the 'Detailed Operations' list view

sentry-5089715517

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
