### PR TITLE
[FIX] pos_self_order: load self order in pos

### DIFF
--- a/addons/point_of_sale/static/src/app/store/pos_store.js
+++ b/addons/point_of_sale/static/src/app/store/pos_store.js
@@ -1061,10 +1061,20 @@ export class PosStore extends Reactive {
         }
     }
     async getServerOrders() {
-        return await this.data.searchRead("pos.order", [
+        return await this.loadServerOrders([
             ["config_id", "in", [...this.config.raw.trusted_config_ids, this.config.id]],
             ["state", "=", "draft"],
         ]);
+    }
+    async loadServerOrders(domain) {
+        const orders = await this.data.searchRead("pos.order", domain);
+        for (const order of orders) {
+            order.update({
+                config_id: this.config,
+                session_id: this.session,
+            });
+        }
+        return orders;
     }
     async getProductInfo(product, quantity, priceExtra = 0) {
         const order = this.get_order();

--- a/addons/pos_online_payment_self_order/static/src/self_order_service.js
+++ b/addons/pos_online_payment_self_order/static/src/self_order_service.js
@@ -46,4 +46,9 @@ patch(SelfOrder.prototype, {
         const exit = encodeURIComponent(exitRouteUrl);
         return `${baseUrl}/pos/pay/${order_id}?access_token=${order_access_token}&exit_route=${exit}`;
     },
+    filterPaymentMethods(pms) {
+        const pm = super.filterPaymentMethods(...arguments);
+        const online_pms = pms.filter((rec) => rec.is_online_payment);
+        return [...new Set([...pm, ...online_pms])];
+    },
 });

--- a/addons/pos_self_order/models/pos_order.py
+++ b/addons/pos_self_order/models/pos_order.py
@@ -77,14 +77,3 @@ class PosOrder(models.Model):
                 'pos.payment.method': order.payment_ids.mapped('payment_method_id').read(self.env['pos.payment.method']._load_pos_data_fields(order.config_id.id), load=False),
                 'product.attribute.custom.value':  order.lines.custom_attribute_value_ids.read(order.lines.custom_attribute_value_ids._load_pos_data_fields(order.config_id.id), load=False),
             })
-
-    @api.model
-    def get_standalone_self_order(self):
-        orders = self.env['pos.order'].search_read([
-            *self.env["pos.order"]._check_company_domain(self.env.company),
-            ('state', '=', 'draft'),
-            '|', ('pos_reference', 'ilike', 'Kiosk'),
-            ('pos_reference', 'ilike', 'Self-Order'),
-            ('table_id', '=', False),
-        ], [], load=False)
-        return {'pos.order': orders}

--- a/addons/pos_self_order/static/src/app/self_order_service.js
+++ b/addons/pos_self_order/static/src/app/self_order_service.js
@@ -299,11 +299,20 @@ export class SelfOrder extends Reactive {
         }
     }
 
+    filterPaymentMethods(pms) {
+        //based on _load_pos_self_data_domain from pos_payment_method.py
+        return this.config.self_ordering_mode === "kiosk"
+            ? pms.filter((rec) => ["adyen", "stripe"].includes(rec.use_payment_terminal))
+            : [];
+    }
+
     async confirmOrder() {
         const payAfter = this.config.self_ordering_pay_after; // each, meal
         const device = this.config.self_ordering_mode; // kiosk, mobile
         const service = this.config.self_ordering_service_mode; // table, counter
-        const paymentMethods = this.models["pos.payment.method"].getAll(); // Stripe, Adyen, Online
+        const paymentMethods = this.filterPaymentMethods(
+            this.models["pos.payment.method"].getAll()
+        ); // Stripe, Adyen, Online
         const order = this.currentOrder;
 
         // Stand number page will recall this function after the stand number is set

--- a/addons/pos_self_order/static/src/overrides/models/pos_store.js
+++ b/addons/pos_self_order/static/src/overrides/models/pos_store.js
@@ -8,7 +8,14 @@ patch(PosStore.prototype, {
     },
     async getServerOrders() {
         if (this.session._self_ordering) {
-            await this.data.callRelated("pos.order", "get_standalone_self_order", []);
+            await this.loadServerOrders([
+                ["company_id", "=", this.config.company_id.id],
+                ["state", "=", "draft"],
+                "|",
+                ["pos_reference", "ilike", "Kiosk"],
+                ["pos_reference", "ilike", "Self-Order"],
+                ["table_id", "=", false],
+            ]);
         }
 
         return await super.getServerOrders(...arguments);


### PR DESCRIPTION
Before this commit, the loading of the self orders in a pos was not working, leading to people not being able to see their orders and pay it.

This commit fixes the issue by adding moving the loading logic in the frontend and using the correct method to load the orders.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
