### PR TITLE
[FIX] iap_tools: allow odoo domain for enrichment

### DIFF
--- a/addons/crm_iap_enrich/models/crm_lead.py
+++ b/addons/crm_iap_enrich/models/crm_lead.py
@@ -65,7 +65,7 @@ class Lead(models.Model):
 
                         email_domain = normalized_email.split('@')[1]
                         # Discard domains of generic email providers as it won't return relevant information
-                        if email_domain in iap_tools._MAIL_DOMAIN_BLACKLIST:
+                        if email_domain in iap_tools._MAIL_PROVIDERS:
                             lead.write({'iap_enrich_done': True})
                             lead.message_post_with_view(
                                 'crm_iap_enrich.mail_message_lead_enrich_notfound',

--- a/addons/iap/tools/iap_tools.py
+++ b/addons/iap/tools/iap_tools.py
@@ -38,7 +38,7 @@ BaseCase.setUp = setUp
 # Tools globals
 #----------------------------------------------------------
 
-_MAIL_DOMAIN_BLACKLIST = set([
+_MAIL_PROVIDERS = {
     'gmail.com', 'hotmail.com', 'yahoo.com', 'qq.com', 'outlook.com', '163.com', 'yahoo.fr', 'live.com', 'hotmail.fr', 'icloud.com', '126.com',
     'me.com', 'free.fr', 'ymail.com', 'msn.com', 'mail.com', 'orange.fr', 'aol.com', 'wanadoo.fr', 'live.fr', 'mail.ru', 'yahoo.co.in',
     'rediffmail.com', 'hku.hk', 'googlemail.com', 'gmx.de', 'sina.com', 'skynet.be', 'laposte.net', 'yahoo.co.uk', 'yahoo.co.id', 'web.de',
@@ -46,7 +46,7 @@ _MAIL_DOMAIN_BLACKLIST = set([
     'sfr.fr', 'libero.it', 'mac.com', 'rocketmail.com', 'protonmail.com', 'gmx.com', 'gamil.com', 'hotmail.es', 'gmx.net', 'comcast.net',
     'yahoo.com.mx', 'linkedin.com', 'yahoo.com.br', 'yahoo.in', 'yahoo.ca', 't-online.de', '139.com', 'yandex.ru', 'yahoo.com.hk','yahoo.de',
     'yeah.net', 'yandex.com', 'nwytg.net', 'neuf.fr', 'yahoo.com.ar', 'outlook.es', 'abv.bg', 'aliyun.com', 'yahoo.com.tw', 'ukr.net', 'live.nl',
-    'wp.pl', 'hotmail.it', 'live.com.mx', 'zoho.com', 'live.co.uk', 'sohu.com', 'twoomail.com', 'yahoo.com.sg', 'odoo.com', 'yahoo.com.vn',
+    'wp.pl', 'hotmail.it', 'live.com.mx', 'zoho.com', 'live.co.uk', 'sohu.com', 'twoomail.com', 'yahoo.com.sg', 'yahoo.com.vn',
     'windowslive.com', 'gmail', 'vols.utk.edu', 'email.com', 'tiscali.it', 'yahoo.it', 'gmx.ch', 'trbvm.com', 'nwytg.com', 'mvrht.com', 'nyit.edu',
     'o2.pl', 'live.cn', 'gmial.com', 'seznam.cz', 'live.be', 'videotron.ca', 'gmil.com', 'live.ca', 'hotmail.de', 'sbcglobal.net', 'connect.hku.hk',
     'yahoo.com.au', 'att.net', 'live.in', 'btinternet.com', 'gmx.fr', 'voila.fr', 'shaw.ca', 'prodigy.net.mx', 'vip.qq.com', 'yahoo.com.ph',
@@ -64,7 +64,8 @@ _MAIL_DOMAIN_BLACKLIST = set([
     'prisme.ch', 'bbox.fr', 'orbitalu.com', 'netcourrier.com', 'iinet.net.au', 'cegetel.net', 'proton.me', 'dbmail.com',
     # Dummy entries
     'example.com',
-])
+}
+_MAIL_DOMAIN_BLACKLIST = _MAIL_PROVIDERS | {'odoo.com'}
 
 # List of country codes for which we should offer state filtering when mining new leads.
 # See crm.iap.lead.mining.request#_compute_available_state_ids() or task-2471703 for more details.

--- a/addons/mail_plugin/controllers/mail_plugin.py
+++ b/addons/mail_plugin/controllers/mail_plugin.py
@@ -262,7 +262,7 @@ class MailPluginController(http.Controller):
         Returns enrichment data for a given domain, in case an error happens the response will
         contain an enrichment_info key explaining what went wrong
         """
-        if domain in iap_tools._MAIL_DOMAIN_BLACKLIST:
+        if domain in iap_tools._MAIL_PROVIDERS:
             # Can not enrich the provider domain names (gmail.com; outlook.com, etc)
             return {'enrichment_info': {'type': 'missing_data'}}
 

--- a/addons/partner_autocomplete/models/res_company.py
+++ b/addons/partner_autocomplete/models/res_company.py
@@ -118,7 +118,7 @@ class ResCompany(models.Model):
         self.ensure_one()
 
         company_domain = tools.email_domain_extract(self.email) if self.email else False
-        if company_domain and company_domain not in iap_tools._MAIL_DOMAIN_BLACKLIST:
+        if company_domain and company_domain not in iap_tools._MAIL_PROVIDERS:
             return company_domain
 
         company_domain = tools.url_domain_extract(self.website) if self.website else False


### PR DESCRIPTION
Removed odoo domain from blacklist, so that emails from odoo.com can be used for enrichment for demo/testing purposes.

Task-3939876
