### PR TITLE
[FIX] base: phone number can span two lines in contact widget

### DIFF
--- a/addons/web/static/src/webclient/actions/reports/report.scss
+++ b/addons/web/static/src/webclient/actions/reports/report.scss
@@ -262,3 +262,9 @@ blockquote {
 li.oe-nested {
     display: block;
 }
+
+.o_portal_address {
+    span[itemprop="telephone"] {
+        white-space: nowrap;
+    }
+}


### PR DESCRIPTION
Issue
----

Phone number can span two lines with some fonts for reports that use the contact widget (e.g. Delivery Slip).

Steps
-----

- Use Raleway font. You can do this by going to Settings -> Configure Document Layout (under Companies) -> Choose Raleway.
- Change the phone number of the current company to `+33 3 28 44 55 01`.
- Create a delivery (without lines) and print a Delivery Slip without validating.
- The phone number spans two lines.

Cause
-----

When the phone number is long and takes up space in some fonts, the phone number is line-wrapped, which is ok for other text but not for phone numbers.

opw-3834061