### PR TITLE
[FIX] web_editor, website: consider videos in s_image_gallery snippets

### DIFF
--- a/addons/web_editor/tools.py
+++ b/addons/web_editor/tools.py
@@ -20,7 +20,7 @@ player_regexes = {
     'youtube': r'^(?:(?:https?:)?//)?(?:www\.)?(?:youtu\.be/|youtube(-nocookie)?\.com/(?:embed/|v/|watch\?v=|watch\?.+&v=))((?:\w|-){11})\S*$',
     'vimeo': r'^(?:(?:https?:)?//)?(?:www\.)?vimeo\.com\/(?P<id>[^/\?]+)(?:/(?P<hash>[^/\?]+))?(?:\?(?P<params>[^\s]+))?$',
     'vimeo_player': r'^(?:(?:https?:)?//)?player\.vimeo\.com\/video\/(?P<id>[^/\?]+)(?:\?(?P<params>[^\s]+))?$',
-    'dailymotion': r'(https?:\/\/)(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
+    'dailymotion': r'^(?:(?:https?:)?//)?(www\.)?(dailymotion\.com\/(embed\/video\/|embed\/|video\/|hub\/.*#video=)|dai\.ly\/)(?P<id>[A-Za-z0-9]{6,7})',
     'instagram': r'(?:(.*)instagram.com|instagr\.am)/p/(.[a-zA-Z0-9-_\.]*)',
     'youku': r'(?:(https?:\/\/)?(v\.youku\.com/v_show/id_|player\.youku\.com/player\.php/sid/|player\.youku\.com/embed/|cloud\.youku\.com/services/sharev\?vid=|video\.tudou\.com/v/)|youku:)(?P<id>[A-Za-z0-9]+)(?:\.html|/v\.swf|)',
 }
@@ -138,27 +138,43 @@ def get_video_embed_code(video_url):
     return Markup('<iframe class="embed-responsive-item" src="%s" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowFullScreen="true" frameborder="0"></iframe>') % data['embed_url']
 
 
-def get_video_thumbnail(video_url):
-    """ Computes the valid thumbnail image from given URL
+def get_video_thumbnail_url(video_url):
+    """ Computes the valid thumbnail image URL from given URL
         (or None in case of invalid URL).
     """
     source = get_video_source_data(video_url)
     if source is None:
         return None
 
-    response = None
+    thumbnail_url = None
     platform, video_id = source[:2]
     if platform == 'youtube':
-        response = requests.get(f'https://img.youtube.com/vi/{video_id}/0.jpg', timeout=10)
+        thumbnail_url = f'https://img.youtube.com/vi/{video_id}/0.jpg'
     elif platform == 'vimeo':
-        res = requests.get(f'http://vimeo.com/api/oembed.json?url={video_url}', timeout=10)
+        video_details = f'http://vimeo.com/api/oembed.json?url={video_url}'
+        res = requests.get(video_details, timeout=10)
         if res.ok:
             data = res.json()
-            response = requests.get(data['thumbnail_url'], timeout=10)
+            thumbnail_url = data['thumbnail_url']
     elif platform == 'dailymotion':
-        response = requests.get(f'https://www.dailymotion.com/thumbnail/video/{video_id}', timeout=10)
+        thumbnail_url = f'https://www.dailymotion.com/thumbnail/video/{video_id}'
     elif platform == 'instagram':
-        response = requests.get(f'https://www.instagram.com/p/{video_id}/media/?size=t', timeout=10)
+        thumbnail_url = f'https://www.instagram.com/p/{video_id}/media/?size=t'
+
+    return platform, thumbnail_url
+
+
+def get_video_thumbnail(video_url):
+    """ Computes the valid thumbnail image from given URL
+        (or None in case of invalid URL).
+    """
+    platform, thumbnail_url = get_video_thumbnail_url(video_url)
+    if platform is None or thumbnail_url is None:
+        return None
+
+    response = None
+    if platform in ['youtube', 'dailymotion', 'instagram', 'vimeo']:
+        response = requests.get(thumbnail_url, timeout=10)
 
     if response and response.ok:
         return image_process(response.content)

--- a/addons/website/controllers/main.py
+++ b/addons/website/controllers/main.py
@@ -28,6 +28,7 @@ from odoo.addons.http_routing.models.ir_http import slug, slugify, _guess_mimety
 from odoo.addons.portal.controllers.portal import pager as portal_pager
 from odoo.addons.portal.controllers.web import Home
 from odoo.addons.web.controllers.binary import Binary
+from odoo.addons.web_editor.tools import get_video_thumbnail_url
 from odoo.addons.website.tools import get_base_domain
 
 logger = logging.getLogger(__name__)
@@ -798,6 +799,14 @@ class Website(Home):
                     return action_res
 
         return request.redirect('/')
+
+    # ------------------------------------------------------
+    # Video information
+    # ------------------------------------------------------
+
+    @http.route(['/website/get_video_thumbnail_url'], type='json', auth='user', website=True)
+    def get_video_thumb_url(self, video_url):
+        return get_video_thumbnail_url(video_url)
 
 
 class WebsiteBinary(Binary):

--- a/addons/website/static/src/js/editor/snippets.editor.js
+++ b/addons/website/static/src/js/editor/snippets.editor.js
@@ -120,6 +120,22 @@ const wSnippetMenu = weSnippetEditor.SnippetsMenu.extend({
         $html.find('[data-attribute-name="interval"]')[0].dataset.attributeName = "bsInterval";
     },
     /**
+     * @override
+     */
+    _patchForComputeSnippetTemplates($html) {
+        this._super(...arguments);
+
+        // TODO adapt in master: remove this and replace the selector in the
+        // "gallery_image" option XML template.
+        // Consider other media types and not only images in the "Image Gallery"
+        // and "Images Wall" snippets.
+        const galleryImageOption = $html.find('[data-js="gallery_img"]')[0];
+        galleryImageOption.dataset.selector = [
+            ".s_image_gallery img", // Normal images
+            ".s_image_gallery .media_iframe_video", // Videos
+        ].join(", ");
+    },
+    /**
      * Depending of the demand, reconfigure they gmap key or configure it
      * if not already defined.
      *

--- a/addons/website/static/src/snippets/s_image_gallery/001.scss
+++ b/addons/website/static/src/snippets/s_image_gallery/001.scss
@@ -78,7 +78,16 @@
                 padding-bottom: 64px;
             }
             ul.carousel-indicators li {
+                position: relative;
                 border: 1px solid #aaa;
+
+                // Play icon for video thumnail indicators.
+                i.o_video_thumbnail {
+                    position: absolute;
+                    top: 50%;
+                    left: 50%;
+                    transform: translate(-50%, -50%);
+                }
             }
             .media_iframe_video {
                 // 70% because the carousel controls are each 15% and the user


### PR DESCRIPTION
[IMP] website: add a route to retrieve video thumbnails

This commit adds a way to retrieve the thumbnail of a given video. It
also adds a new route `/website/get_video_thumbnail_url` allowing to get
the links of the thumbails with an rpc call.

This commit is mainly a backport of what was done in upper versions with
commit [1]. It was however adapted in order to separate the notions of
thumbnail link and thumbnail image. The "dailymotion" regex was also
slightly modified in order to accept URLs starting with "//".

[1]: https://github.com/odoo/odoo/commit/2dd772dab89cbe5ee9354b7242b83c8b8ab9bb2d

opw-3884769

---
[FIX] web_editor, website: consider videos in s_image_gallery snippets 

Before this commit, the `s_image_gallery` snippet did not consider other
media types besides images. This means that adding videos, icons,... in
the "Images Wall" and "Image Gallery" snippets caused some issues.

Steps to reproduce:
- In edit mode, drop an "Images Wall" snippet.
- Double-click on an image to replace it.
- In the media dialog, go to the "Video" tab and add a video.
=> The image was well replaced by the video.
=> Issue 1: In the right panel, notice that the "Re-Order" option is not
present in the "Video" option section. This is because the `gallery_img`
option only targets images, so the option will never appear for other
medias.
=> Issue 2: Inspect the video and notice that is has no `data-index`
attribute. This means that reordering the other images afterwards will
not produce the expected result.

- Change any option requiring to recompute the mode (e.g. change the
gallery layout by setting the "Mode" option to "Grid").
=> Issue 3: The video disappeared. This is because the code getting the
medias contained in the gallery only selects the images, ignoring the
other types.

- Drop the "Image Gallery" snippet.
- Double-click on an image and replace it by a video.
=> Issue 4: The background image of the corresponding carousel indicator
was not updated.

Note that these steps are the same for icons and documents.

All these issues happen because these snippets were considered to only
accept images as medias (the "Add Images" options indeed only allows
images to be uploaded) but they did not prevent these images to be
replaced by something else.

This commit adds the support needed for these snippets to work correctly
with videos and solves the mentioned issues. Note that the icons and
documents were deliberately ignored, as users are really unlikely to
upload them in a gallery.

More precisely:
- When the mode is recomputed, all images and videos are fetched so none
of them is lost.
- The `data-index` is always added when a media is replaced. For the
already dropped snippets, if some medias do not have this attribute, the
mode is recomputed at the start to set it, so everything is consistent.
- When double-clicking on a media to replace it, the media dialog is now
only limited to images and videos.
- When a media is replaced by a video in the "Image Gallery" snippet,
the video thumbnail is fetched and set as the carousel indicator
background. A "play" icon is also added, indicating that the slide
contains a video.
- The `gallery_img` now targets images and videos, making it possible to
reorder a video and to correctly manage the video removal.

opw-3884769