### PR TITLE
[FIX] survey: fix labels in session chart

### DIFF
--- a/addons/survey/static/src/js/survey_session_chart.js
+++ b/addons/survey/static/src/js/survey_session_chart.js
@@ -146,7 +146,8 @@ publicWidget.registry.SurveySessionChart = publicWidget.Widget.extend({
                             maxRotation: 0,
                             fontSize: '35',
                             fontStyle: 'bold',
-                            fontColor: '#212529'
+                            fontColor: '#212529',
+                            autoSkip: false,
                         },
                         gridLines: {
                             drawOnChartArea: false,


### PR DESCRIPTION
Purpose
=======
Fix the session chart labels which were disappearing when zooming on the chart.

Specification
=============
When zooming, the chart x axis ticks were skipped / hidden leading to the labels disappearance.
Fixing the issue by preventing the x axis ticks from being skipped.

Task-3918382


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
