### PR TITLE
[FIX] hr_timesheet,project_timesheet_holidays: fix traceback for external id

### DIFF
--- a/addons/hr_timesheet/models/res_company.py
+++ b/addons/hr_timesheet/models/res_company.py
@@ -57,7 +57,8 @@ class ResCompany(models.Model):
 
     def _create_internal_project_task(self):
         results = []
-        type_ids = [(4, self.env.ref('hr_timesheet.internal_project_default_stage').id)]
+        type_ids_ref = self.env.ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False)
+        type_ids = [(4, type_ids_ref.id)] if type_ids_ref else []
         for company in self:
             company = company.with_company(company)
             results += [{

--- a/addons/project_timesheet_holidays/models/res_company.py
+++ b/addons/project_timesheet_holidays/models/res_company.py
@@ -12,7 +12,8 @@ class Company(models.Model):
         domain="[('project_id', '=', internal_project_id)]")
 
     def init(self):
-        type_ids = [(4, self.env.ref('hr_timesheet.internal_project_default_stage').id)]
+        type_ids_ref = self.env.ref('hr_timesheet.internal_project_default_stage', raise_if_not_found=False)
+        type_ids = [(4, type_ids_ref.id)] if type_ids_ref else []
         companies = self.search(['|', ('internal_project_id', '=', False), ('leave_timesheet_task_id', '=', False)])
         internal_projects_by_company_dict = None
         Project = self.env['project.project']


### PR DESCRIPTION
Currently, a traceback is occurring when the user deletes the master data of project name 'internal' 
and tries to install another module.

To reproduce this issue:-

1) Install `project_timesheet_holidays` without demo data
2) Delete all `My Timesheets` data from `Timesheets` 
3) Delete all the `My tasks` from the project after removing the default filters 
4) Now delete the `internal` task stage from project/configuration/task stages
5) Try to install the `MRP` module

Error:-
```
ValueError: External ID not found in the system: hr_timesheet.internal_project_default_stage
```

When the user installs another module after deleting the project `internal`,
a traceback trigger as the `external_id` is referenced to create a project for master data.

https://github.com/odoo/odoo/blob/5a26d5173cc54bcbed18a251854c5e725c2ba3b4/addons/project_timesheet_holidays/models/res_company.py#L15

After applying this commit will resolve this issue.

sentry-5344711392

