### PR TITLE
[IMP] pos: restore barcode nomenclature in pos.config

### DIFF
--- a/addons/point_of_sale/controllers/main.py
+++ b/addons/point_of_sale/controllers/main.py
@@ -83,7 +83,7 @@ class PosController(PortalAccount):
         session_info['user_context']['allowed_company_ids'] = company.ids
         session_info['user_companies'] = {'current_company': company.id, 'allowed_companies': {company.id: session_info['user_companies']['allowed_companies'][company.id]}}
         session_info['nomenclature_id'] = pos_session.company_id.nomenclature_id.id
-        session_info['fallback_nomenclature_id'] = pos_session._get_pos_fallback_nomenclature_id()
+        session_info['fallback_nomenclature_id'] = pos_session.config_id.fallback_nomenclature_id.id
         context = {
             'from_backend': 1 if from_backend else 0,
             'session_info': session_info,

--- a/addons/point_of_sale/models/pos_config.py
+++ b/addons/point_of_sale/models/pos_config.py
@@ -204,6 +204,7 @@ class PosConfig(models.Model):
     orderlines_sequence_in_cart_by_category = fields.Boolean(string="Order cart by category's sequence", default=False,
         help="When active, orderlines will be sorted based on product category and sequence in the product screen's order cart.")
     last_data_change = fields.Datetime(string='Last Write Date', readonly=True, compute='_compute_local_data_integrity', store=True)
+    fallback_nomenclature_id = fields.Many2one('barcode.nomenclature', string="Fallback Nomenclature")
 
     @api.model
     def _load_pos_data_domain(self, data):

--- a/addons/point_of_sale/models/pos_session.py
+++ b/addons/point_of_sale/models/pos_session.py
@@ -1803,36 +1803,6 @@ class PosSession(models.Model):
 
         return res
 
-    def _get_pos_fallback_nomenclature_id(self):
-        """
-        Retrieve the fallback barcode nomenclature.
-        If a fallback_nomenclature_id is specified in the config parameters,
-        it retrieves the nomenclature with that ID. Otherwise, it retrieves
-        the first non-GS1 nomenclature if the main nomenclature is GS1.
-        """
-        def convert_to_int(string_value):
-            try:
-                return int(string_value)
-            except (TypeError, ValueError, OverflowError):
-                return None
-
-        fallback_nomenclature_id = self.env['ir.config_parameter'].sudo().get_param('point_of_sale.fallback_nomenclature_id')
-
-        if not self.company_id.nomenclature_id.is_gs1_nomenclature and not fallback_nomenclature_id:
-            return None
-
-        if fallback_nomenclature_id:
-            fallback_nomenclature_id = convert_to_int(fallback_nomenclature_id)
-            if not fallback_nomenclature_id or self.company_id.nomenclature_id.id == fallback_nomenclature_id:
-                return None
-            domain = [('id', '=', fallback_nomenclature_id)]
-        else:
-            domain = [('is_gs1_nomenclature', '=', False)]
-
-        record = self.env['barcode.nomenclature'].search(domain=domain, limit=1)
-
-        return record.id if record else None
-
     def _get_partners_domain(self):
         return []
 

--- a/addons/point_of_sale/models/res_config_settings.py
+++ b/addons/point_of_sale/models/res_config_settings.py
@@ -117,6 +117,7 @@ class ResConfigSettings(models.TransientModel):
     pos_order_edit_tracking = fields.Boolean(related="pos_config_id.order_edit_tracking", readonly=False)
     pos_orderlines_sequence_in_cart_by_category = fields.Boolean(related='pos_config_id.orderlines_sequence_in_cart_by_category', readonly=False)
     pos_basic_receipt = fields.Boolean(related='pos_config_id.basic_receipt', readonly=False)
+    pos_fallback_nomenclature_id = fields.Many2one(related='pos_config_id.fallback_nomenclature_id', domain="[('id', '!=', barcode_nomenclature_id)]", readonly=False)
 
     def open_payment_method_form(self):
         bank_journal = self.env['account.journal'].search([('type', '=', 'bank'), ('company_id', 'in', self.env.company.parent_ids.ids)], limit=1)

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -1072,10 +1072,13 @@ class TestUi(TestPointOfSaleHttpCommon):
 
     def test_GS1_pos_barcodes_scan(self):
         barcodes_gs1_nomenclature = self.env.ref("barcodes_gs1_nomenclature.default_gs1_nomenclature")
+        default_nomenclature_id = self.env.ref("barcodes.default_barcode_nomenclature")
         self.main_pos_config.company_id.write({
             'nomenclature_id': barcodes_gs1_nomenclature.id
         })
-
+        self.main_pos_config.write({
+            'fallback_nomenclature_id': default_nomenclature_id
+        })
         self.env['product.product'].create({
             'name': 'Product 1',
             'available_in_pos': True,

--- a/addons/point_of_sale/views/res_config_settings_views.xml
+++ b/addons/point_of_sale/views/res_config_settings_views.xml
@@ -464,6 +464,10 @@
                                     <label for="barcode_nomenclature_id" string="Barcode Nomenclature" class="col-lg-3 o_light_label"/>
                                     <field name="barcode_nomenclature_id"/>
                                 </div>
+                                <div class="content-group mt16 row">
+                                    <label for="pos_fallback_nomenclature_id" string="Fallback Nomenclature" class="col-lg-3 o_light_label"/>
+                                    <field name="pos_fallback_nomenclature_id"/>
+                                </div>
                             </setting>
                             <setting id="update_quantities_stock_setting" groups="base.group_no_one" string="Inventory Management" company_dependent="1" help="Update quantities in stock">
                                 <field name="update_stock_quantities" colspan="4" widget="radio"/>


### PR DESCRIPTION
- Introduced nomenclature_id (Many2one to barcode.nomenclature) in pos.config
- Used nomenclature_id as a fallback to the company's barcode nomenclature in the POS barcode parser
- If parsing fails with the company's nomenclature, retry with nomenclature_id

This change addresses issues for users setting up their company to use GS1 barcode while using the normal barcode parser in POS.

Task ID: 3389545





---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
