### PR TITLE
[FIX] hr_attendance:  Calculating extra hours based on timezone

### DIFF
--- a/addons/hr_attendance/tests/test_hr_attendance_overtime.py
+++ b/addons/hr_attendance/tests/test_hr_attendance_overtime.py
@@ -18,6 +18,11 @@ class TestHrAttendanceOvertime(TransactionCase):
             'overtime_company_threshold': 10,
             'overtime_employee_threshold': 10,
         })
+        cls.company_1 = cls.env['res.company'].create({
+            'name': 'Overtime Inc.',
+            'hr_attendance_overtime': True,
+            'overtime_start_date': datetime(2024, 5, 27),
+        })
         cls.user = new_test_user(cls.env, login='fru', groups='base.group_user,hr_attendance.group_hr_attendance_manager', company_id=cls.company.id).with_company(cls.company)
         cls.employee = cls.env['hr.employee'].create({
             'name': "Marie-Edouard De La Court",
@@ -39,6 +44,11 @@ class TestHrAttendanceOvertime(TransactionCase):
             'name': 'Susan',
             'company_id': cls.company.id,
             'tz': 'Pacific/Honolulu',
+        })
+        cls.europe_employee = cls.env['hr.employee'].create({
+            'name': 'Schmitt',
+            'company_id': cls.company_1.id,
+            'tz': 'Europe/Brussels',
         })
 
     def test_overtime_company_settings(self):
@@ -354,3 +364,18 @@ class TestHrAttendanceOvertime(TransactionCase):
             'check_out': datetime(2023, 1, 3, 21, 30)
         })
         self.assertEqual(m_attendance_3.overtime_hours, 0.5)
+
+        # Create an attendance record for early check-in
+        early_attendance = self.env['hr.attendance'].create({
+            'employee_id': self.europe_employee.id,
+            'check_in': datetime(2024, 5, 27, 23, 30),
+            'check_out': datetime(2024, 5, 28, 13, 30)
+        })
+
+        # 5:00 -> 19:00[in emp tz] should contain 5 hours of overtime
+        self.assertAlmostEqual(early_attendance.overtime_hours, 5)
+
+        # Total overtime for that day : 5 hours
+        overtime_record = self.env['hr.attendance.overtime'].search([('employee_id', '=', self.europe_employee.id),
+                                                              ('date', '=', datetime(2024, 5, 28))])
+        self.assertAlmostEqual(overtime_record.duration, 5)


### PR DESCRIPTION
**Steps to reproduce:**
- open attendance module
- go to overview and create a new attendance within 5:30 AM

**Issue:**
- Extra hours[overtime_hours] are not calculated accurately[output = 0].

**Cause:**
The [SQL Query](https://github.com/odoo/odoo/blob/17.0/addons/hr_attendance/models/hr_attendance.py#L77-L91)
[condition : date_trunc('day',att.check_in) = date_trunc('day', ot.date)] compares `att.check_in` time stored in UTC with `ot.date` stored in employee timezone, leading to incorrect calculations.

**Solution:**
Modify SQL query to convert `att.check_in` time to employee timezone before comparison with `ot.date`.

In saas-16.4, This [SQL Query](https://github.com/odoo/odoo/blob/saas-16.4/addons/hr_attendance/report/hr_attendance_report.py#L40-L46) is responsible for converting `check_in` time to employee 
timezone.

Description of the issue/feature this PR addresses:

**Current behavior before PR:**

RUNBOT-17.0
![runbot_17](https://github.com/odoo/odoo/assets/145324147/93e63367-54f4-49e0-b1e3-363af002bbc2)

**Desired behavior after PR is merged:**

![image](https://github.com/odoo/odoo/assets/145324147/ac73655d-9cc0-4a93-9494-5517fa262d6e)

UPG - 1573228
TASK - 3900287

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
