### PR TITLE
[FIX] mail: error on leaving channel

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -353,9 +353,6 @@ class Channel(models.Model):
         # channel_info is called before actually unpinning the channel
         channel_info['is_pinned'] = False
         notification = Markup('<div class="o_mail_notification">%s</div>') % _('left the channel')
-        # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
-        self.sudo().message_post(body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id)
-        self.env['bus.bus']._sendone(partner, 'discuss.channel/leave', channel_info)
         self.env['bus.bus']._sendone(self, 'mail.record/insert', {
             'Thread': {
                 'channelMembers': [('DELETE', {'id': member.id})],
@@ -364,6 +361,9 @@ class Channel(models.Model):
                 'model': "discuss.channel",
             }
         })
+        # sudo: mail.message - post as sudo since the user just unsubscribed from the channel
+        self.sudo().message_post(body=notification, subtype_xmlid="mail.mt_comment", author_id=partner.id)
+        self.env['bus.bus']._sendone(partner, 'discuss.channel/leave', channel_info)
 
     def add_members(self, partner_ids=None, guest_ids=None, invite_to_rtc_call=False, open_chat_window=False, post_joined_message=True):
         """ Adds the given partner_ids and guest_ids as member of self channels. """

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -777,8 +777,8 @@ export class Thread extends Record {
     }
 
     async leave() {
-        await this.store.env.services.orm.call("discuss.channel", "action_unfollow", [this.id]);
         this.delete();
+        await this.store.env.services.orm.call("discuss.channel", "action_unfollow", [this.id]);
         const thread = this.store.discuss.channels.threads[0]
             ? this.store.discuss.channels.threads[0]
             : this.store.discuss.inbox;


### PR DESCRIPTION
**Current behavior before PR:**

when leaving discuss channel from discuss it results in error because leave notification is send to the leaving person itself.

**Desired behavior after PR is merged:**

The issue was resolved by replacing the logic. Now, before sending a notification to the channel, we remove the channel member and the channel itself from the thread of the person leaving.

task-3893498
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
