### PR TITLE
[REF] hr*: remove the use of utcnow

### DIFF
--- a/addons/hr_holidays/models/hr_department.py
+++ b/addons/hr_holidays/models/hr_department.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-import datetime
+from datetime import datetime, timezone
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models
@@ -23,7 +22,7 @@ class Department(models.Model):
     def _compute_leave_count(self):
         Requests = self.env['hr.leave']
         Allocations = self.env['hr.leave.allocation']
-        today_date = datetime.datetime.utcnow().date()
+        today_date = datetime.now(timezone.utc).date()
         today_start = fields.Datetime.to_string(today_date)  # get the midnight of the current utc day
         today_end = fields.Datetime.to_string(today_date + relativedelta(hours=23, minutes=59, seconds=59))
 

--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -1,6 +1,6 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime, date, time
+from datetime import datetime, date, time, timezone
 from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 import pytz
@@ -175,7 +175,7 @@ class HrEmployeeBase(models.AbstractModel):
             raise UserError(_('Operation not supported'))
         # This search is only used for the 'Absent Today' filter however
         # this only returns employees that are absent right now.
-        today_date = datetime.utcnow().date()
+        today_date = datetime.now(timezone.utc).date()
         today_start = fields.Datetime.to_string(today_date)
         today_end = fields.Datetime.to_string(today_date + relativedelta(hours=23, minutes=59, seconds=59))
         holidays = self.env['hr.leave'].sudo().search([

--- a/addons/hr_holidays/tests/test_out_of_office.py
+++ b/addons/hr_holidays/tests/test_out_of_office.py
@@ -1,7 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from dateutil.relativedelta import relativedelta
 
 from odoo import fields
@@ -105,7 +104,7 @@ class TestOutOfOfficePerformance(TestHrHolidaysCommon, TransactionCaseWithUserDe
     def test_search_absent_employee(self):
         present_employees = self.env['hr.employee'].search([('is_absent', '!=', True)])
         absent_employees = self.env['hr.employee'].search([('is_absent', '=', True)])
-        today_date = datetime.utcnow().date()
+        today_date = datetime.now(timezone.utc).date()
         holidays = self.env['hr.leave'].sudo().search([
             ('employee_id', '!=', False),
             ('state', '=', 'validate'),


### PR DESCRIPTION
utcnow is deprecated and should not be used anymore. this commit swap utcnow() by now(timezone.utc)

see:
https://github.com/python/cpython/issues/103857
https://github.com/python/cpython/issues/81669

python 3.12 changes related to this:
https://docs.python.org/3/whatsnew/3.12.html#deprecated

task-3932942




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
