### PR TITLE
[FIX] purchase_stock,stock_account: sync order qty

### DIFF
--- a/addons/purchase_stock/models/purchase_order_line.py
+++ b/addons/purchase_stock/models/purchase_order_line.py
@@ -43,7 +43,7 @@ class PurchaseOrderLine(models.Model):
             moves = moves.filtered(lambda r: fields.Date.context_today(r, r.date) <= self._context['accrual_entry_date'])
         return moves
 
-    @api.depends('move_ids.state', 'move_ids.product_uom_qty', 'move_ids.product_uom')
+    @api.depends('move_ids.state', 'move_ids.product_uom', 'move_ids.quantity')
     def _compute_qty_received(self):
         from_stock_lines = self.filtered(lambda order_line: order_line.qty_received_method == 'stock_moves')
         super(PurchaseOrderLine, self - from_stock_lines)._compute_qty_received()

--- a/addons/stock_dropshipping/tests/__init__.py
+++ b/addons/stock_dropshipping/tests/__init__.py
@@ -6,3 +6,4 @@ from . import test_dropship
 from . import test_lifo_price
 from . import test_procurement_exception
 from . import test_stockvaluation
+from . import test_purchase_order

--- a/addons/stock_dropshipping/tests/test_purchase_order.py
+++ b/addons/stock_dropshipping/tests/test_purchase_order.py
@@ -1,0 +1,61 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import Command
+from odoo.addons.stock_account.tests.test_anglo_saxon_valuation_reconciliation_common import ValuationReconciliationTestCommon
+from odoo.tests.common import tagged
+
+
+@tagged('-at_install', 'post_install')
+class TestPurchaseOrder(ValuationReconciliationTestCommon):
+
+    @classmethod
+    def setUpClass(cls, chart_template_ref=None):
+        super().setUpClass(chart_template_ref=chart_template_ref)
+
+        cls.dropship_picking_type = cls.env['stock.picking.type'].search([
+            ('code', '=', 'dropship'),
+            ('company_id', '=', cls.env.company.id),
+        ], limit=1)
+
+    def test_qty_received_does_sync_after_changing_validated_move_quantity(self):
+        """ After validating a picking, if it is unlocked and has its move quantity modified,
+        the underlying purchase order's qty_delivered value should reflect the change.
+        """
+        self.product_a.standard_price = 5.0
+        cost_methods = ['standard', 'fifo', 'average']
+        picking_types = [
+            self.env['stock.picking.type'].search([
+                ('code', '=', 'incoming'),
+                ('company_id', '=', self.env.company.id),
+            ], limit=1),
+            self.dropship_picking_type,
+        ]
+
+        for cost_method in cost_methods:
+            for picking_type in picking_types:
+                self.product_a.cost_method = cost_method
+                po = self.env['purchase.order'].create({
+                    'name': 'test_picking_qty_changed_after_validate picking',
+                    'partner_id': self.partner_a.id,
+                    'order_line': [Command.create({
+                        'product_id': self.product_a.id,
+                        'product_qty': 10.0,
+                        'price_unit': 15.0,
+                    })],
+                    'picking_type_id': picking_type.id,
+                })
+                po.button_confirm()
+                dropship = po.picking_ids
+                dropship.move_ids[0].quantity = 10.0
+                dropship.button_validate()
+                dropship.action_toggle_is_locked()
+                dropship.move_ids[0].quantity = 5.0
+
+                self.assertEqual(
+                    po.order_line[0].qty_received, 5.0,
+                    f'picking_type={picking_type.code}, cost_method={cost_method}'
+                )
+                self.assertEqual(
+                    self.product_a.standard_price, 5.0 if cost_method == 'standard' else 15.0,
+                    f'picking_type={picking_type.code}, cost_method={cost_method}'
+                )


### PR DESCRIPTION
**Current behavior:**
Depending on the created picking type and product costing
method, unlocking a validated picking and changing the quantity
field of a move will not update the qty_received field of the
respective purchase order line.

**Expected behavior:**
These values will be synchronized.

**Steps to reproduce:**
1. Make a purchase order with a following combination:
    A) `picking_type = receipt`
       `product cost_method != standard`

    B) `picking_type = dropship`
       (product cost_method is arbitrary)

2. Confirm the order, validate the picking

3. Unlock the picking and change the quantity value of the stock
     move

4. Observe that the purchase order's qty_received value does not
     change

**Cause of the issue:**
In the case of the receipt picking type, when creating a stock
valuation layer for the related move with a 'standard' product
costing method we do not call `_get_price_unit()`. This method
will compute the qty_received value of a purchase order line.
After we unlock the picking and change the move quantity, this
field will not be recomputed (because it is stored). Thus, it is
not updated.

The dropship case is similar, except in the creation of a
dropship SVL, `_get_price_unit()` is called before checking the
product's cost method- so the bug always occurs.

**Fix:**
Make the purchase order line's qty_received field depend on it's
stock moves' quantities.

Reorder the conditional in the dropship SVL creation so it
matches that of the incoming SVL creation- this is for
improving consistency rather than a necessary modification for
the fix.

opw-3863510