### PR TITLE
[FIX] account: align text between currency and payment term

### DIFF
--- a/addons/account/views/account_move_views.xml
+++ b/addons/account/views/account_move_views.xml
@@ -984,16 +984,19 @@
                                      groups="account.group_account_readonly,base.group_multi_currency">
                                     <field name="journal_id"
                                            groups="account.group_account_readonly"
-                                           class="mr4"
                                            options="{'no_create': True, 'no_open': True}"
                                            readonly="posted_before"/>
+
+                                    <span class="o_form_label mx-3 oe_edit_only"
+                                          groups="account.group_account_readonly"
+                                          invisible="move_type == 'entry'">
+                                        <span groups="base.group_multi_currency">in </span>
+                                    </span>
                                     <div name="currency_div"
                                          groups="base.group_multi_currency"
+                                         class="w-100"
                                          style="white-space: pre;"
                                          invisible="move_type == 'entry'">
-                                        <span class="o_form_label"
-                                              groups="account.group_account_readonly"
-                                              invisible="move_type == 'entry'">in </span>
                                         <field name="currency_id"
                                                readonly="state != 'draft'"
                                                class="oe_inline"


### PR DESCRIPTION
Install account_accountant
Activate Second currency
Create an invoice
=> The "or" and the "in" are not aligned.




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
