### PR TITLE
[FIX] stock: bypass reservation on creation of done move

### DIFF
--- a/addons/stock/models/stock_move_line.py
+++ b/addons/stock/models/stock_move_line.py
@@ -331,6 +331,8 @@ class StockMoveLine(models.Model):
 
         move_to_recompute_state = self.env['stock.move']
         for move_line in mls:
+            if move_line.state == 'done':
+                continue
             location = move_line.location_id
             product = move_line.product_id
             move = move_line.move_id


### PR DESCRIPTION
### Steps to reproduce:

- Create a product SP tracked by lots
- Click on "on hand" and create a lot with 10 units on hand
- Create and validate picking for 1 x any other product
- Unlock the delivery
- Add a line (stock move) for 1 x SP
- Click on the list icon of the line and set your lot
- Save the picking
- Go to the on hand quantity of SP

#### > 1 unit was reserved even though the move is 'done'

### Cause of the issue:

Creating the stock move line associating the lot to the stock move will update the reserved quantity of stock quants independently of the state of the move created:
https://github.com/odoo/odoo/blob/347c7e21002313da155ebf872853078de23b38fe/addons/stock/models/stock_move_line.py#L337-L343 https://github.com/odoo/odoo/blob/347c7e21002313da155ebf872853078de23b38fe/addons/stock/models/stock_move.py#L1525-L1528

opw-3906472
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
