### PR TITLE
[FIX]  web:  fix issue with spread operator

### DIFF
--- a/addons/web/static/src/webclient/actions/client_actions.js
+++ b/addons/web/static/src/webclient/actions/client_actions.js
@@ -20,7 +20,7 @@ export function displayNotificationAction(env, action) {
     const links = (params.links || []).map((link) => {
         return `<a href="${escape(link.url)}" target="_blank">${escape(link.label)}</a>`;
     });
-    const message = markup(sprintf(escape(params.message), ...links));
+    const message = markup(sprintf(escape(params.message), links));
     env.services.notification.add(message, options);
     return params.next;
 }


### PR DESCRIPTION
Isuue
=====
There was a problem with using the spread operator in this function when links contained multiple URLs. For example, const array = ['a', 'b', 'c']. When we use the spread operator for the first time, the result is 'a', 'b', 'c'. However ,when  we try to spread it again, it doesn't work properly, it only shows single link inside notification toast

Resolution
===========
The implementation was updated to correctly handle multiple URLs by removing the spread operator before links.