### PR TITLE
[IMP] web, account: shortcut keys for invoice

### DIFF
--- a/addons/account/static/src/components/account_move_form/account_move_form_notebook.xml
+++ b/addons/account/static/src/components/account_move_form/account_move_form_notebook.xml
@@ -4,6 +4,7 @@
     <t t-name="account.AccountMoveFormNotebook" t-inherit="web.Notebook" t-inherit-mode="primary">
         <xpath expr="//a[@class='nav-link']" position="attributes">
             <attribute name="t-on-click.prevent">() => this.changeTabTo(navItem[0])</attribute>
+            <attribute name="tabindex">-1</attribute>
         </xpath>
     </t>
 </templates>

--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -719,7 +719,8 @@
                                 invisible="move_type != 'entry' or state != 'posted' or payment_state == 'reversed'"/>
                         <button name="action_reverse" string='Credit Note'
                                 type='object' groups="account.group_account_invoice"
-                                invisible="move_type not in ('out_invoice', 'in_invoice') or state != 'posted'"/>
+                                invisible="move_type not in ('out_invoice', 'in_invoice') or state != 'posted'"
+                                data-hotkey="n"/>
                         <!-- Cancel -->
                         <button name="button_cancel" string="Cancel Entry" type="object" groups="account.group_account_invoice" data-hotkey="x"
                                 invisible="not id or state != 'draft' or move_type != 'entry'"/>

--- a/addons/account_edi/views/account_move_views.xml
+++ b/addons/account_edi/views/account_move_views.xml
@@ -79,7 +79,8 @@
                             string="Request EDI Cancellation"
                             type="object"
                             groups="account.group_account_invoice"
-                            invisible="not edi_show_cancel_button"/>
+                            invisible="not edi_show_cancel_button"
+                            data-hotkey="x"/>
                     <button name="button_abandon_cancel_posted_posted_moves"
                             string="Call off EDI Cancellation"
                             type="object"

--- a/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
+++ b/addons/l10n_in_edi_ewaybill/views/account_move_views.xml
@@ -7,7 +7,7 @@
         <field name="arch" type="xml">
             <xpath expr="//button[@name='button_set_checked']" position="after">
                 <field name="l10n_in_edi_ewaybill_show_send_button" invisible="1"/>
-                <button name="l10n_in_edi_ewaybill_send" string="Send E-waybill" class="oe_highlight" type="object" groups="account.group_account_invoice" invisible="not l10n_in_edi_ewaybill_show_send_button"/>
+                <button name="l10n_in_edi_ewaybill_send" string="Send E-waybill" class="oe_highlight" type="object" groups="account.group_account_invoice" invisible="not l10n_in_edi_ewaybill_show_send_button" data-hotkey="e"/>
             </xpath>
             <xpath expr="//notebook/page[@name='other_info']" position="before">
                 <page string="eWayBill" name="l10n_in_edi_ewaybill_page"

--- a/addons/web/static/src/core/datetime/datetimepicker_service.js
+++ b/addons/web/static/src/core/datetime/datetimepicker_service.js
@@ -216,6 +216,11 @@ export const datetimePickerService = {
                  * @param {KeyboardEvent} ev
                  */
                 const onInputKeydown = (ev) => {
+                    if (ev.key == "Enter" && ev.ctrlKey) {
+                        ev.preventDefault();
+                        updateValueFromInputs();
+                        return openPicker(ev.target === getInput(1) ? 1 : 0);
+                    }
                     switch (ev.key) {
                         case "Enter":
                         case "Escape": {

--- a/addons/web/static/tests/views/fields/date_field.test.js
+++ b/addons/web/static/tests/views/fields/date_field.test.js
@@ -1,7 +1,11 @@
 import { expect, test } from "@odoo/hoot";
-import { queryAll, queryOne, scroll } from "@odoo/hoot-dom";
+import { edit, press, queryAll, queryOne, scroll } from "@odoo/hoot-dom";
 import { animationFrame, mockDate, mockTimeZone } from "@odoo/hoot-mock";
-import { getPickerCell, zoomOut } from "@web/../tests/core/datetime/datetime_test_helpers";
+import {
+    assertDateTimePicker,
+    getPickerCell,
+    zoomOut,
+} from "@web/../tests/core/datetime/datetime_test_helpers";
 import {
     clickSave,
     contains,
@@ -57,6 +61,52 @@ test("toggle datepicker", async () => {
     expect(".o_datetime_picker").toHaveCount(0);
 });
 
+test.tags("desktop")("open datepicker on Control+Enter", async () => {
+    defineParams({
+        lang_parameters: {
+            date_format: "%d/%m/%Y",
+            time_format: "%H:%M:%S",
+        },
+    });
+    await mountView({
+        resModel: "res.partner",
+        type: "form",
+        arch: `
+            <form>
+                <field name="date"/>
+            </form>
+        `,
+    });
+
+    expect(".o_field_date input").toHaveCount(1);
+
+    press(["ctrl", "enter"]);
+    await animationFrame();
+    expect(".o_datetime_picker").toHaveCount(1);
+
+    //edit the input and open the datepicker again with ctrl+enter
+    await contains(".o_field_date .o_input").click();
+    edit("09/01/1997");
+    press(["ctrl", "enter"]);
+    await animationFrame();
+    assertDateTimePicker({
+        title: "January 1997",
+        date: [
+            {
+                cells: [
+                    [-29, -30, -31, 1, 2, 3, 4],
+                    [5, 6, 7, 8, [9], 10, 11],
+                    [12, 13, 14, 15, 16, 17, 18],
+                    [19, 20, 21, 22, 23, 24, 25],
+                    [26, 27, 28, 29, 30, 31, -1],
+                    [-2, -3, -4, -5, -6, -7, -8],
+                ],
+                daysOfWeek: ["#", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"],
+                weekNumbers: [1, 2, 3, 4, 5, 6],
+            },
+        ],
+    });
+});
 test("toggle datepicker far in the future", async () => {
     Partner._records[0].date = "9999-12-31";
     await mountView({ type: "form", resModel: "res.partner", resId: 1 });


### PR DESCRIPTION
- Added new shortcut keys:
  - Alt+N for creating a credit note
  - Alt+X for EDI cancellation
  - Alt+E to send an e-waybill

- Updated tab navigation in the form view: pressing the Tab key after the last
  field in the sheet now focuses on the `invoice_line_ids` field instead of the
  `notebook pages`.

- As of now, the datetime picker opens on a mouse click.
  This commit provides an option to open the datetime picker by pressing
  the space key.
  Also after entering the date manually when the user presses the space key the
  datetime picker updates according to the date.

Task-3769922