### PR TITLE
 [FIX] web: confirmation_dialog: add optional callback for dialog dismiss

### DIFF
--- a/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
+++ b/addons/web/static/src/core/confirmation_dialog/confirmation_dialog.js
@@ -15,7 +15,7 @@ Think twice before you click that 'Delete' button!`
 
 export class ConfirmationDialog extends Component {
     setup() {
-        this.env.dialogData.dismiss = () => this._cancel();
+        this.env.dialogData.dismiss = () => this._dismiss();
         this.modalRef = useChildRef();
         this.isProcess = false;
     }
@@ -26,6 +26,10 @@ export class ConfirmationDialog extends Component {
 
     async _confirm() {
         return this.execButton(this.props.confirm);
+    }
+
+    async _dismiss() {
+        return this.execButton(this.props.dismiss || this.props.cancel);
     }
 
     setButtonsDisabled(disabled) {
@@ -77,6 +81,7 @@ ConfirmationDialog.props = {
     confirmClass: { type: String, optional: true },
     cancel: { type: Function, optional: true },
     cancelLabel: { type: String, optional: true },
+    dismiss: { type: Function, optional: true },
 };
 ConfirmationDialog.defaultProps = {
     confirmLabel: _t("Ok"),

--- a/addons/web/static/src/model/relational_model/dynamic_list.js
+++ b/addons/web/static/src/model/relational_model/dynamic_list.js
@@ -284,6 +284,7 @@ export class DynamicList extends DataPoint {
             this.model.dialog.add(AlertDialog, {
                 body: _t("No valid record to save"),
                 confirm: () => this.leaveEditMode({ discard: true }),
+                dismiss: () => this.leaveEditMode({ discard: true }),
             });
             return false;
         } else {

--- a/addons/web/static/tests/core/confirmation_dialog_tests.js
+++ b/addons/web/static/tests/core/confirmation_dialog_tests.js
@@ -34,7 +34,7 @@ QUnit.module("Components", (hooks) => {
 
     QUnit.module("ConfirmationDialog");
 
-    QUnit.test("pressing escape to close the dialog", async function (assert) {
+    QUnit.test("Without dismiss callback pressing escape to close the dialog", async function (assert) {
         const env = await makeDialogTestEnv();
         await mount(ConfirmationDialog, target, {
             env,
@@ -44,7 +44,9 @@ QUnit.module("Components", (hooks) => {
                 close: () => {
                     assert.step("Close action");
                 },
-                confirm: () => {},
+                confirm: () => {
+                    throw new Error("should not be called");
+                },
                 cancel: () => {
                     assert.step("Cancel action");
                 },
@@ -56,6 +58,91 @@ QUnit.module("Components", (hooks) => {
         assert.verifySteps(
             ["Cancel action", "Close action"],
             "dialog has called its cancel method before its closure"
+        );
+    });
+
+    QUnit.test("With dismiss callback: pressing escape to close the dialog", async function (assert) {
+        const env = await makeDialogTestEnv();
+        await mount(ConfirmationDialog, target, {
+            env,
+            props: {
+                body: "Some content",
+                title: "Confirmation",
+                close: () => {
+                    assert.step("Close action");
+                },
+                confirm: () => {
+                    throw new Error("should not be called");
+                },
+                cancel: () => {
+                    throw new Error("should not be called");
+                },
+                dismiss: () => {
+                    assert.step("Dismiss action");
+                },
+            },
+        });
+        assert.verifySteps([]);
+        triggerHotkey("escape");
+        await nextTick();
+        assert.verifySteps(
+            ["Dismiss action", "Close action"],
+            "dialog has called its dismiss method before its closure"
+        );
+    });
+
+    QUnit.test("Without dismiss callback: clicking on 'X' to close the dialog", async function (assert) {
+        const env = await makeDialogTestEnv();
+        await mount(ConfirmationDialog, target, {
+            env,
+            props: {
+                body: "Some content",
+                title: "Confirmation",
+                close: () => {
+                    assert.step("Close action");
+                },
+                confirm: () => {
+                    throw new Error("should not be called");
+                },
+                cancel: () => {
+                    assert.step("Cancel action");
+                },
+            },
+        });
+        assert.verifySteps([]);
+        await click(target, ".modal-header .btn-close");
+        assert.verifySteps(
+            ["Cancel action", "Close action"],
+            "dialog has called its cancel method before its closure"
+        );
+    });
+
+    QUnit.test("With dismiss callback: clicking on 'X' to close the dialog", async function (assert) {
+        const env = await makeDialogTestEnv();
+        await mount(ConfirmationDialog, target, {
+            env,
+            props: {
+                body: "Some content",
+                title: "Confirmation",
+                close: () => {
+                    assert.step("Close action");
+                },
+                confirm: () => {
+                    throw new Error("should not be called");
+                },
+                cancel: () => {
+                    throw new Error("should not be called");
+                },
+                dismiss: () => {
+                    assert.step("Dismiss action");
+                },
+            },
+        });
+        assert.verifySteps([]);
+        await click(target, ".modal-header .btn-close");
+        assert.verifySteps(
+            ["Dismiss action", "Close action"],
+            "dialog has called its dismiss method before its closure"
         );
     });
 
@@ -73,6 +160,9 @@ QUnit.module("Components", (hooks) => {
                     assert.step("Confirm action");
                 },
                 cancel: () => {
+                    throw new Error("should not be called");
+                },
+                dismiss: () => {
                     throw new Error("should not be called");
                 },
             },
@@ -97,6 +187,9 @@ QUnit.module("Components", (hooks) => {
                 },
                 cancel: () => {
                     assert.step("Cancel action");
+                },
+                dismiss: () => {
+                    throw new Error("should not be called");
                 },
             },
         });


### PR DESCRIPTION
The main goal of this PR is to ensure that the `X` button or `Esc` shortcut (Dismiss feature) of the confirmation dialog 
is allowed to have a different behavior than the `Cancel` button.

At present, it performs the same action as the `Cancel` button but there might be cases when the dialog does not have 
a `Cancel` button and we still want to handle the dialog dismiss action.

To enable this, this PR adds an optional callback for `dismiss` operation to the dialogData.dismiss 
that will only be executed when a dialog is closed via of the `X` button or the `Escape` shortcut. 
Otherwise, it will execute the callback for `cancel` operation, if any.

This PR also adds/modifies some tests in `confirmation_dialog_tests.js` and `list_view_tests.js` 
to ensure that this new feature works as intended.

**Example Use Case:**
- Go to list view or kanban view.
- Select the document to preview in the inspector.
- Clear the input value of a required field (here, Name or Workspace), and click out or press 'Enter'.
- Dismiss the alert dialog via the "X" button or the "Esc" shortcut.

**Issue:**
An alert dialog indicating a validation error is shown when a field value is cleared. 
Yet, on closing the dialog, the unnamed document is saved as is.

Instead, the changes should be reverted.

**Cause:**
The dismiss operation is never handled in case of alert dialog for invalid selection. 
Hence, by default, it applies the changes made to the field.

**Fix:**
The alert dialog for invalid selection is different from the ones which are simply used to display warnings 
or alert messages because they do not need to perform any action upon dismissing the dialog.

In this case, we want to prevent any invalid changes from being applied. 
It is achieved by calling the `leaveEditMode` method which discards them and switches the config mode. 
Hence, we do something similar to what is done on the click of `OK` button, on dismissing the dialog as well. 
This behavior is introduced because even if the user discards the dialog, any change that is not valid should not be applied.

Task: [3799280](https://www.odoo.com/web#id=3799280&menu_id=4722&cids=2&action=333&active_id=10888&model=project.task&view_type=form)
