### PR TITLE
[REF] web,web_hierarchy: simplify useViewButtons API

### DIFF
--- a/addons/web/static/src/views/fields/relational_utils.js
+++ b/addons/web/static/src/views/fields/relational_utils.js
@@ -551,7 +551,7 @@ export class X2ManyFieldDialog extends Component {
 
         const reload = () => this.record.load();
 
-        useViewButtons(this.props.record.model, this.modalRef, {
+        useViewButtons(this.modalRef, {
             reload,
             beforeExecuteAction: this.beforeExecuteActionButton.bind(this),
         }); // maybe pass the model directly in props

--- a/addons/web/static/src/views/form/form_controller.js
+++ b/addons/web/static/src/views/form/form_controller.js
@@ -240,9 +240,10 @@ export class FormController extends Component {
         }
 
         this.rootRef = useRef("root");
-        useViewButtons(this.model, this.rootRef, {
+        useViewButtons(this.rootRef, {
             beforeExecuteAction: this.beforeExecuteActionButton.bind(this),
             afterExecuteAction: this.afterExecuteActionButton.bind(this),
+            reload: () => this.model.load(),
         });
 
         const state = this.props.state || {};

--- a/addons/web/static/src/views/kanban/kanban_controller.js
+++ b/addons/web/static/src/views/kanban/kanban_controller.js
@@ -140,9 +140,10 @@ export class KanbanController extends Component {
         });
 
         this.rootRef = useRef("root");
-        useViewButtons(this.model, this.rootRef, {
+        useViewButtons(this.rootRef, {
             beforeExecuteAction: this.beforeExecuteActionButton.bind(this),
             afterExecuteAction: this.afterExecuteActionButton.bind(this),
+            reload: () => this.model.load(),
         });
         useSetupView({
             rootRef: this.rootRef,
@@ -182,9 +183,9 @@ export class KanbanController extends Component {
         const { activeFields, fields } = extractFieldsFromArchInfo(archInfo, this.props.fields);
 
         // Remove fields aggregator unused to avoid asking them for no reason
-        const aggregateFieldNames = this.progressBarAggregateFields.map((field) => field.name)
+        const aggregateFieldNames = this.progressBarAggregateFields.map((field) => field.name);
         for (const [key, value] of Object.entries(activeFields)) {
-            if (!aggregateFieldNames.includes(key)){
+            if (!aggregateFieldNames.includes(key)) {
                 value.aggregator = null;
             }
         }

--- a/addons/web/static/src/views/list/list_controller.js
+++ b/addons/web/static/src/views/list/list_controller.js
@@ -115,9 +115,10 @@ export class ListController extends Component {
                 ? !this.props.fields.x_active.readonly
                 : false;
         useSubEnv({ model: this.model }); // do this in useModelWithSampleData?
-        useViewButtons(this.model, this.rootRef, {
+        useViewButtons(this.rootRef, {
             beforeExecuteAction: this.beforeExecuteActionButton.bind(this),
             afterExecuteAction: this.afterExecuteActionButton.bind(this),
+            reload: () => this.model.load(),
         });
         useSetupView({
             rootRef: this.rootRef,

--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -84,7 +84,7 @@ export class ViewButton extends Component {
                 title: this.props.title,
             },
             context: this.props.record && this.props.record.context,
-            model: (this.props.record && this.props.record.resModel) || this.props.resModel,
+            model: this.props.record && this.props.record.resModel,
         });
         this.dropdownControl = useDropdownCloser();
     }

--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -58,6 +58,7 @@ export class ViewButton extends Component {
         tag: "button",
         className: "",
         clickParams: {},
+        attrs: {},
     };
 
     setup() {
@@ -74,10 +75,10 @@ export class ViewButton extends Component {
                 string: this.props.string,
                 help: this.clickParams.help,
                 context: this.clickParams.context,
-                invisible: this.props.attrs?.invisible,
-                column_invisible: this.props.attrs?.column_invisible,
-                readonly: this.props.attrs?.readonly,
-                required: this.props.attrs?.required,
+                invisible: this.props.attrs.invisible,
+                column_invisible: this.props.attrs.column_invisible,
+                readonly: this.props.attrs.readonly,
+                required: this.props.attrs.required,
                 special: this.clickParams.special,
                 type: this.clickParams.type,
                 name: this.clickParams.name,

--- a/addons/web/static/src/views/view_button/view_button.js
+++ b/addons/web/static/src/views/view_button/view_button.js
@@ -122,7 +122,14 @@ export class ViewButton extends Component {
         this.env.onClickViewButton({
             clickParams: this.clickParams,
             getResParams: () =>
-                pick(this.props.record, "context", "evalContext", "resModel", "resId", "resIds"),
+                pick(
+                    this.props.record || {},
+                    "context",
+                    "evalContext",
+                    "resModel",
+                    "resId",
+                    "resIds"
+                ),
             beforeExecute: () => this.dropdownControl.close(),
         });
     }

--- a/addons/web/static/tests/views/view_button_hook.test.js
+++ b/addons/web/static/tests/views/view_button_hook.test.js
@@ -32,7 +32,7 @@ test("action can be prevented", async () => {
         static props = ["*"];
         setup() {
             const rootRef = useRef("root");
-            useViewButtons({}, rootRef, {
+            useViewButtons(rootRef, {
                 beforeExecuteAction: () => {
                     expect.step("beforeExecuteAction in hook");
                     return executeInHook;
@@ -101,7 +101,7 @@ test("ViewButton clicked in Dropdown close the Dropdown", async () => {
         static props = ["*"];
         setup() {
             const rootRef = useRef("root");
-            useViewButtons({}, rootRef);
+            useViewButtons(rootRef);
         }
     }
 

--- a/addons/web_hierarchy/static/src/hierarchy_controller.js
+++ b/addons/web_hierarchy/static/src/hierarchy_controller.js
@@ -47,7 +47,7 @@ export class HierarchyController extends Component {
                 this.render(true);
             }
         );
-        useViewButtons(this.model, this.rootRef, {
+        useViewButtons(this.rootRef, {
             beforeExecuteAction: this.beforeExecuteActionButton.bind(this),
             afterExecuteAction: this.afterExecuteActionButton.bind(this),
             reload: this.model.reload.bind(this.model),


### PR DESCRIPTION
The first parameter "model" has been removed from the API of useViewButtons to make it more natural.
We also simplify a bit ViewButton.

This is done in prevision of https://github.com/odoo/enterprise/pull/54292 as in that context no suitable model is available.

Co-authored-by: Aaron Bohy <aab@odoo.com>
Co-authored-by: Mathieu Duckerts-Antoine <dam@odoo.com>