### PR TITLE
[FIX] base: Access to unauthorized company

### DIFF
--- a/odoo/addons/base/models/ir_ui_view.py
+++ b/odoo/addons/base/models/ir_ui_view.py
@@ -2009,7 +2009,7 @@ actual arch.
         qcontext = dict(
             env=self.env,
             user_id=self.env["res.users"].browse(self.env.user.id),
-            res_company=self.env.company.sudo(),
+            res_company=self.env(su=True).company,
             keep_query=keep_query,
             request=request,  # might be unbound if we're not in an httprequest context
             debug=request.session.debug if request else '',


### PR DESCRIPTION
Access is checked while reading laze property - setting su flag before reading the property should avoid access error

Description of the issue/feature this PR addresses:
An access error is raised, when user does not have access to the company in self.env.company

Current behavior before PR:
"Access to unauthorized or invalid companies."

Desired behavior after PR is merged:
No error




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
