### PR TITLE
[IMP] website, website_*: improve kanban view of website visitors

### DIFF
--- a/addons/website/static/src/scss/website_visitor_views.scss
+++ b/addons/website/static/src/scss/website_visitor_views.scss
@@ -1,22 +1,18 @@
-.o_wvisitor_kanban .o_kanban_renderer {
-    &.o_kanban_ungrouped {
-        padding:0px;
-        .o_kanban_record {
-            width: 100%;
-            margin: 0px;
-            .o_wvisitor_kanban_card {
-                margin: 0px;
-                padding: 0px;
-                border-top: 0px !important;
-                .oe_kanban_details {
-                    display:none !important;
-                }
-            }
+.o_wvisitor_kanban {
+    .o_kanban_renderer {
+        --KanbanRecord-width: 500px;
+    }
+
+    .w_visitor_kanban_actions {
+        .btn {
+            margin: 0 2% 2% 0;
         }
     }
-    &.o_kanban_grouped {
-        .o_kanban_detail_ungrouped {
-            display:none !important;
+
+    .w_visitor_kanban_stats {
+        > div a {
+            float: right;
+            font-weight: bold;
         }
     }
 }
@@ -24,11 +20,4 @@
 .o_country_flag {
     width:24px;
     height: 16px;
-}
-
-.w_visitor_kanban_actions_ungrouped .btn {
-    margin: inherit;
-    &:not(:last-child){
-        margin-right: 0.25rem;
-    }
 }

--- a/addons/website/views/website_visitor_views.xml
+++ b/addons/website/views/website_visitor_views.xml
@@ -79,7 +79,7 @@
         <field name="name">website.visitor.view.kanban</field>
         <field name="model">website.visitor</field>
         <field name="arch" type="xml">
-            <kanban class="o_wvisitor_kanban" sample="1">
+            <kanban class="o_wvisitor_kanban o_emphasize_colors o_kanban_dashboard" sample="1">
                 <field name="id"/>
                 <field name="country_id"/>
                 <field name="country_flag"/>
@@ -92,81 +92,59 @@
                 <field name="partner_image"/>
                 <templates>
                     <t t-name="kanban-box">
-                        <div class="oe_kanban_global_click o_wvisitor_kanban_card">
-                            <!-- displayed in ungrouped mode -->
-                            <div class="o_kanban_detail_ungrouped row mx-0">
-                                <div class="col-lg-2 col-sm-8 col-12 py-0 my-2 my-lg-0">
-                                    <div class="d-flex">
-                                        <div class="o_wvisitor_kanban_image me-3">
-                                            <img t-if="record.partner_image.raw_value"
-                                                t-att-src="kanban_image('res.partner', 'avatar_128', record.partner_id.raw_value)"
-                                                width="54px" height="54px" alt="Visitor"/>
-                                            <img t-else=""
-                                                t-attf-src="/base/static/img/avatar_grey.png"
-                                                width="54px" height="54px" alt="Visitor"/>
-                                        </div>
-                                        <div class="o_wvisitor_name d-flex flex-grow-1 flex-column my-0 my-lg-2">
-                                            <div class="d-flex align-items-start">
-                                                <b><field name="display_name"/></b>
-                                                <span t-if="record.is_connected.raw_value" class="fa fa-circle text-success ms-2 my-1" aria-label="Online" title="Online"/>
-                                                <span t-else="" class="fa fa-circle text-danger ms-2 my-1" aria-label="Offline" title="Offline"/>
-                                            </div>
-                                            <!-- Double check is necessary for sample view (or error image are shown) -->
-                                            <div t-if="record.country_id.raw_value and record.country_flag.raw_value">
-                                                <img t-att-src="record.country_flag.raw_value"
-                                                    class="o_country_flag" alt="Country"/>
-                                            </div>
-                                        </div>
+                        <div class="oe_kanban_card oe_kanban_global_click">
+                            <div class="o_kanban_card_header d-flex gap-2">
+                                <img t-if="record.partner_image.raw_value"
+                                    t-att-src="kanban_image('res.partner', 'avatar_128', record.partner_id.raw_value)"
+                                    width="54px" height="54px" alt="Visitor"/>
+                                <img t-else=""
+                                    t-attf-src="/base/static/img/avatar_grey.png"
+                                    width="54px" height="54px" alt="Visitor"/>
+                                <div class="o_kanban_card_header_title mb16">
+                                    <div class="d-flex align-items-center gap-2">
+                                        <field name="display_name" class="o_primary"/>
+                                        <span t-if="record.is_connected.raw_value" class="fa fa-circle text-success" aria-label="Online" title="Online"/>
+                                        <span t-else="" class="fa fa-circle text-danger" aria-label="Offline" title="Offline"/>
+                                    </div>
+                                    <!-- Double check is necessary for sample view (or error image are shown) -->
+                                    <div t-if="record.country_id.raw_value and record.country_flag.raw_value">
+                                        <img t-att-src="record.country_flag.raw_value" class="o_country_flag" alt="Country"/>
                                     </div>
                                 </div>
-                                <div class="col-lg col-sm-4 col-6 py-0 my-2">
-                                    <b><field name="time_since_last_action"/></b>
-                                    <div>Last Action</div>
-                                </div>
-                                <div class="col-lg col-sm-4 col-6 py-0 my-2">
-                                    <b><field name="visit_count"/></b>
-                                    <div>Visits</div>
-                                </div>
-                                <div class="col-lg col-sm-4 col-6 py-0 my-2">
-                                    <span t-att-class="record.page_count.raw_value ? 'fw-bold' : 'text-muted'">
-                                        <field name="last_visited_page_id"/>
-                                    </span>
-                                    <div t-att-class="record.page_count.raw_value ? '' : 'text-muted'">Last Page</div>
-                                </div>
-                                <div id="wvisitor_visited_page" class="col-lg col-sm-4 col-6 py-0 my-2">
-                                     <span t-att-class="record.page_count.raw_value ? 'fw-bold' : 'text-muted'">
-                                        <field name="page_count"/>
-                                    </span>
-                                    <div t-att-class="record.page_count.raw_value ? '' : 'text-muted'">Visited Pages</div>
-                                </div>
-                                <div class="w_visitor_kanban_actions_ungrouped col-lg-3 col-sm-12 py-0 my-2 text-lg-end">
-                                    <button name="action_send_mail" type="object"
-                                            class="btn btn-secondary" invisible="not email">
-                                            Email
-                                    </button>
-                                </div>
                             </div>
-                            <!-- displayed in grouped mode -->
-                            <div class="oe_kanban_details">
-                                <div class="float-end">
-                                    <span class="fa fa-circle text-success" t-if="record.is_connected.raw_value" aria-label="Online" title="Online"/>
-                                    <span class="fa fa-circle text-danger" t-else="" aria-label="Offline" title="Offline"/>
+                            <div class="container o_kanban_card_content">
+                                <div class="row">
+                                    <div class="col-md-7 w_visitor_kanban_actions">
+                                        <button name="action_send_mail" type="object" icon="fa-envelope-o" class="btn btn-secondary"
+                                                invisible="not email" string="Email"/>
+                                    </div>
+                                    <div class="col-md-5 w_visitor_kanban_stats"/>
                                 </div>
-                                <strong>
-                                    <img t-if="record.country_id.raw_value"
-                                       t-att-src="record.country_flag.raw_value"
-                                       class="o_country_flag" alt="Country"/>
-                                    <field name="display_name"/>
-                                </strong>
-                                <div class="mb-2">Active <field name="time_since_last_action"/></div>
-                                <div t-if="record.page_count.raw_value">Last Page<span class="float-end fw-bold"><field name="last_visited_page_id"/></span></div>
-                                <div>Visits<span class="float-end fw-bold"><field name="visit_count"/></span></div>
-                                <div t-if="record.page_count.raw_value" id="o_page_count">Visited Pages<span class="float-end fw-bold"><field name="page_count"/></span></div>
-                                <div class="w_visitor_kanban_actions">
-                                    <button name="action_send_mail" type="object"
-                                            class="btn btn-secondary" invisible="not email">
-                                            Email
-                                    </button>
+                                <div class="row mt-3 w_kanban_details_bottom">
+                                    <div class="col-3 border-end">
+                                        <div class="d-flex flex-column align-items-center">
+                                            <field name="time_since_last_action" class="fw-bold"/>
+                                            <span class="text-muted">Last Action</span>
+                                        </div>
+                                    </div>
+                                    <div class="col-3 border-end">
+                                        <div class="d-flex flex-column align-items-center">
+                                            <field name="visit_count" class="fw-bold"/>
+                                            <span class="text-muted">Visits</span>
+                                        </div>
+                                    </div>
+                                    <div class="col-3 border-end">
+                                        <div class="d-flex flex-column align-items-center">
+                                            <field name="last_visited_page_id" class="fw-bold"/>
+                                            <span class="text-muted">Last Page</span>
+                                        </div>
+                                    </div>
+                                    <div class="col-3">
+                                        <a type="action" name="website.website_visitor_page_action" class="d-flex flex-column align-items-center">
+                                            <field name="page_count" class="fw-bold"/>
+                                            <span class="text-muted">Visited Pages</span>
+                                        </a>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/addons/website_crm/views/website_visitor_views.xml
+++ b/addons/website_crm/views/website_visitor_views.xml
@@ -44,24 +44,17 @@
         <field name="name">website.visitor.view.kanban.inherit.website.crm</field>
         <field name="model">website.visitor</field>
         <field name="inherit_id" ref="website.website_visitor_view_kanban"/>
+        <field name="priority" eval="18"/>
         <field name="arch" type="xml">
             <field name="page_ids" position="after">
                 <field name="lead_count"/>
             </field>
-            <xpath expr="//div[@id='o_page_count']" position="after">
-                <div t-if="record.lead_count.raw_value" groups="sales_team.group_sale_salesman">
+            <xpath expr="//div[hasclass('w_visitor_kanban_stats')]" position="inside">
+                <div groups="sales_team.group_sale_salesman">
                     Leads / Opportunities
-                    <span class="float-end fw-bold">
+                    <a type="action" name="website_crm.crm_lead_action_from_visitor">
                         <field name="lead_count"/>
-                    </span>
-                </div>
-            </xpath>
-            <xpath expr="//div[@id='wvisitor_visited_page']" position="after">
-                <div class="col-lg col-sm-4 col-6 py-0 my-2" groups="sales_team.group_sale_salesman">
-                    <span t-att-class="record.lead_count.raw_value ? 'fw-bold' : 'text-muted'">
-                        <field name="lead_count"/>
-                    </span>
-                    <div t-att-class="record.lead_count.raw_value ? '' : 'text-muted'">Leads / Opportunities</div>
+                    </a>
                 </div>
             </xpath>
         </field>

--- a/addons/website_event/views/website_visitor_views.xml
+++ b/addons/website_event/views/website_visitor_views.xml
@@ -28,4 +28,21 @@
             </xpath>
         </field>
     </record>
+
+    <record id="website_event_visitor_view_kanban" model="ir.ui.view">
+        <field name="name">website.visitor.view.kanban.inherit.event</field>
+        <field name="model">website.visitor</field>
+        <field name="inherit_id" ref="website.website_visitor_view_kanban"/>
+        <field name="priority" eval="19"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('w_visitor_kanban_stats')]" position="inside">
+                <div id="o_event_registration_count">
+                    Event Registration
+                    <a type="action" name="website_event.event_registration_action_from_visitor">
+                        <field name="event_registration_count"/>
+                    </a>
+                </div>
+            </xpath>
+        </field>
+    </record>
 </data></odoo>

--- a/addons/website_event_track/views/website_visitor_views.xml
+++ b/addons/website_event_track/views/website_visitor_views.xml
@@ -28,4 +28,21 @@
             </xpath>
         </field>
     </record>
+
+    <record id="website_event_track_visitor_view_kanban" model="ir.ui.view">
+        <field name="name">website.visitor.view.kanban.inherit.event</field>
+        <field name="model">website.visitor</field>
+        <field name="inherit_id" ref="website.website_visitor_view_kanban"/>
+        <field name="priority" eval="20"/>
+        <field name="arch" type="xml">
+            <xpath expr="//div[hasclass('w_visitor_kanban_stats')]" position="inside">
+                <div id="o_event_registration_count">
+                    Event Track
+                    <a type="action" name="website_event_track.event_track_action_from_visitor">
+                        <field name="event_track_wishlisted_count"/>
+                    </a>
+                </div>
+            </xpath>
+        </field>
+    </record>
 </data></odoo>

--- a/addons/website_livechat/views/website_visitor_views.xml
+++ b/addons/website_livechat/views/website_visitor_views.xml
@@ -31,18 +31,26 @@
         <field name="name">website.visitor.view.kanban.inherit.website.livechat</field>
         <field name="model">website.visitor</field>
         <field name="inherit_id" ref="website.website_visitor_view_kanban"/>
+        <field name="priority" eval="21"/>
         <field name="arch" type="xml">
             <field name="page_ids" position="after">
                 <field name="livechat_operator_id"/>
                 <field name="session_count"/>
             </field>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="before">
-                <div t-if="record.session_count.raw_value">Chats<span class="float-end fw-bold"><field name="session_count"/></span></div>
+            <xpath expr="//div[hasclass('w_visitor_kanban_stats')]" position="inside">
+                <div t-if="record.session_count.raw_value">
+                    Chats
+                    <a type="action" name="website_livechat.website_visitor_livechat_session_action">
+                        <span class="float-end fw-bold">
+                            <field name="session_count"/>
+                        </span>
+                    </a>
+                </div>
                 <div t-if="record.livechat_operator_id.raw_value">
                     Speaking With
                     <div name="livechat_operator_id"
                         class="fw-bold float-end d-inline-block">
-                        <img class="oe_avatar rounded-circle" width="19" height="19"
+                        <img class="oe_avatar rounded-circle me-1 mb-1" width="19" height="19"
                             t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/avatar_128"
                             alt="Operator Avatar"/>
                         <field name="livechat_operator_name"/>
@@ -52,38 +60,9 @@
                     <br invisible="livechat_operator_id or not is_connected"/>
                 </t>
             </xpath>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions_ungrouped')]" position="before">
-                <div class="col-lg col-sm-4 col-6 py-0 my-2">
-                    <span t-att-class="record.session_count.raw_value ? 'fw-bold' : 'text-muted'">
-                        <field name="session_count"/>
-                    </span>
-                    <div t-att-class="record.session_count.raw_value ? '' : 'text-muted'">Chats</div>
-                </div>
-                <div t-if="record.livechat_operator_id.raw_value" class="col-lg col-sm-4 col-6 py-0 my-2">
-                    <div>
-                        <img name="livechat_operator_id"
-                            class="oe_avatar rounded-circle" width="19" height="19"
-                            t-attf-src="/web/image/res.partner/#{record.livechat_operator_id.raw_value}/avatar_128"
-                            alt="Operator Avatar"/>
-                        <b><field name="livechat_operator_name"/></b>
-                    </div>
-                    <div>Speaking With</div>
-                </div>
-                <div t-else="" class="col-lg d-none d-lg-block"/>
-            </xpath>
             <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="inside">
-                <button name="action_send_chat_request" type="object"
-                        class="btn btn-secondary"
-                        invisible="livechat_operator_id or not is_connected">
-                        Chat
-                </button>
-            </xpath>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions_ungrouped')]" position="inside">
-                <button name="action_send_chat_request" type="object"
-                        class="btn btn-secondary"
-                        invisible="livechat_operator_id or not is_connected">
-                        Chat
-                </button>
+                <button name="action_send_chat_request" type="object" icon="fa-comments-o" class="btn btn-secondary"
+                        invisible="livechat_operator_id or not is_connected" string="Chat"/>
             </xpath>
         </field>
     </record>

--- a/addons/website_sale/views/website_sale_visitor_views.xml
+++ b/addons/website_sale/views/website_sale_visitor_views.xml
@@ -91,12 +91,18 @@
         <field name="name">website.visitor.view.kanban</field>
         <field name="model">website.visitor</field>
         <field name="inherit_id" ref="website.website_visitor_view_kanban"/>
+        <field name="priority" eval="17"/>
         <field name="arch" type="xml">
             <field name="page_ids" position="after">
                 <field name="product_ids"/>
             </field>
-            <xpath expr="//div[@id='o_page_count']" position="after">
-                 <div id="o_product_count">Visited Products<span class="float-end fw-bold"><field name="product_count"/></span></div>
+            <xpath expr="//div[hasclass('w_visitor_kanban_stats')]" position="inside">
+                <div id="o_product_count">
+                    Visited Products
+                    <a type="action" name="website_sale.website_sale_visitor_product_action">
+                        <field name="product_count"/>
+                    </a>
+                </div>
             </xpath>
         </field>
     </record>

--- a/addons/website_sms/views/website_visitor_views.xml
+++ b/addons/website_sms/views/website_visitor_views.xml
@@ -21,14 +21,8 @@
                 <field name="mobile" widget="phone"/>
             </field>
             <xpath expr="//div[hasclass('w_visitor_kanban_actions')]" position="inside">
-                <button name="action_send_sms" type="object" class="btn btn-secondary"
-                        invisible="not mobile">SMS
-                </button>
-            </xpath>
-            <xpath expr="//div[hasclass('w_visitor_kanban_actions_ungrouped')]" position="inside">
-                <button name="action_send_sms" type="object" class="btn btn-secondary"
-                        invisible="not mobile">SMS
-                </button>
+                <button name="action_send_sms" type="object" icon="fa-mobile" class="btn btn-secondary"
+                        invisible="not mobile" string="SMS"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
*: crm, livechat, sale, sms, event, event_track

Purpose:
The current Kanban view of the visitor list appears inconsistent, with two different layouts for grouped and ungrouped views, and it lacks a distinct Kanban style, making it less user-friendly.
To address this, we have unified the Kanban view layout to ensure it appears as Kanban cards rather than a list.

Changes Introduced:
- Unified the Kanban view layout to be more feasible and user-friendly
- Enhanced visual representation of visitor information, aligning with Kanban card standards

Before:

1. Visitor Ungrouped KanBan View.
![image](https://github.com/odoo/odoo/assets/157005855/7ae8bcca-1259-48ff-afd9-61a097367e99)

2. Visitor grouped KanBan View.
![image](https://github.com/odoo/odoo/assets/157005855/5a1b88c4-b3e9-4d0b-b1a2-12eb058ac2d4)

After:

1. New Improved KanBan View.
![image](https://github.com/odoo/odoo/assets/157005855/a3541d45-78ca-43e8-b084-7586e396067c)

task-3895876