### PR TITLE
[IMP] payment: translate payment methods

### DIFF
--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -13,7 +13,7 @@ class PaymentMethod(models.Model):
     _description = "Payment Method"
     _order = 'active desc, sequence, name'
 
-    name = fields.Char(string="Name", required=True)
+    name = fields.Char(string="Name", required=True, translate=True)
     code = fields.Char(
         string="Code", help="The technical code of this payment method.", required=True
     )


### PR DESCRIPTION
Purpose:
Since Odoo 17.0, the payment form now exposes payment methods and not payment providers and there is only option to translate payment providers and not payment methods

Post this commit:
->Allow to translate the name of payment methods

Task: 3890949

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
