### PR TITLE
[FIX] web: enable developper mode from settings

### DIFF
--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.js
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.js
@@ -1,3 +1,4 @@
+import { router } from "@web/core/browser/router";
 import { registry } from "@web/core/registry";
 import { useService } from "@web/core/utils/hooks";
 import { SettingsBlock } from "../settings/settings_block";
@@ -39,6 +40,10 @@ export class ResConfigDevTool extends Component {
      */
     onClickForceDemo() {
         this.action.doAction("base.demo_force_install_action");
+    }
+
+    onClickDebugMode(mode) {
+        router.pushState({ debug: mode }, { reload: true });
     }
 }
 

--- a/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
+++ b/addons/web/static/src/webclient/settings_form_view/widgets/res_config_dev_tool.xml
@@ -5,10 +5,10 @@
             <t t-set="title">Developer Tools</t>
             <SettingsBlock title="title">
                 <Setting addLabel="false">
-                        <a t-if="!isDebug" class="d-block" href="?debug=1">Activate the developer mode</a>
-                        <a t-if="!isAssets" class="d-block" href="?debug=assets">Activate the developer mode (with assets)</a>
-                        <a t-if="!isTests" class="d-block" href="?debug=assets,tests">Activate the developer mode (with tests assets)</a>
-                        <a t-if="isDebug" class="d-block" href="?debug=">Deactivate the developer mode</a>
+                        <a t-if="!isDebug" class="d-block"  t-on-click.prevent="() => this.onClickDebugMode('1')">Activate the developer mode</a>
+                        <a t-if="!isAssets" class="d-block" t-on-click.prevent="() => this.onClickDebugMode('assets')">Activate the developer mode (with assets)</a>
+                        <a t-if="!isTests" class="d-block" t-on-click.prevent="() => this.onClickDebugMode('assets,tests')">Activate the developer mode (with tests assets)</a>
+                        <a t-if="isDebug" class="d-block" t-on-click.prevent="() => this.onClickDebugMode()">Deactivate the developer mode</a>
                         <a t-if="isDebug and !isDemoDataActive" t-on-click.prevent="onClickForceDemo" class="o_web_settings_force_demo" href="#">Load demo data</a>
                 </Setting>
             </SettingsBlock>


### PR DESCRIPTION
Steps to reproduce
==================

- Go to settings
- Click on "Activate the developer mode"

=> Nothing happens

Cause of the issue
==================

The page isn't reloaded

Solution
========

Use the router and pass the reload option.
The same call is done in debug_provider.js

opw-3922717