### PR TITLE
[FIX] web: make the fields readonly in x2many when mode readonly

### DIFF
--- a/addons/web/static/src/views/fields/boolean/boolean_field.js
+++ b/addons/web/static/src/views/fields/boolean/boolean_field.js
@@ -21,6 +21,10 @@ export class BooleanField extends Component {
         });
     }
 
+    get isReadonly() {
+        return this.props.readonly;
+    }
+
     /**
      * @param {boolean} newValue
      */

--- a/addons/web/static/src/views/fields/boolean/boolean_field.xml
+++ b/addons/web/static/src/views/fields/boolean/boolean_field.xml
@@ -2,7 +2,7 @@
 <templates xml:space="preserve">
 
     <t t-name="web.BooleanField">
-        <CheckBox id="props.id" value="state.value" className="'d-inline-block'" disabled="props.readonly" onChange.bind="onChange" />
+        <CheckBox id="props.id" value="state.value" className="'d-inline-block'" disabled="isReadonly" onChange.bind="onChange" />
     </t>
 
 </templates>

--- a/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
+++ b/addons/web/static/src/views/fields/boolean_toggle/boolean_toggle_field.js
@@ -11,6 +11,11 @@ export class BooleanToggleField extends BooleanField {
         autosave: { type: Boolean, optional: true },
     };
 
+    get isReadonly() {
+        const { record, readonly } = this.props;
+        return record.model.config?.mode === 'readonly' || readonly;
+    }
+
     async onChange(newValue) {
         this.state.value = newValue;
         const changes = { [this.props.name]: newValue };

--- a/addons/web/static/tests/views/fields/one2many_field_tests.js
+++ b/addons/web/static/tests/views/fields/one2many_field_tests.js
@@ -3846,6 +3846,43 @@ QUnit.module("Fields", (hooks) => {
         );
     });
 
+    QUnit.test(
+        "Boolean toggle in x2many must not be editable if form is not editable",
+        async function (assert) {
+            assert.expect(7);
+            serverData.views = {
+                "turtle,false,form":
+                    '<form><field name="turtle_bar" widget="boolean_toggle"/></form>',
+            };
+
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                serverData,
+                arch: `
+                    <form edit="0">
+                        <field name="turtles">
+                            <tree>
+                                <field name="turtle_bar" widget="boolean_toggle"/>
+                            </tree>
+                        </field>
+                    </form>`,
+                resId: 1,
+            });
+
+            assert.hasClass(target.querySelector("div.o_form_renderer"), "o_form_readonly");
+            assert.hasClass(target.querySelector("div.o_list_view"), "o_field_x2many o_field_x2many_list");
+            var $booleanToggle = target.querySelector('.o_data_row .o_boolean_toggle input');
+            assert.ok($booleanToggle.disabled, "The boolean toggle should be disabled when the form is readonly");
+            await click(target, ".o_data_cell");
+            assert.containsOnce(target, "div.modal-dialog");
+            assert.hasClass(target.querySelector("div.modal-content"), "o_form_view");
+            assert.hasClass(target.querySelector("div.o_form_renderer"), "o_form_readonly");
+            var $booleanToggle2 = target.querySelector("div.o-checkbox input[type='checkbox']");
+            assert.ok($booleanToggle2.disabled, "The boolean toggle should be disabled when the form is readonly");
+        }
+    );
+
     QUnit.test("many2many list: unlink two records", async function (assert) {
         assert.expect(4);
         serverData.models.partner.records[0].p = [1, 2, 4];


### PR DESCRIPTION
Before this commit:

When a form view was set to non-editable (edit="0"), its x2many fields could still contain editable boolean fields (e.g., Boolean Toggle).

After this commit:
Boolean fields within x2many fields are now also read-only when the form view is non-editable.

Task-3802653

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
