### PR TITLE
[IMP] setup: IoT Box Homepage shortcut to desktop

### DIFF
--- a/setup/win32/setup.nsi
+++ b/setup/win32/setup.nsi
@@ -304,6 +304,7 @@ Section $(TITLE_IOT) IOT
     WriteIniStr "$INSTDIR\server\odoo.conf" "options" "server_wide_modules" "web,hw_posbox_homepage,hw_drivers"
     WriteIniStr "$INSTDIR\server\odoo.conf" "options" "list_db" "False"
     WriteIniStr "$INSTDIR\server\odoo.conf" "options" "max_cron_threads" "0"
+    CreateShortcut "$DESKTOP\Odoo IoT Box Homepage.lnk" "http://localhost:8069"
     nsExec::ExecToStack '"$INSTDIR\python\python.exe" "$INSTDIR\server\odoo-bin" genproxytoken'
     pop $0
     pop $ProxyTokenPwd


### PR DESCRIPTION
We have a lot of feedback of clients who close and fail to find their IoT Box homepage afterwards.
This PR adds a shortcut to the client's desktop when installing Odoo with the IoT option selected

task-3930141
