### PR TITLE
[FIX] base_vat: properly convert HU vat to EU format

### DIFF
--- a/addons/base_vat/models/res_partner.py
+++ b/addons/base_vat/models/res_partner.py
@@ -251,7 +251,8 @@ class ResPartner(models.Model):
         return False
 
     __check_tin_hu_individual_re = re.compile(r'^8\d{9}$')
-    __check_tin_hu_companies_re = re.compile(r'^\d{8}-[1-5]-\d{2}$')
+    __check_tin_hu_companies_re = re.compile(r'^\d{8}-?[1-5]-?\d{2}$')
+    __check_tin_hu_european_re = re.compile(r'^\d{8}$')
 
     def check_vat_hu(self, vat):
         """
@@ -259,12 +260,16 @@ class ResPartner(models.Model):
             - For xxxxxxxx-y-zz, 'x' can be any number, 'y' is a number between 1 and 5 depending on the person and the 'zz'
               is used for region code.
             - 8xxxxxxxxy, Tin number for individual, it has to start with an 8 and finish with the check digit
+            - In case of EU format it will be the first 8 digits of the full VAT
         """
         companies = self.__check_tin_hu_companies_re.match(vat)
         if companies:
             return True
         individual = self.__check_tin_hu_individual_re.match(vat)
         if individual:
+            return True
+        european = self.__check_tin_hu_european_re.match(vat)
+        if european:
             return True
         # Check the vat number
         return stdnum.util.get_cc_module('hu', 'vat').is_valid(vat)


### PR DESCRIPTION
Open web shop
Add item to cart
To to checkout
Enter Customer details
Add as country Hungary and vat 12345678-1-11
Confirm

Error
The VAT number [HU12345678111] does not seem to be valid. Note: the expected format is HU12345676 or 12345678-1-11 or 8071592153

This occurs because, when converting the domestic vat to the EU format, (with the leading country code) all digits are kept

opw-3815478
