### PR TITLE
[FIX] base_import_module: fix tree view

### DIFF
--- a/addons/base_import_module/__manifest__.py
+++ b/addons/base_import_module/__manifest__.py
@@ -18,5 +18,10 @@ for customization purpose.
         'views/base_import_module_view.xml',
         'views/ir_module_views.xml',
     ],
+    'assets': {
+        'web.assets_backend': [
+            'base_import_module/static/src/**/*',
+        ]
+    },
     'license': 'LGPL-3',
 }

--- a/addons/base_import_module/static/src/base_import_list_renderer.js
+++ b/addons/base_import_module/static/src/base_import_list_renderer.js
@@ -1,0 +1,29 @@
+/** @odoo-module */
+import { ListRenderer } from "@web/views/list/list_renderer";
+
+export class ImportModuleListRenderer extends ListRenderer {
+
+    get hasSelectors() {
+        return super.hasSelectors && this.props.list.records.every(record => record._values.module_type != 'industries');
+    }
+
+    async onCellClicked(record, column, ev) {
+        if (record._values.module_type && record._values.module_type !== 'official') {
+            const re_action = {
+                name: "more_info",
+                res_model: "ir.module.module",
+                res_id: -1,
+                type: "ir.actions.act_window",
+                views: [[false, "form"]],
+                context: {
+                    'module_name': record._values.name,
+                    'module_type': record._values.module_type,
+                }
+            }
+            this.env.services.action.doAction(re_action);
+        }
+        else{
+            super.onCellClicked(record, column, ev);
+        }
+    }
+}

--- a/addons/base_import_module/static/src/base_import_list_view.js
+++ b/addons/base_import_module/static/src/base_import_list_view.js
@@ -1,0 +1,13 @@
+/** @odoo-module */
+
+import { registry } from "@web/core/registry";
+import { listView } from "@web/views/list/list_view";
+import { ImportModuleListRenderer } from "./base_import_list_renderer";
+
+
+export const ImportModuleListView = {
+    ...listView,
+    Renderer: ImportModuleListRenderer,
+}
+
+registry.category("views").add("ir_module_module_tree_view", ImportModuleListView);

--- a/addons/base_import_module/views/ir_module_views.xml
+++ b/addons/base_import_module/views/ir_module_views.xml
@@ -35,7 +35,11 @@
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='category_id']" position="after">
                     <field name="module_type" column_invisible="1"/>
+                    <field name="name" column_invisible="1"/>
                 </xpath>
+                <tree position="attributes">
+                    <attribute name="js_class">ir_module_module_tree_view</attribute>
+                </tree>
             </field>
         </record>
         <record model="ir.ui.view" id="module_form_apps_inherit">


### PR DESCRIPTION
[FIX] base_import_module: fix the tree view 

Steps to Reproduce:
When we click on tree view of industry its showing the error that can't fetch 
record they might have been deleted.

Issue:
In Kanban, it works because we passed the context on the xml side, however in 
the tree view, we can't access those contexts, and because the modules aren't 
stored, we only get the resId as -1.

Fix:
So we restricted the click and no redirect on the tree view, and as an alternative, 
we introduced a More Info button that redirects us to the form view.

Task - 3834095