### PR TITLE
[FIX] point_of_sale: show margins and costs for admin

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/product_info_popup/product_info_popup.js
@@ -20,7 +20,7 @@ export class ProductInfoPopup extends Component {
     _hasMarginsCostsAccessRights() {
         const isAccessibleToEveryUser =
             this.pos.config.is_margins_costs_accessible_to_every_user;
-        const isCashierManager = this.pos.get_cashier().role === "manager";
+        const isCashierManager = this.pos.get_cashier().raw.role === "manager";
         return isAccessibleToEveryUser || isCashierManager;
     }
 }

--- a/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
+++ b/addons/point_of_sale/static/tests/tours/ProductScreen.tour.js
@@ -238,3 +238,18 @@ registry.category("web_tour.tours").add("TranslateProductNameTour", {
             Chrome.endTour(),
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("CheckProductInformation", {
+    test: true,
+    url: "/pos/ui",
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            ProductScreen.clickShowProductsMobile(),
+            ProductScreen.clickInfoProduct("product_a"),
+            {
+                trigger: ".section-financials :contains('Margin')",
+                run: () => {},
+            },
+        ].flat(),
+});

--- a/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
+++ b/addons/point_of_sale/static/tests/tours/helpers/ProductScreenTourMethods.js
@@ -33,6 +33,14 @@ export function clickDisplayedProduct(name) {
         },
     ];
 }
+export function clickInfoProduct(name) {
+    return [
+        {
+            content: `click product '${name}'`,
+            trigger: `article.product:contains("${name}") .product-information-tag`,
+        },
+    ];
+}
 export function clickOrderline(productName, quantity = "1.0") {
     return [
         ...clickLine(productName, quantity),

--- a/addons/point_of_sale/tests/test_frontend.py
+++ b/addons/point_of_sale/tests/test_frontend.py
@@ -580,6 +580,11 @@ class TestUi(TestPointOfSaleHttpCommon):
         self.main_pos_config.with_user(self.pos_user).open_ui()
         self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'TicketScreenTour', login="pos_user")
 
+    def test_product_information_screen_admin(self):
+        self.product_a.available_in_pos = True
+        self.main_pos_config.with_user(self.pos_admin).open_ui()
+        self.start_tour("/pos/ui?config_id=%d" % self.main_pos_config.id, 'CheckProductInformation', login="pos_admin")
+
     def test_fixed_tax_negative_qty(self):
         """ Assert the negative amount of a negative-quantity orderline
             with zero-amount product with fixed tax.


### PR DESCRIPTION
Currently administrators for the POS app don't see margins and costs when the setting is disabled. The setting should only affect simple POS users and admins should always see the margins and costs.

Steps to reproduce:
-------------------
* Connect as admin
* Go to the current user settings and make sure he is a POS administrator
* Go the **Point of Sale** App
* Go to setting, make sure **Margins and Costs** is disabled
* Open a shop session
* Select the information icon on a product
> Margins and Costs are not shown

Why the fix:
------------
Data loaded is different since using the new relational model https://github.com/odoo/odoo/commit/28b7d698be8255f933ba5314e44e7059746fc234

opw-3897694