### PR TITLE
[IMP] core, web: Content-Security-Policy on all Streams

### DIFF
--- a/addons/bus/controllers/websocket.py
+++ b/addons/bus/controllers/websocket.py
@@ -61,4 +61,4 @@ class WebsocketController(Controller):
         bundle_name = 'bus.websocket_worker_assets'
         bundle = request.env["ir.qweb"]._get_asset_bundle(bundle_name, debug_assets="assets" in request.session.debug)
         stream = request.env['ir.binary']._get_stream_from(bundle.js())
-        return stream.get_response()
+        return stream.get_response(content_security_policy=None)

--- a/addons/web/controllers/binary.py
+++ b/addons/web/controllers/binary.py
@@ -85,9 +85,7 @@ class Binary(http.Controller):
         if nocache:
             send_file_kwargs['max_age'] = None
 
-        res = stream.get_response(**send_file_kwargs)
-        res.headers['Content-Security-Policy'] = "default-src 'none'"
-        return res
+        return stream.get_response(**send_file_kwargs)
 
     @http.route([
         '/web/assets/<string:unique>/<string:filename>'], type='http', auth="public", readonly=True)
@@ -149,7 +147,7 @@ class Binary(http.Controller):
         if not attachment:
             raise request.not_found()
         stream = env['ir.binary']._get_stream_from(attachment, 'raw', filename)
-        send_file_kwargs = {'as_attachment': False}
+        send_file_kwargs = {'as_attachment': False, 'content_security_policy': None}
         if unique and unique != 'debug':
             send_file_kwargs['immutable'] = True
             send_file_kwargs['max_age'] = http.STATIC_CACHE_LONG
@@ -209,9 +207,7 @@ class Binary(http.Controller):
         if nocache:
             send_file_kwargs['max_age'] = None
 
-        res = stream.get_response(**send_file_kwargs)
-        res.headers['Content-Security-Policy'] = "default-src 'none'"
-        return res
+        return stream.get_response(**send_file_kwargs)
 
     @http.route('/web/binary/upload_attachment', type='http', auth="user")
     def upload_attachment(self, model, id, ufile, callback=None):

--- a/odoo/http.py
+++ b/odoo/http.py
@@ -553,12 +553,12 @@ class Stream:
         """
         Create the corresponding :class:`~Response` for the current stream.
 
-        :param bool as_attachment: Indicate to the browser that it
+        :param bool|None as_attachment: Indicate to the browser that it
             should offer to save the file instead of displaying it.
-        :param bool immutable: Add the ``immutable`` directive to the
-            ``Cache-Control`` response header, allowing intermediary
-            proxies to aggressively cache the response. This option
-            also set the ``max-age`` directive to 1 year.
+        :param bool|None immutable: Add the ``immutable`` directive to
+            the ``Cache-Control`` response header, allowing intermediary
+            proxies to aggressively cache the response. This option also
+            set the ``max-age`` directive to 1 year.
         :param send_file_kwargs: Other keyword arguments to send to
             :func:`odoo.tools._vendor.send_file.send_file` instead of
             the stream sensitive values. Discouraged.


### PR DESCRIPTION
The Content-Security-Policy is a header that help browsers filter the new requests the downloaded document is allowed to perform. For a css file, you could authorize the css file to perform new requests to downloads fonts or background images and restrict the rest. For most documents however all new requests should be prohibited, this is possible with the value `default-src "none"`.

That header was only set by the framework on images. Developers were responsible to add that header on their own controller when those controllers were used to download other kind of documents.

It turns out that most developer nowadays use http.Stream in those documents-driven controllers but forget to manually add CSP where it is actually necessary.

In this work we now to add the CSP header by default on responses generated by the Stream API.