### PR TITLE
[FIX] project_timesheet_holidays: create TS after employee creation

### DIFF
--- a/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
+++ b/addons/project_timesheet_holidays/models/resource_calendar_leaves.py
@@ -153,14 +153,15 @@ class ResourceCalendarLeaves(models.Model):
 
         def get_timesheets_data(employees, work_hours_list, vals_list):
             for employee in employees:
+                work_hours_list_specific_employee = [wh for wh in work_hours_list if wh[0] >= employee.create_date.date()]
                 holidays = holidays_by_employee.get(employee.id)
-                for index, (day_date, work_hours_count) in enumerate(work_hours_list):
+                for index, (day_date, work_hours_count) in enumerate(work_hours_list_specific_employee):
                     if not holidays or all(not (date_from <= day_date and date_to >= day_date) for date_from, date_to in holidays):
                         vals_list.append(
                             leave._timesheet_prepare_line_values(
                                 index,
                                 employee,
-                                work_hours_list,
+                                work_hours_list_specific_employee,
                                 day_date,
                                 work_hours_count
                             )

--- a/addons/project_timesheet_holidays/tests/test_employee.py
+++ b/addons/project_timesheet_holidays/tests/test_employee.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
+from datetime import date, datetime
 from freezegun import freeze_time
+from unittest.mock import patch
 
 from odoo.tests import TransactionCase, tagged
 
@@ -33,11 +35,12 @@ class TestEmployee(TransactionCase):
             2) Check the timesheets representing the time off of this new employee
                is correctly generated
         """
-        employee = self.env['hr.employee'].create({
-            'name': 'Test Employee',
-            'company_id': self.company.id,
-            'resource_calendar_id': self.company.resource_calendar_id.id,
-        })
+        with patch.object(type(self.env.cr), 'now', lambda self: datetime.combine(date(2020, 1, 1), datetime.min.time())):
+            employee = self.env['hr.employee'].create({
+                'name': 'Test Employee',
+                'company_id': self.company.id,
+                'resource_calendar_id': self.company.resource_calendar_id.id,
+            })
         timesheet = self.env['account.analytic.line'].search([
             ('employee_id', '=', employee.id),
             ('global_leave_id', '=', self.global_leave.id),
@@ -47,11 +50,12 @@ class TestEmployee(TransactionCase):
         self.assertEqual(timesheet.unit_amount, 8, 'The timesheet should be created for the correct duration')
 
         # simulate the company of the employee updated is not in the allowed_company_ids of the current user
-        employee2 = self.env['hr.employee'].with_company(self.env.company).create({
-            'name': 'Test Employee',
-            'company_id': self.company.id,
-            'resource_calendar_id': self.company.resource_calendar_id.id,
-        })
+        with patch.object(type(self.env.cr), 'now', lambda self: datetime.combine(date(2020, 1, 1), datetime.min.time())):
+            employee2 = self.env['hr.employee'].with_company(self.env.company).create({
+                'name': 'Test Employee',
+                'company_id': self.company.id,
+                'resource_calendar_id': self.company.resource_calendar_id.id,
+            })
         timesheet = self.env['account.analytic.line'].search([
             ('employee_id', '=', employee2.id),
             ('global_leave_id', '=', self.global_leave.id),
@@ -74,10 +78,11 @@ class TestEmployee(TransactionCase):
             4) Check the timesheets representing the time off of this employee
                is correctly updated
         """
-        employee = self.env['hr.employee'].create({
-            'name': 'Test Employee',
-            'company_id': self.company.id,
-        })
+        with patch.object(type(self.env.cr), 'now', lambda self: datetime.combine(date(2020, 1, 1), datetime.min.time())):
+            employee = self.env['hr.employee'].create({
+                'name': 'Test Employee',
+                'company_id': self.company.id,
+            })
         employee.write({'resource_calendar_id': self.company.resource_calendar_id.id})
         timesheet = self.env['account.analytic.line'].search([
             ('employee_id', '=', employee.id),

--- a/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
+++ b/addons/project_timesheet_holidays/tests/test_timesheet_holidays.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from datetime import datetime
+from datetime import date, datetime
 from dateutil.relativedelta import relativedelta
 from freezegun import freeze_time
+from unittest.mock import patch
 
 from odoo import fields, SUPERUSER_ID
 
@@ -42,6 +43,24 @@ class TestTimesheetHolidays(TestCommonTimesheet):
 
     def setUp(self):
         super(TestTimesheetHolidays, self).setUp()
+
+        (self.empl_employee + self.empl_employee2 + self.empl_manager).unlink()
+        with patch.object(type(self.env.cr), 'now', lambda self: datetime.combine(date(1990, 1, 1), datetime.min.time())):
+            self.empl_employee = self.env['hr.employee'].create({
+                'name': 'User Empl Employee',
+                'user_id': self.user_employee.id,
+                'employee_type': 'freelance',  # Avoid searching the contract if hr_contract module is installed before this module.
+            })
+            self.empl_employee2 = self.env['hr.employee'].create({
+                'name': 'User Empl Employee 2',
+                'user_id': self.user_employee2.id,
+                'employee_type': 'freelance',
+            })
+            self.empl_manager = self.env['hr.employee'].create({
+                'name': 'User Empl Officer',
+                'user_id': self.user_manager.id,
+                'employee_type': 'freelance',
+            })
 
         self.employee_working_calendar = self.empl_employee.resource_calendar_id
         # leave dates : from next monday to next wednesday (to avoid crashing tests on weekend, when


### PR DESCRIPTION
Steps to reproduce:
-------------------
- install project_timesheet_holidays
- create an employee at a time (E)
- create a public holiday at some point in the future (PH)
- create a user linked to the employee (U)

With E < PH < U

Issue:
------
The user has no timesheets linked to him/her,
even though the employee was already present.

Solution:
---------
The solution is to recalculate timesheets
if a new user is detected on an employee.

Timesheets from public holidays to be created
for this user must be after the employee's
creation date or in the future.

opw-3876732