### PR TITLE
[FIX] mail: block usage of non mail.thread model in mail.template

### DIFF
--- a/addons/mail/tests/test_mail_template.py
+++ b/addons/mail/tests/test_mail_template.py
@@ -71,6 +71,7 @@ class TestMailTemplate(MailCommon):
                 'model_id': self.env['ir.model']._get('mail.thread').id,
             })
 
+
     def test_mail_template_acl(self):
         # Sanity check
         self.assertTrue(self.user_admin.has_group('mail.group_mail_template_editor'))


### PR DESCRIPTION
steps to reproduce:
- create a mail.template on Channel/Partner (those are the attendees of an elearning class)
- add a contextual action
- go to elearning/reporting/attendees
- go to the tree view and select an attendee
- in the action menu, select your mail.template
- send it

=> traceback:
`  File "/data/build/odoo/addons/mass_mailing/wizard/mail_compose_message.py", line 28, in _prepare_mail_values
    mail_values_all = super()._prepare_mail_values(res_ids)
  File "/data/build/odoo/addons/mail/wizard/mail_compose_message.py", line 794, in _prepare_mail_values
    additional_values_all = self._prepare_mail_values_dynamic(res_ids)
  File "/data/build/odoo/addons/mail/wizard/mail_compose_message.py", line 967, in _prepare_mail_values_dynamic
    mail_values['attachment_ids'] = record._process_attachments_for_post(
AttributeError: 'slide.channel.partner' object has no attribute '_process_attachments_for_post'`

It's OK to not use the record because we call `_process_attachments_for_post` with `{'model': 'mail.message', 'res_id': 0}` , so we don't use self anyway.

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
