### PR TITLE
[FIX] resource: fix the wrong hours when creating a shift from Gantt view in day

### DIFF
--- a/addons/resource/models/resource_calendar.py
+++ b/addons/resource/models/resource_calendar.py
@@ -546,13 +546,14 @@ class ResourceCalendar(models.Model):
                 day_total[start.date()] += (stop - start).total_seconds() / 3600
         return result
 
-    def _get_closest_work_time(self, dt, match_end=False, resource=None, search_range=None, compute_leaves=True):
+    def _get_closest_work_time(self, dt, match_end=False, resource=None, search_range=None, compute_leaves=True, recompute_start=False):
         """Return the closest work interval boundary within the search range.
         Consider only starts of intervals unless `match_end` is True. It will then only consider
         ends of intervals.
         :param dt: reference datetime
         :param match_end: wether to search for the begining of an interval or the end.
         :param search_range: time interval considered. Defaults to the entire day of `dt`
+        :param recompute_start : Check whether the start datetime is greater than end datetime or not
         :rtype: datetime | None
         """
         def interval_dt(interval):
@@ -579,6 +580,9 @@ class ResourceCalendar(models.Model):
             self._work_intervals_batch(range_start, range_end, resource, compute_leaves=compute_leaves)[resource.id],
             key=lambda i: abs(interval_dt(i) - dt),
         )
+
+        if recompute_start:
+            return work_intervals[1][0]
         return interval_dt(work_intervals[0]) if work_intervals else None
 
     def _get_unusual_days(self, start_dt, end_dt, company_id=False):

--- a/addons/resource/models/resource_resource.py
+++ b/addons/resource/models/resource_resource.py
@@ -130,6 +130,10 @@ class ResourceResource(models.Model):
             calendar_end = calendar._get_closest_work_time(max(start, end), match_end=True,
                                                                        resource=resource, search_range=search_range,
                                                                        compute_leaves=compute_leaves)
+
+            if calendar_end and calendar_start and calendar_end < calendar_start:
+                calendar_start = calendar._get_closest_work_time(start, resource=resource, recompute_start=True,
+                                                                    compute_leaves=compute_leaves)
             result[resource] = (
                 calendar_start and revert_start_tz(calendar_start),
                 calendar_end and revert_end_tz(calendar_end),

--- a/addons/test_resource/tests/common.py
+++ b/addons/test_resource/tests/common.py
@@ -64,6 +64,8 @@ class TestResourceCommon(TransactionCase):
 
         cls.calendar_bob = cls._define_calendar('Calendar with adjacent attendances', sum([((8, 12, i, 0.5), (12, 16, i, 0.5)) for i in range(5)], ()), 'Europe/Brussels')
 
+        cls.calendar_sam = cls._define_calendar('40 Hours working calendar with Lunch break', sum([((8, 12, i, 0.5), (13, 16, i, 0.5)) for i in range(5)], ()), 'Europe/Brussels')
+
         # Employee is linked to a resource.resource via resource.mixin
         cls.jean = cls.env['resource.test'].create({
             'name': 'Jean',
@@ -92,6 +94,10 @@ class TestResourceCommon(TransactionCase):
             'resource_calendar_id': cls.calendar_bob.id,
         })
 
+        cls.sam = cls.env['resource.test'].create({
+            'name': 'Sam',
+            'resource_calendar_id': cls.calendar_sam.id,
+        })
 
         cls.two_weeks_resource = cls._define_calendar_2_weeks(
             'Two weeks resource',

--- a/addons/test_resource/tests/test_resource.py
+++ b/addons/test_resource/tests/test_resource.py
@@ -648,6 +648,16 @@ class TestResMixin(TestResourceCommon):
             datetime_tz(2020, 4, 2, 18, 0, tzinfo='UTC')
         ), "It should have found the start and end of the shift on the same day on April 2nd, 2020")
 
+        result = self.sam._adjust_to_calendar(
+            datetime_tz(2020, 4, 3, 11, 0, 0, tzinfo=self.sam.tz),
+            datetime_tz(2020, 4, 3, 12, 0, 0, tzinfo=self.sam.tz),
+        )
+
+        self.assertEqual(result[self.sam], (
+            datetime_tz(2020, 4, 3, 8, 0, 0, tzinfo=self.sam.tz),
+            datetime_tz(2020, 4, 3, 12, 0, 0, tzinfo=self.sam.tz)
+        ), "The start date should never be greater than end date.")
+
     def test_adjust_calendar_timezone_before(self):
         # Calendar:
         # Every day 8-16


### PR DESCRIPTION
Steps to reproduce
--------------------------
 - Install the planning module.
 - Open Gantt view in day scale.
 - Create a planning slot from 11am to 12pm for an employee whose working hours are 8-12 and 13-17
 - The default hours will be shown as 13 to 12

Issue
--------------------------------
 - When an employee works two shifts for example 8-12 and 13-17, and we are creating a slot from 11-12, the slot timing will show as 13-12 instead of 8-12.

Cause
------------------
 - here is an example of how the planning slot will be calculated and what is
   miscalculation
 - When click on cell 9-10 the calculated hours
   <table><thead><tr><th>Cell</th><th>shift start time </th><th>shift end time </th></tr></thead><tbody><tr><td>9-10</td><td>|8 - 9| = 1<br>|13 - 9| = 4<br></td><td>|12 - 10| = 2<br>|17 - 10| = 5<br></td></tr><tr><td>minimum</td><td>8</td><td>12</td></tr></tbody></table>
 

   so that slot timining will be 8 - 12

- When click on cell 11-12
  <table><tbody><tr><td>Cell</td><td>shift start time </td><td>shift end time </td></tr><tr><td>11-12</td><td>|8 - 11| = 3<br>|13 - 11| = 2<br></td><td>|12 - 12| = 0<br>|17 - 12| = 5<br></td></tr><tr><td>minimum</td><td>13</td><td>12</td></tr></tbody></table>
   So that the slot timining will be 13-12 which should not be possible

Fix
-------------------------
 - When the start time of the slot is greater than the end time, recalculate the start time and return the appropriate hour.

task-3916687