### PR TITLE
[FIX] stock: disable editing of moves if picking is locked

### DIFF
--- a/addons/stock/views/stock_move_views.xml
+++ b/addons/stock/views/stock_move_views.xml
@@ -263,6 +263,7 @@
                     <field name="quant_id" column_invisible="context.get('picking_code') == 'incoming'"
                         domain="[('product_id', '=', product_id), ('location_id', 'child_of', picking_location_id)]"
                         context="{'default_location_id': location_id, 'default_product_id': product_id, 'search_view_ref': 'stock.quant_search_view', 'tree_view_ref': 'stock.view_stock_quant_tree_simple', 'form_view_ref': 'stock.view_stock_quant_form', 'readonly_form': False}"
+                        readonly="state in ('done', 'cancel') and is_locked"
                         widget="pick_from"
                         options="{'no_open': True}"/>
                     <field name="lot_id" column_invisible="context.get('show_lots_text')" groups="stock.group_production_lot" invisible="not lots_visible" context="{'default_product_id': product_id, 'default_company_id': company_id, 'active_picking_id': picking_id}" optional="show"/>


### PR DESCRIPTION
### Steps to reproduce:

- In the inventory, create a delivery order for 1 unit of any product
- Validate the picking and click on detailed operations
- Click on the field of the move named "Pick From", type and create new

#### > Traceback error

### Cause of the issue:

You should not be able to edit the moves of a done locked picking. However the `quant_id` field is not set to `read_only` in this case: https://github.com/odoo/odoo/blob/c016a5306dd90b90c88e083cc0f0d2ae9c0b649f/addons/stock/views/stock_move_views.xml#L263-L267

### Fix:

We add the same `read_only` condition as for the other fields visible on the move.

opw-3935214
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
