### PR TITLE
[FIX] website: fix a singleton error when duplicate pages

### DIFF
--- a/addons/website/models/website_page.py
+++ b/addons/website/models/website_page.py
@@ -113,15 +113,13 @@ class Page(models.Model):
         return self.browse(ids)
 
     def copy_data(self, default=None):
-        vals_list = super().copy_data(default=default)
-        if not default:
-            return vals_list
-        for page, vals in zip(self, vals_list):
+        default = dict(default or {})
+        for page in self:
             if not default.get('view_id'):
                 new_view = page.view_id.copy({'website_id': default.get('website_id')})
-                vals['view_id'] = new_view.id
-            vals['url'] = default.get('url', self.env['website'].get_unique_path(page.url))
-        return vals_list
+                default['view_id'] = new_view.id
+            default['url'] = default.get('url', self.env['website'].get_unique_path(page.url))
+        return super().copy_data(default=default)
 
     @api.model
     def clone_page(self, page_id, page_name=None, clone_menu=True):


### PR DESCRIPTION
Since [1], the `copy` and `copy_data` methods have been refactored to handle recordsets. This change broke the `clone_page` method in the Website Page model, causing the duplicated page to have the same view key as the original. The view key must be unique.

Steps to reproduce:

- Navigate to Website.
- Click on the "Site" menu > "Pages".
- Click on "New" and select the "blank page" template.
- Enter a name for the page (e.g., NewPage1).
- Click on "Create".
- When the editor opens, click on "Discard".
- Click on the "Site" menu > "Pages" again.
- Select the checkbox next to NewPage1.
- Click on "Actions" > "Duplicate".
- Enter a name for the duplicated page (e.g., NewPage2) and click on "Ok"
- Refresh the page (F5).
- The new page appears: click on it.
- Edit the page by clicking on "Edit" in the top-right corner.
- Bug: Traceback error occurs.

This commit fixes the bug by appending a unique ID to the duplicated view key.

opw-3936237

[1]: https://github.com/odoo/odoo/commit/4ac2702c31f0e95f33f9ad554e7350bef9dab8bd

