### PR TITLE
[FIX] account: fix traceback when the user doesn't give from or to value while updating a record

### DIFF
--- a/addons/account/i18n/account.pot
+++ b/addons/account/i18n/account.pot
@@ -6829,7 +6829,9 @@ msgstr ""
 #. module: account
 #: code:addons/account/models/partner.py:0
 #, python-format
-msgid "Invalid \"Zip Range\", please configure it properly."
+msgid ""
+"Invalid \"Zip Range\", You have to configure both \"From\" and \"To\" values"
+" for the zip range and \"To\" should be greater than \"From\"."
 msgstr ""
 
 #. module: account

--- a/addons/account/models/partner.py
+++ b/addons/account/models/partner.py
@@ -70,8 +70,8 @@ class AccountFiscalPosition(models.Model):
     @api.constrains('zip_from', 'zip_to')
     def _check_zip(self):
         for position in self:
-            if position.zip_from and position.zip_to and position.zip_from > position.zip_to:
-                raise ValidationError(_('Invalid "Zip Range", please configure it properly.'))
+            if bool(position.zip_from) != bool(position.zip_to) or position.zip_from > position.zip_to:
+                raise ValidationError(_('Invalid "Zip Range", You have to configure both "From" and "To" values for the zip range and "To" should be greater than "From".'))
 
     @api.constrains('country_id', 'state_ids', 'foreign_vat')
     def _validate_foreign_vat_country(self):
@@ -141,11 +141,12 @@ class AccountFiscalPosition(models.Model):
 
     @api.model
     def _convert_zip_values(self, zip_from='', zip_to=''):
-        max_length = max(len(zip_from), len(zip_to))
-        if zip_from.isdigit():
-            zip_from = zip_from.rjust(max_length, '0')
-        if zip_to.isdigit():
-            zip_to = zip_to.rjust(max_length, '0')
+        if zip_from and zip_to:
+            max_length = max(len(zip_from), len(zip_to))
+            if zip_from.isdigit():
+                zip_from = zip_from.rjust(max_length, '0')
+            if zip_to.isdigit():
+                zip_to = zip_to.rjust(max_length, '0')
         return zip_from, zip_to
 
     @api.model

--- a/addons/account/tests/test_fiscal_position.py
+++ b/addons/account/tests/test_fiscal_position.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo.tests import common
+from odoo.exceptions import ValidationError
 
 
 class TestFiscalPosition(common.TransactionCase):
@@ -268,3 +269,38 @@ class TestFiscalPosition(common.TransactionCase):
             self.env['account.fiscal.position'].get_fiscal_position(partner_us_no_vat.id, partner_us_no_vat.id),
             fp_eu_extra
         )
+
+    def test_fiscal_position_constraint(self):
+        """
+        Test fiscal position constraint by updating the record
+        - with only zip_from value
+        - with only zip_to value
+        - with both zip_from and zip_to values
+        """
+        fiscal_position = self.fp.create({
+            'name': 'Test fiscal',
+            'auto_apply': True,
+            'country_id': self.be.id,
+            'vat_required': True,
+            'sequence': 10,
+        })
+        with self.assertRaises(ValidationError):
+            fiscal_position.write({
+                'zip_from' : '123',
+            })
+        with self.assertRaises(ValidationError):
+            fiscal_position.write({
+                'zip_to': '456',
+            })
+        fiscal_position.write({
+            'zip_from': '123',
+            'zip_to': '456',
+        })
+
+        self.assertRecordValues(fiscal_position, [{
+            'name': 'Test fiscal',
+            'auto_apply': True,
+            'country_id': self.be.id,
+            'zip_from': '123',
+            'zip_to': '456',
+        }])


### PR DESCRIPTION
This traceback occurs when the user tries to update a `fiscal position` record 
by giving either only `from` or `to` value to `zip` range.

To reproduce this issue:-

1) Install `Accounting`
2) Create a new `fiscal position` from `Accounting/Configuration` without
  `Detect Automatically`
3) Now update the record by enabling `Detect Automatically` 
4) Select any country and give only the `from` value for `Zip Range` 
5) Save the record

Error:-
``` 
TypeError: object of type 'bool' has no len()
```
When the user updates the `fiscal position` with only `from or to` 
It triggers `_convert_zip_values` method with one from both. 
This leads to traceback, as `max()` is used between from and to.

https://github.com/odoo/odoo/blob/eb04acf011838d9c8206bedd1908f7a991eb77e3/addons/account/models/partner.py#L143-L144
After applying this commit will resolve this issue by making the code more robust with an additional check.

sentry-5284424770