### PR TITLE
[FIX] analytic: enable analytic account in child company

### DIFF
--- a/addons/analytic/models/analytic_account.py
+++ b/addons/analytic/models/analytic_account.py
@@ -14,6 +14,7 @@ class AccountAnalyticAccount(models.Model):
     _description = 'Analytic Account'
     _order = 'plan_id, name asc'
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
     _rec_names_search = ['name', 'code', 'partner_id']
 
     name = fields.Char(

--- a/addons/analytic/models/analytic_distribution_model.py
+++ b/addons/analytic/models/analytic_distribution_model.py
@@ -15,6 +15,8 @@ class AccountAnalyticDistributionModel(models.Model):
     _description = 'Analytic Distribution Model'
     _rec_name = 'create_date'
     _order = 'id desc'
+    _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
 
     partner_id = fields.Many2one(
         'res.partner',

--- a/addons/analytic/models/analytic_line.py
+++ b/addons/analytic/models/analytic_line.py
@@ -10,6 +10,7 @@ class AccountAnalyticLine(models.Model):
     _description = 'Analytic Line'
     _order = 'date desc, id desc'
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
 
     name = fields.Char(
         'Description',

--- a/addons/analytic/models/analytic_plan.py
+++ b/addons/analytic/models/analytic_plan.py
@@ -12,6 +12,7 @@ class AccountAnalyticPlan(models.Model):
     _rec_name = 'complete_name'
     _order = 'complete_name asc'
     _check_company_auto = True
+    _check_company_domain = models.check_company_domain_parent_of
 
     def _default_color(self):
         return randint(1, 11)

--- a/addons/analytic/security/analytic_security.xml
+++ b/addons/analytic/security/analytic_security.xml
@@ -6,28 +6,28 @@
         <field name="name">Analytic multi company rule</field>
         <field name="model_id" ref="model_account_analytic_account"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">[('company_id', 'parent_of', company_ids + [False])]</field>
     </record>
 
     <record id="analytic_line_comp_rule" model="ir.rule">
         <field name="name">Analytic line multi company rule</field>
         <field name="model_id" ref="model_account_analytic_line"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">[('company_id', 'in', company_ids)]</field>
+        <field name="domain_force">[('company_id', 'parent_of', company_ids)]</field>
     </record>
 
     <record id="analytic_plan_comp_rule" model="ir.rule">
         <field name="name">Analytic plan multi company rule</field>
         <field name="model_id" ref="model_account_analytic_plan"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">[('company_id', 'parent_of', company_ids + [False])]</field>
     </record>
 
     <record id="analytic_distribution_model_comp_rule" model="ir.rule">
         <field name="name">Analytic distribution model multi company rule</field>
         <field name="model_id" ref="model_account_analytic_distribution_model"/>
         <field eval="True" name="global"/>
-        <field name="domain_force">[('company_id', 'in', company_ids + [False])]</field>
+        <field name="domain_force">[('company_id', 'parent_of', company_ids + [False])]</field>
     </record>
 </data>
 <data noupdate="0">


### PR DESCRIPTION
Steps to reproduce:
Have two Companies A and B
Create an Analytic Account (AA) for Company A
In B (A multiselected), create an invoice: company=Company B Set an analytic Distribution

Issue:
AA from company A are available. You can select them. And if you set a analytic distribution with such AA with a line zero amount you will be able to confirm the invoice. Exiting multicompany and trying to open the same invoice with Company B will raise an Access Error

Solution:
After discussion with PO tsb, children companies need to have access to analytic account (and analutic related stuff) from parent

opw-3764627
