### PR TITLE
[IMP] base: allow to set falsy value to config

### DIFF
--- a/addons/account/models/account_move_line.py
+++ b/addons/account/models/account_move_line.py
@@ -7,7 +7,7 @@ import re
 from odoo import api, fields, models, Command, _
 from odoo.exceptions import ValidationError, UserError
 from odoo.osv import expression
-from odoo.tools import frozendict, format_date, float_compare, format_list, Query
+from odoo.tools import frozendict, format_date, float_compare, format_list, Query, str2bool
 from odoo.tools.sql import create_index, SQL
 from odoo.addons.web.controllers.utils import clean_action
 
@@ -2378,7 +2378,7 @@ class AccountMoveLine(models.Model):
 
     def _reconcile_plan_with_sync(self, plan_list, all_amls):
         # Parameter allowing to disable the exchange journal entries on partials.
-        disable_partial_exchange_diff = bool(self.env['ir.config_parameter'].sudo().get_param('account.disable_partial_exchange_diff'))
+        disable_partial_exchange_diff = str2bool(self.env['ir.config_parameter'].sudo().get_param('account.disable_partial_exchange_diff'))
 
         # ==== Prefetch the fields all at once to speedup the reconciliation ====
         # All of those fields will be cached by the orm. Since the amls are split into multiple batches, the orm is not

--- a/addons/crm/models/crm_team.py
+++ b/addons/crm/models/crm_team.py
@@ -11,7 +11,7 @@ from markupsafe import Markup
 
 from odoo import api, exceptions, fields, models, _
 from odoo.osv import expression
-from odoo.tools import float_compare, float_round
+from odoo.tools import float_compare, float_round, str2bool
 from odoo.tools.safe_eval import safe_eval
 
 _logger = logging.getLogger(__name__)
@@ -61,7 +61,7 @@ class Team(models.Model):
             team.assignment_max = sum(member.assignment_max for member in team.crm_team_member_ids)
 
     def _compute_assignment_enabled(self):
-        assign_enabled = self.env['ir.config_parameter'].sudo().get_param('crm.lead.auto.assignment', False)
+        assign_enabled = str2bool(self.env['ir.config_parameter'].sudo().get_param('crm.lead.auto.assignment', False))
         auto_assign_enabled = False
         if assign_enabled:
             assign_cron = self.sudo().env.ref('crm.ir_cron_crm_lead_assign', raise_if_not_found=False)

--- a/addons/hr/models/res_users.py
+++ b/addons/hr/models/res_users.py
@@ -5,7 +5,7 @@ from markupsafe import Markup
 
 from odoo import api, models, fields, _, SUPERUSER_ID
 from odoo.exceptions import AccessError
-from odoo.tools.misc import clean_context
+from odoo.tools.misc import clean_context, str2bool
 
 
 HR_READABLE_FIELDS = [
@@ -154,7 +154,7 @@ class User(models.Model):
         self.is_system = self.env.user._is_system()
 
     def _compute_can_edit(self):
-        can_edit = self.env['ir.config_parameter'].sudo().get_param('hr.hr_employee_self_edit') or self.env.user.has_group('hr.group_hr_user')
+        can_edit = str2bool(self.env['ir.config_parameter'].sudo().get_param('hr.hr_employee_self_edit')) or self.env.user.has_group('hr.group_hr_user')
         for user in self:
             user.can_edit = can_edit
 
@@ -240,7 +240,7 @@ class User(models.Model):
             for field_name, field in self._fields.items()
             if field.related_field and field.related_field.model_name == 'hr.employee' and field_name in vals
         }
-        can_edit_self = self.env['ir.config_parameter'].sudo().get_param('hr.hr_employee_self_edit') or self.env.user.has_group('hr.group_hr_user')
+        can_edit_self = str2bool(self.env['ir.config_parameter'].sudo().get_param('hr.hr_employee_self_edit')) or self.env.user.has_group('hr.group_hr_user')
         if hr_fields and not can_edit_self:
             # Raise meaningful error message
             raise AccessError(_("You are only allowed to update your preferences. Please contact a HR officer to update other information."))

--- a/addons/hr/tests/test_self_user_access.py
+++ b/addons/hr/tests/test_self_user_access.py
@@ -27,7 +27,7 @@ class TestSelfAccessProfile(TestHrCommon):
 
     def test_readonly_fields(self):
         """ Employee related fields should be readonly if self editing is not allowed """
-        self.env['ir.config_parameter'].sudo().set_param('hr.hr_employee_self_edit', False)
+        self.env['ir.config_parameter'].sudo().set_param('hr.hr_employee_self_edit', 'False')
         james = new_test_user(self.env, login='hel', groups='base.group_user', name='Simple employee', email='ric@example.com')
         james = james.with_user(james)
         self.env['hr.employee'].create({
@@ -171,7 +171,7 @@ class TestSelfAccessRights(TestHrCommon):
                 self.richard.with_user(self.richard).write({f: 'dummy'})
 
     def testWriteSelfUserEmployee(self):
-        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', True)
+        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', 'True')
         for f, v in self.self_protected_fields_user.items():
             val = None
             if v.type == 'char' or v.type == 'text':
@@ -182,7 +182,7 @@ class TestSelfAccessRights(TestHrCommon):
     def testWriteSelfUserPreferencesEmployee(self):
         # self should always be able to update non hr.employee fields if
         # they are in SELF_READABLE_FIELDS
-        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', False)
+        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', 'False')
         # should not raise
         vals = [
             {'tz': "Australia/Sydney"},
@@ -197,7 +197,7 @@ class TestSelfAccessRights(TestHrCommon):
     def testWriteOtherUserPreferencesEmployee(self):
         # self should always be able to update non hr.employee fields if
         # they are in SELF_READABLE_FIELDS
-        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', False)
+        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', 'False')
         vals = [
             {'tz': "Australia/Sydney"},
             {'email': "new@example.com"},
@@ -210,7 +210,7 @@ class TestSelfAccessRights(TestHrCommon):
 
     def testWriteSelfPhoneEmployee(self):
         # phone is a related from res.partner (from base) but added in SELF_READABLE_FIELDS
-        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', False)
+        self.env['ir.config_parameter'].set_param('hr.hr_employee_self_edit', 'False')
         with self.assertRaises(AccessError):
             self.richard.with_user(self.richard).write({'phone': '2154545'})
 

--- a/addons/mass_mailing/controllers/main.py
+++ b/addons/mass_mailing/controllers/main.py
@@ -10,7 +10,7 @@ from werkzeug.exceptions import BadRequest, NotFound, Unauthorized
 
 from odoo import _, fields, http, tools
 from odoo.http import request, Response
-from odoo.tools import consteq
+from odoo.tools import consteq, str2bool
 
 
 class MassMailController(http.Controller):
@@ -200,7 +200,7 @@ class MassMailController(http.Controller):
             'feedback_readonly': False,
             'opt_out_reasons': opt_out_reasons,
             # blocklist
-            'blocklist_enabled': bool(
+            'blocklist_enabled': str2bool(
                 request.env['ir.config_parameter'].sudo().get_param(
                     'mass_mailing.show_blacklist_buttons',
                     default=True,

--- a/addons/purchase_stock/models/stock_move.py
+++ b/addons/purchase_stock/models/stock_move.py
@@ -3,6 +3,7 @@
 from collections import deque
 
 from odoo import api, Command, fields, models, _
+from odoo.tools import str2bool
 from odoo.tools.float_utils import float_round, float_is_zero, float_compare
 from odoo.exceptions import UserError
 
@@ -26,7 +27,7 @@ class StockMove(models.Model):
     @api.model
     def _prepare_merge_negative_moves_excluded_distinct_fields(self):
         excluded_fields = super()._prepare_merge_negative_moves_excluded_distinct_fields() + ['created_purchase_line_id']
-        if self.env['ir.config_parameter'].sudo().get_param('purchase_stock.merge_different_procurement'):
+        if str2bool(self.env['ir.config_parameter'].sudo().get_param('purchase_stock.merge_different_procurement')):
             excluded_fields += ['procure_method']
         return excluded_fields
 

--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -11,7 +11,7 @@ from odoo import _, api, Command, fields, models
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
 from odoo.tools.float_utils import float_compare, float_is_zero, float_round
-from odoo.tools.misc import clean_context, OrderedSet, groupby
+from odoo.tools.misc import clean_context, OrderedSet, groupby, str2bool
 
 PROCUREMENT_PRIORITIES = [('0', 'Normal'), ('1', 'Urgent')]
 
@@ -1034,11 +1034,11 @@ Please change the quantity done or the rounding precision of your unit of measur
             'package_level_id', 'propagate_cancel', 'description_picking',
             'product_packaging_id',
         ]
-        if self.env['ir.config_parameter'].sudo().get_param('stock.merge_only_same_date'):
+        if str2bool(self.env['ir.config_parameter'].sudo().get_param('stock.merge_only_same_date')):
             fields.append('date')
         if self.env.context.get('merge_extra'):
             fields.pop(fields.index('procure_method'))
-        if not self.env['ir.config_parameter'].sudo().get_param('stock.merge_ignore_date_deadline'):
+        if not str2bool(self.env['ir.config_parameter'].sudo().get_param('stock.merge_ignore_date_deadline')):
             fields.append('date_deadline')
         return fields
 
@@ -2121,7 +2121,7 @@ Please change the quantity done or the rounding precision of your unit of measur
 
     def _trigger_scheduler(self):
         """ Check for auto-triggered orderpoints and trigger them. """
-        if not self or self.env['ir.config_parameter'].sudo().get_param('stock.no_auto_scheduler'):
+        if not self or str2bool(self.env['ir.config_parameter'].sudo().get_param('stock.no_auto_scheduler')):
             return
 
         orderpoints_by_company = defaultdict(lambda: self.env['stock.warehouse.orderpoint'])
@@ -2147,7 +2147,7 @@ Please change the quantity done or the rounding precision of your unit of measur
         """ Check for and trigger action_assign for confirmed/partially_available moves related to done moves.
             Disable auto reservation if user configured to do so.
         """
-        if not self or self.env['ir.config_parameter'].sudo().get_param('stock.picking_no_auto_reserve'):
+        if not self or str2bool(self.env['ir.config_parameter'].sudo().get_param('stock.picking_no_auto_reserve')):
             return
 
         domains = [

--- a/addons/stock/models/stock_quant.py
+++ b/addons/stock/models/stock_quant.py
@@ -11,7 +11,7 @@ from psycopg2 import Error
 from odoo import _, api, fields, models, SUPERUSER_ID
 from odoo.exceptions import UserError, ValidationError
 from odoo.osv import expression
-from odoo.tools import SQL, check_barcode_encoding, format_list, groupby
+from odoo.tools import SQL, check_barcode_encoding, format_list, groupby, str2bool
 from odoo.tools.float_utils import float_compare, float_is_zero
 
 _logger = logging.getLogger(__name__)
@@ -1247,7 +1247,7 @@ class StockQuant(models.Model):
         :param domain: List for the domain, empty by default.
         :param extend: If True, enables form, graph and pivot views. False by default.
         """
-        if not self.env['ir.config_parameter'].sudo().get_param('stock.skip_quant_tasks'):
+        if not str2bool(self.env['ir.config_parameter'].sudo().get_param('stock.skip_quant_tasks')):
             self._quant_tasks()
         ctx = dict(self.env.context or {})
         ctx['inventory_report_mode'] = True

--- a/addons/web/models/ir_http.py
+++ b/addons/web/models/ir_http.py
@@ -178,7 +178,7 @@ class Http(models.AbstractModel):
             'profile_session': request.session.profile_session,
             'profile_collectors': request.session.profile_collectors,
             'profile_params': request.session.profile_params,
-            'show_effect': bool(request.env['ir.config_parameter'].sudo().get_param('base_setup.show_effect')),
+            'show_effect': str2bool(request.env['ir.config_parameter'].sudo().get_param('base_setup.show_effect')),
             'currencies': self.get_currencies(),
             'bundle_params': {
                 'lang': request.session.context['lang'],

--- a/addons/website_sale/__init__.py
+++ b/addons/website_sale/__init__.py
@@ -4,10 +4,11 @@ from . import controllers
 from . import models
 from . import populate
 from . import report
+from odoo.tools import str2bool
 
 
 def _post_init_hook(env):
-    terms_conditions = env['ir.config_parameter'].get_param('account.use_invoice_terms')
+    terms_conditions = str2bool(env['ir.config_parameter'].get_param('account.use_invoice_terms'))
     if not terms_conditions:
         env['ir.config_parameter'].set_param('account.use_invoice_terms', True)
     companies = env['res.company'].search([])

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -317,7 +317,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                         _logger.warning(WARNING_MESSAGE, value, field, icp)
                         value = 0.0
                 elif field.type == 'boolean':
-                    value = bool(value)
+                    value = value.lower() != 'false' if isinstance(value, str) else bool(value)
             res[name] = value
 
         res.update(self.get_values())
@@ -368,10 +368,12 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                 # bugs when users leave spaces around them
                 value = (value or "").strip() or False
             elif field.type in ('integer', 'float'):
-                value = repr(value) if value else False
+                value = repr(value) if isinstance(value, (int, float)) else False
+            elif field.type == 'boolean':
+                value = str(value) if isinstance(value, bool) else False
             elif field.type == 'many2one':
                 # value is a (possibly empty) recordset
-                value = value.id
+                value = str(value.id) if value else False
 
             if current_value == str(value) or current_value == value:
                 continue

--- a/odoo/addons/base/models/res_config.py
+++ b/odoo/addons/base/models/res_config.py
@@ -373,7 +373,7 @@ class ResConfigSettings(models.TransientModel, ResConfigModuleInstallationMixin)
                 value = str(value) if isinstance(value, bool) else False
             elif field.type == 'many2one':
                 # value is a (possibly empty) recordset
-                value = str(value.id) if value else False
+                value = value.id
 
             if current_value == str(value) or current_value == value:
                 continue

--- a/odoo/addons/test_res_config_settings/__init__.py
+++ b/odoo/addons/test_res_config_settings/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/odoo/addons/test_res_config_settings/__manifest__.py
+++ b/odoo/addons/test_res_config_settings/__manifest__.py
@@ -1,0 +1,11 @@
+{
+    'name': "test_res_config_settings",
+    'description': "Tests for res.config.settings",
+
+    'category': 'Hidden/Tests',
+    'version': '0.1',
+
+    'depends': ['base'],
+
+    'license': 'LGPL-3',
+}

--- a/odoo/addons/test_res_config_settings/models/__init__.py
+++ b/odoo/addons/test_res_config_settings/models/__init__.py
@@ -1,0 +1,1 @@
+from . import res_config_settings

--- a/odoo/addons/test_res_config_settings/models/res_config_settings.py
+++ b/odoo/addons/test_res_config_settings/models/res_config_settings.py
@@ -1,0 +1,12 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class ResConfigSettings(models.TransientModel):
+
+    _inherit = 'res.config.settings'
+
+    test_bool = fields.Boolean(default=True, config_parameter='test_new_api.test_bool')
+    test_int = fields.Integer(default=30, config_parameter='test_new_api.test_int')
+    test_float = fields.Float(digits=(10, 7), default=1.5, config_parameter='test_new_api.test_float')

--- a/odoo/addons/test_res_config_settings/tests/__init__.py
+++ b/odoo/addons/test_res_config_settings/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_res_config_settings

--- a/odoo/addons/test_res_config_settings/tests/test_res_config_settings.py
+++ b/odoo/addons/test_res_config_settings/tests/test_res_config_settings.py
@@ -1,0 +1,35 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo.tests import TransactionCase
+
+
+class TestResConfigSettingsFields(TransactionCase):
+    def test_config_parameter_default_truthy(self):
+        settings = self.env['res.config.settings'].create({})
+        self.assertTrue(settings.test_bool)
+        self.assertEqual(settings.test_int, 30)
+        self.assertTrue(settings.test_float > 0.1)
+
+        settings.write({
+            'test_bool': False,
+            'test_int': 0,
+            'test_float': 0.000,
+        })
+        settings.set_values()
+
+        settings = self.env['res.config.settings'].create({})
+        self.assertFalse(settings.test_bool)
+        self.assertEqual(settings.test_int, 0)
+        self.assertTrue(settings.test_float < 0.1)
+
+        settings.write({
+            'test_bool': True,
+            'test_int': 1,
+            'test_float': 3.0,
+        })
+        settings.set_values()
+
+        settings = self.env['res.config.settings'].create({})
+        self.assertTrue(settings.test_bool)
+        self.assertEqual(settings.test_int, 1)
+        self.assertTrue(settings.test_float > 2.0)


### PR DESCRIPTION
In the res.config.settings, if a field has both attributes ('default', 'config_parameter'), and the 'default' is a truthy value, when the administrator
 set the config to a falsy value, e.g. ``False``, ``0``, ``0.0``

Currently, the config parameter will just fallback to the default value. For example, there is no way to set the following config to ``False`` ``bool_field = field.Boolean(default=True, config_parameter='bool_field')``

This commit changes the behavior, the config parameter can be set to falsy value

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
