### PR TITLE
[FIX] mail: removes archived activities from view

### DIFF
--- a/addons/mail/static/src/core/web/activity_menu.js
+++ b/addons/mail/static/src/core/web/activity_menu.js
@@ -82,7 +82,7 @@ export class ActivityMenu extends Component {
                 });
             return;
         }
-        let domain = [["activity_user_id", "=", this.userId]];
+        let domain = [["activity_user_id", "=", this.userId], ["activity_ids.active", "=", true]];
         if (group.domain) {
             domain = Domain.and([domain, group.domain]).toList();
         }


### PR DESCRIPTION
Current behaviour:
---
When coming from the systray, view shows records with an activity, even if it's archived

Expected behaviour:
---
Only records with active activities should show

Steps to reproduce:
---
1. Install sale_management
2. Go to Activity Types > Email
3. Check Keep Done
4. Go to Sales
5. Create a new Quotation
6. On the quotation, go to Activities
7. Activity type > Email > Schedule
8. On the top right, click on the Clock
9. Select Sales Order
10. On the new sale order, click on the envelope
11. Then Mark as Done > Done
12. Refresh > Sale order still there

Cause of the issue:
---
Caused by: https://github.com/odoo/odoo/blob/821156ce90f7e2a7ed8c1efea2ae5d2433561acb/addons/mail/models/mail_activity.py#L598 And by: https://github.com/odoo/odoo/blob/b09ccfc2d715e8d69421de509e9c64b6c071eaf1/addons/mail/models/mail_activity_mixin.py#L214

opw-3845057

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
