### PR TITLE
[IMP] mrp_subcontracting_landed_costs: add landed costs for subcontract receipts

### DIFF
--- a/addons/mrp_subcontracting_landed_costs/__init__.py
+++ b/addons/mrp_subcontracting_landed_costs/__init__.py
@@ -1,2 +1,4 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from . import models

--- a/addons/mrp_subcontracting_landed_costs/models/__init__.py
+++ b/addons/mrp_subcontracting_landed_costs/models/__init__.py
@@ -1,0 +1,1 @@
+from . import stock_move

--- a/addons/mrp_subcontracting_landed_costs/models/stock_move.py
+++ b/addons/mrp_subcontracting_landed_costs/models/stock_move.py
@@ -1,0 +1,13 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = 'stock.move'
+
+    def _get_stock_valuation_layer_ids(self):
+        self.ensure_one()
+        stock_valuation_layer_ids = super()._get_stock_valuation_layer_ids()
+        subcontracted_productions = self._get_subcontract_production()
+        if self.is_subcontract and subcontracted_productions:
+            return subcontracted_productions.move_finished_ids.stock_valuation_layer_ids
+        return stock_valuation_layer_ids

--- a/addons/mrp_subcontracting_landed_costs/tests/__init__.py
+++ b/addons/mrp_subcontracting_landed_costs/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_subcontracting_landed_costs

--- a/addons/mrp_subcontracting_landed_costs/tests/test_subcontracting_landed_costs.py
+++ b/addons/mrp_subcontracting_landed_costs/tests/test_subcontracting_landed_costs.py
@@ -1,0 +1,132 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import Form, tagged
+
+from odoo.addons.mrp_subcontracting.tests.common import TestMrpSubcontractingCommon
+
+
+@tagged('post_install', '-at_install')
+class TestSubcontractingLandedCosts(TestMrpSubcontractingCommon):
+
+    def test_subcontracting_landed_cost_receipts_flow(self):
+        """
+            This test verifies that landed costs can be applied to subcontracting receipts
+            rather than being added directly to the manufacturing order.
+        """
+        product_category_all = self.env.ref('product.product_category_all')
+        product_category_all.property_cost_method = 'fifo'
+        product_category_all.property_valuation = 'real_time'
+        po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [(0, 0, {
+                'name': self.finished.name,
+                'product_id': self.finished.id,
+                'product_uom_qty': 10,
+                'product_uom': self.finished.uom_id.id,
+                'price_unit': 10,
+            })],
+        })
+        po.button_confirm()
+
+        mo = self.env['mrp.production'].search([('bom_id', '=', self.bom.id)])
+        self.assertTrue(mo)
+
+        action = po.action_view_picking()
+        in_picking = self.env[action['res_model']].browse(action['res_id'])
+        in_picking.move_ids.quantity = 10
+        in_picking.move_ids.picked = True
+        in_picking.button_validate()
+
+        # create a landed cost for the incoming picking
+        default_vals = self.env['stock.landed.cost'].default_get(list(self.env['stock.landed.cost'].fields_get()))
+        freight_charges = self.env['product.product'].create({
+            'name': 'Freight Charges',
+        })
+        default_vals.update({
+            'picking_ids': [in_picking.id],
+            'cost_lines': [(0, 0, {
+                'product_id': freight_charges.id,
+                'name': 'equal split',
+                'split_method': 'equal',
+                'price_unit': 99,
+            })],
+        })
+        stock_landed_cost = self.env['stock.landed.cost'].create(default_vals)
+
+        # compute the landed cost using compute button
+        stock_landed_cost.compute_landed_cost()
+
+        # check the valuation adjustment lines
+        for valuation in stock_landed_cost.valuation_adjustment_lines:
+            if valuation.cost_line_id.name == 'equal split':
+                self.assertEqual(valuation.former_cost, 100)
+                self.assertEqual(valuation.additional_landed_cost, 99, 'Additional Landed Cost should be 99 instead of %s' % (valuation.additional_landed_cost))
+                self.assertEqual(valuation.final_cost, 199)
+            else:
+                raise ValidationError('unrecognized valuation adjustment line')
+
+        # confirm the landed cost
+        stock_landed_cost.button_validate()
+        self.assertEqual(stock_landed_cost.state, "done")
+
+        self.assertEqual(len(in_picking.move_ids.stock_valuation_layer_ids), 1)
+        self.assertEqual(in_picking.move_ids.stock_valuation_layer_ids.value, 99)
+
+        new_po = self.env['purchase.order'].create({
+            'partner_id': self.subcontractor_partner1.id,
+            'order_line': [(0, 0, {
+                'name': self.finished.name,
+                'product_id': self.finished.id,
+                'product_uom_qty': 10,
+                'product_uom': self.finished.uom_id.id,
+                'price_unit': 10,
+            })],
+        })
+
+        # The following checks ensure that the landed cost is distributed uniformly between standard product and subcontracting product
+        product = self.env['product.product'].create({
+            'name': 'Product',
+            'is_storable': True,
+        })
+        with Form(new_po) as po_form:
+            with po_form.order_line.new() as new_line:
+                new_line.product_id = product
+                new_line.product_qty = 10
+                new_line.price_unit = 20
+        new_po.button_confirm()
+
+        new_mo = self.env['mrp.production'].search([('bom_id', '=', self.bom.id)])
+        self.assertTrue(new_mo)
+
+        action = new_po.action_view_picking()
+        in_picking = self.env[action['res_model']].browse(action['res_id'])
+        in_picking.move_ids.quantity = 10
+        in_picking.move_ids.picked = True
+        in_picking.button_validate()
+
+        # create a landed cost for the incoming picking
+        default_vals = self.env['stock.landed.cost'].default_get(list(self.env['stock.landed.cost'].fields_get()))
+        default_vals.update({
+            'picking_ids': [in_picking.id],
+            'cost_lines': [(0, 0, {
+                'product_id': freight_charges.id,
+                'name': 'equal split',
+                'split_method': 'equal',
+                'price_unit': 99,
+            })],
+        })
+        stock_landed_cost = self.env['stock.landed.cost'].create(default_vals)
+
+        # compute the landed cost using compute button
+        stock_landed_cost.compute_landed_cost()
+
+        # check the valuation adjustment lines
+        self.assertEqual(len(stock_landed_cost.valuation_adjustment_lines), 2)
+        for valuation in stock_landed_cost.valuation_adjustment_lines:
+            if valuation.cost_line_id.name == 'equal split':
+                self.assertEqual(valuation.additional_landed_cost, 49.5, 'Additional Landed Cost should be 49.5 instead of %s' % (valuation.additional_landed_cost))
+            else:
+                raise ValidationError('unrecognized valuation adjustment line')
+
+        # confirm the landed cost
+        stock_landed_cost.button_validate()
+        self.assertEqual(stock_landed_cost.state, "done")

--- a/addons/mrp_subcontracting_landed_costs/views/stock_landed_cost_views.xml
+++ b/addons/mrp_subcontracting_landed_costs/views/stock_landed_cost_views.xml
@@ -8,6 +8,9 @@
             <field name="mrp_production_ids" position="attributes">
                 <attribute name="context">{'search_view_ref': 'mrp_subcontracting.mrp_production_subcontracting_filter', 'list_view_ref': 'mrp_subcontracting.mrp_production_subcontracting_tree_view'}</attribute>
             </field>
+            <field name="picking_ids" position="attributes">
+                <attribute name="domain">[('company_id', '=', company_id), '|', ('move_ids.stock_valuation_layer_ids', '!=', False), '&amp;', ('move_ids.is_subcontract', '!=', False), ('move_ids.state', '=', 'done')]</attribute>
+            </field>
         </field>
     </record>
 </odoo>

--- a/addons/stock_landed_costs/models/__init__.py
+++ b/addons/stock_landed_costs/models/__init__.py
@@ -8,3 +8,4 @@ from . import res_config_settings
 from . import stock_landed_cost
 from . import account_move
 from . import stock_valuation_layer
+from . import stock_move

--- a/addons/stock_landed_costs/models/stock_landed_cost.py
+++ b/addons/stock_landed_costs/models/stock_landed_cost.py
@@ -127,8 +127,8 @@ class StockLandedCost(models.Model):
             cost_to_add_byproduct = defaultdict(lambda: 0.0)
             cost_to_add_bylot = defaultdict(lambda: 0.0)
             for line in cost.valuation_adjustment_lines.filtered(lambda line: line.move_id):
-                remaining_qty = sum(line.move_id.stock_valuation_layer_ids.mapped('remaining_qty'))
-                linked_layer = line.move_id.stock_valuation_layer_ids
+                remaining_qty = sum(line.move_id._get_stock_valuation_layer_ids().mapped('remaining_qty'))
+                linked_layer = line.move_id._get_stock_valuation_layer_ids()
 
                 # Prorate the value at what's still in stock
                 cost_to_add = (remaining_qty / line.move_id.quantity) * line.additional_landed_cost
@@ -232,7 +232,7 @@ class StockLandedCost(models.Model):
                 'product_id': move.product_id.id,
                 'move_id': move.id,
                 'quantity': qty,
-                'former_cost': sum(move.stock_valuation_layer_ids.mapped('value')),
+                'former_cost': sum(move._get_stock_valuation_layer_ids().mapped('value')),
                 'weight': move.product_id.weight * qty,
                 'volume': move.product_id.volume * qty
             }

--- a/addons/stock_landed_costs/models/stock_move.py
+++ b/addons/stock_landed_costs/models/stock_move.py
@@ -1,0 +1,9 @@
+from odoo import models
+
+
+class StockMove(models.Model):
+    _inherit = "stock.move"
+
+    def _get_stock_valuation_layer_ids(self):
+        self.ensure_one()
+        return self.stock_valuation_layer_ids


### PR DESCRIPTION
Before this commit
==================
To apply a landed cost on a subcontracted product, we need to select the Manufacturing Order(MO) instead of the receipt in the landed cost form view.

With this commit
================
We can now select receipts containing subcontracted products directly within the landed cost form view, making it easy to manage and track costs.


Task: 3794617