### PR TITLE
[IMP] project_*: prevent drag-drop, access error and hide field for p…

### DIFF
--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -246,14 +246,26 @@ class ProjectTask(models.Model):
             ['task_id'],
         )
         task_with_timesheets_ids = [task.id for task, in timesheet_data]
-        if task_with_timesheets_ids:
-            if len(task_with_timesheets_ids) > 1:
-                warning_msg = _("These tasks have some timesheet entries referencing them. Before removing these tasks, you have to remove these timesheet entries.")
-            else:
-                warning_msg = _("This task has some timesheet entries referencing it. Before removing this task, you have to remove these timesheet entries.")
-            raise RedirectWarning(
-                warning_msg, self.env.ref('hr_timesheet.timesheet_action_task').id,
-                _('See timesheet entries'), {'active_ids': task_with_timesheets_ids})
+        if not task_with_timesheets_ids:
+            return
+        # Fetch task IDs with timesheets that the user has read access.
+        inaccessible_task_ids = set(task_with_timesheets_ids) - set(
+            self.env['account.analytic.line'].search([
+                ('task_id', 'in', task_with_timesheets_ids)
+            ]).mapped('task_id.id')
+        )
+        if inaccessible_task_ids:
+            raise UserError(
+                _("This task can’t be deleted because it’s linked to timesheets. Please contact someone with higher access to remove the timesheets first, "
+                "and then you’ll be able to delete the task.")
+            )
+        if len(task_with_timesheets_ids) > 1:
+            warning_msg = _("These tasks have some timesheet entries referencing them. Before removing these tasks, you have to remove these timesheet entries.")
+        else:
+            warning_msg = _("This task has some timesheet entries referencing it. Before removing this task, you have to remove these timesheet entries.")
+        raise RedirectWarning(
+            warning_msg, self.env.ref('hr_timesheet.timesheet_action_task').id,
+            _('See timesheet entries'), {'active_ids': task_with_timesheets_ids})
 
     @api.model
     def _convert_hours_to_days(self, time):

--- a/addons/hr_timesheet/report/report_timesheet_templates.xml
+++ b/addons/hr_timesheet/report/report_timesheet_templates.xml
@@ -188,6 +188,7 @@
     <record id="timesheet_report_task" model="ir.actions.report">
         <field name="name">Timesheets</field>
         <field name="model">project.task</field>
+        <field name="groups_id" eval="[(4,ref('hr_timesheet.group_hr_timesheet_user'))]"/>
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">hr_timesheet.report_project_task_timesheet</field>
         <field name="report_file">report_timesheet_task</field>
@@ -204,6 +205,7 @@
     <record id="timesheet_report_project" model="ir.actions.report">
         <field name="name">Timesheets</field>
         <field name="model">project.project</field>
+        <field name="groups_id" eval="[(4,ref('hr_timesheet.group_hr_timesheet_user'))]"/>
         <field name="report_type">qweb-pdf</field>
         <field name="report_name">hr_timesheet.report_timesheet_project</field>
         <field name="report_file">report_timesheet_project</field>

--- a/addons/hr_timesheet/views/project_project_views.xml
+++ b/addons/hr_timesheet/views/project_project_views.xml
@@ -100,7 +100,7 @@
             <field name="inherit_id" ref="project.view_project_project_filter"/>
             <field name="arch" type="xml">
                 <filter name="late_milestones" position="before">
-                    <filter string="Timesheets &gt;100%" name="projects_in_overtime" domain="[('is_project_overtime', '=', True)]" groups="hr_timesheet.group_hr_timesheet_user"/>
+                    <filter string="Timesheets &gt;100%" name="projects_in_overtime" domain="[('is_project_overtime', '=', True)]" groups="project.group_project_manager"/>
                 </filter>
             </field>
         </record>

--- a/addons/project/models/project_task.py
+++ b/addons/project/models/project_task.py
@@ -306,7 +306,7 @@ class ProjectTask(models.Model):
 
     _recurring_task_has_no_parent = models.Constraint(
         'CHECK (NOT (recurring_task IS TRUE AND parent_id IS NOT NULL))',
-        'A subtask cannot be recurrent.',
+        'You cannot convert this task into a sub-task because it is recurrent.',
     )
     _private_task_has_no_parent = models.Constraint(
         'CHECK (NOT (project_id IS NULL AND parent_id IS NOT NULL))',

--- a/addons/project/static/src/views/project_form/project_project_form_controller.js
+++ b/addons/project/static/src/views/project_form/project_project_form_controller.js
@@ -1,0 +1,20 @@
+import { onWillStart } from "@odoo/owl";
+import { user } from "@web/core/user";
+import { FormControllerWithHTMLExpander } from '@resource/views/form_with_html_expander/form_controller_with_html_expander'
+
+export class ProjectProjectFormController extends FormControllerWithHTMLExpander {
+    setup() {
+        super.setup();
+        onWillStart(async () => {
+            this.isProjectManager = await user.hasGroup('project.group_project_manager');
+        });
+    }
+
+    getStaticActionMenuItems() {
+        const actionMenuItems = super.getStaticActionMenuItems(...arguments);
+        if (actionMenuItems.archive.isAvailable) {
+            actionMenuItems.archive.isAvailable = () => this.isProjectManager;
+        }
+        return actionMenuItems;
+    }
+}

--- a/addons/project/static/src/views/project_form/project_project_form_view.js
+++ b/addons/project/static/src/views/project_form/project_project_form_view.js
@@ -1,0 +1,10 @@
+import { formViewWithHtmlExpander } from "@resource/views/form_with_html_expander/form_view_with_html_expander";
+import { registry } from "@web/core/registry";
+import { ProjectProjectFormController } from "./project_project_form_controller";
+
+export const projectProjectFormView = {
+    ...formViewWithHtmlExpander,
+    Controller: ProjectProjectFormController,
+};
+
+registry.category("views").add("project_project_form", projectProjectFormView);

--- a/addons/project/static/src/views/project_project_kanban/project_project_kanban_header.js
+++ b/addons/project/static/src/views/project_project_kanban/project_project_kanban_header.js
@@ -1,10 +1,15 @@
 import { KanbanHeader } from "@web/views/kanban/kanban_header";
 import { useService } from "@web/core/utils/hooks";
+import { onWillStart } from "@odoo/owl";
+import { user } from "@web/core/user";
 
 export class ProjectProjectKanbanHeader extends KanbanHeader {
     setup() {
         super.setup();
         this.action = useService("action");
+        onWillStart(async () => {
+            this.isProjectManager = await user.hasGroup('project.group_project_manager');
+        });
     }
 
     async deleteGroup() {
@@ -20,5 +25,8 @@ export class ProjectProjectKanbanHeader extends KanbanHeader {
         }
         super.deleteGroup();
     }
-}
 
+    canArchiveGroup() {
+        return super.canArchiveGroup() && this.isProjectManager;
+    }
+}

--- a/addons/project/static/src/views/project_project_list/project_project_list_controller.js
+++ b/addons/project/static/src/views/project_project_list/project_project_list_controller.js
@@ -1,0 +1,20 @@
+import { ListController } from "@web/views/list/list_controller";
+import { onWillStart } from "@odoo/owl";
+import { user } from "@web/core/user";
+
+export class ProjectListController extends ListController {
+    setup() {
+        super.setup();
+        onWillStart(async () => {
+            this.isProjectManager = await user.hasGroup('project.group_project_manager');
+        });
+    }
+
+    getStaticActionMenuItems() {
+        const actionMenuItems = super.getStaticActionMenuItems(...arguments);
+        if (!this.isProjectManager) {
+            ['duplicate', 'archive', 'unarchive'].forEach(item => delete actionMenuItems[item]);
+        }
+        return actionMenuItems;
+    }
+};

--- a/addons/project/static/src/views/project_project_list/project_project_list_view.js
+++ b/addons/project/static/src/views/project_project_list/project_project_list_view.js
@@ -1,10 +1,12 @@
 import { registry } from "@web/core/registry";
 import { listView } from '@web/views/list/list_view';
 import { ProjectProjectListRenderer } from "./project_project_list_renderer";
+import { ProjectListController } from "./project_project_list_controller";
 
 export const projectProjectListView = {
     ...listView,
     Renderer: ProjectProjectListRenderer,
+    Controller: ProjectListController,
 };
 
 registry.category("views").add("project_project_list", projectProjectListView);

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -6,10 +6,27 @@ export class ProjectProject extends models.Model {
 
     name = fields.Char();
     is_favorite = fields.Boolean();
+    active = fields.Boolean({ default: true });
+    stage_id = fields.Many2one({ relation: "project.project.stage" });
 
     _records = [
-        { id: 1, name: "Project 1" },
-        { id: 2, name: "Project 2" },
+        { id: 1, name: "Project 1", stage_id: 1 },
+        { id: 2, name: "Project 2", stage_id: 2 },
+    ];
+
+    check_access_rights() {
+        return Promise.resolve(true);
+    };
+}
+
+export class ProjectProjectStage extends models.Model {
+    _name = "project.project.stage";
+
+    name = fields.Char();
+
+    _records = [
+        { id: 1, name: "Stage 1" },
+        { id: 2, name: "Stage 2" },
     ];
 }
 
@@ -110,6 +127,7 @@ export function defineProjectModels() {
 
 export const projectModels = {
     ProjectProject,
+    ProjectProjectStage,
     ProjectTask,
     ProjectTaskType,
     ProjectMilestone,

--- a/addons/project/static/tests/project_project.test.js
+++ b/addons/project/static/tests/project_project.test.js
@@ -1,0 +1,68 @@
+import { expect, test, describe } from "@odoo/hoot";
+import { animationFrame } from "@odoo/hoot-mock";
+import {
+    mountView,
+    onRpc,
+    contains,
+    toggleKanbanColumnActions
+} from "@web/../tests/web_test_helpers";
+
+import { defineProjectModels } from "./project_models";
+
+defineProjectModels();
+describe.current.tags("desktop");
+
+const listViewParams = {
+    resModel: "project.project",
+    type: "list",
+    actionMenus: {},
+    arch: `
+        <list multi_edit="1" js_class="project_project_list">
+            <field name="name"/>
+        </list>
+    `,
+}
+
+test("project.project (list) show archive/unarchive action for project manager", async () => {
+    onRpc("has_group", ({ args }) => args[1] === "project.group_project_manager");
+    await mountView(listViewParams);
+    await contains("input.form-check-input").click();
+    await contains(`.o_cp_action_menus .dropdown-toggle`).click();
+    expect(`.oi-archive`).toHaveCount(1, { message: "Archive action should be visible" });
+    expect(`.oi-unarchive`).toHaveCount(1, { message: "Unarchive action should be visible" });
+});
+
+test("project.project (list) hide archive/unarchive action for project user", async () => {
+    onRpc("has_group", ({ args }) => args[1] === "project.group_project_user");
+    await mountView(listViewParams);
+    await contains("input.form-check-input").click();
+    await contains(`.o_cp_action_menus .dropdown-toggle`).click();
+    expect(`.o-dropdown--menu span:contains(Archive)`).toHaveCount(0, { message: "Archive action should not be visible" });
+    expect(`.o-dropdown--menu span:contains(Unarchive)`).toHaveCount(0, { message: "Unarchive action should not be visible" });
+});
+
+test("project.project (kanban) hide archive/unarchive action for project user", async () => {
+    onRpc("has_group", ({ args }) => args[1] === "project.group_project_user");
+    await mountView({
+        resModel: "project.project",
+        type: "kanban",
+        actionMenus: {},
+        arch: `
+            <kanban js_class="project_project_kanban">
+                <field name="stage_id"/>
+                <templates>
+                    <t t-name="card">
+                        <div>
+                            <field name="name"/>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        `,
+        groupBy: ['stage_id']
+    });
+    toggleKanbanColumnActions();
+    await animationFrame();
+    await expect('.o_column_archive_records').toHaveCount(0, { message: "Archive action should not be visible" });
+    await expect('.o_column_unarchive_records').toHaveCount(0, { message: "Unarchive action should not be visible" });
+});

--- a/addons/project/static/tests/project_project_form_view.test.js
+++ b/addons/project/static/tests/project_project_form_view.test.js
@@ -1,5 +1,11 @@
 import { expect, test } from "@odoo/hoot";
-import { mountView } from "@web/../tests/web_test_helpers";
+import {
+    mountView,
+    contains,
+    onRpc,
+    toggleMenuItem,
+    toggleActionMenu,
+} from "@web/../tests/web_test_helpers";
 
 import { defineProjectModels } from "./project_models";
 
@@ -17,4 +23,35 @@ test("project.project (form)", async () => {
         `,
     });
     expect(".o_form_view").toHaveCount(1);
+});
+
+const formViewParams = {
+    resModel: "project.project",
+    type: "form",
+    actionMenus: {},
+    arch: `
+        <form js_class="project_project_form">
+            <field name="active"/>
+            <field name="name"/>
+        </form>
+    `,
+}
+
+test("project.project (form) hide archive action for project user", async () => {
+    onRpc("has_group", ({ args }) => args[1] === "project.group_project_user");
+    await mountView(formViewParams);
+    await toggleActionMenu();
+    expect(`.o-dropdown--menu span:contains(Archive)`).toHaveCount(0, { message: "Archive action should not be visible" });
+});
+
+test("project.project (form) show archive action for project manager", async () => {
+    onRpc("has_group", () => true);
+    await mountView(formViewParams);
+    await toggleActionMenu();
+    expect(`.o-dropdown--menu span:contains(Archive)`).toHaveCount(1, { message: "Arhive action should be visible" });
+    await toggleMenuItem("Archive");
+    await contains(`.modal-footer .btn-primary`).click();
+    await toggleActionMenu();
+    expect(`.o-dropdown--menu span:contains(Unarchive)`).toHaveCount(1, { message: "Unarchive action should be visible" });
+    await toggleMenuItem("UnArchive");
 });

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -20,6 +20,7 @@
             <field name="res_model">mail.compose.message</field>
             <field name="view_mode">form</field>
             <field name="target">new</field>
+            <field name="groups_id" eval="[(4, ref('project.group_project_manager'))]"/>
             <field name="context">{
                 'default_composition_mode': 'mass_mail',
             }</field>
@@ -31,7 +32,7 @@
             <field name="name">project.project.form</field>
             <field name="model">project.project</field>
             <field name="arch" type="xml">
-                <form string="Project" class="o_form_project_project" js_class="form_description_expander">
+                <form string="Project" class="o_form_project_project" js_class="project_project_form">
                     <field name="company_id" invisible="1"/>
                     <header>
                         <button name="action_open_share_project_wizard" string="Share Project" type="object" class="oe_highlight" groups="project.group_project_manager"
@@ -145,7 +146,7 @@
                                                 </span>
                                                 <div class="content-group">
                                                     <div class="mt8">
-                                                        <button name="%(project.open_task_type_form_domain)d" context="{'project_id':id}" icon="oi-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link"/>
+                                                        <button name="%(project.open_task_type_form_domain)d" context="{'project_id':id}" icon="oi-arrow-right" type="action" string="Set a Rating Email Template on Stages" class="btn-link" groups="project.group_project_manager"/>
                                                     </div>
                                                 </div>
                                             </div>

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -304,6 +304,7 @@
             <field name="name">Send Email</field>
             <field name="res_model">mail.compose.message</field>
             <field name="view_mode">form</field>
+            <field name="groups_id" eval="[(4,ref('project.group_project_manager'))]"/>
             <field name="target">new</field>
             <field name="context">{
                 'default_composition_mode': 'mass_mail',

--- a/addons/project_sms/views/project_project_views.xml
+++ b/addons/project_sms/views/project_project_views.xml
@@ -3,6 +3,7 @@
     <record id="project_project_act_window_sms_composer" model="ir.actions.act_window">
         <field name="name">Send SMS</field>
         <field name="res_model">sms.composer</field>
+        <field name="groups_id" eval="[(4,ref('project.group_project_manager'))]"/>
         <field name="view_mode">form</field>
         <field name="target">new</field>
         <field name="context">{

--- a/addons/sale_project/security/ir.model.access.csv
+++ b/addons/sale_project/security/ir.model.access.csv
@@ -1,3 +1,5 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_sale_order_line_project_manager,sale.order.line.project.manager,sale.model_sale_order_line,project.group_project_manager,1,0,0,0
 access_sale_order_project_manager,sale.order.project.manager,sale.model_sale_order,project.group_project_manager,1,0,0,0
+access_sale_order_project_user,sale.order.project.user,sale.model_sale_order,project.group_project_user,1,0,0,0
+access_sale_order_line_project_user,sale.order.line.project.user,sale.model_sale_order_line,project.group_project_user,1,0,0,0

--- a/addons/web/static/src/views/calendar/calendar_model.js
+++ b/addons/web/static/src/views/calendar/calendar_model.js
@@ -34,6 +34,7 @@ export class CalendarModel extends Model {
             filters: {},
             filterSections: {},
             hasCreateRight: null,
+            hasEditRight: null,
             range: null,
             records: {},
             unusualDays: [],
@@ -72,7 +73,7 @@ export class CalendarModel extends Model {
         return this.meta.canDelete;
     }
     get canEdit() {
-        return this.meta.canEdit && !this.meta.fields[this.meta.fieldMapping.date_start].readonly;
+        return this.meta.canEdit && this.data.hasEditRight && !this.meta.fields[this.meta.fieldMapping.date_start].readonly;
     }
     get eventLimit() {
         return this.meta.eventLimit;
@@ -320,6 +321,9 @@ export class CalendarModel extends Model {
     async updateData(data) {
         if (data.hasCreateRight === null) {
             data.hasCreateRight = await user.checkAccessRight(this.meta.resModel, "create");
+        }
+        if (data.hasEditRight === null) {
+            data.hasEditRight = await user.checkAccessRight(this.meta.resModel, "write");
         }
         data.range = this.computeRange();
         if (this.meta.showUnusualDays) {

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -2627,6 +2627,7 @@ test(`Add filters and specific color`, async () => {
     expect.verifySteps([
         "get_views (event)",
         "has_access (event)",
+        "has_access (event)",
         "search_read (filter.partner) [partner_id]",
         "search_read (event) [display_name, start, stop, is_all_day, color, attendee_ids, type_id]",
     ]);
@@ -5399,4 +5400,18 @@ test("calendar: check context is correclty sent to fetch data", async () => {
             </calendar>`,
         context: { active_test: true },
     });
+});
+
+test(`disable editing without write access rights`, async () => {
+    onRpc("has_access", ({ args }) => args[1] != 'write');
+    await mountView({
+        resModel: "event",
+        type: "calendar",
+        arch: `
+            <calendar date_start="start" date_stop="stop">
+                <field name="name"/>
+            </calendar>
+        `,
+    });
+    expect(`.fc-event-draggable`).toHaveCount(0, { message: "Record should not be draggable/editable" });
 });


### PR DESCRIPTION
_*=web,hr_timesheet,project_hr_expense,project_sms,sale_project

Purpose:
=========
Enhance user experience and security by preventing access errors, access rights,
and hiding specific fields and actions for project users.

Changes:
========
Prevent editing for user do not have 'write access rights.

Hide the following filter, actions and fields for project user.
- Timesheet >100%
- Archive All
- Unarchive All
- Timesheets
- Archive
- Unarchive
- Delete
- Send Email
- Send Sms Text Message
- set a rating email template on stages

Prevent access error for project user
- Click on milestone
- Create a milestone on fly
- Create a task from calendar view
- On open project update

Test case is added for the implementation added in project and web

task-3814575