### PR TITLE
[FIX] point_of_sale: correct COGS for kit with different UOM

### DIFF
--- a/addons/pos_mrp/models/pos_order.py
+++ b/addons/pos_mrp/models/pos_order.py
@@ -23,4 +23,9 @@ class PosOrder(models.Model):
         if not bom:
             return super()._get_pos_anglo_saxon_price_unit(product, partner_id, quantity)
         dummy, components = bom.explode(product, quantity)
-        return sum(super(PosOrder, self)._get_pos_anglo_saxon_price_unit(comp[0].product_id, partner_id, comp[1]['qty']) for comp in components)
+        total_price_unit = 0
+        for comp in components:
+            price_unit = super()._get_pos_anglo_saxon_price_unit(comp[0].product_id, partner_id, comp[1]['qty'])
+            price_unit = comp[0].product_id.uom_id._compute_price(price_unit, comp[0].product_uom_id)
+            total_price_unit += price_unit
+        return total_price_unit

--- a/addons/pos_mrp/tests/test_pos_mrp_flow.py
+++ b/addons/pos_mrp/tests/test_pos_mrp_flow.py
@@ -252,3 +252,83 @@ class TestPosMrp(TestPointOfSaleCommon):
         self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).credit, 15.0)
         self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).debit, 0.0)
         self.pos_config.current_session_id.action_pos_session_closing_control()
+
+    def test_bom_kit_different_uom_invoice_valuation(self):
+        """This test make sure that when a kit is made of product using UoM A but the bom line uses UoM B
+           the price unit is correctly computed on the invoice lines.
+        """
+        self.env.user.groups_id += self.env.ref('uom.group_uom')
+        category = self.env['product.category'].create({
+            'name': 'Category for kit',
+            'property_cost_method': 'fifo',
+            'property_valuation': 'real_time',
+        })
+
+        self.kit = self.env['product.product'].create({
+            'name': 'Final Kit',
+            'available_in_pos': True,
+            'categ_id': category.id,
+            'taxes_id': False,
+            'type': 'product',
+        })
+
+        self.component_a = self.env['product.product'].create({
+            'name': 'Comp A',
+            'available_in_pos': True,
+            'standard_price': 12000.0,
+            'categ_id': category.id,
+            'taxes_id': False,
+            'uom_id': self.env.ref('uom.product_uom_dozen').id,
+        })
+
+        bom_product_form = Form(self.env['mrp.bom'])
+        bom_product_form.product_id = self.kit
+        bom_product_form.product_tmpl_id = self.kit.product_tmpl_id
+        bom_product_form.product_qty = 1.0
+        bom_product_form.type = 'phantom'
+        with bom_product_form.bom_line_ids.new() as bom_line:
+            bom_line.product_id = self.component_a
+            bom_line.product_qty = 1.0
+            bom_line.product_uom_id = self.env.ref('uom.product_uom_unit')
+        self.bom_a = bom_product_form.save()
+
+        self.pos_config.open_ui()
+        order_data = {'data':
+            {'to_invoice': True,
+            'amount_paid': 2.0,
+            'amount_return': 0,
+            'amount_tax': 0,
+            'amount_total': 2.0,
+            'creation_date': fields.Datetime.to_string(fields.Datetime.now()),
+            'fiscal_position_id': False,
+            'pricelist_id': self.pos_config.available_pricelist_ids[0].id,
+            'lines': [[0,
+                        0,
+                        {'discount': 0,
+                        'pack_lot_ids': [],
+                        'price_unit': 2,
+                        'product_id': self.kit.id,
+                        'price_subtotal': 2,
+                        'price_subtotal_incl': 2,
+                        'qty': 1,
+                        'tax_ids': []}],
+                        ],
+                'name': 'Order 00042-003-0014',
+                'partner_id': self.partner1.id,
+                'pos_session_id': self.pos_config.current_session_id.id,
+                'sequence_number': 2,
+                'statement_ids': [[0,
+                                    0,
+                                    {'amount': 2.0,
+                                    'name': fields.Datetime.now(),
+                                    'payment_method_id': self.cash_payment_method.id}]],
+                'uid': '00042-003-0014',
+                'user_id': self.env.uid},
+            }
+        order = self.env['pos.order'].create_from_ui([order_data])
+        order = self.env['pos.order'].browse(order[0]['id'])
+        accounts = self.kit.product_tmpl_id.get_product_accounts()
+        expense_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == accounts['expense'].id)
+        self.assertEqual(expense_line.filtered(lambda l: l.product_id == self.kit).debit, 1000.0)
+        interim_line = order.account_move.line_ids.filtered(lambda l: l.account_id.id == accounts['stock_output'].id)
+        self.assertEqual(interim_line.filtered(lambda l: l.product_id == self.kit).credit, 1000.0)


### PR DESCRIPTION
The COGS registered was wrong when invoicing a product that is a kit
with UOM A and component uses UOM B.

Steps to reproduce:
-------------------
* Create Comp A with UOM Dozens. It's cost should be 12000
* Create Product A with UOM Units.
* Make sure both use the same category, and the category should use
  automcatic inventory valuation.
* Create a kit bom for product A that contains 1 comp A.
* Sell this kit in the PoS and invoice it.
* Close the PoS and go to the order then on the invoice.
* Check the journal items

> Observation: the COGS is 12000 it's wrong. It should be
  1000

Why the fix:
------------
The `_get_pos_anglo_saxon_price_unit` is not taking the product uom into
account. So in this example the price unit will be for a dozen, but the
bom specifies that we are using a unit and not a dozen. So the quantity
needs to be modified from a dozen to unit. That's what the 
`_compute_price` method is doing.


opw-3787201
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
