### PR TITLE
[IMP] l10n_in: raise warning for incorrect GST tax selection on overseas invoices

### DIFF
--- a/addons/l10n_in/tests/__init__.py
+++ b/addons/l10n_in/tests/__init__.py
@@ -1,3 +1,4 @@
 from . import test_hsn_summary
 from . import test_partner_details_on_invoice
 from . import test_l10n_in_fiscal_position
+from . import test_l10n_in_warnings

--- a/addons/l10n_in/tests/test_l10n_in_warnings.py
+++ b/addons/l10n_in/tests/test_l10n_in_warnings.py
@@ -1,0 +1,72 @@
+from odoo import _
+from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.tests import tagged
+
+
+@tagged('post_install', '-at_install', 'post_install_l10n')
+class TestWarning(AccountTestInvoicingCommon):
+
+    @classmethod
+    @AccountTestInvoicingCommon.setup_country('in')
+    def setUpClass(cls):
+        super().setUpClass()
+        country_in_id = cls.env.ref("base.in").id
+        cls.company_data["company"].write({
+            "vat": "24AAGCC7144L6ZE",
+            "state_id": cls.env.ref("base.state_in_gj").id,
+            "street": "street1",
+            "city": "city1",
+            "zip": "123456",
+            "country_id": country_in_id,
+        })
+        cls.env.company = cls.company_data["company"]
+        cls.partner_c = cls.env['res.partner'].create({
+            'name': "Overseas partner",
+            'l10n_in_gst_treatment': 'overseas',
+            'state_id': cls.env.ref("base.state_us_1").id,
+            'country_id': cls.env.ref("base.us").id,
+            'zip': "123456",
+        })
+        cls.igst_18 = cls.env['account.chart.template'].ref('igst_sale_18')
+        cls.igst_0 = cls.env['account.chart.template'].ref('igst_sale_0')
+        cls.gst_18 = cls.env['account.chart.template'].ref('sgst_sale_18')
+
+    def test_l10n_in_warnings_for_oversea_invoice(self):
+        # oversea invoice with igst taxes
+        out_invoice_igst = self.init_invoice(
+            move_type='out_invoice',
+            partner=self.partner_c,
+            amounts=[40, 160, 25],
+            taxes=[self.igst_18, self.igst_0]
+        )
+        self.assertRecordValues(
+            out_invoice_igst,
+            [{
+                'state': 'draft',
+                'l10n_in_gst_treatment': self.partner_c.l10n_in_gst_treatment,
+                'l10n_in_state_id': self.env.ref("l10n_in.state_in_oc").id,
+                'l10n_in_warnings': False
+            }]
+        )
+
+        # oversea invoice with gst taxes
+        out_invoice_gst = self.init_invoice(
+            move_type='out_invoice',
+            partner=self.partner_c,
+            amounts=[160, 25],
+            taxes=[self.gst_18]
+        )
+        expected_warnings = {}
+        expected_warnings['invalid_gst_type_on_overseas_invoice'] = {
+            'message': _("IGST should be used when the place of supply is a foreign country."),
+            'level': 'warning',
+        }
+        self.assertRecordValues(
+            out_invoice_gst,
+            [{
+                'state': 'draft',
+                'l10n_in_gst_treatment': self.partner_c.l10n_in_gst_treatment,
+                'l10n_in_state_id': self.env.ref("l10n_in.state_in_oc").id,
+                'l10n_in_warnings': expected_warnings
+            }]
+        )

--- a/addons/l10n_in/views/account_invoice_views.xml
+++ b/addons/l10n_in/views/account_invoice_views.xml
@@ -5,6 +5,9 @@
         <field name="model">account.move</field>
         <field name="inherit_id" ref="account.view_move_form"/>
         <field name="arch" type="xml">
+            <xpath expr="//sheet" position="before">
+                <field name="l10n_in_warnings" widget="actionable_errors"/>
+            </xpath>
             <xpath expr="//field[@name='ref']" position="after">
                 <field name="country_code" invisible="1"/>
                 <field name="l10n_in_journal_type" invisible="1"/>


### PR DESCRIPTION
Before this PR:
When users selected incorrect Tax for exports where the 'place of supply' is 'Foregin Country(IN)' and the GST Treatment Type was set to Overseas, GSTR-1 did not compute the values. This caused difficulties for customers in tracing transactions that were not captured in GSTR-1.

After this PR:
Introduced a non-blocking warning banner on the account.move (invoice) when the GST Treatment is Overseas and the selected tax is not IGST. This helps users identify and correct tax selection issues, ensuring accurate capture of transactions in GSTR-1.

Task ID: 3921997