### PR TITLE
[IMP] stock: add attribute `_get_default_warehouse_id` to res.users

### DIFF
--- a/addons/sale_stock/models/res_users.py
+++ b/addons/sale_stock/models/res_users.py
@@ -12,9 +12,7 @@ class Users(models.Model):
     def _get_default_warehouse_id(self):
         if self.property_warehouse_id:
             return self.property_warehouse_id
-        # !!! Any change to the following search domain should probably
-        # be also applied in sale_stock/models/sale_order.py/_init_column.
-        return self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)
+        return super()._get_default_warehouse_id()
 
     @property
     def SELF_READABLE_FIELDS(self):

--- a/addons/stock/models/__init__.py
+++ b/addons/stock/models/__init__.py
@@ -5,6 +5,7 @@ from . import barcode
 from . import product_strategy
 from . import res_company
 from . import res_partner
+from . import res_users
 from . import res_config_settings
 from . import stock_location
 from . import stock_move

--- a/addons/stock/models/res_users.py
+++ b/addons/stock/models/res_users.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import models
+
+
+class Users(models.Model):
+    _inherit = 'res.users'
+
+    def _get_default_warehouse_id(self):
+        # !!! Any change to the following search domain should probably
+        # be also applied in sale_stock/models/sale_order.py/_init_column.
+        return self.env['stock.warehouse'].search([('company_id', '=', self.env.company.id)], limit=1)


### PR DESCRIPTION
After version >= `16.4` module **repair** is **[using](https://github.com/odoo/odoo/blob/c002aad906bef390d6d7fd5c795a8e6baa5fd31d/addons/repair/models/repair.py#L571-L578)** attribute `_get_default_warehouse_id` which is **[defined](https://github.com/odoo/odoo/blob/c002aad906bef390d6d7fd5c795a8e6baa5fd31d/addons/sale_stock/models/res_users.py#L12-L17)** in module `sale_stock`. There is no dependency between that 2 modules.

But as the module `sale_stock` is **autoinstall=1** and its all dependencies are being installed when we install `repair` the module **sale_stock** is also being installed automatically. That is why when we install **repair** we will not have any problem on using that attribute. If we uninstall that `sale_stock` we will have problem because `repair` module will not be able to find the attribute `_get_default_warehouse_id`.

For fixing the issue I added that attribute in module `stock` as it is dependent for both of `repair` and `sale_stock`, and also I use the inheritence in module `sale_stock`

**Steps to reproduce:**

1. Install `repair` on `16.0`
2. Uninstall `sale_stock`
3. Try to upgrade to `17.0`

You will error similar to this:

```
 File "/home/odoo/src/odoo/17.0/addons/repair/models/repair.py", line 28, in _default_picking_type_id
    return self._get_picking_type().get((self.env.company, self.env.user))
  File "/home/odoo/src/odoo/17.0/addons/repair/models/repair.py", line 563, in _get_picking_type
    default_warehouse = self.env.user.with_company(companies.id)._get_default_warehouse_id()
AttributeError: 'res.users' object has no attribute '_get_default_warehouse_id'
```

upg-1565705

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
