### PR TITLE
[FIX] l10n_hu_edi: Don't set module to auto_install

### DIFF
--- a/addons/l10n_hu_edi/__manifest__.py
+++ b/addons/l10n_hu_edi/__manifest__.py
@@ -36,6 +36,5 @@
         'demo/demo_partner.xml',
     ],
     'post_init_hook': 'post_init',
-    'auto_install': ['l10n_hu'],
     'license': 'LGPL-3',
 }


### PR DESCRIPTION
Unfortunately, setting the module to be auto-installed doesn't just make it installed by default for new Hungarian databases, it also auto-installs during the 16.0 to 17.0 upgrade for users who have l10n_hu installed. This is undesirable, and is also causing an upgrade error currently. To avoid this, we remove the auto_install.

opw-3912298