### PR TITLE
[IMP] account_*: add late payment charges facility

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -731,6 +731,18 @@ class AccountChartTemplate(models.AbstractModel):
                 'code': '999997',
                 'account_type': 'income_other',
             },
+            'account_journal_interest_income_account_id': {
+                'name': _("Interest Income"),
+                'prefix': '451',
+                'code_digits': code_digits,
+                'account_type': 'income_other',
+            },
+            'account_journal_interest_expense_account_id': {
+                'name': _("Interest Expense"),
+                'prefix': '444',
+                'code_digits': code_digits,
+                'account_type': 'expense',
+            },
             'default_cash_difference_income_account_id': {
                 'name': _("Cash Difference Gain"),
                 'prefix': '999',

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -72,6 +72,8 @@ class ResCompany(models.Model):
     account_journal_payment_credit_account_id = fields.Many2one('account.account', string='Journal Outstanding Payments', check_company=True)
     account_journal_early_pay_discount_gain_account_id = fields.Many2one(comodel_name='account.account', string='Cash Discount Write-Off Gain Account', check_company=True)
     account_journal_early_pay_discount_loss_account_id = fields.Many2one(comodel_name='account.account', string='Cash Discount Write-Off Loss Account', check_company=True)
+    account_journal_interest_income_account_id = fields.Many2one(comodel_name='account.account', string='Interest Income Account', check_company=True)
+    account_journal_interest_expense_account_id = fields.Many2one(comodel_name='account.account', string='Interest Expense Account', check_company=True)
     transfer_account_code_prefix = fields.Char(string='Prefix of the transfer accounts')
     account_sale_tax_id = fields.Many2one('account.tax', string="Default Sale Tax", check_company=True)
     account_purchase_tax_id = fields.Many2one('account.tax', string="Default Purchase Tax", check_company=True)
@@ -96,6 +98,7 @@ class ResCompany(models.Model):
     bank_journal_ids = fields.One2many('account.journal', 'company_id', domain=[('type', '=', 'bank')], string='Bank Journals')
     incoterm_id = fields.Many2one('account.incoterms', string='Default incoterm',
         help='International Commercial Terms are a series of predefined commercial terms used in international transactions.')
+    account_lpc_product_id = fields.Many2one('product.product')
 
     qr_code = fields.Boolean(string='Display QR-code on invoices')
 

--- a/addons/account/models/res_config_settings.py
+++ b/addons/account/models/res_config_settings.py
@@ -196,6 +196,22 @@ class ResConfigSettings(models.TransientModel):
         related='company_id.account_journal_early_pay_discount_gain_account_id',
         domain="[('deprecated', '=', False), ('account_type', 'in', ('income', 'income_other', 'expense'))]",
     )
+    account_journal_late_pay_charges_expense_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Late Pay Expense',
+        readonly=False,
+        related='company_id.account_lpc_product_id.property_account_expense_id',
+        check_company=True,
+        domain="[('deprecated', '=', False), ('account_type', 'in', ('expense', 'income', 'income_other'))]",
+    )
+    account_journal_late_pay_charges_income_account_id = fields.Many2one(
+        comodel_name='account.account',
+        string='Late Pay Income',
+        readonly=False,
+        check_company=True,
+        related='company_id.account_lpc_product_id.property_account_income_id',
+        domain="[('deprecated', '=', False), ('account_type', 'in', ('income', 'income_other', 'expense'))]",
+    )
 
     # Accounts for allocation of discounts
     account_discount_income_allocation_id = fields.Many2one(

--- a/addons/account/tests/common.py
+++ b/addons/account/tests/common.py
@@ -248,12 +248,14 @@ class AccountTestInvoicingCommon(ProductCommon):
             'default_account_revenue': cls.env['account.account'].search([
                     ('company_id', '=', company.id),
                     ('account_type', '=', 'income'),
-                    ('id', '!=', company.account_journal_early_pay_discount_gain_account_id.id)
+                    ('id', '!=', company.account_journal_early_pay_discount_gain_account_id.id),
+                    ('id', '!=', company.account_journal_interest_income_account_id.id),
                 ], limit=1),
             'default_account_expense': cls.env['account.account'].search([
                     ('company_id', '=', company.id),
                     ('account_type', '=', 'expense'),
-                    ('id', '!=', company.account_journal_early_pay_discount_loss_account_id.id)
+                    ('id', '!=', company.account_journal_early_pay_discount_loss_account_id.id),
+                    ('id', '!=', company.account_journal_interest_expense_account_id.id),
                 ], limit=1),
             'default_account_receivable': cls.env['ir.property'].with_company(company)._get(
                 'property_account_receivable_id', 'res.partner'

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -826,6 +826,12 @@
                                         <span class="o_stat_text">Cash Basis Entries</span>
                                     </div>
                             </button>
+                            <button type="object" class="oe_stat_button" name="action_view_lpc_notes" icon="fa-plus" invisible="lpc_note_sum == 0">
+                                <div class="o_field_widget o_stat_info">
+                                    <span class="o_stat_value"><field name="lpc_note_sum"/></span>
+                                    <span class="o_stat_text">Late Pay Charges</span>
+                                </div>
+                            </button>
                         </div>
 
                         <!-- Payment status for invoices / receipts -->

--- a/addons/account/views/account_payment_term_views.xml
+++ b/addons/account/views/account_payment_term_views.xml
@@ -43,23 +43,45 @@
                         </div>
                         <group>
                             <field name="company_id" options="{'no_create': True}" class="w-25" groups="base.group_multi_company"/>
-                            <label for="early_discount"/>
-                            <div class="o_field_highlight">
-                                <field name="early_discount"/>
-                                <field name="discount_percentage"
-                                       class="text-end o_field_highlight o_input oe_inline"
-                                       invisible="not early_discount"/>
-                                <span invisible="not early_discount"> % if paid within </span>
-                                <field name="discount_days"
-                                       class="text-end o_field_highlight o_input oe_inline"
-                                       invisible="not early_discount"/>
-                                <span invisible="not early_discount"> days</span>
-                                <div invisible="not early_discount">
-                                    <span> Reduced tax:
-                                        <field name="early_pay_discount_computation" class="w-auto"/>
-                                    </span>
+                        </group>
+                        <group>
+                            <group>
+                                <label for="early_discount"/>
+                                <div class="o_field_highlight">
+                                    <field name="early_discount"/>
+                                    <field name="discount_percentage"
+                                        class="text-end o_field_highlight o_input oe_inline"
+                                        invisible="not early_discount"/>
+                                    <span invisible="not early_discount"> % if paid within </span>
+                                    <field name="discount_days"
+                                        class="text-end o_field_highlight o_input oe_inline"
+                                        invisible="not early_discount"/>
+                                    <span invisible="not early_discount"> days</span>
+                                    <div invisible="not early_discount">
+                                        <span> Reduced tax:
+                                            <field name="early_pay_discount_computation" class="w-auto"/>
+                                        </span>
+                                    </div>
                                 </div>
-                            </div>
+                            </group>
+                            <group>
+                                <label for="late_payment_charges"/>
+                                <div class="o_field_highlight">
+                                    <field name="late_payment_charges"/>
+                                    <field name="late_payment_charges_value"
+                                        class="text-end o_field_highlight o_input" style="width: 100px;" invisible="not late_payment_charges"/>
+                                    <span invisible="late_payment_charges_type in ['flat', 'flat_inst'] or not late_payment_charges"> % </span>
+                                    <span invisible="late_payment_charges_type not in ['flat', 'flat_inst'] or not late_payment_charges"> <field name="currency_symbol" class="w-auto"/> </span>
+                                    <field name="late_payment_charges_type" class="w-auto" invisible="not late_payment_charges"/>
+                                    <span title="days are calculated from due date" invisible="not late_payment_charges"> if paid after <field name="late_payment_charges_days"
+                                        class="text-end o_field_highlight o_input" style="width: 100px;"/> days from due date
+                                    </span>
+                                    <div invisible="not late_payment_charges">
+                                        <span> Calculate Int on: </span>
+                                        <field name="late_payment_charges_computation" class="w-auto"/>
+                                    </div>
+                                </div>
+                            </group>
                         </group>
                         <group>
                             <group string="Due Terms">

--- a/addons/account/views/res_config_settings_views.xml
+++ b/addons/account/views/res_config_settings_views.xml
@@ -311,6 +311,18 @@
                                         </div>
                                     </div>
                                 </setting>
+                                <setting string="Post Late Pay Charges in:">
+                                    <div class="content-group">
+                                        <div class="row mt8">
+                                            <label for="account_journal_late_pay_charges_income_account_id" class="col-lg-5 o_light_label"/>
+                                            <field name="account_journal_late_pay_charges_income_account_id"/>
+                                        </div>
+                                        <div class="row mt8">
+                                            <label for="account_journal_late_pay_charges_expense_account_id" class="col-lg-5 o_light_label"/>
+                                            <field name="account_journal_late_pay_charges_expense_account_id"/>
+                                        </div>
+                                    </div>
+                                </setting>
                             </block>
                         </t>
 

--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -12,6 +12,8 @@
                     <field name="can_edit_wizard" invisible="1" force_save="1"/>
                     <field name="can_group_payments" invisible="1" force_save="1"/>
                     <field name="early_payment_discount_mode" invisible="1" force_save="1"/>
+                    <field name="lpc_eligibility" invisible="1" force_save="1"/>
+                    <field name="lpc_product_id" invisible="1" force_save="1"/>
                     <field name="payment_type" invisible="1" force_save="1"/>
                     <field name="partner_type" invisible="1" force_save="1"/>
                     <field name="source_amount" invisible="1" force_save="1"/>
@@ -35,6 +37,9 @@
 
                     <div role="alert" class="alert alert-info" invisible="not hide_writeoff_section">
                         <p><b>Early Payment Discount of <field name="payment_difference"/> has been applied.</b></p>
+                    </div>
+                    <div role="alert" class="alert alert-warning" invisible="not lpc_eligibility">
+                        <p><b>Late pay penalty is applied</b>, and a new debit note will be created. For more information, refer to the debit note.</p>
                     </div>
                     <div role="alert" class="alert alert-warning" invisible="untrusted_payments_count == 0">
                         <span class="fw-bold"><field name="untrusted_payments_count" class="oe_inline"/> out of <field name="total_payments_amount" class="oe_inline"/> payments will be skipped due to <button class="oe_link p-0 align-baseline" type="object" name="action_open_untrusted_bank_accounts">untrusted bank accounts</button>.</span>
@@ -67,6 +72,8 @@
                                        options="{'no_create': True, 'no_open': True}"
                                        groups="base.group_multi_currency"/>
                             </div>
+                            <field name="account_lpc_income_id" invisible='lpc_product_id or not lpc_eligibility'/>
+                            <field name="account_lpc_expense_id" invisible='lpc_product_id or not lpc_eligibility'/>
                             <field name="payment_date"/>
                             <field name="communication"
                                    invisible="not can_edit_wizard or (can_group_payments and not group_payment)"/>

--- a/addons/account_debit_note/models/__init__.py
+++ b/addons/account_debit_note/models/__init__.py
@@ -2,3 +2,4 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import account_move
+from . import account_payment_register

--- a/addons/account_debit_note/models/account_payment_register.py
+++ b/addons/account_debit_note/models/account_payment_register.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class AccountPaymentRegister(models.TransientModel):
+    _inherit = 'account.payment.register'
+
+    def _get_lpc_note_default_values(self, move):
+        default_values = super()._get_lpc_note_default_values(move)
+        default_values['debit_origin_id'] = move.id
+        return default_values

--- a/addons/spreadsheet_account/tests/test_account_group.py
+++ b/addons/spreadsheet_account/tests/test_account_group.py
@@ -10,7 +10,7 @@ class SpreadsheetAccountGroupTest(AccountTestInvoicingCommon):
         self.assertEqual(self.env["account.account"].get_account_group([]), [])
 
     def test_fetch_account_one_group(self):
-        self.assertEqual(self.env["account.account"].get_account_group(['income_other']), [['450000']])
+        self.assertEqual(self.env["account.account"].get_account_group(['income_other']), [['450000', '451001']])
 
     def test_group_with_no_account(self):
         self.env['account.account']\
@@ -35,7 +35,7 @@ class SpreadsheetAccountGroupTest(AccountTestInvoicingCommon):
 
         self.assertEqual(
             [sorted(x) for x in self.env['account.account'].get_account_group(['income_other'])],
-            [['123', '450000', '789']],
+            [['123', '450000', '451001', '789']],
         )
 
     def test_response_is_ordered(self):


### PR DESCRIPTION
With this **PR** late payment charge option is provided in payment terms.
Penalties can be applied to both the total or taxable amounts. Seven different
ways are provided for calculating penalties:

1) **Monthly**      : Penalty is calculated at the given rate for each month from
                  due date to payment date.
2) **Quarterly**    : Penalty is calculated at the given rate for each fiscal
                  quarter from due date to payment date.
3) **Half-Yearly**  : Penalty is calculated at the given rate for each fiscal
                  half-year from due date to payment date.
4) **Yearly**       : Penalty is calculated at the given rate for each fiscal year
                  from due date to payment date.
5) **Fixed**        : A fixed penalty is charged at the given rate regardless of the
                  payment date.
6) **Flat**         : A flat amount is charged as a penalty.
7) **Flat per Inst**: A flat amount is charged as a penalty per installment.

Late charges are applied if an invoice/bill is overdue. A new debit note is
created with a late payment charges product and its corresponding penalty amount
in draft state, referring to its parent invoice/bill. The late payment charges
product is created when a late penalty is applied for the first time in a
database.

**task**-3774599