### PR TITLE
[FIX] website: prevent the removal of the form's default values

### DIFF
--- a/addons/website/static/src/snippets/s_website_form/000.js
+++ b/addons/website/static/src/snippets/s_website_form/000.js
@@ -22,6 +22,16 @@ odoo.define('website.s_website_form', function (require) {
          */
         start: function () {
             if (this.editableMode) {
+                // TODO: Improve this. Since the form behavior was handled using
+                // two separate public widgets, and the "data-for" values were
+                // removed (on destroy before saving), we still need to restore
+                // them in edit mode in the case of a simple widget refresh.
+                this.dataForValues = wUtils.getParsedDataFor(this.$target[0].id, this.$target[0].ownerDocument);
+                for (const fieldEl of this._getDataForFields()) {
+                    if (!fieldEl.getAttribute("value")) {
+                        fieldEl.setAttribute("value", this.dataForValues[fieldEl.name]);
+                    }
+                }
                 // We do not initialize the datetime picker in edit mode but want the dates to be formated
                 const dateTimeFormat = time.getLangDatetimeFormat();
                 const dateFormat = time.getLangDateFormat();
@@ -35,6 +45,32 @@ odoo.define('website.s_website_form', function (require) {
             }
             return this._super(...arguments);
         },
+        /**
+         * @override
+         */
+        destroy() {
+            if (this.editableMode) {
+                // The "data-for" values are always correctly added to the form
+                // on the form widget start. But if we make any change to it in
+                // "edit" mode, we need to be sure it will not be saved with
+                // the new values.
+                for (const fieldEl of this._getDataForFields()) {
+                    fieldEl.removeAttribute("value");
+                }
+            }
+            this._super(...arguments);
+        },
+        /**
+         * @private
+         */
+        _getDataForFields() {
+            if (!this.dataForValues) {
+                return [];
+            }
+            return Object.keys(this.dataForValues)
+                .map(name => this.$target[0].querySelector(`[name="${CSS.escape(name)}"]`))
+                .filter(dataForValuesFieldEl => dataForValuesFieldEl && dataForValuesFieldEl.name !== "email_to");
+        }
     });
 
     publicWidget.registry.s_website_form = publicWidget.Widget.extend({
@@ -240,8 +276,18 @@ odoo.define('website.s_website_form', function (require) {
             // All 'hidden if' fields start with d-none
             this.$target[0].querySelectorAll('.s_website_form_field_hidden_if:not(.d-none)').forEach(el => el.classList.add('d-none'));
 
+            // Prevent "data-for" values removal on destroy, they are still used
+            // in edit mode to keep the form linked to its predefined server
+            // values (e.g., the default `job_id` value on the application form
+            // for a given job).
+            const dataForValues = wUtils.getParsedDataFor(this.$target[0].id, document) || {};
+            const initialValuesToReset = new Map(
+                [...this.initialValues.entries()].filter(
+                    ([input]) => !dataForValues[input.name] || input.name === "email_to"
+                )
+            );
             // Reset the initial default values.
-            for (const [fieldEl, initialValue] of this.initialValues.entries()) {
+            for (const [fieldEl, initialValue] of initialValuesToReset.entries()) {
                 if (initialValue) {
                     fieldEl.setAttribute('value', initialValue);
                 } else {

--- a/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
+++ b/addons/website_hr_recruitment/static/tests/tours/website_hr_recruitment.js
@@ -120,7 +120,9 @@ odoo.define('website_hr_recruitment.tour', function(require) {
         content: 'Verify that the job_id field has kept its default value',
         trigger: "body",
         run: () => {
-            if (!document.querySelector('.o_iframe:not(.o_ignore_in_tour)').contentDocument.querySelector('input[name="job_id"][value="FAKE_JOB_ID_DEFAULT_VAL"]')) {
+            const doc = document.querySelector(".o_iframe:not(.o_ignore_in_tour)").contentDocument;
+            const id = doc.querySelector('[data-oe-model="hr.job"]').dataset.oeId;
+            if (!doc.querySelector(`input[name="job_id"][value="${id}"]`)) {
                 console.error('The job_id field has lost its default value');
             }
         }


### PR DESCRIPTION
Steps to reproduce [17.1]:

- Add a property field to a job application in the backend.
- Go to the linked website job application form (in edit mode).
- The property field is inaccessible.

To be able to access the new property field in the application form, the
`job_id` value of the related job record needs to be specified by
default. Unfortunately, these values are removed before accessing "edit"
mode:

Starting from [1], a fix was added to clear default values coming from
`data-for` attributes when the form is edited (at `cleanForSave()`) to
prevent saving it with changed default values.

Since the code from [1] can also remove default values set by the user,
a new fix (see [2]) updated this implementation to ensure that only
values from auto-fill and data-for fields will be removed (this time,
when the form public widget is destroyed [3]).

The behaviour from [3] will always unlink the `data-for` values in edit
mode, and as a consequence, the related property fields won't be
correctly retrieved.

The goal of this commit is to fix this behaviour by excluding `data-for`
values from the reset in [3]. An extra check will be added to be sure
the form won't be saved with updated default values if it already has
`data-for` ones [4].

Important: The diff from [5] made the `email_to` field as an exception
for the data-for/prefill priority system and only used the `data-for`
value if nothing has been configured by the user (it also used the
`data-for` value if what was configured by the user is the dummy default
email: `info@yourcompany.example.com`). That's why we need to
exceptionally allow saving the default value added by the user in the
check from [4] to preserve the same behavior.

Following [6], The `email_to` value won't be kept in edit mode to
prevent breaking its dynamic behavior.

[1]: https://github.com/odoo/odoo/commit/b637a5e32f767b62736241042f88fa0cecf9f10b
[2]: https://github.com/odoo/odoo/commit/043e1fdf923d2037dd8da128ab99388f0c92e544
[5]: https://github.com/odoo/odoo/commit/a08574a04ff2ce8ea2d6fd2b79f56cc57bba953b
[6]: https://github.com/odoo/odoo/commit/6658d61e304c9dfd8e512648c4a001dcaac44bc1

task-3922573