### PR TITLE
[FIX] mass_mailing: backport unsubscribe email headers

### DIFF
--- a/addons/mail/models/mail_mail.py
+++ b/addons/mail/models/mail_mail.py
@@ -473,6 +473,8 @@ class MailMail(models.Model):
                 # TDE note: could be great to pre-detect missing to/cc and skip sending it
                 # to go directly to failed state update
                 for email in email_list:
+                    if email.get('headers'):
+                        headers.update(email.get('headers'))
                     msg = IrMailServer.build_email(
                         email_from=email_from,
                         email_to=email.get('email_to'),

--- a/addons/mass_mailing/models/mail_mail.py
+++ b/addons/mass_mailing/models/mail_mail.py
@@ -74,6 +74,19 @@ class MailMail(models.Model):
             for url_to_replace, new_url in urls_to_replace:
                 if url_to_replace in res['body']:
                     res['body'] = res['body'].replace(url_to_replace, new_url if new_url else '#')
+            if urls_to_replace[0][1]:
+                # if we compute a unique unsubscribe URL we prepare the related
+                # unsubscribe email headers for RFC 8058
+                res.update(
+                    {
+                        "headers": {
+                            "List-Unsubscribe": f"<{urls_to_replace[0][1]}>",  # grab one-click unsubscribe link
+                            "List-Unsubscribe-Post": "List-Unsubscribe=One-Click",
+                            "Precedence": "list",
+                            "X-Auto-Response-Suppress": "OOF",  # avoid out-of-office replies from MS Exchange)
+                        }
+                    }
+                )
         return res
 
     def _postprocess_sent_message(self, success_pids, failure_reason=False, failure_type=None):


### PR DESCRIPTION
Starting from 1st June 2024, most major email proivders will start enforcing compliance with RFC 8085 dictating easy unsubscription for marketing emails.

While Odoo 17.0+ is compliant, previous versions did not generate the relevant email headers for outgoing emails (`List-Unsubscribe` and `List-Unsubscribe-Post`).

This commit tries to backport the used approach in 17.0 to be functionally equivalent in versions 15+.

Related github issue https://github.com/odoo/odoo/issues/165169



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
