### PR TITLE
[FIX] point_of_sale: tax layout in order receipt

### DIFF
--- a/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
+++ b/addons/point_of_sale/static/src/app/screens/receipt_screen/receipt/order_receipt.xml
@@ -70,7 +70,7 @@
                 <span>Total</span>
                 <t t-foreach="props.data.tax_details" t-as="tax" t-key="tax.tax.id">
                     <span t-esc="tax.tax.letter || ''"/>
-                    <span t-if="tax.tax.amount_type != 'fixed'"><t t-esc="tax.tax.amount"/> %</span>
+                    <span t-if="tax.tax.amount_type != 'fixed'"><t t-esc="tax.tax.amount"/>%</span>
                     <span t-else="" t-esc="tax.tax.name"/>
                     <span t-esc="props.formatCurrency(tax.amount, false)" />
                     <span t-esc="props.formatCurrency(tax.base, false)" />


### PR DESCRIPTION
Before this commit:
==========
- Tax layout of order receipt was making a bad User experience.

After this commit:
=========
- Improved Tax layout of order receipt.

task-3933459