### PR TITLE
[FIX] hr_holidays: sync changes between parent allocations

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -677,34 +677,52 @@ class HolidaysAllocation(models.Model):
 
         self.add_follower(employee_id)
 
-        if 'number_of_days_display' not in values and 'number_of_hours_display' not in values:
-            res = super().write(values)
+        if 'number_of_days_display' in values\
+                or 'number_of_hours_display' in values\
+                or 'number_of_days' in values:
+            previous_consumed_leaves = self.employee_id._get_consumed_leaves(leave_types=self.holiday_status_id)
+            result = super().write(values)
             if 'allocation_type' in values:
                 self._add_lastcalls()
-            return res
+            consumed_leaves = self.employee_id._get_consumed_leaves(leave_types=self.holiday_status_id)
+            for allocation in self:
+                current_excess = dict(consumed_leaves[1]).get(allocation.employee_id, {}) \
+                    .get(allocation.holiday_status_id, {}).get('excess_days', {})
+                previous_excess = dict(previous_consumed_leaves[1]).get(allocation.employee_id, {}) \
+                    .get(allocation.holiday_status_id, {}).get('excess_days', {})
+                total_current_excess = sum(leave_date['amount'] for leave_date in current_excess.values())
+                total_previous_excess = sum(leave_date['amount'] for leave_date in previous_excess.values())
 
-        previous_consumed_leaves = self.employee_id._get_consumed_leaves(leave_types=self.holiday_status_id)
-        result = super().write(values)
-        consumed_leaves = self.employee_id._get_consumed_leaves(leave_types=self.holiday_status_id)
+                if total_current_excess <= total_previous_excess:
+                    continue
+                lt = allocation.holiday_status_id
+                if lt.allows_negative and total_current_excess <= lt.max_allowed_negative:
+                    continue
+                raise ValidationError(
+                    _('You cannot reduce the duration below the duration of leaves already taken by the employee.'))
+        else:
+            result = super().write(values)
+            if 'allocation_type' in values:
+                self._add_lastcalls()
 
-        if 'allocation_type' in values:
-            self._add_lastcalls()
-        for allocation in self:
-            current_excess = dict(consumed_leaves[1]).get(allocation.employee_id, {}) \
-                .get(allocation.holiday_status_id, {}).get('excess_days', {})
-            previous_excess = dict(previous_consumed_leaves[1]).get(allocation.employee_id, {}) \
-                .get(allocation.holiday_status_id, {}).get('excess_days', {})
-            total_current_excess = sum(map(lambda leave_date: leave_date['amount'], current_excess.values()))
-            total_previous_excess = sum(map(lambda leave_date: leave_date['amount'], previous_excess.values()))
-
-            if total_current_excess <= total_previous_excess:
-                continue
-            lt = allocation.holiday_status_id
-            if lt.allows_negative and total_current_excess <= lt.max_allowed_negative:
-                continue
-            raise ValidationError(
-                _('You cannot reduce the duration below the duration of leaves already taken by the employee.'))
-
+        if not self.linked_request_ids:
+            return result
+        write_vals = {
+            field: values.get(field)
+            for field in [
+                'private_name',
+                'holiday_type',
+                'holiday_status_id',
+                'notes',
+                'number_of_days',
+                'allocation_type',
+                'date_from',
+                'date_to',
+                'accrual_plan_id',
+            ] if field in values
+        }
+        if write_vals:
+            self.linked_request_ids.write(write_vals)
         return result
 
     @api.ondelete(at_uninstall=False)
@@ -760,6 +778,8 @@ class HolidaysAllocation(models.Model):
             # In the case we are in holiday_type `employee` and there is only one employee we can keep the same allocation
             # Otherwise we do need to create an allocation for all employees to have a behaviour that is in line
             # with the other holiday_type
+            if allocation.linked_request_ids:
+                continue
             if allocation.state == 'validate' and (allocation.holiday_type in ['category', 'department', 'company'] or
                 (allocation.holiday_type == 'employee' and len(allocation.employee_ids) > 1)):
                 if allocation.holiday_type == 'employee':
@@ -773,11 +793,11 @@ class HolidaysAllocation(models.Model):
 
                 allocation_vals += allocation._prepare_holiday_values(employees)
         if allocation_vals:
-            children = self.env['hr.leave.allocation'].with_context(
+            self.env['hr.leave.allocation'].with_context(
                 mail_notify_force_send=False,
                 mail_activity_automation_skip=True
             ).create(allocation_vals)
-            children.filtered(lambda c: c.validation_type != 'no').action_validate()
+        self.linked_request_ids.filtered(lambda c: c.state != 'validate').action_validate()
 
     def action_refuse(self):
         current_employee = self.env.user.employee_id
@@ -790,7 +810,6 @@ class HolidaysAllocation(models.Model):
             days_taken = days_per_allocation[allocation.employee_id][allocation.holiday_status_id][allocation]['virtual_leaves_taken']
             if days_taken > 0:
                 raise UserError(_('You cannot refuse this allocation request since the employee has already taken leaves for it. Please refuse or delete those leaves first.'))
-
         self.write({'state': 'refuse', 'approver_id': current_employee.id})
         # If a category that created several holidays, cancel all related
         linked_requests = self.mapped('linked_request_ids')


### PR DESCRIPTION
__Explanation of the issue:__
Creating an allocation for multiple employees create children allocations for each individual employee concerned by that allocation. However, before this commit, refusing a parent allocation would refuse the children allocation, and validating it again would still create new children regardless. This behaviour is reminescent from the draft state which was the only way to modify an allocation

__Reproduce the issue:__
- Create a multiple-employee allocation
- Validate it
- Refuse it
- Validate it again
- Refuse it again
- An error should appear, saying: "Allocation request must be confirmed or validated in order to refuse it."

__How the issue was fixed:__
This commit synchronizes both parent and children allocations upon the write of the parent one, which will also update the children. Additionally, validating those parent allocations will now check if children allocations are present beforehand to avoid duplicating them.

task-3935358