### PR TITLE
[FIX] stock: trigger the _compute_location_dest_id in move line

### DIFF
--- a/addons/stock/views/stock_picking_views.xml
+++ b/addons/stock/views/stock_picking_views.xml
@@ -324,6 +324,11 @@
                                         context="{'default_company_id': company_id, 'default_product_id': product_id, 'active_picking_id': parent.id}"
                                         domain="[('product_id','=',product_id)]"
                                     />
+                                    <field name="move_line_ids" invisible="1">
+                                        <tree>
+                                            <field name="location_dest_id" invisible="1"/>
+                                        </tree>
+                                    </field>
                                 </tree>
                             </field>
                             <field name="id" invisible="1"/>


### PR DESCRIPTION
**Steps to reproduce the bug:**
- Create a storable product and update its quantity to 10 units in WH/stock.
- Create an internal transfer:
  - From: WH/stock
  - To: WH/stock/shelf1

- Mark the picking as "To Do".
- Picking is in the "Ready" state.
- Update the destination location of the picking.

**Problem:**
The `dest_location_id` is updated in the move, thanks to the `_compute_location_dest_id` in the `stock.move`:
https://github.com/odoo/odoo/blob/11e69870db1c49d9a6af79ffd263e4e162b34b6b/addons/mrp/models/stock_move.py#L147-L148

However, the `_compute_location_dest_id` of `stock.move.line` is not triggered because the `location_dest_id` field is not present in the view:
https://github.com/odoo/odoo/blob/0f531b3f68e2401c717879bd484d6125aa83a37d/addons/stock/models/stock_move_line.py#L110-L116

opw-3932717
