### PR TITLE
[FIX] web: add missing ARIA attributes to AutoComplete component

### DIFF
--- a/addons/web/static/src/core/autocomplete/autocomplete.js
+++ b/addons/web/static/src/core/autocomplete/autocomplete.js
@@ -65,6 +65,15 @@ export class AutoComplete extends Component {
         });
     }
 
+    get activeSourceOptionId() {
+        if (!this.isOpened || !this.state.activeSourceOption) {
+            return undefined;
+        }
+        const [sourceIndex, optionIndex] = this.state.activeSourceOption;
+        const source = this.sources[sourceIndex];
+        return `${this.props.id || "autocomplete"}_${sourceIndex}_${source.isLoading ? "loading" : optionIndex}`;
+    }
+
     get isOpened() {
         return this.state.open;
     }

--- a/addons/web/static/src/core/autocomplete/autocomplete.xml
+++ b/addons/web/static/src/core/autocomplete/autocomplete.xml
@@ -9,6 +9,11 @@
                 class="o-autocomplete--input o_input"
                 autocomplete="off"
                 t-att-placeholder="props.placeholder"
+                role="combobox"
+                t-att-aria-activedescendant="activeSourceOptionId"
+                t-att-aria-expanded="(isOpened and hasOptions) ? 'true' : 'false'"
+                aria-autocomplete="list"
+                aria-haspopup="listbox"
                 t-model="state.value"
                 t-on-blur="onInputBlur"
                 t-on-click.stop="onInputClick"
@@ -18,11 +23,17 @@
                 t-ref="input"
             />
             <t t-if="isOpened and hasOptions">
-                <ul class="o-autocomplete--dropdown-menu dropdown-menu ui-widget ui-autocomplete show" t-ref="sourcesList">
+                <ul role="listbox" class="o-autocomplete--dropdown-menu dropdown-menu ui-widget ui-autocomplete show" t-ref="sourcesList">
                     <t t-foreach="sources" t-as="source" t-key="source.id">
                         <t t-if="source.isLoading">
                             <li class="o-autocomplete--dropdown-item ui-menu-item">
-                                <a href="#" class="dropdown-item ui-menu-item-wrapper">
+                                <a
+                                    t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_loading"
+                                    role="option"
+                                    href="#"
+                                    class="dropdown-item ui-menu-item-wrapper"
+                                    aria-selected="true"
+                                >
                                     <i class="fa fa-spin fa-circle-o-notch" /> <t t-esc="source.placeholder" />
                                 </a>
                             </li>
@@ -38,9 +49,12 @@
                                     t-on-pointerdown="() => this.ignoreBlur = true"
                                 >
                                     <a
+                                        t-attf-id="{{props.id or 'autocomplete'}}_{{source_index}}_{{option_index}}"
+                                        role="option"
                                         href="#"
                                         class="dropdown-item ui-menu-item-wrapper text-truncate"
                                         t-att-class="{ 'ui-state-active': isActiveSourceOption([source_index, option_index]) }"
+                                        t-att-aria-selected="isActiveSourceOption([source_index, option_index]) ? 'true' : 'false'"
                                     >
                                         <t t-if="source.optionTemplate">
                                             <t t-call="{{ source.optionTemplate }}" />

--- a/addons/web/static/tests/core/autocomplete_tests.js
+++ b/addons/web/static/tests/core/autocomplete_tests.js
@@ -59,6 +59,22 @@ QUnit.module("Components", (hooks) => {
             options.map((el) => el.textContent),
             ["World", "Hello"]
         );
+
+        const optionItems = [...target.querySelectorAll(".dropdown-item")];
+        assert.deepEqual(
+            optionItems.map((el) => ({
+                id: el.id,
+                role: el.getAttribute("role"),
+                "aria-selected": el.getAttribute("aria-selected"),
+            })),
+            [
+                {"id": "autocomplete_0_0", "role": "option", "aria-selected": "true"},
+                {"id": "autocomplete_0_1", "role": "option", "aria-selected": "false"},
+            ]
+        );
+
+        const input = target.querySelector(".o-autocomplete--input");
+        assert.strictEqual(input.getAttribute("aria-activedescendant"), optionItems[0].id);
     });
 
     QUnit.test("select option", async (assert) => {
@@ -405,6 +421,34 @@ QUnit.module("Components", (hooks) => {
         const input = target.querySelector(".o-autocomplete--input");
         await click(input);
         input.focus();
+
+        // Navigate suggestions using arrow keys
+        const optionItems = [...target.querySelectorAll(".dropdown-item")];
+        assert.deepEqual(
+            optionItems.map((el) => ({
+                id: el.id,
+                role: el.getAttribute("role"),
+                "aria-selected": el.getAttribute("aria-selected"),
+            })),
+            [
+                {"id": "autocomplete_0_0", "role": "option", "aria-selected": "true"},
+                {"id": "autocomplete_0_1", "role": "option", "aria-selected": "false"},
+            ]
+        );
+        assert.strictEqual(input.getAttribute("aria-activedescendant"), optionItems[0].id);
+        await triggerEvent(target, ".o-autocomplete--input", "keydown", { key: "arrowdown" });
+        assert.deepEqual(
+            optionItems.map((el) => ({
+                id: el.id,
+                role: el.getAttribute("role"),
+                "aria-selected": el.getAttribute("aria-selected"),
+            })),
+            [
+                {"id": "autocomplete_0_0", "role": "option", "aria-selected": "false"},
+                {"id": "autocomplete_0_1", "role": "option", "aria-selected": "true"},
+            ]
+        );
+        assert.strictEqual(input.getAttribute("aria-activedescendant"), optionItems[1].id);
 
         // Start typing hello and click on the result
         await triggerEvent(target, ".o-autocomplete--input", "keydown", { key: "h" });


### PR DESCRIPTION
When filling a relational field, suggestions are displayed using the AutoComplete component. Problem is, when choosing any suggestion, some ARIA attributes are missing for assistive technologies to know what is the currently-selected suggestion. That because the actual focus is always on the  field's input, while the actually-selected suggestion is highlighted by toggling classes, which makes not possible anymore to know what is the selected suggestion for e.g. screen reader users.

This commit adds such attributes.

This is similar to what was done on 9764e6f7 for the command palette to handle search results on the home screen.


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
