### PR TITLE
[FIX] l10n_ar: allow COA reload

### DIFF
--- a/addons/l10n_ar/i18n/l10n_ar.pot
+++ b/addons/l10n_ar/i18n/l10n_ar.pot
@@ -2240,7 +2240,7 @@ msgstr ""
 #: code:addons/l10n_ar/models/account_journal.py:0
 #, python-format
 msgid ""
-"You can not change the journal's configuration if it already has validated "
+"You can not change %s journal's configuration if it already has validated "
 "invoices"
 msgstr ""
 

--- a/addons/l10n_ar/models/account_journal.py
+++ b/addons/l10n_ar/models/account_journal.py
@@ -1,7 +1,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
 from odoo import fields, models, api, _
-from odoo.exceptions import ValidationError, RedirectWarning
+from odoo.exceptions import UserError, ValidationError, RedirectWarning
 
 
 class AccountJournal(models.Model):
@@ -128,16 +128,6 @@ class AccountJournal(models.Model):
             codes = expo_codes
         return [('code', 'in', codes)]
 
-    @api.constrains('type', 'l10n_ar_afip_pos_system', 'l10n_ar_afip_pos_number', 'l10n_latam_use_documents')
-    def _check_afip_configurations(self):
-        """ Do not let the user update the journal if it already contains confirmed invoices """
-        journals = self.filtered(lambda x: x.company_id.account_fiscal_country_id.code == "AR" and x.type in ['sale', 'purchase'])
-        invoices = self.env['account.move'].search([('journal_id', 'in', journals.ids), ('posted_before', '=', True)], limit=1)
-        if invoices:
-            raise ValidationError(
-                _("You can not change the journal's configuration if it already has validated invoices") + ' ('
-                + ', '.join(invoices.mapped('journal_id').mapped('name')) + ')')
-
     @api.constrains('l10n_ar_afip_pos_system')
     def _check_afip_pos_system(self):
         journals = self.filtered(
@@ -164,3 +154,27 @@ class AccountJournal(models.Model):
         """
         if self.type == 'sale' and self.l10n_ar_afip_pos_number:
             self.code = "%05i" % self.l10n_ar_afip_pos_number
+
+    def write(self, vals):
+        protected_fields = ('type', 'l10n_ar_afip_pos_system', 'l10n_ar_afip_pos_number', 'l10n_latam_use_documents')
+        fields_to_check = [field for field in protected_fields if field in vals]
+
+        if fields_to_check:
+            self._cr.execute("SELECT DISTINCT(journal_id) FROM account_move WHERE posted_before = True")
+            res = self._cr.fetchall()
+            journal_with_entry_ids = [journal_id for journal_id, in res]
+
+            for journal in self:
+                if (
+                    journal.company_id.account_fiscal_country_id.code != "AR"
+                    or journal.type not in ['sale', 'purchase']
+                    or journal.id not in journal_with_entry_ids
+                ):
+                    continue
+
+                for field in fields_to_check:
+                    # Wouldn't work if there was a relational field, as we would compare an id with a recordset.
+                    if vals[field] != journal[field]:
+                        raise UserError(_("You can not change %s journal's configuration if it already has validated invoices", journal.name))
+
+        return super().write(vals)


### PR DESCRIPTION
The "Reload Chart Template" button currently doesn't work with the
argentinian localization.

It is due to some python constrains that don't allow to modify
some fields if there are accounting entries.

The issue is that the constrains will be raised, when any writing
on those fields is done, even if the new value is the same as the old
one.

When reloading the chart template it is re-writing the values, but
they are not different, so no exception should be raised.

The fix here is to move those constrains into the `def write` override,
where there's more control (as we have the new values as argument).

task-3878511