### PR TITLE
[FIX] mrp: prevent qty_producing/product_qty overlap in MO form view

### DIFF
--- a/addons/mrp/static/src/scss/mrp_fields.scss
+++ b/addons/mrp/static/src/scss/mrp_fields.scss
@@ -1,3 +1,8 @@
 .o_field_widget.o_embed_url_viewer iframe {
     aspect-ratio: 3/2;
 }
+
+.overflow-scrollable {
+    overflow-x: auto;
+    scrollbar-width: thin;
+}

--- a/addons/mrp/views/mrp_production_views.xml
+++ b/addons/mrp/views/mrp_production_views.xml
@@ -249,10 +249,10 @@
                             <label for="product_qty" string="Quantity"/>
                             <div class="o_row g-0 d-flex">
                                 <div invisible="state == 'draft'" class="o_row flex-grow-0">
-                                    <field name="qty_producing" class="text-start" readonly="state == 'cancel' or (state == 'done' and is_locked)"/>
+                                    <field name="qty_producing" class="text-start overflow-scrollable" readonly="state == 'cancel' or (state == 'done' and is_locked)"/>
                                     /
                                 </div>
-                                <field name="product_qty" class="oe_inline text-start" invisible="state not in ('draft', 'done')" readonly="state != 'draft'"/>
+                                <field name="product_qty" class="oe_inline text-start overflow-scrollable" invisible="state not in ('draft', 'done')" readonly="state != 'draft'"/>
                                 <button type="action" name="%(mrp.action_change_production_qty)d"
                                     context="{'default_mo_id': id}" class="oe_link oe_inline" style="margin: 0px; padding: 0px;" invisible="state in ('draft', 'done', 'cancel') or not id">
                                     <field name="product_qty" class="oe_inline" readonly="state != 'draft'"/>


### PR DESCRIPTION
Steps
---
* install mrp
* create new mo for some product
* set a huge `product_qty` ("Quantity") (e.g. 123456789123456789, we
  want to take as much space as possible but not trigger exponential
  notation)
* Confirm > Produce All
* The qty_producing and product_qty fields will overlap and be
illegible

(Note that the order needs to be done and locked, because
if we can still edit the qty_producing the input will be scrollable)

Fix
---
allow the `qty_producing` field to grow;
make the fields scrollable when still too large

opw-3919805

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
