### PR TITLE
[FW][FIX] base: allow to edit vat on child company

### DIFF
--- a/addons/l10n_ar/views/res_partner_view.xml
+++ b/addons/l10n_ar/views/res_partner_view.xml
@@ -10,7 +10,7 @@
                 <field name="l10n_ar_afip_responsibility_type_id"
                        invisible="'AR' not in fiscal_country_codes"
                        options="{'no_open': True, 'no_create': True}"
-                       readonly="parent_id"/>
+                       readonly="parent_id and not is_company"/>
             </xpath>
         </field>
     </record>

--- a/addons/l10n_latam_base/views/res_partner_view.xml
+++ b/addons/l10n_latam_base/views/res_partner_view.xml
@@ -11,7 +11,7 @@
                 <label for="l10n_latam_identification_type_id" string="Identification Number"/>
             </xpath>
             <xpath expr="//field[@name='vat']" position="replace">
-                <field name="l10n_latam_identification_type_id" options="{'no_open': True, 'no_create': True}" placeholder="Type" class="oe_inline" domain="country_id and ['|', ('country_id', '=', False), ('country_id', '=', country_id)] or []" required="True" readonly="parent_id"/>
+                <field name="l10n_latam_identification_type_id" options="{'no_open': True, 'no_create': True}" placeholder="Type" class="oe_inline" domain="country_id and ['|', ('country_id', '=', False), ('country_id', '=', country_id)] or []" required="True" readonly="parent_id and not is_company"/>
                 <span class="oe_read_only"> - </span>
                 <field name="vat" placeholder="Number" class="oe_inline" readonly="parent_id"/>
             </xpath>

--- a/odoo/addons/base/views/res_partner_views.xml
+++ b/odoo/addons/base/views/res_partner_views.xml
@@ -224,7 +224,7 @@
                                         readonly="type == 'contact' and parent_id"/>
                                 </div>
                             </div>
-                            <field name="vat" placeholder="e.g. BE0477472701" readonly="parent_id"/>
+                            <field name="vat" placeholder="e.g. BE0477472701" readonly="parent_id and not is_company"/>
                         </group>
                         <group>
                             <field name="function" placeholder="e.g. Sales Director"


### PR DESCRIPTION
FW of https://github.com/odoo/odoo/pull/55239

Description of the issue/feature this PR addresses:

Create one partner of type "is company" (let's name it "Parent company")
Create another partner, set type "individual", choose a parent company, then change to type "is company" (let's name it "Child company")
Current behavior before PR:

VAT is not editable on "Child Company"
Desired behavior after PR is merged:

VAT should be editable on "Child Company" as other commercial fields.
The Child Company should be able to get a vat different to the parent company, that is already implemented on the method [_commercial_sync_to_children](https://github.com/odoo/odoo/blob/d17b6e8b4872fc579c565ba356e94fab2c370e60/odoo/addons/base/models/res_partner.py#L609), but now the field remains empty and readonly
With this change we are using same criteria as in another commercial field like pricelist and accounts tab
I confirm I have signed the CLA and read the PR guidelines at [www.odoo.com/submit-pr](http://www.odoo.com/submit-pr)