### PR TITLE
FIX: 15.0 demo data for test totp

### DIFF
--- a/addons/auth_totp/tests/test_totp.py
+++ b/addons/auth_totp/tests/test_totp.py
@@ -9,7 +9,7 @@ from odoo import http
 from odoo.addons.base.tests.common import HttpCaseWithUserDemo
 from odoo.exceptions import AccessDenied
 from odoo.service import common as auth, model
-from odoo.tests import tagged, get_db_name, loaded_demo_data
+from odoo.tests import tagged, get_db_name
 
 from ..controllers.home import Home
 
@@ -47,10 +47,6 @@ class TestTOTP(HttpCaseWithUserDemo):
             self.env['ir.http']._clear_routing_map()
 
     def test_totp(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         # 1. Enable 2FA
         self.start_tour('/web', 'totp_tour_setup', login='demo')
 
@@ -90,10 +86,6 @@ class TestTOTP(HttpCaseWithUserDemo):
 
 
     def test_totp_administration(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.start_tour('/web', 'totp_tour_setup', login='demo')
         self.start_tour('/web', 'totp_admin_disables', login='admin')
         self.start_tour('/', 'totp_login_disabled', login=None)
@@ -103,11 +95,6 @@ class TestTOTP(HttpCaseWithUserDemo):
         Ensure that JSON-RPC authentication works and don't return the user id
         without TOTP check
         """
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
-
         self.start_tour('/web', 'totp_tour_setup', login='demo')
         self.url_open('/web/session/logout')
 

--- a/addons/auth_totp_mail/tests/test_totp.py
+++ b/addons/auth_totp_mail/tests/test_totp.py
@@ -3,7 +3,7 @@
 
 import logging
 
-from odoo.tests import tagged, loaded_demo_data
+from odoo.tests import tagged
 from odoo.addons.auth_totp.tests.test_totp import TestTOTP
 
 _logger = logging.getLogger(__name__)
@@ -13,9 +13,5 @@ _logger = logging.getLogger(__name__)
 class TestTOTPInvite(TestTOTP):
 
     def test_totp_administration(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         self.start_tour('/web', 'totp_admin_invite', login='admin')
         self.start_tour('/web', 'totp_admin_self_invite', login='admin')

--- a/addons/auth_totp_portal/tests/test_tour.py
+++ b/addons/auth_totp_portal/tests/test_tour.py
@@ -6,7 +6,7 @@ from passlib.totp import TOTP
 from odoo import http
 from odoo.addons.auth_totp.controllers.home import Home
 from odoo.addons.base.tests.common import HttpCaseWithUserPortal
-from odoo.tests import tagged, loaded_demo_data
+from odoo.tests import tagged
 
 _logger = logging.getLogger(__name__)
 
@@ -17,10 +17,6 @@ class TestTOTPortal(HttpCaseWithUserPortal):
     Largely replicates TestTOTP
     """
     def test_totp(self):
-        # TODO: Make this work if no demo data + hr installed
-        if not loaded_demo_data(self.env):
-            _logger.warning("This test relies on demo data. To be rewritten independently of demo data for accurate and reliable results.")
-            return
         totp = None
         # test endpoint as doing totp on the client side is not really an option
         # (needs sha1 and hmac + BE packing of 64b integers)

--- a/addons/sale_quotation_builder/data/sale_order_template_data.xml
+++ b/addons/sale_quotation_builder/data/sale_order_template_data.xml
@@ -76,6 +76,11 @@
             </field>
         </record>
 
+        <!-- The group must be present otherwise the onchange "_onchange_group_sale_order_template" will request this addon uninstallation. -->
+        <record id="base.group_user" model="res.groups">
+            <field name="implied_ids" eval="[(4, ref('sale_management.group_sale_order_template'))]"/>
+        </record>
+
         <function model="res.company" name="_set_default_sale_order_template_id_if_empty"/>
     </data>
 </odoo>

--- a/odoo/addons/base/tests/common.py
+++ b/odoo/addons/base/tests/common.py
@@ -55,6 +55,8 @@ class HttpCaseWithUserDemo(HttpCase):
                 'password': 'demo',
                 'partner_id': cls.partner_demo.id,
                 'groups_id': [Command.set([cls.env.ref('base.group_user').id, cls.env.ref('base.group_partner_manager').id])],
+                'signup_token': False,
+                'tz': 'Europe/Brussels',
             })
 
 


### PR DESCRIPTION
[FIX] auth_totp,sale_management: test without demo data

When modules are installed by the runbot, "sale_quotation_builder" is
present. However, its installation depends on an option in
"res.config.settings", this option being linked to the
"sale_management.group_sale_order_template" group. The group was added
in the demo data. When "test_totp_authenticate" used the form view of
the config, a warning appeared to warn that the addons were going to be
uninstalled.

So that Odoo (via onchange) does not want to uninstall the module when it
is added via the server, the group is added in the data.