### PR TITLE
[17.0][FIX] The default date in sequence does not take timezone into account

### DIFF
--- a/odoo/addons/base/models/ir_sequence.py
+++ b/odoo/addons/base/models/ir_sequence.py
@@ -121,7 +121,7 @@ class IrSequence(models.Model):
         '''
         if not self.use_date_range:
             return self
-        sequence_date = sequence_date or fields.Date.today()
+        sequence_date = sequence_date or fields.Date.context_today(self)
         seq_date = self.env['ir.sequence.date_range'].search(
             [('sequence_id', '=', self.id), ('date_from', '<=', sequence_date), ('date_to', '>=', sequence_date)], limit=1)
         if seq_date:
@@ -264,7 +264,7 @@ class IrSequence(models.Model):
         if not self.use_date_range:
             return self._next_do()
         # date mode
-        dt = sequence_date or self._context.get('ir_sequence_date', fields.Date.today())
+        dt = sequence_date or self._context.get('ir_sequence_date', fields.Date.context_today(self))
         seq_date = self.env['ir.sequence.date_range'].search([('sequence_id', '=', self.id), ('date_from', '<=', dt), ('date_to', '>=', dt)], limit=1)
         if not seq_date:
             seq_date = self._create_date_range_seq(dt)


### PR DESCRIPTION
Before this commit, the default date of ir_sequence range is taken in UTC timezone. It should take the timezone of the context

Description of the issue/feature this PR addresses:
N/A

Current behavior before PR:
The default date of the sequence range is taken in UTC
Desired behavior after PR is merged:
The default date of the sequence range is taken in context timezone


@etobella 
@coco-invitu

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
