### PR TITLE
[16.0][FIX] sale: handle None values on sorted list when managing grouped parameter on _create_invoices method

### DIFF
--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -1150,9 +1150,9 @@ class SaleOrder(models.Model):
             invoice_grouping_keys = self._get_invoice_grouping_keys()
             invoice_vals_list = sorted(
                 invoice_vals_list,
-                key=lambda x: [
-                    x.get(grouping_key) for grouping_key in invoice_grouping_keys
-                ]
+                key=lambda x: tuple(
+                    (x is None, x)
+                    for x in [x.get(grouping_key) for grouping_key in invoice_grouping_keys])
             )
             for _grouping_keys, invoices in groupby(invoice_vals_list, key=lambda x: [x.get(grouping_key) for grouping_key in invoice_grouping_keys]):
                 origins = set()


### PR DESCRIPTION
Description of the issue/feature this PR addresses: Grouping criteria when creating invoices from multiple Sale Orders

Current behavior before PR: If a field is used on the grouping criteria and is not required and its value is `None`, when trying to sort the `invoice_vals_list` is returning:
```
File "/opt/odoo/odoo-base/odoo-server/addons/sale/models/sale_order.py", line 1151, in _create_invoices
    invoice_vals_list = sorted(
TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

Desired behavior after PR is merged: Applying this changes, it will be possible to handle the `None` values, making it as an agroupation itself.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
