### PR TITLE
[FIX] maintenance: rework calendar_with_recurrence tours

### DIFF
--- a/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
+++ b/addons/maintenance/static/tests/tours/tour_calendar_with_recurrence.js
@@ -20,7 +20,11 @@ registry.category("web_tour.tours").add("test_dblclick_event_from_calendar", {
             trigger: ".o_back_button",
         },
         {
-            content: "Access recurrence",
+            content: "Move to next week",
+            trigger: ".o_calendar_button_next"
+        },
+        {
+            content: "Access occurrence",
             trigger: 'a[data-event-id="2"]',
             run: "dblclick",
         },
@@ -34,7 +38,7 @@ registry.category("web_tour.tours").add("test_dblclick_event_from_calendar", {
             trigger: ".o_back_button",
         },
         {
-            trigger: 'a[data-event-id="1"]',
+            trigger: 'a[data-event-id="2"]',
             isCheck: true,
         }
     ],
@@ -44,14 +48,22 @@ registry.category("web_tour.tours").add("test_drag_and_drop_event_in_calendar", 
     test: true,
     steps: () => [
         {
-            content: "Move event to Wednesday 1.15 PM",
-            trigger: 'a[data-event-id="1"]',
-            run: 'drag_and_drop_native tr[data-time="13:30:00"] td.fc-widget-content:not(.fc-time)',
+            content: "Open calendar display selector",
+            trigger: ".scale_button_selection",
         },
         {
-            content: "Move recurrence to Wednesday 2.45 PM (nothing should happen)",
+            content: "Select monthly display",
+            trigger: ".o_scale_button_month",
+        },
+        {
+            content: "Move event to 15th of the month",
+            trigger: 'a[data-event-id="1"]',
+            run: 'drag_and_drop_native .fc-day.fc-widget-content[data-date$="15"]',
+        },
+        {
+            content: "Move occurrence to 20th of the month (nothing should happen)",
             trigger: 'a[data-event-id="2"]',
-            run: 'drag_and_drop_native tr[data-time="15:00:00"] td.fc-widget-content:not(.fc-time)',
+            run: 'drag_and_drop_native .fc-day.fc-widget-content[data-date$="20"]',
         },
     ],
 });

--- a/addons/maintenance/tests/test_calendar_with_recurrence.py
+++ b/addons/maintenance/tests/test_calendar_with_recurrence.py
@@ -1,80 +1,74 @@
 from odoo.tests import HttpCase, tagged
-from odoo.tools.float_utils import float_compare
-from datetime import timedelta, date, datetime
+from datetime import datetime, time
+from dateutil.relativedelta import relativedelta
 
 
 @tagged('post_install', '-at_install')
 class TestCalendarWithRecurrence(HttpCase):
 
     def test_dblclick_event_from_calendar(self):
+        """Make sure double clicking on an event and its recurrences lead to the correct record"""
         self.env['maintenance.team'].create({
             'name': 'the boys',
         })
         equipment = self.env['maintenance.equipment'].create({
             'name': 'room'
         })
-        self.env['maintenance.request'].create({
+        requests = self.env['maintenance.request'].create([{
             'name': 'send the mails',
-            'schedule_date': datetime.today() - timedelta(weeks=2),
-        })
-        request = self.env['maintenance.request'].create({
+            'schedule_date': datetime.now() + relativedelta(weeks=-2),
+        }, {
+            'name': 'wash the car',
+            'schedule_date': datetime.now() + relativedelta(weeks=+3),
+        }, {
             'name': 'clean the room',
-            'schedule_date': datetime.combine(date.today(), (datetime.min + timedelta(hours=10)).time()),  # today at 10.00 AM
+            'schedule_date': datetime.now(),
             'equipment_id': equipment.id,  # necessary for the tour to work with mrp_maintenance installed
             'maintenance_type': 'preventive',
             'recurring_maintenance': True,
+            'repeat_until': datetime.now() + relativedelta(days=+8),
             'repeat_interval': 1,
             'repeat_unit': 'day',
             'duration': 1,
-        })
-        self.env['maintenance.request'].create({
-            'name': 'wash the car',
-            'schedule_date': datetime.today() + timedelta(weeks=1),
-        })
-
-        # The event should have a different id from the record
-        self.assertNotEqual(request.id, 1)
+        }])
+        request = requests[2]
 
         action = self.env["ir.actions.actions"]._for_xml_id("maintenance.hr_equipment_request_action_cal")
         url = '/web?#action=%s' % (action['id'])
         self.start_tour(url, 'test_dblclick_event_from_calendar', login='admin')
 
-        self.assertEqual(request.name, 'make your bed')
-        self.assertEqual(float_compare(request.duration, 2, 0), 0)
+        self.assertEqual(request.name, 'make your bed', "The event modification should update the request")
+        self.assertEqual(request.duration, 2, "The event modification should update the request")
 
     def test_drag_and_drop_calendar_event(self):
+        """
+        Make sure dragging and dropping an event changes the correct record
+        Occurences should be locked, drag and drop should have no effect
+        """
         self.env['maintenance.team'].create({
             'name': 'the boys',
         })
-        self.env['maintenance.request'].create({
+        requests = self.env['maintenance.request'].create([{
             'name': 'send the mails',
-            'schedule_date': datetime.today() - timedelta(weeks=2),
-        })
-        request = self.env['maintenance.request'].create({
+            'schedule_date': datetime.now() + relativedelta(months=-2),
+        }, {
+            'name': 'wash the car',
+            'schedule_date': datetime.now() + relativedelta(months=+1),
+        }, {
             'name': 'clean the room',
-            'schedule_date': datetime.combine(date.today(), (datetime.min + timedelta(hours=10)).time()),  # today at 10.00 AM
+            'schedule_date': datetime.combine(datetime.now().replace(day=6), time.min.replace(hour=10)),  # 6th of the month at 10 AM
             'maintenance_type': 'preventive',
             'recurring_maintenance': True,
             'repeat_interval': 1,
-            'repeat_unit': 'day',
+            'repeat_until': datetime.now() + relativedelta(weeks=+2),
+            'repeat_unit': 'week',
             'duration': 1,
-        })
-        self.env['maintenance.request'].create({
-            'name': 'wash the car',
-            'schedule_date': datetime.today() + timedelta(weeks=1),
-        })
-
-        # The event should have a different id from the record
-        self.assertNotEqual(request.id, 1)
+        }])
+        request = requests[2]
 
         action = self.env["ir.actions.actions"]._for_xml_id("maintenance.hr_equipment_request_action_cal")
         url = '/web?#action=%s' % (action['id'])
         self.start_tour(url, 'test_drag_and_drop_event_in_calendar', login='admin')
 
-        today_as_weekday = (date.today().weekday() + 1) % 7  # Sunday is the first day of the week in the calendar
-        today_to_wednesday = 3 - today_as_weekday  # difference between Wednesday and today
-        target_datetime = datetime.combine(
-            date.today() + timedelta(days=today_to_wednesday),
-            (datetime.min + timedelta(hours=13.25)).time()
-        )  # this Wednesday at 1.15 PM
-        self.assertEqual(request.schedule_date, target_datetime)
+        target_datetime = datetime.combine(datetime.now().replace(day=15), time.min.replace(hour=10))  # 15h of the month at 10 AM
+        self.assertEqual(request.schedule_date, target_datetime, "The event modification should update the request")


### PR DESCRIPTION
### Issue:

`test_dblclick_event_from_calendar` tour test fails on Saturday

### Explanation:

In the tour, we test an event with daily recurrence. Since the Weekly Calendar starts on Sunday and ends on Saturday, if an event starts on Saturday, the second occurrence of the event is on the next week and can not be reached.

### Fix:

Moving to next week for the occurrence test, limiting recurrence to 8 days to remove useless rendering.
Setting `drag_and_drop` tour in Monthly Calendar view to avoid issues caused by potential `drag_and_drop` behaviour changes. In Monthly Calendar view, some days from previous and following months are visible, with a maximum of 6 before (Feb 23, see Mar 2025) and 14 after (Mar 14, see Feb 2026). Initial date being set in the backend, it does not have to respect those limitations. Changes operated in the frontend are bound to these and must be set between 15 and 22 included with the current selector.

runbot-error-65494