### PR TITLE
[IMP] base: remove redundant constraint check on ir.actions.server

### DIFF
--- a/addons/test_base_automation/tests/test_flow.py
+++ b/addons/test_base_automation/tests/test_flow.py
@@ -34,6 +34,7 @@ def create_automation(self, **kwargs):
             for action in actions_data
         ]
     )
+    action_ids.flush_recordset()
     automation_id.write({'action_server_ids': [Command.set(action_ids.ids)]})
     self.addCleanup(automation_id.unlink)
     return automation_id

--- a/odoo/addons/base/models/ir_actions.py
+++ b/odoo/addons/base/models/ir_actions.py
@@ -974,11 +974,6 @@ class IrActionsServer(models.Model):
     def _selection_target_model(self):
         return [(model.model, model.name) for model in self.env['ir.model'].sudo().search([])]
 
-    @api.constrains('update_field_id', 'evaluation_type')
-    def _raise_many2many_error(self):
-        if self.filtered(lambda line: line.update_field_id.ttype == 'many2many' and line.evaluation_type == 'reference'):
-            raise ValidationError(_('many2many fields cannot be evaluated by reference'))
-
     @api.onchange('resource_ref')
     def _set_resource_ref(self):
         for action in self.filtered(lambda action: action.value_field_to_show == 'resource_ref'):


### PR DESCRIPTION
-Since [1] the value for evaluation_type no longer exists 'reference' and user can update m2m field using evaluation_type 'value' very dynamic therefore this commit remove redundant constraint check for evaluation_type 'reference'

1: https://github.com/odoo/odoo/pull/114352/commits/5ea3b8e998a695ff342b250ed1c1d0d04e1e29c9

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
