### PR TITLE
[IMP] l10n_ma: Add ice number

### DIFF
--- a/addons/l10n_ma/__manifest__.py
+++ b/addons/l10n_ma/__manifest__.py
@@ -18,6 +18,9 @@ This module has been built with the help of Caudigef.
     'auto_install': ['account'],
     'data': [
         'data/account_tax_report_data.xml',
+        "views/res_partner_views.xml",
+        "views/res_company_views.xml",
+        'views/report_invoice.xml',
     ],
     'demo': [
         'demo/demo_company.xml',

--- a/addons/l10n_ma/i18n/fr.po
+++ b/addons/l10n_ma/i18n/fr.po
@@ -548,8 +548,13 @@ msgid "C - Operations carried out with non-resident taxpayers (Article 115 of th
 msgstr "C - Opérations réalisées avec des contribuables non-résidents (Article 115 du CGI)"
 
 #. module: l10n_ma
-#: model:ir.model,name:l10n_ma.model_res_company
-msgid "Companies"
+#: model:ir.model.fields,field_description:l10n_ma.field_base_document_layout__company_details
+msgid "Company Details"
+msgstr ""
+
+#. module: l10n_ma
+#: model:ir.model,name:l10n_ma.model_base_document_layout
+msgid "Company Document Layout"
 msgstr ""
 
 #. module: l10n_ma
@@ -563,9 +568,30 @@ msgid "Deduction adjustments"
 msgstr "Ajustements des déductions"
 
 #. module: l10n_ma
+#: model:ir.model.fields,help:l10n_ma.field_base_document_layout__company_details
+msgid "Header text displayed at the top of all reports."
+msgstr ""
+
+#. module: l10n_ma
+#: model_terms:ir.ui.view,arch_db:l10n_ma.view_company_form
+#: model_terms:ir.ui.view,arch_db:l10n_ma.view_partner_property_form
+msgid "ICE"
+msgstr ""
+
+#. module: l10n_ma
+#: model_terms:ir.ui.view,arch_db:l10n_ma.report_invoice_document
+msgid "ICE:"
+msgstr ""
+
+#. module: l10n_ma
 #: model:account.report.line,name:l10n_ma.tax_report_part_d_1_2
 msgid "Other non-fixed assets purchases"
 msgstr "Autres achats non immobilisés"
+
+#. module: l10n_ma
+#: model:account.report.line,name:l10n_ma.l10n_ma_vat_d_prorata
+msgid "Percentage of prorated deductions (ADC110)"
+msgstr ""
 
 #. module: l10n_ma
 #: model:account.report.column,name:l10n_ma.tax_report_column_pro

--- a/addons/l10n_ma/i18n/l10n_ma.pot
+++ b/addons/l10n_ma/i18n/l10n_ma.pot
@@ -590,8 +590,13 @@ msgid ""
 msgstr ""
 
 #. module: l10n_ma
-#: model:ir.model,name:l10n_ma.model_res_company
-msgid "Companies"
+#: model:ir.model.fields,field_description:l10n_ma.field_base_document_layout__company_details
+msgid "Company Details"
+msgstr ""
+
+#. module: l10n_ma
+#: model:ir.model,name:l10n_ma.model_base_document_layout
+msgid "Company Document Layout"
 msgstr ""
 
 #. module: l10n_ma
@@ -605,8 +610,29 @@ msgid "Deduction adjustments"
 msgstr ""
 
 #. module: l10n_ma
+#: model:ir.model.fields,help:l10n_ma.field_base_document_layout__company_details
+msgid "Header text displayed at the top of all reports."
+msgstr ""
+
+#. module: l10n_ma
+#: model_terms:ir.ui.view,arch_db:l10n_ma.view_company_form
+#: model_terms:ir.ui.view,arch_db:l10n_ma.view_partner_property_form
+msgid "ICE"
+msgstr ""
+
+#. module: l10n_ma
+#: model_terms:ir.ui.view,arch_db:l10n_ma.report_invoice_document
+msgid "ICE:"
+msgstr ""
+
+#. module: l10n_ma
 #: model:account.report.line,name:l10n_ma.tax_report_part_d_1_2
 msgid "Other non-fixed assets purchases"
+msgstr ""
+
+#. module: l10n_ma
+#: model:account.report.line,name:l10n_ma.l10n_ma_vat_d_prorata
+msgid "Percentage of prorated deductions (ADC110)"
 msgstr ""
 
 #. module: l10n_ma

--- a/addons/l10n_ma/models/__init__.py
+++ b/addons/l10n_ma/models/__init__.py
@@ -1,2 +1,3 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
+from . import base_document_layout
 from . import template_ma

--- a/addons/l10n_ma/models/base_document_layout.py
+++ b/addons/l10n_ma/models/base_document_layout.py
@@ -1,0 +1,18 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from markupsafe import Markup
+
+from odoo import api, fields, models
+
+
+class BaseDocumentLayout(models.TransientModel):
+    _inherit = 'base.document.layout'
+
+    @api.model
+    def _default_company_details(self):
+        # OVERRIDE web/models/base_document_layout
+        company_details = super()._default_company_details()
+        if self.env.company.country_code == 'MA':
+            company_details += Markup('<br> ICE: %s') % self.env.company.company_registry
+        return company_details
+
+    company_details = fields.Html(default=_default_company_details)

--- a/addons/l10n_ma/views/report_invoice.xml
+++ b/addons/l10n_ma/views/report_invoice.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+        <xpath expr="//div[@id='partner_vat_address_same_as_shipping']" position="after">
+            <div t-if="o.partner_id.country_code == 'MA' and o.partner_id.company_registry">
+                ICE: <a t-field="o.partner_id.company_registry"/>
+            </div>
+        </xpath>
+    </template>
+</odoo>

--- a/addons/l10n_ma/views/res_company_views.xml
+++ b/addons/l10n_ma/views/res_company_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="name">res.company.form.inherit.l10n_ma</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="account.view_company_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_registry']" position="attributes">
+                <attribute name="nolabel">1</attribute>
+            </xpath>
+            <field name="company_registry" position="before">
+                <label for="company_registry" invisible="country_code == 'MA'" />
+                <label for="company_registry" string="ICE" invisible="country_code != 'MA'" />
+            </field>
+        </field>
+    </record>
+</odoo>

--- a/addons/l10n_ma/views/res_partner_views.xml
+++ b/addons/l10n_ma/views/res_partner_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="view_partner_property_form" model="ir.ui.view">
+        <field name="name">res.partner.form.inherit.l10n_ma</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="account.view_partner_property_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='company_registry']" position="attributes">
+                <attribute name="nolabel">1</attribute>
+            </xpath>
+            <field name="company_registry" position="before">
+                <label for="company_registry" invisible="country_code == 'MA'" />
+                <label for="company_registry" string="ICE" invisible="country_code != 'MA'" />
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
[IMP] l10n_ma_reports: Add ice number to invoicing

Get rid of the l10n_ma_ice and depend on company_registry as both should be the same
And Add the ICE number to the invoice report. it's now part of the company_details of the invoice report if and only if
it's a moroccan company

Adding migration script to replace 'l10n_ma_ice' in 'res.partner' with 'company_registry'

Reason: The ICE (Identifiant Commun de l'Entreprise) is an identification number assigned to businesses and legal entities
for various administrative and legal purposes in Morocco. If the partner has one, it must be indicated on the invoice.

Task-3877546

enterprise-pr#https://github.com/odoo/enterprise/pull/63083
upgrade-pr#https://github.com/odoo/upgrade/pull/6069

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
