### PR TITLE
[IMP] account*: reword automatic labels in accounting

### DIFF
--- a/addons/account/data/account_data.xml
+++ b/addons/account/data/account_data.xml
@@ -128,12 +128,12 @@
 
         <!-- Payment methods -->
         <record id="account_payment_method_manual_in" model="account.payment.method">
-            <field name="name">Manual</field>
+            <field name="name">Manual Payment</field>
             <field name="code">manual</field>
             <field name="payment_type">inbound</field>
         </record>
         <record id="account_payment_method_manual_out" model="account.payment.method">
-            <field name="name">Manual</field>
+            <field name="name">Manual Payment</field>
             <field name="code">manual</field>
             <field name="payment_type">outbound</field>
         </record>

--- a/addons/account/tests/test_account_move_in_invoice.py
+++ b/addons/account/tests/test_account_move_in_invoice.py
@@ -1969,14 +1969,14 @@ class TestAccountMoveInInvoiceOnchanges(AccountTestInvoicingCommon):
 
         accrual_lines = self.env['account.move'].browse(wizard_res['domain'][0][2]).line_ids.sorted('date')
         self.assertRecordValues(accrual_lines, [
-            {'amount_currency': -480.0, 'debit': 0.0,   'credit': 240.0,    'account_id': self.product_line_vals_1['account_id'],   'reconciled': False},
-            {'amount_currency': 480.0,  'debit': 240.0, 'credit': 0.0,      'account_id': wizard.expense_accrual_account.id,        'reconciled': True},
-            {'amount_currency': -96.0,  'debit': 0.0,   'credit': 48.0,     'account_id': self.product_line_vals_2['account_id'],   'reconciled': False},
-            {'amount_currency': 96.0,   'debit': 48.0,  'credit': 0.0,      'account_id': wizard.expense_accrual_account.id,        'reconciled': True},
-            {'amount_currency': 480.0,  'debit': 240.0, 'credit': 0.0,      'account_id': self.product_line_vals_1['account_id'],   'reconciled': False},
-            {'amount_currency': -480.0, 'debit': 0.0,   'credit': 240.0,    'account_id': wizard.expense_accrual_account.id,        'reconciled': True},
-            {'amount_currency': 96.0,   'debit': 48.0,  'credit': 0.0,      'account_id': self.product_line_vals_2['account_id'],   'reconciled': False},
-            {'amount_currency': -96.0,  'debit': 0.0,   'credit': 48.0,     'account_id': wizard.expense_accrual_account.id,        'reconciled': True},
+            {'name': 'Cut-off BILL/2017/01/0001 60.00%', 'amount_currency': -480.0, 'debit': 0.0,   'credit': 240.0,    'account_id': self.product_line_vals_1['account_id'],   'reconciled': False},
+            {'name': 'Cut-off BILL/2017/01/0001 60.00%', 'amount_currency': 480.0,  'debit': 240.0, 'credit': 0.0,      'account_id': wizard.expense_accrual_account.id,        'reconciled': True},
+            {'name': 'Cut-off BILL/2017/01/0001 60.00%', 'amount_currency': -96.0,  'debit': 0.0,   'credit': 48.0,     'account_id': self.product_line_vals_2['account_id'],   'reconciled': False},
+            {'name': 'Cut-off BILL/2017/01/0001 60.00%', 'amount_currency': 96.0,   'debit': 48.0,  'credit': 0.0,      'account_id': wizard.expense_accrual_account.id,        'reconciled': True},
+            {'name': 'Cut-off BILL/2017/01/0001 60.00%', 'amount_currency': 480.0,  'debit': 240.0, 'credit': 0.0,      'account_id': self.product_line_vals_1['account_id'],   'reconciled': False},
+            {'name': 'Cut-off BILL/2017/01/0001 60.00%', 'amount_currency': -480.0, 'debit': 0.0,   'credit': 240.0,    'account_id': wizard.expense_accrual_account.id,        'reconciled': True},
+            {'name': 'Cut-off BILL/2017/01/0001 60.00%', 'amount_currency': 96.0,   'debit': 48.0,  'credit': 0.0,      'account_id': self.product_line_vals_2['account_id'],   'reconciled': False},
+            {'name': 'Cut-off BILL/2017/01/0001 60.00%', 'amount_currency': -96.0,  'debit': 0.0,   'credit': 48.0,     'account_id': wizard.expense_accrual_account.id,        'reconciled': True},
         ])
 
     def test_in_invoice_reverse_caba(self):

--- a/addons/account/tests/test_sequence_mixin.py
+++ b/addons/account/tests/test_sequence_mixin.py
@@ -671,6 +671,7 @@ class TestSequenceMixin(TestSequenceMixinCommon):
 
         for move in payments.move_id:
             self.assertRecordValues(move.line_ids, [{'move_name': move.name}] * len(move.line_ids))
+            self.assertRecordValues(move.line_ids, [{'name': "Manual Payment"}] * len(move.line_ids))
 
     def test_resequence_payment_and_non_payment_without_payment_sequence(self):
         """Resequence wizard could be open for different move type if the payment sequence is set to False on the journal."""

--- a/addons/account_check_printing/models/account_payment.py
+++ b/addons/account_check_printing/models/account_payment.py
@@ -115,12 +115,24 @@ class AccountPayment(models.Model):
 
     def _get_aml_default_display_name_list(self):
         # Extends 'account'
-        values = super()._get_aml_default_display_name_list()
-        if self.check_number:
-            date_index = [i for i, value in enumerate(values) if value[0] == 'date'][0]
-            values.insert(date_index - 1, ('check_number', self.check_number))
-            values.insert(date_index - 1, ('sep', ' - '))
-        return values
+        self.ensure_one()
+
+        if not self.check_number:
+            return super()._get_aml_default_display_name_list()
+
+        result = [
+            ('label', _("Checks")),
+            ('sep', ' - '),
+            ('check_number', self.check_number),
+        ]
+
+        if self.ref:
+            result += [
+                ('sep', ': '),
+                ('memo', self.ref),
+            ]
+
+        return result
 
     def action_post(self):
         payment_method_check = self.env.ref('account_check_printing.account_payment_method_check')

--- a/addons/account_check_printing/tests/test_print_check.py
+++ b/addons/account_check_printing/tests/test_print_check.py
@@ -176,6 +176,20 @@ class TestPrintCheck(AccountTestInvoicingCommon):
 
         self.assertEqual(set(payments.mapped('check_number')), {str(x) for x in range(11111, 11111 + nb_invoices_to_test)})
 
+    def test_check_label(self):
+        payment = self.env['account.payment'].create({
+            'check_number': '2147483647',
+            'payment_type': 'outbound',
+            'partner_type': 'supplier',
+            'amount': 100.0,
+            'journal_id': self.company_data['default_journal_bank'].id,
+            'payment_method_line_id': self.payment_method_line_check.id,
+        })
+        payment.action_post()
+
+        for move in payment.move_id:
+            self.assertRecordValues(move.line_ids, [{'name': "Checks - 2147483647"}] * len(move.line_ids))
+
     def test_print_great_pre_number_check(self):
         """
         Make sure we can use integer of more than 2147483647 in check sequence


### PR DESCRIPTION
Some of the generated labels were confusing. The following changes were therefor implemented:
- Cut-off (100%): "REF: Adjusting Entry of DATE" -> "Cut-off REF"
- Cut-off (X%): "REF: Adjusting Entry of DATE" -> "Cut-off REF X%"
- Payment: "TYPE PRICE - CLIENT - DATE" -> "PAYMENT_METHOD: MEMO"
- Payment (no memo): "TYPE PRICE - CLIENT - DATE" -> "PAYMENT_METHOD"
- Payment (check): "TYPE PRICE - CLIENT - CHECK_NO - DATE" -> "PAYMENT_METHOD - CHECK_NO: MEMO"

task-3943455

**Enterprise PR:** odoo/enterprise#63085