### PR TITLE
[FIX] stock_delivery: reusable package weight

### DIFF
--- a/addons/stock_delivery/models/stock_picking.py
+++ b/addons/stock_delivery/models/stock_picking.py
@@ -71,11 +71,17 @@ class StockPicking(models.Model):
     @api.depends('move_line_ids.result_package_id', 'move_line_ids.result_package_id.shipping_weight', 'weight_bulk')
     def _compute_shipping_weight(self):
         for picking in self:
+            if picking.state == 'done':
+                continue
             # if shipping weight is not assigned => default to calculated product weight
             picking.shipping_weight = (
                 picking.weight_bulk +
                 sum(pack.shipping_weight or pack.weight for pack in picking.package_ids.sudo())
             )
+
+    def _action_done(self):
+        self._compute_shipping_weight()
+        super()._action_done()
 
     def _get_default_weight_uom(self):
         return self.env['product.template']._get_weight_uom_name_from_ir_config_parameter()
@@ -93,7 +99,7 @@ class StockPicking(models.Model):
     weight_uom_name = fields.Char(string='Weight unit of measure label', compute='_compute_weight_uom_name', readonly=True, default=_get_default_weight_uom)
     package_ids = fields.Many2many('stock.quant.package', compute='_compute_packages', string='Packages')
     weight_bulk = fields.Float('Bulk Weight', compute='_compute_bulk_weight', help="Total weight of products which are not in a package.")
-    shipping_weight = fields.Float("Weight for Shipping", compute='_compute_shipping_weight',
+    shipping_weight = fields.Float("Weight for Shipping", compute='_compute_shipping_weight', store=True,
         help="Total weight of packages and products not in a package. Packages with no shipping weight specified will default to their products' total weight. This is the weight used to compute the cost of the shipping.")
     is_return_picking = fields.Boolean(compute='_compute_return_picking')
     return_label_ids = fields.One2many('ir.attachment', compute='_compute_return_label')


### PR DESCRIPTION
Steps to reproduce:
1. Activate packages in inventory > configuration > settings.
2. Create a delivery for any product with a set weight, and put the products of the delivery in a reusable package.
3. Validate the transfer and then unpack the package.
4. Create a new delivery for a different product with a different weight, and put the products of the delivery in the same reusable package as in step 2.
5. If you look at the additional info tab of both inventory transfers, the "weight for shipping" is the same in both cases, even if the products of both packages had different weights.
6. Additionally, if the weight for shipping field is modified in any of the inventory transfers, then the weight will be modified in all of the transfers that used the same reusable package.

Fix:
store the picking weight and do not updated it once it's done this fixes the issue because the package is only used on one picking at a time (the actif one) change the weight field to stored to keep track of it once the picking is done and the package is reused

opw-3834199

