### PR TITLE
[IMP] (hr,sale)_timesheet: set the correct unit_amount label on views

### DIFF
--- a/addons/hr_timesheet/models/hr_timesheet.py
+++ b/addons/hr_timesheet/models/hr_timesheet.py
@@ -270,25 +270,6 @@ class AccountAnalyticLine(models.Model):
                         view_data['toolbar']['print'] = [print_data for print_data in print_data_list if print_data['id'] != wip_report_id]
         return res
 
-    @api.model
-    def _get_view(self, view_id=None, view_type='form', **options):
-        """ Set the correct label for `unit_amount`, for timesheet record"""
-        arch, view = super()._get_view(view_id, view_type, **options)
-        # Use of sudo as the portal user doesn't have access to uom
-        arch = self.sudo()._apply_timesheet_label(arch, view_type=view_type)
-        return arch, view
-
-    @api.model
-    def _apply_timesheet_label(self, view_node, view_type='form'):
-        doc = view_node
-        encoding_uom = self.env.company.timesheet_encode_uom_id
-        # Here, we select only the unit_amount field having no string set to give priority to
-        # custom inheretied view stored in database. Even if normally, no xpath can be done on
-        # 'string' attribute.
-        for node in doc.xpath("//field[@name='unit_amount'][@widget='timesheet_uom'][not(@string)]"):
-            node.set('string', _('Time Spent'))
-        return doc
-
     def _timesheet_get_portal_domain(self):
         if self.env.user.has_group('hr_timesheet.group_hr_timesheet_user'):
             # Then, he is internal user, and we take the domain for this current user

--- a/addons/hr_timesheet/models/project_task.py
+++ b/addons/hr_timesheet/models/project_task.py
@@ -237,12 +237,6 @@ class Task(models.Model):
                     )
                     task.display_name = task.display_name + "\u00A0" + hours_left
 
-    @api.model
-    def _get_view(self, view_id=None, view_type='form', **options):
-        arch, view = super()._get_view(view_id, view_type, **options)
-        arch = self.env['account.analytic.line'].sudo()._apply_timesheet_label(arch)
-        return arch, view
-
     @api.ondelete(at_uninstall=False)
     def _unlink_except_contains_entries(self):
         """

--- a/addons/hr_timesheet/views/hr_timesheet_views.xml
+++ b/addons/hr_timesheet/views/hr_timesheet_views.xml
@@ -15,7 +15,7 @@
                         context="{'default_project_id': project_id, 'search_default_my_tasks': True, 'search_default_open_tasks': True}"
                         readonly="readonly_timesheet"/>
                     <field name="name" optional="show" required="0" readonly="readonly_timesheet"/>
-                    <field name="unit_amount" optional="show" widget="timesheet_uom" sum="Total" readonly="readonly_timesheet"
+                    <field name="unit_amount" string="Time Spent" optional="show" widget="timesheet_uom" sum="Total" readonly="readonly_timesheet"
                         decoration-danger="unit_amount &gt; 24 or unit_amount &lt; 0" decoration-muted="unit_amount == 0"/>
                     <field name="company_id" column_invisible="True"/>
                     <field name="user_id" column_invisible="True"/>
@@ -64,7 +64,7 @@
                 <pivot string="Timesheets" sample="1">
                     <field name="employee_id" type="row"/>
                     <field name="date" interval="month" type="col"/>
-                    <field name="unit_amount" type="measure" widget="timesheet_uom"/>
+                    <field name="unit_amount" string="Time Spent" type="measure" widget="timesheet_uom"/>
                     <field name="amount" string="Timesheet Costs"/>
                 </pivot>
             </field>
@@ -76,7 +76,7 @@
             <field name="arch" type="xml">
                 <pivot string="Timesheet" sample="1">
                     <field name="date" interval="week" type="row"/>
-                    <field name="unit_amount" type="measure" widget="timesheet_uom"/>
+                    <field name="unit_amount" string="Time Spent" type="measure" widget="timesheet_uom"/>
                     <field name="amount" string="Timesheet Costs"/>
                 </pivot>
             </field>
@@ -89,7 +89,7 @@
                 <graph string="Timesheets" sample="1" js_class="hr_timesheet_graphview">
                     <field name="task_id"/>
                     <field name="project_id"/>
-                    <field name="unit_amount" type="measure" widget="timesheet_uom"/>
+                    <field name="unit_amount" string="Time Spent" type="measure" widget="timesheet_uom"/>
                     <field name="amount" string="Timesheet Costs"/>
                 </graph>
             </field>
@@ -104,7 +104,7 @@
                     <field name="date" interval="week"/>
                     <field name="project_id"/>
                     <field name="amount" type="measure" string="Timesheet Costs"/>
-                    <field name="unit_amount" type="measure" widget="timesheet_uom"/>
+                    <field name="unit_amount" string="Time Spent" type="measure" widget="timesheet_uom"/>
                 </graph>
             </field>
         </record>
@@ -118,7 +118,7 @@
                     <field name="employee_id"/>
                     <field name="project_id"/>
                     <field name="amount" type="measure" string="Timesheet Costs"/>
-                    <field name="unit_amount" type="measure" widget="timesheet_uom"/>
+                    <field name="unit_amount" string="Time Spent" type="measure" widget="timesheet_uom"/>
                 </graph>
             </field>
         </record>
@@ -174,7 +174,7 @@
                             <group>
                                 <field name="date" readonly="readonly_timesheet"/>
                                 <field name="amount" invisible="1"/>
-                                <field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"
+                                <field name="unit_amount" string="Time Spent" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"
                                     readonly="readonly_timesheet" decoration-muted="unit_amount == 0"/>
                                 <field name="currency_id" invisible="1"/>
                                 <field name="company_id" invisible="1"/>

--- a/addons/hr_timesheet/views/project_task_sharing_views.xml
+++ b/addons/hr_timesheet/views/project_task_sharing_views.xml
@@ -51,7 +51,7 @@
                             <field name="date"/>
                             <field name="employee_id"/>
                             <field name="name"/>
-                            <field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"/>
+                            <field name="unit_amount" string="Time Spent" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24"/>
                         </tree>
                         <kanban class="o_kanban_mobile">
                             <field name="date"/>

--- a/addons/hr_timesheet/views/project_task_views.xml
+++ b/addons/hr_timesheet/views/project_task_views.xml
@@ -47,7 +47,7 @@
                                 required="1"
                                 readonly="readonly_timesheet"/>
                             <field name="name" required="0" readonly="readonly_timesheet"/>
-                            <field name="unit_amount" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24 or unit_amount &lt; 0"
+                            <field name="unit_amount" string="Time Spent" widget="timesheet_uom" decoration-danger="unit_amount &gt; 24 or unit_amount &lt; 0"
                                 readonly="readonly_timesheet"/>
                             <field name="project_id" column_invisible="True"/>
                             <field name="task_id" column_invisible="True"/>
@@ -95,7 +95,7 @@
                                     <field name="user_id" invisible="1" readonly="readonly_timesheet"/>
                                     <field name="employee_id" widget="many2one_avatar_employee" context="{'active_test': True}" required="1" readonly="readonly_timesheet"/>
                                     <field name="name" required="0" readonly="readonly_timesheet"/>
-                                    <field name="unit_amount" string="Duration" widget="float_time" decoration-danger="unit_amount &gt; 24"
+                                    <field name="unit_amount" string="Time Spent" widget="float_time" decoration-danger="unit_amount &gt; 24"
                                         readonly="readonly_timesheet"/>
                                     <field name="project_id" invisible="1"/>
                                     <field name="task_id" invisible="1"/>

--- a/addons/sale_timesheet/views/hr_timesheet_views.xml
+++ b/addons/sale_timesheet/views/hr_timesheet_views.xml
@@ -95,7 +95,7 @@
             <pivot string="Timesheets" sample="1">
                 <field name="date" interval="month" type="row"/>
                 <field name="timesheet_invoice_type" type="col"/>
-                <field name="unit_amount" type="measure" widget="timesheet_uom"/>
+                <field name="unit_amount" string="Time Spent" type="measure" widget="timesheet_uom"/>
                 <field name="amount" string="Timesheet Costs"/>
             </pivot>
         </field>
@@ -109,7 +109,7 @@
                 <field name="date" interval="month" />
                 <field name="employee_id"/>
                 <field name="amount" type="measure" string="Timesheet Costs"/>
-                <field name="unit_amount" type="measure" widget="timesheet_uom"/>
+                <field name="unit_amount" string="Time Spent" type="measure" widget="timesheet_uom"/>
             </graph>
         </field>
     </record>


### PR DESCRIPTION
With task 3330297, the override made to set the right label to unit_amount field is no longer needed. This PR will remove the override and set the correct label for this field in every view.

task-3911485