### PR TITLE
[IMP] survey: add language selector

### DIFF
--- a/addons/hr_recruitment_survey/data/survey_demo.xml
+++ b/addons/hr_recruitment_survey/data/survey_demo.xml
@@ -14,6 +14,7 @@
 <p>
     Thank you for answering this survey. We will come back to you soon.
 </p></field>
+        <field name="lang_ids" eval="False"/>
     </record>
 
     <record id="survey_recruitment_form_p1" model="survey.question">

--- a/addons/survey/data/survey_demo_certification.xml
+++ b/addons/survey/data/survey_demo_certification.xml
@@ -21,6 +21,7 @@
             <field name="certification_give_badge">True</field>
             <field name="certification_badge_id" ref="vendor_certification_badge"/>
             <field name="background_image" type="base64" file="survey/static/src/img/survey_background_2.jpg"/>
+            <field name="lang_ids" eval="False"/>
         </record>
         <!-- Page 1 -->
         <record model="survey.question" id="vendor_certification_page_1">

--- a/addons/survey/data/survey_demo_conditional.xml
+++ b/addons/survey/data/survey_demo_conditional.xml
@@ -12,6 +12,7 @@
         <field name="is_time_limited" >limited</field>
         <field name="time_limit" >10.0</field>
         <field name="questions_layout">page_per_question</field>
+        <field name="lang_ids" eval="False"/>
         <field name="description" type="html">
             <p>Choose your favourite subject and show how good you are. Ready?</p></field>
         <field name="background_image" type="base64" file="survey/static/src/img/burger_quiz_background.webp"/>
@@ -454,6 +455,7 @@
         <field name="user_id" ref="base.user_demo"/>
         <field name="access_mode">public</field>
         <field name="questions_layout">one_page</field>
+        <field name="lang_ids" eval="False"/>
         <field name="description" type="html">
             <p>Please give us your preferences for this event's dinner!</p>
         </field>

--- a/addons/survey/data/survey_demo_feedback.xml
+++ b/addons/survey/data/survey_demo_feedback.xml
@@ -8,6 +8,7 @@
         <field name="access_mode">public</field>
         <field name="users_can_go_back" eval="True" />
         <field name="questions_layout">page_per_section</field>
+        <field name="lang_ids" eval="False"/>
         <field name="description" type="html">
 <p>This survey allows you to give a feedback about your experience with our products.
     Filling it helps us improving your experience.</p></field>

--- a/addons/survey/data/survey_demo_quiz.xml
+++ b/addons/survey/data/survey_demo_quiz.xml
@@ -10,6 +10,7 @@
         <field name="scoring_type">scoring_with_answers</field>
         <field name="scoring_success_min">55</field>
         <field name="questions_layout">page_per_question</field>
+        <field name="lang_ids" eval="False"/>
         <field name="description" type="html">
 <p>This small quiz will test your knowledge about our Company. Be prepared!</p></field>
         <field name="background_image" type="base64" file="survey/static/src/img/survey_background.jpg"/>

--- a/addons/survey/models/__init__.py
+++ b/addons/survey/models/__init__.py
@@ -3,6 +3,7 @@
 
 from . import badge
 from . import challenge
+from . import ir_http
 from . import res_lang
 from . import res_partner
 from . import survey_question

--- a/addons/survey/models/__init__.py
+++ b/addons/survey/models/__init__.py
@@ -1,10 +1,11 @@
 # -*- encoding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from . import survey_survey
-from . import survey_survey_template
-from . import survey_question
-from . import survey_user_input
 from . import badge
 from . import challenge
+from . import res_lang
 from . import res_partner
+from . import survey_question
+from . import survey_survey
+from . import survey_survey_template
+from . import survey_user_input

--- a/addons/survey/models/ir_http.py
+++ b/addons/survey/models/ir_http.py
@@ -1,0 +1,19 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+import re
+
+from odoo import api, models
+from odoo.http import request
+
+
+class IrHttp(models.AbstractModel):
+    _inherit = 'ir.http'
+
+    @api.model
+    def get_nearest_lang(self, lang_code):
+        if request and self._is_survey_frontend(request.httprequest.path):
+            return super(IrHttp, self.with_context(web_force_installed_langs=True)).get_nearest_lang(lang_code)
+        return super().get_nearest_lang(lang_code)
+
+    @api.model
+    def _is_survey_frontend(self, path):
+        return bool(re.match('/survey/|/[a-z]{2}/survey/|/[a-z]{2}_[A-Z]{2}/survey/', path))

--- a/addons/survey/models/res_lang.py
+++ b/addons/survey/models/res_lang.py
@@ -1,0 +1,27 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command, models, _
+from odoo.exceptions import UserError
+
+
+class ResLang(models.Model):
+    _inherit = "res.lang"
+
+    def write(self, vals):
+        """ When languages are disabled, clear corresponding survey languages. """
+        if 'active' in vals and not vals['active']:
+            self.env['survey.user_input'].sudo().search([('lang_id', 'in', self.ids)]).lang_id = False
+            surveys_sudo = self.env['survey.survey'].sudo().search([('lang_ids', 'in', self.ids)])
+            if will_be_all_lang_survey_sudo := surveys_sudo.filtered(lambda survey: survey.lang_ids <= self):
+                if len(self) > 1:
+                    error = _("Cannot deactivate languages currently used by survey(s) only supporting those languages.")
+                else:
+                    error = _("Cannot deactivate a language currently used by survey(s) only supporting that language.")
+                if self.env['survey.survey'].search(
+                        [('id', 'in', will_be_all_lang_survey_sudo.ids)]) == will_be_all_lang_survey_sudo:
+                    error += '\n'
+                    error += _("Survey(s): %(surveys_list)s",
+                               surveys_list=', '.join(f'"{survey.title}"' for survey in will_be_all_lang_survey_sudo))
+                raise UserError(error)
+            surveys_sudo.write({'lang_ids': [Command.unlink(lang.id) for lang in self]})
+        return super().write(vals)

--- a/addons/survey/models/survey_user_input.py
+++ b/addons/survey/models/survey_user_input.py
@@ -28,6 +28,7 @@ class SurveyUser_Input(models.Model):
     start_datetime = fields.Datetime('Start date and time', readonly=True)
     end_datetime = fields.Datetime('End date and time', readonly=True)
     deadline = fields.Datetime('Deadline', help="Datetime until customer can open the survey and submit answers")
+    lang_id = fields.Many2one('res.lang', string='Language')
     state = fields.Selection([
         ('new', 'New'),
         ('in_progress', 'In Progress'),
@@ -194,11 +195,14 @@ class SurveyUser_Input(models.Model):
     def action_print_answers(self):
         """ Open the website page with the survey form """
         self.ensure_one()
+        url = self.env['ir.http']._url_for(
+            '/survey/print/%s?answer_token=%s' % (self.survey_id.access_token, self.access_token),
+            self.lang_id.code or None)
         return {
             'type': 'ir.actions.act_url',
             'name': "View Answers",
             'target': 'self',
-            'url': '/survey/print/%s?answer_token=%s' % (self.survey_id.access_token, self.access_token)
+            'url': url,
         }
 
     def action_redirect_to_attempts(self):
@@ -704,6 +708,7 @@ class SurveyUser_InputLine(models.Model):
     question_id = fields.Many2one('survey.question', string='Question', ondelete='cascade', required=True, index=True)
     page_id = fields.Many2one(related='question_id.page_id', string="Section", readonly=False)
     question_sequence = fields.Integer('Sequence', related='question_id.sequence', store=True)
+    lang_id = fields.Many2one('res.lang', related="user_input_id.lang_id")
     # answer
     skipped = fields.Boolean('Skipped')
     answer_type = fields.Selection([

--- a/addons/survey/static/src/js/survey_form.js
+++ b/addons/survey/static/src/js/survey_form.js
@@ -24,6 +24,7 @@ var isMac = navigator.platform.toUpperCase().includes('MAC');
 publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloadImageMixin, {
     selector: '.o_survey_form',
     events: {
+        'change .o_survey_lang_selector': '_onChangeLanguage',
         'change .o_survey_form_choice_item': '_onChangeChoiceItem',
         'click .o_survey_matrix_btn': '_onMatrixBtnClick',
         'click input[type="radio"]': '_onRadioChoiceClick',
@@ -47,7 +48,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
         var self = this;
         this.fadeInOutDelay = 400;
         return this._super.apply(this, arguments).then(function () {
-            self.options = self.$('form').data();
+            self.options = self.$("form.o_survey-fill-form").data();
             self.readonly = self.options.readonly;
             self.selectedAnswers = self.options.selectedAnswers;
             self.imgZoomer = false;
@@ -344,6 +345,15 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
         this._goToNextPage({ isFinish: true });
     },
 
+    _onChangeLanguage() {
+        const lang_code = document.querySelector('.o_survey_lang_selector[name="lang_code"]').value;
+        const pathname = document.location.pathname;
+        const indexOfSurvey = pathname.indexOf("/survey/");
+        if (indexOfSurvey >= 0) {
+            document.location = `/${lang_code}${pathname.substring(indexOfSurvey)}`;
+        }
+    },
+
     /**
      * Go to the next page of the survey.
      *
@@ -353,6 +363,7 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
      */
     _goToNextPage: function ({ isFinish = false } = {}) {
         this.$(".o_survey_main_title:visible").fadeOut(400);
+        this.$(".o_lang_selector:visible").fadeOut(400);
         this.preventEnterSubmit = false;
         this.readonly = false;
         this._nextScreen(
@@ -393,13 +404,17 @@ publicWidget.registry.SurveyFormWidget = publicWidget.Widget.extend(SurveyPreloa
         var route = "/survey/submit";
 
         if (this.options.isStartScreen) {
+            params.lang_code = document.querySelector(
+                '.o_survey_lang_selector[name="lang_code"]'
+            ).value;
             route = "/survey/begin";
             // Hide survey title in 'page_per_question' layout: it takes too much space
             if (this.options.questionsLayout === 'page_per_question') {
                 this.$('.o_survey_main_title').fadeOut(400);
             }
+            this.$(".o_survey_lang_selector").fadeOut(400);
         } else {
-            var $form = this.$('form');
+            var $form = this.$("form.o_survey-fill-form");
             var formData = new FormData($form[0]);
 
             if (!options.skipValidation) {

--- a/addons/survey/tests/__init__.py
+++ b/addons/survey/tests/__init__.py
@@ -2,6 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from . import common
+from . import test_ir_http
 from . import test_survey
 from . import test_survey_controller
 from . import test_survey_flow

--- a/addons/survey/tests/common.py
+++ b/addons/survey/tests/common.py
@@ -169,8 +169,8 @@ class SurveyCase(common.TransactionCase):
             return self.url_open('/survey/%s/%s' % (survey.access_token, token))
 
     def _access_begin(self, survey, token):
-        url = survey.get_base_url() + '/survey/begin/%s/%s' % (survey.access_token, token)
-        return self.opener.post(url=url, json={})
+        url = survey.get_base_url() + f'/survey/begin/%s/%s' % (survey.access_token, token)
+        return self.opener.post(url=url, json={'params': {'lang_code': 'en_US'}})
 
     def _access_submit(self, survey, token, post_data, query_count=None):
         url = survey.get_base_url() + '/survey/submit/%s/%s' % (survey.access_token, token)

--- a/addons/survey/tests/test_ir_http.py
+++ b/addons/survey/tests/test_ir_http.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import TransactionCase
+
+
+class TestIrHttp(TransactionCase):
+    def test_is_survey_frontend(self):
+        IrHttp = self.env['ir.http']
+        self.assertTrue(IrHttp._is_survey_frontend('/survey/test'))
+        self.assertTrue(IrHttp._is_survey_frontend('/fr_BE/survey/test'))
+        self.assertTrue(IrHttp._is_survey_frontend('/fr/survey/test'))
+        self.assertTrue(IrHttp._is_survey_frontend('/hr/survey/test'))  # we can't avoid that (hr is a language anyway)
+        self.assertFalse(IrHttp._is_survey_frontend('/hr/event/test'))
+        self.assertFalse(IrHttp._is_survey_frontend('/event'))
+        self.assertFalse(IrHttp._is_survey_frontend('/event/survey/test'))
+        self.assertFalse(IrHttp._is_survey_frontend('/eveNT/survey/test'))
+        self.assertFalse(IrHttp._is_survey_frontend('/fr_BE/event/test'))
+        self.assertFalse(IrHttp._is_survey_frontend('/fr/event/test'))

--- a/addons/survey/tests/test_survey_ui_feedback.py
+++ b/addons/survey/tests/test_survey_ui_feedback.py
@@ -168,9 +168,18 @@ class TestUiFeedback(HttpCaseWithUserDemo):
         access_token = self.survey_feedback.access_token
         self.start_tour("/survey/start/%s" % access_token, 'test_survey', login="demo")
 
-    def test_03_public_survey_tour(self):
+    def test_03_public_multilingual_survey_tour(self):
+        # Setup survey translation
+        self.assertEqual([lang[0] for lang in self.env['res.lang'].get_installed()], ['en_US'])
+        self.env['res.lang']._activate_lang('fr_BE')
+        self.survey_feedback_fr = self.survey_feedback.with_context(lang='fr_BE')
+        self.survey_feedback_fr.title = "Enquête de satisfaction"
+        for survey_item in self.survey_feedback_fr.question_and_page_ids:
+            survey_item.title = f"FR: {survey_item.with_context(lang='en_US').title}"
+        self.survey_feedback.lang_ids = self.env['res.lang'].search([('code', 'in', ['fr_BE', 'en_US'])])
+
         access_token = self.survey_feedback.access_token
-        self.start_tour("/survey/start/%s" % access_token, 'test_survey')
+        self.start_tour("/survey/start/%s" % access_token, 'test_survey_multilang')
 
     def test_04_public_survey_with_triggers(self):
         """ Check that chained conditional questions are correctly

--- a/addons/survey/views/survey_survey_views.xml
+++ b/addons/survey/views/survey_survey_views.xml
@@ -60,9 +60,17 @@
                     <group>
                         <group>
                             <field name="user_id" domain="[('share', '=', False)]" widget="many2one_avatar_user"/>
-                            <field name="restrict_user_ids" widget="many2many_tags_avatar"/>
                             <field name="active" invisible="1"/>
                             <field name="has_conditional_questions" invisible="1"/>
+                        </group>
+                        <group>
+                            <field name="restrict_user_ids" widget="many2many_tags_avatar"/>
+                        </group>
+                    </group>
+                    <group>
+                        <group colspan="4">
+                            <field name="lang_ids" widget="many2many_tags" placeholder="All installed languages"
+                                   options="{'no_quick_create': True, 'no_create_edit': True, 'no_open': True}"/>
                         </group>
                     </group>
                     <notebook>

--- a/addons/survey/views/survey_templates.xml
+++ b/addons/survey/views/survey_templates.xml
@@ -80,23 +80,32 @@
     </template>
 
     <template id="survey_fill_header" name="Survey: main page header">
-        <div class="o_survey_nav pt16 mb-2">
-            <div class="container m-0 p-0">
-                <div class="row">
-                    <div  class="col-lg-10">
-                        <h1 t-if="answer.state == 'new' or survey.questions_layout != 'page_per_question'"
-                            t-esc="survey.title" class="o_survey_main_title pt-4"></h1>
-                    </div>
-                    <div class="o_survey_timer col-lg-2 pt-4">
-                        <h1 class="o_survey_timer_container timer text-end">
-                        </h1>
+        <div class="d-flex flex-wrap flex-md-nowrap justify-content-between pt16 mb-2">
+            <div t-attf-class="o_survey_nav flex-grow-1 #{'order-2 order-md-1' if languages else None}">
+                <div class="container m-0 p-0">
+                    <div class="row">
+                        <div  class="col-lg-10">
+                            <h1 t-if="answer.state == 'new' or survey.questions_layout != 'page_per_question'"
+                                t-esc="survey.title" class="o_survey_main_title pt-4"/>
+                        </div>
+                        <div class="o_survey_timer col-lg-2 pt-4">
+                            <h1 class="o_survey_timer_container timer text-end"/>
+                        </div>
                     </div>
                 </div>
+                <div t-att-class="'o_survey_breadcrumb_container mt8' + (' d-none ' if answer.state != 'in_progress' else '')"
+                     t-if="not survey.has_conditional_questions and survey.questions_layout == 'page_per_section' and answer.state != 'done'"
+                     t-att-data-can-go-back="survey.users_can_go_back"
+                     t-att-data-pages="json.dumps(breadcrumb_pages)" />
             </div>
-            <div t-att-class="'o_survey_breadcrumb_container mt8' + (' d-none ' if answer.state != 'in_progress' else '')"
-                 t-if="not survey.has_conditional_questions and survey.questions_layout == 'page_per_section' and answer.state != 'done'"
-                t-att-data-can-go-back="survey.users_can_go_back"
-                t-att-data-pages="json.dumps(breadcrumb_pages)" />
+            <div t-if="languages" class="order-1 order-md-2">
+                <select name="lang_code"
+                        t-attf-class="form-select o_survey_lang_selector #{'d-none' if len(languages) == 1 else ''}"
+                        aria-label="Select a language">
+                    <option t-foreach="languages" t-as="language" t-att-value="language[0]" t-out="language[1]"
+                            t-att-selected="language[0] == lang_code and 'selected' or None"/>
+                </select>
+            </div>
         </div>
     </template>
 
@@ -108,7 +117,7 @@
                     if page else survey.background_image_url
                     if survey.background_image_url else False"/>
         <form role="form" method="post" t-att-name="survey.id"
-                class="d-flex flex-grow-1 align-items-center"
+                class="o_survey-fill-form d-flex flex-grow-1 align-items-center"
                 t-att-data-scoring-type="survey.scoring_type"
                 t-att-data-answer-token="answer.access_token"
                 t-att-data-survey-token="survey.access_token"

--- a/addons/survey/views/survey_user_views.xml
+++ b/addons/survey/views/survey_user_views.xml
@@ -25,6 +25,7 @@
                     <filter name="group_by_survey" string="Survey" domain="[]" context="{'group_by': 'survey_id'}"/>
                     <filter string="Email" name="group_by_email" domain="[]" context="{'group_by': 'email'}"/>
                     <filter string="Partner" name="group_by_partner" domain="[]" context="{'group_by': 'partner_id'}"/>
+                    <filter string="Language" name="group_by_lang" domain="[]" context="{'group_by': 'lang_id'}"/>
                 </group>
             </search>
         </field>
@@ -219,6 +220,7 @@
                 <field name="survey_id"/>
                 <group expand="1" string="Group By">
                     <filter name="group_by_survey" string="Survey" domain="[]"  context="{'group_by':'survey_id'}"/>
+                    <filter name="group_by_lang" string="Language" domain="[]" context="{'group_by':'lang_id'}"/>
                     <filter name="group_by_user_input" string="User Input" domain="[]"  context="{'group_by':'user_input_id'}"/>
                 </group>
             </search>

--- a/addons/website_slides_survey/data/survey_demo.xml
+++ b/addons/website_slides_survey/data/survey_demo.xml
@@ -15,6 +15,7 @@
             <field name="is_attempts_limited" eval="True" />
             <field name="attempts_limit">3</field>
             <field name="description">&lt;p&gt;Test your furniture knowledge!&lt;/p&gt;</field>
+            <field name="lang_ids" eval="False"/>
         </record>
         <!-- Page 1 -->
         <record model="survey.question" id="furniture_certification_page_1">


### PR DESCRIPTION
We add a language selector in the first page of the survey allowing users to select their language. This selector is only present if more than one language is enabled on the survey and it is removed once the survey begins.

The survey form allows the creator of a survey to configure the available languages among the installed ones. By default, the context language is enabled. If no language is selected for the survey, it means that the survey supports all installed languages. As the demo surveys support multiple language, we left that field empty for them.

When resuming a survey, the language is restored. To support that feature, we now save the user language for each survey_input which allow us also to add the following features:
- add a filter allowing survey reviewer to filter survey/answer based on the survey language.
- print survey in the user language

Technical notes:
- we can't use the language selector of portal as survey doesn't depend on portal.
- to avoid adding new tours, we test the language selector by modifying the public tour. We add a step to switch to French and verify that this language is used during the whole survey.
- we have decided to add the field lang_ids on survey after having tried to auto-detect in which languages a survey is translated. We have given up on that solution because to be reliable it required to use a sql query and it was a bit too magical for the user (the language was enabled as soon as one translation was available as not everything must always be translated. Ex: numbers).

[IMP] website, survey: avoid limiting survey to website language

Without the module website, the survey can be displayed in any language installed but as soon as website is installed, the survey is limited to the main website languages. This commit allows to display a survey in any installed language even if not all installed languages are enabled in the main website.

Task-3884012