### PR TITLE
[FIX] mrp: fix qty_producing overlapping

### DIFF
--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -248,7 +248,7 @@
                             <field name="product_description_variants" invisible="product_description_variants in (False, '')" readonly="state != 'draft'"/>
                             <label for="product_qty" string="Quantity"/>
                             <div class="o_row g-0 d-flex">
-                                <div invisible="state == 'draft'" class="o_row flex-grow-0">
+                                <div invisible="state == 'draft'" class="o_row flex-grow-1">
                                     <field name="qty_producing" class="text-start" readonly="state == 'cancel' or (state == 'done' and is_locked)"/>
                                     /
                                 </div>


### PR DESCRIPTION

**Steps to repduce:**
- Create `mrp.production` record with large number `Quantity`
- Confirm and set same large `Quantity` value
- Click on Produce all Button

https://app.screencastify.com/v2/manage/videos/cy0tbiIT37R0KmST7FNv

Description of the issue/feature this PR addresses:
![Odoo-WH-MO-00027](https://github.com/odoo/odoo/assets/104754706/70997403-9f03-4085-b35b-cd05dc343222)
Current behavior before PR:

Desired behavior after PR is merged:


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
