### PR TITLE
[FIX] pos_hr: login with cashier

### DIFF
--- a/addons/pos_hr/static/src/app/select_cashier_mixin.js
+++ b/addons/pos_hr/static/src/app/select_cashier_mixin.js
@@ -39,6 +39,7 @@ export function useCashierSelector(
         const { confirmed, payload: inputPin } = await popup.add(NumberPopup, {
             isPassword: true,
             title: _t("Password?"),
+            zIndex: 1040,
         });
 
         if (!confirmed) {
@@ -49,6 +50,7 @@ export function useCashierSelector(
             await popup.add(ErrorPopup, {
                 title: _t("Incorrect Password"),
                 body: _t("Please try again."),
+                zIndex: 1040,
             });
             return false;
         }
@@ -83,6 +85,7 @@ export function useCashierSelector(
             const { confirmed, payload: employee } = await popup.add(SelectionPopup, {
                 title: _t("Change Cashier"),
                 list: employeesList,
+                zIndex: 1040,
             });
 
             if (!confirmed || !employee || (employee.pin && !(await checkPin(employee)))) {


### PR DESCRIPTION
Steps to reproduce:
--------------------------
- Open employee and create new one  or use existing 
- Go to HR tab > set pin and badges number
- Go to POS > Edit > set employee in both basic & advance rights
- Open session & click on the select cashier or scan badges

Issue:
--------
Popup isn't visible and not able to login with any employee 

Cause:
----------
The elements were not properly set on z-index so popup was behind the screen
with login info making it invisible.

FIX:
------
Corrected the z-indexing (layers of elements to show).

task- 3932064