### PR TITLE
[IMP] mail: open avatar card in activity and gantt view

### DIFF
--- a/addons/mail/static/src/views/web/fields/avatar/avatar.js
+++ b/addons/mail/static/src/views/web/fields/avatar/avatar.js
@@ -1,4 +1,5 @@
-import { useOpenChat } from "@mail/core/web/open_chat_hook";
+import { usePopover } from "@web/core/popover/popover_hook";
+import { AvatarCardPopover } from "@mail/discuss/web/avatar_card/avatar_card_popover";
 
 import { Component } from "@odoo/owl";
 
@@ -12,10 +13,18 @@ export class Avatar extends Component {
     };
 
     setup() {
-        this.openChat = useOpenChat(this.props.resModel);
+        this.avatarCard = usePopover(AvatarCardPopover);
     }
 
-    onClickAvatar() {
-        this.openChat(this.props.resId);
+    onClickAvatar(ev) {
+        if (this.env.isSmall || !this.props.resId) {
+            return;
+        }
+        const target = ev.currentTarget;
+        if (!this.avatarCard.isOpen) {
+            this.avatarCard.open(target, {
+                id: this.props.resId,
+            });
+        }
     }
 }

--- a/addons/mail/static/tests/web/fields/avatar.test.js
+++ b/addons/mail/static/tests/web/fields/avatar.test.js
@@ -1,6 +1,7 @@
 import { click, contains, defineMailModels, start } from "@mail/../tests/mail_test_helpers";
 import { describe, test } from "@odoo/hoot";
 import { mountWithCleanup } from "@web/../tests/web_test_helpers";
+import { serverState } from "@web/../tests/_framework/mock_server_state.hoot";
 
 import { Avatar } from "@mail/views/web/fields/avatar/avatar";
 
@@ -11,17 +12,17 @@ test("basic rendering", async () => {
     await start();
     await mountWithCleanup(Avatar, {
         props: {
-            resId: 2,
+            resId: serverState.userId,
             resModel: "res.users",
             displayName: "User display name",
         },
     });
     await contains(".o-mail-Avatar");
     await contains(".o-mail-Avatar img");
-    await contains(".o-mail-Avatar img[data-src='/web/image/res.users/2/avatar_128']");
+    await contains(".o-mail-Avatar img[data-src='/web/image/res.users/7/avatar_128']");
     await contains(".o-mail-Avatar span");
     await contains(".o-mail-Avatar span", { text: "User display name" });
-    await contains(".o-mail-ChatWindow", { count: 0 });
+    await contains(".o_avatar_card", { count: 0 });
     await click(".o-mail-Avatar img");
-    await contains(".o-mail-ChatWindow");
+    await contains(".o_avatar_card");
 });


### PR DESCRIPTION
Before this commit when clicked on the avatar the discuss chatter 
window is getting opened which is a bit weird and inconsistency 
among other views for example in kanban view the avatar card gets opened.

After this commit when clicked on the avatar the avatar card will get open 
which will maintain consistency among other views.

Task-3827385

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
