### PR TITLE
[IMP] stock: show visibility days in replenishment info and forecast report

### DIFF
--- a/addons/stock/static/src/stock_forecasted/forecasted_details.xml
+++ b/addons/stock/static/src/stock_forecasted/forecasted_details.xml
@@ -81,6 +81,16 @@
                     <td t-out="line.delivery_date or ''"
                         t-attf-class="#{! line.replenishment_filled and 'o_grid_warning'}"/>
                 </tr>
+                <tr t-if="this.props.docs.qty_to_order">
+                    <td>To Order at Forecasted Date</td>
+                    <td t-out="this.props.docs.lead_days_date"/>
+                    <td t-out="_formatFloat(this.props.docs.qty_to_order)" class="text-end"/>
+                </tr>
+                <tr t-if="this.props.docs.qty_to_order_computed and this.props.docs.visibility !== this.props.docs.lead_days_date">
+                    <td>To Order + Visibility Days</td>
+                    <td t-out="this.props.docs.visibility"/>
+                    <td t-out="_formatFloat(this.props.docs.qty_to_order_computed)" class="text-end"/>
+                </tr>
             </tbody>
             <thead>
                 <tr class="o_forecasted_row bg-200">

--- a/addons/stock/static/src/stock_forecasted/stock_forecasted.js
+++ b/addons/stock/static/src/stock_forecasted/stock_forecasted.js
@@ -54,7 +54,14 @@ export class StockForecasted extends Component {
             context: this.context,
             docids: [this.productId],
         });
-        this.docs = { ...reportValues.docs, ...reportValues.precision };
+        this.docs = {
+            ...reportValues.docs,
+            ...reportValues.precision,
+            qty_to_order: this.context.qty_to_order,
+            qty_to_order_computed: this.context.qty_to_order_computed,
+            lead_days_date: this.context.lead_days_date,
+            visibility: this.context.visibility
+        };
     }
 
     async _getResModel(){

--- a/addons/stock/static/src/widgets/json_widget.xml
+++ b/addons/stock/static/src/widgets/json_widget.xml
@@ -26,6 +26,18 @@
                         = <t t-out="jsonValue.lead_days_date"/>
                     </td>
                 </tr>
+                <tr t-if="jsonValue.visibility > 0">
+                    <td>Visibility days</td>
+                    <td class="text-end text-nowrap">
+                        + <t t-out="jsonValue.visibility"/> Day(s)
+                    </td>
+                </tr>
+                <tr>
+                    <td><b>To Order Date</b></td>
+                    <td class="text-end text-nowrap">
+                        <b>= <t t-out="jsonValue.to_order_date"/></b>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/addons/stock/wizard/stock_replenishment_info.py
+++ b/addons/stock/wizard/stock_replenishment_info.py
@@ -9,6 +9,7 @@ from datetime import datetime, time
 from odoo import api, fields, models, SUPERUSER_ID, _
 from odoo.osv.expression import AND
 from odoo.tools.date_utils import get_month, subtract
+from odoo.tools.float_utils import float_compare
 from odoo.tools.misc import get_lang, format_date
 
 
@@ -55,6 +56,8 @@ class StockReplenishmentInfo(models.TransientModel):
                 'product_max_qty': self.env['ir.qweb.field.float'].value_to_html(orderpoint.product_max_qty, {'decimal_precision': 'Product Unit of Measure'}),
                 'product_uom_name': orderpoint.product_uom_name,
                 'virtual': orderpoint.trigger == 'manual' and orderpoint.create_uid.id == SUPERUSER_ID,
+                'visibility': orderpoint.visibility_days if float_compare(orderpoint.qty_forecast, orderpoint.product_min_qty, precision_rounding=orderpoint.product_uom.rounding) < 0 else 0,
+                'to_order_date': format_date(self.env, fields.Date.add(replenishment_report.orderpoint_id.lead_days_date, days=int(orderpoint.visibility_days)))
             })
 
     @api.depends('orderpoint_id')


### PR DESCRIPTION
- Display visibility days and to order date inside of replenishment information window
- Display to order and visibility days fields in forecast report

Task: 3930803