### PR TITLE
[FIX] mrp: do not update consumed qty if manually set

### DIFF
--- a/addons/mrp/models/stock_move.py
+++ b/addons/mrp/models/stock_move.py
@@ -274,6 +274,12 @@ class StockMove(models.Model):
             new_qty = float_round((mo.qty_producing - mo.qty_produced) * self.unit_factor, precision_rounding=self.product_uom.rounding)
             self.quantity = new_qty
 
+    @api.onchange('quantity', 'product_uom', 'picked')
+    def _onchange_quantity(self):
+        if self.raw_material_production_id and not self.manual_consumption and self.picked and self.product_uom and \
+           float_compare(self.product_uom_qty, self.quantity, precision_rounding=self.product_uom.rounding) != 0:
+            self.manual_consumption = True
+
     @api.model
     def default_get(self, fields_list):
         defaults = super(StockMove, self).default_get(fields_list)

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -230,3 +230,50 @@ class TestManualConsumption(TestMrpCommon):
         move_auto, move_manual = get_moves(backorder)
         self.assertEqual(move_auto.manual_consumption, False)
         self.assertEqual(move_manual.manual_consumption, True)
+
+    def test_update_manual_consumption_00(self):
+        """
+        Check that the manual consumption is set to true when the quantity is manualy set.
+        """
+        bom = self.bom_1
+        components = bom.bom_line_ids.product_id
+        self.env['stock.quant']._update_available_quantity(components[0], self.stock_location, 10)
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.bom_id = bom
+        mo_form.product_qty = 4
+        mo = mo_form.save()
+        mo.action_confirm()
+        self.assertEqual(mo.move_raw_ids.mapped('manual_consumption'), [False, False])
+        self.assertEqual(components[0].stock_quant_ids.reserved_quantity, 2.0)
+        with Form(mo) as fmo:
+            with fmo.move_raw_ids.edit(0) as line_0:
+                line_0.quantity = 3.0
+                line_0.picked = True
+        self.assertEqual(mo.move_raw_ids.mapped('manual_consumption'), [True, False])
+        self.assertEqual(components[0].stock_quant_ids.reserved_quantity, 3.0)
+        mo.button_mark_done()
+        self.assertRecordValues(mo.move_raw_ids, [{'quantity': 3.0, 'picked': True}, {'quantity': 4.0, 'picked': True}])
+
+    def test_update_manual_consumption_01(self):
+        """
+        Check that the quantity of a raw line that is manually consumed is not updated
+        when the qty producing is changed and that others are.
+        """
+        bom = self.bom_1
+        components = bom.bom_line_ids.product_id
+        self.env['stock.quant']._update_available_quantity(components[0], self.stock_location, 10)
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.bom_id = bom
+        mo_form.product_qty = 4
+        mo = mo_form.save()
+        mo.action_confirm()
+        self.assertEqual(mo.move_raw_ids.mapped('manual_consumption'), [False, False])
+        self.assertEqual(components[0].stock_quant_ids.reserved_quantity, 2.0)
+        with Form(mo) as fmo:
+            with fmo.move_raw_ids.edit(0) as line_0:
+                line_0.quantity = 3.0
+                line_0.picked = True
+            fmo.qty_producing = 2.0
+        self.assertEqual(mo.move_raw_ids.mapped('manual_consumption'), [True, False])
+        self.assertEqual(components[0].stock_quant_ids.reserved_quantity, 3.0)
+        self.assertRecordValues(mo.move_raw_ids, [{'quantity': 3.0, 'picked': True}, {'quantity': 2.0, 'picked': True}])

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -431,7 +431,7 @@
                                         force_save="1"/>
                                     <field name="product_uom" readonly="state != 'draft' and id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
                                     <field name="picked" string="Consumed" column_invisible="parent.state == 'draft'" optional="show"/>
-                                    <field name="manual_consumption" column_invisible="True"/>
+                                    <field name="manual_consumption" column_invisible="True" force_save="1"/>
                                     <field name="show_details_visible" column_invisible="True"/>
                                     <field name="lot_ids" widget="many2many_tags"
                                         optional="hide"


### PR DESCRIPTION
### Steps to reproduce:

- Create a product FP with a BOM consuming 1 unit of a product COMP
- Create and confirm a MO for 1 unit of FP using the BOM
- Set the consumed quantity of COMP to 2 and tick consumed
- Save and "Produce All"

#### > the consumed quantity of COMP was updated to 1 according to the BOM

### Cause of the issue:

Clicking on "Produce All" will trigger the `pre_button_mark_done` that will update the qty_producing according to the bom proportions because of these lines:
https://github.com/odoo/odoo/blob/86f977f8f4b9859790ad77af3a40234c8eb374e9/addons/mrp/models/mrp_production.py#L1217-L1227 However, this update should be bypassed if the quantity was set on the move. This is the role of these lines:
https://github.com/odoo/odoo/blob/86f977f8f4b9859790ad77af3a40234c8eb374e9/addons/mrp/models/mrp_production.py#L1218-L1220

The issue does not appear in 17.0 because, thanks to commit https://github.com/odoo/odoo/commit/5bb0f96f1973fa7e19b6701944b4a29577f3314f the `manual_consumption` field of the stock moves related to a manufacturing order is set to be True as soon as the quantity is changed because of these lines:
https://github.com/odoo/odoo/blob/9a11717c17b860ec2f1b2e228517c0d3945c474a/addons/mrp/static/src/widgets/mrp_consumed.js#L25-L27 However, this js file was removed in saas-17.2 by commit https://github.com/odoo/odoo/commit/e143345193577442ffd1f46272a09d7a5801d567.

opw-3934942
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
