### PR TITLE
[IMP] sale_stock: make `route_id` field on SO line many2many

### DIFF
--- a/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
+++ b/addons/mrp_subcontracting_dropshipping/tests/test_anglo_saxon_valuation.py
@@ -171,7 +171,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             'partner_id': self.partner_a.id,
             'order_line': [(0, 0, {
                 'product_id': final_product.id,
-                'route_id': self.dropship_route.id,
+                'route_ids': [Command.link(self.dropship_route.id)],
                 'product_uom_qty': 100,
             })],
         })
@@ -254,7 +254,7 @@ class TestSubcontractingDropshippingValuation(ValuationReconciliationTestCommon)
             'order_line': [(0, 0, {
                 'price_unit': 900,
                 'product_id': kit_final_prod.id,
-                'route_id': self.dropship_route.id,
+                'route_ids': [Command.link(self.dropship_route.id)],
                 'product_uom_qty': 2.0,
             })],
         })

--- a/addons/sale_purchase_stock/models/purchase_order.py
+++ b/addons/sale_purchase_stock/models/purchase_order.py
@@ -26,8 +26,8 @@ class PurchaseOrderLine(models.Model):
         res = super()._prepare_stock_moves(picking)
         for re in res:
             re['sale_line_id'] = self.sale_line_id.id
-            if self.sale_line_id.route_id:
-               re['route_ids'] = [Command.link(self.sale_line_id.route_id.id)]
+            if self.sale_line_id.route_ids:
+               re['route_ids'] = [Command.link(route_id) for route_id in self.sale_line_id.route_ids.ids]
             if self.order_id.dest_address_id:
                 # In a dropshipping context we do not need the description of the purchase order or it will be displayed
                 # in Delivery slip report and it may be confusing for the customer to see several times the same text (product name + description_picking).

--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -113,8 +113,8 @@ class SaleOrder(models.Model):
         for order_line in orders_without_wh.order_line:
             if order_line.product_id.type != 'consu':
                 continue
-            if order_line.route_id.company_id and order_line.route_id.company_id != order_line.company_id:
-                other_company.add(order_line.route_id.company_id.id)
+            if order_line.route_ids.company_id and order_line.route_ids.company_id != order_line.company_id:
+                other_company.add(order_line.route_ids.company_id.id)
                 continue
             if order_line.order_id.company_id.id in company_ids_with_wh:
                 raise UserError(_('You must set a warehouse on your sale order to proceed.'))

--- a/addons/sale_stock/models/sale_order_line.py
+++ b/addons/sale_stock/models/sale_order_line.py
@@ -14,7 +14,7 @@ class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
     qty_delivered_method = fields.Selection(selection_add=[('stock_move', 'Stock Moves')])
-    route_id = fields.Many2one('stock.route', string='Route', domain=[('sale_selectable', '=', True)], ondelete='restrict')
+    route_ids = fields.Many2many('stock.route', string='Routes', domain=[('sale_selectable', '=', True)], ondelete='restrict')
     move_ids = fields.One2many('stock.move', 'sale_line_id', string='Stock Moves')
     virtual_available_at_date = fields.Float(compute='_compute_qty_at_date', digits='Product Unit')
     scheduled_date = fields.Datetime(compute='_compute_qty_at_date')
@@ -30,19 +30,19 @@ class SaleOrderLine(models.Model):
         compute='_compute_customer_lead', store=True, readonly=False, precompute=True,
         inverse='_inverse_customer_lead')
 
-    @api.depends('route_id', 'order_id.warehouse_id', 'product_id')
+    @api.depends('route_ids', 'order_id.warehouse_id', 'product_id')
     def _compute_warehouse_id(self):
         for line in self:
             line.warehouse_id = line.order_id.warehouse_id
-            if line.route_id:
+            if line.route_ids:
                 domain = [
-                    ('location_dest_id', '=', line.order_id.partner_shipping_id.property_stock_customer.id),
+                    ('location_dest_id', 'in', line.order_id.partner_shipping_id.property_stock_customer.ids),
                     ('action', '!=', 'push'),
                 ]
                 # prefer rules on the route itself even if they pull from a different warehouse than the SO's
                 rules = sorted(
                     self.env['stock.rule'].search(
-                        domain=expression.AND([[('route_id', '=', line.route_id.id)], domain]),
+                        domain=expression.AND([[('route_id', 'in', line.route_ids.ids)], domain]),
                         order='route_sequence, sequence'
                     ),
                     # if there are multiple rules on the route, prefer those that pull from the SO's warehouse
@@ -151,7 +151,7 @@ class SaleOrderLine(models.Model):
         remaining.free_qty_today = False
         remaining.qty_available_today = False
 
-    @api.depends('product_id', 'route_id', 'warehouse_id', 'product_id.route_ids')
+    @api.depends('product_id', 'route_ids', 'warehouse_id', 'product_id.route_ids')
     def _compute_is_mto(self):
         """ Verify the route of the product based on the warehouse
             set 'is_available' at True if the product availability in stock does
@@ -162,7 +162,7 @@ class SaleOrderLine(models.Model):
             if not line.display_qty_widget:
                 continue
             product = line.product_id
-            product_routes = line.route_id or (product.route_ids + product.categ_id.total_route_ids)
+            product_routes = line.route_ids or (product.route_ids + product.categ_id.total_route_ids)
 
             # Check MTO
             mto_route = line.warehouse_id.mto_pull_id.route_id
@@ -259,7 +259,7 @@ class SaleOrderLine(models.Model):
             'sale_line_id': self.id,
             'date_planned': date_planned,
             'date_deadline': date_deadline,
-            'route_ids': self.route_id,
+            'route_ids': self.route_ids,
             'warehouse_id': self.warehouse_id,
             'partner_id': self.order_id.partner_shipping_id.id,
             'location_final_id': self._get_location_final(),

--- a/addons/sale_stock/tests/test_create_perf.py
+++ b/addons/sale_stock/tests/test_create_perf.py
@@ -51,7 +51,7 @@ class TestPERF(TransactionCaseWithUserDemo):
     @warmup
     @prepare
     def test_empty_sale_order_creation_perf(self):
-        with self.assertQueryCount(admin=33):
+        with self.assertQueryCount(admin=34):
             self.env['sale.order'].create({
                 'partner_id': self.partners[0].id,
                 'user_id': self.salesmans[0].id,
@@ -66,7 +66,7 @@ class TestPERF(TransactionCaseWithUserDemo):
         # + 1 warehouse fetch
         # + 1 query to get analytic default account
         # + 1 followers queries ?
-        with self.assertQueryCount(admin=37):
+        with self.assertQueryCount(admin=39):
             self.env['sale.order'].create([{
                 'partner_id': self.partners[0].id,
                 'user_id': self.salesmans[0].id,
@@ -78,7 +78,7 @@ class TestPERF(TransactionCaseWithUserDemo):
     def test_dummy_sales_orders_batch_creation_perf(self):
         """ Dummy SOlines (notes/sections) should not add any custom queries other than their insert"""
         # + 2 SOL (batched) insert
-        with self.assertQueryCount(admin=40):
+        with self.assertQueryCount(admin=44):
             self.env['sale.order'].create([{
                 'partner_id': self.partners[0].id,
                 'user_id': self.salesmans[0].id,
@@ -97,7 +97,7 @@ class TestPERF(TransactionCaseWithUserDemo):
         # + 2 SQL insert
         # + 2 queries to get analytic default tags
         # + 9 follower queries ?
-        with self.assertQueryCount(admin=50):  # com 46
+        with self.assertQueryCount(admin=53):  # com 46
             self.env['sale.order'].create([{
                 'partner_id': self.partners[0].id,
                 'user_id': self.salesmans[0].id,

--- a/addons/sale_stock/tests/test_sale_stock_multi_warehouse.py
+++ b/addons/sale_stock/tests/test_sale_stock_multi_warehouse.py
@@ -37,14 +37,14 @@ class TestSaleStockMultiWarehouse(TestSaleStockCommon, ValuationReconciliationTe
                     'product_id': self.product_a.id,
                     'product_uom_qty': 9,
                     'price_unit': 1,
-                    'route_id': self.warehouse_A.delivery_route_id.id,
+                    'route_ids': [self.warehouse_A.delivery_route_id.id],
                 }),
                 (0, 0, {
                     'name': self.product_a.name,
                     'product_id': self.product_a.id,
                     'product_uom_qty': 10,
                     'price_unit': 1,
-                    'route_id': self.warehouse_B.delivery_route_id.id,
+                    'route_ids': [self.warehouse_B.delivery_route_id.id],
                 }),
             ],
         })

--- a/addons/sale_stock/views/sale_order_views.xml
+++ b/addons/sale_stock/views/sale_order_views.xml
@@ -44,10 +44,10 @@
                     <field string=" " name="json_popover" widget="stock_rescheduling_popover" invisible="not show_json_popover"/>
                 </xpath>
                 <xpath expr="//field[@name='order_line']/form/group/group/field[@name='analytic_distribution']" position="before">
-                    <field name="route_id" groups="stock.group_adv_location" options="{'no_create': True}"/>
+                    <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}"/>
                 </xpath>
                 <xpath expr="//field[@name='order_line']/list/field[@name='analytic_distribution']" position="after">
-                    <field name="route_id" groups="stock.group_adv_location" options="{'no_create': True}" optional="hide"/>
+                    <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}" optional="hide"/>
                 </xpath>
            </field>
         </record>
@@ -105,7 +105,7 @@
             <field name="model">sale.order.line</field>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='price_subtotal']" position="before">
-                    <field name="route_id" groups="stock.group_adv_location" options="{'no_create': True}"/>
+                    <field name="route_ids" widget="many2many_tags" groups="stock.group_adv_location" options="{'no_create': True}"/>
                 </xpath>
             </field>
         </record>

--- a/addons/stock_delivery/tests/test_carrier_propagation.py
+++ b/addons/stock_delivery/tests/test_carrier_propagation.py
@@ -177,7 +177,7 @@ class TestCarrierPropagation(TransactionCase):
                 'product_id': self.super_product.id,
                 'product_uom_qty': 2,
                 'price_unit': 750.00,
-                'route_id' : route1.id,
+                'route_ids': route1.ids,
             })],
         })
 

--- a/addons/stock_dropshipping/models/sale.py
+++ b/addons/stock_dropshipping/models/sale.py
@@ -32,7 +32,7 @@ class SaleOrderLine(models.Model):
         for line in self:
             if not line.display_qty_widget or line.is_mto:
                 continue
-            product_routes = line.route_id or (line.product_id.route_ids + line.product_id.categ_id.total_route_ids)
+            product_routes = line.route_ids or (line.product_id.route_ids + line.product_id.categ_id.total_route_ids)
             for pull_rule in product_routes.mapped('rule_ids'):
                 if pull_rule.picking_type_id.sudo().default_location_src_id.usage == 'supplier' and\
                         pull_rule.picking_type_id.sudo().default_location_dest_id.usage == 'customer':

--- a/addons/stock_dropshipping/tests/test_dropship.py
+++ b/addons/stock_dropshipping/tests/test_dropship.py
@@ -100,7 +100,7 @@ class TestDropship(common.TransactionCase):
                 line.product_id = self.dropship_product
                 line.product_uom_qty = 200
                 line.price_unit = 1.00
-                line.route_id = self.dropshipping_route
+                line.route_ids = self.dropshipping_route
         sale_order_drp_shpng = so_form.save()
 
         # Confirm sales order
@@ -268,7 +268,7 @@ class TestDropship(common.TransactionCase):
             with so_form.order_line.new() as line:
                 line.product_id = self.dropship_product
                 line.product_uom_qty = 1
-                line.route_id = self.dropshipping_route
+                line.route_ids = self.dropshipping_route
         sale_order_drp_shpng = so_form.save()
         sale_order_drp_shpng.action_confirm()
 
@@ -283,7 +283,7 @@ class TestDropship(common.TransactionCase):
             with so_form.order_line.new() as line:
                 line.product_id = self.dropship_product
                 line.product_uom_qty = 2
-                line.route_id = self.dropshipping_route
+                line.route_ids = self.dropshipping_route
         sale_order_drp_shpng = so_form.save()
         sale_order_drp_shpng.action_confirm()
 

--- a/addons/stock_dropshipping/tests/test_procurement_exception.py
+++ b/addons/stock_dropshipping/tests/test_procurement_exception.py
@@ -46,7 +46,7 @@ class TestProcurementException(common.TransactionCase):
         with so_form.order_line.new() as line:
             line.product_id = product_with_no_seller
             line.product_uom_qty = 3
-            line.route_id = self.env.ref('stock_dropshipping.route_drop_shipping')
+            line.route_ids = self.env.ref('stock_dropshipping.route_drop_shipping')
         sale_order_route_dropship01 = so_form.save()
 
         # I confirm the sales order, but no purchase quotation should be created


### PR DESCRIPTION
This commits adds the ablility to set multiple routes on the same order line. This enables users to apply complex flows on a specific order without having to apply it on the product level. For example, if some product was set to be replenished by reordering rules, but the user exceptionally wants to replenish using MTO, the user couldn't do so before on a specific order, because two different routes have to be applied on the same SO line (MTO & (Buy or Manufacture)). However, it's now possible to do so since `route_id(s)` field became many2many.

Upgrade PR: odoo/upgrade#6059

Task-3563242

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
