### PR TITLE
[FIX] event_booth_sale: prevent unwanted sol description update

### DIFF
--- a/addons/event_booth_sale/models/sale_order_line.py
+++ b/addons/event_booth_sale/models/sale_order_line.py
@@ -74,7 +74,7 @@ class SaleOrderLine(models.Model):
         if self.event_booth_pending_ids and (not self.event_id or self.event_id != self.event_booth_pending_ids.event_id):
             self.event_booth_pending_ids = None
 
-    @api.depends('event_booth_pending_ids')
+    @api.depends('event_booth_registration_ids.event_booth_id')
     def _compute_name(self):
         """Override to add the compute dependency.
 


### PR DESCRIPTION
Steps
---
* install sale_subscription, event_booth_sale
* create a new SO
* create a SOL for some product, edit **both** the unit price and the
  description
* save
* change the recurrence; the price unit is immediately reset (ok)
* save; the description is reset (unwanted)

Problem
---

When we change the recurrence this triggers the `_compute_price_unit`
method for the SOL,

but, when processing onchanges, for x2many fields, if **any**
field of a related record is modified, we send **all** the fields
to of the record to be written by the orm. ( [code](https://github.com/odoo/odoo/blob/ec5a798166cee25db72954da445e2ee2ed991c77/odoo/models.py#L6467-L6472) )

and, since the SOL is an o2m of the SO and its `price_unit` has been
edited, upon saving, we will send all the fields of the SOL to the orm,
and especially `event_booth_pending_ids`.

This will "look" to the orm, as if the field was written to directly
and trigger the `_compute` methods which depend on this field as well
as its inverse method.

Furthermore, `event_booth_sale` SOL child model, defines a
`_compute_name` method, which has `event_booth_pending_ids` as a
dependency. It is normally only meant to be triggered when the
field is edited "manually", so here it gets triggered while we
do not want it to.

This causes the `name` (Description) field of the SOL to be
undesirable reset.

ie, the flow looks something like this:
* edit the recurrence => sol `_compute_price_unit`
  => (when processing onchange) sol has been edited,
  mark all its fields as needing to be written.
* when saving => write (actually unchanged) sol `event_booth_pending_id`
  => trigger `_compute_name`

Fix
---
Change the compute method dependency to what `event_booth_pending_ids`
reduces to eventually. As this is an indirect dependcy the problem with
onchanges does not occur.

opw-3916560