### PR TITLE
[IMP] stock: set explicit default picking types

### DIFF
--- a/addons/mrp_subcontracting/tests/test_subcontracting.py
+++ b/addons/mrp_subcontracting/tests/test_subcontracting.py
@@ -52,6 +52,8 @@ class TestSubcontractingBasic(TransactionCase):
             "pack_type_id",
             "out_type_id",
             "in_type_id",
+            "qc_type_id",
+            "store_type_id",
             "int_type_id"
         ]
         for operation_type in operation_types:

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -33,11 +33,11 @@ class PickingType(models.Model):
     sequence_code = fields.Char('Sequence Prefix', required=True)
     default_location_src_id = fields.Many2one(
         'stock.location', 'Default Source Location', compute='_compute_default_location_src_id',
-        check_company=True, store=True, readonly=False, precompute=True,
+        check_company=True, store=True, readonly=False, precompute=True, required=True,
         help="This is the default source location when you create a picking manually with this operation type. It is possible however to change it or that the routes put another location.")
     default_location_dest_id = fields.Many2one(
         'stock.location', 'Default Destination Location', compute='_compute_default_location_dest_id',
-        check_company=True, store=True, readonly=False, precompute=True,
+        check_company=True, store=True, readonly=False, precompute=True, required=True,
         help="This is the default destination location when you create a picking manually with this operation type. It is possible however to change it or that the routes put another location.")
     default_location_return_id = fields.Many2one('stock.location', 'Default returns location', check_company=True,
         help="This is the default location for returns created from a picking with this operation type.",

--- a/addons/stock/tests/test_move2.py
+++ b/addons/stock/tests/test_move2.py
@@ -2054,7 +2054,7 @@ class TestSinglePicking(TestStockCommon):
         receipt2 = self.env['stock.picking'].create({
             'location_id': warehouse.wh_input_stock_loc_id.id,
             'location_dest_id': warehouse.wh_qc_stock_loc_id.id,
-            'picking_type_id': warehouse.int_type_id.id,
+            'picking_type_id': warehouse.qc_type_id.id,
             'state': 'draft',
         })
         move1_receipt_2 = self.MoveObj.create({

--- a/addons/stock/tests/test_multicompany.py
+++ b/addons/stock/tests/test_multicompany.py
@@ -509,7 +509,7 @@ class TestMultiCompany(TransactionCase):
         self.assertEqual(self.env['stock.quant']._get_available_quantity(product_lot, self.stock_location_b, lot_2), 0.1)
 
     def test_intercom_lot_pull(self):
-        """Use warehouse of comany a to resupply warehouse of company b. Check
+        """Use warehouse of company a to resupply warehouse of company b. Check
         pull rule works correctly in two companies and moves are unchained from
         inter-company transit location."""
         customer_location = self.env.ref('stock.stock_location_customers')

--- a/addons/stock/tests/test_packing.py
+++ b/addons/stock/tests/test_packing.py
@@ -466,7 +466,7 @@ class TestPacking(TestPackingCommon):
         # Settings of receipt.
         self.warehouse.in_type_id.show_entire_packs = True
         # Settings of internal transfer.
-        self.warehouse.int_type_id.show_entire_packs = True
+        self.warehouse.store_type_id.show_entire_packs = True
 
         # Creates two new locations for putaway.
         location_form = Form(self.env['stock.location'])
@@ -524,7 +524,7 @@ class TestPacking(TestPackingCommon):
 
         # Checks an internal transfer was created following the validation of the receipt.
         internal_transfer = self.env['stock.picking'].search([
-            ('picking_type_id', '=', self.warehouse.int_type_id.id)
+            ('picking_type_id', '=', self.warehouse.store_type_id.id)
         ], order='id desc', limit=1)
         self.assertEqual(internal_transfer.origin, receipt.name)
         self.assertEqual(
@@ -550,7 +550,7 @@ class TestPacking(TestPackingCommon):
         internal_transfer.action_cancel()
         picking = self.env['stock.picking'].create({
             'state': 'draft',
-            'picking_type_id':  self.warehouse.int_type_id.id,
+            'picking_type_id':  self.warehouse.store_type_id.id,
             })
         internal_form = Form(picking)
         # The test specifically removes the ability to see the location fields
@@ -603,7 +603,7 @@ class TestPacking(TestPackingCommon):
         # Settings of receipt.
         self.warehouse.in_type_id.show_entire_packs = True
         # Settings of internal transfer.
-        self.warehouse.int_type_id.show_entire_packs = True
+        self.warehouse.store_type_id.show_entire_packs = True
 
         # Creates two new locations for putaway.
         location_form = Form(self.env['stock.location'])
@@ -668,7 +668,7 @@ class TestPacking(TestPackingCommon):
 
         # Checks an internal transfer was created following the validation of the receipt.
         internal_transfer = self.env['stock.picking'].search([
-            ('picking_type_id', '=', self.warehouse.int_type_id.id)
+            ('picking_type_id', '=', self.warehouse.store_type_id.id)
         ], order='id desc', limit=1)
         self.assertEqual(internal_transfer.origin, receipt.name)
         self.assertEqual(
@@ -694,7 +694,7 @@ class TestPacking(TestPackingCommon):
         internal_transfer.action_cancel()
         picking = self.env['stock.picking'].create({
             'state': 'draft',
-            'picking_type_id':  self.warehouse.int_type_id.id,
+            'picking_type_id':  self.warehouse.store_type_id.id,
             })
         internal_form = Form(picking)
         # The test specifically removes the ability to see the location fields

--- a/addons/stock/views/stock_warehouse_views.xml
+++ b/addons/stock/views/stock_warehouse_views.xml
@@ -55,11 +55,14 @@
                                         <field name="wh_output_stock_loc_id" readonly="1"/>
                                     </group>
                                     <group string="Operation Types">
-                                        <field name="in_type_id" readonly="1"/>
                                         <field name="int_type_id" readonly="1"/>
+                                        <field name="in_type_id" readonly="1"/>
+                                        <field name="qc_type_id" readonly="1"/>
+                                        <field name="store_type_id" readonly="1"/>
                                         <field name="pick_type_id" readonly="1"/>
                                         <field name="pack_type_id" readonly="1"/>
                                         <field name="out_type_id" readonly="1"/>
+                                        <field name="xdock_type_id" readonly="1"/>
                                     </group>
                                 </group>
                             </page>

--- a/addons/stock_picking_batch/tests/test_batch_picking.py
+++ b/addons/stock_picking_batch/tests/test_batch_picking.py
@@ -499,7 +499,7 @@ class TestBatchPicking(TransactionCase):
             'auto_batch': True,
             'batch_group_by_src_loc': True,
         })
-        warehouse_2.int_type_id.write({
+        (warehouse_2.qc_type_id | warehouse_2.store_type_id).write({
             'auto_batch': True,
             'batch_group_by_dest_loc': True,
         })


### PR DESCRIPTION
Following the changes from the pull&push rules in #156437, a new field was added to maintain compatibility with the old behavior of the pull rules.
When this field is enabled, the pull rule would fetch its destination from the rule instead of from the picking type. While this works nicely, it creates an unintuitive behavior for the default picking types such as internal transfers used in the multi-step reception.

Decision was made to create instead new picking types for default types that would require this field to be true for basic flows that would have the right destinations from the start, without requiring obscure configuration.

This means the creation of the following picking types, which used to be 'Internal Transfers':
- Input -> Quality Control: 'Quality Control'
- Quality Control -> Stock: 'Storage'
- Input -> Output: 'Cross Dock'

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
