### PR TITLE
[IMP] purchase: add improvements on dashboard and reporting

### DIFF
--- a/addons/purchase/report/purchase_report.py
+++ b/addons/purchase/report/purchase_report.py
@@ -35,8 +35,8 @@ class PurchaseReport(models.Model):
     delay = fields.Float('Days to Confirm', digits=(16, 2), readonly=True, aggregator='avg', help="Amount of time between purchase approval and order by date.")
     delay_pass = fields.Float('Days to Receive', digits=(16, 2), readonly=True, aggregator='avg',
                               help="Amount of time between date planned and order by date for each purchase order line.")
-    price_total = fields.Float('Total', readonly=True)
-    price_average = fields.Float('Average Cost', readonly=True, aggregator="avg", digits='Product Price')
+    price_total = fields.Monetary('Total', readonly=True)
+    price_average = fields.Monetary('Average Cost', readonly=True, aggregator="avg")
     nbr_lines = fields.Integer('# of Lines', readonly=True)
     category_id = fields.Many2one('product.category', 'Product Category', readonly=True)
     product_tmpl_id = fields.Many2one('product.template', 'Product Template', readonly=True)
@@ -46,11 +46,12 @@ class PurchaseReport(models.Model):
     weight = fields.Float('Gross Weight', readonly=True)
     volume = fields.Float('Volume', readonly=True)
     order_id = fields.Many2one('purchase.order', 'Order', readonly=True)
-    untaxed_total = fields.Float('Untaxed Total', readonly=True)
+    untaxed_total = fields.Monetary('Untaxed Total', readonly=True)
     qty_ordered = fields.Float('Qty Ordered', readonly=True)
     qty_received = fields.Float('Qty Received', readonly=True)
     qty_billed = fields.Float('Qty Billed', readonly=True)
     qty_to_be_billed = fields.Float('Qty to be Billed', readonly=True)
+    days_to_arrival = fields.Float('Effective Days To Arrival', digits=(16, 2), readonly=True, aggregator='avg')
 
     @property
     def _table_query(self) -> SQL:
@@ -77,6 +78,15 @@ class PurchaseReport(models.Model):
                     c.currency_id,
                     t.uom_id as product_uom,
                     extract(epoch from age(po.date_approve,po.date_order))/(24*60*60)::decimal(16,2) as delay,
+                    extract(
+                        epoch from age(
+                            l.date_planned,
+                            COALESCE(
+                                order_effective_date.date_done,
+                                po.date_order
+                            )
+                        )
+                    )/(24*60*60)::decimal(16,2) as days_to_arrival,
                     extract(epoch from age(l.date_planned,po.date_order))/(24*60*60)::decimal(16,2) as delay_pass,
                     count(*) as nbr_lines,
                     sum(l.price_total / COALESCE(po.currency_rate, 1.0))::decimal(16,2) * currency_table.rate as price_total,
@@ -109,8 +119,10 @@ class PurchaseReport(models.Model):
                 left join uom_uom line_uom on (line_uom.id=l.product_uom)
                 left join uom_uom product_uom on (product_uom.id=t.uom_id)
                 left join %(currency_table)s ON currency_table.company_id = po.company_id
+                %(days_to_arrival)s
             """,
             currency_table=self.env['res.currency']._get_query_currency_table(self.env.companies.ids, fields.Date.today()),
+            days_to_arrival=self._join_days_to_arrival()
         )
 
     def _where(self) -> SQL:
@@ -118,6 +130,31 @@ class PurchaseReport(models.Model):
             """
             WHERE
                 l.display_type IS NULL
+            """,
+        )
+
+    def _join_days_to_arrival(self) -> SQL:
+        return SQL(
+            """
+            LEFT JOIN (
+                SELECT MIN(picking.date_done)                       AS date_done,
+                       purchase.id                                  AS purchase_id
+                FROM purchase_order 							    AS purchase
+                JOIN purchase_order_line						    AS order_line
+                    ON order_line.order_id = purchase.id
+                JOIN stock_move									    AS move
+                    ON move.purchase_line_id = order_line.id
+                JOIN stock_picking								    AS picking
+                    ON picking.id = move.picking_id
+                JOIN stock_location								    AS location_dest
+                    ON location_dest.id = picking.location_dest_id
+                WHERE picking.state = 'done'
+                    AND location_dest.usage != 'supplier'
+                    AND picking.date_done IS NOT NULL
+                GROUP BY
+                    purchase.id
+            ) order_effective_date
+                ON order_effective_date.purchase_id = l.order_id
             """,
         )
 
@@ -150,7 +187,8 @@ class PurchaseReport(models.Model):
                 partner.country_id,
                 partner.commercial_partner_id,
                 po.id,
-                currency_table.rate
+                currency_table.rate,
+                order_effective_date.date_done
             """,
         )
 

--- a/addons/purchase_stock/models/stock.py
+++ b/addons/purchase_stock/models/stock.py
@@ -13,6 +13,31 @@ class StockPicking(models.Model):
         'purchase.order', related='move_ids.purchase_line_id.order_id',
         string="Purchase Orders", readonly=True)
 
+    days_to_arrive = fields.Datetime(compute='_compute_effective_date', search="_search_days_to_arrive", copy=False)
+    delay_pass = fields.Datetime(compute='_compute_date_order', search="_search_delay_pass", index=True, copy=False)
+
+    @api.depends('state', 'location_dest_id.usage', 'date_done')
+    def _compute_effective_date(self):
+        for picking in self:
+            if picking.state == 'done' and picking.location_dest_id.usage != 'supplier' and picking.date_done:
+                picking.days_to_arrive = picking.date_done
+            else:
+                picking.days_to_arrive = False
+
+    def _compute_date_order(self):
+        for picking in self:
+            picking.delay_pass = picking.purchase_id.date_order if picking.purchase_id else fields.Datetime.now()
+
+    @api.model
+    def _search_days_to_arrive(self, operator, value):
+        date_value = fields.Datetime.from_string(value)
+        return [('date_done', operator, date_value)]
+
+    @api.model
+    def _search_delay_pass(self, operator, value):
+        date_value = fields.Datetime.from_string(value)
+        return [('purchase_id.date_order', operator, date_value)]
+
 
 class StockWarehouse(models.Model):
     _inherit = 'stock.warehouse'

--- a/addons/spreadsheet_dashboard_purchase_stock/data/files/purchase_dashboard.json
+++ b/addons/spreadsheet_dashboard_purchase_stock/data/files/purchase_dashboard.json
@@ -173,7 +173,7 @@
                 },
                 "A45": {
                     "style": 1,
-                    "content": "[Late Receipts](odoo://view/{\"viewType\":\"list\",\"action\":{\"domain\":\"['&',['picking_type_code','=','incoming'],'&',['state','in',['assigned','waiting','confirmed']],'|','|',['has_deadline_issue','=',true],['date_deadline','<',context_today().strftime('%Y-%m-%d')],['scheduled_date','<',context_today().strftime('%Y-%m-%d')]]\",\"context\":{\"group_by\":[]},\"modelName\":\"stock.picking\",\"views\":[[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"calendar\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Late Receipts\"})",
+                    "content": "[Late Receipts](odoo://view/{\"viewType\":\"list\",\"action\":{\"domain\":\"['&',['delay_pass', '<', 'days_to_arrive'],'&',['picking_type_code','=','incoming'],'&',['state','in',['assigned','waiting','confirmed']],'|','|',['has_deadline_issue','=',true],['date_deadline','<',context_today().strftime('%Y-%m-%d')],['scheduled_date','<',context_today().strftime('%Y-%m-%d')]]\",\"context\":{\"group_by\":[]},\"modelName\":\"stock.picking\",\"views\":[[false,\"list\"],[false,\"kanban\"],[false,\"form\"],[false,\"calendar\"],[false,\"search\"]]},\"threshold\":0,\"name\":\"Late Receipts\"})",
                     "border": 1
                 },
                 "A46": {


### PR DESCRIPTION
Add currency symbols in the purchase dashboard. Ensure that the total, untaxed total, and average cost display with the correct currency symbol.

Add a new column for "Effective Days to Arrival." If the effective arrival date is set, use it to calculate the days. Otherwise, use the "Days to Receive" value.

Add a new constraint for late receipts: only show receipts where the "Days to Receive" is less than the "Days to Arrival."

task: 3691573