### PR TITLE
[IMP] calendar: replace datetime.datetime.utcnow() usages

### DIFF
--- a/addons/calendar/models/res_users.py
+++ b/addons/calendar/models/res_users.py
@@ -66,9 +66,8 @@ class Users(models.Model):
         #   |           |
         #   |           | <--- `stop_dt_utc` = `stop_dt` if user lives in an area of West longitude (positive shift compared to UTC, America for example)
         #   |           |
-        now_utc = datetime.datetime.utcnow()
-        start_dt_utc = start_dt = now_utc.replace(tzinfo=UTC)
-        stop_dt_utc = datetime.datetime.combine(now_utc.date(), datetime.time.max).replace(tzinfo=UTC)
+        start_dt_utc = start_dt = datetime.datetime.now(UTC)
+        stop_dt_utc = datetime.datetime.combine(start_dt_utc.date(), datetime.time.max).replace(tzinfo=UTC)
 
         tz = self.env.user.tz
         if tz:


### PR DESCRIPTION
Starting python 3.12, utcnow() function is depreciated.
See https://docs.python.org/3/library/datetime.html#datetime.datetime.utcnow
https://github.com/odoo/odoo/pull/163794/files

taskid: 3932486





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
