### PR TITLE
[FIX] web: cog menu clipped on mobile when too wide

### DIFF
--- a/addons/web/static/src/search/cog_menu/cog_menu.scss
+++ b/addons/web/static/src/search/cog_menu/cog_menu.scss
@@ -3,4 +3,7 @@
         width: var(--oi-font-size, 1em);
         vertical-align: -0.2em;
     }
+    .o-dropdown--menu {
+        max-width: 60vw;
+    }
 }

--- a/addons/web/static/src/search/cog_menu/cog_menu.xml
+++ b/addons/web/static/src/search/cog_menu/cog_menu.xml
@@ -17,14 +17,15 @@
                             t-foreach="printItems"
                             t-as="item"
                             t-key="item.key"
-                            class="'o_menu_item'"
+                            class="'text-truncate o_menu_item'"
+                            title="item.description"
                             onSelected="() => this.onItemSelected(item)"
                             >
                             <t t-esc="item.description"/>
                         </DropdownItem>
                     </Dropdown>
 
-                    <DropdownItem t-else="" class="'o_menu_item'" onSelected="() => this.onItemSelected(printItems[0])">
+                    <DropdownItem t-else="" class="'text-truncate o_menu_item'" title="printItems[0].description" onSelected="() => this.onItemSelected(printItems[0])">
                         <i class="fa fa-print me-1"/> <t t-out="printItems[0].description"/>
                     </DropdownItem>
                 </t>
@@ -36,7 +37,7 @@
 
                     <t t-if="item.Component" t-component="item.Component" t-props="item.props"/>
 
-                    <DropdownItem t-else="" class="'o_menu_item'" onSelected="() => this.onItemSelected(item)">
+                    <DropdownItem t-else="" class="'text-truncate o_menu_item'" title="item.description" onSelected="() => this.onItemSelected(item)">
                         <i t-if="item.icon" t-att-class="item.icon" class="fa-fw oi-fw me-1"/>
                         <t t-esc="item.description"/>
                     </DropdownItem>


### PR DESCRIPTION
Before this commit, the cog dropdown was getting clipped on mobile for longer widths

Steps to reproduce:

- Project> Open any project > Open any task.
- Click on the cog button
- Minimize the window or switch to mobile view

After this commit, the width of the dropdown adjusts accordingly to prevent clipping. And the text of dropdown items is truncated.

Task: 3763899