### PR TITLE
[IMP] web: add onResize options to useAutoResize

### DIFF
--- a/addons/web/static/src/core/utils/autoresize.js
+++ b/addons/web/static/src/core/utils/autoresize.js
@@ -16,11 +16,14 @@ export function useAutoresize(ref, options = {}) {
     useEffect(
         (el) => {
             if (el) {
-                resize = (el instanceof HTMLInputElement ? resizeInput : resizeTextArea).bind(
-                    null,
-                    el,
-                    options
-                );
+                resize = () => {
+                    if (el instanceof HTMLInputElement) {
+                        resizeInput(el, options);
+                    } else {
+                        resizeTextArea(el, options);
+                    }
+                    options.onResize?.(el, options);
+                };
                 el.addEventListener("input", resize);
                 return () => {
                     el.removeEventListener("input", resize);
@@ -32,7 +35,7 @@ export function useAutoresize(ref, options = {}) {
     );
     useEffect(() => {
         if (resize) {
-            resize(ref.el, options);
+            resize();
         }
     });
 }

--- a/addons/web/static/tests/core/utils/autoresize.test.js
+++ b/addons/web/static/tests/core/utils/autoresize.test.js
@@ -1,0 +1,79 @@
+import { expect, test } from "@odoo/hoot";
+import { queryRect } from "@odoo/hoot-dom";
+import { Component, useRef, xml } from "@odoo/owl";
+import { contains, mountWithCleanup } from "@web/../tests/web_test_helpers";
+
+import { useAutoresize } from "@web/core/utils/autoresize";
+
+test(`resizable input`, async () => {
+    class ResizableInput extends Component {
+        static template = xml`<input class="resizable-input" t-ref="input"/>`;
+        static props = ["*"];
+
+        setup() {
+            useAutoresize(useRef("input"));
+        }
+    }
+    await mountWithCleanup(ResizableInput);
+    const initialWidth = queryRect(`.resizable-input`).width;
+
+    await contains(`.resizable-input`).edit("new value");
+    expect(`.resizable-input`).not.toHaveRect({ width: initialWidth });
+});
+
+test(`resizable textarea`, async () => {
+    class ResizableTextArea extends Component {
+        static template = xml`<textarea class="resizable-textarea" t-ref="textarea"/>`;
+        static props = ["*"];
+
+        setup() {
+            useAutoresize(useRef("textarea"));
+        }
+    }
+    await mountWithCleanup(ResizableTextArea);
+    const initialHeight = queryRect(`.resizable-textarea`).height;
+
+    await contains(`.resizable-textarea`).edit("new value\n".repeat(5));
+    expect(`.resizable-textarea`).not.toHaveRect({ height: initialHeight });
+});
+
+test(`resizable textarea with minimum height`, async () => {
+    class ResizableTextArea extends Component {
+        static template = xml`<textarea class="resizable-textarea" t-ref="textarea"/>`;
+        static props = ["*"];
+
+        setup() {
+            useAutoresize(useRef("textarea"), { minimumHeight: 100 });
+        }
+    }
+    await mountWithCleanup(ResizableTextArea);
+    const initialHeight = queryRect(`.resizable-textarea`).height;
+    expect(initialHeight).toBe(100);
+
+    await contains(`.resizable-textarea`).edit("new value\n".repeat(5));
+    expect(`.resizable-textarea`).not.toHaveRect({ height: initialHeight });
+});
+
+test(`call onResize callback`, async () => {
+    class ResizableInput extends Component {
+        static template = xml`<input class="resizable-input" t-ref="input"/>`;
+        static props = ["*"];
+
+        setup() {
+            const inputRef = useRef("input");
+            useAutoresize(inputRef, {
+                randomParam: true,
+                onResize(el, options) {
+                    expect.step("onResize");
+                    expect(el).toBe(inputRef.el);
+                    expect(options).toInclude("randomParam");
+                },
+            });
+        }
+    }
+    await mountWithCleanup(ResizableInput);
+    expect(["onResize"]).toVerifySteps();
+
+    await contains(`.resizable-input`).edit("new value", { instantly: true });
+    expect(["onResize"]).toVerifySteps();
+});


### PR DESCRIPTION
This commit adds an onResize callback to useAutoResize hook which is
called just after the element is resized.
The callback can be used to perform more change on the resized element.

This commit also adds some tests for useAutoResize hook.