### PR TITLE
[FIX] resource: compute duration days on onchange

### DIFF
--- a/addons/resource/models/resource_calendar_attendance.py
+++ b/addons/resource/models/resource_calendar_attendance.py
@@ -74,7 +74,7 @@ class ResourceCalendarAttendance(models.Model):
         for attendance in self:
             attendance.duration_hours = (attendance.hour_to - attendance.hour_from) if attendance.day_period != 'lunch' else 0
 
-    @api.depends('day_period', 'hour_from', 'hour_to')
+    @api.depends('day_period', 'duration_hours', 'calendar_id.hours_per_day')
     def _compute_duration_days(self):
         for attendance in self:
             if attendance.day_period == 'lunch':


### PR DESCRIPTION
Steps to reproduce:
- Install Time Off app
- Go to working schedule 'Standard 40 hours/week'
- Change the afternoon slots for Monday end time to 18
- Change the afternoon slots for Tuesday end time to 18

Issue:
With the current depends, step 4, we will have an issue
in the compute. This is due to the fact that
`attendance.calendar_id.hours_per_day` depends on its siblings, however
the dependencies are not indicating that.

https://github.com/odoo/odoo/blob/dd2da708bc4a42bba9670b874282a2206d8f5ffe/addons/resource/models/resource_calendar_attendance.py#L83

As such we will not trigger `_compute_duration_days` after changing the
hours which will cause issues.

On a side note no test was made due to a limitation of the test form,
which didn't replicate the real behaviour of the web client.

opw-3783809