### PR TITLE
[FIX] account: uplaod vendor bill popup on journals dashboard

### DIFF
--- a/addons/account/views/account_journal_dashboard_view.xml
+++ b/addons/account/views/account_journal_dashboard_view.xml
@@ -290,13 +290,13 @@
                                 </button>
                             </t>
                             <t t-if="journal_type == 'purchase'">
-                                <t t-if="dashboard.entries_count > 0">
-                                    <widget name="account_file_uploader" btnClass="btn btn-primary oe_kanban_action_button"/>
-                                </t>
-                                <t t-else="">
+                                <t t-if="dashboard.is_sample_data">
                                     <button type="object" name="action_create_vendor_bill" class="btn btn-primary d-block" journal_type="purchase" groups="account.group_account_invoice">
                                         <span>Upload</span>
                                     </button>
+                                </t>
+                                <t t-else="">
+                                    <widget name="account_file_uploader" btnClass="btn btn-primary oe_kanban_action_button"/>
                                 </t>
                                 <a type="object" name="action_create_new" class="o_invoice_new" groups="account.group_account_invoice">Create Manually</a>
                             </t>


### PR DESCRIPTION
When clicking on the upload button on vendor bills journal,
the `account_tour_upload_bill` popup is displayed even if we have
already some entries in this journal, it should appear only
if there is no entry.

Since d29a622740f6c34d25c52add5367bfdf58bbaf49 `entries_count` is not
present in dashboard datas anymore, so we use `is_sample_data` instead,
as `is_sample_data == entries_count == 0`

opw-3928821
