### PR TITLE
[IMP] project: open expanded view of project/task in Gantt/Calendar 

### DIFF
--- a/addons/project/models/project_project.py
+++ b/addons/project/models/project_project.py
@@ -724,6 +724,16 @@ class Project(models.Model):
             }
         }
 
+    def action_view_project(self):
+        self.ensure_one()
+        return {
+            'name': _('Project'),
+            'type': 'ir.actions.act_window',
+            'res_model': 'project.project',
+            'view_mode': 'form',
+            'res_id': self.id,
+        }
+
     # ---------------------------------------------
     #  PROJECT UPDATES
     # ---------------------------------------------

--- a/addons/project/static/tests/project_models.js
+++ b/addons/project/static/tests/project_models.js
@@ -4,10 +4,12 @@ export class ProjectProject extends models.Model {
     _name = "project.project";
 
     name = fields.Char();
+    planned_date_begin = fields.Datetime({ string: "Start Date" });
+    planned_date_stop = fields.Datetime({ string: "stop Date" });
 
     _records = [
-        { id: 1, name: "Project 1" },
-        { id: 2, name: "Project 2" },
+        { id: 1, name: "Project 1", planned_date_begin: "2019-03-12 06:30:00"},
+        { id: 2, name: "Project 2", planned_date_begin: "2019-03-14 06:30:00"},
     ];
 }
 

--- a/addons/project/static/tests/project_task_calendar_view.test.js
+++ b/addons/project/static/tests/project_task_calendar_view.test.js
@@ -1,0 +1,103 @@
+import { expect, test,beforeEach, describe } from "@odoo/hoot";
+import { click,} from "@mail/../tests/mail_test_helpers";
+import { mountView, onRpc, contains, webModels } from "@web/../tests/web_test_helpers";
+import { ProjectTask } from "./project_models";
+import { defineProjectModels, ProjectProject } from "@project/../tests/project_models";
+
+defineProjectModels();
+describe.current.tags("desktop");
+
+beforeEach(() => {
+    webModels.ResUsers._records = [
+        { id: 1, name: "User1" },
+        ...webModels.ResUsers._records,
+    ];
+    ProjectProject._records = [
+        { id: 1, name: "service", planned_date_begin: "2019-03-12 06:30:00",},
+    ];
+    ProjectTask._records = [
+        {
+            name: "Task 1",
+            planned_date_begin: "2019-03-12 06:30:00",
+            date_deadline: "2019-03-12 12:30:00",
+            project_id: 1,
+            user_ids: [1],
+        },
+    ];
+});
+
+onRpc(async ({ method }) => {
+    if (method === "check_access_rights") {
+        return true;
+    } else if(method === "get_formview_id") {
+        return true;
+    }
+});
+
+test("fa-expand button test for task form view ", async () => {
+    ProjectTask._views.form = `
+    <form>
+        <field name="name"/>
+        <footer>
+            <button string="Save &amp; Close" special="save" data-hotkey="q" class="btn btn-primary" close="1"/>
+            <button string="Discard" special="cancel" data-hotkey="x" class="btn btn-secondary" close="1"/>
+            <button name="action_open_task" type="object" title="View task" class="btn btn-secondary w-md-auto ms-auto" close="1">
+                <i class="fa fa-expand"/>
+            </button>
+        </footer>
+    </form>`;
+
+    onRpc(async ({ method }) => {
+        if(method === "action_open_task") {
+            expect.step(method)
+            return true;
+        }
+    });
+
+    await mountView({
+        type:'calendar',
+        resModel:'project.task',
+        arch: `<calendar date_start="planned_date_begin" event_open_popup="1" js_class="project_task_calendar" mode="month"/>`,
+    });
+
+    expect(".o_event_title").toHaveCount(1);
+    await click(".o_event_title");
+
+    await click(".o_cw_popover_edit");
+    await contains("button[name='action_open_task']").click();
+    expect(['action_open_task']).toVerifySteps();
+});
+
+test("fa-expand button test for project form view ", async () => {
+    ProjectProject._views.form = `
+    <form>
+        <field name="name"/>
+        <footer>
+            <button string="Save &amp; Close" special="save" data-hotkey="q" class="btn btn-primary" close="1"/>
+            <button string="Discard" special="cancel" data-hotkey="x" class="btn btn-secondary" close="1"/>
+            <button name="action_view_project" type="object" title="View Project" class="btn btn-secondary w-md-auto ms-auto" close="1">
+                <i class="fa fa-expand"/>
+            </button>
+        </footer>
+    </form>`;
+
+    onRpc(async ({ method }) => {
+        if(method === "action_view_project") {
+            expect.step(method)
+            return true;
+        }
+    });
+
+    await mountView({
+        type:'calendar',
+        resModel:'project.project',
+        arch: `<calendar date_start="planned_date_begin" event_open_popup="true" js_class="project_project_calendar" mode="month"/>`,
+    });
+
+    expect(".o_event_title").toHaveCount(1);
+    await click(".o_event_title");
+
+    await click(".o_cw_popover_edit");
+    await contains("button[name='action_view_project']").click();
+    expect(['action_view_project']).toVerifySteps();
+});

--- a/addons/project/views/project_project_views.xml
+++ b/addons/project/views/project_project_views.xml
@@ -558,6 +558,25 @@
             </field>
         </record>
 
+        <record id="project_project_view_form_in_calendar" model="ir.ui.view">
+            <field name="name">project.project.view.form.calendar</field>
+            <field name="model">project.project</field>
+            <field name="inherit_id" ref="edit_project"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//sheet" position="after">
+                    <footer>
+                        <button string="Save &amp; Close" special="save" data-hotkey="q" class="btn btn-primary" close="1"/>
+                        <button string="Discard" special="cancel" data-hotkey="x" class="btn btn-secondary" close="1"/>
+                        <button name="action_view_project" type="object" title="View project"
+                            class="btn btn-secondary w-md-auto ms-auto">
+                            <i class="fa fa-expand"/>
+                        </button>
+                    </footer>
+                </xpath>
+            </field>
+        </record>
+
         <record id="view_project_calendar" model="ir.ui.view">
             <field name="name">project.project.calendar</field>
             <field name="model">project.project</field>
@@ -565,6 +584,7 @@
                 <calendar
                     date_start="date_start"
                     date_stop="date"
+                    form_view_id="%(project.project_project_view_form_in_calendar)d"
                     string="Projects"
                     mode="month"
                     scales="month,year"

--- a/addons/project/views/project_task_views.xml
+++ b/addons/project/views/project_task_views.xml
@@ -820,12 +820,32 @@
             </field>
         </record>
 
+        <record id="project_task_view_form_in_calendar" model="ir.ui.view">
+            <field name="name">project.task.view.form.calendar</field>
+            <field name="model">project.task</field>
+            <field name="inherit_id" ref="view_task_form2"/>
+            <field name="mode">primary</field>
+            <field name="arch" type="xml">
+                <xpath expr="//sheet" position="after">
+                    <footer>
+                        <button string="Save &amp; Close" special="save" data-hotkey="q" class="btn btn-primary" close="1"/>
+                        <button string="Discard" special="cancel" data-hotkey="x" class="btn btn-secondary" close="1"/>
+                        <button name="action_open_task" type="object" title="View task"
+                            class="btn btn-secondary w-md-auto ms-auto">
+                            <i class="fa fa-expand"/>
+                        </button>
+                    </footer>
+                </xpath>
+            </field>
+        </record>
+
         <record id="view_task_calendar" model="ir.ui.view">
             <field name="name">project.task.calendar</field>
             <field name="model">project.task</field>
             <field eval="2" name="priority"/>
             <field name="arch" type="xml">
                 <calendar date_start="date_deadline" string="Tasks" mode="month"
+                          form_view_id="%(project_task_view_form_in_calendar)d"
                           color="stage_id" event_limit="5" hide_time="true"
                           event_open_popup="true" quick_create="0" show_unusual_days="True"
                           js_class="project_task_calendar"


### PR DESCRIPTION
Currently, when user open a task or project in the calendar or Gantt view, they cannot access the chatter. With this commit, they can now access the form view through the expanded button.

Task: 3837229

