### PR TITLE
[FIX] hr_holidays : Set env user as self if not employee in context

### DIFF
--- a/addons/hr_holidays/models/hr_employee.py
+++ b/addons/hr_holidays/models/hr_employee.py
@@ -385,9 +385,9 @@ class HrEmployee(models.Model):
     @api.model
     def _get_contextual_employee(self):
         ctx = self.env.context
-        if 'employee_id' in ctx:
+        if self.env.context.get('employee_id') is not None:
             return self.browse(ctx.get('employee_id'))
-        if 'default_employee_id' in ctx:
+        if self.env.context.get('default_employee_id') is not None:
             return self.browse(ctx.get('default_employee_id'))
         return self.env.user.employee_id
 


### PR DESCRIPTION
Steps to reproduce:
	- Install Time off module
	- Create a public holiday with Working Hours 'calendar_id'
	- Go to env user Time off dashboard

Current behavior before PR:
The public holidays that has 'calendar_id' assigned to it will not be shown in Legend when checking the dashboard of the env user. This is happening because we assign the self 'hr.employee' with the employee_id in context https://github.com/odoo/odoo/blob/c6142d9f1432cfabedcaa7264af9e5bc8e538c20/addons/hr_holidays/models/hr_employee.py#L313 and in '_get_contextual_employee' we just check if employee_id exists in ctx or not
https://github.com/odoo/odoo/blob/17.0/addons/hr_holidays/models/hr_employee.py#L388:L392 
but we don't check the value so if ctx is like {'employee_id': None} it will return None.

Desired behavior after PR is merged:
We are now checking if the 'employee_id' in ctx
has a valid value as if it is not we need to return the employee object of the env user.

Other solution that we can add in this line https://github.com/odoo/odoo/blob/c6142d9f1432cfabedcaa7264af9e5bc8e538c20/addons/hr_holidays/models/hr_employee.py#L313 to check if the self._get_contetxtual_employee is None we assign self to self.env.user.employee_id

opw-3863947