### PR TITLE
[IMP] l10n_es_edi_tbai: allow for more than one original vendor bill

### DIFF
--- a/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
+++ b/addons/l10n_es_edi_tbai/data/template_LROE_bizkaia.xml
@@ -100,8 +100,8 @@
                                     <Codigo t-out="credit_note_code"/>
                                     <Tipo>I</Tipo>
                                 </FacturaRectificativa>
-                                <FacturasRectificadasSustituidas t-if="credit_note_invoice">
-                                    <IDFacturaRectificadaSustituida>
+                                <FacturasRectificadasSustituidas t-if="credit_note_invoices">
+                                    <IDFacturaRectificadaSustituida t-foreach="credit_note_invoices" t-as="credit_note_invoice">
                                         <t t-set="seq_and_num" t-value="credit_note_invoice._get_l10n_es_tbai_sequence_and_number()"/>
                                         <SerieFactura t-out="seq_and_num[0]"/>
                                         <NumFactura t-out="seq_and_num[1]"/>

--- a/addons/l10n_es_edi_tbai/i18n/es.po
+++ b/addons/l10n_es_edi_tbai/i18n/es.po
@@ -18,36 +18,30 @@ msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner_recibidas
 msgid "1.0"
-msgstr "1.0"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
 msgid "1.1"
-msgstr "1.1"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner_recibidas
 msgid "240"
-msgstr "240"
-
-#. module: l10n_es_edi_tbai
-#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.res_config_settings_view_form
-msgid ""
-"<span class=\"o_form_label\">Registro de Libros connection SII/TicketBAI</"
-"span>"
 msgstr ""
-"<span class=\"o_form_label\">Conexión Registro de Libros SII/TicketBAI</span>"
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model,name:l10n_es_edi_tbai.model_account_move_reversal
 msgid "Account Move Reversal"
-msgstr "Revertir movimientos de diario"
+msgstr "Reversión de asiento"
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model,name:l10n_es_edi_tbai.model_ir_attachment
 msgid "Attachment"
-msgstr "Archivo adjunto"
+msgstr "Adjunto"
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_refund_reason
@@ -58,8 +52,6 @@ msgid ""
 "BOE-A-1992-28740. Ley 37/1992, de 28 de diciembre, del Impuesto sobre el "
 "Valor Añadido. Artículo 80. Modificación de la base imponible."
 msgstr ""
-"BOE-A-1992-28740. Ley 37/1992, de 28 de diciembre, del Impuesto sobre el "
-"Valor Añadido. Artículo 80. Modificación de la base imponible."
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_cancel_xml
@@ -76,18 +68,18 @@ msgid ""
 "Cancellation XML sent to TicketBAI. Kept if accepted or no response "
 "(timeout), cleared otherwise."
 msgstr ""
-"El XML de cancelación se envió a TicketBAI. Se mantiene si se acepta o no se "
-"obtiene respuesta (timeout), de lo contrario, se borra."
+"El XML de cancelación se envió a TicketBAI. Se mantiene si se acepta o no se"
+" obtiene respuesta (timeout), de lo contrario, se borra."
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model,name:l10n_es_edi_tbai.model_res_company
 msgid "Companies"
-msgstr "Empresas"
+msgstr "Compañías"
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model,name:l10n_es_edi_tbai.model_res_config_settings
 msgid "Config Settings"
-msgstr "Ajustes de configuración"
+msgstr "Opciones de configuración"
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model,name:l10n_es_edi_tbai.model_account_edi_format
@@ -107,12 +99,22 @@ msgstr "Hacienda Foral de la Diputación de Álava"
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__res_company__l10n_es_tbai_tax_agency__bizkaia
 msgid "Hacienda Foral de Bizkaia"
-msgstr "Hacienda Foral de Bizkaia"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__res_company__l10n_es_tbai_tax_agency__gipuzkoa
 msgid "Hacienda Foral de Gipuzkoa"
 msgstr "Diputación Foral de Gipuzkoa"
+
+#. module: l10n_es_edi_tbai
+#: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_move__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_payment__l10n_es_tbai_reversed_ids
+msgid ""
+"In the case where a vendor refund has multiple original invoices, you can "
+"set them here. "
+msgstr "En el caso de que una factura rectificativa de proveedor tenga varias facturas "
+"reembolsadas, puede establecerlas aquí."
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_refund_reason
@@ -127,11 +129,11 @@ msgstr "Código de motivo de reembolso de la factura (TicketBai)"
 #: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_move__l10n_es_tbai_chain_index
 #: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_payment__l10n_es_tbai_chain_index
 msgid ""
-"Invoice index in chain, set if and only if an in-chain XML was submitted and "
-"did not error"
+"Invoice index in chain, set if and only if an in-chain XML was submitted and"
+" did not error"
 msgstr ""
-"Índice de facturas en cadena que se establece si y solo si se envió un XML y "
-"no dio error."
+"Índice de facturas en cadena que se establece si y solo si se envió un XML y"
+" no dio error."
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_move_reversal__l10n_es_tbai_is_required
@@ -148,7 +150,7 @@ msgstr "¿Se necesita el EDI vasco (TicketBai)?"
 #. module: l10n_es_edi_tbai
 #: model:ir.model,name:l10n_es_edi_tbai.model_account_move
 msgid "Journal Entry"
-msgstr "Asiento de diario"
+msgstr "Asiento contable"
 
 #. module: l10n_es_edi_tbai
 #. odoo-python
@@ -217,13 +219,13 @@ msgstr "R1: Art. 80.1, 80.2, 80.6 y por error fundado de derecho"
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__account_move__l10n_es_tbai_refund_reason__r2
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__account_move_reversal__l10n_es_tbai_refund_reason__r2
 msgid "R2: Art. 80.3"
-msgstr "R2: Art. 80.3"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__account_move__l10n_es_tbai_refund_reason__r3
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__account_move_reversal__l10n_es_tbai_refund_reason__r3
 msgid "R3: Art. 80.4"
-msgstr "R3: Art. 80.4"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__account_move__l10n_es_tbai_refund_reason__r4
@@ -235,12 +237,12 @@ msgstr "R4: Art. 80 - resto"
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__account_move__l10n_es_tbai_refund_reason__r5
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__account_move_reversal__l10n_es_tbai_refund_reason__r5
 msgid "R5: Factura rectificativa en facturas simplificadas"
-msgstr "R5: Factura rectificativa en facturas simplificadas"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_invoice_desglose
 msgid "RL"
-msgstr "RL"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #. odoo-python
@@ -264,9 +266,16 @@ msgid "Refund reason must be specified (TicketBAI)"
 msgstr "Se debe especificar el motivo del reembolso (TicketBai)"
 
 #. module: l10n_es_edi_tbai
-#: model:ir.model,name:l10n_es_edi_tbai.model_ir_actions_report
-msgid "Report Action"
-msgstr "Reportar acción"
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_move__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_payment__l10n_es_tbai_reversed_ids
+msgid "Refunded Vendor Bills"
+msgstr "Facturas Proveedor Reembolsadas"
+
+#. module: l10n_es_edi_tbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.res_config_settings_view_form
+msgid "Registro de Libros connection SII/TicketBAI"
+msgstr "Conexión Registro de Libros SII/TicketBAI"
 
 #. module: l10n_es_edi_tbai
 #. odoo-python
@@ -292,8 +301,8 @@ msgstr "XML de envío"
 #: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_move__l10n_es_tbai_post_xml
 #: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_payment__l10n_es_tbai_post_xml
 msgid ""
-"Submission XML sent to TicketBAI. Kept if accepted or no response (timeout), "
-"cleared otherwise."
+"Submission XML sent to TicketBAI. Kept if accepted or no response (timeout),"
+" cleared otherwise."
 msgstr ""
 "Se envió el XML de envío a TicketBai. Se mantiene si se acepta o no se "
 "obtiene respuesta (timeout), de lo contrario, se borra."
@@ -301,7 +310,7 @@ msgstr ""
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_invoice_bundle
 msgid "TEST-DEVICE-001"
-msgstr "TEST-DEVICE-001"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_res_company__l10n_es_tbai_tax_agency
@@ -335,7 +344,7 @@ msgstr "Licencia de prueba (Gipuzkoa)"
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.view_move_form_inherit_l10n_es_edi_tbai
 msgid "TicketBAI"
-msgstr "TicketBAI"
+msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_chain_index

--- a/addons/l10n_es_edi_tbai/i18n/l10n_es_edi_tbai.pot
+++ b/addons/l10n_es_edi_tbai/i18n/l10n_es_edi_tbai.pot
@@ -17,6 +17,7 @@ msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner_recibidas
 msgid "1.0"
 msgstr ""
 
@@ -27,14 +28,8 @@ msgstr ""
 
 #. module: l10n_es_edi_tbai
 #: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.template_LROE_240_inner_recibidas
 msgid "240"
-msgstr ""
-
-#. module: l10n_es_edi_tbai
-#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.res_config_settings_view_form
-msgid ""
-"<span class=\"o_form_label\">Registro de Libros connection "
-"SII/TicketBAI</span>"
 msgstr ""
 
 #. module: l10n_es_edi_tbai
@@ -106,6 +101,15 @@ msgstr ""
 #. module: l10n_es_edi_tbai
 #: model:ir.model.fields.selection,name:l10n_es_edi_tbai.selection__res_company__l10n_es_tbai_tax_agency__gipuzkoa
 msgid "Hacienda Foral de Gipuzkoa"
+msgstr ""
+
+#. module: l10n_es_edi_tbai
+#: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_move__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,help:l10n_es_edi_tbai.field_account_payment__l10n_es_tbai_reversed_ids
+msgid ""
+"In the case where a vendor refund has multiple original invoices, you can "
+"set them here. "
 msgstr ""
 
 #. module: l10n_es_edi_tbai
@@ -253,8 +257,15 @@ msgid "Refund reason must be specified (TicketBAI)"
 msgstr ""
 
 #. module: l10n_es_edi_tbai
-#: model:ir.model,name:l10n_es_edi_tbai.model_ir_actions_report
-msgid "Report Action"
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_bank_statement_line__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_move__l10n_es_tbai_reversed_ids
+#: model:ir.model.fields,field_description:l10n_es_edi_tbai.field_account_payment__l10n_es_tbai_reversed_ids
+msgid "Refunded Vendor Bills"
+msgstr ""
+
+#. module: l10n_es_edi_tbai
+#: model_terms:ir.ui.view,arch_db:l10n_es_edi_tbai.res_config_settings_view_form
+msgid "Registro de Libros connection SII/TicketBAI"
 msgstr ""
 
 #. module: l10n_es_edi_tbai

--- a/addons/l10n_es_edi_tbai/models/account_edi_format.py
+++ b/addons/l10n_es_edi_tbai/models/account_edi_format.py
@@ -602,7 +602,7 @@ class AccountEdiFormat(models.Model):
         values['is_refund'] = invoice.move_type == 'in_refund'
         if values['is_refund']:
             values['credit_note_code'] = invoice.l10n_es_tbai_refund_reason
-            values['credit_note_invoice'] = invoice.reversed_entry_id
+            values['credit_note_invoices'] = invoice.reversed_entry_id | invoice.l10n_es_tbai_reversed_ids
         values['tipofactura'] = 'F5' if invoice._l10n_es_is_dua() else 'F1'
         return values
 

--- a/addons/l10n_es_edi_tbai/models/account_move.py
+++ b/addons/l10n_es_edi_tbai/models/account_move.py
@@ -73,6 +73,12 @@ class AccountMove(models.Model):
         "Valor Añadido. Artículo 80. Modificación de la base imponible.",
         copy=False,
     )
+    l10n_es_tbai_reversed_ids = fields.Many2many(
+        'account.move', 'account_move_tbai_reversed_moves', 'refund_id', 'reversed_move_id',
+        string="Refunded Vendor Bills",
+        domain="[('move_type', '=', 'in_invoice'), ('commercial_partner_id', '=', commercial_partner_id)]",
+        help="In the case where a vendor refund has multiple original invoices, you can set them here. ",
+    )
 
     # -------------------------------------------------------------------------
     # API-DECORATED & EXTENDED METHODS

--- a/addons/l10n_es_edi_tbai/views/account_move_view.xml
+++ b/addons/l10n_es_edi_tbai/views/account_move_view.xml
@@ -11,8 +11,10 @@
                         <field name="l10n_es_tbai_is_required" invisible="1"/>
                         <field name="l10n_es_tbai_chain_index" groups="base.group_no_one"/>
                         <field name="l10n_es_tbai_refund_reason"
-                            invisible="not l10n_es_tbai_refund_reason"
+                            invisible="move_type not in ('in_refund', 'out_refund')"
                             readonly="state != 'draft'"/>
+                        <field name="l10n_es_tbai_reversed_ids" invisible="move_type != 'in_refund'" widget="many2many_tags"/>
+                        <field name="reversed_entry_id" invisible="move_type != 'in_refund'"/>
                     </group>
                 </xpath>
             </field>


### PR DESCRIPTION
For the Bizkaia tax agency in Bask country, we also need to send
vendor bills and vendor bill refunds.  In Odoo standard however, we only have
a link towards one original vendor bill for a vendor bill refund.

The problem however is that your vendor can send you a vendor refund for multiple
original vendor bills and that for the moment, you do not really have a good
way to encode it.

So, we added a field to put the other original vendor bills as a many2many.

We also updated the translations.

opw-3719158

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
