### PR TITLE
[FIX] website_sale{_product_configurator}: split sale tour

### DIFF
--- a/addons/website_sale/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale/static/tests/tours/website_sale_buy.js
@@ -7,48 +7,16 @@ registry.category("web_tour.tours").add('shop_buy_product', {
     test: true,
     url: '/shop',
     steps: () => [
-        ...tourUtils.searchProduct("conference chair"),
+        ...tourUtils.searchProduct("Storage Box"),
         {
-            content: "select conference chair",
-            trigger: '.oe_product_cart:first a:contains("Conference Chair")',
+            content: "select Storage Box",
+            trigger: '.oe_product_cart:first a:contains("Storage Box")',
         },
         {
-            content: "select Conference Chair Aluminium",
-            extra_trigger: '#product_detail',
-            trigger: 'label:contains(Aluminium) input',
-        },
-        {
-            content: "select Conference Chair Steel",
-            extra_trigger: '#product_detail',
-            trigger: 'label:contains(Steel) input',
-        },
-        {
-            id: 'add_cart_step',
             content: "click on add to cart",
-            extra_trigger: 'label:contains(Steel) input:propChecked',
             trigger: '#product_detail form[action^="/shop/cart/update"] #add_to_cart',
         },
-            tourUtils.goToCart(),
-        {
-            content: "add suggested",
-            trigger: '.js_cart_lines:has(a:contains("Storage Box")) a:contains("Add to cart")',
-        },
-        {
-            content: "add one more",
-            extra_trigger: '#cart_products div>a>h6:contains("Storage Box")',
-            trigger: '#cart_products div:has(div>a>h6:contains("Steel")) a.js_add_cart_json:eq(1)',
-        },
-        {
-            content: "remove Storage Box",
-            extra_trigger: '#cart_products div:has(div>a>h6:contains("Steel")) input.js_quantity:propValue(2)',
-            trigger: '#cart_products div:has(div>a>h6:contains("Storage Box")) a.js_add_cart_json:first',
-        },
-        {
-            content: "set one",
-            extra_trigger: '#wrap:not(:has(#cart_products div>a>h6:contains("Storage Box")))',
-            trigger: '#cart_products input.js_quantity',
-            run: 'text 1',
-        },
+        tourUtils.goToCart(),
         tourUtils.goToCheckout(),
         ...tourUtils.payWithTransfer(true),
     ]

--- a/addons/website_sale/static/tests/tours/website_sale_update_cart.js
+++ b/addons/website_sale/static/tests/tours/website_sale_update_cart.js
@@ -1,0 +1,53 @@
+/** @odoo-module **/
+
+import {registry} from '@web/core/registry';
+import tourUtils from '@website_sale/js/tours/tour_utils';
+
+registry.category('web_tour.tours').add('shop_update_cart', {
+    test: true,
+    url: '/shop',
+    steps: () => [
+        ...tourUtils.searchProduct("conference chair"),
+        {
+            content: "select conference chair",
+            trigger: '.oe_product_cart:first a:contains("Conference Chair")',
+        },
+        {
+            content: "select Conference Chair Aluminium",
+            extra_trigger: '#product_detail',
+            trigger: 'label:contains(Aluminium) input',
+        },
+        {
+            content: "select Conference Chair Steel",
+            extra_trigger: '#product_detail',
+            trigger: 'label:contains(Steel) input',
+        },
+        {
+            id: 'add_cart_step',
+            content: "click on add to cart",
+            extra_trigger: 'label:contains(Steel) input:propChecked',
+            trigger: '#product_detail form[action^="/shop/cart/update"] #add_to_cart',
+        },
+        tourUtils.goToCart(),
+        {
+            content: "add suggested",
+            trigger: '.js_cart_lines:has(a:contains("Storage Box")) a:contains("Add to cart")',
+        },
+        {
+            content: "add one more",
+            extra_trigger: '#cart_products div>a>h6:contains("Storage Box")',
+            trigger: '#cart_products div:has(div>a>h6:contains("Steel")) a.js_add_cart_json:eq(1)',
+        },
+        {
+            content: "remove Storage Box",
+            extra_trigger: '#cart_products div:has(div>a>h6:contains("Steel")) input.js_quantity:propValue(2)',
+            trigger: '#cart_products div:has(div>a>h6:contains("Storage Box")) a.js_add_cart_json:first',
+        },
+        {
+            content: "set one",
+            extra_trigger: '#wrap:not(:has(#cart_products div>a>h6:contains("Storage Box")))',
+            trigger: '#cart_products input.js_quantity',
+            run: 'text 1',
+        },
+    ]
+});

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -79,6 +79,9 @@ class TestUi(HttpCaseWithUserDemo):
     def test_01_admin_shop_tour(self):
         self.start_tour(self.env['website'].get_client_action_url('/shop'), 'shop', login='admin')
 
+    def test_01_cart_update_check(self):
+        self.start_tour('/', 'shop_update_cart', login='admin')
+
     def test_02_admin_checkout(self):
         if self.env['ir.module.module']._get('payment_custom').state != 'installed':
             self.skipTest("Transfer provider is not installed")

--- a/addons/website_sale_product_configurator/static/tests/tours/website_sale_buy.js
+++ b/addons/website_sale_product_configurator/static/tests/tours/website_sale_buy.js
@@ -7,7 +7,7 @@ import { registry } from "@web/core/registry";
 import { patch } from "@web/core/utils/patch";
 import "@website_sale/../tests/tours/website_sale_buy";
 
-patch(registry.category("web_tour.tours").get("shop_buy_product"), {
+patch(registry.category('web_tour.tours').get('shop_update_cart'), {
     steps() {
         const originalSteps = super.steps();
         const addCartStepIndex = originalSteps.findIndex((step) => step.id === "add_cart_step");


### PR DESCRIPTION
Tour 'shop_buy_product' checks the correctness of manipulating products
and their quantities in the cart and the payment step of the order.
With the additional check on the payment step introduced by commit
023d549 the tour was failing due to the relatively late rpc request
handling compared to immediate clicks of the tour. `shop/payment` page
was rendered faster than the update cart rpc (`shop/cart/update_json`)
was processed. Cart update resets the delivery method on the order
causing the validation error. That is why the tour is  split in 2
separate functional parts.