### PR TITLE
[IMP] website: adapt "thank you" page

### DIFF
--- a/addons/website/data/website_data.xml
+++ b/addons/website/data/website_data.xml
@@ -166,17 +166,14 @@
                         <section class="s_text_block pt40 pb40 o_colored_level " data-snippet="s_text_block">
                             <div class="container s_allow_columns">
                                 <div class="row">
-                                    <div class="col-lg-7 col-xl-6 me-lg-auto">
-                                        <span class="d-block fa fa-4x fa-thumbs-up mx-auto rounded-circle bg-primary"/><br/>
-                                        <h1 class="text-center">Thank You!</h1>
-                                        <div class="s_hr pb16 pt16" data-snippet="s_hr" data-name="Separator">
-                                            <hr class="w-50 mx-auto border-dark"/>
+                                    <div class="col-lg-7 col-xl-6 me-lg-auto text-center">
+                                        <div class="d-inline-block mx-auto p-4">
+                                            <i class="fa fa-paper-plane fa-2x mb-3 rounded-circle text-bg-success" role="presentation"/>
+                                            <h1 class="fw-bolder">Thank You!</h1>
+                                            <p class="lead mb-0">Your message has been sent.</p>
+                                            <p class="lead">We will get back to you shortly.</p>
+                                            <a href="/">Go to Homepage</a>
                                         </div>
-                                        <h5 class="text-center">
-                                            <span class="fa fa-check-circle"/>
-                                            <span>Your message has been sent <b>successfully</b></span>
-                                        </h5>
-                                        <p class="text-center">We will get back to you shortly.</p>
                                     </div>
                                     <div class="col-lg-4">
                                         <ul class="list-unstyled mb-0 ps-2">

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -873,7 +873,7 @@ function editContactUs(steps) {
             run: "click",
         }, {
             content: "Check the form was sent (success page without form)",
-            trigger: ':iframe body:not(:has([data-snippet="s_website_form"])) .fa-check-circle',
+            trigger: ':iframe body:not(:has([data-snippet="s_website_form"])) .fa-paper-plane',
         }, {
             content: "Go back to the form",
             trigger: ':iframe a.navbar-brand.logo',
@@ -890,7 +890,7 @@ function editContactUs(steps) {
             run: "click",
         }, {
             content: "Check the form was again sent (success page without form)",
-            trigger: ':iframe body:not(:has([data-snippet="s_website_form"])) .fa-check-circle',
+            trigger: ':iframe body:not(:has([data-snippet="s_website_form"])) .fa-paper-plane',
         }
     ]);
 
@@ -1012,7 +1012,7 @@ function editContactUs(steps) {
             run: "click",
         }, {
             content: "Check the form was again sent (success page without form)",
-            trigger: ":iframe body:not(:has([data-snippet='s_website_form'])) .fa-check-circle",
+            trigger: ":iframe body:not(:has([data-snippet='s_website_form'])) .fa-paper-plane",
         },
     ]);
 


### PR DESCRIPTION
This PR enhances the layout of the "thank you" page of `website` to make it more elegant.
The purpose is also to use the same design for the other pages of the same type to maintain layout consistency (see [enterprise/#62839](https://github.com/odoo/enterprise/pull/62839)).

task-3790303

Requires:
- https://github.com/odoo/enterprise/pull/62839
---
| Before | After |
|--------|--------|
| <img width="547" alt="Capture d’écran 2024-05-30 à 13 17 13" src="https://github.com/odoo/odoo/assets/80679690/15c025f3-26f4-4fd4-9dcf-f2f5ae390922"> | <img width="429" alt="Capture d’écran 2024-05-30 à 13 17 25" src="https://github.com/odoo/odoo/assets/80679690/f64b6ee6-2061-4f2e-ace5-2266b82ba244"> |

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
