### PR TITLE
[IMP] *: always name gettext placeholders when there are more than one

### DIFF
--- a/addons/account/models/account_account_tag.py
+++ b/addons/account/models/account_account_tag.py
@@ -26,7 +26,7 @@ class AccountAccountTag(models.Model):
         for tag in self:
             name = tag.name
             if tag.applicability == "taxes" and tag.country_id and tag.country_id != self.env.company.account_fiscal_country_id:
-                name = _("%s (%s)", tag.name, tag.country_id.code)
+                name = _("%(tag)s (%(country_code)s)", tag=tag.name, country_code=tag.country_id.code)
             tag.display_name = name
 
     @api.model

--- a/addons/account/models/account_bank_statement.py
+++ b/addons/account/models/account_bank_statement.py
@@ -123,7 +123,7 @@ class AccountBankStatement(models.Model):
     @api.depends('create_date')
     def _compute_name(self):
         for stmt in self:
-            stmt.name = _("%s Statement %s", stmt.journal_id.code, stmt.date)
+            stmt.name = _("%(journal_code)s Statement %(date)s", journal_code=stmt.journal_id.code, date=stmt.date)
 
     @api.depends('line_ids.internal_index', 'line_ids.state')
     def _compute_date_index(self):

--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2069,13 +2069,13 @@ class AccountMove(models.Model):
                 move = self.browse(move_id)
                 error_msg += _(
                     "\n\n"
-                    "The move (%s) is not balanced.\n"
-                    "The total of debits equals %s and the total of credits equals %s.\n"
-                    "You might want to specify a default account on journal \"%s\" to automatically balance each move.",
-                    move.display_name,
-                    format_amount(self.env, sum_debit, move.company_id.currency_id),
-                    format_amount(self.env, sum_credit, move.company_id.currency_id),
-                    move.journal_id.name)
+                    "The move (%(move)s) is not balanced.\n"
+                    "The total of debits equals %(debit_total)s and the total of credits equals %(credit_total)s.\n"
+                    "You might want to specify a default account on journal \"%(journal)s\" to automatically balance each move.",
+                    move=move.display_name,
+                    debit_total=format_amount(self.env, sum_debit, move.company_id.currency_id),
+                    credit_total=format_amount(self.env, sum_credit, move.company_id.currency_id),
+                    journal=move.journal_id.name)
             raise UserError(error_msg)
 
     def _get_unbalanced_moves(self, container):
@@ -3547,7 +3547,11 @@ class AccountMove(models.Model):
                 except RedirectWarning:
                     raise
                 except Exception:
-                    message = _("Error importing attachment '%s' as invoice (decoder=%s)", file_data['filename'], decoder.__name__)
+                    message = _(
+                        "Error importing attachment '%(file_name)s' as invoice (decoder=%(decoder)s)",
+                        file_name=file_data['filename'],
+                        decoder=decoder.__name__,
+                    )
                     invoice.sudo().message_post(body=message)
                     _logger.exception(message)
 
@@ -4175,10 +4179,10 @@ class AccountMove(models.Model):
                 and invoice.currency_id.compare_amounts(invoice.quick_edit_total_amount, invoice.amount_total) != 0
             ):
                 validation_msgs.add(_(
-                    "The current total is %s but the expected total is %s. In order to post the invoice/bill, "
+                    "The current total is %(current_total)s but the expected total is %(expected_total)s. In order to post the invoice/bill, "
                     "you can adjust its lines or the expected Total (tax inc.).",
-                    formatLang(self.env, invoice.amount_total, currency_obj=invoice.currency_id),
-                    formatLang(self.env, invoice.quick_edit_total_amount, currency_obj=invoice.currency_id),
+                    current_total=formatLang(self.env, invoice.amount_total, currency_obj=invoice.currency_id),
+                    expected_total=formatLang(self.env, invoice.quick_edit_total_amount, currency_obj=invoice.currency_id),
                 ))
             if invoice.partner_bank_id and not invoice.partner_bank_id.active:
                 validation_msgs.add(_(
@@ -4208,7 +4212,7 @@ class AccountMove(models.Model):
 
         for move in self:
             if move.state in ['posted', 'cancel']:
-                validation_msgs.add(_('The entry %s (id %s) must be in draft.', move.name, move.id))
+                validation_msgs.add(_('The entry %(name)s (id %(id)s) must be in draft.', name=move.name, id=move.id))
             if not move.line_ids.filtered(lambda line: line.display_type not in ('line_section', 'line_note')):
                 validation_msgs.add(_('You need to add a line before posting.'))
             if not soft and move.auto_post != 'no' and move.date > fields.Date.context_today(self):

--- a/addons/account/models/account_payment.py
+++ b/addons/account/models/account_payment.py
@@ -328,8 +328,8 @@ class AccountPayment(models.Model):
 
         if not self.outstanding_account_id:
             raise UserError(_(
-                "You can't create a new payment without an outstanding payments/receipts account set either on the company or the %s payment method in the %s journal.",
-                self.payment_method_line_id.name, self.journal_id.display_name))
+                "You can't create a new payment without an outstanding payments/receipts account set either on the company or the %(payment_method)s payment method in the %(journal)s journal.",
+                payment_method=self.payment_method_line_id.name, journal=self.journal_id.display_name))
 
         # Compute amounts.
         write_off_line_vals_list = write_off_line_vals or []

--- a/addons/account/models/account_payment_method.py
+++ b/addons/account/models/account_payment_method.py
@@ -152,8 +152,8 @@ class AccountPaymentMethodLine(models.Model):
         res = self._cr.fetchall()
         if res:
             (name, payment_type) = res[0]
-            raise UserError(_("You can't have two payment method lines of the same payment type (%s) "
-                              "and with the same name (%s) on a single journal.", payment_type, name))
+            raise UserError(_("You can't have two payment method lines of the same payment type (%(payment_type)s) "
+                              "and with the same name (%(name)s) on a single journal.", payment_type=payment_type, name=name))
 
     def unlink(self):
         """

--- a/addons/account/models/account_report.py
+++ b/addons/account/models/account_report.py
@@ -183,8 +183,8 @@ class AccountReport(models.Model):
         for line in self.line_ids:
             if line.parent_id and line.parent_id not in previous_lines:
                 raise ValidationError(
-                    _('Line "%s" defines line "%s" as its parent, but appears before it in the report. '
-                      'The parent must always come first.', line.name, line.parent_id.name))
+                    _('Line "%(line)s" defines line "%(parent_line)s" as its parent, but appears before it in the report. '
+                      'The parent must always come first.', line=line.name, parent_line=line.parent_id.name))
             previous_lines |= line
 
     @api.constrains('section_report_ids')
@@ -566,8 +566,8 @@ class AccountReportExpression(models.Model):
                 domain = ast.literal_eval(expression.formula)
                 self.env['account.move.line']._where_calc(domain)
             except:
-                raise UserError(_("Invalid domain for expression '%s' of line '%s': %s",
-                                expression.label, expression.report_line_name, expression.formula))
+                raise UserError(_("Invalid domain for expression '%(label)s' of line '%(line)s': %(formula)s",
+                                label=expression.label, line=expression.report_line_name, formula=expression.formula))
 
     @api.depends('engine')
     def _compute_auditable(self):

--- a/addons/account/models/company.py
+++ b/addons/account/models/company.py
@@ -701,7 +701,11 @@ class ResCompany(models.Model):
                         'restricted_by_hash_table': 'V',
                         'journal_name': f"{journal.name} ({prefix}...)",
                         'status': 'corrupted',
-                        'msg_cover': _("Corrupted data on journal entry with id %s (%s).", corrupted_move.id, corrupted_move.name),
+                        'msg_cover': _(
+                            "Corrupted data on journal entry with id %(id)s (%(name)s).",
+                            id=corrupted_move.id,
+                            name=corrupted_move.name,
+                        ),
                     })
                 else:
                     results.append({

--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -308,7 +308,7 @@ class ResPartnerBank(models.Model):
     def unlink(self):
         # EXTENDS base res.partner.bank
         for account in self:
-            msg = _("Bank Account %s with number %s deleted", account._get_html_link(title=f"#{account.id}"), account.acc_number)
+            msg = _("Bank Account %(link)s with number %(number)s deleted", link=account._get_html_link(title=f"#{account.id}"), number=account.acc_number)
             account.partner_id._message_log(body=msg)
         return super().unlink()
 

--- a/addons/account/wizard/account_tour_upload_bill.py
+++ b/addons/account/wizard/account_tour_upload_bill.py
@@ -54,7 +54,11 @@ class AccountTourUploadBill(models.TransientModel):
 
         values = [('sample', _('Try a sample vendor bill')), ('upload', _('Upload your own bill'))]
         if journal_alias.alias_name and journal_alias.alias_domain:
-            values.append(('email', _('Send a bill to \n%s@%s', journal_alias.alias_name, journal_alias.alias_domain)))
+            values.append(('email', _(
+                'Send a bill to \n%(alias_name)s@%(alias_domain)s',
+                alias_name=journal_alias.alias_name,
+                alias_domain=journal_alias.alias_domain,
+            )))
         else:
             values.append(('email_no_alias', _('Send a bill by email')))
         return values

--- a/addons/account/wizard/accrued_orders.py
+++ b/addons/account/wizard/accrued_orders.py
@@ -180,13 +180,27 @@ class AccruedExpenseRevenue(models.TransientModel):
                         amount_currency = order_line.currency_id.round(order_line.qty_to_invoice * order_line.price_unit)
                         amount = order.currency_id._convert(amount_currency, self.company_id.currency_id, self.company_id)
                         fnames = ['qty_to_invoice', 'qty_received', 'qty_invoiced', 'invoice_lines']
-                        label = _('%s - %s; %s Billed, %s Received at %s each', order.name, _ellipsis(order_line.name, 20), order_line.qty_invoiced, order_line.qty_received, formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id))
+                        label = _(
+                            '%(order)s - %(order_line)s; %(quantity_billed)s Billed, %(quantity_received)s Received at %(unit_price)s each',
+                            order=order.name,
+                            order_line=_ellipsis(order_line.name, 20),
+                            quantity_billed=order_line.qty_invoiced,
+                            quantity_received=order_line.qty_received,
+                            unit_price=formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id),
+                        )
                     else:
                         account = self._get_computed_account(order, order_line.product_id, is_purchase)
                         amount_currency = order_line.untaxed_amount_to_invoice
                         amount = order.currency_id._convert(amount_currency, self.company_id.currency_id, self.company_id)
                         fnames = ['qty_to_invoice', 'untaxed_amount_to_invoice', 'qty_invoiced', 'qty_delivered', 'invoice_lines']
-                        label = _('%s - %s; %s Invoiced, %s Delivered at %s each', order.name, _ellipsis(order_line.name, 20), order_line.qty_invoiced, order_line.qty_delivered, formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id))
+                        label = _(
+                            '%(order)s - %(order_line)s; %(quantity_invoiced)s Invoiced, %(quantity_delivered)s Delivered at %(unit_price)s each',
+                            order=order.name,
+                            order_line=_ellipsis(order_line.name, 20),
+                            quantity_invoiced=order_line.qty_invoiced,
+                            quantity_delivered=order_line.qty_delivered,
+                            unit_price=formatLang(self.env, order_line.price_unit, currency_obj=order.currency_id),
+                        )
                     distribution = order_line.analytic_distribution if order_line.analytic_distribution else {}
                     if not is_purchase and order.analytic_account_id:
                         analytic_account_id = str(order.analytic_account_id.id)
@@ -215,7 +229,7 @@ class AccruedExpenseRevenue(models.TransientModel):
 
         move_type = _('Expense') if is_purchase else _('Revenue')
         move_vals = {
-            'ref': _('Accrued %s entry as of %s', move_type, format_date(self.env, self.date)),
+            'ref': _('Accrued %(entry_type)s entry as of %(date)s', entry_type=move_type, date=format_date(self.env, self.date)),
             'journal_id': self.journal_id.id,
             'date': self.date,
             'line_ids': move_lines,

--- a/addons/account/wizard/setup_wizards.py
+++ b/addons/account/wizard/setup_wizards.py
@@ -35,8 +35,8 @@ class FinancialYearOpeningWizard(models.TransientModel):
                 date(2020, int(wiz.fiscalyear_last_month), wiz.fiscalyear_last_day)
             except ValueError:
                 raise ValidationError(
-                    _('Incorrect fiscal year date: day is out of range for month. Month: %s; Day: %s',
-                    wiz.fiscalyear_last_month, wiz.fiscalyear_last_day)
+                    _('Incorrect fiscal year date: day is out of range for month. Month: %(month)s; Day: %(day)s',
+                    month=wiz.fiscalyear_last_month, day=wiz.fiscalyear_last_day)
                 )
 
     def write(self, vals):

--- a/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
+++ b/addons/account_edi_proxy_client/models/account_edi_proxy_user.py
@@ -132,7 +132,7 @@ class AccountEdiProxyClientUser(models.Model):
                 _('The url that this service requested returned an error. The url it tried to contact was %s', url))
 
         if 'error' in response:
-            message = _('The url that this service requested returned an error. The url it tried to contact was %s. %s', url, response['error']['message'])
+            message = _('The url that this service requested returned an error. The url it tried to contact was %(url)s. %(error_message)s', url=url, error_message=response['error']['message'])
             if response['error']['code'] == 404:
                 message = _('The url that this service tried to contact does not exist. The url was %r', url)
             raise AccountEdiProxyError('connection_error', message)

--- a/addons/account_tax_python/models/account_tax.py
+++ b/addons/account_tax_python/models/account_tax.py
@@ -72,10 +72,10 @@ class AccountTaxPython(models.Model):
                 safe_eval(tax.python_applicable, local_dict, mode="exec", nocopy=True)
             except Exception as e: # noqa: BLE001
                 raise UserError(_(
-                    "You entered invalid code %r in %r taxes\n\nError : %s",
-                    tax.python_applicable,
-                    tax_data['name'],
-                    e
+                    'You entered invalid code "%(code)s" in "%(tax_type)s" taxes\n\nError : %(error_message)s',
+                    code=tax.python_applicable,
+                    tax_type=tax_data['name'],
+                    error_message=e,
                 )) from e
             is_applicable = local_dict.get('result', False)
             if not is_applicable:
@@ -85,10 +85,10 @@ class AccountTaxPython(models.Model):
                 safe_eval(tax.python_compute, local_dict, mode="exec", nocopy=True)
             except Exception as e: # noqa: BLE001
                 raise UserError(_(
-                    "You entered invalid code %r in %r taxes\n\nError : %s",
-                    tax.python_compute,
-                    tax_data['name'],
-                    e
+                    'You entered invalid code "%(code)s" in "%(tax_type)s" taxes\n\nError : %(error_message)s',
+                    code=tax.python_compute,
+                    tax_type=tax_data['name'],
+                    error_message=e,
                 )) from e
             return local_dict.get('result', 0.0)
         return super()._eval_tax_amount(tax_data, evaluation_context)

--- a/addons/base_import/models/base_import.py
+++ b/addons/base_import/models/base_import.py
@@ -1052,7 +1052,11 @@ class Import(models.TransientModel):
         _file_length, rows_to_import = self._read_file(options)
         if len(rows_to_import[0]) != len(fields):
             raise ImportValidationError(
-                _("Error while importing records: all rows should be of the same size, but the title row has %d entries while the first row has %d. You may need to change the separator character.", len(fields), len(rows_to_import[0]))
+                _(
+                    "Error while importing records: all rows should be of the same size, but the title row has %(title_row_entries)d entries while the first row has %(first_row_entries)d. You may need to change the separator character.",
+                    title_row_entries=len(fields),
+                    first_row_entries=len(rows_to_import[0]),
+                ),
             )
 
         if options.get('has_headers'):
@@ -1118,7 +1122,7 @@ class Import(models.TransientModel):
             old_value = line[index]
             line[index] = self._remove_currency_symbol(line[index])
             if line[index] is False:
-                raise ImportValidationError(_("Column %s contains incorrect values (value: %s)", name, old_value), field=name)
+                raise ImportValidationError(_("Column %(column)s contains incorrect values (value: %(value)s)", column=name, value=old_value), field=name)
 
     def _infer_separators(self, value, options):
         """ Try to infer the shape of the separators: if there are two
@@ -1223,12 +1227,12 @@ class Import(models.TransientModel):
                 line[index] = fmt(dt.strptime(v, d_fmt))
             except ValueError as e:
                 raise ImportValidationError(
-                    _("Column %s contains incorrect values. Error in line %d: %s") % (name, num + 1, e),
+                    _("Column %(column)s contains incorrect values. Error in line %(line)d: %(error)s", column=name, line=num + 1, error=e),
                     field=name, field_type=field_type
                 )
             except Exception as e:
                 raise ImportValidationError(
-                    _("Error Parsing Date [%s:L%d]: %s") % (name, num + 1, e),
+                    _("Error Parsing Date [%(field)s:L%(line)d]: %(error)s", field=name, line=num + 1, error=e),
                     field=name, field_type=field_type
                 )
 

--- a/addons/base_import/static/src/import_model.js
+++ b/addons/base_import/static/src/import_model.js
@@ -426,7 +426,10 @@ export class BaseImportModel {
                     if (error.record !== undefined) {
                         this._addMessage("danger", [
                             error.rows.from === error.rows.to
-                                ? _t('Error at row %s: "%s"', error.record, error.message)
+                                ? _t('Error at row %(row)s: "%(error)s"', {
+                                      row: error.record,
+                                      error: error.message,
+                                  })
                                 : _t("%s at multiple rows", error.message),
                         ]);
                     }

--- a/addons/base_import_module/models/ir_module.py
+++ b/addons/base_import_module/models/ir_module.py
@@ -410,7 +410,7 @@ class IrModule(models.Model):
         except requests.exceptions.HTTPError:
             raise UserError(_('The module %s cannot be downloaded') % module_name)
         except requests.exceptions.ConnectionError:
-            raise UserError(_('Connection to %s failed, the module %s cannot be downloaded.', APPS_URL, module_name))
+            raise UserError(_('Connection to %(url)s failed, the module %(module)s cannot be downloaded.', url=APPS_URL, module=module_name))
 
     @api.model
     def _get_missing_dependencies(self, zip_data):

--- a/addons/base_sparse_field/models/models.py
+++ b/addons/base_sparse_field/models/models.py
@@ -62,8 +62,11 @@ class IrModelFields(models.Model):
                 try:
                     value = existing[(model_name, field.sparse)][0] if field.sparse else None
                 except KeyError:
-                    msg = _("Serialization field %r not found for sparse field %s!")
-                    raise UserError(msg % (field.sparse, field))
+                    raise UserError(_(
+                        'Serialization field "%(serialization_field)s" not found for sparse field %(sparse_field)s!',
+                        serialization_field=field.sparse,
+                        sparse_field=field,
+                    ))
                 if current_value != value:
                     updates[value].append(field_id)
 

--- a/addons/crm/models/res_config_settings.py
+++ b/addons/crm/models/res_config_settings.py
@@ -5,6 +5,7 @@ from datetime import timedelta
 from dateutil.relativedelta import relativedelta
 
 from odoo import api, exceptions, fields, models, _
+from odoo.tools import format_list
 
 
 class ResConfigSettings(models.TransientModel):
@@ -126,7 +127,7 @@ class ResConfigSettings(models.TransientModel):
         for setting in self:
             if setting.predictive_lead_scoring_fields:
                 field_names = [_('Stage')] + [field.name for field in setting.predictive_lead_scoring_fields]
-                setting.predictive_lead_scoring_field_labels = _('%s and %s', ', '.join(field_names[:-1]), field_names[-1])
+                setting.predictive_lead_scoring_field_labels = format_list(self.env, field_names)
             else:
                 setting.predictive_lead_scoring_field_labels = _('Stage')
 

--- a/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
+++ b/addons/crm_iap_mine/models/crm_iap_lead_mining_request.py
@@ -82,8 +82,16 @@ class CRMLeadMiningRequest(models.Model):
             company_credits = CREDIT_PER_COMPANY * record.lead_number
             contact_credits = CREDIT_PER_CONTACT * record.contact_number
             total_contact_credits = contact_credits * record.lead_number
-            record.lead_contacts_credits = _("Up to %d additional credits will be consumed to identify %d contacts per company.", contact_credits*company_credits, record.contact_number)
-            record.lead_credits = _('%d credits will be consumed to find %d companies.', company_credits, record.lead_number)
+            record.lead_contacts_credits = _(
+                "Up to %(credit_count)d additional credits will be consumed to identify %(contact_count)d contacts per company.",
+                credit_count=contact_credits * company_credits,
+                contact_count=record.contact_number,
+            )
+            record.lead_credits = _(
+                "%(credit_count)d credits will be consumed to find %(company_count)d companies.",
+                credit_count=company_credits,
+                company_count=record.lead_number,
+            )
             record.lead_total_credits = _("This makes a total of %d credits for this request.", total_contact_credits + company_credits)
 
     @api.depends('lead_ids.lead_mining_request_id')

--- a/addons/gamification/models/gamification_goal_definition.py
+++ b/addons/gamification/models/gamification_goal_definition.py
@@ -91,7 +91,11 @@ class GoalDefinition(models.Model):
                 msg = e
                 if isinstance(e, SyntaxError):
                     msg = (e.msg + '\n' + e.text)
-                raise exceptions.UserError(_("The domain for the definition %s seems incorrect, please check it.\n\n%s", definition.name, msg))
+                raise exceptions.UserError(_(
+                    "The domain for the definition %(definition)s seems incorrect, please check it.\n\n%(error_message)s",
+                    definition=definition.name,
+                    error_message=msg,
+                ))
         return True
 
     def _check_model_validity(self):

--- a/addons/gamification/models/gamification_karma_tracking.py
+++ b/addons/gamification/models/gamification_karma_tracking.py
@@ -124,7 +124,7 @@ class KarmaTracking(models.Model):
             'from_date': from_date,
             'end_date': end_date,
             'origin_ref': f'res.users,{self.env.user.id}',
-            'reason': _('Consolidation from %s to %s', from_date.date(), end_date.date()),
+            'reason': _('Consolidation from %(from_date)s to %(end_date)s', from_date=from_date.date(), end_date=end_date.date()),
         })
 
         trackings = self.search([

--- a/addons/hr_attendance/models/hr_attendance.py
+++ b/addons/hr_attendance/models/hr_attendance.py
@@ -124,10 +124,10 @@ class HrAttendance(models.Model):
                 )
             else:
                 attendance.display_name = _(
-                    "%s : (%s-%s)",
-                    format_duration(attendance.worked_hours),
-                    format_datetime(self.env, attendance.check_in, dt_format="HH:mm"),
-                    format_datetime(self.env, attendance.check_out, dt_format="HH:mm"),
+                    "%(worked_hours)s : (%(check_in)s-%(check_out)s)",
+                    worked_hours=format_duration(attendance.worked_hours),
+                    check_in=format_datetime(self.env, attendance.check_in, dt_format="HH:mm"),
+                    check_out=format_datetime(self.env, attendance.check_out, dt_format="HH:mm"),
                 )
 
     def _get_employee_calendar(self):

--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -169,10 +169,10 @@ class HolidaysAllocation(models.Model):
                 if allocation.env.context.get('is_employee_allocation'):
                     if allocation.holiday_status_id:
                         allocation_duration = allocation.number_of_days_display if allocation.type_request_unit != 'hour' else allocation.number_of_hours_display
-                        title = _("%s allocation request (%s %s)",
-                            allocation.holiday_status_id.name,
-                            allocation_duration,
-                            allocation.type_request_unit)
+                        title = _("%(status)s allocation request (%(duration)s %(unit)s)",
+                            status=allocation.holiday_status_id.name,
+                            duration=allocation_duration,
+                            unit=allocation.type_request_unit)
                     else:
                         title = _("Allocation Request")
                 allocation.name = title
@@ -203,9 +203,18 @@ class HolidaysAllocation(models.Model):
     def _compute_description_validity(self):
         for allocation in self:
             if allocation.date_to:
-                name_validity = _("%s (from %s to %s)", allocation.name, allocation.date_from.strftime("%b %d %Y"), allocation.date_to.strftime("%b %d %Y"))
+                name_validity = _(
+                    "%(allocation_name)s (from %(date_from)s to %(date_to)s)",
+                    allocation_name=allocation.name,
+                    date_from=allocation.date_from.strftime("%b %d %Y"),
+                    date_to=allocation.date_to.strftime("%b %d %Y"),
+                )
             else:
-                name_validity = _("%s (from %s to No Limit)", allocation.name, allocation.date_from.strftime("%b %d %Y"))
+                name_validity = _(
+                    "%(allocation_name)s (from %(date_from)s to No Limit)",
+                    allocation_name=allocation.name,
+                    date_from=allocation.date_from.strftime("%b %d %Y"),
+                )
             allocation.name_validity = name_validity
 
     @api.depends('employee_id', 'holiday_status_id')
@@ -608,11 +617,11 @@ class HolidaysAllocation(models.Model):
                     second=allocation.employee_ids[1].sudo().name,
                     amount=len(allocation.employee_ids) - 2)
 
-            allocation.display_name = _("Allocation of %s: %.2f %s to %s",
-                allocation.holiday_status_id.sudo().name,
-                allocation.number_of_hours_display if allocation.type_request_unit == 'hour' else allocation.number_of_days,
-                _('hours') if allocation.type_request_unit == 'hour' else _('days'),
-                target,
+            allocation.display_name = _("Allocation of %(leave_type)s: %(amount).2f %(unit)s to %(target)s",
+                leave_type=allocation.holiday_status_id.sudo().name,
+                amount=allocation.number_of_hours_display if allocation.type_request_unit == 'hour' else allocation.number_of_days,
+                unit=_('hours') if allocation.type_request_unit == 'hour' else _('days'),
+                target=target,
             )
 
     def _add_lastcalls(self):

--- a/addons/hr_holidays/models/hr_leave_type.py
+++ b/addons/hr_holidays/models/hr_leave_type.py
@@ -297,9 +297,9 @@ class HolidaysType(models.Model):
             if record.requires_allocation == "yes" and not self._context.get('from_manager_leave_form'):
                 name = "{name} ({count})".format(
                     name=name,
-                    count=_('%g remaining out of %g') % (
-                        float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0,
-                        float_round(record.max_leaves, precision_digits=2) or 0.0,
+                    count=_('%(remaining)g remaining out of %(maximum)g',
+                        remaining=float_round(record.virtual_remaining_leaves, precision_digits=2) or 0.0,
+                        maximum=float_round(record.max_leaves, precision_digits=2) or 0.0,
                     ) + (_(' hours') if record.request_unit == 'hour' else _(' days')),
             )
             record.display_name = name

--- a/addons/hr_holidays_contract/models/hr_leave.py
+++ b/addons/hr_holidays_contract/models/hr_leave.py
@@ -70,15 +70,15 @@ class HrLeave(models.Model):
 Please create one time off for each contract.
 
 Time off:
-%s
+%(time_off)s
 
 Contracts:
-%s""",
-                      holiday.display_name,
-                      '\n'.join(_(
-                          "Contract %s from %s to %s, status: %s",
-                          contract.name,
-                          format_date(self.env, contract.date_start),
-                          format_date(self.env, contract.date_end) if contract.date_end else _("undefined"),
-                          state_labels[contract.state]
+%(contracts)s""",
+                      time_off=holiday.display_name,
+                      contracts='\n'.join(_(
+                          "Contract %(contract)s from %(start_date)s to %(end_date)s, status: %(status)s",
+                          contract=contract.name,
+                          start_date=format_date(self.env, contract.date_start),
+                          end_date=format_date(self.env, contract.date_end) if contract.date_end else _("undefined"),
+                          status=state_labels[contract.state]
                       ) for contract in contracts)))

--- a/addons/hr_work_entry_contract/models/hr_work_entry.py
+++ b/addons/hr_work_entry_contract/models/hr_work_entry.py
@@ -127,10 +127,15 @@ class HrWorkEntry(models.Model):
             employee = self.env['hr.employee'].browse(vals.get('employee_id'))
             contracts = employee._get_contracts(contract_start, contract_end, states=['open', 'pending', 'close'])
             if not contracts:
-                raise ValidationError(_("%s does not have a contract from %s to %s.", employee.name, contract_start, contract_end))
+                raise ValidationError(_(
+                    "%(employee)s does not have a contract from %(date_start)s to %(date_end)s.",
+                    employee=employee.name,
+                    date_start=contract_start,
+                    date_end=contract_end,
+                ))
             elif len(contracts) > 1:
-                raise ValidationError(_("%s has multiple contracts from %s to %s. A work entry cannot overlap multiple contracts.",
-                                        employee.name, contract_start, contract_end))
+                raise ValidationError(_("%(employee)s has multiple contracts from %(date_start)s to %(date_end)s. A work entry cannot overlap multiple contracts.",
+                                        employee=employee.name, date_start=contract_start, date_end=contract_end))
             return dict(vals, contract_id=contracts[0].id)
         return vals
 

--- a/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
+++ b/addons/hw_drivers/iot_handlers/drivers/SerialBaseDriver.py
@@ -107,7 +107,7 @@ class SerialDriver(Driver):
                 self._actions[data['action']](data)
                 time.sleep(self._protocol.commandDelay)
         except Exception:
-            msg = _('An error occurred while performing action %s on %s', data, self.device_name)
+            msg = _('An error occurred while performing action %(action)s on %(device)s', action=data, device=self.device_name)
             _logger.exception(msg)
             self._status = {'status': self.STATUS_ERROR, 'message_title': msg, 'message_body': traceback.format_exc()}
             self._push_status()

--- a/addons/hw_drivers/tools/helpers.py
+++ b/addons/hw_drivers/tools/helpers.py
@@ -120,7 +120,7 @@ def check_certificate():
         _logger.info(message)
         return {"status": CertificateStatus.NEED_REFRESH}
     else:
-        message = _('Your certificate %s is valid until %s', cn, cert_end_date)
+        message = _('Your certificate %(certificate)s is valid until %(end_date)s', certificate=cn, end_date=cert_end_date)
         _logger.info(message)
         return {"status": CertificateStatus.OK, "message": message}
 

--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -150,7 +150,7 @@ class AccountJournal(models.Model):
             j.l10n_ar_afip_pos_system not in ['II_IM', 'RLI_RLM', 'RAW_MAW'])
         if journals:
             raise ValidationError("\n".join(
-                _("The pos system %s can not be used on a purchase journal (id %s)", x.l10n_ar_afip_pos_system, x.id)
+                _("The pos system %(system)s can not be used on a purchase journal (id %(id)s)", system=x.l10n_ar_afip_pos_system, id=x.id)
                 for x in journals
             ))
 

--- a/addons/l10n_ch/wizard/qr_invoice_wizard.py
+++ b/addons/l10n_ch/wizard/qr_invoice_wizard.py
@@ -32,7 +32,7 @@ class QrInvoiceWizard(models.TransientModel):
                 return _("No invoice could be printed in the %s format.", inv_format)
             if nb_inv == 1:
                 return _("One invoice could be printed in the %s format.", inv_format)
-            return _("%s invoices could be printed in the %s format.", nb_inv, inv_format)
+            return _("%(amount)s invoices could be printed in the %(format)s format.", amount=nb_inv, format=inv_format)
 
         if not self._context.get('active_ids'):
             raise UserError(_("No invoice was found to be printed."))

--- a/addons/l10n_es_edi_facturae/models/account_move.py
+++ b/addons/l10n_es_edi_facturae/models/account_move.py
@@ -667,7 +667,7 @@ class AccountMove(models.Model):
                     tax_ids.append(tax_incl)
                     line_vals['price_unit'] *= (1.0 + float(tax_rate) / 100.0)
                 else:
-                    logs.append(_("Could not retrieve the tax: %s %% for line '%s'.", tax_rate, line_vals.get('name', "")))
+                    logs.append(_("Could not retrieve the tax: %(tax_rate)s %% for line '%(line)s'.", tax_rate=tax_rate, line=line_vals.get('name', "")))
 
         return logs
 

--- a/addons/l10n_es_edi_sii/models/account_edi_format.py
+++ b/addons/l10n_es_edi_sii/models/account_edi_format.py
@@ -576,7 +576,7 @@ class AccountEdiFormat(models.Model):
 
             else:
                 results[inv] = {
-                    'error': _("[%s] %s", respl.CodigoErrorRegistro, respl.DescripcionErrorRegistro),
+                    'error': _("[%(error_code)s] %(error_message)s", error_code=respl.CodigoErrorRegistro, error_message=respl.DescripcionErrorRegistro),
                     'blocking_level': 'error',
                 }
 

--- a/addons/l10n_fr/models/res_company.py
+++ b/addons/l10n_fr/models/res_company.py
@@ -49,7 +49,7 @@ class ResCompany(models.Model):
             for seq_field in sequence_fields:
                 if not company[seq_field]:
                     vals = {
-                        'name': _('Securisation of %s - %s', seq_field, company.name),
+                        'name': _('Securisation of %(field)s - %(company)s', field=seq_field, company=company.name),
                         'code': 'FRSECURE%s-%s' % (company.id, seq_field),
                         'implementation': 'no_gap',
                         'prefix': '',

--- a/addons/l10n_fr_pos_cert/models/pos.py
+++ b/addons/l10n_fr_pos_cert/models/pos.py
@@ -43,7 +43,6 @@ class pos_session(models.Model):
 
 ORDER_FIELDS = ['date_order', 'user_id', 'lines', 'payment_ids', 'pricelist_id', 'partner_id', 'session_id', 'pos_reference', 'sale_journal', 'fiscal_position_id']
 LINE_FIELDS = ['notice', 'product_id', 'qty', 'price_unit', 'discount', 'tax_ids', 'tax_ids_after_fiscal_position']
-ERR_MSG = _lt('According to the French law, you cannot modify a %s. Forbidden fields: %s.')
 
 
 class pos_order(models.Model):

--- a/addons/l10n_hu_edi/models/account_move.py
+++ b/addons/l10n_hu_edi/models/account_move.py
@@ -580,9 +580,9 @@ class AccountMove(models.Model):
         for processing_result in results['processing_results']:
             invoice = self.filtered(lambda m: str(m.l10n_hu_edi_batch_upload_index) == processing_result['index'])
             if not invoice:
-                _logger.error(_('Could not match NAV transaction_code %s, index %s to an invoice in Odoo',
-                                self[0].l10n_hu_edi_transaction_code,
-                                processing_result['index']))
+                _logger.error(_('Could not match NAV transaction_code %(code)s, index %(index)s to an invoice in Odoo',
+                                code=self[0].l10n_hu_edi_transaction_code,
+                                index=processing_result['index']))
                 continue
 
             invoice._l10n_hu_edi_process_query_transaction_result(processing_result, results['annulment_status'])

--- a/addons/l10n_id/models/account_move.py
+++ b/addons/l10n_id/models/account_move.py
@@ -118,9 +118,9 @@ class AccountMove(models.Model):
                 paid_status = statuses['qr_statuses'][0]
                 if 'qris_payment_customername' in paid_status and 'qris_payment_methodby' in paid_status:
                     message = _(
-                        "This invoice was paid by %s using QRIS with the payment method %s.",
-                        paid_status['qris_payment_customername'],
-                        paid_status['qris_payment_methodby'],
+                        "This invoice was paid by %(customer)s using QRIS with the payment method %(method)s.",
+                        customer=paid_status['qris_payment_customername'],
+                        method=paid_status['qris_payment_methodby'],
                     )
                 else:
                     message = _("This invoice was paid using QRIS.")

--- a/addons/l10n_in_edi/models/account_edi_format.py
+++ b/addons/l10n_in_edi/models/account_edi_format.py
@@ -101,7 +101,7 @@ class AccountEdiFormat(models.Model):
                     error_message.append(_("HSN code is not set in product %s", line.product_id.name))
                 elif not re.match("^[0-9]+$", hsn_code):
                     error_message.append(_(
-                        "Invalid HSN Code (%s) in product %s", hsn_code, line.product_id.name
+                        "Invalid HSN Code (%(hsn_code)s) in product %(product)s", hsn_code=hsn_code, product=line.product_id.name,
                     ))
             else:
                 error_message.append(_("product is required to get HSN code"))

--- a/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
+++ b/addons/l10n_in_edi_ewaybill/models/account_edi_format.py
@@ -117,7 +117,7 @@ class AccountEdiFormat(models.Model):
                     error_message.append(_("HSN code is not set in product %s", line.product_id.name))
                 elif not re.match("^[0-9]+$", hsn_code):
                     error_message.append(_(
-                        "Invalid HSN Code (%s) in product %s", hsn_code, line.product_id.name
+                        "Invalid HSN Code (%(hsn_code)s) in product %(product)s", hsn_code=hsn_code, product=line.product_id.name,
                     ))
             else:
                 error_message.append(_("product is required to get HSN code"))

--- a/addons/l10n_in_edi_ewaybill/models/ewaybill_type.py
+++ b/addons/l10n_in_edi_ewaybill/models/ewaybill_type.py
@@ -26,4 +26,4 @@ class EWayBillType(models.Model):
     def _compute_display_name(self):
         """Show name and sub_type in name"""
         for ewaybill_type in self:
-            ewaybill_type.display_name = _("%s (Sub-Type: %s)", ewaybill_type.name, ewaybill_type.sub_type)
+            ewaybill_type.display_name = _("%(name)s (Sub-Type: %(type)s)", name=ewaybill_type.name, type=ewaybill_type.sub_type)

--- a/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
+++ b/addons/l10n_in_ewaybill_stock/models/l10n_in_ewaybill.py
@@ -314,7 +314,9 @@ class Ewaybill(models.Model):
                 error_message.append(_("HSN code is not set in product %s", line.product_id.name))
             elif not re.match("^[0-9]+$", hsn_code):
                 error_message.append(_(
-                    "Invalid HSN Code (%s) in product %s", hsn_code, line.product_id.name
+                    "Invalid HSN Code (%(hsn_code)s) in product %(product)s",
+                    hsn_code=hsn_code,
+                    product=line.product_id.name,
                 ))
         return error_message
 

--- a/addons/l10n_ke_edi_tremol/models/account_move.py
+++ b/addons/l10n_ke_edi_tremol/models/account_move.py
@@ -238,7 +238,7 @@ class AccountMove(models.Model):
             error_msg = ""
             for move, error_list in errors:
                 error_list = '\n'.join(error_list)
-                error_msg += _("Invalid invoice configuration on %s:\n%s\n\n", move, error_list)
+                error_msg += _("Invalid invoice configuration on %(invoice)s:\n%(error_list)s\n\n", invoice=move, error_list=error_list)
             raise UserError(error_msg)
         return {
             'type': 'ir.actions.client',

--- a/addons/l10n_latam_check/models/account_payment.py
+++ b/addons/l10n_latam_check/models/account_payment.py
@@ -148,12 +148,12 @@ class AccountPayment(models.Model):
         for rec in self.filtered('l10n_latam_check_id'):
             if rec.currency_id != rec.l10n_latam_check_id.currency_id:
                 msgs.append(_(
-                    'The currency of the payment (%s) and the currency of the check (%s) must be the same.') % (
-                        rec.currency_id.name, rec.l10n_latam_check_id.currency_id.name))
+                    'The currency of the payment (%(payment_currency)s) and the currency of the check (%(check_currency)s) must be the same.',
+                        payment_currency=rec.currency_id.name, check_currency=rec.l10n_latam_check_id.currency_id.name))
             if not rec.currency_id.is_zero(rec.l10n_latam_check_id.amount - rec.amount):
                 msgs.append(_(
-                    'The amount of the payment (%s) does not match the amount of the selected check (%s). '
-                    'Please try to deselect and select the check again.', rec.amount, rec.l10n_latam_check_id.amount))
+                    'The amount of the payment (%(payment_amount)s) does not match the amount of the selected check (%(check_amount)s). '
+                    'Please try to deselect and select the check again.', payment_amount=rec.amount, check_amount=rec.l10n_latam_check_id.amount))
             if rec.payment_method_line_id.code in ['in_third_party_checks', 'out_third_party_checks']:
                 if rec.l10n_latam_check_id.state != 'posted':
                     msgs.append(_('Selected check "%s" is not posted', rec.l10n_latam_check_id.display_name))
@@ -163,13 +163,13 @@ class AccountPayment(models.Model):
                         rec.l10n_latam_check_id.l10n_latam_check_current_journal_id != rec.destination_journal_id):
                     # check outbound payment and transfer or inbound transfer
                     msgs.append(_(
-                        'Check "%s" is not anymore in journal "%s", it seems it has been moved by another payment.',
-                        rec.l10n_latam_check_id.display_name, rec.journal_id.name
+                        'Check "%(check)s" is not anymore in journal "%(journal)s", it seems it has been moved by another payment.',
+                        check=rec.l10n_latam_check_id.display_name, journal=rec.journal_id.name
                         if rec.payment_type == 'outbound' else rec.destination_journal_id.name))
                 elif rec.payment_type == 'inbound' and not rec.is_internal_transfer and \
                         rec.l10n_latam_check_id.l10n_latam_check_current_journal_id:
-                    msgs.append(_("Check '%s' is on journal '%s', it can't be received it again",
-                                rec.l10n_latam_check_id.display_name, rec.journal_id.name))
+                    msgs.append(_("Check '%(check)s' is on journal '%(journal)s', it can't be received it again",
+                                check=rec.l10n_latam_check_id.display_name, journal=rec.journal_id.name))
             # moved third party check
             if rec.l10n_latam_check_id:
                 date = rec.date or fields.Datetime.now()
@@ -180,10 +180,10 @@ class AccountPayment(models.Model):
                 ], order="date desc, id desc", limit=1)
                 if last_operation and last_operation[0].date > date:
                     msgs.append(_(
-                        "It seems you're trying to move a check with a date (%s) prior to last operation done with "
-                        "the check (%s). This may be wrong, please double check it. By continue, the last operation on "
-                        "the check will remain being %s",
-                        format_date(self.env, date), last_operation.display_name, last_operation.display_name))
+                        "It seems you're trying to move a check with a date (%(date)s) prior to last operation done "
+                        "with the check (%(last_operation)s). This may be wrong, please double check it. By continue, "
+                        "the last operation on the check will remain being %(last_operation)s",
+                        date=format_date(self.env, date), last_operation=last_operation.display_name))
         return msgs
 
     @api.depends('is_internal_transfer')

--- a/addons/l10n_sa_edi/models/res_config_settings.py
+++ b/addons/l10n_sa_edi/models/res_config_settings.py
@@ -12,8 +12,8 @@ class ResConfigSettings(models.TransientModel):
         for record in self:
             if self.company_id.country_code == 'SA':
                 record.company_informations += _(
-                    '\nBuilding Number: %s, Plot Identification: %s\nNeighborhood: %s',
-                    self.company_id.l10n_sa_edi_building_number,
-                    self.company_id.l10n_sa_edi_plot_identification,
-                    self.company_id.street2,
+                    '\nBuilding Number: %(building_number)s, Plot Identification: %(plot_identification)s\nNeighborhood: %(neighborhood)s',
+                    building_number=self.company_id.l10n_sa_edi_building_number,
+                    plot_identification=self.company_id.l10n_sa_edi_plot_identification,
+                    neighborhood=self.company_id.street2,
                 )

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -416,7 +416,7 @@ class Message(models.Model):
                                     message.id = ANY (%%s)''' % (self._table), ('comment', self.ids,))
             if self._cr.fetchall():
                 raise AccessError(
-                    _('The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %s, Operation: %s)', self._description, operation)
+                    _('The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %(type)s, Operation: %(operation)s)', type=self._description, operation=operation)
                     + ' - ({} {}, {} {})'.format(_('Records:'), self.ids[:6], _('User:'), self._uid)
                 )
 
@@ -586,7 +586,7 @@ class Message(models.Model):
         if not self.browse(messages_to_check).exists():
             return
         raise AccessError(
-            _('The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %s, Operation: %s)', self._description, operation)
+            _('The requested operation cannot be completed due to security restrictions. Please contact your system administrator.\n\n(Document type: %(type)s, Operation: %(operation)s)', type=self._description, operation=operation)
             + ' - ({} {}, {} {})'.format(_('Records:'), list(messages_to_check)[:6], _('User:'), self._uid)
         )
 

--- a/addons/mail/static/src/core/common/message_reactions.js
+++ b/addons/mail/static/src/core/common/message_reactions.js
@@ -20,38 +20,43 @@ export class MessageReactions extends Component {
         );
         switch (reaction.count) {
             case 1:
-                return _t("%s has reacted with %s", firstUserName, reaction.content);
+                return _t("%(user)s has reacted with %(reaction)s", {
+                    user: firstUserName,
+                    reaction: reaction.content,
+                });
             case 2:
-                return _t(
-                    "%s and %s have reacted with %s",
-                    firstUserName,
-                    secondUserName,
-                    reaction.content
-                );
+                return _t("%(user1)s and %(user2)s have reacted with %(reaction)s", {
+                    user1: firstUserName,
+                    user2: secondUserName,
+                    reaction: reaction.content,
+                });
             case 3:
-                return _t(
-                    "%s, %s, %s have reacted with %s",
-                    firstUserName,
-                    secondUserName,
-                    thirdUserName,
-                    reaction.content
-                );
+                return _t("%(user1)s, %(user2)s, %(user3)s have reacted with %(reaction)s", {
+                    user1: firstUserName,
+                    user2: secondUserName,
+                    user3: thirdUserName,
+                    reaction: reaction.content,
+                });
             case 4:
                 return _t(
-                    "%s, %s, %s and 1 other person have reacted with %s",
-                    firstUserName,
-                    secondUserName,
-                    thirdUserName,
-                    reaction.content
+                    "%(user1)s, %(user2)s, %(user3)s and 1 other person have reacted with %(reaction)s",
+                    {
+                        user1: firstUserName,
+                        user2: secondUserName,
+                        user3: thirdUserName,
+                        reaction: reaction.content,
+                    }
                 );
             default:
                 return _t(
-                    "%s, %s, %s and %s other persons have reacted with %s",
-                    firstUserName,
-                    secondUserName,
-                    thirdUserName,
-                    reaction.personas.length - 3,
-                    reaction.content
+                    "%(user1)s, %(user2)s, %(user3)s and %(count)s other persons have reacted with %(reaction)s",
+                    {
+                        user1: firstUserName,
+                        user2: secondUserName,
+                        user3: thirdUserName,
+                        count: reaction.personas.length - 3,
+                        reaction: reaction.content,
+                    }
                 );
         }
     }

--- a/addons/mail/static/src/discuss/typing/common/typing.js
+++ b/addons/mail/static/src/discuss/typing/common/typing.js
@@ -24,8 +24,14 @@ export class Typing extends Component {
             return _t("%s is typing...", typingMemberNames[0]);
         }
         if (typingMemberNames.length === 2) {
-            return _t("%s and %s are typing...", typingMemberNames[0], typingMemberNames[1]);
+            return _t("%(user1)s and %(user2)s are typing...", {
+                user1: typingMemberNames[0],
+                user2: typingMemberNames[1],
+            });
         }
-        return _t("%s, %s and more are typing...", typingMemberNames[0], typingMemberNames[1]);
+        return _t("%(user1)s, %(user2)s and more are typing...", {
+            user1: typingMemberNames[0],
+            user2: typingMemberNames[1],
+        });
     }
 }

--- a/addons/mail/wizard/base_partner_merge_automatic_wizard.py
+++ b/addons/mail/wizard/base_partner_merge_automatic_wizard.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 from odoo import api, models, _
+from odoo.tools import format_list
 
 
 class MergePartnerAutomatic(models.TransientModel):
@@ -9,4 +10,15 @@ class MergePartnerAutomatic(models.TransientModel):
 
     def _log_merge_operation(self, src_partners, dst_partner):
         super(MergePartnerAutomatic, self)._log_merge_operation(src_partners, dst_partner)
-        dst_partner.message_post(body='%s %s' % (_("Merged with the following partners:"), ", ".join('%s <%s> (ID %s)' % (p.name, p.email or 'n/a', p.id) for p in src_partners)))
+        dst_partner.message_post(
+            body=_(
+                "Merged with the following partners: %s",
+                format_list(
+                    self.env,
+                    [
+                        _("%(partner)s <%(email)s> (ID %(id)s)", partner=p.name, email=p.email or "n/a", id=p.id)
+                        for p in src_partners
+                    ]
+                ),
+            )
+        )

--- a/addons/mass_mailing_sms/controllers/main.py
+++ b/addons/mass_mailing_sms/controllers/main.py
@@ -70,8 +70,8 @@ class MailingSMSController(http.Controller):
             else:
                 blacklist_rec = request.env['phone.blacklist'].sudo().add(tocheck_number)
                 blacklist_rec._message_log(
-                    body=_('Blacklist through SMS Marketing unsubscribe (mailing ID: %s - model: %s)',
-                           trace.mass_mailing_id.id, trace.mass_mailing_id.mailing_model_id.display_name))
+                    body=_('Blacklist through SMS Marketing unsubscribe (mailing ID: %(mailing_id)s - model: %(model)s)',
+                           mailing_id=trace.mass_mailing_id.id, model=trace.mass_mailing_id.mailing_model_id.display_name))
             lists_optin = request.env['mailing.subscription'].sudo().search([
                 ('contact_id.phone_sanitized', '=', tocheck_number),
                 ('list_id', 'not in', mailing_list_ids.ids),

--- a/addons/mass_mailing_sms/wizard/mailing_sms_test.py
+++ b/addons/mass_mailing_sms/wizard/mailing_sms_test.py
@@ -54,9 +54,11 @@ class MassSMSTest(models.TransientModel):
                     _('Test SMS successfully sent to %s', sent_sms.get('res_id')))
             elif sent_sms.get('state'):
                 notification_messages.append(
-                    _('Test SMS could not be sent to %s: %s',
-                    sent_sms.get('res_id'),
-                    error_messages.get(sent_sms['state'], _("An error occurred.")))
+                    _(
+                        "Test SMS could not be sent to %(destination)s: %(state)s",
+                        destination=sent_sms.get("res_id"),
+                        state=error_messages.get(sent_sms["state"], _("An error occurred.")),
+                    )
                 )
 
         if notification_messages:

--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -632,8 +632,8 @@ class Meeting(models.Model):
                                     "all attendees must have an email address. However, some events do "
                                     "not respect this condition. As long as the events are incorrect, "
                                     "the calendars will not be synchronized."
-                                    "\nEither update the events/attendees or archive these events %s:"
-                                    "\n%s", details, invalid_events))
+                                    "\nEither update the events/attendees or archive these events %(details)s:"
+                                    "\n%(invalid_events)s", details=details, invalid_events=invalid_events))
 
     def _microsoft_values_occurence(self, initial_values={}):
         values = initial_values

--- a/addons/mrp/models/mrp_bom.py
+++ b/addons/mrp/models/mrp_bom.py
@@ -229,7 +229,7 @@ class MrpBom(models.Model):
                 domain.append(('id', '!=', self.id.origin))
             number_of_bom_of_this_product = self.env['mrp.bom'].search_count(domain)
             if number_of_bom_of_this_product:  # add a reference to the bom if there is already a bom for this product
-                self.code = _("%s (new) %s", self.product_tmpl_id.name, number_of_bom_of_this_product)
+                self.code = _("%(product_name)s (new) %(number_of_boms)s", product_name=self.product_tmpl_id.name, number_of_boms=number_of_bom_of_this_product)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/payment/wizards/payment_onboarding_wizard.py
+++ b/addons/payment/wizards/payment_onboarding_wizard.py
@@ -27,10 +27,10 @@ class PaymentWizard(models.TransientModel):
     @api.onchange('journal_name', 'acc_number')
     def _set_manual_post_msg_value(self):
         self.manual_post_msg = _(
-            '<h3>Please make a payment to: </h3><ul><li>Bank: %s</li><li>Account Number: %s</li><li>Account Holder: %s</li></ul>',
-            self.journal_name or _("Bank"),
-            self.acc_number or _("Account"),
-            self.env.company.name
+            '<h3>Please make a payment to: </h3><ul><li>Bank: %(bank)s</li><li>Account Number: %(account_number)s</li><li>Account Holder: %(account_holder)s</li></ul>',
+            bank=self.journal_name or _("Bank"),
+            account_number=self.acc_number or _("Account"),
+            account_holder=self.env.company.name,
         )
 
     _payment_provider_onboarding_cache = {}

--- a/addons/payment_adyen/models/payment_transaction.py
+++ b/addons/payment_adyen/models/payment_transaction.py
@@ -231,8 +231,8 @@ class PaymentTransaction(models.Model):
         status = response_content.get('status')
         if status == 'received':
             self._log_message_on_linked_documents(_(
-                "A request was sent to void the transaction with reference %s (%s).",
-                self.reference, self.provider_id.name
+                "A request was sent to void the transaction with reference %(reference)s (%(provider)s).",
+                reference=self.reference, provider=self.provider_id.name,
             ))
 
         if child_void_tx:

--- a/addons/payment_asiapay/models/payment_transaction.py
+++ b/addons/payment_asiapay/models/payment_transaction.py
@@ -163,8 +163,8 @@ class PaymentTransaction(models.Model):
             self._set_done()
         elif success_code in const.SUCCESS_CODE_MAPPING['error']:
             self._set_error(_(
-                "An error occurred during the processing of your payment (success code %s; primary "
-                "response code %s). Please try again.", success_code, primary_response_code
+                "An error occurred during the processing of your payment (success code %(success_code)s; primary "
+                "response code %(response_code)s). Please try again.", success_code=success_code, response_code=primary_response_code,
             ))
         else:
             _logger.warning(

--- a/addons/payment_authorize/models/payment_transaction.py
+++ b/addons/payment_authorize/models/payment_transaction.py
@@ -100,8 +100,8 @@ class PaymentTransaction(models.Model):
         tx_details = authorize_api.get_transaction_details(self.provider_reference)
         if 'err_code' in tx_details:  # Could not retrieve the transaction details.
             raise ValidationError("Authorize.Net: " + _(
-                "Could not retrieve the transaction details. (error code: %s; error_details: %s)",
-                tx_details['err_code'], tx_details.get('err_msg')
+                "Could not retrieve the transaction details. (error code: %(error_code)s; error_details: %(error_message)s)",
+                error_code=tx_details['err_code'], error_message=tx_details.get('err_msg'),
             ))
 
         refund_tx = self.env['payment.transaction']
@@ -139,8 +139,8 @@ class PaymentTransaction(models.Model):
             tx_to_process._handle_notification_data('authorize', data)
         else:
             raise ValidationError("Authorize.net: " + _(
-                "The transaction is not in a status to be refunded. (status: %s, details: %s)",
-                tx_status, tx_details.get('messages', {}).get('message')
+                "The transaction is not in a status to be refunded. (status: %(status)s, details: %(message)s)",
+                status=tx_status, message=tx_details.get('messages', {}).get('message'),
             ))
         return refund_tx
 

--- a/addons/payment_mercado_pago/models/payment_provider.py
+++ b/addons/payment_mercado_pago/models/payment_provider.py
@@ -71,7 +71,8 @@ class PaymentProvider(models.Model):
                         error_message = response_content.get('message')
                         raise ValidationError("Mercado Pago: " + _(
                             "The communication with the API failed. Mercado Pago gave us the"
-                            " following information: '%s' (code %s)", error_message, error_code
+                            " following information: '%(error_message)s' (code %(error_code)s)",
+                            error_message=error_message, error_code=error_code,
                         ))
                     except ValueError:  # The response can be empty when the access token is wrong.
                         raise ValidationError("Mercado Pago: " + _(

--- a/addons/point_of_sale/models/pos_order.py
+++ b/addons/point_of_sale/models/pos_order.py
@@ -232,9 +232,9 @@ class PosOrder(models.Model):
             invoice_lines.append((0, None, invoice_lines_values))
             if line.order_id.pricelist_id.discount_policy == 'without_discount' and float_compare(line.price_unit, line.product_id.lst_price, precision_rounding=self.currency_id.rounding) < 0:
                 invoice_lines.append((0, None, {
-                    'name': _('Price discount from %s -> %s',
-                              float_repr(line.product_id.lst_price, self.currency_id.decimal_places),
-                              float_repr(line.price_unit, self.currency_id.decimal_places)),
+                    'name': _('Price discount from %(original_price)s to %(discounted_price)s',
+                              original_price=float_repr(line.product_id.lst_price, self.currency_id.decimal_places),
+                              discounted_price=float_repr(line.price_unit, self.currency_id.decimal_places)),
                     'display_type': 'line_note',
                 }))
             if line.customer_note:
@@ -818,7 +818,7 @@ class PosOrder(models.Model):
         ).create({
             'journal_id': self.config_id.journal_id.id,
             'date': fields.Date.context_today(self),
-            'ref': _('Reversal of POS closing entry %s for order %s from session %s', self.session_move_id.name, self.name, self.session_id.name),
+            'ref': _('Reversal of POS closing entry %(entry)s for order %(order)s from session %(session)s', entry=self.session_move_id.name, order=self.name, session=self.session_id.name),
             'invoice_line_ids': [(0, 0, aml_value) for aml_value in move_lines],
         })
         reversal_entry.action_post()
@@ -1440,8 +1440,8 @@ class PosOrderLine(models.Model):
             account = line.product_id._get_product_accounts()['income'] or self.order_id.config_id.journal_id.default_account_id
             if not account:
                 raise UserError(_(
-                    "Please define income account for this product: '%s' (id:%d).",
-                    line.product_id.name, line.product_id.id,
+                    "Please define income account for this product: '%(product)s' (id:%(id)d).",
+                    product=line.product_id.name, id=line.product_id.id,
                 ))
 
             if fiscal_position:

--- a/addons/point_of_sale/models/pos_payment.py
+++ b/addons/point_of_sale/models/pos_payment.py
@@ -66,7 +66,7 @@ class PosPayment(models.Model):
             payment_move = self.env['account.move'].with_context(default_journal_id=journal.id).create({
                 'journal_id': journal.id,
                 'date': fields.Date.context_today(order, order.date_order),
-                'ref': _('Invoice payment for %s (%s) using %s', order.name, order.account_move.name, payment_method.name),
+                'ref': _('Invoice payment for %(order)s (%(account_move)s) using %(payment_method)s', order=order.name, account_move=order.account_move.name, payment_method=payment_method.name),
                 'pos_payment_ids': payment.ids,
             })
             result |= payment_move

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -579,7 +579,7 @@ class PosSession(models.Model):
         diff_move._post()
 
     def _get_diff_account_move_ref(self, payment_method):
-        return _('Closing difference in %s (%s)', payment_method.name, self.name)
+        return _('Closing difference in %(payment_method)s (%(session)s)', payment_method=payment_method.name, session=self.name)
 
     def _get_diff_vals(self, payment_method_id, diff_amount):
         payment_method = self.env['pos.payment.method'].browse(payment_method_id)
@@ -1036,7 +1036,7 @@ class PosSession(models.Model):
             'journal_id': payment_method.journal_id.id,
             'force_outstanding_account_id': outstanding_account.id,
             'destination_account_id':  destination_account.id,
-            'ref': _('Combine %s POS payments from %s', payment_method.name, self.name),
+            'ref': _('Combine %(payment_method)s POS payments from %(session)s', payment_method=payment_method.name, session=self.name),
             'pos_payment_method_id': payment_method.id,
             'pos_session_id': self.id,
             'company_id': self.company_id.id,
@@ -1082,7 +1082,7 @@ class PosSession(models.Model):
             'journal_id': payment_method.journal_id.id,
             'force_outstanding_account_id': outstanding_account.id,
             'destination_account_id': destination_account.id,
-            'ref': _('%s POS payment of %s in %s', payment_method.name, payment.partner_id.display_name, self.name),
+            'ref': _('%(payment_method)s POS payment of %(partner)s in %(session)s', payment_method=payment_method.name, partner=payment.partner_id.display_name, session=self.name),
             'pos_payment_method_id': payment_method.id,
             'pos_session_id': self.id,
         })
@@ -1281,10 +1281,10 @@ class PosSession(models.Model):
     def _get_split_receivable_vals(self, payment, amount, amount_converted):
         accounting_partner = self.env["res.partner"]._find_accounting_partner(payment.partner_id)
         if not accounting_partner:
-            raise UserError(_("You have enabled the \"Identify Customer\" option for %s payment method,"
-                              "but the order %s does not contain a customer.",
-                              payment.payment_method_id.name,
-                              payment.pos_order_id.name))
+            raise UserError(_("You have enabled the \"Identify Customer\" option for %(payment_method)s payment method,"
+                              "but the order %(order)s does not contain a customer.",
+                              payment_method=payment.payment_method_id.name,
+                              order=payment.pos_order_id.name))
         partial_vals = {
             'account_id': accounting_partner.property_account_receivable_id.id,
             'move_id': self.move_id.id,

--- a/addons/point_of_sale/models/stock_picking.py
+++ b/addons/point_of_sale/models/stock_picking.py
@@ -172,7 +172,7 @@ class StockPickingType(models.Model):
         for picking_type in self:
             pos_config = self.env['pos.config'].sudo().search([('picking_type_id', '=', picking_type.id)], limit=1)
             if pos_config:
-                raise ValidationError(_("You cannot archive '%s' as it is used by a POS configuration '%s'.", picking_type.name, pos_config.name))
+                raise ValidationError(_("You cannot archive '%(picking_type)s' as it is used by POS configuration '%(config)s'.", picking_type=picking_type.name, config=pos_config.name))
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/pos_adyen/models/pos_payment_method.py
+++ b/addons/pos_adyen/models/pos_payment_method.py
@@ -44,13 +44,13 @@ class PosPaymentMethod(models.Model):
                                                   limit=1)
             if existing_payment_method:
                 if existing_payment_method.company_id == payment_method.company_id:
-                    raise ValidationError(_('Terminal %s is already used on payment method %s.',
-                                      payment_method.adyen_terminal_identifier, existing_payment_method.display_name))
+                    raise ValidationError(_('Terminal %(terminal)s is already used on payment method %(payment_method)s.',
+                                      terminal=payment_method.adyen_terminal_identifier, payment_method=existing_payment_method.display_name))
                 else:
-                    raise ValidationError(_('Terminal %s is already used in company %s on payment method %s.',
-                                             payment_method.adyen_terminal_identifier,
-                                             existing_payment_method.company_id.name,
-                                             existing_payment_method.display_name))
+                    raise ValidationError(_('Terminal %(terminal)s is already used in company %(company)s on payment method %(payment_method)s.',
+                                             terminal=payment_method.adyen_terminal_identifier,
+                                             company=existing_payment_method.company_id.name,
+                                             payment_method=existing_payment_method.display_name))
 
     def _get_adyen_endpoints(self):
         return {

--- a/addons/pos_hr/models/hr_employee.py
+++ b/addons/pos_hr/models/hr_employee.py
@@ -5,6 +5,7 @@ import hashlib
 
 from odoo import api, models, _
 from odoo.exceptions import UserError
+from odoo.tools import format_list
 
 class HrEmployee(models.Model):
     _inherit = 'hr.employee'
@@ -71,6 +72,6 @@ class HrEmployee(models.Model):
             for employee in self:
                 config_ids = configs_with_all_employees | configs_with_specific_employees.filtered(lambda c: employee in c.basic_employee_ids)
                 if config_ids:
-                    error_msg += _("Employee: %s - PoS Config(s): %s \n", employee.name, ', '.join(config.name for config in config_ids))
+                    error_msg += _("Employee: %(employee)s - PoS Config(s): %(config_list)s \n", employee=employee.name, config_list=format_list(self.env, config_ids.mapped("name")))
 
             raise UserError(error_msg)

--- a/addons/pos_loyalty/models/loyalty_program.py
+++ b/addons/pos_loyalty/models/loyalty_program.py
@@ -42,7 +42,11 @@ class LoyaltyProgram(models.Model):
                 if not program.mail_template_id:
                     mail_template_label = program._fields.get('mail_template_id').get_description(self.env)['string']
                     pos_report_print_label = program._fields.get('pos_report_print_id').get_description(self.env)['string']
-                    raise UserError(_("You must set '%s' before setting '%s'.", mail_template_label, pos_report_print_label))
+                    raise UserError(_(
+                        "You must set '%(mail_template)s' before setting '%(report)s'.",
+                        mail_template=mail_template_label,
+                        report=pos_report_print_label,
+                    ))
                 else:
                     if not program.communication_plan_ids:
                         program.communication_plan_ids = self.env['loyalty.mail'].create({

--- a/addons/pos_online_payment/models/pos_payment_method.py
+++ b/addons/pos_online_payment/models/pos_payment_method.py
@@ -123,5 +123,9 @@ class PosPaymentMethod(models.Model):
                     'company_id': company_id,
                 })
                 if not payment_method_id:
-                    raise ValidationError(_('Could not create an online payment method (company_id=%d, pos_config_id=%d)', company_id, pos_config_id))
+                    raise ValidationError(_(
+                        "Could not create an online payment method (company_id=%(company_id)d, pos_config_id=%(pos_config_id)d)",
+                        company_id=company_id,
+                        pos_config_id=pos_config_id,
+                    ))
         return payment_method_id

--- a/addons/pos_restaurant/models/pos_restaurant.py
+++ b/addons/pos_restaurant/models/pos_restaurant.py
@@ -38,7 +38,7 @@ class RestaurantFloor(models.Model):
             for floor in self:
                 for session in opened_session:
                     if floor in session.config_id.floor_ids:
-                        error_msg += _("Floor: %s - PoS Config: %s \n", floor.name, session.config_id.name)
+                        error_msg += _("Floor: %(floor)s - PoS Config: %(config)s \n", floor=floor.name, config=session.config_id.name)
             raise UserError(error_msg)
 
     def write(self, vals):

--- a/addons/pos_stripe/models/pos_payment_method.py
+++ b/addons/pos_stripe/models/pos_payment_method.py
@@ -34,8 +34,8 @@ class PosPaymentMethod(models.Model):
                                                    ('stripe_serial_number', '=', payment_method.stripe_serial_number)],
                                                   limit=1)
             if existing_payment_method:
-                raise ValidationError(_('Terminal %s is already used on payment method %s.',\
-                     payment_method.stripe_serial_number, existing_payment_method.display_name))
+                raise ValidationError(_('Terminal %(terminal)s is already used on payment method %(payment_method)s.',
+                     terminal=payment_method.stripe_serial_number, payment_method=existing_payment_method.display_name))
 
     def _get_stripe_payment_provider(self):
         stripe_payment_provider = self.env['payment.provider'].search([

--- a/addons/product/models/product_pricelist.py
+++ b/addons/product/models/product_pricelist.py
@@ -369,7 +369,7 @@ class Pricelist(models.Model):
         ])
         if linked_items:
             raise UserError(_(
-                'You cannot delete those pricelist(s):\n(%s)\n, they are used in other pricelist(s):\n%s',
-                '\n'.join(linked_items.base_pricelist_id.mapped('display_name')),
-                '\n'.join(linked_items.pricelist_id.mapped('display_name'))
+                'You cannot delete pricelist(s):\n(%(pricelists)s)\nThey are used within pricelist(s):\n%(other_pricelists)s',
+                pricelists='\n'.join(linked_items.base_pricelist_id.mapped('display_name')),
+                other_pricelists='\n'.join(linked_items.pricelist_id.mapped('display_name')),
             ))

--- a/addons/product/models/product_pricelist_item.py
+++ b/addons/product/models/product_pricelist_item.py
@@ -197,7 +197,12 @@ class PricelistItem(models.Model):
     def _check_date_range(self):
         for item in self:
             if item.date_start and item.date_end and item.date_start >= item.date_end:
-                raise ValidationError(_('%s: end date (%s) should be greater than start date (%s)', item.display_name, format_datetime(self.env, item.date_end), format_datetime(self.env, item.date_start)))
+                raise ValidationError(_(
+                    '%(item_name)s: end date (%(end_date)s) should be after start date (%(start_date)s)',
+                    item_name=item.display_name,
+                    end_date=format_datetime(self.env, item.date_end),
+                    start_date=format_datetime(self.env, item.date_start),
+                ))
         return True
 
     @api.constrains('price_min_margin', 'price_max_margin')

--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -8,7 +8,7 @@ from operator import itemgetter
 from odoo import api, fields, models, tools, _
 from odoo.exceptions import ValidationError
 from odoo.osv import expression
-from odoo.tools import float_compare, groupby
+from odoo.tools import float_compare, format_list, groupby
 from odoo.tools.misc import unique
 
 
@@ -217,8 +217,8 @@ class ProductProduct(models.Model):
 
         duplicates_as_str = "\n".join(
             _(
-                "- Barcode \"%s\" already assigned to product(s): %s",
-                record['barcode'], ", ".join(p.display_name for p in self.search([('id', 'in', record['id'])]))
+                "- Barcode \"%(barcode)s\" already assigned to product(s): %(product_list)s",
+                barcode=record['barcode'], product_list=format_list(self.env, [p.display_name for p in self.search([('id', 'in', record['id'])])]),
             )
             for record in products_by_barcode if len(record['id']) > 1
         )

--- a/addons/product/models/uom_uom.py
+++ b/addons/product/models/uom_uom.py
@@ -15,7 +15,7 @@ class UoM(models.Model):
                 'title': _('Warning!'),
                 'message': _(
                     "This rounding precision is higher than the Decimal Accuracy"
-                    " (%s digits).\nThis may cause inconsistencies in computations.\n"
-                    "Please set a precision between %s and 1.",
-                    precision, 1.0 / 10.0**precision),
+                    " (%(digits)s digits).\nThis may cause inconsistencies in computations.\n"
+                    "Please set a precision between %(min_precision)s and 1.",
+                    digits=precision, min_precision=1.0 / 10.0**precision),
             }}

--- a/addons/product/tests/test_barcode.py
+++ b/addons/product/tests/test_barcode.py
@@ -75,8 +75,8 @@ class TestProductBarcode(TransactionCase):
         try:
             self.env['product.product'].create(batch)
         except ValidationError as exc:
-            assert 'Barcode "3" already assigned to product(s): BC3, BC4' in exc.args[0]
-            assert 'Barcode "4" already assigned to product(s): BC5, BC6' in exc.args[0]
+            assert 'Barcode "3" already assigned to product(s): BC3 and BC4' in exc.args[0]
+            assert 'Barcode "4" already assigned to product(s): BC5 and BC6' in exc.args[0]
             assert 'Barcode "1" already assigned to product(s): BC1' in exc.args[0]
 
     def test_delete_package_and_use_its_barcode_in_product(self):

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -340,7 +340,11 @@ class Task(models.Model):
 
     def _search_is_closed(self, operator, value):
         if operator not in ('=', '!=') or not isinstance(value, bool):
-            raise NotImplementedError(_('The search does not support the %s operator or %s value.', operator, value))
+            raise NotImplementedError(_(
+                "The search does not support operator %(operator)s or value %(value)s.",
+                operator=operator,
+                value=value,
+            ))
         if (operator == '!=' and value) or (operator == '=' and not value):
             searched_states = self.OPEN_STATES
         else:
@@ -1387,7 +1391,11 @@ class Task(models.Model):
 
     def _search_has_late_and_unreached_milestone(self, operator, value):
         if operator not in ('=', '!=') or not isinstance(value, bool):
-            raise NotImplementedError(_('The search does not support the %s operator or %s value.', operator, value))
+            raise NotImplementedError(_(
+                "The search does not support operator %(operator)s or value %(value)s.",
+                operator=operator,
+                value=value,
+            ))
         domain = [
             ('allow_milestones', '=', True),
             ('milestone_id', '!=', False),

--- a/addons/project/static/src/views/widget/subtask_counter.js
+++ b/addons/project/static/src/views/widget/subtask_counter.js
@@ -24,11 +24,17 @@ export class SubtaskCounter extends Component {
     }
 
     get counterTitle() {
-        return _t("%s sub-tasks closed out of %s", this.closedSubtaskCount, this.subtaskCount);
+        return _t("%(closedCount)s sub-tasks closed out of %(totalCount)s", {
+            closedCount: this.closedSubtaskCount,
+            totalCount: this.subtaskCount,
+        });
     }
 
     get counterDisplay() {
-        return _t("%s/%s", this.closedSubtaskCount, this.subtaskCount);
+        return _t("%(count1)s/%(count2)s", {
+            count1: this.closedSubtaskCount,
+            count2: this.subtaskCount,
+        });
     }
 }
 

--- a/addons/project/static/tests/legacy/portal_components_tests.js
+++ b/addons/project/static/tests/legacy/portal_components_tests.js
@@ -61,7 +61,7 @@ QUnit.module("Project", ({ beforeEach }) => {
                 assert.step("notification");
                 assert.strictEqual(
                     message,
-                    "The selected file (4B) is over the maximum allowed file size (2B)."
+                    "The selected file (4B) is larger than the maximum allowed file size (2B)."
                 );
             },
         });

--- a/addons/project/static/tests/portal_file_input.test.js
+++ b/addons/project/static/tests/portal_file_input.test.js
@@ -14,7 +14,7 @@ import { PortalFileInput } from "@project/project_sharing/components/portal_file
 mockService("notification", () => ({
     add(message) {
         expect.step("notification");
-        expect(message).toBe("The selected file (4B) is over the maximum allowed file size (2B).");
+        expect(message).toBe("The selected file (4B) is larger than the maximum allowed file size (2B).");
     },
 }));
 mockService("http", () => ({

--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -947,7 +947,7 @@ class PurchaseOrder(models.Model):
             if order.state in ['purchase', 'done'] and not order.mail_reminder_confirmed:
                 order.mail_reminder_confirmed = True
                 date_planned = order.get_localized_date_planned(confirmed_date).date()
-                order.message_post(body=_("%s confirmed the receipt will take place on %s.", order.partner_id.name, date_planned))
+                order.message_post(body=_("%(vendor)s confirmed the receipt will take place on %(date)s.", vendor=order.partner_id.name, date=date_planned))
 
     def _approval_allowed(self):
         """Returns whether the order qualifies to be approved by the current user"""

--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -262,8 +262,8 @@ class PurchaseOrderLine(models.Model):
         warehouse_loc = self.order_id.picking_type_id.warehouse_id.view_location_id
         dest_loc = self.move_dest_ids.location_id or self.orderpoint_id.location_id
         if warehouse_loc and dest_loc and dest_loc.warehouse_id and not warehouse_loc.parent_path in dest_loc[0].parent_path:
-            raise UserError(_('For the product %s, the warehouse of the operation type (%s) is inconsistent with the location (%s) of the reordering rule (%s). Change the operation type or cancel the request for quotation.',
-                              self.product_id.display_name, self.order_id.picking_type_id.display_name, self.orderpoint_id.location_id.display_name, self.orderpoint_id.display_name))
+            raise UserError(_('The warehouse of operation type (%(operation_type)s) is inconsistent with location (%(location)s) of reordering rule (%(reordering_rule)s) for product %(product)s. Change the operation type or cancel the request for quotation.',
+                              product=self.product_id.display_name, operation_type=self.order_id.picking_type_id.display_name, location=self.orderpoint_id.location_id.display_name, reordering_rule=self.orderpoint_id.display_name))
 
     def _prepare_stock_move_vals(self, picking, price_unit, product_uom_qty, product_uom):
         self.ensure_one()

--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -151,8 +151,12 @@ class ResourceCalendar(models.Model):
         week_type_str = _("second") if week_type else _("first")
         first_day = date_utils.start_of(today, 'week')
         last_day = date_utils.end_of(today, 'week')
-        self.two_weeks_explanation = _("The current week (from %s to %s) correspond to the  %s one.", first_day,
-                                       last_day, week_type_str)
+        self.two_weeks_explanation = _(
+            "The current week (from %(first_day)s to %(last_day)s) corresponds to week number %(number)s.",
+            first_day=first_day,
+            last_day=last_day,
+            number=week_type_str,
+        )
 
     def _get_global_attendances(self):
         return self.attendance_ids.filtered(lambda attendance:

--- a/addons/sale/models/product_template.py
+++ b/addons/sale/models/product_template.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from odoo import api, fields, models, _
 from odoo.addons.base.models.res_partner import WARNING_MESSAGE, WARNING_HELP
 from odoo.exceptions import ValidationError
-from odoo.tools.float_utils import float_round
+from odoo.tools import float_round, format_list
 
 
 class ProductTemplate(models.Model):
@@ -178,9 +178,9 @@ class ProductTemplate(models.Model):
             incompatible_fields = [f for f in incompatible_types if val[f]]
             if len(incompatible_fields) > 1:
                 raise ValidationError(_(
-                    "The product (%s) has incompatible values: %s",
-                    val['name'],
-                    ','.join(field_descriptions[v] for v in incompatible_fields),
+                    "The product (%(product)s) has incompatible values: %(value_list)s",
+                    product=val['name'],
+                    value_list=format_list(self.env, [field_descriptions[v] for v in incompatible_fields]),
                 ))
 
     def get_single_product_variant(self):

--- a/addons/sale_loyalty/models/sale_order.py
+++ b/addons/sale_loyalty/models/sale_order.py
@@ -1118,10 +1118,10 @@ class SaleOrder(models.Model):
                 and self._best_global_discount_already_applied(applied_global_reward, global_reward)
             ):
                 return {'error': _(
-                    'This discount (%s) is not compatible with "%s". '
+                    'This discount (%(discount)s) is not compatible with "%(other_discount)s". '
                     'Please remove it in order to apply this one.',
-                    global_reward.description,
-                    applied_global_reward.program_id.reward_ids.description,
+                    discount=global_reward.description,
+                    other_discount=applied_global_reward.program_id.reward_ids.description,
                 )}
         # Check for applicability from the program's triggers/rules.
         # This step should also compute the amount of points to give for that program on that order.

--- a/addons/sale_project/models/sale_order_line.py
+++ b/addons/sale_project/models/sale_order_line.py
@@ -137,7 +137,7 @@ class SaleOrderLine(models.Model):
                 line.sudo()._timesheet_service_generation()
                 # if the SO line created a task, post a message on the order
                 if line.task_id and not has_task:
-                    msg_body = _("Task Created (%s): %s", line.product_id.name, line.task_id._get_html_link())
+                    msg_body = _("Task Created (%(name)s): %(link)s", name=line.product_id.name, link=line.task_id._get_html_link())
                     line.order_id.message_post(body=msg_body)
 
         # Set a service SOL on the project, if any is given
@@ -258,9 +258,9 @@ class SaleOrderLine(models.Model):
         task = self.env['project.task'].sudo().create(values)
         self.write({'task_id': task.id})
         # post message on task
-        task_msg = _("This task has been created from: %s (%s)",
-            self.order_id._get_html_link(),
-            self.product_id.name
+        task_msg = _("This task has been created from: %(order_link)s (%(product_name)s)",
+            order_link=self.order_id._get_html_link(),
+            product_name=self.product_id.name,
         )
         task.message_post(body=task_msg)
         return task

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -107,9 +107,9 @@ class SaleOrder(models.Model):
             for record in self:
                 picking = record.mapped('picking_ids').filtered(lambda x: x.state not in ('done', 'cancel'))
                 message = _("""The delivery address has been changed on the Sales Order<br/>
-                        From <strong>"%s"</strong> To <strong>"%s"</strong>,
+                        From <strong>"%(old_address)s"</strong> to <strong>"%(new_address)s"</strong>,
                         You should probably update the partner on this document.""",
-                            record.partner_shipping_id.display_name, new_partner.display_name)
+                            old_address=record.partner_shipping_id.display_name, new_address=new_partner.display_name)
                 picking.activity_schedule('mail.mail_activity_data_warning', note=message, user_id=self.env.user.id)
 
         if 'commitment_date' in values:

--- a/addons/sms/models/sms_sms.py
+++ b/addons/sms/models/sms_sms.py
@@ -119,7 +119,7 @@ class SmsSms(models.Model):
             if success_sms > 0:
                 notification_title = _('Success')
                 notification_type = 'success'
-                notification_message = _('%s out of the %s selected SMS Text Messages have successfully been resent.', success_sms, len(self))
+                notification_message = _('%(count)s out of the %(total)s selected SMS Text Messages have successfully been resent.', count=success_sms, total=len(self))
             else:
                 notification_message = _('The SMS Text Messages could not be resent.')
         else:

--- a/addons/spreadsheet/static/src/pivot/pivot_model.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_model.js
@@ -25,7 +25,10 @@ function isNotSupported(fieldType) {
 
 function throwUnsupportedFieldError(field) {
     throw new EvaluationError(
-        sprintf(_t("Field %s is not supported because of its type (%s)"), field.string, field.type)
+        sprintf(_t("Field %(field)s is not supported because of its type (%(type)s)"), {
+            field: field.string,
+            type: field.type,
+        })
     );
 }
 
@@ -327,7 +330,10 @@ export class OdooPivotModel extends PivotModel {
             });
         if (!displayName) {
             throw new EvaluationError(
-                _t("Unable to fetch the label of %s of model %s", resId, resModel)
+                _t("Unable to fetch the label of %(id)s of model %(model)s", {
+                    id: resId,
+                    model: resModel,
+                })
             );
         }
         return displayName;

--- a/addons/stock/models/stock_location.py
+++ b/addons/stock/models/stock_location.py
@@ -211,7 +211,11 @@ class Location(models.Model):
 
     def _search_is_empty(self, operator, value):
         if operator not in ('=', '!=') or not isinstance(value, bool):
-            raise NotImplementedError(_('The search does not support the %(operator)s operator or %(value)s value.'), operator=operator, value=value)
+            raise NotImplementedError(_(
+                "The search does not support the %(operator)s operator or %(value)s value.",
+                operator=operator,
+                value=value,
+            ))
         groups = self.env['stock.quant']._read_group([
             ('location_id.usage', 'in', ['internal', 'transit'])],
             ['location_id'], ['quantity:sum'])
@@ -249,8 +253,8 @@ class Location(models.Model):
                     warehouses = self.env['stock.warehouse'].search([('active', '=', True), '|', ('lot_stock_id', '=', location.id), ('view_location_id', '=', location.id)], limit=1)
                     if warehouses:
                         raise UserError(_(
-                            "You cannot archive the location %s as it is used by your warehouse %s",
-                            location.display_name, warehouses.display_name))
+                            "You cannot archive location %(location)s because it is used by warehouse %(warehouse)s",
+                            location=location.display_name, warehouse=warehouses.display_name))
 
             if not self.env.context.get('do_not_check_quant'):
                 children_location = self.env['stock.location'].with_context(active_test=False).search([('id', 'child_of', self.ids)])
@@ -528,4 +532,9 @@ class StockRoute(models.Model):
 
             for rule in route.rule_ids:
                 if route.company_id.id != rule.company_id.id:
-                    raise ValidationError(_("Rule %s belongs to %s while the route belongs to %s.", rule.display_name, rule.company_id.display_name, route.company_id.display_name))
+                    raise ValidationError(_(
+                        "Rule %(rule)s belongs to %(rule_company)s while the route belongs to %(route_company)s.",
+                        rule=rule.display_name,
+                        rule_company=rule.company_id.display_name,
+                        route_company=route.company_id.display_name,
+                    ))

--- a/addons/stock/models/stock_lot.py
+++ b/addons/stock/models/stock_lot.py
@@ -103,9 +103,9 @@ class StockLot(models.Model):
                 cross_lots.add((product, name))
                 continue
             if (product, name) in cross_lots:
-                error_message_lines.append(_(" - Product: %s, Serial Number: %s", product.display_name, name))
+                error_message_lines.append(_(" - Product: %(product)s, Lot/Serial Number: %(lot)s", product=product.display_name, lot=name))
         if error_message_lines:
-            raise ValidationError(_('The combination of serial number and product must be unique across a company and no company defined.\nFollowing combination contains duplicates:\n') + '\n'.join(error_message_lines))
+            raise ValidationError(_("The combination of lot/serial number and product must be unique within a company including when no company is defined.\nThe following combinations contain duplicates:\n") + '\n'.join(error_message_lines))
 
     def _check_create(self):
         active_picking_id = self.env.context.get('active_picking_id', False)

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -396,9 +396,9 @@ class StockMove(models.Model):
             qty = float_round(move.quantity, precision_digits=precision_digits, rounding_method='HALF-UP')
             if float_compare(uom_qty, qty, precision_digits=precision_digits) != 0:
                 err.append(_("""
-The quantity done for the product %s doesn't respect the rounding precision defined on the unit of measure %s.
+The quantity done for the product %(product)s doesn't respect the rounding precision defined on the unit of measure %(unit)s.
 Please change the quantity done or the rounding precision of your unit of measure.""",
-                             move.product_id.display_name, move.product_uom.display_name))
+                             product=move.product_id.display_name, unit=move.product_uom.display_name))
                 continue
             delta_qty = move.quantity - move._quantity_sml()
             if float_compare(delta_qty, 0, precision_rounding=move.product_uom.rounding) > 0:
@@ -580,9 +580,14 @@ Please change the quantity done or the rounding precision of your unit of measur
         moves_error = self.filtered(lambda move: move.product_id.uom_id.category_id != move.product_uom.category_id)
         if moves_error:
             user_warnings = [
-                _('You cannot perform the move because the unit of measure has a different category as the product unit of measure.'),
+                _('You cannot perform moves because their unit of measure has a different category from their product unit of measure.'),
                 *(
-                    _('%s --> Product UoM is %s (%s) - Move UoM is %s (%s)', move.product_id.display_name, move.product_id.uom_id.name, move.product_id.uom_id.category_id.name, move.product_uom.name, move.product_uom.category_id.name)
+                    _('%(product_name)s --> Product UoM is %(product_uom)s (%(product_uom_category)s) - Move UoM is %(move_uom)s (%(move_uom_category)s)',
+                      product_name=move.product_id.display_name,
+                      product_uom=move.product_id.uom_id.name,
+                      product_uom_category=move.product_id.uom_id.category_id.name,
+                      move_uom=move.product_uom.name,
+                      move_uom_category=move.product_uom.category_id.name)
                     for move in moves_error
                 ),
                 _('Blocking: %s', ' ,'.join(moves_error.mapped('name')))
@@ -1208,7 +1213,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         if quants:
             sn_to_location = ""
             for quant in quants:
-                sn_to_location += _("\n(%s) exists in location %s", quant.lot_id.display_name, quant.location_id.display_name)
+                sn_to_location += _("\n(%(serial_number)s) exists in location %(location)s", serial_number=quant.lot_id.display_name, location=quant.location_id.display_name)
             return {
                 'warning': {'title': _('Warning'), 'message': _('Unavailable Serial numbers. Please correct the serial numbers encoded:') + sn_to_location}
             }

--- a/addons/stock/models/stock_orderpoint.py
+++ b/addons/stock/models/stock_orderpoint.py
@@ -210,7 +210,11 @@ class StockWarehouseOrderpoint(models.Model):
     def action_stock_replenishment_info(self):
         self.ensure_one()
         action = self.env['ir.actions.actions']._for_xml_id('stock.action_stock_replenishment_info')
-        action['name'] = _('Replenishment Information for %s in %s', self.product_id.display_name, self.warehouse_id.display_name)
+        action['name'] = _(
+            'Replenishment Information for %(product)s in %(warehouse)s',
+            product=self.product_id.display_name,
+            warehouse=self.warehouse_id.display_name,
+        )
         res = self.env['stock.replenishment.info'].create({
             'orderpoint_id': self.id,
         })

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -13,7 +13,7 @@ from odoo.addons.stock.models.stock_move import PROCUREMENT_PRIORITIES
 from odoo.addons.web.controllers.utils import clean_action
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, format_datetime, format_date, groupby, SQL
+from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT, format_datetime, format_date, format_list, groupby, SQL
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
 
 
@@ -1177,7 +1177,11 @@ class Picking(models.Model):
             if pickings_without_moves:
                 message += _('Transfers %s: Please add some items to move.', ', '.join(pickings_without_moves.mapped('name')))
             if pickings_without_lots:
-                message += _('\n\nTransfers %s: You need to supply a Lot/Serial number for products %s.', ', '.join(pickings_without_lots.mapped('name')), ', '.join(products_without_lots.mapped('display_name')))
+                message += _(
+                    '\n\nTransfers %(transfer_list)s: You need to supply a Lot/Serial number for products %(product_list)s.',
+                    transfer_list=format_list(self.env, pickings_without_lots.mapped('name')),
+                    product_list=format_list(self.env, products_without_lots.mapped('display_name')),
+                )
             if message:
                 raise UserError(message.lstrip())
 

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -38,12 +38,12 @@ class ProductTemplate(models.Model):
 
                 # Empty out the stock with the current cost method.
                 description = _(
-                    "Due to a change of product category (from %s to %s), the costing method has changed for product template %s: from %s to %s.",
-                    product_template.categ_id.display_name,
-                    new_product_category.display_name,
-                    product_template.display_name,
-                    product_template.cost_method,
-                    new_product_category.property_cost_method)
+                    "Due to a change of product category (from %(old_category)s to %(new_category)s), the costing method has changed for product %(product)s: from %(old_method)s to %(new_method)s.",
+                    old_category=product_template.categ_id.display_name,
+                    new_category=new_product_category.display_name,
+                    product=product_template.display_name,
+                    old_method=product_template.cost_method,
+                    new_method=new_product_category.property_cost_method)
                 out_svl_vals_list, products_orig_quantity_svl, products = Product\
                     ._svl_empty_stock(description, product_template=product_template)
                 out_stock_valuation_layers = SVL.create(out_svl_vals_list)
@@ -252,7 +252,11 @@ class ProductProduct(models.Model):
             svl_vals = {
                 'company_id': company_id.id,
                 'product_id': product.id,
-                'description': _('Product value manually modified (from %s to %s)', product.standard_price, rounded_new_price),
+                'description': _(
+                    'Product value manually modified (from %(original_price)s to %(new_price)s)',
+                    original_price=product.standard_price,
+                    new_price=rounded_new_price,
+                ),
                 'value': value,
                 'quantity': 0,
             }
@@ -739,9 +743,7 @@ class ProductCategory(models.Model):
         help="""Standard Price: The products are valued at their standard cost defined on the product.
         Average Cost (AVCO): The products are valued at weighted average cost.
         First In First Out (FIFO): The products are valued supposing those that enter the company first will also leave it first.
-        """,
-        tracking=True,
-    )
+        """)
     property_stock_journal = fields.Many2one(
         'account.journal', 'Stock Journal', company_dependent=True,
         help="When doing automated inventory valuation, this is the Accounting Journal in which entries will be automatically posted when stock moves are processed.")
@@ -868,12 +870,12 @@ class ProductCategory(models.Model):
                 # Empty out the stock with the current cost method.
                 if new_cost_method:
                     description = _(
-                        "Costing method change for product category %s: from %s to %s.",
-                        product_category.display_name, product_category.property_cost_method, new_cost_method)
+                        "Costing method change for product category %(category)s: from %(old_method)s to %(new_method)s.",
+                        category=product_category.display_name, old_method=product_category.property_cost_method, new_method=new_cost_method)
                 else:
                     description = _(
-                        "Valuation method change for product category %s: from %s to %s.",
-                        product_category.display_name, product_category.property_valuation, new_valuation)
+                        "Valuation method change for product category %(category)s: from %(old_method)s to %(new_method)s.",
+                        category=product_category.display_name, old_method=product_category.property_valuation, new_method=new_valuation)
                 out_svl_vals_list, products_orig_quantity_svl, products = Product\
                     ._svl_empty_stock(description, product_category=product_category)
                 out_stock_valuation_layers = SVL.sudo().create(out_svl_vals_list)

--- a/addons/stock_picking_batch/models/stock_picking_batch.py
+++ b/addons/stock_picking_batch/models/stock_picking_batch.py
@@ -6,7 +6,7 @@ from markupsafe import Markup
 from odoo import api, fields, models, _
 from odoo.exceptions import UserError
 from odoo.osv.expression import AND
-from odoo.tools.float_utils import float_is_zero
+from odoo.tools import float_is_zero, format_list
 
 class StockPickingBatch(models.Model):
     _inherit = ['mail.thread', 'mail.activity.mixin']
@@ -276,9 +276,11 @@ class StockPickingBatch(models.Model):
             if not batch.picking_ids <= batch.allowed_picking_ids:
                 erroneous_pickings = batch.picking_ids - batch.allowed_picking_ids
                 raise UserError(_(
-                    "The following transfers cannot be added to batch transfer %s. "
+                    "The following transfers cannot be added to batch transfer %(batch)s. "
                     "Please check their states and operation types.\n\n"
-                    "Incompatibilities: %s", batch.name, ', '.join(erroneous_pickings.mapped('name'))))
+                    "Incompatibilities: %(incompatible_transfers)s",
+                    batch=batch.name,
+                    incompatible_transfers=format_list(self.env, erroneous_pickings.mapped('name'))))
 
     def _track_subtype(self, init_values):
         if 'state' in init_values:

--- a/addons/uom/models/uom_uom.py
+++ b/addons/uom/models/uom_uom.py
@@ -223,8 +223,8 @@ class UoM(models.Model):
         if self != to_unit and self.category_id.id != to_unit.category_id.id:
             if raise_if_failure:
                 raise UserError(_(
-                    'The unit of measure %s defined on the order line doesn\'t belong to the same category as the unit of measure %s defined on the product. Please correct the unit of measure defined on the order line or on the product, they should belong to the same category.',
-                    self.name, to_unit.name))
+                    'The unit of measure %(unit)s defined on the order line doesn\'t belong to the same category as the unit of measure %(product_unit)s defined on the product. Please correct the unit of measure defined on the order line or on the product. They should belong to the same category.',
+                    unit=self.name, product_unit=to_unit.name))
             else:
                 return qty
 

--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -189,7 +189,7 @@ class ExportXlsxWriter:
         self.monetary_format = f'#,##0.{max(decimal_places or [2]) * "0"}'
 
         if row_count > self.worksheet.xls_rowmax:
-            raise UserError(_('There are too many rows (%s rows, limit: %s) to export as Excel 2007-2013 (.xlsx) format. Consider splitting the export.') % (row_count, self.worksheet.xls_rowmax))
+            raise UserError(_('There are too many rows (%(count)s rows, limit: %(limit)s) to export as Excel 2007-2013 (.xlsx) format. Consider splitting the export.', count=row_count, limit=self.worksheet.xls_rowmax))
 
     def __enter__(self):
         self.write_header()

--- a/addons/web/controllers/view.py
+++ b/addons/web/controllers/view.py
@@ -18,6 +18,10 @@ class View(Controller):
         """
         custom_view = request.env['ir.ui.view.custom'].sudo().browse(custom_id)
         if not custom_view.user_id == request.env.user:
-            raise AccessError(_("Custom view %s does not belong to user %s", custom_id, self.env.user.login))
+            raise AccessError(_(
+                "Custom view %(view)s does not belong to user %(user)s",
+                view=custom_id,
+                user=self.env.user.login,
+            ))
         custom_view.write({'arch': arch})
         return {'result': True}

--- a/addons/web/static/src/core/file_upload/file_upload_progress_record.js
+++ b/addons/web/static/src/core/file_upload/file_upload_progress_record.js
@@ -25,7 +25,7 @@ export class FileUploadProgressRecord extends Component {
             const mbTotal = Math.round(fileUpload.total / 1000000);
             return {
                 left: _t("Uploading... (%s%)", percent),
-                right: _t("(%s/%sMB)", mbLoaded, mbTotal),
+                right: _t("(%(mbLoaded)s/%(mbTotal)sMB)", { mbLoaded, mbTotal }),
             };
         }
     }

--- a/addons/web/static/src/core/utils/files.js
+++ b/addons/web/static/src/core/utils/files.js
@@ -15,9 +15,8 @@ export function checkFileSize(fileSize, notificationService) {
     if (fileSize > maxUploadSize) {
         notificationService.add(
             _t(
-                "The selected file (%sB) is over the maximum allowed file size (%sB).",
-                humanNumber(fileSize),
-                humanNumber(maxUploadSize)
+                "The selected file (%(size)sB) is larger than the maximum allowed file size (%(maxSize)sB).",
+                { size: humanNumber(fileSize), maxSize: humanNumber(maxUploadSize) }
             ),
             {
                 type: "danger",

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -243,9 +243,8 @@ export class DynamicList extends DataPoint {
             resIds.length < this.count
         ) {
             const msg = _t(
-                `Only the first %s records have been deleted (out of %s selected)`,
-                resIds.length,
-                this.count
+                "Only the first %(count)s records have been deleted (out of %(total)s selected)",
+                { count: resIds.length, total: this.count }
             );
             this.model.notification.add(msg, { title: _t("Warning") });
         }
@@ -409,9 +408,11 @@ export class DynamicList extends DataPoint {
             resIds.length < this.count
         ) {
             const msg = _t(
-                "Of the %s records selected, only the first %s have been archived/unarchived.",
-                resIds.length,
-                this.count
+                "Of the %(selectedRecord)s selected records, only the first %(firstRecords)s have been archived/unarchived.",
+                {
+                    selectedRecords: resIds.length,
+                    firstRecords: this.count,
+                }
             );
             this.model.notification.add(msg, { title: _t("Warning") });
         }

--- a/addons/web/static/src/views/debug_items.js
+++ b/addons/web/static/src/views/debug_items.js
@@ -222,7 +222,7 @@ export function viewRawRecord({ component, env }) {
         callback: async () => {
             const records = await component.model.orm.read(resModel, [resId]);
             env.services.dialog.add(RawRecordDialog, {
-                title: _t("Raw Record Data: %s(%s)", resModel, resId),
+                title: _t("Raw Record Data: %(model)s(%(id)s)", { model: resModel, id: resId }),
                 record: records[0],
             });
         },

--- a/addons/web/static/src/views/fields/many2one/many2one_field.js
+++ b/addons/web/static/src/views/fields/many2one/many2one_field.js
@@ -6,7 +6,7 @@ import { _t } from "@web/core/l10n/translation";
 import { evaluateBooleanExpr } from "@web/core/py_js/py";
 import { registry } from "@web/core/registry";
 import { useChildRef, useOwnedDialogs, useService } from "@web/core/utils/hooks";
-import { escape } from "@web/core/utils/strings";
+import { escape, sprintf } from "@web/core/utils/strings";
 import { Many2XAutocomplete, useOpenMany2XRecord } from "@web/views/fields/relational_utils";
 import * as BarcodeScanner from "@web/webclient/barcode/barcode_scanner";
 import { standardFieldProps } from "../standard_field_props";
@@ -30,11 +30,10 @@ class CreateConfirmationDialog extends Component {
 
     get dialogContent() {
         return markup(
-            _t(
-                "Create <strong>%s</strong> as a new %s?",
-                escape(this.props.value),
-                escape(this.props.name)
-            )
+            sprintf(escape(_t("Create %(value)s as a new %(field)s?")), {
+                value: `<strong>${escape(this.props.value)}</strong>`,
+                field: escape(this.props.name),
+            })
         );
     }
 

--- a/addons/web/static/src/views/fields/properties/properties_field.js
+++ b/addons/web/static/src/views/fields/properties/properties_field.js
@@ -560,9 +560,8 @@ export class PropertiesField extends Component {
         const dialogProps = {
             title: _t("Delete Property Field"),
             body: _t(
-                'Are you sure you want to delete this property field? It will be removed for everyone using the "%s" %s.',
-                this.parentName,
-                this.parentString
+                'Are you sure you want to delete this property field? It will be removed for everyone using the "%(parentName)s" %(parentFieldLabel)s.',
+                { parentName: this.parentName, parentFieldLabel: this.parentString }
             ),
             confirmLabel: _t("Delete"),
             confirm: () => {

--- a/addons/web/static/tests/core/file_input.test.js
+++ b/addons/web/static/tests/core/file_input.test.js
@@ -154,7 +154,7 @@ test("uploading a file that is too heavy will send a notification", async () => 
             expect.step("notification");
             // Message is a bit weird because values (2 and 4 bytes) are simplified to 2 decimals in regards to megabytes
             expect(message).toBe(
-                "The selected file (4B) is over the maximum allowed file size (2B)."
+                "The selected file (4B) is larger than the maximum allowed file size (2B)."
             );
         },
     });

--- a/addons/web_editor/models/ir_qweb_fields.py
+++ b/addons/web_editor/models/ir_qweb_fields.py
@@ -342,7 +342,7 @@ class DateTime(models.AbstractModel):
             datetime_format = f'{lg.date_format} {lg.time_format}'
             dt = datetime.strptime(value, datetime_format)
         except ValueError:
-            raise ValidationError(_("The datetime %s does not match the format %s", value, datetime_format))
+            raise ValidationError(_("The datetime %(value)s does not match the format %(format)s", value=value, format=datetime_format))
 
         # convert back from user's timezone to UTC
         tz_name = element.attrib.get('data-oe-original-tz') or self.env.context.get('tz') or self.env.user.tz

--- a/addons/web_editor/models/ir_ui_view.py
+++ b/addons/web_editor/models/ir_ui_view.py
@@ -81,7 +81,11 @@ class IrUiView(models.Model):
                     self._copy_custom_snippet_translations(record, field)
 
         except (ValueError, TypeError):
-            raise ValidationError(_("Invalid field value for %s: %s", Model._fields[field].string, el.text_content().strip()))
+            raise ValidationError(_(
+                "Invalid field value for %(field_name)s: %(value)s",
+                field_name=Model._fields[field].string,
+                value=el.text_content().strip(),
+            ))
 
     def save_oe_structure(self, el):
         self.ensure_one()

--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -226,7 +226,12 @@ def handle_history_divergence(record, html_field_name, vals):
             server_last_history_id = server_history_matches[1].split(',')[-1]
             if server_last_history_id not in incoming_history_ids:
                 logger.warning('The document was already saved from someone with a different history for model %r, field %r with id %r.', record._name, html_field_name, record.id)
-                raise ValidationError(_('The document was already saved from someone with a different history for model %r, field %r with id %r.', record._name, html_field_name, record.id))
+                raise ValidationError(_(
+                    'The document was already saved from someone with a different history for model "%(model)s", field "%(field)s" with id "%(id)d".',
+                    model=record._name,
+                    field=html_field_name,
+                    id=record.id,
+                ))
 
     # Save only the latest id.
     vals[html_field_name] = incoming_html[0:incoming_history_matches.start(1)] + last_step_id + incoming_html[incoming_history_matches.end(1):]

--- a/addons/web_hierarchy/models/ir_ui_view.py
+++ b/addons/web_hierarchy/models/ir_ui_view.py
@@ -3,6 +3,7 @@
 from lxml import etree
 
 from odoo import fields, models, _
+from odoo.tools import format_list
 
 HIERARCHY_VALID_ATTRIBUTES = {
     '__validate__',                     # ir.ui.view implementation detail
@@ -46,7 +47,8 @@ class View(models.Model):
         remaining = set(node.attrib) - HIERARCHY_VALID_ATTRIBUTES
         if remaining:
             msg = _(
-                "Invalid attributes (%s) in hierarchy view. Attributes must be in (%s)",
-                ','.join(remaining), ','.join(HIERARCHY_VALID_ATTRIBUTES),
+                "Invalid attributes (%(invalid_attributes)s) in hierarchy view. Attributes must be in (%(valid_attributes)s)",
+                invalid_attributes=format_list(self.env, remaining),
+                valid_attributes=format_list(self.env, HIERARCHY_VALID_ATTRIBUTES),
             )
             self._raise_view_error(msg, node)

--- a/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
+++ b/addons/web_unsplash/static/src/components/media_dialog/image_selector.js
@@ -263,9 +263,13 @@ patch(uploadService, {
                 service.incrementId();
                 const file = service.addFile({
                     id: service.fileId,
-                    name: records.length > 1 ?
-                    _t("Uploading %s '%s' images.", records.length, records[0].query) :
-                    _t("Uploading '%s' image.", records[0].query),
+                    name:
+                        records.length > 1
+                            ? _t("Uploading %(count)s '%(query)s' images.", {
+                                  count: records.length,
+                                  query: records[0].query,
+                              })
+                            : _t("Uploading '%s' image.", records[0].query),
                 });
 
                 try {

--- a/addons/website/controllers/form.py
+++ b/addons/website/controllers/form.py
@@ -255,7 +255,7 @@ class WebsiteForm(http.Controller):
     def insert_record(self, request, model, values, custom, meta=None):
         model_name = model.sudo().model
         if model_name == 'mail.mail':
-            email_from = _('"%s form submission" <%s>') % (request.env.company.name, request.env.company.email)
+            email_from = _('"%(company)s form submission" <%(email)s>', company=request.env.company.name, email=request.env.company.email)
             values.update({'reply_to': values.get('email_from'), 'email_from': email_from})
         record = request.env[model_name].with_user(SUPERUSER_ID).with_context(
             mail_create_nosubscribe=True,

--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -288,9 +288,8 @@ import wUtils from '@website/js/utils';
                             this.fileInputError.limit
                         )
                         : _t(
-                            "Please fill in the form correctly. The file \"%s\" is too big. (Maximum %s MB)", 
-                            this.fileInputError.fileName,
-                            this.fileInputError.limit
+                            "Please fill in the form correctly. The file “%(file name)s” is too large. (Maximum %(max)s MB)", 
+                            { "file name": this.fileInputError.fileName, max:this.fileInputError.limit }
                         );
                     this.update_status("error", errorMessage);
                     delete this.fileInputError;

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -1732,7 +1732,10 @@ options.registry.WebsiteFormFieldRequired = DisableOverlayButtonOption.extend({
         const fieldName = this.$target[0]
             .querySelector("input.s_website_form_input").getAttribute("name");
         const spanEl = document.createElement("span");
-        spanEl.innerText = _t("The field '%s' is mandatory for the action '%s'.", fieldName, currentActionName);
+        spanEl.innerText = _t("The field “%(field)s” is mandatory for the action “%(action)s”.", {
+            field: fieldName,
+            action: currentActionName,
+        });
         uiFragment.querySelector("we-alert").appendChild(spanEl);
     },
 });

--- a/addons/website_blog/static/src/js/website_blog.js
+++ b/addons/website_blog/static/src/js/website_blog.js
@@ -73,11 +73,10 @@ publicWidget.registry.websiteBlog = publicWidget.Widget.extend({
         var blogPostTitle = $('#o_wblog_post_name').html() || '';
         var articleURL = window.location.href;
         if ($element.hasClass('o_twitter')) {
-            var tweetText = _t(
-                "Amazing blog article: %s! Check it live: %s",
-                blogPostTitle,
-                articleURL
-            );
+            const tweetText = _t("Amazing blog article: %(title)s! Check it live: %(url)s", {
+                title: blogPostTitle,
+                url: articleURL,
+            });
             url = 'https://twitter.com/intent/tweet?tw_p=tweetbutton&text=' + encodeURIComponent(tweetText);
         } else if ($element.hasClass('o_facebook')) {
             url = 'https://www.facebook.com/sharer/sharer.php?u=' + encodeURIComponent(articleURL);

--- a/addons/website_event_meet/controllers/website_event_main.py
+++ b/addons/website_event_meet/controllers/website_event_main.py
@@ -18,8 +18,8 @@ class WebsiteEventController(main.WebsiteEventController):
                 date_begin = format_datetime(event.date_begin, format="medium", tzinfo=event.date_tz)
 
                 values["toast_message"] = (
-                    _('The event %s starts on %s (%s). \nJoin us there to chat about "%s"!',
-                    event.name, date_begin, event.date_tz, meeting_room.name)
+                    _('The event %(name)s starts on %(date_begin)s (%(timezone)s).\nJoin us there to chat about "%(subject)s"!',
+                    name=event.name, date_begin=date_begin, timezone=event.date_tz, subject=meeting_room.name)
                 )
 
         return values

--- a/addons/website_livechat/models/discuss_channel.py
+++ b/addons/website_livechat/models/discuss_channel.py
@@ -59,15 +59,15 @@ class DiscussChannel(models.Model):
         return ' → '.join(visit.page_id.name + ' (' + visit.visit_datetime.strftime('%H:%M') + ')' for visit in reversed(recent_history))
 
     def _get_visitor_leave_message(self, operator=False, cancel=False):
-        if cancel:
-            name = self.livechat_visitor_id.display_name or _('The visitor')
-            message = _("""%s started a conversation with %s.
-                        The chat request has been canceled.""",
-                        name, operator or _('an operator'))
-        else:
-            message = _('Visitor %s left the conversation.', ("#%d" % self.livechat_visitor_id.id) if self.livechat_visitor_id else '')
-
-        return message
+        if not cancel:
+            if self.livechat_visitor_id.id:
+                return _("Visitor #%(id)d left the conversation.", id=self.livechat_visitor_id.id)
+            return _("Visitor left the conversation.")
+        return _(
+            "%(visitor)s started a conversation with %(operator)s.\nThe chat request has been cancelled",
+            visitor=self.livechat_visitor_id.display_name or _("The visitor"),
+            operator=operator or _("an operator"),
+        )
 
     @api.returns('mail.message', lambda value: value.id)
     def message_post(self, **kwargs):

--- a/addons/website_payment/static/src/snippets/s_donation/000.js
+++ b/addons/website_payment/static/src/snippets/s_donation/000.js
@@ -1,5 +1,4 @@
-/** @odoo-module **/
-
+import { formatCurrency } from "@web/core/currency";
 import { _t } from "@web/core/l10n/translation";
 import publicWidget from '@web/legacy/js/public/public_widget';
 import { rpc } from "@web/core/network/rpc";
@@ -137,9 +136,12 @@ publicWidget.registry.DonationSnippet = publicWidget.Widget.extend({
                 if (!amount) {
                     errorMessage = _t("Please select or enter an amount");
                 } else if (amount < parseFloat(minAmount)) {
-                    const before = this.currency.position === "before" ? this.currency.symbol : "";
-                    const after = this.currency.position === "after" ? this.currency.symbol : "";
-                    errorMessage = _t("The minimum donation amount is %s%s%s", before, minAmount, after);
+                    errorMessage = _t(
+                        "The minimum donation amount is %(amount)s",
+                        {
+                            amount: formatCurrency(minAmount, this.currency.id),
+                        }
+                    );
                 }
                 if (errorMessage) {
                     $(ev.currentTarget).before($('<p>', {

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -150,10 +150,10 @@ class SaleOrder(models.Model):
                     company = self.env['res.company'].browse(vals['company_id'])
                     if website.company_id.id != company.id:
                         raise ValueError(_(
-                            "The company of the website you are trying to sale from (%s)"
-                            " is different than the one you want to use (%s)",
-                            website.company_id.name,
-                            company.name,
+                            "The company of the website you are trying to sell from (%(website_company)s)"
+                            " is different than the one you want to use (%(company)s)",
+                            website_company=website.company_id.name,
+                            company=company.name,
                         ))
                 else:
                     vals['company_id'] = website.company_id.id

--- a/addons/website_sale_slides/models/product_product.py
+++ b/addons/website_sale_slides/models/product_product.py
@@ -16,4 +16,4 @@ class Product(models.Model):
             return super(Product, self).get_product_multiline_description_sale()
 
         new_line = '' if len(payment_channels) == 1 else '\n'
-        return _('Access to: %s%s', new_line, '\n'.join(payment_channels.mapped('name')))
+        return _('Access to: %(new_line)s%(channel_list)s', new_line=new_line, channel_list='\n'.join(payment_channels.mapped('name')))

--- a/addons/website_sale_stock/static/src/js/website_sale_reorder.js
+++ b/addons/website_sale_stock/static/src/js/website_sale_reorder.js
@@ -34,9 +34,11 @@ patch(ReorderDialog.prototype, {
         }
         if (product.max_quantity_available < product.qty) {
             product.qty_warning = _t(
-                "You ask for %s Units but only %s are available.",
-                product.qty.toFixed(1),
-                product.max_quantity_available.toFixed(1)
+                "You ask for %(quantity1)s Units but only %(quantity2)s are available.",
+                {
+                    quantity1: product.qty.toFixed(1),
+                    quantity2: product.max_quantity_available.toFixed(1),
+                }
             );
             product.qty = product.max_quantity_available;
             product.stock_warning = true;
@@ -64,9 +66,11 @@ patch(ReorderDialog.prototype, {
     changeProductQty(product, newQty) {
         if (product.max_quantity_available && newQty > product.max_quantity_available) {
             product.qty_warning = _t(
-                "You ask for %s Units but only %s are available.",
-                newQty.toFixed(1),
-                product.max_quantity_available.toFixed(1)
+                "You ask for %(quantity1)s Units but only %(quantity2)s are available.",
+                {
+                    quantity1: newQty.toFixed(1),
+                    quantity2: product.max_quantity_available.toFixed(1),
+                }
             );
             product.stock_warning = true;
             newQty = product.max_quantity_available;

--- a/addons/website_slides/static/src/js/slides_slide_like.js
+++ b/addons/website_slides/static/src/js/slides_slide_like.js
@@ -66,9 +66,9 @@ var SlideLikeWidget = publicWidget.Widget.extend({
             } else {
                 if (data.error === 'public_user') {
                     const message = data.error_signup_allowed ?
-                        _t('Please <a href="/web/login?redirect=%s">login</a> or <a href="/web/signup?redirect=%s">create an account</a> to vote for this lesson') :
-                        _t('Please <a href="/web/login?redirect=%s">login</a> to vote for this lesson');
-                    self._popoverAlert(self.$el, sprintf(message, encodeURIComponent(document.URL), encodeURIComponent(document.URL)));
+                        _t('Please <a href="/web/login?redirect=%(url)s">login</a> or <a href="/web/signup?redirect=%(url)s">create an account</a> to vote for this lesson') :
+                        _t('Please <a href="/web/login?redirect=%(url)s">login</a> to vote for this lesson');
+                    self._popoverAlert(self.$el, sprintf(message, { url: encodeURIComponent(document.URL) }));
                 } else if (data.error === 'slide_access') {
                     self._popoverAlert(self.$el, _t('You don\'t have access to this lesson'));
                 } else if (data.error === 'channel_membership_required') {

--- a/addons/website_slides_survey/models/survey_survey.py
+++ b/addons/website_slides_survey/models/survey_survey.py
@@ -5,6 +5,7 @@ import ast
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
+from odoo.tools import format_list
 
 
 
@@ -32,7 +33,14 @@ class Survey(models.Model):
         # even if they don't have access to those surveys hence the sudo usage
         certifications = self.sudo().slide_ids.filtered(lambda slide: slide.slide_type == "certification").mapped('survey_id').exists()
         if certifications:
-            certifications_course_mapping = [_('- %s (Courses - %s)', certi.title, '; '.join(certi.slide_channel_ids.mapped('name'))) for certi in certifications]
+            certifications_course_mapping = [
+                _(
+                    "- %(certification)s (Courses - %(courses)s)",
+                    certification=certi.title,
+                    courses=format_list(self.env, certi.slide_channel_ids.mapped("name")),
+                )
+                for certi in certifications
+            ]
             raise ValidationError(_(
                 'Any Survey listed below is currently used as a Course Certification and cannot be deleted:\n%s',
                 '\n'.join(certifications_course_mapping)))

--- a/odoo/addons/base/models/assetsbundle.py
+++ b/odoo/addons/base/models/assetsbundle.py
@@ -466,7 +466,11 @@ class AssetsBundle(object):
                     inherit_mode = template_tree.get('t-inherit-mode', 'primary')
                     if inherit_mode not in ['primary', 'extension']:
                         addon = asset.url.split('/')[1]
-                        return asset.generate_error(_("Invalid inherit mode. Module %r and template name %r", addon, template_name))
+                        return asset.generate_error(_(
+                            'Invalid inherit mode. Module "%(module)s" and template name "%(template_name)s"',
+                            module=addon,
+                            template_name=template_name,
+                        ))
                 if inherit_mode == "extension":
                     if block is None or block["type"] != "extensions":
                         block = {"type": "extensions", "extensions": OrderedDict()}

--- a/odoo/addons/base/models/ir_actions_report.py
+++ b/odoo/addons/base/models/ir_actions_report.py
@@ -491,15 +491,15 @@ class IrActionsReport(models.Model):
             if process.returncode not in [0, 1]:
                 if process.returncode == -11:
                     message = _(
-                        'Wkhtmltopdf failed (error code: %s). Memory limit too low or maximum file number of subprocess reached. Message : %s',
-                        process.returncode,
-                        err[-1000:],
+                        'Wkhtmltopdf failed (error code: %(error_code)s). Memory limit too low or maximum file number of subprocess reached. Message : %(message)s',
+                        error_code=process.returncode,
+                        message=err[-1000:],
                     )
                 else:
                     message = _(
-                        'Wkhtmltopdf failed (error code: %s). Message: %s',
-                        process.returncode,
-                        err[-1000:],
+                        'Wkhtmltopdf failed (error code: %(error_code)s). Message: %(message)s',
+                        error_code=process.returncode,
+                        message=err[-1000:],
                     )
                 _logger.warning(message)
                 raise UserError(message)

--- a/odoo/addons/base/models/ir_default.py
+++ b/odoo/addons/base/models/ir_default.py
@@ -76,11 +76,11 @@ class IrDefault(models.Model):
             parsed = field.convert_to_cache(value, model)
             json_value = json.dumps(value, ensure_ascii=False)
         except KeyError:
-            raise ValidationError(_("Invalid field %s.%s", model_name, field_name))
+            raise ValidationError(_("Invalid field %(model)s.%(field)s", model=model_name, field=field_name))
         except Exception:
-            raise ValidationError(_("Invalid value for %s.%s: %s", model_name, field_name, value))
+            raise ValidationError(_("Invalid value for %(model)s.%(field)s: %(value)s", model=model_name, field=field_name, value=value))
         if field.type == 'integer' and not (-2**31 < parsed < 2**31-1):
-            raise ValidationError(_("Invalid value for %s.%s: %s is out of bounds (integers should be between -2,147,483,648 and 2,147,483,647)", model_name, field_name, value))
+            raise ValidationError(_("Invalid value for %(model)s.%(field)s: %(value)s is out of bounds (integers should be between -2,147,483,648 and 2,147,483,647)", model=model_name, field=field_name, value=value))
 
         # update existing default for the same scope, or create one
         field = self.env['ir.model.fields']._get(model_name, field_name)

--- a/odoo/addons/base/models/ir_fields.py
+++ b/odoo/addons/base/models/ir_fields.py
@@ -461,9 +461,9 @@ class IrFieldsConverter(models.AbstractModel):
             if ids:
                 if len(ids) > 1:
                     warnings.append(ImportWarning(_(
-                        "Found multiple matches for value %r in field %%(field)r (%d matches)",
-                        str(value).replace('%', '%%'),
-                        len(ids),
+                        'Found multiple matches for value "%(value)s" in field "%%(field)s" (%(match_count)s matches)',
+                        value=str(value).replace('%', '%%'),
+                        match_count=len(ids),
                     )))
                 id, _name = ids[0]
             else:

--- a/odoo/addons/base/models/ir_mail_server.py
+++ b/odoo/addons/base/models/ir_mail_server.py
@@ -192,11 +192,11 @@ class IrMailServer(models.Model):
                                         for line in usage_details_per_server[server])
         if is_multiple_server_usage:
             raise UserError(
-                _('You cannot archive these Outgoing Mail Servers (%s) because they are still used in the following case(s):\n%s',
-                  error_server_usage, error_usage_details))
+                _('You cannot archive these Outgoing Mail Servers (%(server_usage)s) because they are still used in the following case(s):\n%(usage_details)s',
+                  server_usage=error_server_usage, usage_details=error_usage_details))
         raise UserError(
-            _('You cannot archive this Outgoing Mail Server (%s) because it is still used in the following case(s):\n%s',
-              error_server_usage, error_usage_details))
+            _('You cannot archive this Outgoing Mail Server (%(server_usage)s) because it is still used in the following case(s):\n%(usage_details)s',
+              server_usage=error_server_usage, usage_details=error_usage_details))
 
     def _active_usages_compute(self):
         """Compute a dict server id to list of user-friendly outgoing mail servers usage of this record set.
@@ -717,8 +717,12 @@ class IrMailServer(models.Model):
         except smtplib.SMTPServerDisconnected:
             raise
         except Exception as e:
-            params = (ustr(smtp_server), e.__class__.__name__, ustr(e))
-            msg = _("Mail delivery failed via SMTP server '%s'.\n%s: %s", *params)
+            msg = _(
+                "Mail delivery failed via SMTP server '%(server)s'.\n%(exception_name)s: %(message)s",
+                server=smtp_server,
+                exception_name=e.__class__.__name__,
+                message=e,
+            )
             _logger.info(msg)
             raise MailDeliveryException(_("Mail Delivery Failed"), msg)
         return message_id

--- a/odoo/addons/base/models/ir_module.py
+++ b/odoo/addons/base/models/ir_module.py
@@ -349,11 +349,11 @@ class Module(models.Model):
             modules.check_manifest_dependencies(terp)
         except Exception as e:
             if newstate == 'to install':
-                msg = _('Unable to install module "%s" because an external dependency is not met: %s', module_name, e.args[0])
+                msg = _('Unable to install module "%(module)s" because an external dependency is not met: %(dependency)s', module=module_name, dependency=e.args[0])
             elif newstate == 'to upgrade':
-                msg = _('Unable to upgrade module "%s" because an external dependency is not met: %s', module_name, e.args[0])
+                msg = _('Unable to upgrade module "%(module)s" because an external dependency is not met: %(dependency)s', module=module_name, dependency=e.args[0])
             else:
-                msg = _('Unable to process module "%s" because an external dependency is not met: %s', module_name, e.args[0])
+                msg = _('Unable to process module "%(module)s" because an external dependency is not met: %(dependency)s', module=module_name, dependency=e.args[0])
             raise UserError(msg)
 
     def _state_update(self, newstate, states_to_update, level=100):
@@ -372,7 +372,10 @@ class Module(models.Model):
             update_mods, ready_mods = self.browse(), self.browse()
             for dep in module.dependencies_id:
                 if dep.state == 'unknown':
-                    raise UserError(_("You try to install module %r that depends on module %r.\nBut the latter module is not available in your system.", module.name, dep.name))
+                    raise UserError(_(
+                        'You try to install module "%(module)s" that depends on module "%(dependency)s".\nBut the latter module is not available in your system.',
+                        module=module.name, dependency=dep.name,
+                    ))
                 if dep.depend_id.state == newstate:
                     ready_mods += dep.depend_id
                 else:
@@ -423,7 +426,11 @@ class Module(models.Model):
         for module in install_mods:
             for exclusion in module.exclusion_ids:
                 if exclusion.name in install_names:
-                    raise UserError(_('Modules %r and %r are incompatible.', module.shortdesc, exclusion.exclusion_id.shortdesc))
+                    raise UserError(_(
+                        'Modules "%(module)s" and "%(incompatible_module)s" are incompatible.',
+                        module=module.shortdesc,
+                        incompatible_module=exclusion.exclusion_id.shortdesc,
+                    ))
 
         # check category exclusions
         def closure(module):
@@ -443,7 +450,7 @@ class Module(models.Model):
             if modules and not any(modules <= closure(module) for module in modules):
                 labels = dict(self.fields_get(['state'])['state']['selection'])
                 raise UserError(
-                    _('You are trying to install incompatible modules in category %r:%s', category.name, ''.join(
+                    _('You are trying to install incompatible modules in category "%(category)s":%(module_list)s', category=category.name, module_list=''.join(
                         f"\n- {module.shortdesc} ({labels[module.state]})"
                         for module in modules
                     ))
@@ -703,7 +710,7 @@ class Module(models.Model):
                 continue
             for dep in module.dependencies_id:
                 if dep.state == 'unknown':
-                    raise UserError(_('You try to upgrade the module %s that depends on the module: %s.\nBut this module is not available in your system.', module.name, dep.name))
+                    raise UserError(_('You try to upgrade the module %(module)s that depends on the module: %(dependency)s.\nBut this module is not available in your system.', module=module.name, dependency=dep.name))
                 if dep.state == 'uninstalled':
                     to_install += self.search([('name', '=', dep.name)]).ids
 

--- a/odoo/addons/base/models/ir_rule.py
+++ b/odoo/addons/base/models/ir_rule.py
@@ -213,8 +213,8 @@ class IrRule(models.Model):
         }
         user_description = f"{self.env.user.name} (id={self.env.user.id})"
         operation_error = _("Uh-oh! Looks like you have stumbled upon some top-secret records.\n\n" \
-            "Sorry, %s doesn't have '%s' access to:", user_description, operations[operation])
-        failing_model = _("- %s (%s)", description, model)
+            "Sorry, %(user)s doesn't have '%(operation)s' access to:", user=user_description, operation=operations[operation])
+        failing_model = _("- %(description)s (%(model)s)", description=description, model=model)
 
         resolution_info = _("If you really, really need access, perhaps you can win over your friendly administrator with a batch of freshly baked cookies.")
 

--- a/odoo/addons/base/wizard/base_import_language.py
+++ b/odoo/addons/base/wizard/base_import_language.py
@@ -43,9 +43,9 @@ class BaseLanguageImport(models.TransientModel):
                 except Exception as e:
                     _logger.warning('Could not import the file due to a format mismatch or it being malformed.')
                     raise UserError(
-                        _('File %r not imported due to format mismatch or a malformed file.'
-                          ' (Valid formats are .csv, .po)\n\nTechnical Details:\n%s',
-                          base_lang_import.filename, tools.ustr(e))
+                        _('File "%(file_name)s" not imported due to format mismatch or a malformed file.'
+                          ' (Valid formats are .csv, .po)\n\nTechnical Details:\n%(error_message)s',
+                          file_name=base_lang_import.filename, error_message=tools.ustr(e)),
                     )
             translation_importer.save(overwrite=overwrite)
         return True

--- a/odoo/addons/test_impex/tests/test_load.py
+++ b/odoo/addons/test_impex/tests/test_load.py
@@ -620,7 +620,7 @@ class test_m2o(ImporterCase):
         result = self.import_(['value'], [[record2.display_name]])
         self.assertEqual(
             result['messages'],
-            [message(u"Found multiple matches for value 'export.integer:42' in field 'Value' (2 matches)",
+            [message('Found multiple matches for value "export.integer:42" in field "Value" (2 matches)',
                      type='warning')])
         self.assertEqual(len(result['ids']), 1)
         self.assertEqual([
@@ -1315,11 +1315,11 @@ class test_unique(ImporterCase):
         )
         self.assertIsNotNone(m)
         self.assertItemsEqual(
-            m.group(1).split(', '),
+            m.group(1).split(' and '),
             ['value2', 'value3']
         )
         self.assertItemsEqual(
-            m.group(2).split(', '),
+            m.group(2).split(' and '),
             ['Value2', 'Value3']
         )
 

--- a/odoo/addons/test_lint/tests/_odoo_checker_gettext.py
+++ b/odoo/addons/test_lint/tests/_odoo_checker_gettext.py
@@ -1,3 +1,5 @@
+import re
+
 import astroid
 import pylint.interfaces
 from pylint.checkers import BaseChecker
@@ -7,10 +9,23 @@ try:
 except ImportError:
     from pylint.checkers.utils import check_messages as only_required_for_messages
 
+# https://docs.python.org/2.6/library/stdtypes.html#string-formatting-operations
+PLACEHOLDER_REGEXP = re.compile(r"""
+    (?<!%)             # avoid matching escaped %
+    %
+    [#0\- +]*          # conversion flag
+    (?:\d+|\*)?        # minimum field width
+    (?:\.(?:\d+|\*))?  # precision
+    [hlL]?             # length modifier
+    [bcdeEfFgGnorsxX]  # conversion type
+""", re.VERBOSE)
+
+
 def parse_version(s):
     # can't use odoo.tools.parse_version because pythonpath is screwed from
     # inside pylint on runbot
     return [s.rjust(3, '0') for s in s.split('.')]
+
 
 class OdooBaseChecker(BaseChecker):
     if parse_version(pylint.__version__) < parse_version('2.14.0'):
@@ -22,15 +37,23 @@ class OdooBaseChecker(BaseChecker):
             'Bad usage of _, _lt function.',
             'gettext-variable',
             'See https://www.odoo.com/documentation/master/developer/misc/i18n/translations.html#variables'
-        )
+        ),
+        'E8505': (
+            'Usage of _, _lt function with multiple unnamed placeholders',
+            'gettext-placeholders',
+            'Use keyword arguments when you have multiple placeholders',
+        ),
     }
 
-    @only_required_for_messages('gettext-variable')
+    @only_required_for_messages('gettext-variable', 'gettext-placeholders')
     def visit_call(self, node):
         if isinstance(node.func, astroid.Name) and node.func.name in ('_', '_lt'):
             first_arg = node.args[0]
-            if not (isinstance(first_arg, astroid.Const) and isinstance(first_arg.value, str)):
-                self.add_message('gettext-variable', node=node)
+            if isinstance(first_arg.value, str):
+                if not isinstance(first_arg, astroid.Const):
+                    self.add_message('gettext-variable', node=node)
+                elif len(PLACEHOLDER_REGEXP.findall(str(first_arg.value))) >= 2:
+                    self.add_message('gettext-placeholders', node=node)
 
 
 def register(linter):

--- a/odoo/addons/test_lint/tests/eslintrc
+++ b/odoo/addons/test_lint/tests/eslintrc
@@ -29,6 +29,10 @@
             {
                 "selector": "ClassDeclaration[superClass.name='Component']:not(:has(ClassBody.body > PropertyDefinition[key.name='template'][static='true']))",
                 "message": "Component should declare static template"
+            },
+            {
+                "selector": "CallExpression[callee.name='_t'] > :first-child[value=/(.*%s){2,}/]",
+                "message": "Usage of _t function with multiple unnamed placeholders"
             }
         ],
         "no-unused-vars": ["error", { "vars": "all", "args": "none", "ignoreRestSiblings": false, "caughtErrors": "all" }]

--- a/odoo/addons/test_lint/tests/test_pylint.py
+++ b/odoo/addons/test_lint/tests/test_pylint.py
@@ -32,6 +32,7 @@ class TestPyLint(TransactionCase):
         # custom checkers
         'sql-injection',
         'gettext-variable',
+        'gettext-placeholders',
         'raise-unlink-override',
     ]
 

--- a/odoo/fields.py
+++ b/odoo/fields.py
@@ -1242,7 +1242,7 @@ class Field(MetaField('DummyField', (object,), {})):
             if not env.cache.contains(record, self):
                 raise MissingError("\n".join([
                     _("Record does not exist or has been deleted."),
-                    _("(Record: %s, User: %s)", record, env.uid),
+                    _("(Record: %(record)s, User: %(user)s)", record=record, user=env.uid),
                 ])) from None
             value = env.cache.get(record, self)
 
@@ -2128,11 +2128,11 @@ class Html(_String):
                     _logger.info(diff_str)
 
                     raise UserError(_(
-                        "The field value you're saving (%s %s) includes content that is "
+                        "The field value you're saving (%(model)s %(field)s) includes content that is "
                         "restricted for security reasons. It is possible that someone "
                         "with higher privileges previously modified it, and you are therefore "
                         "not able to modify it yourself while preserving the content.",
-                        record._description, self.string,
+                        model=record._description, field=self.string,
                     ))
 
         return html_sanitize(value, **sanitize_vals)
@@ -2416,7 +2416,7 @@ class Binary(Field):
         try:
             return psycopg2.Binary(str(value).encode('ascii'))
         except UnicodeEncodeError:
-            raise UserError(_("ASCII characters are required for %s in %s") % (value, self.name))
+            raise UserError(_("ASCII characters are required for %(value)s in %(field)s", value=value, field=self.name))
 
     def convert_to_cache(self, value, record, validate=True):
         if isinstance(value, _BINARY):
@@ -4463,7 +4463,11 @@ class One2many(_RelationalMulti):
         if self.comodel_name in model.env:
             comodel = model.env[self.comodel_name]
             if self.inverse_name not in comodel._fields:
-                raise UserError(_("No inverse field %r found for %r") % (self.inverse_name, self.comodel_name))
+                raise UserError(_(
+                    'No inverse field "%(inverse_field)s" found for "%(comodel)s"',
+                    inverse_field=self.inverse_name,
+                    comodel=self.comodel_name
+                ))
 
     def get_domain_list(self, records):
         comodel = records.env.registry[self.comodel_name]

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -669,7 +669,12 @@ def convert_csv_import(env, module, fname, csvcontent, idref=None, mode='init',
     if any(msg['type'] == 'error' for msg in result['messages']):
         # Report failed import and abort module install
         warning_msg = "\n".join(msg['message'] for msg in result['messages'])
-        raise Exception(_('Module loading %s failed: file %s could not be processed:\n %s') % (module, fname, warning_msg))
+        raise Exception(_(
+            "Module loading %(module)s failed: file %(file)s could not be processed:\n%(message)s",
+            module=module,
+            file=fname,
+            message=warning_msg,
+        ))
 
 def convert_xml_import(env, module, xmlfile, idref=None, mode='init', noupdate=False, report=None):
     doc = etree.parse(xmlfile)

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -244,9 +244,9 @@ def apply_inheritance_specs(source, specs_tree, inherit_branding=False, pre_loca
                             separator = separator.strip()
                             if separator not in ('and', 'or'):
                                 raise ValueError(_(
-                                    "Invalid separator %s for python expression %s; "
+                                    "Invalid separator %(separator)s for python expression %(expression)s; "
                                     "valid values are 'and' and 'or'",
-                                    repr(separator), repr(attribute),
+                                    separator=repr(separator), expression=repr(attribute),
                                 ))
                             if remove:
                                 if re.match(rf'^\(*{remove}\)*$', value):


### PR DESCRIPTION
## The problem
Translating text in a language sometimes involves reordering words. Positional arguments are always inserted in the same order, which order matches English syntax, but this isn't necessarily right for every syntax of every language in the world.

Here's an eloquent example of the problem, taken from the GNU gettext documentation:
```c
printf(gettext("String '%s' has %d characters\n"), s, strlen(s));
```

which one could translate in German as follows:
```c
"%d Zeichen lang ist die Zeichenkette `%s'"
```

Even without knowing any of German, you could notice that the positions of  `%d` and `%s` have been swapped; yet printf would still insert its arguments in the same order.

That's the reason why, whenever there is more than one “format specifier” (`%s`), you should always use keyworded arguments so that the translators can freely reorder the words without any problems.

## The fix
This pull request fixes the problem by providing a name to the placeholders of every call to gettext with more than one placeholders.

It also adds a linter check to prevent people from repeating the mistake.

Part of task-3869533
Enterprise: https://github.com/odoo/enterprise/pull/62769