### PR TITLE
[FIX] account: step down logging when decoding invalid xml or pdf

### DIFF
--- a/addons/account/models/account_move.py
+++ b/addons/account/models/account_move.py
@@ -3126,16 +3126,13 @@ class AccountMove(models.Model):
             passed_file_data_list.append(file_data)
             attachment = file_data.get('attachment') or file_data.get('originator_pdf')
             if attachment:
-                if attachments_by_invoice[attachment]:
+                if attachments_by_invoice.get(attachment):
                     attachments_by_invoice[attachment] |= invoice
                 else:
                     attachments_by_invoice[attachment] = invoice
 
         file_data_list = attachments._unwrap_edi_attachments()
-        attachments_by_invoice = {
-            attachment: None
-            for attachment in attachments
-        }
+        attachments_by_invoice = {}
         invoices = self
         current_invoice = self
         passed_file_data_list = []
@@ -3163,6 +3160,10 @@ class AccountMove(models.Model):
                 close_file(file_data)
                 continue
 
+            extend_with_existing_lines = file_data.get('process_if_existing_lines', False)
+            if current_invoice.invoice_line_ids and not extend_with_existing_lines:
+                continue
+
             decoder = (current_invoice or current_invoice.new(self.default_get(['move_type', 'journal_id'])))._get_edi_decoder(file_data, new=new)
             if decoder:
                 try:
@@ -3176,6 +3177,8 @@ class AccountMove(models.Model):
                             invoices |= invoice
                             current_invoice = self.env['account.move']
                             add_file_data_results(file_data, invoice)
+                        if extend_with_existing_lines:
+                            return attachments_by_invoice
 
                 except RedirectWarning:
                     raise
@@ -4707,14 +4710,8 @@ class AccountMove(models.Model):
             return res
 
         odoobot = self.env.ref('base.partner_root')
-        if attachments and self.state != 'draft':
+        if self.state != 'draft':
             self.message_post(body=_('The invoice is not a draft, it was not updated from the attachment.'),
-                              message_type='comment',
-                              subtype_xmlid='mail.mt_note',
-                              author_id=odoobot.id)
-            return res
-        if attachments and self.invoice_line_ids:
-            self.message_post(body=_('The invoice already contains lines, it was not updated from the attachment.'),
                               message_type='comment',
                               subtype_xmlid='mail.mt_note',
                               author_id=odoobot.id)
@@ -4722,7 +4719,14 @@ class AccountMove(models.Model):
 
         # As we are coming from the mail, we assume that ONE of the attachments
         # will enhance the invoice thanks to EDI / OCR / .. capabilities
+        has_existing_lines = bool(self.invoice_line_ids)
         results = self._extend_with_attachments(attachments, new=bool(self._context.get('from_alias')))
+        if has_existing_lines and not results:
+            self.message_post(body=_('The invoice already contains lines, it was not updated from the attachment.'),
+                              message_type='comment',
+                              subtype_xmlid='mail.mt_note',
+                              author_id=odoobot.id)
+            return res
         attachments_per_invoice = defaultdict(self.env['ir.attachment'].browse)
         for attachment, invoices in results.items():
             invoices = invoices or self

--- a/addons/account/models/ir_attachment.py
+++ b/addons/account/models/ir_attachment.py
@@ -37,7 +37,7 @@ class IrAttachment(models.Model):
         try:
             xml_tree = etree.fromstring(content)
         except Exception as e:
-            _logger.exception("Error when converting the xml content to etree: %s", e)
+            _logger.info('Error when reading the xml file "%s": %s', filename, e)
             return []
 
         to_process = []
@@ -61,7 +61,7 @@ class IrAttachment(models.Model):
             pdf_reader = OdooPdfFileReader(buffer, strict=False)
         except Exception as e:
             # Malformed pdf
-            _logger.warning("Error when reading the pdf: %s", e, exc_info=True)
+            _logger.info('Error when reading the pdf file "%s": %s', filename, e)
             return []
 
         # Process embedded files.


### PR DESCRIPTION
Previously, when the attempting to decode a pdf or xml file as EDI attachment, if an xml or pdf file was malformed, we would log a warning (for pdf) or error (for xml).

There are tests in which we post messages to the chatter with an XML file with embedded PDF which is actually a generated report. These tests don't actually generate a valid PDF because wkhtmltopdf isn't available in those tests, but these tests also do not particularly care that the PDF is valid. Similarly, there are tests that post messages with xml attachments that don't contain valid xml but they also do not care that the xml in valid in those flows.

The linked enterprise PR adds an override of _message_post that will attempt to decode posted attachments so that it can take some action based on their contents. While this works perfectly fine and doesn't break any behaviour, as the decoding methods will simply return an empty list when the attachments are malformed, because they log warnings or errors, it causes tests/runbot to fail.

The information that an invalid xml or pdf was uploaded is not particularly useful or urgent information for the server admin, and users already get a notification when uploading a malformed file. As such, this commit changes these warning/exception logs to simple info logs. This means this information remains available but isn't given disporoportionate importance in the logs, and doesn't cause tests that work perfecly fine to fail.

task-3731034