### PR TITLE
[IMP] project: add duplicate action for project and task in kanban view

### DIFF
--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -798,6 +798,8 @@ class Task(models.Model):
 
             if not default.get('stage_id'):
                 vals['stage_id'] = task.stage_id.id
+            if 'active' not in default and not task['active'] and not self.env.context.get('copy_project'):
+                vals['active'] = True
             vals['name'] = task.name if self.env.context.get('copy_project') else _("%s (copy)", task.name)
             if task.recurrence_id and not default.get('recurrence_id'):
                 vals['recurrence_id'] = task.recurrence_id.copy().id

--- a/addons/project/tests/test_project_base.py
+++ b/addons/project/tests/test_project_base.py
@@ -506,3 +506,20 @@ class TestProjectBase(TestProjectCommon):
         self.assertEqual(project2.task_count, 2)
         self.assertEqual(project2.open_task_count, 2)
         self.assertEqual(project2.closed_task_count, 0)
+
+    def test_archived_duplicate_task(self):
+        """ Test to check duplication of an archived task.
+            The duplicate of an archived task should be active.
+        """
+        project = self.env['project.project'].create({
+            'name': 'Project',
+        })
+        task = self.env['project.task'].create({
+            'name': 'Task',
+            'project_id': project.id,
+        })
+        copy_task1 = task.copy()
+        self.assertTrue(copy_task1.active, "Active task should be active when duplicating an active task")
+        task.active = False
+        copy_task2 = task.copy()
+        self.assertTrue(copy_task2.active, "Archived task should be active when duplicating an archived task")

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -422,6 +422,7 @@
 
                                         <a t-if="record.privacy_visibility.raw_value == 'portal'" class="dropdown-item" role="menuitem" name="action_open_share_project_wizard" type="object">Share Project</a>
 
+                                        <a class="dropdown-item" role="menuitem" name="copy" type="object">Duplicate</a>
                                         <a class="dropdown-item" role="menuitem" type="open">Settings</a>
                                     </div>
                                     <div class="col-12 ps-0" groups="!project.group_project_manager">

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -671,6 +671,7 @@
                     <t t-name="menu" t-if="!selection_mode" groups="base.group_user">
                         <a t-if="widget.editable" role="menuitem" type="set_cover" class="dropdown-item" data-field="displayed_image_id">Set Cover Image</a>
                         <a name="%(portal.portal_share_action)d" role="menuitem" type="action" class="dropdown-item" context="{'dialog_size': 'medium'}">Share Task</a>
+                        <a class="dropdown-item" role="menuitem" type="object" name="copy">Duplicate</a>
                         <div role="separator" class="dropdown-divider"></div>
                         <field name="color" widget="kanban_color_picker"/>
                     </t>


### PR DESCRIPTION
With this commit, we are adding duplicate action to project and task in kanban view. 
Also if we copy an archived task, then its copy will be an active task.

task-3884777