### PR TITLE
[FIX] hr_contract: prevent deletion of employees with running contracts

### DIFF
--- a/addons/hr_contract/i18n/hr_contract.pot
+++ b/addons/hr_contract/i18n/hr_contract.pot
@@ -931,3 +931,9 @@ msgstr ""
 #: model_terms:ir.ui.view,arch_db:hr_contract.hr_contract_view_search
 msgid "Working Schedule"
 msgstr ""
+
+#. module: hr_contract
+#: code:addons/hr_contract/models/hr_employee.py:0
+#, python-format
+msgid "You cannot delete an employee with a running contract."
+msgstr ""

--- a/addons/hr_contract/models/hr_employee.py
+++ b/addons/hr_contract/models/hr_employee.py
@@ -3,9 +3,10 @@
 from datetime import date, datetime, time
 from pytz import timezone
 
-from odoo import api, fields, models
+from odoo import _, api, fields, models
 from odoo.osv import expression
 from odoo.addons.resource.models.resource import Intervals
+from odoo.exceptions import UserError
 
 
 class Employee(models.Model):
@@ -121,6 +122,11 @@ class Employee(models.Model):
                 employee.resource_calendar_id.transfer_leaves_to(employee.contract_id.resource_calendar_id, employee.resource_id)
                 employee.resource_calendar_id = employee.contract_id.resource_calendar_id
         return res
+    
+    @api.ondelete(at_uninstall=False)
+    def _unlink_except_open_contract(self):
+        if any(contract.state == 'open' for contract in self.contract_ids):
+            raise UserError(_('You cannot delete an employee with a running contract.'))
 
     def action_open_contract_history(self):
         self.ensure_one()


### PR DESCRIPTION
Before this commit it was possible to remove employees with ongoing contracts. This commit adds a check to prevent this case.

task: 3930155

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
