### PR TITLE
[FIX] pos_adyen: fix payment status when cancelling payment

### DIFF
--- a/addons/pos_adyen/models/pos_payment_method.py
+++ b/addons/pos_adyen/models/pos_payment_method.py
@@ -79,7 +79,7 @@ class PosPaymentMethod(models.Model):
         if not data:
             raise UserError(_('Invalid Adyen request'))
 
-        if 'SaleToPOIRequest' in data and data['SaleToPOIRequest']['MessageHeader']['MessageCategory'] == 'Payment': # Clear only if it is a payment request
+        if 'SaleToPOIRequest' in data and data['SaleToPOIRequest']['MessageHeader']['MessageCategory'] == 'Payment' and 'PaymentRequest' in data['SaleToPOIRequest']: # Clear only if it is a payment request
             self.sudo().adyen_latest_response = ''  # avoid handling old responses multiple times
 
         if not operation:


### PR DESCRIPTION
Current behavior:
Sometimes payment made with adyen where blocked in the "Waiting for
card" status when cancelling a payment. As the issue is not reproducible
consistantly I made a diagram to show what I think is happening.
It was probably happening because the last_adyen_status was emptied at
a wrong moment. To fix this we make sure that a real new payment request
is made before emptying it.
Before this fix when doing a cancel request, it would empty the
last_adyen_status

![Adyen Status](https://github.com/odoo/odoo/assets/32939472/fa2b03c5-7f45-4be9-86f0-21ee7fb57170)

opw-3427860
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
