### PR TITLE
[FIX] web: display correct week days in month view calendar

### DIFF
--- a/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
+++ b/addons/web/static/src/views/calendar/calendar_common/calendar_common_renderer.js
@@ -359,7 +359,10 @@ export class CalendarCommonRenderer extends Component {
 
     headerTemplateProps(date) {
         const scale = this.props.model.scale;
-        const { weekdayShort, weekdayLong, day } = DateTime.fromJSDate(date);
+        // when rendering months, FullCalendar uses a date w/out tz
+        // so use UTC instead of local tz when converting to DateTime
+        const options = scale === "month" ? { zone: "UTC" } : {};
+        const { weekdayShort, weekdayLong, day } = DateTime.fromJSDate(date, options);
         return {
             weekdayShort,
             weekdayLong,

--- a/addons/web/static/tests/views/calendar/calendar_view.test.js
+++ b/addons/web/static/tests/views/calendar/calendar_view.test.js
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "@odoo/hoot";
+import { queryAllTexts } from "@odoo/hoot-dom";
+import { mockTimeZone } from "@odoo/hoot-mock";
+
+import {
+    defineModels,
+    defineParams,
+    fields,
+    models,
+    mountView,
+} from "@web/../tests/web_test_helpers";
+
+class Event extends models.Model {
+    name = fields.Char();
+    start = fields.Datetime();
+    stop = fields.Datetime();
+
+    check_access_rights = function () {
+        return Promise.resolve(true);
+    };
+
+    _records = [
+        {
+            id: 1,
+            name: "May Day",
+            start: "2024-05-01 08:00:00",
+            stop: "2024-05-01 18:00:00",
+        },
+    ];
+}
+
+defineModels([Event]);
+
+const MON_TO_SUN = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"];
+
+async function setupCalendarView(mode, options = {}) {
+    const { utc_offset, week_start } = options;
+    mockTimeZone(utc_offset ?? 0);
+    defineParams({ lang_parameters: { week_start: week_start ?? 1 } });
+    return await mountView({
+        type: "calendar",
+        resModel: "event",
+        resId: 1,
+        arch: /* xml */ `<calendar mode="${mode}" date_start="start"/>`,
+    });
+}
+
+function weekDaysTest(mode, options) {
+    return async () => {
+        expect.assertions(8);
+        await setupCalendarView(mode, options);
+
+        const { week_start } = options;
+        const week =
+            week_start === 1
+                ? MON_TO_SUN
+                : MON_TO_SUN.map((_, i) => MON_TO_SUN[(week_start + i - 1) % 7]);
+
+        expect(queryAllTexts(".o_cw_day_name")).toEqual(week);
+        for (const day of week) {
+            expect(`.fc-day-${day.toLowerCase()} .o_cw_day_name`).toHaveText(day);
+        }
+    };
+}
+
+describe("EU", () => {
+    const options = { utc_offset: +2, week_start: 1 };
+    test("week days (week view)", weekDaysTest("week", options));
+    test("week days (month view)", weekDaysTest("month", options));
+});
+
+describe("US", () => {
+    const options = { utc_offset: -7, week_start: 7 };
+    test("week days (week view)", weekDaysTest("week", options));
+    test("week days (month view)", weekDaysTest("month", options));
+});


### PR DESCRIPTION
Versions
--------
- saas-17.2+

Steps
-----
1. Change browser time zone to America/Los_Angeles;
2. go to Calendar;
3. switch to Month view.

Issue
-----
The day names displayed are one day off, e.g. showing 2024-05-01 as TUE instead of WED.

Cause
-----
Commit 90f85a19deae updated FullCalendar to V6.1.10.

One of the changes it introduced is that month view renders no longer look at a specified date, but one in the distant past, see: https://github.com/fullcalendar/fullcalendar/issues/5854#issuecomment-702495211

The time zone of this "distant past" should get interpreted as UTC instead of defaulting to the local time zone.

Solution
--------
In the custom render function passed to FullCalendar, interpret the Date object as UTC time instead of local time when scale is set to month.

opw-3934014