### PR TITLE
[FIX] web: update the selected input date after removing the existing date

### DIFF
--- a/addons/web/static/src/core/datetime/datetime_picker.js
+++ b/addons/web/static/src/core/datetime/datetime_picker.js
@@ -481,6 +481,11 @@ export class DateTimePicker extends Component {
     applyValueAtIndex(value, valueIndex) {
         const result = [...this.values];
         if (this.isRange) {
+            if (result[0] && result[1] === false){
+                valueIndex = 1;
+            }else if (result[1] && result[0] === false){
+                valueIndex = 0;
+            }
             if (result[0] && value.endOf("day") < result[0].startOf("day")) {
                 valueIndex = 0;
             } else if (result[1] && result[1].endOf("day") < value.startOf("day")) {

--- a/addons/web/static/tests/views/fields/daterange_field_tests.js
+++ b/addons/web/static/tests/views/fields/daterange_field_tests.js
@@ -850,4 +850,30 @@ QUnit.module("Fields", (hooks) => {
             "No arrow should be displayed with no values and in readonly"
         );
     });
+
+    QUnit.test(
+        "update the selected input date after removing the existing date",
+        async (assert) => {
+            serverData.models.partner.fields.date_end = { string: "Date End", type: "date" };
+            serverData.models.partner.records[0].date_end = "2017-02-08";
+            await makeView({
+                type: "form",
+                resModel: "partner",
+                resId: 1,
+                serverData,
+                arch: `
+                        <form>
+                            <field name="date" widget="daterange" options="{'end_date_field': 'date_end'}" attrs="{'required': ['|', ('date', '!=', False), ('date_end', '!=', False)]}"/>
+                        </form>`,
+            });
+            await click(target, "input[data-field=date_end]");
+            await editInput(target, "input[data-field=date_end]",null);
+            await click(getPickerCell("12").at(0));
+
+            assert.equal(
+                target.querySelector("input[data-field=date_end]").value,
+                "02/12/2017"
+            );
+        }
+    );
 });


### PR DESCRIPTION
Specification:
When both the start and end dates are set, and the user removes the end date, any subsequent date selection should automatically update the end date.

Observed behavior:
When the user removes the end date and then selects a new date, that date is update the start date.

Expected behavior:
When the user removes the end date and then select a new date, that date should update the end date.

Task-3899581