### PR TITLE
[FIX] account_edi_ubl_cii: prevent import factur-x tax amount mismatch

### DIFF
--- a/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
+++ b/addons/account_edi_ubl_cii/models/account_edi_xml_ubl_20.py
@@ -601,6 +601,16 @@ class AccountEdiXmlUBL20(models.AbstractModel):
                 invl_logs = self._import_fill_invoice_line_form(journal, invl_el, invoice_form, invoice_line_form, qty_factor)
                 logs += invl_logs
 
+        # ==== total tax (to avoid rounding mismatch) ====
+
+        xml_tax_amount_per_rate = {}
+        for tax_node in tree.findall('.//{*}TaxSubtotal'):
+            rate = tax_node.find('.//{*}Percent').text
+            amount = tax_node.find('.//{*}TaxAmount').text
+            xml_tax_amount_per_rate[float(rate)] = float(amount)
+
+        self._force_invoice_tax_lines(invoice_form.line_ids._records, xml_tax_amount_per_rate)
+
         return invoice_form, logs
 
     def _import_fill_invoice_line_form(self, journal, tree, invoice_form, invoice_line_form, qty_factor):


### PR DESCRIPTION
Previously, when importing a factur-x invoice, the total tax amount was
calculated by Odoo using the current company's rounding method. This
could lead to a mismatch between the tax amount in the factur-x/UBL file
and the tax amount calculated by Odoo. This commit resolves the issue by
ensuring the tax amount matches the one in the factur-x file.

Steps to reproduce the issue:
- Set up a French company (Company A) with 'Round per Line' rounding.
- Set up a French company (Company B) with 'Round Globally' rounding.
- With Company A, create a factur-x invoice.
- With Company B, import the factur-x invoice.

Result: The tax amount and the total amount in the PDF from Odoo differ.

task-3943302