### PR TITLE
[FIX] mrp: update the qty to consume when the MO is done

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1695,6 +1695,10 @@ class MrpProduction(models.Model):
             for key, values in tools_groupby(moves_to_do, key=lambda m: m.raw_material_production_id.id)
         ])
         for order in self:
+            # match the qty to consume with the qty producing
+            if order.qty_producing != order.product_uom_qty:
+                for move in moves_to_do_by_order[order.id]:
+                    move.product_uom_qty = move.should_consume_qty
             finish_moves = order.move_finished_ids.filtered(lambda m: m.product_id == order.product_id and m.state not in ('done', 'cancel'))
             # the finish move can already be completed by the workorder.
             for move in finish_moves:

--- a/addons/mrp/tests/test_manual_consumption.py
+++ b/addons/mrp/tests/test_manual_consumption.py
@@ -271,3 +271,19 @@ class TestManualConsumption(TestMrpCommon):
         action = consumption_warning.save().action_confirm()
         self.assertEqual(len(mo.move_raw_ids), 1)
         self.assertEqual(mo.move_raw_ids.quantity, 2)
+
+    def test_update_should_consume_for_done_mo(self):
+        """
+        Check that the qty to consume is updated with respect to the qty_producing
+        when the MO is marked as donetest_under_consumption
+        """
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.product_id = self.bom_1.product_id
+        mo_form.bom_id = self.bom_1
+        mo_form.product_qty = 1
+        mo = mo_form.save()
+        mo.action_confirm()
+        with Form(mo) as fmo:
+            fmo.qty_producing = 4.0
+        mo.button_mark_done()
+        self.assertRecordValues(mo.move_raw_ids, [{'product_uom_qty': 2.0, 'quantity': 2.0, 'picked': True}, {'product_uom_qty': 4.0, 'quantity': 4.0, 'picked': True}])


### PR DESCRIPTION
### Steps to reproduce:

- Create and confirm an MO for 1 unit of a product P1 that should consume 2 units of a product P2
- Change the quantity of the MO to 5 without changing the initial demand 
           - **the displayed values of the "To consume" and "Quantity" of P2 are updated to '10/2' and '10'**
- Click on produce

### Expected behavior:

To know if the quantity consumed by the MO ("quantity" of the raw line) match the quantity that should have been consumed displayed as "10/2" before production we need the "To consume" qty to be updated to 10

### Current behavior:

The "To consume" quantity of P2  stays at 2 to match the initial demand.

opw-3850336
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
