### PR TITLE
[FIX] web: include archived records when exporting grouped results

### DIFF
--- a/addons/test_xlsx_export/models.py
+++ b/addons/test_xlsx_export/models.py
@@ -27,6 +27,7 @@ class GroupOperator(models.Model):
     bool_or = fields.Boolean(group_operator='bool_or')
     many2one = fields.Many2one('export.integer')
     one2many = fields.One2many('export.group_operator.one2many', 'parent_id')
+    active = fields.Boolean(default=True)
 
 class GroupOperatorO2M(models.Model):
     _name = 'export.group_operator.one2many'

--- a/addons/test_xlsx_export/tests/test_export.py
+++ b/addons/test_xlsx_export/tests/test_export.py
@@ -81,6 +81,21 @@ class TestGroupedExport(XlsxCreatorCase):
     model_name = 'export.group_operator'
     # pylint: disable=bad-whitespace
 
+    def test_archived_groupped(self):
+        """ The decimal separator of the language used shouldn't impact the float representation in the exported xlsx """
+        get_lang(self.env).decimal_point = ','
+        get_lang(self.env).thousands_sep = '.'
+
+        values = [
+                {'int_sum': 1, 'active': False},
+        ]
+        export = self.export(values, fields=['int_sum', 'active'], params={'groupby': ['int_sum']})
+
+        self.assertExportEqual(export, [
+            ['Int Sum'          ,'Active'],
+            ['1 (1)'            ,''],
+        ])
+
     def test_int_sum_max(self):
         values = [
             {'int_sum': 10, 'int_max': 20},

--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -1809,7 +1809,7 @@ class ExportFormat(object):
         if not import_compat and groupby:
             groupby_type = [Model._fields[x.split(':')[0]].type for x in groupby]
             domain = [('id', 'in', ids)] if ids else domain
-            groups_data = Model.read_group(domain, [x if x != '.id' else 'id' for x in field_names], groupby, lazy=False)
+            groups_data = Model.with_context(active_test=False).read_group(domain, [x if x != '.id' else 'id' for x in field_names], groupby, lazy=False)
 
             # read_group(lazy=False) returns a dict only for final groups (with actual data),
             # not for intermediary groups. The full group tree must be re-constructed.


### PR DESCRIPTION
When exporting non-grouped records we include archived records in results, this commits makes grouped results consiste with that, i.e. now also grouped records will include archived results

[Reproduce]
- Install crm
- Go to: crm app
	- Switch to List view
	- Remove all filters
	- Use filter "Lost"
	- Group by "Stage"
	- Select all and Export -> BUG: exported xlsx file is empty

Note: Above we have a specyfic case, to generalize that steps we can say, that whenever we filter with "Lost" and use whatever "group by" then export is empty

opw-3901258