### PR TITLE
[IMP] project(_todo),web: generic improvement for to-do app

### DIFF
--- a/addons/project/static/src/components/subtask_one2many_field/subtask_list_renderer.js
+++ b/addons/project/static/src/components/subtask_one2many_field/subtask_list_renderer.js
@@ -1,29 +1,10 @@
 /** @odoo-module **/
 
 import { _t } from "@web/core/l10n/translation";
-import { useService } from "@web/core/utils/hooks";
 import { ConfirmationDialog } from "@web/core/confirmation_dialog/confirmation_dialog";
-import { ListRenderer } from '@web/views/list/list_renderer';
+import { TaskListRenderer } from "../task_list_renderer";
 
-import { useEffect } from "@odoo/owl";
-
-export class SubtaskListRenderer extends ListRenderer {
-    setup() {
-        super.setup();
-        this.dialog = useService("dialog");
-        useEffect(
-            () => this.focusName(this.props.list.editedRecord),
-            () => [this.props.list.editedRecord]
-        );
-    }
-
-    focusName(editedRecord) {
-        if (editedRecord?.isNew && !editedRecord.dirty) {
-            const col = this.columns.find((c) => c.name === "name");
-            this.focusCell(col);
-        }
-    }
-
+export class SubtaskListRenderer extends TaskListRenderer {
     async onDeleteRecord(record) {
         this.dialog.add(ConfirmationDialog, {
             body: _t("Are you sure you want to delete this record?"),

--- a/addons/project/static/src/components/task_list_renderer.js
+++ b/addons/project/static/src/components/task_list_renderer.js
@@ -1,0 +1,22 @@
+import { useService } from "@web/core/utils/hooks";
+import { ListRenderer } from "@web/views/list/list_renderer";
+
+import { useEffect } from "@odoo/owl";
+
+export class TaskListRenderer extends ListRenderer {
+    setup() {
+        super.setup();
+        this.dialog = useService("dialog");
+        useEffect(
+            () => this.focusName(this.props.list.editedRecord),
+            () => [this.props.list.editedRecord]
+        );
+    }
+
+    focusName(editedRecord) {
+        if (editedRecord?.isNew && !editedRecord.dirty) {
+            const col = this.columns.find((c) => c.name === "name");
+            this.focusCell(col);
+        }
+    }
+}

--- a/addons/project_todo/static/src/components/todo_done_checkmark/todo_done_checkmark.xml
+++ b/addons/project_todo/static/src/components/todo_done_checkmark/todo_done_checkmark.xml
@@ -3,14 +3,14 @@
 
     <t t-name="project_todo.TodoDoneCheckmark">
         <t t-if="!env.isSmall">
-            <a title="Mark as done"
+            <a t-att-title="stateDone.isDone ? 'Mark as to-do' : 'Mark as done'"
                t-on-click.stop="onDoneToggled"
                t-on-mouseleave="actualizeDoneState"
                t-on-mouseover="freezeDoneState"
                t-attf-class="o_todo_done_button fa fa-lg fa-check-circle{{!stateDone.isDone ? '-o' : ' done_button_enabled'}}"/>
         </t>
         <t t-else="">
-            <a title="Mark as done"
+            <a t-att-title="stateDone.isDone ? 'Mark as to-do' : 'Mark as done'"
                t-on-click.stop="onDoneToggled"
                t-attf-class="o_todo_done_button_mobile fa fa-lg fa-check-circle{{!stateDone.isDone ? '-o' : ' done_button_enabled'}}"/>
         </t>

--- a/addons/project_todo/static/src/views/todo_list/todo_list_view.js
+++ b/addons/project_todo/static/src/views/todo_list/todo_list_view.js
@@ -3,10 +3,12 @@
 import { registry } from "@web/core/registry";
 import { listView } from "@web/views/list/list_view";
 import { TodoListController } from "./todo_list_controller";
+import { TaskListRenderer } from "@project/components/task_list_renderer";
 
 export const todoListView = {
     ...listView,
     Controller: TodoListController,
+    Renderer: TaskListRenderer,
 };
 
 registry.category("views").add("todo_list", todoListView);

--- a/addons/project_todo/views/project_task_views.xml
+++ b/addons/project_todo/views/project_task_views.xml
@@ -59,7 +59,7 @@
                                     </div>
                                     <div class="oe_kanban_bottom_right">
                                         <div t-att-class="{'opacity-50': ['1_done', '1_canceled'].includes(record.state.raw_value), 'o_todo_hide_avatar': !todoHasAssignees}">
-                                            <field name="user_ids" widget="many2many_avatar_user"/>
+                                            <field name="user_ids" widget="many2many_avatar_user" readonly="True"/>
                                         </div>
                                         <field name="state" widget="todo_done_checkmark"/>
                                     </div>
@@ -86,7 +86,7 @@
                 <field name="priority" widget="priority" nolabel="1"/>
                 <field name="state" widget="todo_done_checkmark" nolabel="1"/>
                 <field name="name"/>
-                <field name="user_ids" optional="show" widget="many2many_avatar_user" options="{'no_quick_create': True}"/>
+                <field name="user_ids" optional="show" required="1" widget="many2many_avatar_user" options="{'no_quick_create': True}"/>
                 <field name="tag_ids" optional="show" widget="many2many_tags" options="{'color_field': 'color', 'no_create_edit': True}"/>
                 <field name="personal_stage_type_id" string="Stage" optional="hide"/>
                 <field name="activity_ids" optional="show" widget="list_activity"/>
@@ -115,6 +115,7 @@
                     <div class="py-1 px-2 border rounded bg-view">
                         <field name="user_ids"
                                widget="many2many_avatar_user"
+                               required="1"
                                options="{'no_quick_create': True}"
                                placeholder="Assignees"/>
                     </div>
@@ -164,7 +165,6 @@
                         <field name="company_id" invisible="1"/>
                         <field name="project_id"
                                required="1"
-                               placeholder="Select an existing project"
                                default_focus="1"/>
                         <field name="user_ids"
                                class="o_task_user_field"
@@ -199,7 +199,7 @@
                                 <field name="name" display="full" class="w-100 o_text_block align-middle"/>
                             </span>
                         </div>
-                        <field name="user_ids" widget="many2many_avatar_user"/>
+                        <field name="user_ids" widget="many2many_avatar_user" readonly="True"/>
                     </div>
                 </templates>
             </activity>
@@ -299,6 +299,7 @@
         <field name="res_model">project.task</field>
         <field name="view_mode">form</field>
         <field name="target">new</field>
+        <field name="context">{'dialog_size': 'medium'}</field>
     </record>
 
     <record model="ir.actions.act_window.view" id="project_task_action_convert_todo_to_task_form_view">

--- a/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
+++ b/addons/web/static/src/views/kanban/kanban_cover_image_dialog.xml
@@ -23,6 +23,7 @@
                     Select
                 </button>
                 <FileInput
+                    autoOpen="!attachments.length"
                     acceptedFileExtensions="'image/*'"
                     onUpload.bind="onUpload"
                     resModel="props.record.resModel"

--- a/addons/web/static/tests/views/kanban/kanban_view.test.js
+++ b/addons/web/static/tests/views/kanban/kanban_view.test.js
@@ -14,7 +14,9 @@ import {
     queryOne,
     queryText,
     resize,
+    setInputFiles,
 } from "@odoo/hoot-dom";
+import { FileInput } from "@web/core/file_input/file_input";
 import { Deferred, animationFrame, runAllTimers } from "@odoo/hoot-mock";
 import { Component, onRendered, onWillRender, xml } from "@odoo/owl";
 import {
@@ -85,6 +87,16 @@ const { IrAttachment } = webModels;
 const fieldRegistry = registry.category("fields");
 const viewRegistry = registry.category("views");
 const viewWidgetRegistry = registry.category("view_widgets");
+
+async function createFileInput({ mockPost, mockAdd, props }) {
+    mockService("notification", {
+        add: mockAdd || (() => {}),
+    });
+    mockService("http", {
+        post: mockPost || (() => {}),
+    });
+    await mountWithCleanup(FileInput, { props });
+}
 
 class Partner extends models.Model {
     _name = "partner";
@@ -10654,6 +10666,64 @@ test.tags("desktop")("set cover image", async () => {
 
     // should writes on both kanban records
     expect.verifySteps(["1", "2"]);
+});
+
+test.tags("desktop")("open file explorer if no cover image", async () => {
+    expect.assertions(2);
+
+    Partner._fields.displayed_image_id = fields.Many2one({
+        string: "Cover",
+        relation: "ir.attachment",
+    });
+
+    const uploadedPromise = new Deferred();
+    await createFileInput({
+        mockPost: async (route) => {
+            if (route === "/web/binary/upload_attachment") {
+                await uploadedPromise;
+            }
+            return "[]";
+        },
+        props: {},
+    });
+
+    await mountView({
+        type: "kanban",
+        resModel: "partner",
+        arch: `
+            <kanban>
+                <templates>
+                    <t t-name="kanban-menu">
+                        <a type="set_cover" data-field="displayed_image_id" class="dropdown-item">Set Cover Image</a>
+                    </t>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <field name="foo"/>
+                            <div>
+                                <field name="displayed_image_id" widget="attachment_image"/>
+                            </div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>`,
+    });
+
+    await toggleKanbanRecordDropdown(0);
+    await contains(".oe_kanban_action", {
+        root: getDropdownMenu(getKanbanRecord({ index: 0 })),
+    }).click();
+    setInputFiles([]);
+    await animationFrame();
+
+    expect(`.o_file_input input`).not.toBeEnabled({
+        message: "the upload button should be disabled on upload",
+    });
+    uploadedPromise.resolve();
+    await animationFrame();
+
+    expect(`.o_file_input input`).toBeEnabled({
+        message: "the upload button should be enabled for upload",
+    });
 });
 
 test.tags("desktop")("unset cover image", async () => {


### PR DESCRIPTION
In this PR, did the below changes:
- Remove the possibility of adding/editing/removing assignees from the kanban view.
- improve the layout of to-do form.
- Make the input for the title bigger in the to-do form view.
- When we add a new line, it will focus on the title field.
- In the to-dos list view make the assignee's field required.
- Reduce the size of the 'convert to task' wizard.
- The 'convert to task' wizard removed the placeholder of the project field.
- When a to-do is marked as done, the button marks it as done then the tooltip is done.
- if there is no cover image uploaded yet, open the file explorer directly instead of this empty dialog.

task-3931142


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
