### PR TITLE
[FIX] point_of_sale: set extra price for variants

### DIFF
--- a/addons/point_of_sale/static/src/js/models.js
+++ b/addons/point_of_sale/static/src/js/models.js
@@ -1600,7 +1600,7 @@ class Product extends PosModel {
                 let base_pricelist = _.find(self.pos.pricelists, function (pricelist) {
                     return pricelist.id === rule.base_pricelist_id[0];});
                 if (base_pricelist) {
-                    price = self.get_price(base_pricelist, quantity);
+                    price = self.get_price(base_pricelist, quantity, price_extra);
                 }
             } else if (rule.base === 'standard_price') {
                 price = self.standard_price;

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -256,3 +256,26 @@ odoo.define('point_of_sale.tour.limitedProductPricelistLoading', function (requi
 
     Tour.register('limitedProductPricelistLoading', { test: true, url: '/pos/ui' }, getSteps());
 });
+
+odoo.define('point_of_sale.tour.priceExtraVariant', function (require) {
+    'use strict';
+
+    const { ProductScreen } = require('point_of_sale.tour.ProductScreenTourMethods');
+    const { getSteps, startSteps } = require('point_of_sale.tour.utils');
+    var Tour = require('web_tour.tour');
+
+    startSteps();
+
+    ProductScreen.do.confirmOpeningPopup();
+    ProductScreen.do.clickHomeCategory();
+
+    ProductScreen.do.clickDisplayedProduct('Test Product');
+    ProductScreen.do.clickVariantCombination('M');
+    ProductScreen.check.selectedOrderlineHas('Test Product', '1', '22.50')
+
+    ProductScreen.do.clickDisplayedProduct('Test Product');
+    ProductScreen.do.clickVariantCombination('S');
+    ProductScreen.check.selectedOrderlineHas('Test Product', '1', '18.00')
+
+    Tour.register('priceExtraVariant', { test: true, url: '/pos/ui' }, getSteps());
+});

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -127,6 +127,20 @@ odoo.define('point_of_sale.tour.ProductScreenTourMethods', function (require) {
                 },
             ];
         }
+
+        clickVariantCombination(name) {
+            return [
+                {
+                    content: `click variant combination '${name}'`,
+                    trigger: `.attribute-name-cell:contains("${name}") input[type="radio"]`
+                },
+                {
+                    content: `add product variant '${name}'`,
+                    trigger: '.button:contains("Add")'
+                },
+            ];
+        }
+
         confirmOpeningPopup() {
             return [{ trigger: '.opening-cash-control .button:contains("Open session")' }];
         }


### PR DESCRIPTION
Problem:
When using a pricelist depending on another one and we have product variants with an attribute configured to have "Variants Creation Mode" set as "Never", extra prices are not applied

Steps to reproduce:
- Install "Sales" and "Point of Sale" apps
- Go to Sales settings, activate "Flexible Pricelists" and set "Advanced price rules"
- Create a pricelist with fixed price applying on product
- Create a second pricelist with formula based on "Other Pricelist" with the last created pricelist as "Other Pricelist". Set a discount (eg. 10%) and apply on "All Products"
- Create attributes with "Variants Creation Mode" set as "Never" and set values
- Create a product, set a price (eg. 20)
- Add attributes to the product and configure an extra price for one (or more) of the value
- Go to POS settings and scroll to the "Pricing" section. Add the previously created pricelists to "Available"
- Go to the shop, select the product previously created and select a variant which has an extra price and another one without extra price
- You should see that the two orderlines have the same price while one of them should be more expensive

opw-3812113


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
