### PR TITLE
[ADD] stock: added the filter full availability

### DIFF
--- a/addons/repair/views/repair_views.xml
+++ b/addons/repair/views/repair_views.xml
@@ -259,6 +259,7 @@
                 <separator/>
                 <filter string="Ready" name="ready" domain="[('state', 'in', ('confirmed', 'under_repair')),('is_parts_available', '=', True)]" invisible="True"/>
                 <filter string="Late" name="filter_late" domain="[('state', 'in', ('confirmed', 'under_repair')), '|', ('schedule_date', '&lt;', context_today().strftime('%Y-%m-%d')), ('is_parts_late', '=', True)]"/>
+                <filter string="Components Available" name="available" domain="[('is_parts_available', '=', True)]"/>
                 <filter name="filter_create_date" date="create_date"/>
                 <separator/>
                 <filter invisible="1" string="Late Activities" name="activities_overdue"

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -438,6 +438,9 @@ class PickingType(models.Model):
                     'default_company_id': allowed_company_ids[0],
                 })
 
+        if self.code == 'incoming':
+            context.update({'is_receipt': True})
+
         action_context = literal_eval(action['context'])
         context = {**action_context, **context}
         action['context'] = context

--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -367,7 +367,8 @@
                         domain="[('state', 'in', ('assigned', 'waiting', 'confirmed')), '|', '|', ('has_deadline_issue', '=', True), ('date_deadline', '&lt;', current_date), ('scheduled_date', '&lt;', current_date)]"/>
                     <filter string="Planning Issues" name="planning_issues" help="Transfers that are late on scheduled time or one of pickings will be late"
                         domain="['|', ('delay_alert_date', '!=', False), '&amp;', ('scheduled_date','&lt;', time.strftime('%Y-%m-%d %H:%M:%S')), ('state', 'in', ('assigned', 'waiting', 'confirmed'))]"/>
-                    <filter string="Late Availability" name="late" domain="[('products_availability_state', '=', 'late')]"/>
+                    <filter string="Full Availability" name="full_availability" domain="[('products_availability_state', '=', 'available')]" invisible="context.get('is_receipt')"/>
+                    <filter string="Late Availability" name="late" domain="[('products_availability_state', '=', 'late')]" invisible="context.get('is_receipt')"/>
                     <separator/>
                     <filter name="backorder" string="Backorders" domain="[('backorder_id', '!=', False), ('state', 'in', ('assigned', 'waiting', 'confirmed'))]" help="Remaining parts of picking partially processed"/>
                     <separator/>


### PR DESCRIPTION
In this commit
==============
- Add a new filter called full availability in all operations except operation
   type is a receipt.
- Hide filter name in receipt list view as it seems useless.

TaskId: 3912321
