### PR TITLE
[IMP] calendar: land on the same date when going back

### DIFF
--- a/addons/calendar/static/tests/calendar_tests.js
+++ b/addons/calendar/static/tests/calendar_tests.js
@@ -5,6 +5,7 @@ import { makeView, setupViewRegistries } from "@web/../tests/views/helpers";
 
 let serverData;
 let target;
+const uid = -1;
 
 QUnit.module(
     "calendar",
@@ -125,5 +126,157 @@ QUnit.module(
             );
             assert.verifySteps(["get_attendee_detail"]);
         });
+
+        QUnit.debug("Land on the same date when going back", async function(assert) {
+            assert.expect(0);
+            serverData = {
+                models: {
+                    'calendar.event': {
+                        fields: {
+                            id: {string: "ID", type: "integer"},
+                            user_id: {string: "user", type: "many2one", relation: 'user'},
+                            partner_id: {string: "user", type: "many2one", relation: 'partner', related: 'user_id.partner_id'},
+                            name: {string: "name", type: "char"},
+                            start_date: {string: "start date", type: "date"},
+                            stop_date: {string: "stop date", type: "date"},
+                            start: {string: "start datetime", type: "datetime"},
+                            stop: {string: "stop datetime", type: "datetime"},
+                            allday: {string: "allday", type: "boolean"},
+                            partner_ids: {string: "attendees", type: "one2many", relation: 'partner'},
+                            type: {string: "type", type: "integer"},
+                        },
+                        records: [
+                            {id: 5, user_id: uid, partner_id: 4, name: "event 1", start: "2016-12-13 15:55:05", stop: "2016-12-15 18:55:05", allday: false, partner_ids: [4], type: 2},
+                            {id: 6, user_id: uid, partner_id: 5, name: "event 2", start: "2016-12-18 08:00:00", stop: "2016-12-18 09:00:00", allday: false, partner_ids: [4], type: 3}
+                        ],
+                        check_access_rights: function () {
+                            return Promise.resolve(true);
+                        }
+                    },
+                    'appointment.type': {
+                        fields: {},
+                        records: [],
+                    },
+                    user: {
+                        fields: {
+                            id: {string: "ID", type: "integer"},
+                            display_name: {string: "Displayed name", type: "char"},
+                            partner_id: {string: "partner", type: "many2one", relation: 'partner'},
+                            image_1920: {string: "image", type: "integer"},
+                        },
+                        records: [
+                            {id: 4, display_name: "user 4", partner_id: 4},
+                        ]
+                    },
+                    partner: {
+                        fields: {
+                            id: {string: "ID", type: "integer"},
+                            display_name: {string: "Displayed name", type: "char"},
+                            image_1920: {string: "image", type: "integer"},
+                        },
+                        records: [
+                            {id: 4, display_name: "partner 4", image_1920: 'DDD'},
+                            {id: 5, display_name: "partner 5", image_1920: 'DDD'},
+                        ]
+                    },
+                    filter_partner: {
+                        fields: {
+                            id: {string: "ID", type: "integer"},
+                            user_id: {string: "user", type: "many2one", relation: 'user'},
+                            partner_id: {string: "partner", type: "many2one", relation: 'partner'},
+                            partner_checked: {string: "checked", type: "boolean"},
+                        },
+                        records: [
+                            {id: 3, user_id: uid, partner_id: 4, partner_checked: true}
+                        ]
+                    },
+                },
+                views: {
+                    "calendar.event,false,form": `
+                        <form>
+                            <field name="name" />
+                            <field name="allday" />
+                            <group attrs="{'invisible': [['allday', '=', True]]}">
+                                <field name="start" />
+                                <field name="stop" />
+                            </group>
+                            <group attrs="{'invisible': [['allday', '=', False]]}">
+                                <field name="start_date" />
+                                <field name="stop_date" />
+                            </group>
+                        </form>
+                    `,
+                },
+            };
+
+            await makeView({
+                type: "calendar",
+                resModel: 'calendar.event',
+                serverData,
+                arch:
+                '<calendar class="o_calendar_test" '+
+                    'js_class="attendee_calendar" '+
+                    'date_start="start" '+
+                    'date_stop="stop" '+
+                    'attendee="partner_ids">'+
+                        '<field name="name"/>'+
+                        '<field name="partner_ids" write_model="filter_partner" write_field="partner_id"/>'+
+                '</calendar>',
+                mockRPC: async function (route, args, method) {
+                    console.log("ROUTE: ", route);
+                    console.log("ARGS: ", args);
+                    console.log("METHOD: ", method);
+                    console.log(route === "/web/dataset/call_kw/calendar.event/get_views")
+                    if(args.kwargs && args.kwargs.views){
+                        console.log("HERE: ", args.kwargs.views[0]);
+                    }
+                    if (route === '/web/dataset/call_kw/res.partner/get_attendee_detail') {
+                        return Promise.resolve([]);
+                    } else if (route === '/web/dataset/call_kw/res.users/has_group') {
+                        return Promise.resolve(true);
+                    } 
+                    else if (route === "/web/dataset/call_kw/calendar.event/get_views" && args.kwargs && args.kwargs.views && args.kwargs.views[0][1] === "form"){
+                        
+                        await makeView({
+                            type: "calendar",
+                            resModel: "calendar.event",
+                            serverData,
+                            arch: `
+                                <form>
+                                    <field name="name" />
+                                    <field name="allday" />
+                                    <group attrs="{'invisible': [['allday', '=', True]]}">
+                                        <field name="start" />
+                                        <field name="stop" />
+                                    </group>
+                                    <group attrs="{'invisible': [['allday', '=', False]]}">
+                                        <field name="start_date" />
+                                        <field name="stop_date" />
+                                    </group>
+                                </form>
+                            `
+                        })
+                        // return Promise.resolve({
+                        //     "result": {
+                        //         "views": {
+                        //             "form": `
+                        //                 <form>
+                        //                     <group>
+                        //                         <field name="name" />
+                        //                         <field name="start" />
+                        //                         <field name="stop" />
+                        //                         <field name="user_id" />
+                        //                     </group>
+                        //                 </form>
+                        //             `,
+                        //             "search": `<search />`,
+                        //         }
+                        //     }
+                        // })
+                    }
+                },
+            });
+
+        })
     }
 );

--- a/addons/web/static/src/views/calendar/calendar_controller.js
+++ b/addons/web/static/src/views/calendar/calendar_controller.js
@@ -45,6 +45,7 @@ export class CalendarController extends Component {
             resModel: this.props.resModel,
             domain: this.props.domain,
             fields: this.props.fields,
+            date: this.props.state ? this.props.state.date : undefined,
         });
         this.displayName = this.env.config.getDisplayName();
 

--- a/addons/web/static/tests/views/calendar/calendar_view_tests.js
+++ b/addons/web/static/tests/views/calendar/calendar_view_tests.js
@@ -478,6 +478,38 @@ QUnit.module("Views", ({ beforeEach }) => {
         );
     });
 
+    // QUnit.debug("land on the same date range when going back", async (assert) => {
+    //     assert.expect(2);
+    //     await makeView({
+    //         type: "calendar",
+    //         resModel: "event",
+    //         serverData,
+    //         arch: `<calendar date_start="start" date_stop="stop" all_day="allday" can_create="true"/>`,
+    //     });
+    //     assert.strictEqual(
+    //         target.querySelector(".o_control_panel .breadcrumb-item.active").textContent,
+    //         "undefined (Dec 11 – 17, 2016)",
+    //         "should display the current week"
+    //     );
+    //     await navigate(target, "next");
+    //     await new Promise(resolve => setTimeout(resolve, 10));
+    //     assert.strictEqual(
+    //         target.querySelector(".o_control_panel .breadcrumb-item.active").textContent,
+    //         "undefined (Dec 18 – 24, 2016)",
+    //         "should display the next week"
+    //     );
+
+    //     await click(target, ".o_calendar_create_buttons o-calendar-button-new")
+    //     await new Promise(resolve => setTimeout(resolve, 10));
+    //     await click(target, ".o_control_panel .o_back_button");
+    //     await new Promise(resolve => setTimeout(resolve, 10));
+    //     assert.strictEqual(
+    //         target.querySelector(".o_control_panel .breadcrumb-item.active").textContent,
+    //         "undefined (Dec 18 – 24, 2016)",
+    //         "should display the next week"
+    //     );
+    // });
+
     QUnit.test("filter panel autocomplete: updates when typing", async (assert) => {
         await makeView({
             type: "calendar",


### PR DESCRIPTION
Before this commit when navigating to a week in the future, then create a new meeting and then going back to meetings, we go back to the current day not the week we were at.

This commit changes the behavior so that when going back it leads to the place where were at previously.

Task: 3874838
