### PR TITLE
[FIX] point_of_sale: missing model comment in PO file

### DIFF
--- a/addons/point_of_sale/i18n/point_of_sale.pot
+++ b/addons/point_of_sale/i18n/point_of_sale.pot
@@ -994,6 +994,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/point_of_sale/models/pos_config.py:0
 #: model:ir.model.fields.selection,name:point_of_sale.selection__pos_payment_method__type__bank
+#: model:pos.payment.method,name:point_of_sale.pos_payment_method_2_599bee1f
 #, python-format
 msgid "Bank"
 msgstr ""
@@ -1909,6 +1910,7 @@ msgstr ""
 #. odoo-python
 #: code:addons/point_of_sale/models/pos_config.py:0
 #: model:ir.model.fields.selection,name:point_of_sale.selection__pos_payment_method__type__pay_later
+#: model:pos.payment.method,name:point_of_sale.pos_payment_method_3_b02dec91
 #, python-format
 msgid "Customer Account"
 msgstr ""


### PR DESCRIPTION
Issue
----

POS payment methods that are already translated don't have their translation show up.

Steps
-----

Go to Point of Sale -> New/Continue Session -> Add something to pay for -> Click on "payment". The listed payment methods are not translated if you chose another language.

Cause
-----

Although the terms were translated, they were not showing up because the model referral comment wasn't there.

opw-3880510
