### PR TITLE
[FIX] hr_expense: raise exception when user click report button without category

### DIFF
--- a/addons/hr_expense/models/hr_expense.py
+++ b/addons/hr_expense/models/hr_expense.py
@@ -644,6 +644,7 @@ class HrExpense(models.Model):
             expense.currency_id.is_zero(expense.total_amount_currency)
             or expense.company_currency_id.is_zero(expense.total_amount)
             or not float_round(expense.quantity, precision_rounding=expense.product_uom_id.rounding)
+            if expense.product_uom_id else None
         ))
 
         if any(expense.state != 'draft' or expense.sheet_id for expense in expenses_with_amount):


### PR DESCRIPTION
This traceback arises when the user clicks the `create report` button without `category` in the list view.

To reproduce this issue:

1) Install `hr_expense`
2) Create a new expense with the `category` and  `Total values` 
3) Now go to list view and select that record
4) Remove the `category` and click on the `Create Report` button

Error:-
```
AssertionError: precision_rounding must be positive, got 0.0
```

When the user removes the `category` in the list view of the expense, it leads to traceback because for `precision_rounding` `product_uom_id.rounding` is used in the below line.

https://github.com/odoo/odoo/blob/ccd16cc15eaffe865bcc80848a8b467f01c3eb37/addons/hr_expense/models/hr_expense.py#L643-L647

After applying the changes from this commit it will resolve this issue by making an extra check for `product_uom_id`. 

After that, an exception is raised. if no category is there for any expense from the below lines.

https://github.com/odoo/odoo/blob/ccd16cc15eaffe865bcc80848a8b467f01c3eb37/addons/hr_expense/models/hr_expense.py#L655-L656

sentry-5353887862