### PR TITLE
[FIX] base,account: keep localized demo when activated manually

### DIFF
--- a/addons/account/demo/account_demo.xml
+++ b/addons/account/demo/account_demo.xml
@@ -6,12 +6,6 @@
         </record>
     </data>
     <data>
-        <function model="account.chart.template" name="try_loading">
-            <value eval="[]"/>
-            <value>generic_coa</value>
-            <value model="res.company" search="[('partner_id.country_id.code', 'in', ['US', False])]"/>
-        </function>
-
         <!-- TAGS FOR RETRIEVING THE DEMO ACCOUNTS -->
         <record id="demo_capital_account" model="account.account.tag">
             <field name="name">Demo Capital Account</field>
@@ -28,6 +22,18 @@
         <record id="demo_office_furniture_account" model="account.account.tag">
             <field name="name">Office Furniture</field>
         </record>
+
+        <!-- Install the demo if demo installation is triggered manually after install without demo -->
+        <function model="account.chart.template" name="_install_demo">
+            <value model="res.company" search="[('chart_template', '!=', False)]"/>
+        </function>
+
+        <function model="account.chart.template" name="try_loading">
+            <value eval="[]"/>
+            <value>generic_coa</value>
+            <value model="res.company" search="[('partner_id.country_id.code', 'in', ['US', False])]"/>
+        </function>
+
         <!-- Payment Terms -->
 
         <record id="account_payment_term_advance" model="account.payment.term">

--- a/odoo/addons/base/data/res_partner_demo.xml
+++ b/odoo/addons/base/data/res_partner_demo.xml
@@ -38,11 +38,6 @@
        <!--
         Resource: res.partner
         -->
-        <record id="main_partner" model="res.partner">
-            <field name="email">info@yourcompany.com</field>
-            <field name="website">www.example.com</field>
-            <field name="vat">US12345671</field>
-        </record>
         <record id="res_partner_1" model="res.partner">
             <field name="name">Wood Corner</field>
             <field eval="[Command.set([ref('res_partner_category_14'), ref('res_partner_category_12')])]" name="category_id"/>

--- a/odoo/addons/base/data/res_users_demo.xml
+++ b/odoo/addons/base/data/res_users_demo.xml
@@ -16,18 +16,22 @@
             <field name="phone">(441)-695-2334</field>
         </record>
 
-        <record id="main_partner" model="res.partner">
-            <field name="name">YourCompany</field>
-            <field name="company_name">YourCompany</field>
-            <field name="street">250 Executive Park Blvd, Suite 3400</field>
-            <field name="city">San Francisco</field>
-            <field name="zip">94134</field>
-            <field name='country_id' ref='base.us'/>
-            <field name='state_id' ref='state_us_5'/>
-            <field name="phone">+5 555-555-5555</field>
-            <field name="email">info@yourcompany.example.com</field>
-            <field name="website">www.example.com</field>
-        </record>
+        <!-- Only update if we don't have information coming from the database manager -->
+        <function model="res.partner" name="write">
+            <value eval="[ref('base.main_partner')]"/>
+            <value eval="{
+                'name': 'YourCompany',
+                'street': '250 Executive Park Blvd, Suite 3400',
+                'city': 'San Francisco',
+                'zip': '94134',
+                'country_id': ref('base.us'),
+                'state_id': ref('base.state_us_5'),
+                'phone': '+5 555-555-5555',
+                'website': 'www.example.com',
+                'email': 'info@yourcompany.com',
+                'vat': 'US12345671',
+            } if obj(ref('base.main_partner')).name == 'My Company' else {}" model="res.partner"/>
+        </function>
 
         <record id="user_demo" model="res.users">
             <field name="partner_id" ref="base.partner_demo"/>


### PR DESCRIPTION
Reproduce:
* Create a database without demo data
* Complete some information related to the main company (i.e. from the database manager form)
* Install `account`
* In the settings, in debug mode, trigger the installation of the demo data manually

Result:
The data manually set on the company is overridden to be in US, making the demo data of `account` lose its localized aspect. If for some reason the CoA could not be reloaded, we even don't have any demo at all because `try_loading` won't do anything at all.

Solution:
Do not override value possibly set by the user in the database configuration. We use the company name as a heuristic. If there is already a chart template installed (because the installation of a `l10n` module triggered it), then we try to load the dynamic demo data when loading the demo XML file.
