### PR TITLE
[IMP] web: Pager on small screen

### DIFF
--- a/addons/web/static/src/core/pager/pager.js
+++ b/addons/web/static/src/core/pager/pager.js
@@ -1,7 +1,10 @@
 import { useAutofocus } from "../utils/hooks";
 import { clamp } from "../utils/numbers";
 
-import { Component, useExternalListener, useState } from "@odoo/owl";
+import { Component, useExternalListener, useState, EventBus } from "@odoo/owl";
+
+export const PAGER_UPDATED_EVENT = "PAGER:UPDATED";
+export const pagerBus = new EventBus();
 
 /**
  * Pager
@@ -131,6 +134,12 @@ export class Pager extends Component {
         try {
             await this.props.onUpdate({ offset, limit }, hasNavigated);
         } finally {
+            if (this.env.isSmall) {
+                pagerBus.trigger(PAGER_UPDATED_EVENT, {
+                    value: this.value,
+                    total: this.props.total,
+                });
+            }
             this.state.isDisabled = false;
             this.state.isEditing = false;
         }

--- a/addons/web/static/src/core/pager/pager.xml
+++ b/addons/web/static/src/core/pager/pager.xml
@@ -3,7 +3,7 @@
 
     <t t-name="web.Pager">
         <nav class="o_pager d-flex gap-2 h-100" aria-label="Pager">
-            <span class="o_pager_counter align-self-center" t-on-click.stop="">
+            <span t-if="!env.isSmall" class="o_pager_counter align-self-center" t-on-click.stop="">
                 <t t-if="state.isEditing">
                     <input type="text" class="o_pager_value o_input d-inline-block w-auto text-end mb-n1" size="7" t-ref="autofocus" t-att-value="value" t-on-blur="onInputBlur" t-on-change="onInputChange" t-on-keydown.stop="onInputKeydown" />
                 </t>

--- a/addons/web/static/src/core/pager/pager_indicator.js
+++ b/addons/web/static/src/core/pager/pager_indicator.js
@@ -1,0 +1,37 @@
+import { browser } from "../browser/browser";
+import { registry } from "../registry";
+import { Transition } from "../transition";
+import { useBus } from "../utils/hooks";
+
+import { Component, useState } from "@odoo/owl";
+import { PAGER_UPDATED_EVENT, pagerBus } from "./pager";
+
+export class PagerIndicator extends Component {
+    static template = "web.PagerIndicator";
+    static components = { Transition };
+    static props = {};
+
+    setup() {
+        this.state = useState({
+            show: false,
+            value: "-",
+            total: 0,
+        });
+        this.startShowTimer = null;
+        useBus(pagerBus, PAGER_UPDATED_EVENT, this.pagerUpdate);
+    }
+
+    pagerUpdate({ detail }) {
+        this.state.value = detail.value;
+        this.state.total = detail.total;
+        browser.clearTimeout(this.startShowTimer);
+        this.state.show = true;
+        this.startShowTimer = browser.setTimeout(() => {
+            this.state.show = false;
+        }, 1400);
+    }
+}
+
+registry.category("main_components").add("PagerIndicator", {
+    Component: PagerIndicator,
+});

--- a/addons/web/static/src/core/pager/pager_indicator.scss
+++ b/addons/web/static/src/core/pager/pager_indicator.scss
@@ -1,0 +1,7 @@
+.o_pager_indicator {
+    z-index: $zindex-modal + 1;
+    transition: opacity 0.4s;
+    &.o-fade-leave, &.o-fade-enter {
+        opacity: 0;
+    }
+}

--- a/addons/web/static/src/core/pager/pager_indicator.xml
+++ b/addons/web/static/src/core/pager/pager_indicator.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates xml:space="preserve">
+
+    <t t-name="web.PagerIndicator">
+        <Transition visible="state.show" name="'o-fade'" t-slot-scope="transition" leaveDuration="400">
+            <div class="o_pager_indicator position-fixed top-0 w-100 mt-2 d-flex justify-content-center" t-att-class="transition.className">
+                <span class="o_pager_indicator_inner px-3 py-1 text-bg-primary shadow rounded-4 fs-4">
+                    <span class="o_pager_value" t-esc="state.value" />
+                    <span> / </span>
+                    <span class="o_pager_limit" t-esc="state.total"/>
+                </span>
+            </div>
+        </Transition>
+    </t>
+
+</templates>

--- a/addons/web/static/tests/core/components/pager_indicator.test.js
+++ b/addons/web/static/tests/core/components/pager_indicator.test.js
@@ -1,0 +1,25 @@
+import { PagerIndicator } from "@web/core/pager/pager_indicator";
+import { mountWithCleanup, patchWithCleanup } from "../../web_test_helpers";
+import { config as transitionConfig } from "@web/core/transition";
+import { expect, test } from "@odoo/hoot";
+import { PAGER_UPDATED_EVENT, pagerBus } from "@web/core/pager/pager";
+import { animationFrame, runAllTimers } from "@odoo/hoot-mock";
+
+test("displays the pager indicator", async () => {
+    patchWithCleanup(transitionConfig, { disabled: true });
+    await mountWithCleanup(PagerIndicator, { noMainContainer: true });
+    expect(".o_pager_indicator").toHaveCount(0, {
+        message: "the pager indicator should not be displayed",
+    });
+    pagerBus.trigger(PAGER_UPDATED_EVENT, { value: "1-4", total: 10 });
+    await animationFrame();
+    expect(".o_pager_indicator").toHaveCount(1, {
+        message: "the pager indicator should be displayed",
+    });
+    expect(".o_pager_indicator").toHaveText("1-4 / 10");
+    await runAllTimers();
+    await animationFrame();
+    expect(".o_pager_indicator").toHaveCount(0, {
+        message: "the pager indicator should not be displayed",
+    });
+});

--- a/addons/web/static/tests/search/pager_hook.test.js
+++ b/addons/web/static/tests/search/pager_hook.test.js
@@ -40,6 +40,30 @@ test("pager is correctly displayed", async () => {
         searchMenuTypes: [],
     });
     expect(`.o_pager`).toHaveCount(1);
+    expect(".o_pager button.o_pager_next").toHaveCount(1);
+    expect(".o_pager button.o_pager_previous").toHaveCount(1);
+});
+
+test.tags("desktop")("pager is correctly displayed on desktop", async () => {
+    class TestComponent extends Component {
+        static components = { ControlPanel };
+        static template = xml`<ControlPanel />`;
+        static props = ["*"];
+        setup() {
+            usePager(() => ({
+                offset: 0,
+                limit: 10,
+                total: 50,
+                onUpdate: () => {},
+            }));
+        }
+    }
+
+    await mountWithSearch(TestComponent, {
+        resModel: "foo",
+        searchMenuTypes: [],
+    });
+    expect(`.o_pager`).toHaveCount(1);
     expect(getPagerValue()).toEqual([1, 10]);
     expect(getPagerLimit()).toBe(50);
 });
@@ -67,20 +91,52 @@ test("pager is correctly updated", async () => {
         searchMenuTypes: [],
     });
     expect(`.o_pager`).toHaveCount(1);
+    expect(component.state).toEqual({ offset: 0, limit: 10 });
+
+    await pagerNext();
+    expect(`.o_pager`).toHaveCount(1);
+    expect(component.state).toEqual({ offset: 10, limit: 10 });
+
+    component.state.offset = 20;
+    await animationFrame();
+    expect(`.o_pager`).toHaveCount(1);
+    expect(component.state).toEqual({ offset: 20, limit: 10 });
+});
+
+test.tags("desktop")("pager is correctly updated on desktop", async () => {
+    class TestComponent extends Component {
+        static components = { ControlPanel };
+        static template = xml`<ControlPanel />`;
+        static props = ["*"];
+        setup() {
+            this.state = useState({ offset: 0, limit: 10 });
+            usePager(() => ({
+                offset: this.state.offset,
+                limit: this.state.limit,
+                total: 50,
+                onUpdate: (newState) => {
+                    Object.assign(this.state, newState);
+                },
+            }));
+        }
+    }
+
+    const component = await mountWithSearch(TestComponent, {
+        resModel: "foo",
+        searchMenuTypes: [],
+    });
+    expect(`.o_pager`).toHaveCount(1);
     expect(getPagerValue()).toEqual([1, 10]);
     expect(getPagerLimit()).toBe(50);
-    expect(component.state).toEqual({ offset: 0, limit: 10 });
 
     await pagerNext();
     expect(`.o_pager`).toHaveCount(1);
     expect(getPagerValue()).toEqual([11, 20]);
     expect(getPagerLimit()).toBe(50);
-    expect(component.state).toEqual({ offset: 10, limit: 10 });
 
     component.state.offset = 20;
     await animationFrame();
     expect(`.o_pager`).toHaveCount(1);
     expect(getPagerValue()).toEqual([21, 30]);
     expect(getPagerLimit()).toBe(50);
-    expect(component.state).toEqual({ offset: 20, limit: 10 });
 });

--- a/addons/web/static/tests/views/form/auto_save.test.js
+++ b/addons/web/static/tests/views/form/auto_save.test.js
@@ -765,18 +765,35 @@ test(`save when action button clicked`, async () => {
     expect(`.o_field_widget[name='expertise'] input`).toHaveValue("Sales");
 
     await contains(`.o_field_widget[name='expertise'] input`).edit("test");
-    expect(`.o_pager_counter`).toHaveText("1 / 1");
     expect(`.o_field_widget[name='expertise'] input`).toHaveValue("test");
 
     await contains(`.o_cp_action_menus button`).click();
     await contains(`.o-dropdown--menu .dropdown-item`).click();
     expect(["save"]).toVerifySteps();
-    expect(`.o_pager_counter`).toHaveText("2 / 2");
     expect(`.o_field_widget[name='expertise'] input`).toHaveValue("test");
 
     await contains(`.o_pager_previous`).click();
-    expect(`.o_pager_counter`).toHaveText("1 / 2");
     expect(`.o_field_widget[name='expertise'] input`).toHaveValue("test");
+});
+
+test.tags("desktop")(`save when action button clicked on desktop`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="expertise"/></form>`,
+        actionMenus: {},
+        resId: 1,
+    });
+
+    await contains(`.o_field_widget[name='expertise'] input`).edit("test");
+    expect(`.o_pager_counter`).toHaveText("1 / 1");
+
+    await contains(`.o_cp_action_menus button`).click();
+    await contains(`.o-dropdown--menu .dropdown-item`).click();
+    expect(`.o_pager_counter`).toHaveText("2 / 2");
+
+    await contains(`.o_pager_previous`).click();
+    expect(`.o_pager_counter`).toHaveText("1 / 2");
 });
 
 test(`error on save when action button clicked`, async () => {

--- a/addons/web/static/tests/views/form/form_view.test.js
+++ b/addons/web/static/tests/views/form/form_view.test.js
@@ -4553,22 +4553,37 @@ test(`switching to another record from a dirty one`, async () => {
         resIds: [1, 2],
         resId: 1,
     });
-    expect(getPagerValue()).toEqual([1]);
-    expect(getPagerLimit()).toBe(2);
     expect(`.o_field_widget[name=foo] input`).toHaveValue("yop");
 
     await contains(`.o_field_widget[name=foo] input`).edit("new value");
     expect(`.o_field_widget[name=foo] input`).toHaveValue("new value");
 
     await contains(`.o_pager_next`).click();
-    expect(getPagerValue()).toEqual([2]);
     expect(`.o_field_widget[name=foo] input`).toHaveValue("blip");
     expect(["web_save"]).toVerifySteps();
 
     await contains(`.o_pager_previous`).click();
-    expect(getPagerValue()).toEqual([1]);
     expect(`.o_field_widget[name=foo] input`).toHaveValue("new value");
     expect([]).toVerifySteps();
+});
+
+test.tags("desktop")(`switching to another record from a dirty one on desktop`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo"></field></form>`,
+        resIds: [1, 2],
+        resId: 1,
+    });
+    expect(getPagerValue()).toEqual([1]);
+    expect(getPagerLimit()).toBe(2);
+
+    await contains(`.o_field_widget[name=foo] input`).edit("new value");
+    await contains(`.o_pager_next`).click();
+    expect(getPagerValue()).toEqual([2]);
+
+    await contains(`.o_pager_previous`).click();
+    expect(getPagerValue()).toEqual([1]);
 });
 
 test(`do not reload after save when using pager`, async () => {
@@ -4581,15 +4596,28 @@ test(`do not reload after save when using pager`, async () => {
         resId: 1,
     });
     expect(["get_views", "web_read"]).toVerifySteps();
-    expect(getPagerValue()).toEqual([1]);
-    expect(getPagerLimit()).toBe(2);
     expect(`.o_input`).toHaveValue("yop");
 
     await contains(`.o_field_widget[name=foo] input`).edit("new value");
     await contains(`.o_pager_next`).click();
-    expect(getPagerValue()).toEqual([2]);
     expect(`.o_input`).toHaveValue("blip");
     expect(["web_save"]).toVerifySteps();
+});
+
+test.tags("desktop")(`do not reload after save when using pager on desktop`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo"></field></form>`,
+        resIds: [1, 2],
+        resId: 1,
+    });
+    expect(getPagerValue()).toEqual([1]);
+    expect(getPagerLimit()).toBe(2);
+
+    await contains(`.o_field_widget[name=foo] input`).edit("new value");
+    await contains(`.o_pager_next`).click();
+    expect(getPagerValue()).toEqual([2]);
 });
 
 test(`switching to another record from an invalid one`, async () => {
@@ -4603,8 +4631,6 @@ test(`switching to another record from an invalid one`, async () => {
     });
     expect(`.o_breadcrumb`).toHaveText("first record");
     expect(`.o_field_widget[name=foo]`).toHaveClass("o_required_modifier");
-    expect(getPagerValue()).toEqual([1]);
-    expect(getPagerLimit()).toBe(2);
 
     await contains(`.o_field_widget[name=foo] input`).edit("");
     await contains(`.o_pager_next`).click();
@@ -4613,11 +4639,26 @@ test(`switching to another record from an invalid one`, async () => {
         "data-tooltip",
         "Unable to save. Correct the issue or discard all changes"
     );
-    expect(getPagerValue()).toEqual([1]);
-    expect(getPagerLimit()).toBe(2);
     expect(`.o_field_widget[name=foo]`).toHaveClass("o_field_invalid");
     expect(`.o_notification_manager .o_notification`).toHaveCount(1);
     expect([]).toVerifySteps();
+});
+
+test.tags("desktop")(`switching to another record from an invalid one on desktop`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo" required="1"/></form>`,
+        resIds: [1, 2],
+        resId: 1,
+    });
+    expect(getPagerValue()).toEqual([1]);
+    expect(getPagerLimit()).toBe(2);
+
+    await contains(`.o_field_widget[name=foo] input`).edit("");
+    await contains(`.o_pager_next`).click();
+    expect(getPagerValue()).toEqual([1]);
+    expect(getPagerLimit()).toBe(2);
 });
 
 test(`keynav: switching to another record from an invalid one`, async () => {
@@ -4631,7 +4672,6 @@ test(`keynav: switching to another record from an invalid one`, async () => {
     });
     expect(`.o_breadcrumb`).toHaveText("first record");
     expect(`.o_field_widget[name=foo]`).toHaveClass("o_required_modifier");
-    expect(`.o_pager_counter`).toHaveText("1 / 2");
 
     await contains(`.o_field_widget[name=foo] input`).edit("");
     press(["alt", "n"]);
@@ -4641,11 +4681,30 @@ test(`keynav: switching to another record from an invalid one`, async () => {
         "data-tooltip",
         "Unable to save. Correct the issue or discard all changes"
     );
-    expect(`.o_pager_counter`).toHaveText("1 / 2");
     expect(`.o_field_widget[name=foo]`).toHaveClass("o_field_invalid");
     expect(`.o_notification_manager .o_notification`).toHaveCount(1);
     expect([]).toVerifySteps();
 });
+
+test.tags("desktop")(
+    `keynav: switching to another record from an invalid one on desktop`,
+    async () => {
+        onRpc("web_save", () => expect.step("web_save"));
+        await mountView({
+            resModel: "partner",
+            type: "form",
+            arch: `<form><field name="foo" required="1"/></form>`,
+            resIds: [1, 2],
+            resId: 1,
+        });
+        expect(`.o_pager_counter`).toHaveText("1 / 2");
+
+        await contains(`.o_field_widget[name=foo] input`).edit("");
+        press(["alt", "n"]);
+        await animationFrame();
+        expect(`.o_pager_counter`).toHaveText("1 / 2");
+    }
+);
 
 test(`switching to another record from an invalid one (2)`, async () => {
     // in this scenario, the record is already invalid in db, so we should be allowed to
@@ -4661,15 +4720,33 @@ test(`switching to another record from an invalid one (2)`, async () => {
     });
     expect(`.o_breadcrumb`).toHaveText("first record");
     expect(`.o_field_widget[name=foo]`).toHaveClass("o_required_modifier");
-    expect(`.o_pager_counter`).toHaveText("1 / 2");
 
     await contains(`.o_pager_next`).click();
     expect(`.o_breadcrumb`).toHaveText("second record");
-    expect(`.o_pager_counter`).toHaveText("2 / 2");
 
     await contains(`.o_pager_previous`).click();
     expect(`.o_breadcrumb`).toHaveText("first record");
     expect(`.o_field_widget[name=foo]`).toHaveClass("o_required_modifier");
+});
+
+test.tags("desktop")(`switching to another record from an invalid one (2) on desktop`, async () => {
+    // in this scenario, the record is already invalid in db, so we should be allowed to
+    // leave it
+    Partner._records[0].foo = false;
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo" required="1"/></form>`,
+        resIds: [1, 2],
+        resId: 1,
+    });
+    expect(`.o_pager_counter`).toHaveText("1 / 2");
+
+    await contains(`.o_pager_next`).click();
+    expect(`.o_pager_counter`).toHaveText("2 / 2");
+
+    await contains(`.o_pager_previous`).click();
     expect(`.o_pager_counter`).toHaveText("1 / 2");
 });
 
@@ -4682,23 +4759,43 @@ test(`keynav: switching to another record from a dirty one`, async () => {
         resIds: [1, 2],
         resId: 1,
     });
-    expect(getPagerValue()).toEqual([1]);
-    expect(getPagerLimit()).toBe(2);
     expect(`.o_field_widget[name=foo] input`).toHaveValue("yop");
 
     await contains(`.o_field_widget[name=foo] input`).edit("new value", { confirm: false });
     press(["alt", "n"]);
     await animationFrame();
     expect(["web_save"]).toVerifySteps();
-    expect(`.o_pager_counter`).toHaveText("2 / 2");
     expect(`.o_field_widget[name=foo] input`).toHaveValue("blip");
 
     press(["alt", "p"]);
     await animationFrame();
     expect([]).toVerifySteps();
-    expect(`.o_pager_counter`).toHaveText("1 / 2");
     expect(`.o_field_widget[name=foo] input`).toHaveValue("new value");
 });
+
+test.tags("desktop")(
+    `keynav: switching to another record from a dirty one on desktop`,
+    async () => {
+        await mountView({
+            resModel: "partner",
+            type: "form",
+            arch: `<form><field name="foo"></field></form>`,
+            resIds: [1, 2],
+            resId: 1,
+        });
+        expect(getPagerValue()).toEqual([1]);
+        expect(getPagerLimit()).toBe(2);
+
+        await contains(`.o_field_widget[name=foo] input`).edit("new value", { confirm: false });
+        press(["alt", "n"]);
+        await animationFrame();
+        expect(`.o_pager_counter`).toHaveText("2 / 2");
+
+        press(["alt", "p"]);
+        await animationFrame();
+        expect(`.o_pager_counter`).toHaveText("1 / 2");
+    }
+);
 
 test(`handling dirty state: switching to another record`, async () => {
     Partner._fields.priority = fields.Selection({
@@ -4722,7 +4819,7 @@ test(`handling dirty state: switching to another record`, async () => {
         resIds: [1, 2],
         resId: 1,
     });
-    expect(`.o_pager_counter`).toHaveText("1 / 2");
+    expect(`.o_breadcrumb`).toHaveText("first record");
     expect(`.o_field_widget[name=foo] input`).toHaveValue("yop");
 
     await contains(`.o_field_widget[name=foo] input`).edit("new value");
@@ -4730,15 +4827,56 @@ test(`handling dirty state: switching to another record`, async () => {
 
     await contains(`.o_form_button_save`).click();
     await contains(`.o_pager_next`).click();
-    expect(`.o_pager_counter`).toHaveText("2 / 2");
+    expect(`.o_breadcrumb`).toHaveText("second record");
     expect(`.o_priority .fa-star-o`).toHaveCount(2);
 
     await contains(`.o_priority .fa-star-o`).click();
     expect(`.o_priority .fa-star`).toHaveCount(1);
 
     await contains(`.o_pager_next`).click();
-    expect(`.o_pager_counter`).toHaveText("1 / 2");
+    expect(`.o_breadcrumb`).toHaveText("first record");
     expect(`.o_field_widget[name=foo] input`).toHaveValue("new value");
+
+    await contains(`.o_field_widget[name=foo] input`).edit("wrong value");
+    await contains(`.o_form_button_cancel`).click();
+    await contains(`.o_pager_next`).click();
+    expect(`.o_breadcrumb`).toHaveText("second record");
+});
+
+test.tags("desktop")(`handling dirty state: switching to another record on desktop`, async () => {
+    Partner._fields.priority = fields.Selection({
+        default: 1,
+        selection: [
+            [1, "Low"],
+            [2, "Medium"],
+            [3, "High"],
+        ],
+    });
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `
+            <form>
+                <field name="foo"></field>
+                <field name="priority" widget="priority"></field>
+            </form>
+        `,
+        resIds: [1, 2],
+        resId: 1,
+    });
+    expect(`.o_pager_counter`).toHaveText("1 / 2");
+
+    await contains(`.o_field_widget[name=foo] input`).edit("new value");
+
+    await contains(`.o_form_button_save`).click();
+    await contains(`.o_pager_next`).click();
+    expect(`.o_pager_counter`).toHaveText("2 / 2");
+
+    await contains(`.o_priority .fa-star-o`).click();
+
+    await contains(`.o_pager_next`).click();
+    expect(`.o_pager_counter`).toHaveText("1 / 2");
 
     await contains(`.o_field_widget[name=foo] input`).edit("wrong value");
     await contains(`.o_form_button_cancel`).click();
@@ -4936,6 +5074,22 @@ test(`pager is hidden in create mode`, async () => {
         resIds: [1, 2],
     });
     expect(`.o_pager`).toHaveCount(1);
+
+    await contains(`.o_form_button_create`).click();
+    expect(`.o_pager`).toHaveCount(0);
+
+    await contains(`.o_form_button_save`).click();
+    expect(`.o_pager`).toHaveCount(1);
+});
+
+test.tags("desktop")(`pager is hidden in create mode on desktop`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo"/></form>`,
+        resId: 1,
+        resIds: [1, 2],
+    });
     expect(getPagerValue()).toEqual([1]);
     expect(getPagerLimit()).toBe(2);
 
@@ -4943,12 +5097,25 @@ test(`pager is hidden in create mode`, async () => {
     expect(`.o_pager`).toHaveCount(0);
 
     await contains(`.o_form_button_save`).click();
-    expect(`.o_pager`).toHaveCount(1);
     expect(getPagerValue()).toEqual([3]);
     expect(getPagerLimit()).toBe(3);
 });
 
 test(`switching to another record`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo"></field></form>`,
+        resId: 1,
+        resIds: [1, 2],
+    });
+    expect(`.o_breadcrumb`).toHaveText("first record");
+
+    await contains(`.o_pager_next`).click();
+    expect(`.o_breadcrumb`).toHaveText("second record");
+});
+
+test.tags("desktop")(`switching to another record on desktop`, async () => {
     await mountView({
         resModel: "partner",
         type: "form",
@@ -4972,12 +5139,10 @@ test(`switching to non-existing record`, async () => {
         resId: 1,
         resIds: [1, 999, 2],
     });
-    expect(getPagerValue()).toEqual([1]);
-    expect(getPagerLimit()).toBe(3);
+    expect(`.o_breadcrumb`).toHaveText("first record");
 
     await contains(`.o_pager_next`).click();
-    expect(getPagerValue()).toEqual([1]);
-    expect(getPagerLimit()).toBe(2);
+    expect(`.o_breadcrumb`).toHaveText("first record");
 
     await animationFrame();
     expect(`.o_notification_body`).toHaveCount(1);
@@ -4986,9 +5151,32 @@ test(`switching to non-existing record`, async () => {
     ]).toVerifyErrors();
 
     await contains(`.o_pager_next`).click();
+    expect(`.o_breadcrumb`).toHaveText("second record");
+    expect(`.o_notification_body`).toHaveCount(1);
+});
+
+test.tags("desktop")(`switching to non-existing record on desktop`, async () => {
+    expect.errors(1);
+
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo"></field></form>`,
+        resId: 1,
+        resIds: [1, 999, 2],
+    });
+    expect(getPagerValue()).toEqual([1]);
+    expect(getPagerLimit()).toBe(3);
+
+    await contains(`.o_pager_next`).click();
+    expect(getPagerValue()).toEqual([1]);
+    expect(getPagerLimit()).toBe(2);
+
+    await animationFrame();
+
+    await contains(`.o_pager_next`).click();
     expect(getPagerValue()).toEqual([2]);
     expect(getPagerLimit()).toBe(2);
-    expect(`.o_notification_body`).toHaveCount(1);
 });
 
 test(`modifiers are reevaluated when creating new record`, async () => {
@@ -5070,8 +5258,7 @@ test(`deleting a record`, async () => {
         resIds: [1, 2, 4],
         resId: 1,
     });
-    expect(getPagerValue()).toEqual([1]);
-    expect(getPagerLimit()).toBe(3);
+    expect(`.o_breadcrumb`).toHaveText("first record");
 
     // open action menu and delete
     await toggleActionMenu();
@@ -5079,9 +5266,29 @@ test(`deleting a record`, async () => {
     expect(`.modal`).toHaveCount(1);
 
     await contains(`.modal-footer button.btn-primary`).click();
+    expect(`.o_breadcrumb`).toHaveText("second record");
+    expect(`.o_field_widget[name=foo] input`).toHaveValue("blip");
+});
+
+test.tags("desktop")(`deleting a record on desktop`, async () => {
+    await mountView({
+        resModel: "partner",
+        type: "form",
+        arch: `<form><field name="foo"></field></form>`,
+        actionMenus: {},
+        resIds: [1, 2, 4],
+        resId: 1,
+    });
+    expect(getPagerValue()).toEqual([1]);
+    expect(getPagerLimit()).toBe(3);
+
+    // open action menu and delete
+    await toggleActionMenu();
+    await toggleMenuItem("Delete");
+
+    await contains(`.modal-footer button.btn-primary`).click();
     expect(getPagerValue()).toEqual([1]);
     expect(getPagerLimit()).toBe(2);
-    expect(`.o_field_widget[name=foo] input`).toHaveValue("blip");
 });
 
 test(`deleting the last record`, async () => {
@@ -8428,7 +8635,7 @@ test.tags("desktop")(`do not display unset attributes in debug field tooltip`, a
     ]);
 });
 
-test(`do not change pager when discarding current record`, async () => {
+test.tags("desktop")(`do not change pager when discarding current record on desktop`, async () => {
     await mountView({
         resModel: "partner",
         type: "form",


### PR DESCRIPTION
In the search to optimize the screen realestate on smaller screens (e.g.
smartphones), this commit removes the counter part from the Pager as it
takes a subtential amount of space in the ControlPanel, leaving only the
Next/Previous buttons. The desktop-like version remains untouched.

Although this change lets us reclaim some space, it's important to still
provides feedback to the user once he moves from one records' page to
the other. To do so, the Pager's counter is temporarily displayed as an
overlay at the top-center of the screen, fading out after a quick delay
(currently 1sec).

task-3336242

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
