### PR TITLE
[FIX] web_editor: display list in quick edit html_field

### DIFF
--- a/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
+++ b/addons/web_editor/static/lib/odoo-editor/src/commands/commands.js
@@ -584,6 +584,14 @@ export const editorCommands = {
         }
 
         let target = [...(blocks.size ? blocks : li)];
+        if (blocks.size) {
+            // Remove hardcoded padding to have default padding of list element 
+            for (const block of blocks) {
+                if (block.style) {
+                    block.style.padding = "";
+                }
+            }
+        }
         while (target.length) {
             const node = target.pop();
             // only apply one li per ul


### PR DESCRIPTION
Issue:
======
list doesn't appear in quick edit of html_field

Steps to reproduce the issue:
=============================
- Go to any sale order
- Send by email
- Add a list inside the email
- It doesn't appear

Origin of the issue:
====================
Most of the templates have hardcoded `padding = 0px`, so when we convert a `p` element to a `ul` or `ol` element it will have have the same styling and we loose the default padding for the list elements.

Solution:
=========
We set the padding as null to remove any forced padding used.

opw-3900433