### PR TITLE
[IMP] odoo/template_inheritance: replace text when inserting node

### DIFF
--- a/odoo/addons/base/tests/test_views.py
+++ b/odoo/addons/base/tests/test_views.py
@@ -695,6 +695,28 @@ class TestApplyInheritanceMoveSpecs(ViewCase):
             )
         )
 
+    def test_move_with_tail(self):
+        moved_paragraph_xpath = E.xpath(expr="//p", position="move")
+        moved_paragraph_xpath.tail = "tail of paragraph"
+        spec = E.xpath(
+            E.p("Content2", {'class': 'new_p'}),
+            moved_paragraph_xpath,
+            expr="//div[@class='target']", position="after")
+
+        self.apply_spec(self.wrapped_arch, spec)
+
+        moved_paragraph = E.p("Content", {'class': 'some'})
+        moved_paragraph.tail = "tail of paragraph"
+        self.assertEqual(
+            self.wrapped_arch,
+            E.template(
+                E.div("aaaabbbb"),
+                E.div({'class': 'target'}),
+                E.p("Content2", {'class': 'new_p'}),
+                moved_paragraph,
+            )
+        )
+
     @mute_logger('odoo.addons.base.models.ir_ui_view')
     def test_incorrect_move_1(self):
         # cannot move an inexisting element

--- a/odoo/tools/template_inheritance.py
+++ b/odoo/tools/template_inheritance.py
@@ -42,7 +42,9 @@ def add_stripped_items_before(node, spec, extract):
 
     for child in spec:
         if child.get('position') == 'move':
+            tail = child.tail
             child = extract(child)
+            child.tail = tail
         node.addprevious(child)
 
 


### PR DESCRIPTION
Before this commit, when inserting a node into a tree via Odoo's xpath DSL with the xpath positions "before"|"after"|"inside", the texts around the targeted node were kept.

This was fine until one would like to also change those texts, as it is the case in Studio's ReportEditor.

This commit adds an xpath attribute "replace_text", taking "0" or "1", the former being the default, obviously

task-3790609

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
