### PR TITLE
[IMP] website_hr_recruitment: copy job url

### DIFF
--- a/addons/website_hr_recruitment/__manifest__.py
+++ b/addons/website_hr_recruitment/__manifest__.py
@@ -30,6 +30,10 @@
             'website_hr_recruitment/static/src/scss/**/*',
             'website_hr_recruitment/static/src/js/website_hr_applicant_form.js',
         ],
+        'web.assets_backend': [
+            'website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.js',
+            'website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.xml',
+        ],
         'website.assets_wysiwyg': [
             'website_hr_recruitment/static/src/js/website_hr_recruitment_editor.js',
         ],

--- a/addons/website_hr_recruitment/models/hr_job.py
+++ b/addons/website_hr_recruitment/models/hr_job.py
@@ -1,5 +1,6 @@
-# -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from werkzeug.urls import url_join
 
 from odoo import fields, models, api
 from odoo.addons.http_routing.models.ir_http import slug
@@ -50,6 +51,12 @@ class Job(models.Model):
             <h6>4 Days after Interview</h6>
         """)
     published_date = fields.Date(compute='_compute_published_date', store=True)
+    full_url = fields.Char('job URL', compute='_compute_full_url')
+
+    @api.depends('website_url')
+    def _compute_full_url(self):
+        for job in self:
+            job.full_url = url_join(job.get_base_url(), (job.website_url or '/jobs'))
 
     @api.depends('website_published')
     def _compute_published_date(self):

--- a/addons/website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.js
+++ b/addons/website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.js
@@ -1,0 +1,35 @@
+import { _t } from "@web/core/l10n/translation";
+import { registry } from "@web/core/registry";
+import { CopyButton } from "@web/core/copy_button/copy_button";
+import { useService } from "@web/core/utils/hooks";
+import { Component } from "@odoo/owl";
+import { standardFieldProps } from "@web/views/fields/standard_field_props";
+
+export class CopyButtonJob extends CopyButton {
+    static template = "website_hr_recruitment.CopyButtonJob";
+
+    setup() {
+        super.setup();
+        this.notification = useService("notification");
+    }
+
+    showTooltip() {
+        this.notification.add(_t("The job link has been copied to the clipboard."), { type: 'success', });
+    }
+}
+export class CopyClipboardCharField extends Component {
+    static components = { CopyButtonJob };
+    static template = "website_hr_recruitment.CopyJobLinkButton";
+    static props = { ...standardFieldProps }
+
+    setup() {
+        this.copyText = _t("Share Job");
+        this.successText = _t("Copied");
+    }
+}
+
+export const copyClipboardJobLinkButton = {
+    component: CopyClipboardCharField,
+};
+
+registry.category("fields").add("CopyClipboardJobLinkButton", copyClipboardJobLinkButton);

--- a/addons/website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.xml
+++ b/addons/website_hr_recruitment/static/src/js/widgets/copy_link_menuitem.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="website_hr_recruitment.CopyJobLinkButton">
+        <CopyButtonJob
+            content="props.record.data[props.name]"
+            copyText="copyText"
+            successText="successText"/>
+    </t>
+
+    <t t-name="website_hr_recruitment.CopyButtonJob">
+        <a
+            t-ref="button"
+            role="button"
+            class="oe_kanban_action oe_kanban_action_a"
+            t-on-click.stop="onClick">
+            <span t-esc="props.copyText"/>
+        </a>
+    </t>
+</templates>

--- a/addons/website_hr_recruitment/views/hr_job_views.xml
+++ b/addons/website_hr_recruitment/views/hr_job_views.xml
@@ -55,6 +55,10 @@
                     </a>
                 </div>
             </xpath>
+
+            <xpath expr="//div[@name='menu_new_applications']" position="after">
+                <field name="full_url" widget="CopyClipboardJobLinkButton"/>
+            </xpath>
         </field>
     </record>
 


### PR DESCRIPTION
This commit adds the possibility to copy the job url to the clipboard from the kanban menu to not cut the flow of the user when sharing the job position.

task-3863751


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
