### PR TITLE
[IMP] mail: open channels to the last read message

### DIFF
--- a/addons/im_livechat/controllers/cors/channel.py
+++ b/addons/im_livechat/controllers/cors/channel.py
@@ -12,9 +12,9 @@ class LivechatChannelController(ChannelController):
         return self.discuss_channel_messages(channel_id, before, after, limit, around)
 
     @route("/im_livechat/cors/channel/mark_as_read", methods=["POST"], type="json", auth="public", cors="*")
-    def livechat_channel_mark_as_read(self, guest_token, channel_id, last_message_id):
+    def livechat_channel_mark_as_read(self, guest_token, **kwargs):
         force_guest_env(guest_token)
-        return self.discuss_channel_mark_as_read(channel_id, last_message_id)
+        return self.discuss_channel_mark_as_read(**kwargs)
 
     @route("/im_livechat/cors/channel/fold", methods=["POST"], type="json", auth="public", cors="*")
     def livechat_channel_fold(self, guest_token, channel_id, state, state_count):

--- a/addons/im_livechat/static/src/embed/common/livechat_service.js
+++ b/addons/im_livechat/static/src/embed/common/livechat_service.js
@@ -217,6 +217,7 @@ export class LivechatService {
             this.leave({ notifyServer: false });
             return;
         }
+        data.Thread["scrollUnread"] = false;
         this.state = persist ? SESSION_STATE.PERSISTED : SESSION_STATE.CREATED;
         this._saveLivechatState(data.Thread, { persisted: persist });
         this.store.insert(data);

--- a/addons/im_livechat/static/tests/embed/unread_messages.test.js
+++ b/addons/im_livechat/static/tests/embed/unread_messages.test.js
@@ -116,7 +116,7 @@ test("focus on unread livechat marks it as read", async () => {
         ],
     ]);
     // send after init_messaging because bus subscription is done after init_messaging
-    withUser(userId, () =>
+    await withUser(userId, () =>
         rpc("/mail/message/post", {
             post_data: { body: "Are you there?", message_type: "comment" },
             thread_id: channelId,
@@ -124,6 +124,7 @@ test("focus on unread livechat marks it as read", async () => {
         })
     );
     await contains(".o-mail-ChatWindow-counter", { text: "1" });
+    await contains(".o-mail-Message", { text: "Are you there?" });
     await focus(".o-mail-Composer-input");
     await contains(".o-mail-ChatWindow-counter", { count: 0 });
 });

--- a/addons/im_livechat/static/tests/go_to_oldest_unread_thread.test.js
+++ b/addons/im_livechat/static/tests/go_to_oldest_unread_thread.test.js
@@ -92,7 +92,7 @@ test("switching to folded chat window unfolds it [REQUIRE FOCUS]", async () => {
     const pyEnv = await startServer();
     const guestId_1 = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor 12" });
-    pyEnv["discuss.channel"].create([
+    const channelIds = pyEnv["discuss.channel"].create([
         {
             anonymous_name: "Visitor 11",
             channel_member_ids: [
@@ -112,7 +112,6 @@ test("switching to folded chat window unfolds it [REQUIRE FOCUS]", async () => {
                 Command.create({
                     partner_id: serverState.partnerId,
                     fold_state: "folded",
-                    message_unread_counter: 1,
                     last_interest_dt: "2021-01-02 10:00:00",
                 }),
                 Command.create({ guest_id: guestId_2 }),
@@ -122,6 +121,12 @@ test("switching to folded chat window unfolds it [REQUIRE FOCUS]", async () => {
             name: "Livechat 2",
         },
     ]);
+    pyEnv["mail.message"].create({
+        author_guest_id: guestId_2,
+        body: "Hello",
+        model: "discuss.channel",
+        res_id: channelIds[1],
+    });
     await start();
     await contains(".o-mail-ChatWindow.o-folded", { text: "Visitor 12" });
     await focus(".o-mail-Composer-input", {
@@ -138,7 +143,7 @@ test("switching to hidden chat window unhides it [REQUIRE FOCUS]", async () => {
     const pyEnv = await startServer();
     const guestId_1 = pyEnv["mail.guest"].create({ name: "Visitor 11" });
     const guestId_2 = pyEnv["mail.guest"].create({ name: "Visitor 12" });
-    pyEnv["discuss.channel"].create([
+    const channelIds = pyEnv["discuss.channel"].create([
         {
             anonymous_name: "Visitor 11",
             channel_member_ids: [
@@ -158,7 +163,6 @@ test("switching to hidden chat window unhides it [REQUIRE FOCUS]", async () => {
                 Command.create({
                     partner_id: serverState.partnerId,
                     fold_state: "open",
-                    message_unread_counter: 1,
                     last_interest_dt: "2021-01-02 10:00:00",
                 }),
                 Command.create({ guest_id: guestId_2 }),
@@ -173,6 +177,12 @@ test("switching to hidden chat window unhides it [REQUIRE FOCUS]", async () => {
             ],
         },
     ]);
+    pyEnv["mail.message"].create({
+        author_guest_id: guestId_2,
+        body: "Hello",
+        model: "discuss.channel",
+        res_id: channelIds[1],
+    });
     patchUiSize({ width: 900 }); // enough for 2 chat windows
     await start();
     await contains(".o-mail-ChatWindow", { count: 2 });

--- a/addons/im_livechat/static/tests/sidebar_patch.test.js
+++ b/addons/im_livechat/static/tests/sidebar_patch.test.js
@@ -198,17 +198,22 @@ test("No counter if category is folded and without unread messages", async () =>
 test("Counter should have correct value of unread threads if category is folded and with unread messages", async () => {
     const pyEnv = await startServer();
     const guestId = pyEnv["mail.guest"].create({ name: "Visitor 11" });
-    pyEnv["discuss.channel"].create({
+    const channelId = pyEnv["discuss.channel"].create({
         anonymous_name: "Visitor 11",
         channel_member_ids: [
             Command.create({
-                message_unread_counter: 10,
                 partner_id: serverState.partnerId,
             }),
             Command.create({ guest_id: guestId }),
         ],
         channel_type: "livechat",
         livechat_operator_id: serverState.partnerId,
+    });
+    pyEnv["mail.message"].create({
+        author_guest_id: guestId,
+        message_type: "comment",
+        model: "discuss.channel",
+        res_id: channelId,
     });
     await start();
     await openDiscuss();

--- a/addons/mail/controllers/discuss/channel.py
+++ b/addons/mail/controllers/discuss/channel.py
@@ -117,11 +117,11 @@ class ChannelController(http.Controller):
 
     @http.route("/discuss/channel/mark_as_read", methods=["POST"], type="json", auth="public")
     @add_guest_to_context
-    def discuss_channel_mark_as_read(self, channel_id, last_message_id):
+    def discuss_channel_mark_as_read(self, channel_id, last_message_id, sync=False):
         channel = request.env["discuss.channel"].search([("id", "=", channel_id)])
         if not channel:
             raise NotFound()
-        return channel._mark_as_read(last_message_id)
+        return channel._mark_as_read(last_message_id, sync=sync)
 
     @http.route("/discuss/channel/mark_as_unread", methods=["POST"], type="json", auth="public")
     @add_guest_to_context

--- a/addons/mail/models/discuss/discuss_channel.py
+++ b/addons/mail/models/discuss/discuss_channel.py
@@ -1044,13 +1044,15 @@ class Channel(models.Model):
         else:
             self.env['bus.bus']._sendone(self.env.user.partner_id, 'mail.record/insert', {"Thread": self._channel_info()[0]})
 
-    def _mark_as_read(self, last_message_id=None):
+    def _mark_as_read(self, last_message_id=None, sync=False):
         """
         Mark channel as read by updating seen message id of the current persona
         as well as its new message separator.
         :param last_message_id: the id of the message to be marked as seen, last message of the
         thread by default. This param SHOULD be required, the default behaviour is DEPRECATED and
         kept only for compatibility reasons.
+        :param sync: whether the new message separator and the unread counter
+            in the UX will sync to their server values.
         """
         self.ensure_one()
         domain = ["&", ("model", "=", "discuss.channel"), ("res_id", "in", self.ids)]
@@ -1066,7 +1068,7 @@ class Channel(models.Model):
         current_member = self.env["discuss.channel.member"].search(
             [("channel_id", "=", self.id), ("is_self", "=", True)]
         )
-        current_member._set_new_message_separator(last_message.id + 1)
+        current_member._set_new_message_separator(last_message.id + 1, sync=sync)
         return last_message.id
 
     def _set_last_seen_message(self, last_message, notify=True):

--- a/addons/mail/models/discuss/discuss_channel_member.py
+++ b/addons/mail/models/discuss/discuss_channel_member.py
@@ -420,8 +420,8 @@ class ChannelMember(models.Model):
         """
         :param message_id: id of the message above which the new message
             separator should be displayed.
-        :param sync: if True, the new message separator in the UX will be
-            updated to the `message_id` value.
+        :param sync: whether the new message separator and the unread counter
+            in the UX will sync to their server values.
 
         """
         self.ensure_one()
@@ -440,6 +440,5 @@ class ChannelMember(models.Model):
                 "model": "discuss.channel",
             },
         }
-        if sync:
-            channel_member["localNewMessageSeparator"] = self.new_message_separator
+        channel_member["syncUnread"] = sync
         self.env["bus.bus"]._sendone(target, "mail.record/insert", {"ChannelMember": channel_member})

--- a/addons/mail/models/mail_message.py
+++ b/addons/mail/models/mail_message.py
@@ -1051,7 +1051,7 @@ class Message(models.Model):
             ])])
             domain = expression.AND([domain, [("message_type", "not in", ["user_notification", "notification"])]])
             res["count"] = self.search_count(domain)
-        if around:
+        if around is not None:
             messages_before = self.search(domain=[*domain, ('id', '<=', around)], limit=limit // 2, order="id DESC")
             messages_after = self.search(domain=[*domain, ('id', '>', around)], limit=limit // 2, order='id ASC')
             return {**res, "messages": (messages_after + messages_before).sorted('id', reverse=True)}

--- a/addons/mail/static/src/core/common/message_model.js
+++ b/addons/mail/static/src/core/common/message_model.js
@@ -77,8 +77,8 @@ export class Message extends Record {
     isReadBySelf = Record.attr(false, {
         compute() {
             return (
-                this.thread.selfMember?.seen_message_id?.id >= this.id &&
-                this.thread.selfMember?.new_message_separator > this.id
+                this.thread?.selfMember?.seen_message_id?.id >= this.id &&
+                this.thread?.selfMember?.new_message_separator > this.id
             );
         },
     });

--- a/addons/mail/static/src/core/common/thread.scss
+++ b/addons/mail/static/src/core/common/thread.scss
@@ -16,11 +16,6 @@
     display: inline;
 }
 
-.o-mail-Thread-jumpPresent {
-    background-color: mix(map-get($theme-colors, 'info'), $o-webclient-background-color, 5%);
-    z-index: $o-mail-NavigableList-zIndex - 1;
-}
-
 .o-mail-NotificationMessage p {
     margin-bottom: 0;
 }
@@ -29,4 +24,12 @@
     & .o-mail-NotificationMessage-author {
         display: none!important;
     }
+}
+
+.o-mail-Thread-banner {
+    z-index: $o-mail-NavigableList-zIndex - 1;
+}
+
+.o-mail-Thread-bannerHover:hover {
+    filter: brightness(98%);
 }

--- a/addons/mail/static/src/core/common/thread.xml
+++ b/addons/mail/static/src/core/common/thread.xml
@@ -3,6 +3,7 @@
 
 <t t-name="mail.Thread">
     <t t-if="env.inChatter" t-call="mail.Thread.jumpPresent"/> <!-- chatter has its own scrollable, this ensures proper sticky showing -->
+    <t t-else="" t-call="mail.Thread.jumpUnread"/>
     <div class="o-mail-Thread position-relative flex-grow-1 d-flex flex-column overflow-auto" t-att-class="{ 'pb-4':  props.showJumpPresent and !state.showJumpPresent, 'px-3': !env.inChatter and !props.isInChatWindow }" t-ref="messages" tabindex="-1">
         <t t-if="!props.thread.isEmpty or props.thread.loadOlder or props.thread.hasLoadingFailed" name="content">
             <div class="d-flex flex-column position-relative flex-grow-1" t-att-class="{'justify-content-end': !env.inChatter and props.thread.model !== 'mail.box'}">
@@ -12,10 +13,7 @@
                     <t t-if="props.thread.loadOlder and !props.thread.isTransient and !props.thread.hasLoadingFailed" t-call="mail.Thread.loadOlder"/>
                     <t t-if="props.thread.hasLoadingFailed" t-call="mail.Thread.loadingError"/>
                 </t>
-                <t t-else="">
-                    <span t-ref="load-newer"/>
-                    <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
-                </t>
+                <span t-else="" t-ref="load-newer"/>
                 <t t-set="messages" t-value="props.order === 'asc' ? props.thread.nonEmptyMessages : [...props.thread.nonEmptyMessages].reverse()"/>
                 <t t-if="state.mountedAndLoaded" t-foreach="messages" t-as="msg" t-key="msg.id">
                     <t t-set="prevMsg" t-value="messages[msg_index -1]"/>
@@ -23,7 +21,7 @@
                         <DateSection date="msg.dateDay" className="'pt-2'"/>
                         <t t-set="currentDay" t-value="msg.dateDay"/>
                     </t>
-                    <div t-if="msg.threadAsFirstUnread" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder">
+                    <div t-if="msg.threadAsFirstUnread" class="o-mail-Thread-newMessage d-flex align-items-center fw-bolder z-index-1">
                         <hr class="ms-2 flex-grow-1 border border-danger opacity-50"/><span class="px-2 text-danger">New messages</span><hr class="me-2 flex-grow-1 border border-danger opacity-50"/>
                     </div>
                     <t t-if="msg.isNotification">
@@ -44,10 +42,7 @@
                         showDates="props.showDates"
                     />
                 </t>
-                <t t-if="props.order === 'asc'">
-                    <span t-ref="load-newer"/>
-                    <t t-call="mail.Thread.jumpPresent"/>
-                </t>
+                <span t-if="props.order === 'asc'" t-ref="load-newer"/>
                 <t t-else="">
                     <t t-if="props.thread.loadOlder and !props.thread.isTransient and !props.thread.hasLoadingFailed" t-call="mail.Thread.loadOlder"/>
                     <t t-if="props.thread.hasLoadingFailed" t-call="mail.Thread.loadingError"/>
@@ -93,6 +88,7 @@
             </div>
         </t>
     </div>
+    <t t-if="!env.inChatter" t-call="mail.Thread.jumpPresent"/>
 </t>
 
 <t t-name="mail.Thread.inboxHint">
@@ -102,14 +98,21 @@
 </t>
 
 <t t-name="mail.Thread.jumpPresent">
-    <span t-if="props.showJumpPresent and state.showJumpPresent" class="o-mail-Thread-jumpPresent position-sticky btn btn-link alert alert-info d-flex cursor-pointer align-items-center py-2 m-0" t-att-class="{ 'px-4': !env.inChatWindow, 'px-2': env.inChatWindow, 'top-0': props.order !== 'asc', 'bottom-0': props.order === 'asc' }" role="button" t-on-click="() => this.jumpToPresent()">
-        <span class="small">You're viewing older messages</span>
-        <span class="flex-grow-1"/>
-        <span class="fw-bolder small pe-2">Jump to Present</span>
-        <i class="fa" t-att-class="{ 'fa-caret-up': props.order !== 'asc', 'fa-caret-down': props.order === 'asc' }"/>
+    <span t-if="props.showJumpPresent and state.showJumpPresent" t-att-class="{
+        'm-0 px-4 position-sticky top-0': env.inChatter,
+    }" class="o-mail-Thread-banner o-mail-Thread-bannerHover d-flex justify-content-between alert alert-primary border-0 rounded-0 mb-0 py-1 cursor-pointer shadow-sm small fw-bold" t-on-click="() => this.jumpToPresent()">
+        <span>You're viewing older messages</span>
+        <span>Jump to Present<i class="ms-2 fa" t-att-class="{ 'fa-caret-up': props.order !== 'asc', 'fa-caret-down': props.order === 'asc' }"/></span>
     </span>
 </t>
 
+<t t-name="mail.Thread.jumpUnread">
+    <span t-if="props.thread.selfMember?.localMessageUnreadCounter > 0" class="o-mail-Thread-banner d-flex cursor-pointer shadow-sm small fw-bold">
+        <t t-set="alertClass" t-value="'alert alert-info m-0 border-start-0 o-mail-Thread-bannerHover rounded-0 py-1'"/>
+        <span t-attf-class="{{ alertClass }} flex-grow-1" t-on-click="onClickUnreadMessagesBanner" t-esc="newMessageBannerText"/>
+        <span t-attf-class="{{ alertClass }}" t-on-click="() => props.thread.markAsRead({ sync: true })">Mark as Read<i class="ms-2 fa fa-check-square"/></span>
+    </span>
+</t>
 <t t-name="mail.Thread.loadOlder">
     <button class="btn btn-link" t-on-click="onClickLoadOlder" t-ref="load-older">Load More</button>
 </t>

--- a/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
+++ b/addons/mail/static/src/discuss/core/common/discuss_core_common_service.js
@@ -186,10 +186,15 @@ export class DiscussCoreCommon {
             } else if (channel.status === "loading") {
                 channel.pendingNewMessages.push(message);
             }
-            if (message.isSelfAuthored) {
+            if (message.isSelfAuthored && channel.selfMember) {
+                channel.selfMember.syncUnread = true;
                 channel.selfMember.seen_message_id = message;
-                channel.selfMember.localNewMessageSeparator = message.id + 1;
+                channel.selfMember.new_message_separator = message.id + 1;
             } else {
+                if (!channel.isDisplayed && channel.selfMember) {
+                    channel.selfMember.syncUnread = true;
+                    channel.scrollUnread = true;
+                }
                 if (notifId > channel.message_unread_counter_bus_id) {
                     channel.incrementUnreadCounter();
                 }

--- a/addons/mail/static/tests/chat_window/chat_window.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "@odoo/hoot";
-import { mockDate } from "@odoo/hoot-mock";
+import { mockDate, tick } from "@odoo/hoot-mock";
 import { Command, getService, serverState, withUser } from "@web/../tests/web_test_helpers";
 import {
     SIZES,
@@ -858,7 +858,8 @@ test("chat window: scroll conservation on toggle discuss", async () => {
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-Message", { count: 30 });
-    await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: "bottom" });
+    await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 0 });
+    await tick(); // wait for the scroll to first unread to complete
     await scroll(".o-mail-ChatWindow .o-mail-Thread", 142);
     await openDiscuss();
     await contains(".o-mail-ChatWindow", { count: 0 });
@@ -881,7 +882,8 @@ test("chat window with a thread: keep scroll position in message list on folded"
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-Message", { count: 30 });
-    await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: "bottom" });
+    await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 0 });
+    await tick(); // wait for the scroll to first unread to complete
     await scroll(".o-mail-ChatWindow .o-mail-Thread", 142);
     // fold chat window
     await click(".o-mail-ChatWindow-command[title='Fold']");
@@ -907,7 +909,8 @@ test("chat window with a thread: keep scroll position in message list on toggle 
     await click(".o_menu_systray .dropdown-toggle:has(i[aria-label='Messages'])");
     await click(".o-mail-NotificationItem");
     await contains(".o-mail-Message", { count: 30 });
-    await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: "bottom" });
+    await contains(".o-mail-ChatWindow .o-mail-Thread", { scroll: 0 });
+    await tick(); // wait for the scroll to first unread to complete
     await scroll(".o-mail-ChatWindow .o-mail-Thread", 142);
     // fold chat window
     await click(".o-mail-ChatWindow-command[title='Fold']");

--- a/addons/mail/static/tests/chat_window/chat_window_manager.test.js
+++ b/addons/mail/static/tests/chat_window/chat_window_manager.test.js
@@ -133,8 +133,8 @@ test("click on hidden chat window should fetch its messages", async () => {
     await contains(".o-mail-ChatWindow", { count: 2 });
     await contains(".o-mail-ChatWindowHiddenToggler");
     // FIXME: expected ordering: Apple, Banana, Orange
-    await contains(".o-mail-Message-content", { text: "Orange" });
     await contains(".o-mail-Message-content", { text: "Banana" });
+    await contains(".o-mail-Message-content", { text: "Orange" });
     await contains(".o-mail-Message-content", { count: 0, text: "Apple" });
     await assertSteps(["fetch_messages", "fetch_messages"]);
     await click(".o-mail-ChatWindowHiddenToggler");

--- a/addons/mail/static/tests/discuss/core/web/discuss.test.js
+++ b/addons/mail/static/tests/discuss/core/web/discuss.test.js
@@ -85,7 +85,11 @@ test("can create a new channel [REQUIRE FOCUS]", async () => {
     await click(".o-discuss-ChannelSelector-suggestion");
     await contains(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-Discuss-content .o-mail-Message", { count: 0 });
-    const channelId = pyEnv["discuss.channel"].search([["name", "=", "abc"]]);
+    const [channelId] = pyEnv["discuss.channel"].search([["name", "=", "abc"]]);
+    const [selfMember] = pyEnv["discuss.channel.member"].search_read([
+        ["channel_id", "=", channelId],
+        ["partner_id", "=", serverState.partnerId],
+    ]);
     await assertSteps([
         `/web/dataset/call_kw/discuss.channel/channel_create - ${JSON.stringify({
             args: ["abc", null],
@@ -100,7 +104,7 @@ test("can create a new channel [REQUIRE FOCUS]", async () => {
             method: "channel_create",
             model: "discuss.channel",
         })}`,
-        `/discuss/channel/messages - {"channel_id":${channelId},"limit":30}`,
+        `/discuss/channel/messages - {"channel_id":${channelId},"limit":60,"around":${selfMember.new_message_separator}}`,
     ]);
 });
 
@@ -188,7 +192,9 @@ test("can join a chat conversation", async () => {
     await contains(".o-mail-DiscussSidebarChannel");
     await contains(".o-mail-Message", { count: 0 });
     const channelId = pyEnv["discuss.channel"].search([["name", "=", "Mitchell Admin, Mario"]]);
-    await assertSteps([`/discuss/channel/messages - {"channel_id":${channelId},"limit":30}`]);
+    await assertSteps([
+        `/discuss/channel/messages - {"channel_id":${channelId},"limit":60,"around":0}`,
+    ]);
 });
 
 test("can create a group chat conversation", async () => {

--- a/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
+++ b/addons/mail/static/tests/discuss/message_pin/pinned_messages.test.js
@@ -4,6 +4,7 @@ import {
     contains,
     defineMailModels,
     openDiscuss,
+    scroll,
     start,
     startServer,
 } from "../../mail_test_helpers";
@@ -142,6 +143,7 @@ test("Jump to message from notification", async () => {
     await click(".dropdown-item", { text: "Pin" });
     await click(".modal-footer button", { text: "Yeah, pin it!" });
     await contains(".o_mail_notification");
+    await scroll(".o-mail-Thread", "bottom");
     await contains(".o-mail-Thread", { scroll: "bottom" });
     await click(".o_mail_notification a", { text: "message" });
     await contains(".o-mail-Thread", { count: 0, scroll: "bottom" });

--- a/addons/mail/static/tests/discuss_app/sidebar.test.js
+++ b/addons/mail/static/tests/discuss_app/sidebar.test.js
@@ -598,24 +598,38 @@ test("chat - counter: should have correct value of unread threads if category is
         user_id: serverState.userId,
         is_discuss_sidebar_category_chat_open: false,
     });
-    pyEnv["discuss.channel"].create([
+    const bobUserId = pyEnv["res.users"].create({ name: "Bob" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob", user_id: bobUserId.id });
+    const channelIds = pyEnv["discuss.channel"].create([
         {
             channel_member_ids: [
-                Command.create({
-                    message_unread_counter: 10,
-                    partner_id: serverState.partnerId,
-                }),
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ partner_id: bobPartnerId.id }),
             ],
             channel_type: "chat",
         },
         {
             channel_member_ids: [
-                Command.create({
-                    message_unread_counter: 20,
-                    partner_id: serverState.partnerId,
-                }),
+                Command.create({ partner_id: serverState.partnerId }),
+                Command.create({ partner_id: bobPartnerId.id }),
             ],
             channel_type: "chat",
+        },
+    ]);
+    pyEnv["mail.message"].create([
+        {
+            author_id: bobPartnerId,
+            body: `hello channel 1`,
+            model: "discuss.channel",
+            res_id: channelIds[0],
+            message_type: "comment",
+        },
+        {
+            author_id: bobPartnerId,
+            body: "hello channel 2",
+            model: "discuss.channel",
+            res_id: channelIds[1],
+            message_type: "comment",
         },
     ]);
     await start();

--- a/addons/mail/static/tests/mail_test_helpers.js
+++ b/addons/mail/static/tests/mail_test_helpers.js
@@ -582,3 +582,18 @@ export function observeRenders() {
         return result;
     };
 }
+
+/**
+ * Determine if the child element is in the view port of the parent.
+ *
+ * @param {HTMLElement} parent
+ * @param {HTMLElement} child
+ */
+export function isInViewportOf(parent, child) {
+    const childRect = child.getBoundingClientRect();
+    const parentRect = parent.getBoundingClientRect();
+
+    return childRect.top <= parentRect.top
+        ? parentRect.top - childRect.top <= childRect.height
+        : childRect.bottom - parentRect.bottom <= childRect.height;
+}

--- a/addons/mail/static/tests/messaging_menu/notification.test.js
+++ b/addons/mail/static/tests/messaging_menu/notification.test.js
@@ -8,9 +8,13 @@ import {
     step,
     triggerEvents,
 } from "@mail/../tests/mail_test_helpers";
+import { rpcWithEnv } from "@mail/utils/common/misc";
 import { describe, expect, test } from "@odoo/hoot";
 import { mockDate } from "@odoo/hoot-mock";
-import { Command, mockService, serverState } from "@web/../tests/web_test_helpers";
+import { Command, mockService, serverState, withUser } from "@web/../tests/web_test_helpers";
+
+/** @type {ReturnType<import("@mail/utils/common/misc").rpcWithEnv>} */
+let rpc;
 
 describe.current.tags("desktop");
 defineMailModels();
@@ -266,8 +270,16 @@ test("marked as read thread notifications are ordered by last message date", asy
 
 test("thread notifications are re-ordered on receiving a new message", async () => {
     const pyEnv = await startServer();
+    const bobUserId = pyEnv["res.users"].create({ name: "Bob" });
+    const bobPartnerId = pyEnv["res.partner"].create({ name: "Bob", user_id: bobUserId.id });
     const [channelId_1, channelId_2] = pyEnv["discuss.channel"].create([
-        { name: "Channel 2019" },
+        {
+            name: "Channel 2019",
+            channel_member_ids: [
+                Command.create({ partner_id: bobPartnerId }),
+                Command.create({ partner_id: serverState.partnerId }),
+            ],
+        },
         { name: "Channel 2020" },
     ]);
     pyEnv["mail.message"].create([
@@ -282,23 +294,21 @@ test("thread notifications are re-ordered on receiving a new message", async () 
             res_id: channelId_2,
         },
     ]);
-    await start();
+    const env = await start();
+    rpc = rpcWithEnv(env);
     await click(".o_menu_systray i[aria-label='Messages']");
     await contains(".o-mail-NotificationItem", { count: 2 });
-    const channel_1 = pyEnv["discuss.channel"].search_read([["id", "=", channelId_1]])[0];
-    pyEnv["bus.bus"]._sendone(channel_1, "discuss.channel/new_message", {
-        id: channelId_1,
-        message: {
-            author: { id: 7, name: "Demo User" },
-            body: "<p>New message !</p>",
-            date: "2020-03-23 10:00:00",
-            id: 44,
-            message_type: "comment",
-            model: "discuss.channel",
-            record_name: "Channel 2019",
-            res_id: channelId_1,
-        },
-    });
+    await withUser(bobUserId, () =>
+        rpc("/mail/message/post", {
+            post_data: {
+                body: "<p>New message !</p>",
+                message_type: "comment",
+                subtype_xmlid: "mail.mt_comment",
+            },
+            thread_id: channelId_1,
+            thread_model: "discuss.channel",
+        })
+    );
     await contains(":nth-child(1 of .o-mail-NotificationItem)", { text: "Channel 2019" });
     await contains(":nth-child(2 of .o-mail-NotificationItem)", { text: "Channel 2020" });
     await contains(".o-mail-NotificationItem", { count: 2 });
@@ -338,19 +348,18 @@ test("messaging menu counter should ignore unread messages in channels that are 
 });
 
 test("subtype description should be displayed when body is empty", async () => {
-        const pyEnv = await startServer();
-        const partnerId = pyEnv["res.partner"].create({ name: "Partner1" });
-        const channelId = pyEnv["discuss.channel"].create({ name: "Test" });
-        const subtypeId = pyEnv["mail.message.subtype"].create({ description: "hello" });
-        pyEnv["mail.message"].create({
-            author_id: partnerId,
-            body: "",
-            model: "discuss.channel",
-            res_id: channelId,
-            subtype_id: subtypeId,
-        });
-        await start();
-        await click(".o_menu_systray i[aria-label='Messages']");
-        await contains(".o-mail-NotificationItem-text", { text: "Partner1: hello" });
-    }
-);
+    const pyEnv = await startServer();
+    const partnerId = pyEnv["res.partner"].create({ name: "Partner1" });
+    const channelId = pyEnv["discuss.channel"].create({ name: "Test" });
+    const subtypeId = pyEnv["mail.message.subtype"].create({ description: "hello" });
+    pyEnv["mail.message"].create({
+        author_id: partnerId,
+        body: "",
+        model: "discuss.channel",
+        res_id: channelId,
+        subtype_id: subtypeId,
+    });
+    await start();
+    await click(".o_menu_systray i[aria-label='Messages']");
+    await contains(".o-mail-NotificationItem-text", { text: "Partner1: hello" });
+});

--- a/addons/mail/static/tests/mock_server/mail_mock_server.js
+++ b/addons/mail/static/tests/mock_server/mail_mock_server.js
@@ -420,8 +420,8 @@ async function discuss_channel_mark_as_read(request) {
     /** @type {import("mock_models").DiscussChannel} */
     const DiscussChannel = this.env["discuss.channel"];
 
-    const { channel_id, last_message_id } = await parseRequestParams(request);
-    return DiscussChannel._mark_as_read([channel_id], last_message_id);
+    const { channel_id, last_message_id, sync } = await parseRequestParams(request);
+    return DiscussChannel._mark_as_read([channel_id], last_message_id, sync);
 }
 
 registerRoute("/discuss/channel/mark_as_unread", discuss_channel_mark_as_unread);
@@ -454,9 +454,9 @@ async function discuss_history_messages(request) {
     /** @type {import("mock_models").MailNotification} */
     const MailNotification = this.env["mail.notification"];
 
-    const { after, before, limit = 30, search_term } = await parseRequestParams(request);
+    const { after, around, before, limit = 30, search_term } = await parseRequestParams(request);
     const domain = [["needaction", "=", false]];
-    const res = MailMessage._message_fetch(domain, search_term, before, after, false, limit);
+    const res = MailMessage._message_fetch(domain, search_term, before, after, around, limit);
     const messagesWithNotification = res.messages.filter((message) => {
         const notifs = MailNotification.search_read([
             ["mail_message_id", "=", message.id],

--- a/addons/mail/static/tests/mock_server/mock_models/mail_message.js
+++ b/addons/mail/static/tests/mock_server/mock_models/mail_message.js
@@ -426,7 +426,7 @@ export class MailMessage extends models.ServerModel {
             domain.push(["body", "ilike", search_term]);
             res.count = this.search_count(domain);
         }
-        if (around) {
+        if (around !== undefined) {
             const messagesBefore = this._filter(domain.concat([["id", "<=", around]])).sort(
                 (m1, m2) => m2.id - m1.id
             );

--- a/addons/mail/static/tests/thread/unread_messages_banner.test.js
+++ b/addons/mail/static/tests/thread/unread_messages_banner.test.js
@@ -1,0 +1,55 @@
+import {
+    click,
+    contains,
+    defineMailModels,
+    openDiscuss,
+    start,
+    startServer,
+} from "@mail/../tests/mail_test_helpers";
+import { describe, test } from "@odoo/hoot";
+import { serverState } from "@web/../tests/web_test_helpers";
+
+describe.current.tags("desktop");
+defineMailModels();
+
+test("show unread messages banner when there are unread messages", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    for (let i = 0; i < 30; ++i) {
+        pyEnv["mail.message"].create({
+            author_id: serverState.partnerId,
+            body: `message ${i}`,
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", {
+        text: "message 0",
+    });
+    await contains("span", { text: "30 new messagesMark as Read" });
+});
+
+test("mark thread as read from unread messages banner", async () => {
+    const pyEnv = await startServer();
+    const channelId = pyEnv["discuss.channel"].create({ name: "General" });
+    for (let i = 0; i < 30; ++i) {
+        pyEnv["mail.message"].create({
+            author_id: serverState.partnerId,
+            body: `message ${i}`,
+            model: "discuss.channel",
+            res_id: channelId,
+        });
+    }
+    await start();
+    await openDiscuss(channelId);
+    await contains(".o-mail-Thread-newMessage ~ .o-mail-Message", {
+        text: "message 0",
+    });
+    await click("span", {
+        text: "Mark as Read",
+        parent: ["span", { text: "30 new messagesMark as Read" }],
+    });
+    await contains(".o-mail-Thread-jumpToUnread", { count: 0 });
+});

--- a/addons/mail/static/tests/tours/mail_message_load_order_tour.js
+++ b/addons/mail/static/tests/tours/mail_message_load_order_tour.js
@@ -24,20 +24,20 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
             run: "click",
         },
         {
-            // Messages depends on FETCH_LIMIT (currently set to 30) in
+            // Messages depends on FETCH_LIMIT (currently set to 60) in
             // the thread service. Thus, at first load the message range
             // will be (31 - 60). This trigger ensures the next messages
             // are fetched after jumping to the message.
             trigger: ".o-mail-Thread .o-mail-Message:first:not(:contains(31))",
             async run() {
-                await contains(".o-mail-Thread .o-mail-Message", { count: 16 });
+                await contains(".o-mail-Thread .o-mail-Message", { count: 31 });
                 await contains(".o-mail-Thread", { scroll: 0 });
-                // ensure 1 - 16 are loaded in order: 15 below and the
+                // ensure 1 - 31 are loaded in order: 30 below and the
                 // one we're loading messages around.
                 const messages = Array.from(
                     document.querySelectorAll(".o-mail-Thread .o-mail-Message-content")
                 ).map((el) => el.innerText);
-                for (let i = 0; i < 16; i++) {
+                for (let i = 0; i < 31; i++) {
                     if (messages[i] !== (i + 1).toString()) {
                         throw new Error("Wrong message order after loading around");
                     }
@@ -47,17 +47,17 @@ registry.category("web_tour.tours").add("mail_message_load_order_tour", {
         },
         {
             // After jumping to the pinned message, the message range
-            // was (1 -16): 15 before (but none were found), 15 after
+            // was (1 -31): 30 before (but none were found), 30 after
             // and the pinned message itself. This trigger ensures the
             // next messages are fetched after scrolling to the bottom.
             trigger: ".o-mail-Thread .o-mail-Message:contains(17)",
             async run() {
-                await contains(".o-mail-Thread .o-mail-Message", { count: 46 });
-                // ensure 1 - 46  are loaded in order.
+                await contains(".o-mail-Thread .o-mail-Message", { count: 60 });
+                // ensure 1 - 60  are loaded in order.
                 const messages = Array.from(
                     document.querySelectorAll(".o-mail-Thread .o-mail-Message-content")
                 ).map((el) => el.innerText);
-                for (let i = 0; i < 46; i++) {
+                for (let i = 0; i < 60; i++) {
                     if (messages[i] !== (i + 1).toString()) {
                         throw new Error("Wrong message order after loading after");
                     }

--- a/addons/mail/tests/discuss/test_discuss_channel.py
+++ b/addons/mail/tests/discuss/test_discuss_channel.py
@@ -227,7 +227,8 @@ class TestChannelInternals(MailCommon, HttpCase):
                                 "message_unread_counter": 0,
                                 "message_unread_counter_bus_id": last_bus_id + 1,
                                 "model": "discuss.channel",
-                            }
+                            },
+                            "syncUnread": False,
                         },
                     },
                 },

--- a/addons/mail/tests/discuss/test_load_messages.py
+++ b/addons/mail/tests/discuss/test_load_messages.py
@@ -20,4 +20,5 @@ class TestLoadMessages(HttpCaseWithUserDemo):
             "author_id": partner_admin.id,
             "message_type": "comment",
         } for n in range(1, 61)])
+        channel_id.with_user(partner_admin.user_ids[0])._mark_as_read(channel_id.message_ids[0].id)
         self.start_tour("/web#action=mail.action_discuss", "mail_message_load_order_tour", login="admin")


### PR DESCRIPTION
Currently, discuss channels open at the bottom of the discussion.
This is annoying as users have to scroll up to find the last message
they read.

After this PR, channels will directly open to the last read message
of the user.

To ease channel navigation further, a banner to jump to the last read
message is added.

task-3551627

enterprise: https://github.com/odoo/enterprise/pull/63180