### PR TITLE
[IMP] survey: show retake btn even when users succeed

### DIFF
--- a/addons/survey/views/survey_templates_management.xml
+++ b/addons/survey/views/survey_templates_management.xml
@@ -110,7 +110,7 @@
     </template>
 
     <template id="survey_button_retake" name="Survey: retake button">
-        <div t-if="not answer.scoring_success and not answer.is_session_answer" class="d-print-none">
+        <div t-if="not answer.is_session_answer and not (survey.certification and answer.scoring_success)" class="d-print-none">
             <t t-if="survey.is_attempts_limited">
                 <t t-set="attempts_left" t-value="survey._get_number_of_attempts_lefts(answer.partner_id, answer.email, answer.invite_token)" />
                 <p t-if="attempts_left > 0">


### PR DESCRIPTION
Currently, when you take a survey with scoring (e.g: quiz/test), you
are allowed to retake it when your score is below the
minimum required score, and provided you are not in the middle of a live
session.

Functionally, this translates into a 'Take Again/Retry' button on the
survey completion page.

We would like to show the retake button even when the users succeed.

To do this, we modify the condition that determines the display of the
retake button as follows: the user is not in a live session. And in case
of limited attempts: the user shall have attempts left.
