### PR TITLE
[FIX] spreadsheet: falsy pivot values

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -289,7 +289,11 @@ export class SpreadsheetPivotModel extends PivotModel {
         const { cols, rows } = this._getColsRowsValuesFromDomain(domain);
         const group = JSON.stringify([rows, cols]);
         const values = this.data.measurements[group];
-        return (values && values[0][measure]) ?? "";
+
+        if (values && (values[0][measure] || values[0][measure] === 0)) {
+            return values[0][measure];
+        }
+        return "";
     }
 
     /**

--- a/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
+++ b/addons/spreadsheet/static/tests/pivots/model/pivot_plugin_test.js
@@ -622,6 +622,43 @@ QUnit.module("spreadsheet > pivot plugin", {}, () => {
         assert.strictEqual(getEvaluatedCell(model, "A3").value, 0);
     });
 
+    QUnit.test(
+        "pivot formula for total should return empty string instead of 'FALSE' when pivot doesn't match any data",
+        async function (assert) {
+            const serverData = getBasicServerData();
+            serverData.models.partner.records = [{ id: 1, name: "A", probability: 10 }];
+
+            const { model } = await createSpreadsheetWithPivot({
+                serverData,
+                arch: /*xml*/ `
+                <pivot>
+                    <field name="name" type="row"/>
+                    <field name="probability" type="measure"/>
+                </pivot>`,
+            });
+
+            model.dispatch("UPDATE_ODOO_PIVOT_DOMAIN", {
+                pivotId: 1,
+                domain: [["probability", "=", 100]],
+            });
+            await waitForDataSourcesLoaded(model);
+
+            setCellContent(model, "A1", '=ODOO.PIVOT(1, "probability", "name", "A")');
+            setCellContent(model, "A2", '=ODOO.PIVOT(1, "probability")');
+            assert.strictEqual(getEvaluatedCell(model, "A1").value, "");
+            assert.strictEqual(getEvaluatedCell(model, "A2").value, "");
+
+            model.dispatch("UPDATE_ODOO_PIVOT_DOMAIN", {
+                pivotId: 1,
+                domain: [],
+            });
+            await waitForDataSourcesLoaded(model);
+
+            assert.strictEqual(getEvaluatedCell(model, "A1").value, 10);
+            assert.strictEqual(getEvaluatedCell(model, "A2").value, 10);
+        }
+    );
+
     QUnit.test("can import/export sorted pivot", async (assert) => {
         const spreadsheetData = {
             pivots: {

--- a/addons/web/static/tests/helpers/mock_server.js
+++ b/addons/web/static/tests/helpers/mock_server.js
@@ -1050,9 +1050,13 @@ export class MockServer {
                         if (func === "array_agg") {
                             group[name] = records.map((r) => r[fieldName]);
                         } else {
-                            group[name] = 0;
-                            for (const r of records) {
-                                group[name] += r[fieldName];
+                            if (!records.length) {
+                                group[name] = false;
+                            } else {
+                                group[name] = 0;
+                                for (const r of records) {
+                                    group[name] += r[fieldName];
+                                }
                             }
                         }
                         break;
@@ -1128,7 +1132,7 @@ export class MockServer {
         }
 
         if (!groupBy.length) {
-            const group = { __count: records.length };
+            const group = { __count: records.length, __domain: kwargs.domain };
             aggregateFields(group, records);
             return [group];
         }

--- a/addons/web/static/tests/mock_server_tests.js
+++ b/addons/web/static/tests/mock_server_tests.js
@@ -242,6 +242,21 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result, 2);
     });
 
+    QUnit.test("performRPC: read_group, no group", async function (assert) {
+        const server = new MockServer(data, {});
+        const result = await server.performRPC("", {
+            model: "bar",
+            method: "read_group",
+            args: [[]],
+            kwargs: {
+                fields: ["foo"],
+                domain: [["foo", "=", -10]],
+                groupby: [],
+            },
+        });
+        assert.deepEqual(result, [{ __count: 0, foo: false, __domain: [["foo", "=", -10]] }]);
+    });
+
     QUnit.test("performRPC: read_group, group by char", async function (assert) {
         const server = new MockServer(data, {});
         const result = await server.performRPC("", {
@@ -1044,6 +1059,7 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result1, [
             {
                 __count: 6,
+                __domain: [],
                 aggregateLabel: aggregateValue,
             },
         ]);
@@ -1060,6 +1076,7 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result2, [
             {
                 __count: 6,
+                __domain: [],
                 partner_id: aggregateValue,
             },
         ]);
@@ -1080,6 +1097,7 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result1, [
             {
                 __count: 6,
+                __domain: [],
                 aggregateLabel: [1, 2, 3, 4, 5, 6],
             },
         ]);
@@ -1096,6 +1114,7 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result2, [
             {
                 __count: 3,
+                __domain: [["id", "in", [2, 3, 5]]],
                 id: [2, 3, 5],
             },
         ]);
@@ -1119,6 +1138,7 @@ QUnit.module("MockServer", (hooks) => {
             assert.deepEqual(result1, [
                 {
                     __count: 6,
+                    __domain: [],
                     aggregateLabel: aggregateValue,
                 },
             ]);
@@ -1135,6 +1155,7 @@ QUnit.module("MockServer", (hooks) => {
             assert.deepEqual(result2, [
                 {
                     __count: 6,
+                    __domain: [],
                     foo: aggregateValue,
                 },
             ]);
@@ -1156,6 +1177,7 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result1, [
             {
                 __count: 6,
+                __domain: [],
                 aggregateLabel: 2,
             },
         ]);
@@ -1172,6 +1194,7 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result2, [
             {
                 __count: 6,
+                __domain: [],
                 partner_id: 2,
             },
         ]);
@@ -1189,6 +1212,7 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result3, [
             {
                 __count: 0,
+                __domain: [[0, "=", 1]],
                 partner_id: 0,
             },
         ]);
@@ -1206,6 +1230,7 @@ QUnit.module("MockServer", (hooks) => {
         assert.deepEqual(result4, [
             {
                 __count: 6,
+                __domain: [],
                 partner_ref: 2,
             },
         ]);


### PR DESCRIPTION
## Description:

Previously, when entering a pivot and applying a filter domain, the pivot formula (without domain field and domain value in function parameter) would return 'FALSE' if it did not match any records. The code now checks the value and returns an empty string if it's 'FALSE'.

Task - [3888401](https://www.odoo.com/web#id=3888401&cids=2&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
