### PR TITLE
[FIX] web_editor: properly sanitize paragraphs in list items

### DIFF
--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/editor.test.js
@@ -126,10 +126,34 @@ describe('Editor', () => {
             });
         });
         describe('sanitize should modify p within li', () => {
-            it('should convert p into span if p has classes and split link items for each p', async () => {
+            it('should convert p into span if p has classes and add br between each span', async () => {
                 await testEditor(BasicEditor, {
                     contentBefore: '<ul><li><p class="class-1">abc</p><p class="class-2">def</p></li></ul>',
-                    contentAfter: '<ul><li><span class="class-1">abc</span></li><li class="oe-nested"><span class="class-2">def</span></li></ul>',
+                    contentAfter: '<ul><li><span class="class-1">abc</span><br><span class="class-2">def</span></li></ul>',
+                });
+            });
+            it('should convert p into span and add display block if p had text align style', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li><p style="text-align: center;">abc</p></li></ul>',
+                    contentAfter: '<ul><li><span style="text-align: center; display: block;">abc</span></li></ul>',
+                });
+            });
+            it('should convert two p into span and add display block if p had text align style without adding br', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li><p style="text-align: center;">abc</p><p style="text-align: center;">def</p></li></ul>',
+                    contentAfter: '<ul><li><span style="text-align: center; display: block;">abc</span><span style="text-align: center; display: block;">def</span></li></ul>',
+                });
+            });
+            it('should unwrap two p if they do not have any attributes', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li><p>abc</p><p>def</p></li></ul>',
+                    contentAfter: '<ul><li>abc<br>def</li></ul>',
+                });
+            });
+            it('should unwrap two p one containing br and other containing text', async () => {
+                await testEditor(BasicEditor, {
+                    contentBefore: '<ul><li><p><br></p><p>a</p></li></ul>',
+                    contentAfter: '<ul><li><br>a</li></ul>',
                 });
             });
         });

--- a/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
+++ b/addons/web_editor/static/src/js/editor/odoo-editor/test/spec/list.test.js
@@ -2809,7 +2809,7 @@ describe('List', () => {
                                 '<ul><li><p>abc</p></li><li><p>def[]</p><p>ghi</p></li><li><p>klm</p></li></ul>',
                             // Paragraphs in list items are treated as nonsense.
                             contentBeforeEdit:
-                                '<ul><li>abc</li><li>def[]</li><li class="oe-nested">ghi</li><li>klm</li></ul>',
+                                '<ul><li>abc</li><li>def[]<br>ghi</li><li>klm</li></ul>',
                             stepFunction: deleteForward,
                             contentAfter:
                                 '<ul><li>abc</li><li>def[]ghi</li><li>klm</li></ul>',
@@ -5473,10 +5473,10 @@ describe('List', () => {
                                 '<ol><li><p>abc</p></li><li><p>def</p><p>[]ghi</p></li><li><p>klm</p></li></ol>',
                             // Paragraphs in list items are treated as nonsense.
                             contentBeforeEdit:
-                                '<ol><li>abc</li><li>def</li><li class="oe-nested">[]ghi</li><li>klm</li></ol>',
+                                '<ol><li>abc</li><li>def<br>[]ghi</li><li>klm</li></ol>',
                             stepFunction: deleteBackward,
                             contentAfter:
-                                '<ol><li>abc</li><li>def</li></ol><p>[]ghi</p><ol><li>klm</li></ol>',
+                                '<ol><li>abc</li><li>def[]ghi</li><li>klm</li></ol>',
                         });
                         await testEditor(BasicEditor, {
                             contentBefore:
@@ -5497,10 +5497,10 @@ describe('List', () => {
                             // Two paragraphs in a list item = Two list items.
                             // Paragraphs in list items are treated as nonsense.
                             contentBeforeEdit:
-                                '<ol><li>abc</li><li><b>de</b>fg</li><li class="oe-nested"><b>[]hij</b>klm</li><li>nop</li></ol>',
+                                '<ol><li>abc</li><li><b>de</b>fg<br><b>[]hij</b>klm</li><li>nop</li></ol>',
                             stepFunction: deleteBackward,
                             contentAfter:
-                                '<ol><li>abc</li><li><b>de</b>fg</li></ol><p><b>[]hij</b>klm</p><ol><li>nop</li></ol>',
+                                '<ol><li>abc</li><li><b>de</b>fg[]<b>hij</b>klm</li><li>nop</li></ol>',
                         });
                     });
                     it('should treat two blocks in a list item and keep blocks', async () => {
@@ -5509,10 +5509,10 @@ describe('List', () => {
                                 '<ul><li><p>abc</p></li><li><p>def</p><p>[]ghi</p></li><li><p>klm</p></li></ul>',
                             // Paragraphs in list items are treated as nonsense.
                             contentBeforeEdit:
-                                '<ul><li>abc</li><li>def</li><li class="oe-nested">[]ghi</li><li>klm</li></ul>',
+                                '<ul><li>abc</li><li>def<br>[]ghi</li><li>klm</li></ul>',
                             stepFunction: deleteBackward,
                             contentAfter:
-                                '<ul><li>abc</li><li>def</li></ul><p>[]ghi</p><ul><li>klm</li></ul>',
+                                '<ul><li>abc</li><li>def[]ghi</li><li>klm</li></ul>',
                         });
                         await testEditor(BasicEditor, {
                             contentBefore:
@@ -5533,10 +5533,10 @@ describe('List', () => {
                             // Two paragraphs in a list item = Two list items.
                             // Paragraphs in list items are treated as nonsense.
                             contentBeforeEdit:
-                                '<ul><li>abc</li><li><b>de</b>fg</li><li class="oe-nested"><b>[]hij</b>klm</li><li>nop</li></ul>',
+                                '<ul><li>abc</li><li><b>de</b>fg<br><b>[]hij</b>klm</li><li>nop</li></ul>',
                             stepFunction: deleteBackward,
                             contentAfter:
-                                '<ul><li>abc</li><li><b>de</b>fg</li></ul><p><b>[]hij</b>klm</p><ul><li>nop</li></ul>',
+                                '<ul><li>abc</li><li><b>de</b>fg[]<b>hij</b>klm</li><li>nop</li></ul>',
                         });
                     });
                     it('should treat two blocks in a list item and keep blocks', async () => {
@@ -5546,10 +5546,10 @@ describe('List', () => {
                                 '<ul class="o_checklist"><li class="o_checked"><p>abc</p></li><li class="o_checked"><p>def</p><p>[]ghi</p></li><li class="o_checked"><p>klm</p></li></ul>',
                             // Paragraphs in list items are treated as nonsense.
                             contentBeforeEdit:
-                                '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked">def</li><li class="oe-nested">[]ghi</li><li class="o_checked">klm</li></ul>',
+                                '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked">def<br>[]ghi</li><li class="o_checked">klm</li></ul>',
                             stepFunction: deleteBackward,
                             contentAfter:
-                                '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked">def</li></ul><p>[]ghi</p><ul class="o_checklist"><li class="o_checked">klm</li></ul>',
+                                '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked">def[]ghi</li><li class="o_checked">klm</li></ul>',
                         });
                         await testEditor(BasicEditor, {
                             removeCheckIds: true,
@@ -5570,12 +5570,12 @@ describe('List', () => {
                             contentBefore:
                                 '<ul class="o_checklist"><li class="o_checked"><p>abc</p></li><li class="o_checked"><p><b>de</b>fg</p><p><b>[]hij</b>klm</p></li><li class="o_checked"><p>nop</p></li></ul>',
                             contentBeforeEdit:
-                                '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked"><b>de</b>fg</li><li class="oe-nested"><b>[]hij</b>klm</li><li class="o_checked">nop</li></ul>',
+                                '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked"><b>de</b>fg<br><b>[]hij</b>klm</li><li class="o_checked">nop</li></ul>',
                             // Two paragraphs in a list item = Two list items.
                             // Paragraphs in list items are treated as nonsense.
                             stepFunction: deleteBackward,
                             contentAfter:
-                                '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked"><b>de</b>fg</li></ul><p><b>[]hij</b>klm</p><ul class="o_checklist"><li class="o_checked">nop</li></ul>',
+                                '<ul class="o_checklist"><li class="o_checked">abc</li><li class="o_checked"><b>de</b>fg[]<b>hij</b>klm</li><li class="o_checked">nop</li></ul>',
                         });
                     });
                 });


### PR DESCRIPTION
Description of the issue this PR addresses:

Paragraphs are not admitted in list items in the editor. But the way they were sanitized away was broken.

After commit [1] contiguous paragraphs in a list item were converted to their own new list item with oe-nested class to remove the bullet point (eg, `<li><p>a</p><p>b</p></li>` became `<li>a</li><li class=oe-nested>b</li>`), which broke some snippet using paragraphs nested within list item.

This commit convert those p tags with attributes to span tags and use `<br>` tags to separate those spans and unwraps those without attributes.

task-3932057

[1]: https://github.com/odoo/odoo/commit/3f9938823189935a013846db9c9a96b5d8bd15d0