### PR TITLE
[FIX] l10n_ug: Taxes payable account type

### DIFF
--- a/addons/l10n_ug/data/template/account.account-ug.csv
+++ b/addons/l10n_ug/data/template/account.account-ug.csv
@@ -111,7 +111,7 @@ id,name,code,account_type,tag_ids,reconcile
 4115,Investment Fund Shares or Units,4115,liability_non_current,,False
 4117,Accounts Payable,4117,liability_payable,,True
 411721,Trade creditors,411721,liability_payable,,True
-411722,Taxes payable,411722,liability_payable,,True
+411722,Taxes payable,411722,liability_current,,True
 411723,Taxes due to state,411723,liability_current,,False
 411724,Deposits received,411724,liability_payable,,True
 411725,Advances from Other Government Units,411725,liability_payable,,True


### PR DESCRIPTION
With an Uganda company setup
Create an invoice to Uganda customer
Try to register a payment

Error
"You can't register payments for both inbound and outbound moves at the same time"
This occurs because the Taxes payable account type is set to Liability Payable, so the tax line will be detected as possible receivable by the payment wizard creating the issue

opw-3944574
