### PR TITLE
[IMP] sale: no down payment check on regular inv.

### DIFF
--- a/addons/sale/wizard/sale_make_invoice_advance.py
+++ b/addons/sale/wizard/sale_make_invoice_advance.py
@@ -161,12 +161,12 @@ class SaleAdvancePaymentInv(models.TransientModel):
     @api.constrains('product_id')
     def _check_down_payment_product_is_valid(self):
         for wizard in self:
-            if wizard.count > 1 or not wizard.product_id:
+            if wizard.count > 1 or not wizard.product_id or wizard.advance_payment_method == "delivered":
                 continue
             if wizard.product_id.invoice_policy != 'order':
                 raise UserError(_(
                     "The product used to invoice a down payment should have an invoice policy"
-                    "set to \"Ordered quantities\"."
+                    " set to \"Ordered quantities\"."
                     " Please update your deposit product to be able to create a deposit invoice."))
             if wizard.product_id.type != 'service':
                 raise UserError(_(


### PR DESCRIPTION
Before this commit, the `sale.advance.payment.inv` wizard would validate the down payment product even when making a regular invoice. Unless making more than one regular invoice. That was somewhat confusing.

This commit changes the wizard to only perform that check when actually creating a down payment invoice.

Low hanging fruit: adds a missing space in the related error message.

Task-[3935820](https://www.odoo.com/web#id=3935820&cids=1&model=project.task&view_type=form)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
