### PR TITLE
[IMP] pos_restaurant: same end price eat in take out

### DIFF
--- a/addons/pos_self_order/views/res_config_settings_views.xml
+++ b/addons/pos_self_order/views/res_config_settings_views.xml
@@ -98,7 +98,7 @@
             </setting>
 
             <setting id="flexible_taxes" position="attributes">
-                <attribute name="invisible">is_kiosk_mode</attribute>
+                <attribute name="invisible">is_kiosk_mode or pos_takeaway</attribute>
             </setting>
         </field>
     </record>


### PR DESCRIPTION
In this commit:
================
To ensure that the final price of a product remains unchanged regardless of the VAT applied, adjust the base price of the product accordingly so that when VAT is added, the total amount equals the original intended price.

EX:

```
flow      product    price_vat_excl.    vat rate    vat amount    total vat incl

Eat in      pizza         $8.93             12%         $1.07         $10.00
Take out    pizza         $8.93             6%          $0.54         $9.47
To be       pizza         $9.43             6%          $0.57         $10.0
```

task - 3935347


