### PR TITLE
[FIX] hr_holidays: correctly send leave confirmation emails

### DIFF
--- a/addons/hr_holidays/tests/test_company_leave.py
+++ b/addons/hr_holidays/tests/test_company_leave.py
@@ -293,7 +293,7 @@ class TestCompanyLeave(TransactionCase):
         })
         company_leave._compute_date_from_to()
 
-        with self.assertQueryCount(__system__=1350):  # 770 community
+        with self.assertQueryCount(__system__=1855):  # 770 community
             # Original query count: 1987
             # Without tracking/activity context keys: 5154
             company_leave.action_validate()

--- a/addons/hr_holidays/tests/test_holidays_mail.py
+++ b/addons/hr_holidays/tests/test_holidays_mail.py
@@ -1,0 +1,57 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+import time
+from datetime import date
+from dateutil.relativedelta import relativedelta
+from freezegun import freeze_time
+
+from odoo import Command
+from odoo.tools import mute_logger
+
+from odoo.addons.hr_holidays.tests.common import TestHrHolidaysCommon
+from odoo.addons.mail.tests.common import MailCase
+
+
+class TestHolidaysMail(TestHrHolidaysCommon, MailCase):
+    """Test that mails are correctly sent when a timeoff is taken"""
+
+    @mute_logger('odoo.addons.base.models.ir_model', 'odoo.models')
+    def test_email_sent_when_approved(self):
+        """ Testing leave request flow: limited type of leave request """
+        with freeze_time('2022-01-15'):
+            self.env.ref('hr.employee_admin').tz = "Europe/Brussels"
+
+            holiday_status_paid_time_off = self.env['hr.leave.type'].create({
+                'name': 'Paid Time Off',
+                'requires_allocation': 'yes',
+                'employee_requests': 'no',
+                'allocation_validation_type': 'officer',
+                'leave_validation_type': 'both',
+                'responsible_ids': [Command.link(self.env.ref('base.user_admin').id)],
+            })
+
+            self.env['hr.leave.allocation'].create([
+                {
+                    'name': 'Paid Time off for David',
+                    'holiday_status_id': holiday_status_paid_time_off.id,
+                    'number_of_days': 20,
+                    'employee_id': self.employee_emp_id,
+                    'state': 'confirm',
+                    'date_from': time.strftime('%Y-%m-01'),
+                }
+            ]).action_validate()
+
+            leave_vals = {
+                'name': 'Sick Time Off',
+                'holiday_status_id': holiday_status_paid_time_off.id,
+                'request_date_from': date.today() + relativedelta(day=2),
+                'request_date_to': date.today() + relativedelta(day=3),
+                'employee_id': self.ref('hr.employee_admin'),
+            }
+            leave = self.env['hr.leave'].create(leave_vals)
+            leave.action_approve()
+            with self.mock_mail_gateway():
+                leave.action_validate()
+                admin_emails = self._new_mails.filtered(lambda x: x.partner_ids.employee_ids.id == self.ref('hr.employee_admin'))
+                self.assertEqual(len(admin_emails), 1, "Mitchell Admin should receive an email")
+                self.assertTrue("has been accepted" in admin_emails.preview)

--- a/addons/hr_work_entry_holidays/tests/test_performance.py
+++ b/addons/hr_work_entry_holidays/tests/test_performance.py
@@ -32,7 +32,7 @@ class TestWorkEntryHolidaysPerformance(TestWorkEntryHolidaysBase):
         self.richard_emp.generate_work_entries(date(2018, 1, 1), date(2018, 1, 2))
         leave = self.create_leave(datetime(2018, 1, 1, 7, 0), datetime(2018, 1, 1, 18, 0))
 
-        with self.assertQueryCount(__system__=107, admin=108):  # com 96/97
+        with self.assertQueryCount(__system__=112, admin=113):  # com 96/97
             leave.action_validate()
         leave.action_refuse()
 


### PR DESCRIPTION
Current behavior:
When confirming a leave that required 2 approvals, the confirmation mail was not sent correctly to the user that asked the leave.

Steps to reproduce:
- Login as demo, and create a paid leave (make sure it's using the 2 approvals)
- Login as admin, validate the leave
- No email is sent to the user to notify him that the leave was accepted

To fix the issue we now send the message when the leave is validated in `_validate_leave_request`

opw-3719345
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
