### PR TITLE
[IMP] hr_timesheet: portal sorting order when groupby date

### DIFF
--- a/addons/hr_timesheet/controllers/portal.py
+++ b/addons/hr_timesheet/controllers/portal.py
@@ -133,7 +133,7 @@ class TimesheetCustomerPortal(CustomerPortal):
             if field:
                 if groupby == 'date':
                     raw_timesheets_group = Timesheet_sudo._read_group(
-                        domain, ['date:day'], ['unit_amount:sum', 'id:recordset']
+                        domain, ['date:day'], ['unit_amount:sum', 'id:recordset'], order='date:day desc'
                     )
                     grouped_timesheets = [(records, unit_amount) for __, unit_amount, records in raw_timesheets_group]
 


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
----
This commit aims to fix the order of the timesheets in the portal view, when grouped by date with the sorting set by `newest`. It also fixes the pagination not working properly when the timesheets are grouped by date. With this commit, when grouped by date, the timesheets will be sorted by latest when the sorting is set to `newest`, and by oldest when the sorting is set to other fields (e.g. Employee, Project etc.)

Current behavior before PR:
----
Prior to this commit, when a user chose groupby `date` and sortby `newest`, on the protal view, the timesheets were returned by the oldest order. Additionally, the pagination was still reflecting data from the non-groupby timesheets, leading to a wrong number of pages shown when using the groupby date.

task-3770909

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
