### PR TITLE
[FIX] payment_adyen: handle connection error when make payment

### DIFF
--- a/addons/payment_adyen/models/payment_provider.py
+++ b/addons/payment_adyen/models/payment_provider.py
@@ -122,7 +122,7 @@ class PaymentProvider(models.Model):
             try:
                 response.raise_for_status()
             except requests.exceptions.HTTPError:
-                _logger.exception(
+                _logger.warning(
                     "invalid API request at %s with data %s: %s", url, payload, response.text
                 )
                 msg = response.json().get('message', '')
@@ -130,7 +130,7 @@ class PaymentProvider(models.Model):
                     "Adyen: " + _("The communication with the API failed. Details: %s", msg)
                 )
         except requests.exceptions.ConnectionError:
-            _logger.exception("unable to reach endpoint at %s", url)
+            _logger.warning("unable to reach endpoint at %s", url)
             raise ValidationError("Adyen: " + _("Could not establish the connection to the API."))
         return response.json()
 


### PR DESCRIPTION
Currently, The traceback message is occurring when making a payment with an invalid API.

This error message occurs during the make a payment request with an invalid API key, we need to change the logger error message to a logger warning message at [1] to prevent an error log in a terminal.

Traceback on sentry:

```
gaierror: [Errno -2] Name or service not known
  File "urllib3/connection.py", line 169, in _new_conn
    conn = connection.create_connection(
  File "urllib3/util/connection.py", line 73, in create_connection
    for res in socket.getaddrinfo(host, port, family, socket.SOCK_STREAM):
  File "socket.py", line 955, in getaddrinfo
    for res in _socket.getaddrinfo(host, port, family, type, proto, flags):
NewConnectionError: <urllib3.connection.HTTPSConnection object at 0x7f608ee1e1a0>: Failed to establish a new connection: [Errno -2] Name or service not known
  File "urllib3/connectionpool.py", line 700, in urlopen
    httplib_response = self._make_request(
  File "urllib3/connectionpool.py", line 383, in _make_request
    self._validate_conn(conn)
  File "urllib3/connectionpool.py", line 1017, in _validate_conn
    conn.connect()
  File "urllib3/connection.py", line 353, in connect
    conn = self._new_conn()
  File "urllib3/connection.py", line 181, in _new_conn
    raise NewConnectionError(
MaxRetryError: HTTPSConnectionPool(host='yourneed-checkout-live.adyenpayments.com', port=443): Max retries exceeded with url: /checkout/V70/paymentMethods (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f608ee1e1a0>: Failed to establish a new connection: [Errno -2] Name or service not known'))
  File "requests/adapters.py", line 439, in send
    resp = conn.urlopen(
  File "urllib3/connectionpool.py", line 756, in urlopen
    retries = retries.increment(
  File "urllib3/util/retry.py", line 574, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
ConnectionError: HTTPSConnectionPool(host='yourneed-checkout-live.adyenpayments.com', port=443): Max retries exceeded with url: /checkout/V70/paymentMethods (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0x7f608ee1e1a0>: Failed to establish a new connection: [Errno -2] Name or service not known'))
  File "addons/payment_adyen/models/payment_provider.py", line 121, in _adyen_make_request
    response = requests.request(method, url, json=payload, headers=headers, timeout=60)
  File "requests/api.py", line 61, in request
    return session.request(method=method, url=url, **kwargs)
  File "requests/sessions.py", line 544, in request
    resp = self.send(prep, **send_kwargs)
  File "requests/sessions.py", line 657, in send
    r = adapter.send(request, **kwargs)
  File "requests/adapters.py", line 516, in send
    raise ConnectionError(e, request=request)
```

link[1]: https://github.com/odoo/odoo/blob/e3ee1f8bd85f3ea7287ab6b78847798190246b5d/addons/payment_adyen/models/payment_provider.py#L124-L127

sentry-4955120723

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
