### PR TITLE
[FIX] account_payment_term: allows use of days_next_month in (30,31)

### DIFF
--- a/addons/account_payment_term/models/account_payment_term.py
+++ b/addons/account_payment_term/models/account_payment_term.py
@@ -2,7 +2,6 @@ from dateutil.relativedelta import relativedelta
 
 from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
-from odoo.tools import date_utils
 
 
 class AccountPaymentTermLine(models.Model):
@@ -40,15 +39,9 @@ class AccountPaymentTermLine(models.Model):
 
         due_date = fields.Date.from_string(date_ref) or fields.Date.today()
         if self.delay_type == 'days_end_of_month_on_the':
-            date_end_of_month = date_utils.end_of(due_date + relativedelta(days=self.nb_days), 'month')
-
-            # Special case handling when the day of the month is 29, 30 or 31 to avoid exceeding the next month's end
-            # For instance, with a payment term of 30 days end of month and using the 31st of a month,
-            # prevent calculation from moving beyond the end of the next month (e.g., early March instead of end February)
-            if self.days_next_month in {'29', '30', '31'}:
-                # We get the min of the days the user enter in the payment term and the last day of the next month
-                days_next_month = relativedelta(days=min(int(self.days_next_month), (date_end_of_month + relativedelta(month=2)).day))
-            else:
-                days_next_month = relativedelta(days=int(self.days_next_month))
-            return date_end_of_month + days_next_month
+            try:
+                days_next_month = int(self.days_next_month)
+            except ValueError:
+                days_next_month = 1
+            return due_date + relativedelta(days=self.nb_days) + relativedelta(months=1, day=days_next_month)
         return res

--- a/addons/account_payment_term/tests/test_payment_term.py
+++ b/addons/account_payment_term/tests/test_payment_term.py
@@ -25,7 +25,7 @@ class TestAccountPaymentTerms(AccountTestInvoicingCommon):
             ],
         })
         cls.pay_term_days_end_of_month_31 = cls.env['account.payment.term'].create({
-            'name': "special case",
+            'name': "special case 31",
             'line_ids': [
                 Command.create({
                     'value': 'percent',
@@ -33,6 +33,30 @@ class TestAccountPaymentTerms(AccountTestInvoicingCommon):
                     'nb_days': 30,
                     'delay_type': 'days_end_of_month_on_the',
                     'days_next_month': 31,
+                }),
+            ],
+        })
+        cls.pay_term_days_end_of_month_30 = cls.env['account.payment.term'].create({
+            'name': "special case 30",
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 100,
+                    'delay_type': 'days_end_of_month_on_the',
+                    'days_next_month': 30,
+                    'nb_days': 0,
+                }),
+            ],
+        })
+        cls.pay_term_days_end_of_month_29 = cls.env['account.payment.term'].create({
+            'name': "special case 29",
+            'line_ids': [
+                Command.create({
+                    'value': 'percent',
+                    'value_amount': 100,
+                    'delay_type': 'days_end_of_month_on_the',
+                    'days_next_month': 29,
+                    'nb_days': 0,
                 }),
             ],
         })
@@ -56,3 +80,70 @@ class TestAccountPaymentTerms(AccountTestInvoicingCommon):
 
         expected_date_special_case = self.invoice.line_ids.filtered(lambda l: l.account_id == self.company_data['default_account_receivable']).mapped('date_maturity'),
         self.assertEqual(expected_date_special_case[0], [fields.Date.from_string('2024-02-29')])
+
+    def test_payment_term_days_end_of_month_nb_days_0(self):
+        """
+        This test will check that payment terms with a delay_type 'days_end_of_month_on_the'
+        in combination with nb_days works as expected
+
+        Invoice date = 2024-05-23
+        # case 1
+        'nb_days' = 0
+        `days_next_month` = 29
+            -> 2024-05-23 + 0 days = 2024-05-23
+            => `date_maturity` -> 2024-06-29
+        # case 2
+        'nb_days' = 0
+        `days_next_month` = 31
+            -> 2024-05-23 + 0 days = 2024-05-23
+            => `date_maturity` -> 2024-06-30
+        """
+        self.pay_term_days_end_of_month_29.line_ids.nb_days = 0
+        self.pay_term_days_end_of_month_31.line_ids.nb_days = 0
+        with Form(self.invoice) as case_1:
+            case_1.invoice_payment_term_id = self.pay_term_days_end_of_month_29
+            case_1.invoice_date = '2024-05-23'
+
+        expected_date_case_1 = self.invoice.line_ids.filtered(lambda l: l.account_id == self.company_data['default_account_receivable']).mapped('date_maturity')
+        self.assertEqual(expected_date_case_1, [fields.Date.from_string('2024-06-29')])
+
+        with Form(self.invoice) as case_2:
+            case_2.invoice_payment_term_id = self.pay_term_days_end_of_month_31
+            case_2.invoice_date = '2024-05-23'
+
+        expected_date_case_2 = self.invoice.line_ids.filtered(lambda l: l.account_id == self.company_data['default_account_receivable']).mapped('date_maturity')
+        self.assertEqual(expected_date_case_2, [fields.Date.from_string('2024-06-30')])
+
+    def test_payment_term_days_end_of_month_nb_days_15(self):
+        """
+        This test will check that payment terms with a delay_type 'days_end_of_month_on_the'
+        in combination with nb_days works as expected
+
+        Invoice date = 2024-05-23
+        # case 1
+        'nb_days' = 15
+        `days_next_month` = 30
+            -> 2024-05-23 + 15 days = 2024-06-07
+            => `date_maturity` -> 2024-07-30
+        # case 2
+        'nb_days' = 15
+        `days_next_month` = 31
+            -> 2024-05-23 + 15 days = 2024-06-07
+            => `date_maturity` -> 2024-07-31
+        """
+        self.pay_term_days_end_of_month_30.line_ids.nb_days = 15
+        self.pay_term_days_end_of_month_31.line_ids.nb_days = 15
+
+        with Form(self.invoice) as case_1:
+            case_1.invoice_payment_term_id = self.pay_term_days_end_of_month_30
+            case_1.invoice_date = '2024-05-24'
+
+        expected_date_case_1 = self.invoice.line_ids.filtered(lambda l: l.account_id == self.company_data['default_account_receivable']).mapped('date_maturity')
+        self.assertEqual(expected_date_case_1, [fields.Date.from_string('2024-07-30')])
+
+        with Form(self.invoice) as case_2:
+            case_2.invoice_payment_term_id = self.pay_term_days_end_of_month_31
+            case_2.invoice_date = '2024-05-23'
+
+        expected_date_case_2 = self.invoice.line_ids.filtered(lambda l: l.account_id == self.company_data['default_account_receivable']).mapped('date_maturity')
+        self.assertEqual(expected_date_case_2, [fields.Date.from_string('2024-07-31')])


### PR DESCRIPTION
Steps to reproduce:
- Create a new payment term; "days end of month on the 30"
- create an invoice in may
- set the newly created payment term
- create a invoice line
- save

Issue:
the due date (`maturity_date`) is 2024-06-29

Cause:
Use of `relativedelta` with the singular form of `month` -> absolute value

It was set to 2 so it would always give 29 -> year-02-29

and so  `days_next_month = relativedelta(days=min(int(self.days_next_month), (date_end_of_month + relativedelta(month=2)).day))`

would always return 29 since 29 <= (29, 30, 31)

```
>>> import datetime
>>> from dateutil.relativedelta import relativedelta
>>> date_end_of_month
datetime.datetime(2024, 5, 31, 17, 4, 14, 791820)
>>> (date_end_of_month + relativedelta(month=2))
datetime.datetime(2024, 2, 29, 17, 4, 14, 791820)
>>> min(31, 30, (date_end_of_month + relativedelta(month=2)).day)
29
```

Solution:
use the relative form of `relativedelta`; that is, the plural form `months`
```
>>> (date_end_of_month + relativedelta(months=1))
datetime.datetime(2024, 6, 30, 17, 4, 14, 791820)
```
source: https://dateutil.readthedocs.io/en/stable/relativedelta.html

Note:
Had to change the existing test on the overlapping year since
```
>>> december_date
datetime.datetime(2023, 12, 12, 0, 0)
>>> december_date + datetime.timedelta(days=30)
datetime.datetime(2024, 1, 11, 0, 0)
```
and from date the maturity date would be 31st of January

opw-3916451