### PR TITLE
[IMP] portal, _*: allow multiple address management for portal users

### DIFF
--- a/addons/l10n_ar_website_sale/controllers/main.py
+++ b/addons/l10n_ar_website_sale/controllers/main.py
@@ -19,7 +19,7 @@ class L10nARWebsiteSale(WebsiteSale):
         return mandatory_fields
 
     def _prepare_address_form_values(self, partner_sudo, address_type, **kwargs):
-        partner_sudo, rendering_values = super()._prepare_address_form_values(
+        rendering_values = super()._prepare_address_form_values(
             partner_sudo, address_type, **kwargs
         )
         if address_type == 'billing' and request.website.sudo().company_id.country_id.code == 'AR':

--- a/addons/l10n_ar_website_sale/controllers/main.py
+++ b/addons/l10n_ar_website_sale/controllers/main.py
@@ -18,9 +18,9 @@ class L10nARWebsiteSale(WebsiteSale):
             }
         return mandatory_fields
 
-    def _prepare_address_form_values(self, *args, address_type, **kwargs):
-        rendering_values = super()._prepare_address_form_values(
-            *args, address_type=address_type, **kwargs
+    def _prepare_address_form_values(self, partner_sudo, address_type, **kwargs):
+        partner_sudo, rendering_values = super()._prepare_address_form_values(
+            partner_sudo, address_type, **kwargs
         )
         if address_type == 'billing' and request.website.sudo().company_id.country_id.code == 'AR':
             can_edit_vat = rendering_values['can_edit_vat']

--- a/addons/l10n_ar_website_sale/views/templates.xml
+++ b/addons/l10n_ar_website_sale/views/templates.xml
@@ -62,14 +62,14 @@
         </div>
     </template>
 
-    <template id="portal_my_details_fields" name="portal_my_details_fields" inherit_id="portal.portal_my_details_fields">
-        <xpath expr="//input[@name='vat']/.." position="before">
+    <template id="portal_my_details_fields" name="portal_my_details_fields" inherit_id="portal.portal_my_details">
+        <xpath expr="//input[@name='company_name']/.." position="after">
             <t t-if="res_company.country_code == 'AR'">
                 <t t-call="l10n_ar_website_sale.partner_info"/>
             </t>
         </xpath>
 
-        <label for="vat" position="replace">
+        <label for="o_vat" position="replace">
             <t t-if="res_company.country_id.code != 'AR'">$0</t>
             <t t-else="">
                 <label class="col-form-label label-optional" for="vat">

--- a/addons/l10n_br_website_sale/controllers/main.py
+++ b/addons/l10n_br_website_sale/controllers/main.py
@@ -36,7 +36,7 @@ class L10nBRWebsiteSale(WebsiteSale):
         return mandatory_fields
 
     def _prepare_address_form_values(self, partner_sudo, address_type, **kwargs):
-        partner_sudo, rendering_values = super()._prepare_address_form_values(
+        rendering_values = super()._prepare_address_form_values(
             partner_sudo, address_type, **kwargs
         )
         if address_type == 'billing' and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR':

--- a/addons/l10n_br_website_sale/controllers/main.py
+++ b/addons/l10n_br_website_sale/controllers/main.py
@@ -35,9 +35,9 @@ class L10nBRWebsiteSale(WebsiteSale):
 
         return mandatory_fields
 
-    def _prepare_address_form_values(self, order_sudo, partner_sudo, *args, address_type, **kwargs):
-        rendering_values = super()._prepare_address_form_values(
-            order_sudo, partner_sudo, *args, address_type=address_type, **kwargs
+    def _prepare_address_form_values(self, partner_sudo, address_type, **kwargs):
+        partner_sudo, rendering_values = super()._prepare_address_form_values(
+            partner_sudo, address_type, **kwargs
         )
         if address_type == 'billing' and request.website.sudo().company_id.account_fiscal_country_id.code == 'BR':
             can_edit_vat = rendering_values['can_edit_vat']

--- a/addons/l10n_br_website_sale/static/src/js/address.js
+++ b/addons/l10n_br_website_sale/static/src/js/address.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import websiteSaleAddress from '@website_sale/js/address';
+import websiteSaleAddress from "@portal/js/portal_address"
 
 websiteSaleAddress.include({
     events: Object.assign(

--- a/addons/l10n_br_website_sale/views/portal.xml
+++ b/addons/l10n_br_website_sale/views/portal.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
     <!-- FIXME JCO should be in the base loca module, it's portal content, not eCommerce -->
-    <template id="portal_my_details_fields" inherit_id="portal.portal_my_details_fields">
+    <template id="portal_my_details_fields" inherit_id="portal.portal_my_details">
         <xpath expr="//input[@name='vat']/.." position="before">
             <t t-if="res_company.country_id.code == 'BR'">
                 <div class="mb-1 col-xl-6"/> <!-- Empty div to put the vat and identification type on the same line -->

--- a/addons/l10n_ec_website_sale/controllers/main.py
+++ b/addons/l10n_ec_website_sale/controllers/main.py
@@ -16,10 +16,11 @@ class L10nECWebsiteSale(WebsiteSale):
         mandatory_fields.add('l10n_latam_identification_type_id')
         return mandatory_fields
 
-    def _prepare_address_form_values(self, *args, address_type, use_delivery_as_billing, **kwargs):
-        rendering_values = super()._prepare_address_form_values(
-            *args,
-            address_type=address_type,
+    def _prepare_address_form_values(self, partner_sudo, address_type, **kwargs):
+        use_delivery_as_billing = kwargs.get('use_delivery_as_billing')
+        partner_sudo, rendering_values = super()._prepare_address_form_values(
+            partner_sudo,
+            address_type,
             use_delivery_as_billing=use_delivery_as_billing,
             **kwargs,
         )

--- a/addons/l10n_ec_website_sale/controllers/main.py
+++ b/addons/l10n_ec_website_sale/controllers/main.py
@@ -18,10 +18,9 @@ class L10nECWebsiteSale(WebsiteSale):
 
     def _prepare_address_form_values(self, partner_sudo, address_type, **kwargs):
         use_delivery_as_billing = kwargs.get('use_delivery_as_billing')
-        partner_sudo, rendering_values = super()._prepare_address_form_values(
+        rendering_values = super()._prepare_address_form_values(
             partner_sudo,
             address_type,
-            use_delivery_as_billing=use_delivery_as_billing,
             **kwargs,
         )
         if (

--- a/addons/l10n_ec_website_sale/views/portal_templates.xml
+++ b/addons/l10n_ec_website_sale/views/portal_templates.xml
@@ -24,15 +24,15 @@
 
     </template>
 
-    <template id="portal_my_details_fields" name="portal_my_details_fields" inherit_id="portal.portal_my_details_fields">
-        <xpath expr="//input[@name='vat']/.." position="before">
+    <template id="portal_my_details_fields" name="portal_my_details_fields" inherit_id="portal.portal_my_details">
+        <xpath expr="//input[@name='company_name']/.." position="after">
             <t t-if="res_company.country_code == 'EC'">
                 <div class="clearfix"/>
                 <t t-call="l10n_ec_website_sale.partner_info"/>
             </t>
         </xpath>
 
-        <label for="vat" position="replace">
+        <label for="o_vat" position="replace">
             <t t-if="res_company.country_id.code != 'EC'">$0</t>
             <t t-else="">
                 <label class="col-form-label label-optional" for="vat">

--- a/addons/l10n_it_edi_website_sale/controllers/main.py
+++ b/addons/l10n_it_edi_website_sale/controllers/main.py
@@ -14,19 +14,20 @@ class L10nITWebsiteSale(WebsiteSale):
             address_values, *args, **kwargs
         )
 
-        if address_values.get('l10n_it_codice_fiscale'):
-            partner_dummy = request.env['res.partner'].new({
-                'l10n_it_codice_fiscale': address_values.get('l10n_it_codice_fiscale')
-            })
-            try:
-                partner_dummy.validate_codice_fiscale()
-            except UserError as e:
-                invalid_fields.add('l10n_it_codice_fiscale')
-                error_messages.append(e.name)
+        if not kwargs.get('portal_address'):
+            if address_values.get('l10n_it_codice_fiscale'):
+                partner_dummy = request.env['res.partner'].new({
+                    'l10n_it_codice_fiscale': address_values.get('l10n_it_codice_fiscale')
+                })
+                try:
+                    partner_dummy.validate_codice_fiscale()
+                except UserError as e:
+                    invalid_fields.add('l10n_it_codice_fiscale')
+                    error_messages.append(e.name)
 
-        pa_index = address_values.get('l10n_it_pa_index')
-        if pa_index and (len(pa_index) < 6 or len(pa_index) > 7):
-            invalid_fields.add('l10n_it_pa_index')
-            error_messages.append(_("Destination Code (SDI) must have between 6 and 7 characters"))
+            pa_index = address_values.get('l10n_it_pa_index')
+            if pa_index and (len(pa_index) < 6 or len(pa_index) > 7):
+                invalid_fields.add('l10n_it_pa_index')
+                error_messages.append(_("Destination Code (SDI) must have between 6 and 7 characters"))
 
         return invalid_fields, missing_fields, error_messages

--- a/addons/l10n_it_edi_website_sale/controllers/main.py
+++ b/addons/l10n_it_edi_website_sale/controllers/main.py
@@ -14,20 +14,19 @@ class L10nITWebsiteSale(WebsiteSale):
             address_values, *args, **kwargs
         )
 
-        if not kwargs.get('portal_address'):
-            if address_values.get('l10n_it_codice_fiscale'):
-                partner_dummy = request.env['res.partner'].new({
-                    'l10n_it_codice_fiscale': address_values.get('l10n_it_codice_fiscale')
-                })
-                try:
-                    partner_dummy.validate_codice_fiscale()
-                except UserError as e:
-                    invalid_fields.add('l10n_it_codice_fiscale')
-                    error_messages.append(e.name)
+        if address_values.get('l10n_it_codice_fiscale'):
+            partner_dummy = request.env['res.partner'].new({
+                'l10n_it_codice_fiscale': address_values.get('l10n_it_codice_fiscale')
+            })
+            try:
+                partner_dummy.validate_codice_fiscale()
+            except UserError as e:
+                invalid_fields.add('l10n_it_codice_fiscale')
+                error_messages.append(e.name)
 
-            pa_index = address_values.get('l10n_it_pa_index')
-            if pa_index and (len(pa_index) < 6 or len(pa_index) > 7):
-                invalid_fields.add('l10n_it_pa_index')
-                error_messages.append(_("Destination Code (SDI) must have between 6 and 7 characters"))
+        pa_index = address_values.get('l10n_it_pa_index')
+        if pa_index and (len(pa_index) < 6 or len(pa_index) > 7):
+            invalid_fields.add('l10n_it_pa_index')
+            error_messages.append(_("Destination Code (SDI) must have between 6 and 7 characters"))
 
         return invalid_fields, missing_fields, error_messages

--- a/addons/l10n_pe_website_sale/controllers/main.py
+++ b/addons/l10n_pe_website_sale/controllers/main.py
@@ -30,9 +30,9 @@ class L10nPEWebsiteSale(WebsiteSale):
             mandatory_fields.remove('city')
         return mandatory_fields
 
-    def _prepare_address_form_values(self, order_sudo, partner_sudo, address_type, **kwargs):
+    def _prepare_address_form_values(self, partner_sudo, address_type, **kwargs):
         rendering_values = super()._prepare_address_form_values(
-            order_sudo, partner_sudo, address_type=address_type, **kwargs
+            partner_sudo, address_type=address_type, **kwargs
         )
         if request.website.sudo().company_id.country_id.code != 'PE':
             return rendering_values

--- a/addons/l10n_pe_website_sale/controllers/main.py
+++ b/addons/l10n_pe_website_sale/controllers/main.py
@@ -32,10 +32,10 @@ class L10nPEWebsiteSale(WebsiteSale):
 
     def _prepare_address_form_values(self, partner_sudo, address_type, **kwargs):
         rendering_values = super()._prepare_address_form_values(
-            partner_sudo, address_type=address_type, **kwargs
+            partner_sudo, address_type, **kwargs
         )
         if request.website.sudo().company_id.country_id.code != 'PE':
-            return rendering_values
+            return partner_sudo, rendering_values
 
         if address_type == 'billing':
             can_edit_vat = rendering_values['can_edit_vat']

--- a/addons/l10n_pe_website_sale/controllers/main.py
+++ b/addons/l10n_pe_website_sale/controllers/main.py
@@ -35,7 +35,7 @@ class L10nPEWebsiteSale(WebsiteSale):
             partner_sudo, address_type, **kwargs
         )
         if request.website.sudo().company_id.country_id.code != 'PE':
-            return partner_sudo, rendering_values
+            return rendering_values
 
         if address_type == 'billing':
             can_edit_vat = rendering_values['can_edit_vat']

--- a/addons/l10n_pe_website_sale/static/src/js/website_sale.js
+++ b/addons/l10n_pe_website_sale/static/src/js/website_sale.js
@@ -1,6 +1,6 @@
 /** @odoo-module **/
 
-import websiteSaleAddress from "@website_sale/js/address";
+import websiteSaleAddress from "@portal/js/portal_address"
 import { rpc } from "@web/core/network/rpc";
 
 websiteSaleAddress.include({

--- a/addons/point_of_sale/views/pos_ticket_view.xml
+++ b/addons/point_of_sale/views/pos_ticket_view.xml
@@ -95,7 +95,7 @@
                             <div class="row o_portal_details">
                                 <div class="col-lg-12">
                                     <div class="row">
-                                        <t t-call="portal.portal_my_details_fields" />
+                                        <t t-call="portal.portal_my_details"/>
                                         <t t-if="partner_required_fields">
                                             <t t-set="required_fields" t-value="partner_required_fields"/>
                                             <t t-set="field_prefix" t-value="'partner_'"/>

--- a/addons/portal/__manifest__.py
+++ b/addons/portal/__manifest__.py
@@ -38,6 +38,8 @@ a dependency towards website editing and customization capabilities.""",
         'web.assets_frontend': [
             'portal/static/src/scss/portal.scss',
             'portal/static/src/js/portal.js',
+            'portal/static/src/js/portal_address.js',
+            'portal/static/src/js/portal_default_address.js',
             'portal/static/src/xml/portal_chatter.xml',
             'portal/static/src/js/portal_composer.js',
             'portal/static/src/js/portal_security.js',

--- a/addons/portal/controllers/portal.py
+++ b/addons/portal/controllers/portal.py
@@ -4,8 +4,9 @@ import math
 import re
 
 from werkzeug import urls
+from werkzeug.exceptions import Forbidden
 
-from odoo import http, tools, _, SUPERUSER_ID
+from odoo import http, tools, _, SUPERUSER_ID, _lt
 from odoo.exceptions import AccessDenied, AccessError, MissingError, UserError, ValidationError
 from odoo.http import content_disposition, Controller, request, route
 from odoo.tools import consteq
@@ -211,7 +212,7 @@ class CustomerPortal(Controller):
         states = request.env['res.country.state'].sudo().search([])
 
         values.update({
-            'partner': partner,
+            'partner_sudo': partner,
             'countries': countries,
             'states': states,
             'has_check_vat': hasattr(request.env['res.partner'], 'check_vat'),
@@ -227,6 +228,384 @@ class CustomerPortal(Controller):
 
     def on_account_update(self, values, partner):
         pass
+
+    @route(['/my/addresses'], type='http', auth='user', website=True)
+    def addresses(self, **kwargs):
+        values = {
+            **self._prepare_portal_layout_values(),
+            'partner': request.env.user.partner_id,
+            'page_name': 'my_addresses'
+        }
+        # test default
+        if request.env.user.partner_id:
+            if not request.env.user.partner_id.is_default_billing_address and not any(child.is_default_billing_address for child in request.env.user.partner_id.child_ids):
+                request.env.user.partner_id.is_default_billing_address = True
+
+            if not request.env.user.partner_id.is_default_shipping_address and not any(child.is_default_shipping_address for child in request.env.user.partner_id.child_ids):
+                request.env.user.partner_id.is_default_shipping_address = True
+        return request.render("portal.portal_my_addresses", values)
+
+    @route('/portal/address', type='http', methods=['GET'], auth='public', website=True, sitemap=False)
+    def portal_address(self,
+                       partner_id=None,
+                       address_type='invoice',
+                       template_to_render='portal.portal_my_details',
+                       **query_params
+                    ):
+        """ Display the checkout page.
+
+        :param dict query_params: The additional query string parameters.
+        :return: The rendered checkout page.
+        :rtype: str
+        """
+        partner_id = partner_id and int(partner_id)
+
+        # Retrieve the partner whose address to update, if any, and its address type.
+        partner_sudo, address_type = self._prepare_address_update(
+            partner_id=partner_id, address_type=address_type, **query_params
+        )
+
+        # Render the address form.
+        address_form_values = self._prepare_address_form_values(
+            partner_sudo,
+            address_type=address_type,
+            **query_params
+        )
+        return request.render(template_to_render, address_form_values)
+
+    @route('/address/update_address', type='json', auth='public', website=True)
+    def portal_update_address(self, partner_id, address_type='billing', **kw):
+        partner_id = int(partner_id)
+        ResPartner = request.env['res.partner'].sudo()
+        partner_sudo = ResPartner.browse(partner_id).exists()
+        if not partner_sudo._can_be_edited_by_current_customer(address_type):
+            raise Forbidden()
+
+        partner_sudo._update_delivery_and_shipping_address(partner_id, address_type, **kw)
+
+    @route(['/archive/address/<int:partner_id>'], type='http', auth="user")
+    def address_archive(self, partner_id):
+        """ Archive an address associated with the logged-in user.
+
+        This method deactivates the address if it belongs to the current user or one of their
+        child addresses.If the address is associated with an active user, the request is
+        redirected with an error.
+
+        :param int partner_id: The ID of the partner address to archive.
+        :raises Forbidden: If the address does not belong to the logged-in user or their child addresses.
+        :return: A redirect to the addresses page.
+        """
+        partner = request.env['res.partner'].browse(partner_id)
+        address_type = partner.type
+        if not partner._can_be_edited_by_current_customer(address_type):
+            raise Forbidden()
+
+        if partner.user_ids.filtered(lambda user: user.active):
+            return request.redirect('/my/addresses?error=True')
+        else:
+            partner.sudo().write({'active': False})
+        return request.redirect('/my/addresses')
+
+    def _prepare_address_update(self, partner_id=None, address_type=None, **kwargs):
+        """ Find the partner whose address to update and return it along with its address type.
+
+        :param int partner_id: The partner whose address to update, if any, as a `res.partner` id.
+        :param str address_type: The type of the address: 'billing' or 'delivery'.
+        :return: The partner whose address to update, if any, and its address type.
+        :rtype: tuple[res.partner, str]
+        :raise Forbidden: If the customer is not allowed to update the given address.
+        """
+        PartnerSudo = request.env['res.partner'].with_context(show_address=1).sudo()
+        partner_sudo = PartnerSudo.browse(partner_id)
+
+        if partner_sudo and not partner_sudo._can_be_edited_by_current_customer(
+                address_type=address_type, **kwargs
+            ):
+            raise Forbidden()
+
+        return partner_sudo, address_type
+
+    def _prepare_address_form_values(
+        self, partner_sudo, address_type, use_same=None, callback='', **_kwargs
+    ):
+        """ Prepare and return the values to use to render the address form.
+
+        :param partner_sudo: The partner whose address to update through the address form.
+        :param str address_type: The type of the address: 'billing' or 'delivery'.
+        :param str callback:
+        :return: The checkout page values.
+        :rtype: dict
+        """
+        can_edit_vat = (
+            address_type in ['invoice', 'billing']
+            and (not partner_sudo or partner_sudo.can_edit_vat())
+        )
+
+        ResCountrySudo = request.env['res.country'].sudo()
+        country_sudo = partner_sudo.country_id
+        if not country_sudo:
+            country_sudo = request.env.user.country_id
+
+        state_id = partner_sudo.state_id.id
+        address_fields = country_sudo and country_sudo.get_address_fields() or ['city', 'zip']
+
+        return {
+            'partner_sudo': partner_sudo,  # If set, customer is editing an existing address
+            'partner_id': partner_sudo.id,
+            'address_type': address_type,  # 'billing' or 'delivery'
+            'type': address_type,
+            'can_edit_vat': can_edit_vat,
+            'callback': callback,
+            'use_same': use_same,
+            'discard_url': '/my/addresses',
+            'country': country_sudo,
+            'countries': ResCountrySudo.search([]),
+            'has_invoice': partner_sudo.can_edit_info() if partner_sudo else True,
+            'state_id': state_id or 1,
+            'country_states': country_sudo.state_ids,
+            'zip_before_city': (
+                'zip' in address_fields
+                and address_fields.index('zip') < address_fields.index('city')
+            ),
+            'show_vat': bool(address_type in ['contact', 'billing', 'invoice'] and not partner_sudo.parent_id),
+            'vat_label': _lt("VAT"),
+        }
+
+    @route(
+        '/portal/address/submit', type='http', methods=['POST'], auth='public', website=True,
+        sitemap=False
+    )
+    def portal_address_submit(
+            self,
+            partner_id=None,
+            address_type='billing',
+            use_same=None,
+            required_fields=None,
+            **form_data
+        ):
+        """ Create or update an address.
+
+        If it succeeds, it returns the URL to redirect (client-side) to. If it fails (missing or
+        invalid information), it highlights the problematic form input with the appropriate error
+        message.
+
+        :param str partner_id: The partner whose address to update with the address form, if any.
+        :param str address_type: The type of the address: 'billing' or 'delivery'.
+        :param str use_same: Whether the provided address should be used as both the billing and the
+                             delivery address. 'true' or 'false'.
+        :param str required_fields: The additional required address values, as a comma-separated
+                                    list of `res.partner` fields.
+        :param dict form_data: The form data to process as address values.
+        :return: A JSON-encoded feedback, with either the success URL or an error message.
+        :rtype: str
+        """
+        partner_sudo, address_type = self._prepare_address_update(
+            partner_id=partner_id and int(partner_id), address_type=address_type
+        )
+
+        required_fields = required_fields or ''
+
+        # Parse form data into address values, and extract incompatible data as extra form data.
+        address_values, extra_form_data = self._parse_portal_form_data(form_data)
+        if 'country_id' not in address_values and partner_sudo.country_id:
+            address_values['country_id'] = partner_sudo.country_id.id
+        if 'state_id' not in address_values and partner_sudo.state_id:
+            address_values['state_id'] = partner_sudo.state_id.id
+
+        # Validate the address values and highlights the problems in the form, if any.
+        invalid_fields, missing_fields, error_messages = self._validate_portal_address_values(
+            address_values, partner_sudo, address_type, use_same, required_fields, **extra_form_data
+        )
+
+        if error_messages:
+            return json.dumps({
+                'invalid_fields': list(invalid_fields | missing_fields),
+                'messages': error_messages,
+            })
+        if not partner_sudo:  # Creation of a new address.
+            address_values['parent_id'] = request.env.user.partner_id.id
+            create_context = tools.clean_context(request.env.context)
+            create_context.update({
+                'tracking_disable': True,
+                'no_vat_validation': True,
+            })
+            partner_sudo = request.env['res.partner'].sudo().with_context(
+                create_context
+            ).create(address_values)
+        else:
+            partner_sudo.write(address_values)
+
+        return json.dumps({
+            'successUrl': 'my/addresses',
+        })
+
+    def _parse_portal_form_data(self, form_data):
+        """ Parse the form data and return them converted into address values and extra form data.
+
+        :param dict form_data: The form data to convert to address values.
+        :return: A tuple of converted address values and extra form data.
+        :rtype: tuple[dict, dict]
+        """
+        address_values = {}
+        extra_form_data = {}
+
+        ResPartner = request.env['res.partner']
+        partner_fields = ResPartner._fields
+        for key, value in form_data.items():
+            if isinstance(value, str):
+                value = value.strip()
+            if key in partner_fields:
+                field = partner_fields[key]
+                if field.type == 'many2one' and isinstance(value, str) and value.isdigit():
+                    address_values[key] = field.convert_to_cache(int(value), ResPartner)
+                else:
+                    # Always keep field values, even if falsy, as it might be for resetting a field.
+                    address_values[key] = field.convert_to_cache(value, ResPartner)
+            elif value:  # The value cannot be saved on the `res.partner` model.
+                extra_form_data[key] = value
+
+        if (
+            hasattr(ResPartner, 'check_vat')  # The `base_vat` module is installed.
+            and address_values.get('vat')
+            and address_values.get('country_id')
+        ):
+            address_values['vat'] = ResPartner.fix_eu_vat_number(
+                address_values['country_id'],
+                address_values['vat'],
+            )
+
+        return address_values, extra_form_data
+
+    def _get_writable_fields(self):
+        # Need to override it in ecommerce
+        return {}
+
+    def _validate_portal_address_values(
+        self, address_values, partner_sudo, address_type, use_same, required_fields, **_kwargs
+    ):
+        """ Validate the address values and return the invalid fields, the missing fields, and any
+        error messages.
+        :param dict address_values: The address values to validates.
+        :param res.partner partner_sudo: The partner whose address values to validate, if any (can
+                                         be empty).
+        :param str address_type: The type of the address: 'billing' or 'delivery'.
+        :param bool use_same: Whether the provided address should be used as both the billing and
+                              the delivery address.
+        :param str required_fields: The additional required address values, as a comma-separated
+                                    list of `res.partner` fields.
+        :param dict _kwargs: Locally unused parameters including the extra form data.
+        :return: The invalid fields, the missing fields, and any error messages.
+        :rtype: tuple[set, set, list]
+        """
+        # data: values after preprocess
+        invalid_fields = set()
+        missing_fields = set()
+        error_messages = []
+
+        if partner_sudo:
+            # Prevent changing the VAT number if invoices have been issued.
+            if (
+                'vat' in address_values
+                and address_values['vat'] != partner_sudo.vat
+                and not partner_sudo.can_edit_vat()
+            ):
+                invalid_fields.add('vat')
+                error_messages.append(_(
+                    "Changing VAT number is not allowed once document(s) have been issued for your"
+                    " account. Please contact us directly for this operation."
+                ))
+
+        # Validate the email.
+        if address_values.get('email') and not tools.single_email_re.match(address_values['email']):
+            invalid_fields.add('email')
+            error_messages.append(_("Invalid Email! Please enter a valid email address."))
+
+        # Validate the VAT number.
+        ResPartnerSudo = request.env['res.partner'].sudo()
+        if (
+            address_values.get('vat') and hasattr(ResPartnerSudo, 'check_vat')
+            and 'vat' not in invalid_fields
+        ):
+            partner_dummy = ResPartnerSudo.new({
+                fname: address_values[fname]
+                for fname in self._get_vat_validation_fields()
+                if fname in address_values
+            })
+            try:
+                partner_dummy.check_vat()
+            except ValidationError as exception:
+                invalid_fields.add('vat')
+                error_messages.append(exception.args[0])
+
+        # Build the set of required fields from the address form's requirements.
+        required_field_set = {f for f in required_fields.split(',') if f}
+
+        # Complete the set of required fields based on the address type.
+        country_id = address_values.get('country_id')
+        country = request.env['res.country'].browse(country_id)
+        if address_type == 'delivery':
+            required_field_set |= self._get_mandatory_delivery_address_fields(country)
+        if address_type == 'invoice':
+            required_field_set |= self._get_mandatory_billing_address_fields(country)
+
+        # Verify that no required field has been left empty.
+        for field_name in required_field_set:
+            if not address_values.get(field_name):
+                missing_fields.add(field_name)
+        if missing_fields:
+            error_messages.append(_("Some required fields are empty."))
+
+        return invalid_fields, missing_fields, error_messages
+
+    def _get_vat_validation_fields(self):
+        return {'country_id', 'vat'}
+
+    def _check_delivery_address(self, partner_sudo):
+        """ Check that all mandatory delivery fields are filled for the given partner.
+
+        :param res.partner: The partner whose delivery address to check.
+        :return: Whether all mandatory fields are filled.
+        :rtype: bool
+        """
+        mandatory_delivery_fields = self._get_mandatory_delivery_address_fields(
+            partner_sudo.country_id
+        )
+        return all(partner_sudo.read(mandatory_delivery_fields)[0].values())
+
+    def _get_mandatory_delivery_address_fields(self, country_sudo):
+        """ Return the set of mandatory delivery field names.
+
+        :param res.country country_sudo: The country to use to build the set of mandatory fields.
+        :return: The set of mandatory delivery field names.
+        :rtype: set
+        """
+        return self._get_mandatory_address_fields(country_sudo)
+
+    def _get_mandatory_billing_address_fields(self, country_sudo):
+        """ Return the set of mandatory billing field names.
+
+        :param res.country country_sudo: The country to use to build the set of mandatory fields.
+        :return: The set of mandatory billing field names.
+        :rtype: set
+        """
+        field_names = self._get_mandatory_address_fields(country_sudo)
+        # Include the required billing fields from the portal logic.
+        field_names |= set(self._get_mandatory_fields())
+        return field_names
+
+    def _get_mandatory_address_fields(self, country_sudo):
+        """ Return the set of common mandatory address fields.
+
+        :param res.country country_sudo: The country to use to build the set of mandatory fields.
+        :return: The set of common mandatory address field names.
+        :rtype: set
+        """
+        field_names = {'name', 'street', 'city', 'country_id', 'phone'}
+        if country_sudo.state_required:
+            field_names.add('state_id')
+        if country_sudo.zip_required:
+            field_names.add('zip')
+        return field_names
 
     @route('/my/security', type='http', auth='user', website=True, methods=['GET', 'POST'])
     def security(self, **post):
@@ -315,6 +694,21 @@ class CustomerPortal(Controller):
             raise UserError(_("The attachment %s cannot be removed because it is linked to a message.", attachment_sudo.name))
 
         return attachment_sudo.unlink()
+
+    @route(['/portal/country_info/<model("res.country"):country>'], type='json', auth="public", methods=['POST'], website=True)
+    def portal_country_info(self, country, address_type, **kw):
+        address_fields = country.get_address_fields()
+        if address_type in ['invoice', 'billing']:
+            required_fields = self._get_mandatory_billing_address_fields(country)
+        else:
+            required_fields = self._get_mandatory_delivery_address_fields(country)
+        return {
+            'fields': address_fields,
+            'zip_before_city': address_fields.index('zip') < address_fields.index('city'),
+            'states': [(st.id, st.name, st.code) for st in country.sudo().state_ids],
+            'phone_code': country.phone_code,
+            'required_fields': list(required_fields),
+        }
 
     def details_form_validate(self, data, partner_creation=False):
         error = dict()

--- a/addons/portal/models/res_partner.py
+++ b/addons/portal/models/res_partner.py
@@ -1,11 +1,33 @@
 # -*- coding: utf-8 -*-
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 
-from odoo import models
+from odoo import fields, models
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
+
+    is_default_billing_address = fields.Boolean(default=False, store=True)
+    is_default_shipping_address = fields.Boolean(default=False, store=True)
+
+    def _update_delivery_and_shipping_address(self, partner_id, address_type, **kw):
+        partner_sudo = self.browse(partner_id)
+
+        address_type = 'invoice' if address_type == 'invoice' or address_type == 'billing' else 'delivery'
+        default_field = 'is_default_billing_address' if address_type == 'invoice' else 'is_default_shipping_address'
+        if partner_sudo.parent_id:
+            partner_sudo.parent_id.child_ids.filtered(lambda p: p.type == address_type or p.type == 'other').write({default_field: False})
+            partner_sudo.parent_id.child_ids.filtered(lambda p: p.type == address_type).write({'type': 'other'})
+            partner_sudo.parent_id.write({default_field: False})
+        else:
+            partner_sudo.child_ids.filtered(lambda p: p.type == address_type or p.type == 'other').write({default_field: False})
+            partner_sudo.child_ids.filtered(lambda p: p.type == address_type).write({'type': 'other'})
+        if partner_sudo.type == 'contact':
+            partner_sudo.write({default_field: True})
+        else:
+            partner_sudo.write({default_field: True, 'type': address_type})
+
+        return partner_sudo.address_get([address_type])
 
     def _can_edit_name(self):
         """ Name can be changed more often than the VAT """
@@ -18,3 +40,16 @@ class ResPartner(models.Model):
         edit it (as in backend)."""
         self.ensure_one()
         return not self.parent_id
+
+    def can_edit_info(self):
+        """ Overide this method to allow user to change address information. """
+        return True
+
+    def _can_be_edited_by_current_customer(self, address_type, **kwargs):
+        self.ensure_one()
+        commercial_partner_id = self.env.user.partner_id.commercial_partner_id.id
+        children_partner_ids = self.env['res.partner']._search([
+            ('id', 'child_of', commercial_partner_id),
+            ('type', 'in', ('invoice', 'delivery', 'other')),
+        ])
+        return self.id in children_partner_ids or self.id == commercial_partner_id

--- a/addons/portal/models/res_partner.py
+++ b/addons/portal/models/res_partner.py
@@ -37,8 +37,7 @@ class ResPartner(models.Model):
         return self.id in children_partner_ids or self.id == commercial_partner_id
 
     def _update_default_address(self, address_type):
-        """ Update the current address as the default one in his address type.
-        """
+        """ Update the current address as the default one in his address type. """
         self.ensure_one()
         address_type = 'invoice' if address_type == 'invoice' or address_type == 'billing' else 'delivery'
         default_field = 'is_default_billing_address' if address_type == 'invoice' else 'is_default_shipping_address'
@@ -50,9 +49,8 @@ class ResPartner(models.Model):
         all_partners.filtered(lambda p: p.type == address_type).write({'type': 'other'})
         all_partners.write({default_field: False})
 
-        if self.type == 'contact':
-            self.write({default_field: True})
-        else:
-            self.write({default_field: True, 'type': address_type})
+        self.write({default_field: True})
+        if self.type != 'contact':
+            self.write({'type': address_type})
 
         return self.address_get([address_type])

--- a/addons/portal/models/res_partner.py
+++ b/addons/portal/models/res_partner.py
@@ -7,27 +7,8 @@ from odoo import fields, models
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    is_default_billing_address = fields.Boolean(default=False, store=True)
-    is_default_shipping_address = fields.Boolean(default=False, store=True)
-
-    def _update_delivery_and_shipping_address(self, partner_id, address_type, **kw):
-        partner_sudo = self.browse(partner_id)
-
-        address_type = 'invoice' if address_type == 'invoice' or address_type == 'billing' else 'delivery'
-        default_field = 'is_default_billing_address' if address_type == 'invoice' else 'is_default_shipping_address'
-        if partner_sudo.parent_id:
-            partner_sudo.parent_id.child_ids.filtered(lambda p: p.type == address_type or p.type == 'other').write({default_field: False})
-            partner_sudo.parent_id.child_ids.filtered(lambda p: p.type == address_type).write({'type': 'other'})
-            partner_sudo.parent_id.write({default_field: False})
-        else:
-            partner_sudo.child_ids.filtered(lambda p: p.type == address_type or p.type == 'other').write({default_field: False})
-            partner_sudo.child_ids.filtered(lambda p: p.type == address_type).write({'type': 'other'})
-        if partner_sudo.type == 'contact':
-            partner_sudo.write({default_field: True})
-        else:
-            partner_sudo.write({default_field: True, 'type': address_type})
-
-        return partner_sudo.address_get([address_type])
+    is_default_billing_address = fields.Boolean()
+    is_default_shipping_address = fields.Boolean()
 
     def _can_edit_name(self):
         """ Name can be changed more often than the VAT """
@@ -41,15 +22,37 @@ class ResPartner(models.Model):
         self.ensure_one()
         return not self.parent_id
 
-    def can_edit_info(self):
+    def _can_edit_info(self):
         """ Overide this method to allow user to change address information. """
+        self.ensure_one()
         return True
 
-    def _can_be_edited_by_current_customer(self, address_type, **kwargs):
+    def _can_be_edited_by_current_partner(self, **kwargs):
         self.ensure_one()
-        commercial_partner_id = self.env.user.partner_id.commercial_partner_id.id
+        commercial_partner_id = kwargs.get('parent_id', self.env.user.partner_id.commercial_partner_id.id)
         children_partner_ids = self.env['res.partner']._search([
             ('id', 'child_of', commercial_partner_id),
             ('type', 'in', ('invoice', 'delivery', 'other')),
         ])
         return self.id in children_partner_ids or self.id == commercial_partner_id
+
+    def _update_default_address(self, address_type):
+        """ Update the current address as the default one in his address type.
+        """
+        self.ensure_one()
+        address_type = 'invoice' if address_type == 'invoice' or address_type == 'billing' else 'delivery'
+        default_field = 'is_default_billing_address' if address_type == 'invoice' else 'is_default_shipping_address'
+        if self.parent_id:
+            all_partners = self.parent_id.child_ids.filtered(lambda p: p.type == address_type or p.type == 'other') + self.parent_id
+        else:
+            all_partners = self.child_ids.filtered(lambda p: p.type == address_type or p.type == 'other')
+        # The default address type is set to 'other' to ease reusability and don't confuse customer
+        all_partners.filtered(lambda p: p.type == address_type).write({'type': 'other'})
+        all_partners.write({default_field: False})
+
+        if self.type == 'contact':
+            self.write({default_field: True})
+        else:
+            self.write({default_field: True, 'type': address_type})
+
+        return self.address_get([address_type])

--- a/addons/portal/static/src/js/portal.js
+++ b/addons/portal/static/src/js/portal.js
@@ -4,7 +4,7 @@ import publicWidget from "@web/legacy/js/public/public_widget";
 import { rpc } from "@web/core/network/rpc";
 
 publicWidget.registry.portalDetails = publicWidget.Widget.extend({
-    selector: '.o_portal_details',
+    selector: '.o_portal_address_fill',
     events: {
         'change select[name="country_id"]': '_onCountryChange',
     },
@@ -35,6 +35,10 @@ publicWidget.registry.portalDetails = publicWidget.Widget.extend({
         this.$stateOptions.detach();
         var $displayedState = this.$stateOptions.filter('[data-country_id=' + countryID + ']');
         var nb = $displayedState.appendTo(this.$state).show().length;
+        // Clear the state field if the selected country has no states
+        if (nb === 0) {
+            this.$('select[name="state_id"]').val('').change();  // Clear the state selection
+        }
         this.$state.parent().toggle(nb >= 1);
     },
 

--- a/addons/portal/static/src/js/portal_address.js
+++ b/addons/portal/static/src/js/portal_address.js
@@ -67,7 +67,7 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
             {address_type: this.addressType},
         );
 
-        if (data.phone_code !== 0) {
+        if (data.phone_code) {
             this.addressForm.phone.placeholder = '+' + data.phone_code;
         } else {
             this.addressForm.phone.placeholder = '';

--- a/addons/portal/static/src/js/portal_address.js
+++ b/addons/portal/static/src/js/portal_address.js
@@ -176,7 +176,7 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
                 new FormData(this.addressForm),
             )
             if (result.successUrl) {
-                window.location = '/' + result.successUrl;
+                window.location = result.successUrl;
             } else {
                 // Highlight missing/invalid form values
                 document.querySelectorAll('.is-invalid').forEach(element => {

--- a/addons/portal/static/src/js/portal_address.js
+++ b/addons/portal/static/src/js/portal_address.js
@@ -1,0 +1,207 @@
+/** @odoo-module **/
+
+import publicWidget from "@web/legacy/js/public/public_widget";
+import { rpc } from "@web/core/network/rpc";
+import { debounce } from "@web/core/utils/timing";
+
+publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
+    selector: '.o_portal_address_fill',
+    events: {
+        'change select[name="country_id"]': '_onChangeCountry',
+        'click #save_address_portal': '_onSaveAddressPortal',
+    },
+
+    /**
+     * @constructor
+     */
+    init: function () {
+        this._super.apply(this, arguments);
+
+        this.http = this.bindService('http');
+
+        this._changeCountry = debounce(this._changeCountry.bind(this), 500);
+        this.addressForm = document.querySelector('form.checkout_autoformat');
+        this.errorsDiv = document.getElementById('errors');
+        this.addressType = this.addressForm['address_type'].value;
+        this.countryCode = this.addressForm.dataset.companyCountryCode;
+        this.requiredFields = this.addressForm.required_fields.value.split(',');
+    },
+
+    /**
+     * @override
+     */
+    start() {
+        const def = this._super(...arguments);
+
+        this.requiredFields.forEach((fname) => {
+            this._markRequired(fname, true);
+        })
+        this._changeCountry(true);
+
+        return def;
+    },
+
+    //--------------------------------------------------------------------------
+    // Handlers
+    //--------------------------------------------------------------------------
+
+    /**
+     * @private
+     * @param {Event} ev
+     */
+    _onChangeCountry(ev) {
+        return this._changeCountry();
+    },
+
+    /**
+     * @private
+     */
+    async _changeCountry(init=false) {
+        const countryId = parseInt(this.addressForm.country_id.value);
+        if (!countryId) {
+            return;
+        }
+
+        const data = await rpc(
+            `/portal/country_info/${parseInt(countryId)}`,
+            {address_type: this.addressType},
+        );
+
+        if (data.phone_code !== 0) {
+            this.addressForm.phone.placeholder = '+' + data.phone_code;
+        } else {
+            this.addressForm.phone.placeholder = '';
+        }
+
+        // populate states and display
+        var selectStates = this.addressForm.state_id;
+        if (!init || selectStates.options.length === 1) {
+            // dont reload state at first loading (done in qweb)
+            if (data.states.length || data.state_required) {
+                // empty existing options, only keep the placeholder.
+                selectStates.options.length = 1;
+
+                // create new options and append them to the select element
+                data.states.forEach((state) => {
+                    let option = new Option(state[1], state[0]);
+                    // Used by localizations
+                    option.setAttribute('data-code', state[2]);
+                    selectStates.appendChild(option);
+                });
+                this._showInput('state_id');
+            } else {
+                this._hideInput('state_id');
+            }
+        }
+
+        // manage fields order / visibility
+        if (data.fields) {
+            if (data.zip_before_city) {
+                this._getInputDiv('zip').after(this._getInputDiv('city'));
+            } else {
+                this._getInputDiv('zip').before(this._getInputDiv('city'));
+            }
+
+            var all_fields = ['street', 'zip', 'city'];
+            all_fields.forEach((fname) => {
+                if (data.fields.includes(fname)) {
+                    this._showInput(fname);
+                } else {
+                    this._hideInput(fname);
+                }
+            });
+        }
+
+        const required_fields = this.addressForm.querySelectorAll(':required');
+        required_fields.forEach((element) => {
+            // remove requirement on previously required fields
+            if (
+                !data.required_fields.includes(element.name)
+                && !this.requiredFields.includes(element.name)
+            ) {
+                this._markRequired(element.name, false);
+            }
+        });
+        data.required_fields.forEach((fieldName) => {
+            this._markRequired(fieldName, true);
+        })
+    },
+
+    _getInputDiv(name) {
+        return this.addressForm[name].parentElement;
+    },
+
+    _getInputLabel(name) {
+        const input = this.addressForm[name];
+        return input.parentElement.querySelector(`label[for='${input.id}']`);
+    },
+
+    _showInput(name) {
+        // show parent div, containing label and input
+        this.addressForm[name].parentElement.style.display = '';
+    },
+
+    _hideInput(name) {
+        // show parent div, containing label and input
+        this.addressForm[name].parentElement.style.display = 'none';
+    },
+
+    _markRequired(name, required) {
+        this.addressForm[name].required = required;
+        this._getInputLabel(name)?.classList.toggle('label-optional', !required);
+    },
+
+    /**
+     * Disable the button, submit the form and add a spinner while the submission is ongoing
+     *
+     * @private
+     * @override
+     * @param {Event} ev
+     */
+    async _onSaveAddressPortal(ev) {
+        if (!this.addressForm.reportValidity()) {
+            return
+        }
+
+        const submitButton = ev.currentTarget;
+        if (!ev.isDefaultPrevented() && !submitButton.disabled) {
+            ev.preventDefault();
+
+            submitButton.disabled = true;
+            const spinner = document.createElement('span');
+            spinner.classList.add('fa', 'fa-cog', 'fa-spin');
+            submitButton.appendChild(spinner);
+            const result = await this.http.post(
+                '/portal/address/submit',
+                new FormData(this.addressForm),
+            )
+            if (result.successUrl) {
+                window.location = '/' + result.successUrl;
+            } else {
+                // Highlight missing/invalid form values
+                document.querySelectorAll('.is-invalid').forEach(element => {
+                    if (!result.invalid_fields.includes(element.name)) {
+                        element.classList.remove('is-invalid');
+                    }
+                })
+                result.invalid_fields.forEach(
+                    fieldName => this.addressForm[fieldName].classList.add('is-invalid')
+                );
+                const newErrors = result.messages.map(message => {
+                    const errorHeader = document.createElement('h5');
+                    errorHeader.classList.add('text-danger');
+                    errorHeader.appendChild(document.createTextNode(message));
+                    return errorHeader;
+                });
+
+                this.errorsDiv.replaceChildren(...newErrors);
+
+                // Re-enable button and remove spinner
+                submitButton.disabled = false;
+                spinner.remove();
+            }
+        }
+    },
+});
+
+export default publicWidget.registry.websiteSaleAddress;

--- a/addons/portal/static/src/js/portal_default_address.js
+++ b/addons/portal/static/src/js/portal_default_address.js
@@ -7,10 +7,12 @@ publicWidget.registry.portalAddress = publicWidget.Widget.extend({
     selector: '#address_checkout_billing, #address_checkout_shipping',
     events: {
         'click .js_set_default': '_changePortalAddress',
+        'click .js_archive': '_archivePortalAddress',
+
     },
 
     /**
-     * Set the billing or shipping address on the order and update the corresponding card.
+     * Set the billing or shipping address by default
      *
      * @private
      * @param {Event} ev
@@ -30,10 +32,29 @@ publicWidget.registry.portalAddress = publicWidget.Widget.extend({
         card.classList.remove('js_change_billing', 'js_change_delivery');
         card.classList.add('bg-primary', 'border', 'border-primary');
         this._toggleCardButtons(card, false);
-
         await rpc('/address/update_address', {
-            address_type: setDefaultButton.dataset.mode,
+            address_type: setDefaultButton.dataset.addressType,
             partner_id: setDefaultButton.dataset.partnerId,
+            action: 'set_default',
+        });
+
+        location.reload();
+    },
+
+    /**
+     * Archive the address
+     *
+     * @private
+     * @param {Event} ev
+     * @return {void}
+     */
+    async _archivePortalAddress(ev) {
+        ev.preventDefault();
+        const setDefaultButton = ev.currentTarget;
+        await rpc('/address/update_address', {
+            address_type: setDefaultButton.dataset.addressType,
+            partner_id: setDefaultButton.dataset.partnerId,
+            action: 'archive',
         });
 
         location.reload();

--- a/addons/portal/static/src/js/portal_default_address.js
+++ b/addons/portal/static/src/js/portal_default_address.js
@@ -1,0 +1,54 @@
+/** @odoo-module **/
+
+import publicWidget from '@web/legacy/js/public/public_widget';
+import { rpc } from '@web/core/network/rpc';
+
+publicWidget.registry.portalAddress = publicWidget.Widget.extend({
+    selector: '#address_checkout_billing, #address_checkout_shipping',
+    events: {
+        'click .js_set_default': '_changePortalAddress',
+    },
+
+    /**
+     * Set the billing or shipping address on the order and update the corresponding card.
+     *
+     * @private
+     * @param {Event} ev
+     * @return {void}
+     */
+    async _changePortalAddress(ev) {
+        ev.preventDefault();
+        const setDefaultButton = ev.currentTarget;
+        const card = setDefaultButton.closest('.card');
+
+        const oldCard = card.closest('.row').querySelector('.card.border.border-primary');
+        if (oldCard) {
+            oldCard.classList.add(card.dataset.mode === 'invoice' ? 'js_change_billing' : 'js_change_delivery');
+            oldCard.classList.remove('bg-primary', 'border', 'border-primary');
+            this._toggleCardButtons(oldCard, true);
+        }
+        card.classList.remove('js_change_billing', 'js_change_delivery');
+        card.classList.add('bg-primary', 'border', 'border-primary');
+        this._toggleCardButtons(card, false);
+
+        await rpc('/address/update_address', {
+            address_type: setDefaultButton.dataset.mode,
+            partner_id: setDefaultButton.dataset.partnerId,
+        });
+
+        location.reload();
+    },
+
+    _toggleCardButtons(card, show) {
+        const deleteButton = card.querySelector('#delete-button');
+        const defaultButton = card.querySelector('#default-button');
+        if (deleteButton) {
+            deleteButton.style.display = show ? 'inline-block' : 'd-none';
+        }
+        if (defaultButton) {
+            defaultButton.style.display = show ? 'inline-block' : 'd-none';
+        }
+    },
+});
+
+export default publicWidget.registry.portalAddress;

--- a/addons/portal/static/src/js/portal_default_address.js
+++ b/addons/portal/static/src/js/portal_default_address.js
@@ -8,7 +8,6 @@ publicWidget.registry.portalAddress = publicWidget.Widget.extend({
     events: {
         'click .js_set_default': '_changePortalAddress',
         'click .js_archive': '_archivePortalAddress',
-
     },
 
     /**
@@ -23,7 +22,7 @@ publicWidget.registry.portalAddress = publicWidget.Widget.extend({
         const setDefaultButton = ev.currentTarget;
         const card = setDefaultButton.closest('.card');
 
-        const oldCard = card.closest('.row').querySelector('.card.border.border-primary');
+        const oldCard = card?.closest('.row').querySelector('.card.border.border-primary');
         if (oldCard) {
             oldCard.classList.add(card.dataset.mode === 'invoice' ? 'js_change_billing' : 'js_change_delivery');
             oldCard.classList.remove('bg-primary', 'border', 'border-primary');

--- a/addons/portal/static/tests/tours/portal.js
+++ b/addons/portal/static/tests/tours/portal.js
@@ -8,7 +8,7 @@ registry.category("web_tour.tours").add('portal_load_homepage', {
     steps: () => [
         {
             content: "Check portal is loaded",
-            trigger: 'a[href*="/my/account"]:contains("Edit"):first',
+            trigger: 'a[role="button"]:contains("Edit"):first',
             run: "click",
         },
         {
@@ -27,8 +27,29 @@ registry.category("web_tour.tours").add('portal_load_homepage', {
             run: "click",
         },
         {
+            content: "Address view is opened",
+            trigger: 'a[href*="/my/home"]',
+            run: "click",
+        },
+        {
             content: "Check that we are back on the portal",
-            trigger: 'a[href*="/my/account"]:contains("Edit"):first',
+            trigger: 'a[role="button"]:contains("Edit"):first',
+        }
+    ]
+});
+
+registry.category("web_tour.tours").add('portal_load_homepage_forbidden', {
+    test: true,
+    url: '/my',
+    steps: () => [
+        {
+            content: "Check portal is loaded",
+            trigger: 'a[role="button"]:contains("Edit"):first',
+            run: "click",
+        },
+        {
+            content: "Load my account details",
+            trigger: 'h1:contains("403: Forbidden")',
         }
     ]
 });

--- a/addons/portal/tests/test_tours.py
+++ b/addons/portal/tests/test_tours.py
@@ -27,8 +27,8 @@ class TestUi(HttpCaseWithUserDemo, HttpCaseWithUserPortal):
     def test_02_portal_load_tour_cant_edit_vat(self):
         willis = self.user_portal
         willis.parent_id = self.user_demo.partner_id.id
-        self.start_tour("/", 'portal_load_homepage', login="portal")
-        self.assertEqual(willis.phone, "+1 555 666 7788")
+        self.start_tour("/", 'portal_load_homepage_forbidden', login="portal")
+        self.assertNotEqual(willis.phone, "+1 555 666 7788")
 
     def test_03_skip_to_content(self):
         self.start_tour("/", "skip_to_content", login="portal")

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -746,7 +746,7 @@
             <div t-if="request.params.get('error')" class="alert alert-warning" role="alert" groups="account.group_delivery_invoice_address">
                 <h4 class="alert-heading">You are not allowed to delete this address!</h4>
                 <p>
-                    You cannot archive contacts linked to an active user.You first need to archive their associated user.Linked active users
+                    You cannot archive contacts linked to an active user.You first need to archive their associated user.
                 </p>
             </div>
             <h5 class="mt-4">Billing address</h5>
@@ -769,7 +769,7 @@
                         </div>
                     </t>
                     <div class="col-lg-4 mb-3" style="min-height: 200px">
-                        <a role="button" href="/portal/address?address_type=other&amp;portal_address=True" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
+                        <a role="button" href="/portal/address?address_type=invoice&amp;portal_address=True" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
                             <i class="fa fa-plus fa-2x mb-2"/>Add Address
                         </a>
                     </div>
@@ -795,7 +795,7 @@
                         </div>
                     </t>
                     <div class="col-lg-4 mb-3" style="min-height: 200px">
-                        <a role="button" href="/portal/address?address_type=other&amp;portal_address=True" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
+                        <a role="button" href="/portal/address?address_type=delivery&amp;portal_address=True" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
                             <i class="fa fa-plus fa-2x mb-2"/>Add Address
                         </a>
                     </div>
@@ -806,10 +806,10 @@
 
     <template id="address_card">
         <t t-set="partner" t-value="address"/>
-        <t t-set="mode" t-value="is_invoice and 'invoice' or 'delivery'"/>
+        <t t-set="addressType" t-value="is_invoice and 'invoice' or 'delivery'"/>
         <div t-attf-class="card position-relative h-100 #{selected and 'bg-primary border border-primary' or is_invoice and 'js_change_billing' or 'js_change_delivery'}"
-             t-att-data-mode="mode"
-             t-att-data-partner-id="partner.id">
+            t-att-data-address-type="addressType"
+            t-att-data-partner-id="partner.id">
             <div class="card-body d-flex flex-column justify-content-between">
                 <div>
                     <div class="d-flex align-items-start">
@@ -834,11 +834,12 @@
                     </a>
                     <span id="delete-button" t-att-hidden="partner.type == 'contact'" t-att-style="'display: none;' if selected else ''">
                         <span class="mx-2">|</span>
-                        <a t-attf-href="/archive/address/#{partner.id}"
-                            class="btn btn-link text-danger p-0"
+                        <a  class="btn btn-link text-danger p-0 js_archive"
                             role="button"
                             title="Archive this address"
-                            aria-label="Archive this address">
+                            aria-label="Archive this address"
+                            t-att-data-partner-id="partner.id"
+                            >
                             Delete
                         </a>
                     </span>
@@ -848,8 +849,9 @@
                            role="button"
                            title="Default this address"
                            aria-label="Default this address"
-                           t-att-data-mode="mode"
-                           t-att-data-partner-id="partner.id">
+                           t-att-data-partner-id="partner.id"
+                           t-att-data-address-type="addressType"
+                           >
                             Set as default
                         </a>
                     </span>
@@ -949,7 +951,7 @@
                                                         id="o_vat"
                                                         name="vat"
                                                         t-att-value="partner_sudo.vat"
-                                                        t-att-disabled="'1' if vat_warning or not has_invoice else None"
+                                                        t-att-disabled="'1' if vat_warning or has_invoice else None"
                                                         class="form-control"
                                                     />
                                                     <small t-if="vat_warning" class="form-text text-muted d-block d-lg-none">
@@ -991,7 +993,7 @@
                                         <div class="w-100"/>
                                         <div id="div_country" class="col-lg-6 mb-2">
                                             <label class="col-form-label" for="o_country_id">Country</label>
-                                            <select id="o_country_id" name="country_id" class="form-select" t-att-disabled="not has_invoice">
+                                            <select id="o_country_id" name="country_id" class="form-select" t-att-disabled="has_invoice">
                                                 <option value="">Country...</option>
                                                 <t t-foreach="countries" t-as="c">
                                                     <option t-att-value="c.id" t-att-selected="c.id == int(country_id) if country_id else c.id == partner_sudo.country_id.id" t-att-code="c.code">
@@ -1003,7 +1005,7 @@
                                         <div id="div_state" class="col-lg-6 mb-2"
                                                 t-att-style="not country_states and 'display: none'">
                                             <label class="col-form-label" for="o_state_id">State / Province</label>
-                                            <select id="o_state_id" name="state_id" class="form-select" t-att-disabled="not has_invoice">
+                                            <select id="o_state_id" name="state_id" class="form-select" t-att-disabled="has_invoice">
                                                 <option value="">State / Province...</option>
                                                 <t t-foreach="country_states" t-as="s">
                                                     <option t-att-value="s.id" t-att-selected="s.id == (int(state_id) if state_id else partner_sudo.state_id.id)">

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -143,7 +143,11 @@
     <template id="portal_breadcrumbs" name="Portal Breadcrumbs">
         <ol t-if="page_name != 'home'" class="o_portal_submenu breadcrumb mb-0 flex-grow-1 px-0">
             <li class="breadcrumb-item ms-1"><a href="/my/home" aria-label="Home" title="Home"><i class="fa fa-home"/></a></li>
-            <li t-if="page_name == 'my_details'" class="breadcrumb-item">Details</li>
+            <li t-if="page_name == 'my_addresses'" class="breadcrumb-item">Addresses</li>
+            <t t-if="page_name == 'my_details'">
+                <li class="breadcrumb-item"><a href="/my/addresses" aria-label="Addresses" title="Addresses">Addresses</a></li>
+                <li class="breadcrumb-item">Details</li>
+            </t>
         </ol>
     </template>
 
@@ -230,7 +234,13 @@
                     <div t-if="portal_service_category_enable" class="o_portal_category row g-2 mt-3" id="portal_service_category"/>
                     <div t-if="portal_vendor_category_enable" class="o_portal_category row g-2 mt-3" id="portal_vendor_category"/>
                     <div class="o_portal_category row g-2 mt-3" id="portal_common_category">
-                        <t t-call="portal.portal_docs_entry" t-if="False"/>
+                        <t t-call="portal.portal_docs_entry">
+                            <t t-set="icon" t-value="'/portal/static/src/img/portal-addresses.svg'"/>
+                            <t t-set="title">Addresses</t>
+                            <t t-set="text">Add, remove or modify your addresses</t>
+                            <t t-set="url" t-value="'/my/addresses'"/>
+                            <t t-set="config_card" t-value="True"/>
+                        </t>
                         <t t-call="portal.portal_docs_entry">
                             <t t-set="icon" t-value="'/portal/static/src/img/portal-connection.svg'"/>
                             <t t-set="title">Connection &amp; Security</t>
@@ -438,118 +448,6 @@
             </div>
             <t t-out="0"/>
         </div>
-    </template>
-
-    <template id="portal_my_details_fields">
-        <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()"/>
-        <div t-if="error_message" class="alert alert-danger" role="alert">
-            <div class="col-lg-12">
-                <t t-foreach="error_message" t-as="err"><t t-esc="err"/><br /></t>
-            </div>
-        </div>
-        <div t-if="not partner_can_edit_vat" class="col-12 d-none d-xl-block">
-            <small class="form-text text-muted">
-                Company name, VAT Number and country can not be changed once document(s) have been issued for your account.
-                <br/>Please contact us directly for that operation.
-            </small>
-        </div>
-        <div t-attf-class="mb-3 #{error.get('name') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label" for="name">Name</label>
-            <input type="text" name="name" t-attf-class="form-control #{error.get('name') and 'is-invalid' or ''}" t-att-value="name or partner.name" />
-        </div>
-        <div t-attf-class="mb-3 #{error.get('email') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label" for="email">Email</label>
-            <input type="email" name="email" t-attf-class="form-control #{error.get('email') and 'is-invalid' or ''}" t-att-value="email or partner.email" />
-        </div>
-
-        <div class="clearfix" />
-        <div t-attf-class="mb-1 #{error.get('company_name') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label label-optional" for="company_name">Company Name</label>
-            <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
-                 The user might not have rights to change company_name but should still be able to see it.
-            -->
-            <input type="text" name="company_name" t-attf-class="form-control #{error.get('company_name') and 'is-invalid' or ''}" t-att-value="company_name or partner.commercial_company_name" t-att-disabled="None if partner_can_edit_vat else '1'" />
-            <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">
-                Changing company name is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.
-            </small>
-        </div>
-        <div t-attf-class="mb-1 #{error.get('vat') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label label-optional" for="vat">VAT Number</label>
-            <!-- The <input> use "disabled" attribute to avoid sending an unauthorized value on form submit.
-                 The user might not have rights to change company_name but should still be able to see it.
-            -->
-            <input type="text" name="vat" t-attf-class="form-control #{error.get('vat') and 'is-invalid' or ''}" t-att-value="vat or partner.vat" t-att-disabled="None if partner_can_edit_vat else '1'" />
-            <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">Changing VAT number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.</small>
-        </div>
-        <div t-attf-class="mb-3 #{error.get('phone') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label" for="phone">Phone</label>
-            <input type="tel" name="phone" t-attf-class="form-control #{error.get('phone') and 'is-invalid' or ''}" t-att-value="phone or partner.phone" />
-        </div>
-
-        <div class="clearfix" />
-        <div t-attf-class="mb-3 #{error.get('street') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label" for="street">Street</label>
-            <input type="text" name="street" t-attf-class="form-control #{error.get('street') and 'is-invalid' or ''}" t-att-value="street or partner.street"/>
-        </div>
-        <div t-attf-class="mb-3 #{error.get('city') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label" for="city">City</label>
-            <input type="text" name="city" t-attf-class="form-control #{error.get('city') and 'is-invalid' or ''}" t-att-value="city or partner.city" />
-        </div>
-        <div t-attf-class="mb-3 #{error.get('street2') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label" for="street2">Street 2</label>
-            <input type="text" name="street2" t-attf-class="form-control #{error.get('street2') and 'is-invalid' or ''}" t-att-value="street2 or partner.street2"/>
-        </div>
-        <div t-attf-class="mb-3 #{error.get('state_id') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label label-optional" for="state_id">State / Province</label>
-            <select name="state_id" t-attf-class="form-select #{error.get('state_id') and 'is-invalid' or ''}">
-                <option value="">select...</option>
-                <t t-foreach="states or []" t-as="state">
-                    <option t-att-value="state.id" class="d-none" t-att-data-country_id="state.country_id.id" t-att-selected="state.id == int(state_id) if state_id else state.id == partner.state_id.id">
-                        <t t-esc="state.name" />
-                    </option>
-                </t>
-            </select>
-        </div>
-        <div t-attf-class="mb-3 #{error.get('zip') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label label-optional" for="zipcode">Zip / Postal Code</label>
-            <input type="text" name="zipcode" t-attf-class="form-control #{error.get('zip') and 'is-invalid' or ''}" t-att-value="zipcode or partner.zip" />
-        </div>
-        <div t-attf-class="mb-3 #{error.get('country_id') and 'o_has_error' or ''} col-xl-6">
-            <label class="col-form-label" for="country_id">Country</label>
-            <select name="country_id" t-attf-class="form-select #{error.get('country_id') and 'is-invalid' or ''}" t-att-disabled="None if partner_can_edit_vat else '1'">
-                <option value="">Country...</option>
-                <t t-foreach="countries or []" t-as="country">
-                    <option t-att-value="country.id" t-att-selected="country.id == int(country_id) if country_id else country.id == partner.country_id.id">
-                        <t t-esc="country.name" />
-                    </option>
-                </t>
-            </select>
-            <small t-if="not partner_can_edit_vat" class="form-text text-muted d-block d-xl-none">Changing the country is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.</small>
-        </div>
-    </template>
-
-    <template id="portal_my_details">
-        <t t-call="portal.portal_layout">
-            <t t-set="additional_title">Contact Details</t>
-            <form action="/my/account" method="post">
-                <div class="row o_portal_details">
-                    <div class="col-lg-8">
-                        <div class="row">
-                            <t t-call="portal.portal_my_details_fields"/>
-                            <input type="hidden" name="redirect" t-att-value="redirect"/>
-                        </div>
-                        <div class="clearfix text-end mb-5">
-                            <a href="/my/" class="btn btn-light me-2">
-                                Discard
-                            </a>
-                            <button type="submit" class="btn btn-primary float-end">
-                                Save
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </form>
-        </t>
     </template>
 
     <template id="portal_my_security">
@@ -833,10 +731,330 @@
             <div class="o_portal_my_details">
                 <div t-field="user_id.partner_id" t-options='{"widget": "contact", "fields": ["email", "phone", "address"]}'/>
             </div>
-            <a role="button" href="/my/account" class="btn btn-link p-0 mt-3"><i class="fa fa-pencil"/> Edit information</a>
+            <a t-attf-href="/portal/address?partner_id={{user_id.partner_id.id}}&amp;portal_address=True" class="btn btn-link o_edit_info p-0" role="button">
+                <i class="fa fa-pencil"/> Edit information
+            </a>
             <div name="portal_contact" class="o_my_contact mt-5" t-if="sales_user">
                 <t t-call="portal.portal_contact"/>
             </div>
         </div>
+    </template>
+
+    <template id="portal_my_addresses">
+        <t t-set="additional_title" t-value="'My Addresses'"/>
+        <t t-call="portal.portal_layout">
+            <div t-if="request.params.get('error')" class="alert alert-warning" role="alert" groups="account.group_delivery_invoice_address">
+                <h4 class="alert-heading">You are not allowed to delete this address!</h4>
+                <p>
+                    You cannot archive contacts linked to an active user.You first need to archive their associated user.Linked active users
+                </p>
+            </div>
+            <h5 class="mt-4">Billing address</h5>
+            <div id="address_checkout_billing" class="one_kanban all_billing_address row">
+                <t t-if="partner">
+                    <div class="col-lg-4 mb-3" style="min-height: 200px">
+                        <t t-call="portal.address_card">
+                            <t t-set="address" t-value="partner"/>
+                            <t t-set="is_invoice" t-value="True"/>
+                            <t t-set="selected" t-value="partner.is_default_billing_address"/>
+                        </t>
+                    </div>
+                    <t t-foreach="partner.child_ids.filtered(lambda c: c.type == 'invoice' or c.type == 'other')" t-as="billing_address">
+                        <div class="col-lg-4 mb-3" style="min-height: 200px">
+                            <t t-call="portal.address_card">
+                                <t t-set="is_invoice" t-value="True"/>
+                                <t t-set="address" t-value="billing_address"/>
+                                <t t-set="selected" t-value="billing_address.is_default_billing_address"/>
+                            </t>
+                        </div>
+                    </t>
+                    <div class="col-lg-4 mb-3" style="min-height: 200px">
+                        <a role="button" href="/portal/address?address_type=other&amp;portal_address=True" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
+                            <i class="fa fa-plus fa-2x mb-2"/>Add Address
+                        </a>
+                    </div>
+                </t>
+            </div>
+            <h5 class="mt-4">Shipping address</h5>
+            <div id="address_checkout_shipping" class="one_kanban all_shipping_address row">
+                <t t-if="partner">
+                    <div class="col-lg-4 mb-3" style="min-height: 200px">
+                        <t t-call="portal.address_card">
+                            <t t-set="is_invoice" t-value="False"/>
+                            <t t-set="address" t-value="partner"/>
+                            <t t-set="selected" t-value="partner.is_default_shipping_address"/>
+                        </t>
+                    </div>
+                    <t t-foreach="partner.child_ids.filtered(lambda c: c.type == 'delivery' or  c.type == 'other')" t-as="shipping_address">
+                        <div class="col-lg-4 mb-3" style="min-height: 200px">
+                            <t t-call="portal.address_card">
+                                <t t-set="is_invoice" t-value="False"/>
+                                <t t-set="address" t-value="shipping_address"/>
+                                <t t-set="selected" t-value="shipping_address.is_default_shipping_address"/>
+                            </t>
+                        </div>
+                    </t>
+                    <div class="col-lg-4 mb-3" style="min-height: 200px">
+                        <a role="button" href="/portal/address?address_type=other&amp;portal_address=True" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
+                            <i class="fa fa-plus fa-2x mb-2"/>Add Address
+                        </a>
+                    </div>
+                </t>
+            </div>
+        </t>
+    </template>
+
+    <template id="address_card">
+        <t t-set="partner" t-value="address"/>
+        <t t-set="mode" t-value="is_invoice and 'invoice' or 'delivery'"/>
+        <div t-attf-class="card position-relative h-100 #{selected and 'bg-primary border border-primary' or is_invoice and 'js_change_billing' or 'js_change_delivery'}"
+             t-att-data-mode="mode"
+             t-att-data-partner-id="partner.id">
+            <div class="card-body d-flex flex-column justify-content-between">
+                <div>
+                    <div class="d-flex align-items-start">
+                        <span class="fw-bold">
+                            <t t-out="partner.name"/>
+                        </span>
+                    </div>
+                    <div class="mt-2">
+                        <span t-if="partner.street" t-out="partner.street" class="d-block small"/>
+                        <span t-if="partner.zip" t-out="partner.zip + ' ' + partner.city" class="d-block small"/>
+                        <span t-if="partner.state_id" t-out="partner.state_id.name + ', ' + partner.country_id.name" class="d-block small"/>
+                        <span t-if="not partner.state_id" t-out="partner.country_id.name" class="d-block small"/>
+                    </div>
+                </div>
+                <div class="mt-3">
+                    <a t-attf-href="/portal/address?address_type={{partner.type}}&amp;partner_id={{partner.id}}&amp;portal_address=True"
+                        class="btn btn-link p-0"
+                        role="button"
+                        title="Edit this address"
+                        aria-label="Edit this address">
+                        Edit
+                    </a>
+                    <span id="delete-button" t-att-hidden="partner.type == 'contact'" t-att-style="'display: none;' if selected else ''">
+                        <span class="mx-2">|</span>
+                        <a t-attf-href="/archive/address/#{partner.id}"
+                            class="btn btn-link text-danger p-0"
+                            role="button"
+                            title="Archive this address"
+                            aria-label="Archive this address">
+                            Delete
+                        </a>
+                    </span>
+                    <span id="default-button" t-att-style="'display: none;' if selected else ''">
+                        <span class="mx-2">|</span>
+                        <a class="btn btn-link p-0 js_set_default"
+                           role="button"
+                           title="Default this address"
+                           aria-label="Default this address"
+                           t-att-data-mode="mode"
+                           t-att-data-partner-id="partner.id">
+                            Set as default
+                        </a>
+                    </span>
+                </div>
+            </div>
+        </div>
+    </template>
+
+    <template id="portal.portal_my_details" name="Address Management">
+        <t t-set="no_footer" t-value="1"/>
+        <t t-call="portal.portal_layout">
+            <div id="wrap">
+                <div class="o_portal_address_fill">
+                    <div class="row">
+                        <div class="oe_cart col-12 col-lg-8">
+                            <div>
+                                <t t-if="partner_sudo.type == 'invoice'">
+                                    <h3 class="mb-3">Billing address</h3>
+                                </t>
+                                <t t-elif="partner_sudo.type == 'delivery'">
+                                    <h3 class="mb-3">Delivery address</h3>
+                                </t>
+                                <t t-else="">
+                                    <h3 class="mb-3">Address</h3>
+                                </t>
+                                <div id="errors"/> <!-- for js -->
+                                <form
+                                    action="/portal/address/submit?portal_address=True"
+                                    method="post"
+                                    class="checkout_autoformat"
+                                    t-att-data-company-country-code="res_company.country_id.code"
+                                >
+                                    <div class="row">
+                                        <div id="div_name" class="col-lg-12 mb-2">
+                                            <label class="col-form-label" for="o_name">Full name</label>
+                                            <input
+                                                id="o_name"
+                                                type="text"
+                                                name="name"
+                                                t-att-value="name or partner_sudo.name"
+                                                class="form-control"
+                                            />
+                                        </div>
+                                        <div class="w-100"/>
+                                        <div
+                                            id="div_email"
+                                            class="col-lg-6 mb-2"
+                                        >
+                                            <label class="col-form-label" for="o_email">Email</label>
+                                            <input
+                                                id="o_email"
+                                                type="email"
+                                                name="email"
+                                                t-att-value="email or partner_sudo.email"
+                                                class="form-control"
+                                            />
+                                        </div>
+                                        <div id="div_phone" class="col-lg-6 mb-2">
+                                            <label class="col-form-label" for="o_phone">Phone</label>
+                                            <input
+                                                id="o_phone"
+                                                type="tel"
+                                                name="phone"
+                                                t-att-value="phone or partner_sudo.phone"
+                                                class="form-control"
+                                            />
+                                        </div>
+                                        <t name="o_override_b2b_fields">
+                                            <div class="w-100"/>
+                                            <t t-if="show_vat">
+                                                <t t-set="vat_warning" t-value="partner_sudo.vat and not can_edit_vat"/>
+                                                <div id="company_name_div" class="col-lg-6 mb-2">
+                                                    <label
+                                                        class="col-form-label fw-normal label-optional"
+                                                        for="o_company_name"
+                                                    >
+                                                        Company Name
+                                                    </label>
+                                                    <input
+                                                        id="o_company_name"
+                                                        type="text"
+                                                        name="company_name"
+                                                        t-att-value="partner_sudo.commercial_company_name"
+                                                        t-att-disabled="'1' if vat_warning or not has_invoice else None"
+                                                        class="form-control"
+                                                    />
+                                                    <small t-if="vat_warning" class="form-text text-muted d-block d-lg-none">
+                                                        Changing company name is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.
+                                                    </small>
+                                                </div>
+                                                <div id="div_vat" class="col-lg-6 mb-2">
+                                                    <label class="col-form-label fw-normal label-optional" for="o_vat">
+                                                        <t t-out="vat_label"/>
+                                                    </label>
+                                                    <input
+                                                        type="text"
+                                                        id="o_vat"
+                                                        name="vat"
+                                                        t-att-value="partner_sudo.vat"
+                                                        t-att-disabled="'1' if vat_warning or not has_invoice else None"
+                                                        class="form-control"
+                                                    />
+                                                    <small t-if="vat_warning" class="form-text text-muted d-block d-lg-none">
+                                                        Changing VAT number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.
+                                                    </small>
+                                                </div>
+                                                <div t-if="vat_warning" class="col-12 d-none d-lg-block mb-1">
+                                                    <small class="form-text text-muted">
+                                                        Changing company name or VAT number is not allowed once document(s) have been issued for your account. Please contact us directly for this operation.
+                                                    </small>
+                                                </div>
+                                            </t>
+                                        </t>
+                                        <div id="div_street" class="col-lg-12 mb-2">
+                                            <label class="col-form-label" for="o_street">Street and Number</label>
+                                            <input id="o_street" type="text" name="street" class="form-control" t-att-value="street or partner_sudo.street"/>
+                                        </div>
+                                        <div id="div_street2" class="col-lg-12 mb-2">
+                                            <label class="col-form-label label-optional" for="o_street2">Apartment, suite, etc.</label>
+                                            <input id="o_street2" type="text" name="street2" class="form-control" t-att-value="street2 or partner_sudo.street2" />
+                                        </div>
+                                        <div class="w-100"/>
+                                        <t t-if="zip_before_city">
+                                            <div id="div_zip" class="col-md-4 mb-2">
+                                                <label class="col-form-label label-optional" for="o_zip">Zip Code</label>
+                                                <input id="o_zip" type="text" name="zip" class="form-control" t-att-value="zipcode or partner_sudo.zip"/>
+                                            </div>
+                                        </t>
+                                        <div id="div_city" class="col-md-8 mb-2">
+                                            <label class="col-form-label" for="o_city">City</label>
+                                            <input id="o_city" type="text" name="city" class="form-control" t-att-value="city or partner_sudo.city"/>
+                                        </div>
+                                        <t t-if="not zip_before_city">
+                                            <div id="div_zip" class="col-md-4 mb-2">
+                                                <label class="col-form-label label-optional" for="o_zip">Zip Code</label>
+                                                <input id="o_zip" type="text" name="zip" class="form-control" t-att-value="zipcode or partner_sudo.zip"/>
+                                            </div>
+                                        </t>
+                                        <div class="w-100"/>
+                                        <div id="div_country" class="col-lg-6 mb-2">
+                                            <label class="col-form-label" for="o_country_id">Country</label>
+                                            <select id="o_country_id" name="country_id" class="form-select" t-att-disabled="not has_invoice">
+                                                <option value="">Country...</option>
+                                                <t t-foreach="countries" t-as="c">
+                                                    <option t-att-value="c.id" t-att-selected="c.id == int(country_id) if country_id else c.id == partner_sudo.country_id.id" t-att-code="c.code">
+                                                        <t t-esc="c.name" />
+                                                    </option>
+                                                </t>
+                                            </select>
+                                        </div>
+                                        <div id="div_state" class="col-lg-6 mb-2"
+                                                t-att-style="not country_states and 'display: none'">
+                                            <label class="col-form-label" for="o_state_id">State / Province</label>
+                                            <select id="o_state_id" name="state_id" class="form-select" t-att-disabled="not has_invoice">
+                                                <option value="">State / Province...</option>
+                                                <t t-foreach="country_states" t-as="s">
+                                                    <option t-att-value="s.id" t-att-selected="s.id == (int(state_id) if state_id else partner_sudo.state_id.id)">
+                                                        <t t-esc="s.name"/>
+                                                    </option>
+
+                                                </t>
+                                            </select>
+                                        </div>
+                                    </div>
+                                    <div t-attf-class="col-xl-6 mb-3" t-att-hidden="true">
+                                        <label class="col-form-label label-optional" for="type">Use this address for</label>
+                                        <select name="type" t-attf-class="form-select">
+                                            <option value="other" t-att-selected="type == 'other' or partner_sudo.type == 'other'"></option>
+                                            <option value="delivery" t-att-selected="type == 'delivery' or partner_sudo.type == 'delivery'">Delivery</option>
+                                            <option value="invoice" t-att-selected="type == 'invoice' or partner_sudo.type == 'invoice'">Invoice</option>
+                                            <option value="contact" t-att-selected="type == 'contact' or partner_sudo.type == 'contact'">Contact</option>
+                                        </select>
+                                    </div>
+                                    <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
+                                    <input type="hidden" name="address_type" t-att-value="address_type"/>
+                                    <t t-if="partner_id">
+                                        <input type="hidden" name="partner_id" t-att-value="partner_id"/>
+                                    </t>
+                                    <t t-if="callback">
+                                        <input type="hidden" name="callback" t-att-value="callback"/>
+                                    </t>
+
+                                    <!-- Example -->
+                                    <input type="hidden" name="required_fields" t-att-value="'name,country_id'"/>
+
+                                    <div class="d-flex flex-column flex-md-row align-items-center justify-content-between mt32 mb32">
+                                        <a role="button" t-att-href="discard_url" class="btn btn-outline-secondary w-100 w-md-auto order-md-1 order-3">
+                                            <i class="fw-light fa fa-angle-left me-2"/>Discard
+                                        </a>
+                                        <div class="position-relative w-100 d-flex d-md-none justify-content-center align-items-center order-2 my-2 opacity-75">
+                                            <hr class="w-100"/>
+                                            <span class="px-3">or</span>
+                                            <hr class="w-100"/>
+                                        </div>
+                                        <button id="save_address_portal" class="btn btn-primary w-100 w-md-auto order-1 order-md-3" type="submit">
+                                                Save address
+                                            <i class="fw-light fa fa-angle-right ms-2"/>
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </t>
     </template>
 </odoo>

--- a/addons/portal/views/portal_templates.xml
+++ b/addons/portal/views/portal_templates.xml
@@ -769,7 +769,7 @@
                         </div>
                     </t>
                     <div class="col-lg-4 mb-3" style="min-height: 200px">
-                        <a role="button" href="/portal/address?address_type=invoice&amp;portal_address=True" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
+                        <a role="button" t-attf-href="/portal/address?address_type=invoice&amp;portal_address=True&amp;parent_id={{user_id.partner_id.id}}" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
                             <i class="fa fa-plus fa-2x mb-2"/>Add Address
                         </a>
                     </div>
@@ -795,7 +795,7 @@
                         </div>
                     </t>
                     <div class="col-lg-4 mb-3" style="min-height: 200px">
-                        <a role="button" href="/portal/address?address_type=delivery&amp;portal_address=True" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
+                        <a role="button" t-attf-href="/portal/address?address_type=delivery&amp;portal_address=True&amp;parent_id={{user_id.partner_id.id}}" class="d-flex flex-column align-items-center justify-content-center h-100 p-4 mx-auto rounded text-decoration-none" style="border: 1px dashed">
                             <i class="fa fa-plus fa-2x mb-2"/>Add Address
                         </a>
                     </div>
@@ -1027,6 +1027,7 @@
                                     </div>
                                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
                                     <input type="hidden" name="address_type" t-att-value="address_type"/>
+                                    <input type="hidden" name="parent_id" t-att-value="parent_id"/>
                                     <t t-if="partner_id">
                                         <input type="hidden" name="partner_id" t-att-value="partner_id"/>
                                     </t>

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -71,6 +71,10 @@ class ResPartner(models.Model):
             [('partner_id', 'child_of', self.commercial_partner_id.id)]
         )
 
+    def can_edit_info(self):
+        """ this method allows user to change address information. """
+        return not self._has_invoice([('partner_id', '=', self.id)])
+
     def action_view_sale_order(self):
         action = self.env['ir.actions.act_window']._for_xml_id('sale.act_res_partner_2_sale_order')
         all_child = self.with_context(active_test=False).search([('id', 'child_of', self.ids)])

--- a/addons/sale/models/res_partner.py
+++ b/addons/sale/models/res_partner.py
@@ -71,9 +71,11 @@ class ResPartner(models.Model):
             [('partner_id', 'child_of', self.commercial_partner_id.id)]
         )
 
-    def can_edit_info(self):
+    def _can_edit_info(self):
         """ this method allows user to change address information. """
-        return not self._has_invoice([('partner_id', '=', self.id)])
+        # arj fix
+        res = super()._can_edit_info()
+        return res and not self._has_invoice([('partner_id', '=', self.id)])
 
     def action_view_sale_order(self):
         action = self.env['ir.actions.act_window']._for_xml_id('sale.act_res_partner_2_sale_order')

--- a/addons/website_sale/controllers/main.py
+++ b/addons/website_sale/controllers/main.py
@@ -1075,11 +1075,9 @@ class WebsiteSale(payment_portal.PaymentPortal):
         return True
 
     @route(
-        '/shop/address', type='http', methods=['GET'], auth='public', website=True, sitemap=False
+        '/portal/address'
     )
-    def shop_address(
-        self, partner_id=None, address_type='billing', use_delivery_as_billing=None, **query_params
-    ):
+    def portal_address(self, partner_id=None, address_type='billing', template_to_render='portal.portal_my_details', **query_params):
         """ Display the address form.
 
         A partner and/or an address type can be given through the query string params to specify
@@ -1094,35 +1092,26 @@ class WebsiteSale(payment_portal.PaymentPortal):
         :return: The rendered address form.
         :rtype: str
         """
-        partner_id = partner_id and int(partner_id)
-        use_delivery_as_billing = str2bool(use_delivery_as_billing or 'false')
         order_sudo = request.website.sale_get_order()
+        use_delivery_as_billing = query_params.get('use_delivery_as_billing')
+        use_delivery_as_billing = str2bool(use_delivery_as_billing or 'false')
 
-        if redirection := self._check_cart(order_sudo):
-            return redirection
-
-        # Retrieve the partner whose address to update, if any, and its address type.
-        partner_sudo, address_type = self._prepare_address_update(
-            order_sudo, partner_id=partner_id, address_type=address_type
-        )
-
-        if partner_sudo:  # If editing an existing partner.
+        if query_params.get('partner_sudo'):  # If editing an existing partner.
             use_delivery_as_billing = (
                 order_sudo.partner_shipping_id == order_sudo.partner_invoice_id
             )
+        address_template = 'portal.portal_my_details'
+        if not query_params.get('portal_address'):
+            if redirection := self._check_cart(order_sudo):
+                return redirection
+            address_template = 'website_sale.address'
 
-        # Render the address form.
-        address_form_values = self._prepare_address_form_values(
-            order_sudo,
-            partner_sudo,
-            address_type=address_type,
-            use_delivery_as_billing=use_delivery_as_billing,
-            **query_params
+        return super().portal_address(
+            partner_id=partner_id, address_type=address_type, order_sudo=order_sudo, template_to_render=address_template, use_delivery_as_billing=use_delivery_as_billing, **query_params
         )
-        return request.render('website_sale.address', address_form_values)
 
     def _prepare_address_form_values(
-        self, order_sudo, partner_sudo, address_type, use_delivery_as_billing, callback='', **kwargs
+        self, partner_sudo, address_type, **_kwargs
     ):
         """ Prepare and return the values to use to render the address form.
 
@@ -1135,24 +1124,27 @@ class WebsiteSale(payment_portal.PaymentPortal):
         :return: The checkout page values.
         :rtype: dict
         """
-        can_edit_vat = (
-            (address_type == 'billing' or use_delivery_as_billing)
-            and (not partner_sudo or partner_sudo.can_edit_vat())
-        )
-        is_anonymous_cart = order_sudo._is_anonymous_cart()
-
-        ResCountrySudo = request.env['res.country'].sudo()
-        country_sudo = partner_sudo.country_id
-        if not country_sudo:
-            if is_anonymous_cart:
-                if request.geoip.country_code:
-                    country_sudo = ResCountrySudo.search([
-                        ('code', '=', request.geoip.country_code),
-                    ], limit=1)
+        val = super()._prepare_address_form_values(partner_sudo, address_type, callback, **_kwargs)
+        use_delivery_as_billing = _kwargs.get('use_delivery_as_billing')
+        order_sudo = _kwargs.get('order_sudo')
+        if order_sudo and not _kwargs.get('portal_address'):
+            is_anonymous_cart = order_sudo._is_anonymous_cart()
+            can_edit_vat = (
+                address_type == 'billing' or use_delivery_as_billing
+                and (not partner_sudo or partner_sudo.can_edit_vat())
+            )
+            ResCountrySudo = request.env['res.country'].sudo()
+            country_sudo = partner_sudo.country_id
+            if not country_sudo:
+                if is_anonymous_cart:
+                    if request.geoip.country_code:
+                        country_sudo = ResCountrySudo.search([
+                            ('code', '=', request.geoip.country_code),
+                        ], limit=1)
+                    else:
+                        country_sudo = order_sudo.website_id.user_id.country_id
                 else:
-                    country_sudo = order_sudo.website_id.user_id.country_id
-            else:
-                country_sudo = order_sudo.partner_id.country_id
+                    country_sudo = order_sudo.partner_id.country_id
 
         state_id = partner_sudo.state_id.id
 
@@ -1168,6 +1160,8 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'only_services': order_sudo.only_services,
             'is_anonymous_cart': is_anonymous_cart,
             'use_delivery_as_billing': use_delivery_as_billing,
+            # 'use_same': order_sudo._is_anonymous_cart(),
+            # 'callback': callback,
             'discard_url': is_anonymous_cart and '/shop/cart' or '/shop/checkout',
             'country': country_sudo,
             'countries': ResCountrySudo.search([]),
@@ -1220,13 +1214,17 @@ class WebsiteSale(payment_portal.PaymentPortal):
             return redirection
 
         partner_sudo, address_type = self._prepare_address_update(
-            order_sudo, partner_id=partner_id and int(partner_id), address_type=address_type
+            partner_id=partner_id and int(partner_id), address_type=address_type, order_sudo=order_sudo
         )
         use_delivery_as_billing = str2bool(use_delivery_as_billing or 'false')
         required_fields = required_fields or ''
 
         # Parse form data into address values, and extract incompatible data as extra form data.
         address_values, extra_form_data = self._parse_form_data(form_data)
+        if 'country_id' not in address_values and partner_sudo.country_id:
+            address_values['country_id'] = partner_sudo.country_id.id
+        if 'state_id' not in address_values and partner_sudo.state_id:
+            address_values['state_id'] = partner_sudo.state_id.id
 
         # Validate the address values and highlights the problems in the form, if any.
         invalid_fields, missing_fields, error_messages = self._validate_address_values(
@@ -1294,7 +1292,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
             'successUrl': callback,
         })
 
-    def _prepare_address_update(self, order_sudo, partner_id=None, address_type=None):
+    def _prepare_address_update(self, partner_id=None, address_type=None, **kwargs):
         """ Find the partner whose address to update and return it along with its address type.
 
         :param sale.order order_sudo: The current cart.
@@ -1305,32 +1303,34 @@ class WebsiteSale(payment_portal.PaymentPortal):
         :raise Forbidden: If the customer is not allowed to update the given address.
         """
         PartnerSudo = request.env['res.partner'].with_context(show_address=1).sudo()
-        if order_sudo._is_anonymous_cart():
-            partner_sudo = PartnerSudo
-        else:
-            partner_sudo = PartnerSudo.browse(partner_id)
-            if partner_sudo and partner_sudo not in {
-                order_sudo.partner_id,
-                order_sudo.partner_invoice_id,
-                order_sudo.partner_shipping_id,
-            }:  # The partner is not yet linked to the SO.
-                partner_sudo = partner_sudo.exists()
 
-        if partner_sudo and not address_type:  # The desired address type was not specified.
-            # Identify the address type based on the cart's billing and delivery partners.
-            if partner_id == order_sudo.partner_invoice_id.id:
-                address_type = 'billing'
-            elif partner_id == order_sudo.partner_shipping_id.id:
-                address_type = 'delivery'
+        partner_sudo = PartnerSudo.browse(partner_id)
+        if order_sudo := kwargs.get('order_sudo'):
+            if order_sudo._is_anonymous_cart():
+                partner_sudo = PartnerSudo
             else:
-                address_type = 'billing'
+                if partner_sudo and partner_sudo not in {
+                    order_sudo.partner_id,
+                    order_sudo.partner_invoice_id,
+                    order_sudo.partner_shipping_id,
+                }:  # The partner is not yet linked to the SO.
+                    partner_sudo = partner_sudo.exists()
 
-        if partner_sudo and not partner_sudo._can_be_edited_by_current_customer(
-            order_sudo, address_type
-        ):
-            raise Forbidden()
+            if partner_sudo and not address_type:  # The desired address type was not specified.
+                # Identify the address type based on the cart's billing and delivery partners.
+                if partner_id == order_sudo.partner_invoice_id.id:
+                    address_type = 'billing'
+                elif partner_id == order_sudo.partner_shipping_id.id:
+                    address_type = 'delivery'
+                else:
+                    address_type = 'billing'
 
-        return partner_sudo, address_type
+            if partner_sudo and not partner_sudo._can_be_edited_by_current_customer(
+                address_type, order_sudo=order_sudo
+            ):
+                raise Forbidden()
+
+        return super()._prepare_address_update(partner_id=partner_sudo.id, address_type=address_type, **kwargs)
 
     def _parse_form_data(self, form_data):
         """ Parse the form data and return them converted into address values and extra form data.
@@ -1486,9 +1486,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             error_messages.append(_("Some required fields are empty."))
 
         return invalid_fields, missing_fields, error_messages
-
-    def _get_vat_validation_fields(self):
-        return {'country_id', 'vat'}
 
     def _complete_address_values(
         self, address_values, address_type, use_delivery_as_billing, order_sudo
@@ -1706,13 +1703,13 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ], limit=1)
         address.update(country_id=country.id, state_id=state.id)
 
-    @route('/shop/update_address', type='json', auth='public', website=True)
-    def shop_update_address(self, partner_id, address_type='billing', **kw):
+    @route('/address/update_address', type='json')
+    def portal_update_address(self, partner_id, address_type='billing', **kw):
         partner_id = int(partner_id)
 
         order_sudo = request.website.sale_get_order()
         if not order_sudo:
-            return
+            return super().portal_update_address(partner_id, address_type, **kw)
 
         ResPartner = request.env['res.partner'].sudo()
         partner_sudo = ResPartner.browse(partner_id).exists()
@@ -1729,7 +1726,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
 
         partner_fnames = set()
         if (
-            address_type == 'billing'
+            address_type == 'billing' or address_type == 'invoice'
             and partner_sudo != order_sudo.partner_invoice_id
         ):
             partner_fnames.add('partner_invoice_id')
@@ -1739,6 +1736,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         ):
             partner_fnames.add('partner_shipping_id')
 
+        partner_sudo._update_delivery_and_shipping_address(partner_id, address_type, **kw)
         order_sudo._update_address(partner_id, partner_fnames)
 
     @route(['/shop/confirm_order'], type='http', auth="public", website=True, sitemap=False)
@@ -2009,7 +2007,7 @@ class WebsiteSale(payment_portal.PaymentPortal):
         """
         # Check that an address has been added.
         if order_sudo._is_anonymous_cart():
-            return request.redirect('/shop/address')
+            return request.redirect('/portal/address')
 
         # Check that the delivery address is complete.
         delivery_partner_sudo = order_sudo.partner_shipping_id
@@ -2018,35 +2016,14 @@ class WebsiteSale(payment_portal.PaymentPortal):
             and not self._check_delivery_address(delivery_partner_sudo)
         ):
             return request.redirect(
-                f'/shop/address?partner_id={delivery_partner_sudo.id}&address_type=delivery'
+                f'/portal/address?partner_id={delivery_partner_sudo.id}&address_type=delivery'
             )
         # Check that the billing address is complete.
         invoice_partner_sudo = order_sudo.partner_invoice_id
         if not self._check_billing_address(invoice_partner_sudo):
             return request.redirect(
-                f'/shop/address?partner_id={invoice_partner_sudo.id}&address_type=billing'
+                f'/portal/address?partner_id={invoice_partner_sudo.id}&address_type=billing'
             )
-
-    def _check_delivery_address(self, partner_sudo):
-        """ Check that all mandatory delivery fields are filled for the given partner.
-
-        :param res.partner: The partner whose delivery address to check.
-        :return: Whether all mandatory fields are filled.
-        :rtype: bool
-        """
-        mandatory_delivery_fields = self._get_mandatory_delivery_address_fields(
-            partner_sudo.country_id
-        )
-        return all(partner_sudo.read(mandatory_delivery_fields)[0].values())
-
-    def _get_mandatory_delivery_address_fields(self, country_sudo):
-        """ Return the set of mandatory delivery field names.
-
-        :param res.country country_sudo: The country to use to build the set of mandatory fields.
-        :return: The set of mandatory delivery field names.
-        :rtype: set
-        """
-        return self._get_mandatory_address_fields(country_sudo)
 
     def _check_billing_address(self, partner_sudo):
         """ Check that all mandatory billing fields are filled for the given partner.
@@ -2059,32 +2036,6 @@ class WebsiteSale(payment_portal.PaymentPortal):
             partner_sudo.country_id
         )
         return all(partner_sudo.read(mandatory_billing_fields)[0].values())
-
-    def _get_mandatory_billing_address_fields(self, country_sudo):
-        """ Return the set of mandatory billing field names.
-
-        :param res.country country_sudo: The country to use to build the set of mandatory fields.
-        :return: The set of mandatory billing field names.
-        :rtype: set
-        """
-        field_names = self._get_mandatory_address_fields(country_sudo)
-        # Include the required billing fields from the portal logic.
-        field_names |= set(self._get_mandatory_fields())
-        return field_names
-
-    def _get_mandatory_address_fields(self, country_sudo):
-        """ Return the set of common mandatory address fields.
-
-        :param res.country country_sudo: The country to use to build the set of mandatory fields.
-        :return: The set of common mandatory address field names.
-        :rtype: set
-        """
-        field_names = {'name', 'street', 'city', 'country_id', 'phone'}
-        if country_sudo.state_required:
-            field_names.add('state_id')
-        if country_sudo.zip_required:
-            field_names.add('zip')
-        return field_names
 
     # ------------------------------------------------------
     # Edit

--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -49,10 +49,15 @@ class ResPartner(models.Model):
                 ),
             }}
 
-    def _can_be_edited_by_current_customer(self, sale_order, address_type):
+    def _can_be_edited_by_current_customer(self, address_type, **kwargs):
         self.ensure_one()
-        children_partner_ids = self.env['res.partner']._search([
-            ('id', 'child_of', sale_order.partner_id.commercial_partner_id.id),
-            ('type', 'in', ('invoice', 'delivery', 'other')),
-        ])
-        return self == sale_order.partner_id or self.id in children_partner_ids
+        if sale_order := kwargs.get('order_sudo'):
+            children_partner_ids = self.env['res.partner']._search([
+                ('id', 'child_of', sale_order.partner_id.commercial_partner_id.id),
+                ('type', 'in', ('invoice', 'delivery', 'other')),
+            ])
+            if self == sale_order.partner_id or self.id in children_partner_ids:
+                if address_type == 'billing' or (address_type == 'delivery' and self.type == 'delivery'):
+                    # Billing addresses and delivery addresses are editable.
+                    return True
+        return super()._can_be_edited_by_current_customer(address_type, order_sudo=sale_order)

--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -49,15 +49,23 @@ class ResPartner(models.Model):
                 ),
             }}
 
-    def _can_be_edited_by_current_customer(self, address_type, **kwargs):
+    def _can_be_edited_by_current_partner(self, **kwargs):
         self.ensure_one()
+        address_type = kwargs.get('address_type')
         if sale_order := kwargs.get('order_sudo'):
             children_partner_ids = self.env['res.partner']._search([
                 ('id', 'child_of', sale_order.partner_id.commercial_partner_id.id),
                 ('type', 'in', ('invoice', 'delivery', 'other')),
             ])
-            if self == sale_order.partner_id or self.id in children_partner_ids:
-                if address_type == 'billing' or (address_type == 'delivery' and self.type == 'delivery'):
-                    # Billing addresses and delivery addresses are editable.
+            if (
+                self == sale_order.partner_id
+                or self.id in children_partner_ids
+            ):
+                # address belongs to the customer
+                if address_type == 'billing':
+                    # All addresses are editable as billing
                     return True
-        return super()._can_be_edited_by_current_customer(address_type, order_sudo=sale_order)
+                if address_type == 'delivery' and self.type == 'delivery':
+                    # Only delivery addresses are editable as delivery
+                    return True
+        return super()._can_be_edited_by_current_partner(**kwargs)

--- a/addons/website_sale/models/res_partner.py
+++ b/addons/website_sale/models/res_partner.py
@@ -51,21 +51,10 @@ class ResPartner(models.Model):
 
     def _can_be_edited_by_current_partner(self, **kwargs):
         self.ensure_one()
-        address_type = kwargs.get('address_type')
         if sale_order := kwargs.get('order_sudo'):
-            children_partner_ids = self.env['res.partner']._search([
+            children_partner_ids = self.env['res.partner'].search([
                 ('id', 'child_of', sale_order.partner_id.commercial_partner_id.id),
                 ('type', 'in', ('invoice', 'delivery', 'other')),
             ])
-            if (
-                self == sale_order.partner_id
-                or self.id in children_partner_ids
-            ):
-                # address belongs to the customer
-                if address_type == 'billing':
-                    # All addresses are editable as billing
-                    return True
-                if address_type == 'delivery' and self.type == 'delivery':
-                    # Only delivery addresses are editable as delivery
-                    return True
+            return self == sale_order.partner_id or self.id in children_partner_ids.ids
         return super()._can_be_edited_by_current_partner(**kwargs)

--- a/addons/website_sale/models/sale_order.py
+++ b/addons/website_sale/models/sale_order.py
@@ -681,7 +681,6 @@ class SaleOrder(models.Model):
         :return: Whether the cart is anonymous.
         :rtype: bool
         """
-        self.ensure_one()
         return self.partner_id.id == request.website.user_id.sudo().partner_id.id
 
     def _get_lang(self):

--- a/addons/website_sale/static/src/js/address.js
+++ b/addons/website_sale/static/src/js/address.js
@@ -1,59 +1,16 @@
 /** @odoo-module **/
 
-import publicWidget from "@web/legacy/js/public/public_widget";
-import { rpc } from "@web/core/network/rpc";
-import { debounce } from "@web/core/utils/timing";
+import websiteSaleAddress from "@portal/js/portal_address"
 
-publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
-    // /shop/address
-    selector: '.o_wsale_address_fill',
-    events: {
-        'change select[name="country_id"]': '_onChangeCountry',
-        'click #save_address': '_onSaveAddress',
-        "change select[name='state_id']": "_onChangeState",
-    },
-
-    /**
-     * @constructor
-     */
-    init: function () {
-        this._super.apply(this, arguments);
-
-        this.http = this.bindService('http');
-
-        this._changeCountry = debounce(this._changeCountry.bind(this), 500);
-        this.addressForm = document.querySelector('form.checkout_autoformat');
-        this.errorsDiv = document.getElementById('errors');
-        this.addressType = this.addressForm['address_type'].value;
-        this.countryCode = this.addressForm.dataset.companyCountryCode;
-        this.requiredFields = this.addressForm.required_fields.value.split(',');
-    },
-
-    /**
-     * @override
-     */
-    start() {
-        const def = this._super(...arguments);
-
-        this.requiredFields.forEach((fname) => {
-            this._markRequired(fname, true);
-        })
-        this._changeCountry(true);
-
-        return def;
-    },
-
-    //--------------------------------------------------------------------------
-    // Handlers
-    //--------------------------------------------------------------------------
-
-    /**
-     * @private
-     * @param {Event} ev
-     */
-    _onChangeCountry(ev) {
-        return this._changeCountry();
-    },
+websiteSaleAddress.include({
+    events: Object.assign(
+        {},
+        websiteSaleAddress.prototype.events,
+        {
+            'click #save_address': '_onSaveAddress',
+            "change select[name='state_id']": "_onChangeState",
+        }
+    ),
 
     /**
      * @private
@@ -64,107 +21,10 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
     },
 
     /**
-     * @private
-     */
-    async _changeCountry(init=false) {
-        const countryId = parseInt(this.addressForm.country_id.value);
-        if (!countryId) {
-            return;
-        }
-
-        const data = await rpc(
-            `/shop/country_info/${parseInt(countryId)}`,
-            {address_type: this.addressType},
-        );
-
-        if (data.phone_code !== 0) {
-            this.addressForm.phone.placeholder = '+' + data.phone_code;
-        } else {
-            this.addressForm.phone.placeholder = '';
-        }
-
-        // populate states and display
-        var selectStates = this.addressForm.state_id;
-        if (!init || selectStates.options.length === 1) {
-            // dont reload state at first loading (done in qweb)
-            if (data.states.length || data.state_required) {
-                // empty existing options, only keep the placeholder.
-                selectStates.options.length = 1;
-
-                // create new options and append them to the select element
-                data.states.forEach((state) => {
-                    let option = new Option(state[1], state[0]);
-                    // Used by localizations
-                    option.setAttribute('data-code', state[2]);
-                    selectStates.appendChild(option);
-                });
-                this._showInput('state_id');
-            } else {
-                this._hideInput('state_id');
-            }
-        }
-
-        // manage fields order / visibility
-        if (data.fields) {
-            if (data.zip_before_city) {
-                this._getInputDiv('zip').after(this._getInputDiv('city'));
-            } else {
-                this._getInputDiv('zip').before(this._getInputDiv('city'));
-            }
-
-            var all_fields = ['street', 'zip', 'city'];
-            all_fields.forEach((fname) => {
-                if (data.fields.includes(fname)) {
-                    this._showInput(fname);
-                } else {
-                    this._hideInput(fname);
-                }
-            });
-        }
-
-        const required_fields = this.addressForm.querySelectorAll(':required');
-        required_fields.forEach((element) => {
-            // remove requirement on previously required fields
-            if (
-                !data.required_fields.includes(element.name)
-                && !this.requiredFields.includes(element.name)
-            ) {
-                this._markRequired(element.name, false);
-            }
-        });
-        data.required_fields.forEach((fieldName) => {
-            this._markRequired(fieldName, true);
-        })
-    },
-
-    _getInputDiv(name) {
-        return this.addressForm[name].parentElement;
-    },
-
-    _getInputLabel(name) {
-        const input = this.addressForm[name];
-        return input.parentElement.querySelector(`label[for='${input.id}']`);
-    },
-
-    _showInput(name) {
-        // show parent div, containing label and input
-        this.addressForm[name].parentElement.style.display = '';
-    },
-
-    _hideInput(name) {
-        // show parent div, containing label and input
-        this.addressForm[name].parentElement.style.display = 'none';
-    },
-
-    _markRequired(name, required) {
-        this.addressForm[name].required = required;
-        this._getInputLabel(name)?.classList.toggle('label-optional', !required);
-    },
-
-    /**
      * Disable the button, submit the form and add a spinner while the submission is ongoing
      *
      * @private
+     * @override
      * @param {Event} ev
      */
     async _onSaveAddress(ev) {
@@ -221,4 +81,3 @@ publicWidget.registry.websiteSaleAddress = publicWidget.Widget.extend({
 
 });
 
-export default publicWidget.registry.websiteSaleAddress;

--- a/addons/website_sale/static/src/js/address.js
+++ b/addons/website_sale/static/src/js/address.js
@@ -40,11 +40,10 @@ websiteSaleAddress.include({
             const spinner = document.createElement('span');
             spinner.classList.add('fa', 'fa-cog', 'fa-spin');
             submitButton.appendChild(spinner);
-
             const result = await this.http.post(
                 '/shop/address/submit',
                 new FormData(this.addressForm),
-            )
+            );
             if (result.successUrl) {
                 window.location = result.successUrl;
             } else {

--- a/addons/website_sale/static/src/js/checkout.js
+++ b/addons/website_sale/static/src/js/checkout.js
@@ -400,7 +400,7 @@ publicWidget.registry.WebsiteSaleCheckout = publicWidget.Widget.extend({
      * @return {void}
      */
     async updateAddress(addressType, partnerId) {
-        await rpc('/shop/update_address', {address_type: addressType, partner_id: partnerId})
+        await rpc('/portal/update_address', {address_type: addressType, partner_id: partnerId})
     },
 
     // #=== DELIVERY FLOW ===#

--- a/addons/website_sale/static/src/scss/website_sale.scss
+++ b/addons/website_sale/static/src/scss/website_sale.scss
@@ -895,7 +895,7 @@ a.no-decoration {
         font-size: $font-size-sm;
     }
 
-    .o_wsale_address_fill {
+    .o_portal_address_fill {
         .col-form-label:not(.label-optional)::after {
             content: " *";
             font-weight: normal;

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -91,7 +91,7 @@
     },
     {
         content: "Add a billing address",
-        trigger: '.all_billing a[href^="/shop/address"]:contains("Add address")',
+        trigger: '.all_billing a[href^="/portal/address"]:contains("Add address")',
         run: "click",
     },
     {

--- a/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
+++ b/addons/website_sale/static/tests/tours/website_sale_complete_flow.js
@@ -342,7 +342,7 @@
     },
     {
         content: "Add new delivery address",
-        trigger: '.all_delivery a[href^="/shop/address"]:contains("Add address")',
+        trigger: '.all_delivery a[href^="/portal/address"]:contains("Add address")',
         run: "click",
     },
     {

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -59,9 +59,9 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
 
         with MockRequest(self.env, website=self.website, sale_order_id=so.id) as req:
             req.httprequest.method = "POST"
+            self.default_address_values.update({'parent_id': p.id})
             self.WebsiteSaleController.shop_address_submit(**self.default_address_values)
             self.assertFalse(self._get_last_address(p).website_id, "New shipping address should not have a website set on it (no specific_user_account).")
-
             self.website.specific_user_account = True
 
             self.WebsiteSaleController.shop_address_submit(**self.default_address_values)
@@ -324,11 +324,9 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             [so.amount_untaxed, so.amount_tax, so.amount_total],
             [90.91, 9.09, 100.0]
         )
-
         env = api.Environment(self.env.cr, self.website.user_id.id, {})
         with MockRequest(self.env, website=self.website.with_env(env), sale_order_id=so.id) as req:
             req.httprequest.method = "POST"
-
             self.WebsiteSaleController.shop_address_submit(**be_address_POST)
             self.assertEqual(
                 so.fiscal_position_id,
@@ -476,8 +474,8 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
         so = self._create_so(partner_id=user_partner.id)
         self.assertNotEqual(so.partner_shipping_id, shipping)
         self.assertNotEqual(so.partner_invoice_id, invoicing)
-        self.assertFalse(colleague._can_be_edited_by_current_customer('billing', order_sudo=so))
-        self.assertFalse(colleague._can_be_edited_by_current_customer('delivery', order_sudo=so))
+        self.assertFalse(colleague._can_be_edited_by_current_partner(address_type='billing', order_sudo=so))
+        self.assertFalse(colleague._can_be_edited_by_current_partner(address_type='delivery', order_sudo=so))
 
         env = api.Environment(self.env.cr, user.id, {})
         # change also website env for `sale_get_order` to not change order partner_id

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -154,7 +154,7 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
         ) as rate_shipment_mock:
             # Change a shipping address of the order in the checkout.
             shipping_partner2 = shipping_partner.copy()
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=shipping_partner2.id, address_type='delivery'
             )
             self.assertGreaterEqual(
@@ -476,8 +476,8 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
         so = self._create_so(partner_id=user_partner.id)
         self.assertNotEqual(so.partner_shipping_id, shipping)
         self.assertNotEqual(so.partner_invoice_id, invoicing)
-        self.assertFalse(colleague._can_be_edited_by_current_customer(so, 'billing'))
-        self.assertFalse(colleague._can_be_edited_by_current_customer(so, 'delivery'))
+        self.assertFalse(colleague._can_be_edited_by_current_customer('billing', order_sudo=so))
+        self.assertFalse(colleague._can_be_edited_by_current_customer('delivery', order_sudo=so))
 
         env = api.Environment(self.env.cr, user.id, {})
         # change also website env for `sale_get_order` to not change order partner_id
@@ -486,57 +486,57 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             # Invalid addresses unaccessible to current customer
             with self.assertRaises(Forbidden):
                 # cannot use contact type addresses
-                self.WebsiteSaleController.shop_update_address(partner_id=colleague.id)
+                self.WebsiteSaleController.portal_update_address(partner_id=colleague.id)
             with self.assertRaises(Forbidden):
                 # unrelated partner
-                self.WebsiteSaleController.shop_update_address(partner_id=self.env.user.partner_id.id)
+                self.WebsiteSaleController.portal_update_address(partner_id=self.env.user.partner_id.id)
 
             # Good addresses
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=colleague_shipping.id, address_type='delivery')
             self.assertEqual(so.partner_shipping_id, colleague_shipping)
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=shipping.id, address_type='delivery',
             )
             self.assertEqual(so.partner_shipping_id, shipping)
 
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=invoicing.id, address_type='billing',
             )
             self.assertEqual(so.partner_shipping_id, shipping)
             self.assertEqual(so.partner_invoice_id, invoicing)
 
             # Using invalid addresses --> change and the customer is forced to update the address
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=bad_invoicing.id, address_type='billing')
             self.assertEqual(so.partner_invoice_id, bad_invoicing)
             redirection = self.WebsiteSaleController._check_addresses(so)
             self.assertTrue(redirection is not None)
-            self.assertEqual(redirection.location, f'/shop/address?partner_id={bad_invoicing.id}&address_type=billing')
+            self.assertEqual(redirection.location, f'/portal/address?partner_id={bad_invoicing.id}&address_type=billing')
 
             # reset to valid one
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=invoicing.id, address_type='billing',
             )
 
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=bad_shipping.id, address_type='delivery')
             self.assertEqual(so.partner_shipping_id, bad_shipping)
             redirection = self.WebsiteSaleController._check_addresses(so)
             self.assertTrue(redirection is not None)
-            self.assertEqual(redirection.location, f'/shop/address?partner_id={bad_shipping.id}&address_type=delivery')
+            self.assertEqual(redirection.location, f'/portal/address?partner_id={bad_shipping.id}&address_type=delivery')
 
             # reset to valid one
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=shipping.id, address_type='delivery',
             )
 
             # Using commercial partner address
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=partner_company.id, address_type='billing',
             )
             self.assertEqual(so.partner_invoice_id, partner_company)
-            self.WebsiteSaleController.shop_update_address(
+            self.WebsiteSaleController.portal_update_address(
                 partner_id=partner_company.id, address_type='delivery',
             )
             self.assertEqual(so.partner_shipping_id, partner_company)

--- a/addons/website_sale/tests/test_address.py
+++ b/addons/website_sale/tests/test_address.py
@@ -324,9 +324,11 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             [so.amount_untaxed, so.amount_tax, so.amount_total],
             [90.91, 9.09, 100.0]
         )
+
         env = api.Environment(self.env.cr, self.website.user_id.id, {})
         with MockRequest(self.env, website=self.website.with_env(env), sale_order_id=so.id) as req:
             req.httprequest.method = "POST"
+
             self.WebsiteSaleController.shop_address_submit(**be_address_POST)
             self.assertEqual(
                 so.fiscal_position_id,
@@ -362,12 +364,14 @@ class TestCheckoutAddress(BaseUsersCommon, WebsiteSaleCommon):
             self.assertEqual(self.demo_partner, so.partner_shipping_id)
 
             # 1. Logged-in user, new shipping
+            self.default_address_values.update({'parent_id': self.demo_partner.id})
             self.WebsiteSaleController.shop_address_submit(**self.default_address_values)
             new_shipping = self._get_last_address(self.demo_partner)
             msg = "New shipping address should have its type set as 'delivery'"
             self.assertTrue(new_shipping.type == 'delivery', msg)
 
             # 2. Logged-in user, new billing
+            self.default_billing_address_values.update({'parent_id': self.demo_partner.id})
             self.WebsiteSaleController.shop_address_submit(**self.default_billing_address_values)
             new_billing = self._get_last_address(self.demo_partner)
             msg = "New billing should have its type set as 'invoice'"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2284,12 +2284,12 @@
             >
                 <!-- We don't allow public users to have multiple delivery addresses. -->
                 <t t-if="is_invoice">
-                    <t t-set="new_address_href" t-valuef="/portal/address?address_type=billing"/>
+                    <t t-set="new_address_href" t-valuef="/portal/address?address_type=billing&amp;parent_id={{not order._is_anonymous_cart() and order.partner_id.commercial_partner_id.id}}"/>
                 </t>
                 <t t-else="">
                     <t
                         t-set="new_address_href"
-                        t-valuef="/portal/address?address_type=delivery&amp;use_delivery_as_billing={{use_delivery_as_billing}}"
+                        t-valuef="/portal/address?address_type=delivery&amp;parent_id={{not order._is_anonymous_cart() and order.partner_id.commercial_partner_id.id}}&amp;use_delivery_as_billing={{use_delivery_as_billing}}"
                     />
                 </t>
                 <a
@@ -2316,7 +2316,7 @@
         >
             <div class="card-body d-flex flex-column align-items-start">
                 <t t-esc="contact" t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True)"/>
-                <t t-if="contact._can_be_edited_by_current_customer(address_type, order_sudo=website_sale_order)">
+                <t t-if="contact._can_be_edited_by_current_partner(address_type=address_type, order_sudo=website_sale_order)">
                     <t t-set="new_address_href" t-value="'/portal/address?address_type=' + address_type"/>
                     <a
                         t-att-href="new_address_href + '&amp;partner_id=' + str(contact.id)"
@@ -2514,7 +2514,7 @@
                                         <div class="w-100"/>
                                         <div id="div_country" class="col-lg-6 mb-2">
                                             <label class="col-form-label" for="o_country_id">Country</label>
-                                            <select id="o_country_id" name="country_id" class="form-select" t-att-disabled="not has_invoice">
+                                            <select id="o_country_id" name="country_id" class="form-select">
                                                 <option value="">Country...</option>
                                                 <t t-foreach="countries" t-as="c">
                                                     <option t-att-value="c.id" t-att-selected="c.id == country.id" t-att-code="c.code">
@@ -2526,7 +2526,7 @@
                                         <div id="div_state" class="col-lg-6 mb-2"
                                              t-att-style="not country_states and 'display: none'">
                                             <label class="col-form-label" for="o_state_id">State / Province</label>
-                                            <select id="o_state_id" name="state_id" class="form-select" t-att-disabled="not has_invoice">
+                                            <select id="o_state_id" name="state_id" class="form-select" t-att-disabled="has_invoice">
                                                 <option value="">State / Province...</option>
                                                 <t t-foreach="country_states" t-as="s">
                                                     <option t-att-value="s.id" t-att-selected="s.id == state_id">
@@ -2538,6 +2538,7 @@
                                     </div>
                                     <input type="hidden" name="csrf_token" t-att-value="request.csrf_token()" t-nocache="The csrf token must always be up to date."/>
                                     <input type="hidden" name="address_type" t-att-value="address_type"/>
+                                    <input type="hidden" name="parent_id" t-att-value="parent_id"/>
                                     <input
                                         type="hidden"
                                         name="use_delivery_as_billing"

--- a/addons/website_sale/views/templates.xml
+++ b/addons/website_sale/views/templates.xml
@@ -2284,12 +2284,12 @@
             >
                 <!-- We don't allow public users to have multiple delivery addresses. -->
                 <t t-if="is_invoice">
-                    <t t-set="new_address_href" t-valuef="/shop/address?address_type=billing"/>
+                    <t t-set="new_address_href" t-valuef="/portal/address?address_type=billing"/>
                 </t>
                 <t t-else="">
                     <t
                         t-set="new_address_href"
-                        t-valuef="/shop/address?address_type=delivery&amp;use_delivery_as_billing={{use_delivery_as_billing}}"
+                        t-valuef="/portal/address?address_type=delivery&amp;use_delivery_as_billing={{use_delivery_as_billing}}"
                     />
                 </t>
                 <a
@@ -2316,8 +2316,8 @@
         >
             <div class="card-body d-flex flex-column align-items-start">
                 <t t-esc="contact" t-options="dict(widget='contact', fields=['name', 'address'], no_marker=True)"/>
-                <t t-if="contact._can_be_edited_by_current_customer(website_sale_order, address_type)">
-                    <t t-set="new_address_href" t-value="'/shop/address?address_type=' + address_type"/>
+                <t t-if="contact._can_be_edited_by_current_customer(address_type, order_sudo=website_sale_order)">
+                    <t t-set="new_address_href" t-value="'/portal/address?address_type=' + address_type"/>
                     <a
                         t-att-href="new_address_href + '&amp;partner_id=' + str(contact.id)"
                         class="js_edit_address btn btn-link p-0 mt-auto"
@@ -2336,7 +2336,7 @@
         <t t-set="no_footer" t-value="1"/>
         <t t-call="website.layout">
             <div id="wrap">
-                <div class="oe_website_sale o_wsale_address_fill container py-2">
+                <div class="oe_website_sale o_portal_address_fill container py-2">
                     <div class="row">
                         <div class="col-12">
                             <t t-call="website_sale.wizard_checkout"/>
@@ -2367,7 +2367,7 @@
                                         You are editing your <b>delivery and billing</b> addresses
                                         at the same time!<br/>
                                         If you want to modify your billing address, create a
-                                        <a href="/shop/address?address_type=billing">new address</a>.
+                                        <a href="/portal/address?address_type=billing">new address</a>.
                                     </p>
                                 </div>
                                 <div id="errors"/> <!-- for js -->
@@ -2514,7 +2514,7 @@
                                         <div class="w-100"/>
                                         <div id="div_country" class="col-lg-6 mb-2">
                                             <label class="col-form-label" for="o_country_id">Country</label>
-                                            <select id="o_country_id" name="country_id" class="form-select">
+                                            <select id="o_country_id" name="country_id" class="form-select" t-att-disabled="not has_invoice">
                                                 <option value="">Country...</option>
                                                 <t t-foreach="countries" t-as="c">
                                                     <option t-att-value="c.id" t-att-selected="c.id == country.id" t-att-code="c.code">
@@ -2526,7 +2526,7 @@
                                         <div id="div_state" class="col-lg-6 mb-2"
                                              t-att-style="not country_states and 'display: none'">
                                             <label class="col-form-label" for="o_state_id">State / Province</label>
-                                            <select id="o_state_id" name="state_id" class="form-select">
+                                            <select id="o_state_id" name="state_id" class="form-select" t-att-disabled="not has_invoice">
                                                 <option value="">State / Province...</option>
                                                 <t t-foreach="country_states" t-as="s">
                                                     <option t-att-value="s.id" t-att-selected="s.id == state_id">

--- a/addons/website_sale_mondialrelay/models/res_partner.py
+++ b/addons/website_sale_mondialrelay/models/res_partner.py
@@ -7,5 +7,5 @@ from odoo import models
 class ResPartner(models.Model):
     _inherit = 'res.partner'
 
-    def _can_be_edited_by_current_customer(self, *args, **kwargs):
-        return super()._can_be_edited_by_current_customer(*args, **kwargs) and not self.is_mondialrelay
+    def _can_be_edited_by_current_partner(self, **kwargs):
+        return super()._can_be_edited_by_current_partner(**kwargs) and not self.is_mondialrelay

--- a/odoo/tests/common.py
+++ b/odoo/tests/common.py
@@ -1552,7 +1552,7 @@ which leads to stray network requests and inconsistencies."""
 
         for f in self.screencast_frames:
             with open(f['file_path'], 'rb') as b64_file:
-                frame = base64.decodebytes(b64_file.read())
+                frame = base64.decodebytes(b64_file.read() + b'==')
             os.unlink(f['file_path'])
             f['file_path'] = f['file_path'].replace('.b64', '.png')
             with open(f['file_path'], 'wb') as png_file:
@@ -1566,7 +1566,7 @@ which leads to stray network requests and inconsistencies."""
             ffmpeg_path = find_in_path('ffmpeg')
         except IOError:
             ffmpeg_path = None
-
+        ffmpeg_path = None
         if ffmpeg_path:
             nb_frames = len(self.screencast_frames)
             concat_script_path = os.path.join(self.screencasts_dir, fname.replace('.mp4', '.txt'))


### PR DESCRIPTION
_*= account

Before this PR, customers were unable to manage their addresses autonomously. This could be frustrating as they had to request changes, which might be slow and would add extra work for sales personnel or customer support.

In this PR, users can add multiple addresses, delete them, and set default addresses. Additionally, if the user type is a company, the company name, VAT number and country fields are editable, provided the VAT number is not set. this allows users to update their information directly.

task-3628329