### PR TITLE
[FIX] account: Fix 'percentage_st_line' on reco model

### DIFF
--- a/addons/account/models/account_reconcile_model.py
+++ b/addons/account/models/account_reconcile_model.py
@@ -187,7 +187,10 @@ class AccountReconcileModelLine(models.Model):
 
         amount_currency = None
         if self.amount_type == 'percentage_st_line':
-            amount_currency = currency.round(residual_amount_currency * (self.amount / 100.0))
+            _transaction_amount, _transaction_currency, journal_amount, journal_currency, _company_amount, _company_currency \
+                = st_line._get_accounting_amounts_and_currencies()
+            amount_currency = journal_currency.round(-journal_amount * (self.amount / 100.0))
+            currency = journal_currency
         elif self.amount_type == 'regex':
             match = re.search(self.amount_string, st_line.payment_ref)
             if match:


### PR DESCRIPTION
The current code is taking the residual amount instead of the statement line amount. When doing a reco model 'percentage_st_line' on 1000: Line 1 - 74%
Line 2 - 24%
Line 3 - 2%

We get:
1000 * 0.74 = 740
(1000 - 740) * 0.24 = 62.4
(1000 - 740 - 62.4) * 0.02 = 3.95

Instead of:
1000 * 0.74 = 740
1000 * 0.24 = 240
1000 * 0.02 = 20

task_id: 3940370

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
