### PR TITLE
[FIX] hr_holidays: update warning if negative excess

### DIFF
--- a/addons/hr_holidays/static/src/dashboard/time_off_card.js
+++ b/addons/hr_holidays/static/src/dashboard/time_off_card.js
@@ -66,7 +66,7 @@ export class TimeOffCard extends Component {
         const excess = Math.max(data.exceeding_duration, -data.virtual_remaining_leaves);
         const exceeding_duration = data.allows_negative
             ? excess > data.max_allowed_negative
-            : excess > 0;
+            : Math.abs(excess) > 0;
         const errorLeavesSignificant = data.allows_negative
             ? this.errorLeavesDuration > data.max_allowed_negative
             : this.errorLeavesDuration > 0;


### PR DESCRIPTION
Issue:
------
There's no warning on the dashboard when you've
taken too much time off
(which can be cancelled with the cron
`Time Off: Cancel invalid leaves`).

Cause:
------
Excess detection is determined by:
```js
Math.max(data.exceeding_duration, -data.virtual_remaining_leaves);
```
with `exceeding_duration` lower than zero because:
```py
content['exceeding_duration'] = round(min(0, latest_remaining - additional_leaves_duration), 2)
```
Consequently, we must detect an excess
if the value is negative.

opw-3860081