### PR TITLE
[FIX] sale_management: display discounted price in consistent format

### DIFF
--- a/addons/sale_management/report/sale_report_templates.xml
+++ b/addons/sale_management/report/sale_report_templates.xml
@@ -32,7 +32,7 @@
                                     t-att-style="option.discount and 'text-decoration: line-through' or None"
                                     t-att-class="option.discount and 'text-danger' or None"/>
                                 <div t-if="option.discount">
-                                    <t t-out="'%.2f' % ((1-option.discount / 100.0) * option.price_unit)"/>
+                                    <t t-out="((1-option.discount / 100.0) * option.price_unit)" t-options='{"widget": "monetary", "display_currency": doc.currency_id}'/>
                                 </div>
                             </strong>
                         </td>


### PR DESCRIPTION
Problem: When a quotation is printed for a client in a different language that uses different decimal separators, the discounted price for optional products are not being displayed with the same decimal separators used throughout the quotation.

Purpose: The formats of the price should be consistent.

Steps to Reproduce on Runbot:
1. Install Sales
2. Enable Discounts in Setting > Sales
3. Create a quotation with a German customer and discounted optional products
4. Print the quotation
5. Observe the discounted price has inconsistent formatting (ex. shows 140.00 instead of 140,00 since German uses , as decimal separators)

opw-3853464

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
