### PR TITLE
[FIX] account: fix acct. dashboard 'Upload' always showing onboarding wizard

### DIFF
--- a/addons/account/models/account_journal_dashboard.py
+++ b/addons/account/models/account_journal_dashboard.py
@@ -549,6 +549,7 @@ class account_journal(models.Model):
                 'sum_late': currency.format(sum_late),
                 'has_sequence_holes': journal.has_sequence_holes,
                 'is_sample_data': is_sample_data_by_journal_id[journal.id],
+                'entries_count': 1 if not is_sample_data_by_journal_id[journal.id] else 0,  # TODO: remove in master
             })
 
     def _fill_general_dashboard_data(self, dashboard_data):


### PR DESCRIPTION
To reproduce:

- Connect as administrator
- Create a new purchase journal "Vendor Bills Test"
- Go to the accounting dashboard
- Click on 'Upload' button on the "Vendor Bills Test" journal record => The 'Import your first bill' wizard open

- Import a bill
- Go back to the accounting dashboard
- Click again on 'Upload' button on the "Vendor Bills Test" journal record => The 'Import your first bill' still open even if the journal has already some entries.

After odoo/odoo@d29a622740 the `entries_count` are not returned anymore as part of kanban data for sale/purchase journals, so the view always show the button to open the 'Import your first bill' wizard.

This commit re-add the `entries_count` in returned data (we arbitrarily use of count of 1 if there is some entries has its only used to determine what button is display on the kanban record)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
