### PR TITLE
[IMP] stock: onchange correctly update quant qty

### DIFF
--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -936,8 +936,7 @@ class StockQuant(models.Model):
             quant = self._gather(
                 self.product_id, self.location_id, lot_id=self.lot_id,
                 package_id=self.package_id, owner_id=self.owner_id, strict=True)
-            if quant:
-                self.quantity = sum(quant.filtered(lambda q: q.lot_id == self.lot_id).mapped('quantity'))
+            self.quantity = sum(quant.filtered(lambda q: q.lot_id == self.lot_id).mapped('quantity'))
 
             # Special case: directly set the quantity to one for serial numbers,
             # it'll trigger `inventory_quantity` compute.


### PR DESCRIPTION
In this PR:
---------------------------
- In inventory adjustment, when adding a product using the '+ Add Product' button, the quantity displayed now updates according to its current quantity. Previously, when updating a product (with an on-hand quantity of 0), the quantity would not update, which has been fixed.

task-id : 3801674

