### PR TITLE
[IMP] website_forum: add left padding to user sidebar in mobile

### DIFF
--- a/addons/website_forum/views/forum_forum_templates_layout.xml
+++ b/addons/website_forum/views/forum_forum_templates_layout.xml
@@ -249,7 +249,7 @@
     <div id="o_wforum_offcanvas" class="o_website_offcanvas offcanvas offcanvas-end d-lg-none mw-75 p-0 overflow-visible">
         <button type="button" class="btn-close mt-3 ms-auto me-3" data-bs-dismiss="offcanvas" aria-label="Close"/>
         <div class="offcanvas-header align-items-start px-0" t-call="website_forum.user_sidebar_header"/>
-        <div class="offcanvas-body d-flex flex-column ps-0 py-0">
+        <div class="offcanvas-body d-flex flex-column py-0">
             <t t-call="website_forum.user_sidebar_body"/>
             <div t-if="forum" class="mb-2 d-flex justify-content-center align-items-end flex-grow-1">
                 <a class="btn btn-sm btn-link" t-att-href="_forum_path + '/faq'">
@@ -312,7 +312,7 @@
     </div>
     <div t-if="forum and user.karma>=forum.karma_moderate" class="o_wforum_sidebar_section pt-3">
         <!-- Moderation Tools -->
-        <div class="px-3 pb-1 fw-bold">Moderation tools</div>
+        <div class="pb-1 fw-bold">Moderation tools</div>
         <a t-attf-class="nav-link my-1 py-1 #{ 'rounded text-bg-light disabled' if queue_type == 'validation' else 'text-reset'}" t-attf-href="/forum/#{_forum_slug}/validation_queue">
             <i t-attf-class="fa fa-check-square-o fa-fw #{ 'opacity-50' if queue_type != 'validation' else ''}"/> To Validate
             <span id="count_posts_queue_validation" t-attf-class="badge #{ 'text-bg-warning' if forum.count_posts_waiting_validation > 0 else 'd-none'}" t-out="forum.count_posts_waiting_validation"/>
@@ -326,7 +326,7 @@
         </a>
     </div>
     <div t-if="forum and forum.tag_most_used_ids" class="o_wforum_sidebar_section pt-3">
-        <div class="d-flex align-items-center px-3 pb-1 fw-bold">Tags
+        <div class="d-flex align-items-center pb-1 fw-bold">Tags
             <a class="ms-2 px-0 fw-normal" t-att-href="_forum_path + '/tag'">
                 <small>(View all)</small>
             </a>
@@ -339,7 +339,7 @@
         </a>
     </div>
     <div t-if="my_other_forums" class="o_wforum_sidebar_section pt-3">
-        <div class="px-3 pb-1 fw-bold">My forums</div>
+        <div class="pb-1 fw-bold">My forums</div>
         <t t-foreach="my_other_forums.sorted(lambda f: f.name.casefold())" t-as="my_forum">
             <a class="nav-link my-1 py-1 text-reset" t-attf-href="/forum/#{slug(my_forum)}">
                 <i class="fa fa-file-o fa-fw opacity-50"/>


### PR DESCRIPTION
Currently, in mobile, the menuitems in the user sidebar sections of the forum stick too much to the left edge of the menu.

This PR removes the class `ps-0` from the offcanvas-body to allow some left padding. 
It also addresses the misaligned section titles for better UI.

Task-[3935463](https://www.odoo.com/web#id=3935463&cids=2&model=project.task&view_type=form)