### PR TITLE
[FIX] website_sale: fixed alternative product traceback

### DIFF
--- a/addons/website_sale/models/website_snippet_filter.py
+++ b/addons/website_sale/models/website_snippet_filter.py
@@ -93,6 +93,10 @@ class WebsiteSnippetFilter(models.Model):
         website = self.env['website'].get_current_website()
         search_domain = self.env.context.get('search_domain')
         limit = self.env.context.get('limit')
+        hide_variants = False
+        if search_domain and 'hide_variants' in search_domain:
+            hide_variants = True
+            search_domain.remove('hide_variants')
         domain = expression.AND([
             [('website_published', '=', True)] if self.env.user._is_public() else [],
             website.website_domain(),
@@ -100,7 +104,9 @@ class WebsiteSnippetFilter(models.Model):
             search_domain or [],
         ])
         products = handler(website, limit, domain, **kwargs)
-        return dynamic_filter._filter_records_to_values(products, is_sample=False)
+        return dynamic_filter.with_context(
+            hide_variants=hide_variants,
+        )._filter_records_to_values(products, is_sample=False)
 
     def _get_products_latest_sold(self, website, limit, domain, **kwargs):
         products = self.env['product.product']


### PR DESCRIPTION
-> master
-> Steps to reproduce:
- Select the product add an alternative product
- Go to the website

-> Issue:
-when a product has alternate products a traceback is thrown on the
front end on the product page.

-> Cause:
- When we add an alternative product, a traceback occurs due to a ValueError
stating that there are too many values to unpack. The values should be in the
format left, operator, right = item = tuple(item), but they are not, resulting
in the traceback.

-> Solution:
- To address the ValueError, I made small changes and removed the
hide_variants value from the search_domain.

opw-3933011
