### PR TITLE
[FIX] web_editor: selection across contenteditable false element

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -6562,6 +6562,37 @@ X[]
                     contentAfter: '<p>ab<a href="#">cd</a>[]ef</p>',
                 });
             });
+            it('should select banner forward', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p>abc</p>
+                        <p>de[f]</p>
+                        <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                            <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                            <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                                <p>ghi</p>
+                                <p>jkl</p>
+                            </div>
+                        </div>
+                        <p>mno</p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowRight', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p>abc</p>
+                        <p>de[f</p>
+                        <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                            <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                            <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                                <p>ghi</p>
+                                <p>jkl</p>
+                            </div>
+                        </div>
+                        <p>]mno</p>
+                    `),
+                });
+            });
         });
         describe('ArrowLeft', () => {
             it('should move past a zws (collapsed)', async () => {
@@ -6772,6 +6803,103 @@ X[]
                         '\ufeff' + // after zwnbsp
                     'ef</p>',
                     contentAfter: '<p>ab<a href="#">cd[]</a>ef</p>',
+                });
+            });
+            it('should select banner backwards', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p>abc</p>
+                        <p>def</p>
+                        <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                            <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                            <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                                <p>ghi</p>
+                                <p>jkl</p>
+                            </div>
+                        </div>
+                        <p>]m[no</p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowLeft', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p>abc</p>
+                        <p>def]</p>
+                        <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                            <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                            <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                                <p>ghi</p>
+                                <p>jkl</p>
+                            </div>
+                        </div>
+                        <p>m[no</p>
+                    `),
+                });
+            });
+        });
+        describe('ArrowUp', () => {
+            it('should select banner backwards', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p>abc</p>
+                        <p>def</p>
+                        <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                            <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                            <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                                <p>ghi</p>
+                                <p>jkl</p>
+                            </div>
+                        </div>
+                        <p>mn[]o</p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowUp', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p>abc</p>
+                        <p>def]</p>
+                        <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                            <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                            <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                                <p>ghi</p>
+                                <p>jkl</p>
+                            </div>
+                        </div>
+                        <p>mn[o</p>
+                    `),
+                });
+            });
+        });
+        describe('ArrowDown', () => {
+            it('should select banner forwards', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: unformat(`
+                        <p>abc</p>
+                        <p>d[]ef</p>
+                        <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                            <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                            <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                                <p>ghi</p>
+                                <p>jkl</p>
+                            </div>
+                        </div>
+                        <p>mno</p>
+                    `),
+                    stepFunction: async editor => {
+                        await triggerEvent(editor.editable, 'keydown', { key: 'ArrowDown', shiftKey: true });
+                    },
+                    contentAfter: unformat(`
+                        <p>abc</p>
+                        <p>d[ef</p>
+                        <div class="o_editor_banner o_not_editable lh-1 d-flex align-items-center alert alert-info pb-0 pt-3" role="status" data-oe-protected="true" contenteditable="false">
+                            <i class="fs-4 fa fa-info-circle mb-3" aria-label="Banner Info"></i>
+                            <div class="w-100 ms-3" data-oe-protected="false" contenteditable="true">
+                                <p>ghi</p>
+                                <p>jkl</p>
+                            </div>
+                        </div>
+                        <p>]mno</p>
+                    `),
                 });
             });
         });


### PR DESCRIPTION

Description of the issue this PR addresses:

Previously, selection using Shift + Arrow keys was not possible across contenteditable="false" elements such as banners and clipboards. This commit makes sure now selection be done across these elements using Shift + Arrow keys.

task-3502724