### PR TITLE
[FIX] mail: fix non reliable message unread counter

### DIFF
--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -794,6 +794,8 @@ class Channel(models.Model):
         """
         if not self:
             return []
+        # sudo: bus.bus: reading non-sensitive last id
+        bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         channel_infos = []
         # sudo: discuss.channel.rtc.session - reading sessions of accessible channel is acceptable
         rtc_sessions_by_channel = self.sudo().rtc_session_ids._mail_rtc_session_format_by_channel(extra=True)
@@ -840,6 +842,7 @@ class Channel(models.Model):
                     info['channelMembers'] = [('ADD', list(member._discuss_channel_member_format().values()))]
                     info['state'] = member.fold_state or 'open'
                     info['message_unread_counter'] = member.message_unread_counter
+                    info["message_unread_counter_bus_id"] = bus_last_id
                     info['is_minimized'] = member.is_minimized
                     info['custom_notifications'] = member.custom_notifications
                     info['mute_until_dt'] = member.mute_until_dt.strftime(DEFAULT_SERVER_DATETIME_FORMAT) if member.mute_until_dt else False

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -102,6 +102,11 @@ export class Message extends Record {
     is_discussion;
     /** @type {boolean} */
     is_note;
+    isSeenBySelf = Record.attr(false, {
+        compute() {
+            return this.originThread?.selfMember?.lastSeenMessage?.id >= this.id;
+        },
+    });
     /** @type {boolean} */
     isStarred;
     /** @type {boolean} */

--- a/addons/mail/static/src/core/common/thread_model.js
+++ b/addons/mail/static/src/core/common/thread_model.js
@@ -235,6 +235,7 @@ export class Thread extends Record {
     memberCount = 0;
     message_needaction_counter = 0;
     message_unread_counter = 0;
+    message_unread_counter_bus_id = 0;
     /**
      * Contains continuous sequence of messages to show in message list.
      * Messages are ordered from older to most recent.

--- a/addons/mail/static/src/core/common/thread_service.js
+++ b/addons/mail/static/src/core/common/thread_service.js
@@ -106,49 +106,27 @@ export class ThreadService {
                 .then(() => this.markAsRead(thread));
         }
         thread.seen_message_id = newestPersistentMessage?.id ?? false;
-        if (
-            thread.message_unread_counter > 0 &&
-            thread.model === "discuss.channel" &&
-            newestPersistentMessage
-        ) {
+        const alreadySeenBySelf = newestPersistentMessage?.isSeenBySelf;
+        if (thread.selfMember) {
+            thread.selfMember.lastSeenMessage = newestPersistentMessage;
+        }
+        if (newestPersistentMessage && thread.selfMember && !alreadySeenBySelf) {
             this.rpc("/discuss/channel/set_last_seen_message", {
                 channel_id: thread.id,
                 last_message_id: newestPersistentMessage.id,
-            })
-                .then(() => {
-                    this.updateSeen(thread, newestPersistentMessage.id);
-                })
-                .catch((e) => {
-                    if (e.code !== 404) {
-                        throw e;
-                    }
-                });
-        } else if (newestPersistentMessage) {
-            this.updateSeen(thread);
+            }).catch((e) => {
+                if (e.code !== 404) {
+                    throw e;
+                }
+            });
         }
         if (thread.needactionMessages.length > 0) {
             this.markAllMessagesAsRead(thread);
         }
     }
 
-    updateSeen(thread, lastSeenId = thread.newestPersistentOfAllMessage?.id) {
-        const lastReadIndex = thread.messages.findIndex((message) => message.id === lastSeenId);
-        let newNeedactionCounter = 0;
-        let newUnreadCounter = 0;
-        for (const message of thread.messages.slice(lastReadIndex + 1)) {
-            if (message.isNeedaction) {
-                newNeedactionCounter++;
-            }
-            if (Number.isInteger(message.id)) {
-                newUnreadCounter++;
-            }
-        }
-        Object.assign(thread, {
-            seen_message_id: lastSeenId,
-            message_needaction_counter: newNeedactionCounter,
-            message_unread_counter: newUnreadCounter,
-        });
-    }
+    /** @deprecated */
+    updateSeen(thread, lastSeenId = thread.newestPersistentOfAllMessage?.id) {}
 
     async markAllMessagesAsRead(thread) {
         await this.orm.silent.call("mail.message", "mark_all_as_read", [
@@ -738,6 +716,9 @@ export class ThreadService {
             );
             thread.messages.push(tmpMsg);
             thread.seen_message_id = tmpMsg.id;
+            if (thread.selfMember) {
+                thread.selfMember.lastSeenMessage = tmpMsg;
+            }
         }
         const data = await this.rpc(this.getMessagePostRoute(thread), params);
         tmpMsg?.delete();
@@ -749,6 +730,10 @@ export class ThreadService {
         }
         const message = this.store.Message.insert(data, { html: true });
         thread.messages.add(message);
+        if (thread.selfMember && !message.isSeenBySelf) {
+            thread.seen_message_id = message.id;
+            thread.selfMember.lastSeenMessage = message;
+        }
         if (!message.isEmpty && this.store.hasLinkPreviewFeature) {
             this.rpc("/mail/link_preview", { message_id: data.id }, { silent: true });
         }

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -260,7 +260,7 @@ export class DiscussCoreCommon {
             if (message.isSelfAuthored) {
                 channel.seen_message_id = message.id;
             } else {
-                if (notif.id > this.store.initBusId) {
+                if (notif.id > this.store.message_unread_counter_bus_id) {
                     channel.message_unread_counter++;
                 }
             }

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -150,38 +150,6 @@ export class DiscussCoreCommon {
                     thread: { id: channel_id, model: "discuss.channel" },
                 });
             });
-            this.busService.subscribe("discuss.channel.member/seen", (payload) => {
-                const { channel_id, guest_id, id, last_message_id, partner_id } = payload;
-                const channel = this.store.Thread.get({ model: "discuss.channel", id: channel_id });
-                if (!channel) {
-                    // for example seen from another browser, the current one has no
-                    // knowledge of the channel
-                    return;
-                }
-                const member = id
-                    ? this.store.ChannelMember.insert({
-                          id,
-                          persona: {
-                              id: partner_id ?? guest_id,
-                              type: partner_id ? "partner" : "guest",
-                          },
-                          thread: { id: channel_id, model: "discuss.channel" },
-                      })
-                    : channel.channelMembers.find((member) => {
-                          const persona = this.store.Persona.get({
-                              type: partner_id ? "partner" : "guest",
-                              id: partner_id ?? guest_id,
-                          });
-                          return persona?.eq(member.persona);
-                      });
-                if (!member) {
-                    return;
-                }
-                member.lastSeenMessage = { id: last_message_id };
-                if (member.persona.eq(this.store.self)) {
-                    this.threadService.updateSeen(channel, last_message_id);
-                }
-            });
             this.env.bus.addEventListener("mail.message/delete", ({ detail: { message } }) => {
                 if (message.originThread) {
                     if (message.id > message.originThread.seen_message_id) {
@@ -260,7 +228,7 @@ export class DiscussCoreCommon {
             if (message.isSelfAuthored) {
                 channel.seen_message_id = message.id;
             } else {
-                if (notif.id > this.store.message_unread_counter_bus_id) {
+                if (notif.id > channel.message_unread_counter_bus_id) {
                     channel.message_unread_counter++;
                 }
             }

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -640,6 +640,7 @@ patch(MockServer.prototype, {
      * @returns {Object[]}
      */
     _mockDiscussChannelChannelInfo(ids) {
+        const bus_last_id = this.lastBusNotificationId;
         const channels = this.getRecords("discuss.channel", [["id", "in", ids]]);
         return channels.map((channel) => {
             const members = this.getRecords("discuss.channel.member", [
@@ -673,6 +674,7 @@ patch(MockServer.prototype, {
                 Object.assign(res, {
                     custom_channel_name: memberOfCurrentUser.custom_channel_name,
                     message_unread_counter: memberOfCurrentUser.message_unread_counter,
+                    message_unread_counter_bus_id: bus_last_id,
                 });
                 if (memberOfCurrentUser.rtc_inviting_session_id) {
                     res["rtc_inviting_session"] = {

--- a/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
+++ b/addons/mail/static/tests/helpers/mock_server/models/discuss_channel.js
@@ -1036,24 +1036,52 @@ patch(MockServer.prototype, {
      */
     _mockDiscussChannel_SetLastSeenMessage(ids, message_id) {
         const memberOfCurrentUser = this._mockDiscussChannelMember__getAsSudoFromContext(ids[0]);
+        const message_unread_counter = this.pyEnv["mail.message"].search([
+            ["res_id", "=", ids[0]],
+            ["model", "=", "discuss.channel"],
+            ["id", ">", message_id],
+        ]).length;
         if (memberOfCurrentUser) {
             this.pyEnv["discuss.channel.member"].write([memberOfCurrentUser.id], {
                 fetched_message_id: message_id,
                 seen_message_id: message_id,
+                message_unread_counter,
             });
         }
         const [channel] = this.pyEnv["discuss.channel"].searchRead([["id", "in", ids]]);
         const [partner, guest] = this._mockResPartner__getCurrentPersona();
-        let target = guest ?? partner;
-        if (this._mockDiscussChannel__typesAllowingSeenInfos().includes(channel.channel_type)) {
-            target = channel;
-        }
-        this.pyEnv["bus.bus"]._sendone(target, "discuss.channel.member/seen", {
-            channel_id: channel.id,
+        const memberBasicInfo = {
             id: memberOfCurrentUser?.id,
-            last_message_id: message_id,
-            [guest ? "guest_id" : "partner_id"]: guest?.id ?? partner.id,
-        });
+            lastSeenMessage: message_id ? { id: message_id } : false,
+        };
+        const memberSelfInfo = {
+            ...memberBasicInfo,
+            thread: {
+                id: channel.id,
+                model: "discuss.channel",
+                message_unread_counter,
+                message_unread_counter_bus_id: this.lastBusNotificationId,
+                seen_message_id: message_id || false,
+            },
+        };
+        const notifications = [];
+        if (memberOfCurrentUser) {
+            notifications.push([
+                guest ?? partner,
+                "mail.record/insert",
+                { ChannelMember: memberSelfInfo },
+            ]);
+        }
+        if (this._mockDiscussChannel__typesAllowingSeenInfos().includes(channel.channel_type)) {
+            notifications.push([
+                channel,
+                "mail.record/insert",
+                {
+                    ChannelMember: memberBasicInfo,
+                },
+            ]);
+        }
+        this.pyEnv["bus.bus"]._sendmany(notifications);
     },
     /**
      * Simulates `_types_allowing_seen_infos` on `discuss.channel`.

--- a/addons/mail/static/tests/message/message_seen_indicator_tests.js
+++ b/addons/mail/static/tests/message/message_seen_indicator_tests.js
@@ -209,7 +209,7 @@ QUnit.test("'channel_fetch' notification received is correctly handled", async (
     await contains(".o-mail-MessageSeenIndicator i");
 });
 
-QUnit.test("'channel_seen' notification received is correctly handled", async () => {
+QUnit.test("mark channel as seen from the bus", async () => {
     const pyEnv = await startServer();
     const partnerId = pyEnv["res.partner"].create({ name: "test" });
     const channelId = pyEnv["discuss.channel"].create({
@@ -220,7 +220,7 @@ QUnit.test("'channel_seen' notification received is correctly handled", async ()
         ],
         channel_type: "chat",
     });
-    pyEnv["mail.message"].create({
+    const messageId = pyEnv["mail.message"].create({
         author_id: pyEnv.currentPartnerId,
         body: "<p>Test</p>",
         model: "discuss.channel",
@@ -233,16 +233,20 @@ QUnit.test("'channel_seen' notification received is correctly handled", async ()
 
     const channel = pyEnv["discuss.channel"].searchRead([["id", "=", channelId]])[0];
     // Simulate received channel seen notification
-    pyEnv["bus.bus"]._sendone(channel, "discuss.channel.member/seen", {
-        channel_id: channelId,
-        last_message_id: 100,
-        partner_id: partnerId,
+    pyEnv["bus.bus"]._sendone(channel, "mail.record/insert", {
+        ChannelMember: {
+            id: pyEnv["discuss.channel.member"].search([
+                ["channel_id", "=", channelId],
+                ["partner_id", "=", partnerId],
+            ])[0],
+            lastSeenMessage: { id: messageId },
+        },
     });
     await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
 });
 
 QUnit.test(
-    "'channel_fetch' notification then 'channel_seen' received are correctly handled",
+    "should display message indicator when message is fetched/seen",
     async () => {
         const pyEnv = await startServer();
         const partnerId = pyEnv["res.partner"].create({ name: "Recipient" });
@@ -254,7 +258,7 @@ QUnit.test(
             ],
             channel_type: "chat",
         });
-        pyEnv["mail.message"].create({
+        const messageId = pyEnv["mail.message"].create({
             author_id: pyEnv.currentPartnerId,
             body: "<p>Test</p>",
             model: "discuss.channel",
@@ -269,16 +273,20 @@ QUnit.test(
         // Simulate received channel fetched notification
         pyEnv["bus.bus"]._sendone(channel, "discuss.channel.member/fetched", {
             channel_id: channelId,
-            last_message_id: 100,
+            last_message_id: messageId,
             partner_id: partnerId,
         });
         await contains(".o-mail-MessageSeenIndicator i");
 
         // Simulate received channel seen notification
-        pyEnv["bus.bus"]._sendone(channel, "discuss.channel.member/seen", {
-            channel_id: channelId,
-            last_message_id: 100,
-            partner_id: partnerId,
+        pyEnv["bus.bus"]._sendone(channel, "mail.record/insert", {
+            ChannelMember: {
+                id: pyEnv["discuss.channel.member"].search([
+                    ["channel_id", "=", channelId],
+                    ["partner_id", "=", partnerId],
+                ])[0],
+                lastSeenMessage: { id: messageId },
+            },
         });
         await contains(".o-mail-MessageSeenIndicator i", { count: 2 });
     }

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -203,19 +203,41 @@ class TestChannelInternals(MailCommon):
     def test_set_last_seen_message_should_send_notification_only_once(self):
         chat = self.env['discuss.channel'].with_user(self.user_admin).channel_get((self.partner_employee | self.user_admin.partner_id).ids)
         msg_1 = self._add_messages(chat, 'Body1', author=self.user_employee.partner_id)
+        member = chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id)
 
         self.env['bus.bus'].sudo().search([]).unlink()
         with self.assertBus(
-            [(self.env.cr.dbname, "discuss.channel", chat.id)],
-            [{
-                "type": "discuss.channel.member/seen",
-                "payload": {
-                    'channel_id': chat.id,
-                    'id': chat.channel_member_ids.filtered(lambda m: m.partner_id == self.user_admin.partner_id).id,
-                    'last_message_id': msg_1.id,
-                    'partner_id': self.user_admin.partner_id.id,
+            [
+                (self.env.cr.dbname, "discuss.channel", chat.id),
+                (self.env.cr.dbname, "res.partner", self.user_admin.partner_id.id)
+            ],
+            [
+                {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "ChannelMember": {
+                            "id": member.id,
+                            "lastSeenMessage": {"id": msg_1.id},
+                        },
+                    },
                 },
-            }],
+                   {
+                    "type": "mail.record/insert",
+                    "payload": {
+                        "ChannelMember": {
+                            "id": member.id,
+                            "lastSeenMessage": {"id": msg_1.id},
+                            "thread": {
+                                "id": chat.id,
+                                "message_unread_counter": 0,
+                                "message_unread_counter_bus_id": self.env['bus.bus'].sudo()._bus_last_id(),
+                                "model": "discuss.channel",
+                                "seen_message_id": msg_1.id
+                            }
+                        },
+                    },
+                },
+            ],
         ):
             chat._channel_seen(msg_1.id)
         # There should be no channel member to be set as seen in the second time

--- a/addons/mail/tests/discuss/test_rtc.py
+++ b/addons/mail/tests/discuss/test_rtc.py
@@ -98,7 +98,8 @@ class TestChannelRTC(MailCommon):
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update new session
-                (self.cr.dbname, 'discuss.channel', channel.id),  # channel_seen after posting join message
+                (self.cr.dbname, 'discuss.channel', channel.id),  # channel_seen basic infos after posting join message
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # channel seen member infos (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # message_post "started a live conference" (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id, "members"),  # update of pin state (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update of last interest (not asserted below)
@@ -177,7 +178,8 @@ class TestChannelRTC(MailCommon):
         with self.assertBus(
             [
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update new session
-                (self.cr.dbname, 'discuss.channel', channel.id),  # channel_seen after posting join message
+                (self.cr.dbname, 'discuss.channel', channel.id),  # channel_seen basic infos after posting join message
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # channel seen member info (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # message_post "started a live conference" (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id, "members"),  # update of pin state (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # update of last interest (not asserted below)
@@ -620,9 +622,11 @@ class TestChannelRTC(MailCommon):
                 (self.cr.dbname, 'discuss.channel', channel.id),  # channel joined -- seen (not asserted below)
                 (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # channel joined  -- last_interrest (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # message_post -- new_message (not asserted below)
-                (self.cr.dbname, 'discuss.channel', channel.id),  # message_post -- seen (not asserted below)
+                (self.cr.dbname, 'discuss.channel', channel.id),  # message_post -- seen basic infos (not asserted below)
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # message post -- seen member infos (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id, "members"),  # update of pin state (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # message_post -- last_interrest (not asserted below)
+                (self.cr.dbname, 'res.partner', self.user_employee.partner_id.id),  # message post -- seen member infos (not asserted below)
                 (self.cr.dbname, 'discuss.channel', channel.id),  # new members (not asserted below)
                 (self.cr.dbname, 'res.partner', test_user.partner_id.id),  # incoming invitation
                 (self.cr.dbname, 'mail.guest', test_guest.id),  # incoming invitation

--- a/addons/test_discuss_full/tests/test_performance.py
+++ b/addons/test_discuss_full/tests/test_performance.py
@@ -12,7 +12,7 @@ from odoo.tools.misc import DEFAULT_SERVER_DATETIME_FORMAT
 
 @tagged('post_install', '-at_install')
 class TestDiscussFullPerformance(HttpCase):
-    _query_count = 62
+    _query_count = 63
 
     def setUp(self):
         super().setUp()
@@ -136,6 +136,8 @@ class TestDiscussFullPerformance(HttpCase):
 
             The point of having a separate getter is to allow it to be overriden.
         """
+        # sudo: bus.bus: reading non-sensitive last id
+        bus_last_id = self.env["bus.bus"].sudo()._bus_last_id()
         return {
             'action_discuss_id': self.env['ir.model.data']._xmlid_to_res_id('mail.action_discuss'),
             'initBusId': self.env['bus.bus'].sudo()._bus_last_id(),
@@ -182,6 +184,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_general.id,
                     'memberCount': len(self.group_user.users),
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.user_root.id,
                     'defaultDisplayMode': False,
@@ -237,6 +240,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_channel_public_1.id,
                     'memberCount': 5,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -292,6 +296,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_channel_public_2.id,
                     'memberCount': 5,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -347,6 +352,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_channel_group_1.id,
                     'memberCount': 5,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -402,6 +408,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_channel_group_2.id,
                     'memberCount': 5,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -484,6 +491,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_group_1.id,
                     'memberCount': 2,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -580,6 +588,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_chat_1.id,
                     'memberCount': 2,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -676,6 +685,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_chat_2.id,
                     'memberCount': 2,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -772,6 +782,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_chat_3.id,
                     'memberCount': 2,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -868,6 +879,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_chat_4.id,
                     'memberCount': 2,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.user.id,
                     'defaultDisplayMode': False,
@@ -960,6 +972,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_livechat_1.id,
                     'memberCount': 2,
                     'message_unread_counter': 0,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.users[1].id,
                     'defaultDisplayMode': False,
@@ -1047,6 +1060,7 @@ class TestDiscussFullPerformance(HttpCase):
                     'id': self.channel_livechat_2.id,
                     'memberCount': 2,
                     'message_unread_counter': 1,
+                    'message_unread_counter_bus_id': bus_last_id,
                     'model': "discuss.channel",
                     'create_uid': self.env.ref('base.public_user').id,
                     'defaultDisplayMode': False,


### PR DESCRIPTION
Since 17.0, message unread counter is not reliable. Indeed, it is computed on the client side which is aware of all messages. This PR fixes this issue by backporting the PR that made the unread counter rely on the server state instead.

enterprise: https://github.com/odoo/enterprise/pull/63265