### PR TITLE
[IMP] account: allow change of journal for posted before

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -2763,10 +2763,20 @@ class AccountMove(models.Model):
                     "Therefore, you cannot edit the following fields: %s.",
                     ', '.join(f['string'] for f in self.fields_get(violated_fields).values())
                 ))
-            if (move.posted_before and 'journal_id' in vals and move.journal_id.id != vals['journal_id']):
-                raise UserError(_('You cannot edit the journal of an account move if it has been posted once.'))
-            if (move.name and move.name != '/' and move.sequence_number not in (0, 1) and 'journal_id' in vals and move.journal_id.id != vals['journal_id'] and not move.quick_edit_mode):
-                raise UserError(_('You cannot edit the journal of an account move if it already has a sequence number assigned.'))
+            if (
+                    move.posted_before
+                    and 'journal_id' in vals and move.journal_id.id != vals['journal_id']
+                    and not (move.name == '/' or not move.name or ('name' in vals and (vals['name'] == '/' or not vals['name'])))
+            ):
+                raise UserError(_('You cannot edit the journal of an account move if it has been posted once, unless the name is removed or set to "/". This might create a gap in the sequence.'))
+            if (
+                    move.name and move.name != '/'
+                    and move.sequence_number not in (0, 1)
+                    and 'journal_id' in vals and move.journal_id.id != vals['journal_id']
+                    and not move.quick_edit_mode
+                    and not ('name' in vals and (vals['name'] == '/' or not vals['name']))
+            ):
+                raise UserError(_('You cannot edit the journal of an account move with a sequence number assigned, unless the name is removed or set to "/". This might create a gap in the sequence.'))
 
             # You can't change the date or name of a move being inside a locked period.
             if move.state == "posted" and (

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -984,7 +984,7 @@
                                     <field name="journal_id"
                                            groups="account.group_account_readonly"
                                            options="{'no_create': True, 'no_open': True}"
-                                           readonly="posted_before"/>
+                                           readonly="name and name != '/'"/>
 
                                     <span class="o_form_label mx-3 oe_edit_only"
                                           groups="account.group_account_readonly"


### PR DESCRIPTION
Once a move or journal entry is posted, even if it is set back to draft, the journal cannot be edited. This commit gives the user the option to do so, by allowing the journal to be changed to a journal of the same type if the name of the move is removed.

This can introduce gaps in the sequence, but that is already allowed behavior when the user deletes the move name.

task-3829848

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
