### PR TITLE
[FIX] purchase_stock: Inventory user SVL access

### DIFF
--- a/addons/purchase_stock/tests/test_average_price.py
+++ b/addons/purchase_stock/tests/test_average_price.py
@@ -130,3 +130,52 @@ class TestAveragePrice(ValuationReconciliationTestCommon):
         self.assertEqual(product_cable_management_box.qty_available, 20.5, 'Reception of purchase order in grams leads to wrong quantity in stock')
         self.assertEqual(round(product_cable_management_box.standard_price, 2), 78.05,
             'Standard price as average price of third reception with other UoM incorrect! Got %s instead of 78.05' % (round(product_cable_management_box.standard_price, 2)))
+
+    def test_inventory_user_svl_access(self):
+        """ Test to check if Inventory/User is able to validate a
+        transfer when the product has been invoiced already """
+
+        user = self.env['res.users'].create({
+            'name': 'Inventory Manager',
+            'login': 'test',
+            'email': 'test@test.com',
+            'groups_id': [(6, 0, [self.env.ref('stock.group_stock_user').id])]
+        })
+
+        avco_product = self.env['product.product'].create({
+            'name': 'Average Ice Cream',
+            'type': 'product',
+            'categ_id': self.stock_account_product_categ.id,
+        })
+        avco_product.categ_id.property_cost_method = 'average'
+        avco_product.standard_price = 300
+
+        # Add a previous move to triger "run_fifo_vaccum"
+        out_move = self.env['stock.move'].create({
+            'name': 'out move',
+            'product_id': avco_product.id,
+            'location_id': self.company_data['default_warehouse'].lot_stock_id.id,
+            'location_dest_id': self.env.ref('stock.stock_location_customers').id,
+            'product_uom': self.env.ref('uom.product_uom_unit').id,
+            'product_uom_qty': 10,
+        })
+        out_move._action_confirm()
+        out_move._action_assign()
+        out_move.quantity_done = 10
+        out_move._action_done()
+
+        purchase_order = self.env['purchase.order'].create({
+            'partner_id': self.partner_a.id,
+            'order_line': [(0, 0, {
+                'product_id': avco_product.id,
+                'product_qty': 1.0,
+                'price_unit': 750.00,
+            })]
+        })
+        purchase_order.button_confirm()
+
+        picking = purchase_order.picking_ids[0]
+        picking.move_line_ids.qty_done = 1
+        picking.with_user(user).button_validate()
+
+        self.assertEqual(picking.state, 'done', 'Transfer should be in the DONE state')

--- a/addons/stock_account/models/product.py
+++ b/addons/stock_account/models/product.py
@@ -379,9 +379,9 @@ class ProductProduct(models.Model):
         """
         if company is None:
             company = self.env.company
-        ValuationLayer = self.env['stock.valuation.layer']
+        ValuationLayer = self.env['stock.valuation.layer'].sudo()
         svls_to_vacuum_by_product = defaultdict(lambda: ValuationLayer)
-        res = ValuationLayer.sudo().read_group([
+        res = ValuationLayer.read_group([
             ('product_id', 'in', self.ids),
             ('remaining_qty', '<', 0),
             ('stock_move_id', '!=', False),
@@ -392,7 +392,7 @@ class ProductProduct(models.Model):
             svls_to_vacuum_by_product[group['product_id'][0]] = ValuationLayer.browse(group['ids'])
             min_create_date = min(min_create_date, group['create_date'])
         all_candidates_by_product = defaultdict(lambda: ValuationLayer)
-        res = ValuationLayer.sudo().read_group([
+        res = ValuationLayer.read_group([
             ('product_id', 'in', self.ids),
             ('remaining_qty', '>', 0),
             ('company_id', '=', company.id),
@@ -472,8 +472,8 @@ class ProductProduct(models.Model):
                 if product.valuation == 'real_time':
                     current_real_time_svls |= svl_to_vacuum
             real_time_svls_to_vacuum |= current_real_time_svls
-        ValuationLayer.sudo().create(new_svl_vals_manual)
-        vacuum_svls = ValuationLayer.sudo().create(new_svl_vals_real_time)
+        ValuationLayer.create(new_svl_vals_manual)
+        vacuum_svls = ValuationLayer.create(new_svl_vals_real_time)
 
         # If some negative stock were fixed, we need to recompute the standard price.
         for product in self:


### PR DESCRIPTION
Steps to reproduce:
- Create a new storable product
- Add it to a category with AVCO/Automated (configure COA if needed)
- Add a value to the ‘Cost’ field (ex: 10$)
- Create an inventory adjustment such the stock on hand is negative (set stock to -10)
- Create and confirm a purchase order for the product
- Create a new user belonging to only the “Inventory/User” group
- Log in as the new user
- Attempt to confirm the receipt -> access error occurs

Bugs:
“Inventory/User” does not have acces to the purchase_line and SVLs

Fix:
add sudo to allow user to validate the picking

opw-3917456
