### PR TITLE
[FIX] stock: fix warehouse id in context of reports

### DIFF
--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -132,7 +132,7 @@ class ReplenishmentReport(models.AbstractModel):
         assert product_template_ids or product_variant_ids
         res = {}
 
-        if self.env.context.get('warehouse'):
+        if self.env.context.get('warehouse') and isinstance(self.env.context['warehouse'], int):
             warehouse = self.env['stock.warehouse'].browse(self.env.context.get('warehouse'))
         else:
             warehouse = self.env['stock.warehouse'].browse(self.get_warehouses()[0]['id'])


### PR DESCRIPTION
Steps to reproduce:

- Navigate to Product Variants list view in the Inventory module
- Search for a warehouse e.g. "My Company" in the list view
- Click on any storable product e.g. DESK0005
- In the product form view click on the "Forecasted" button

This gives a traceback because the 'warehouse' in the context is the name and not the id.

Fixes #165330