### PR TITLE
[FIX] mail: handle IMAP connection errors in fetch_mail method

### DIFF
--- a/addons/mail/models/fetchmail.py
+++ b/addons/mail/models/fetchmail.py
@@ -223,7 +223,7 @@ odoo_mailgate: "|/path/to/odoo-mailgate.py --host=localhost -u %(uid)d -p PASSWO
                         try:
                             imap_server.close()
                             imap_server.logout()
-                        except OSError:
+                        except (OSError, IMAP4.error):
                             _logger.warning('Failed to properly finish imap connection: %s.', server.name, exc_info=True)
             elif connection_type == 'pop':
                 try:


### PR DESCRIPTION
The error indicates that the ``CLOSE`` command is being issued to an IMAP server while the connection is in the ``AUTH`` state rather than the ``SELECTED`` state. In IMAP, the ``CLOSE`` command can only be issued when a mailbox is selected.

Error: 
``IMAP4.error command CLOSE illegal in state AUTH, only allowed in states SELECTED``

This commit will handle IMAP4.error exceptions and raise a warning message when an error occurs.

sentry - 5371607133

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
