### PR TITLE
[FIX] calendar: allow attendee removing itself

### DIFF
--- a/addons/calendar/models/calendar_event.py
+++ b/addons/calendar/models/calendar_event.py
@@ -288,7 +288,12 @@ class Meeting(models.Model):
     @api.depends_context('uid')
     def _compute_user_can_edit(self):
         for event in self:
-            event.user_can_edit = self.env.user in event.partner_ids.user_ids + event.user_id
+            # By default, only current attendees and the organizer can edit the event.
+            editor_candidates = event.partner_ids.user_ids + event.user_id
+            # Right before saving the event, old partners must be able to save changes.
+            if event._origin:
+                editor_candidates += event._origin.partner_ids.user_ids
+            event.user_can_edit = self.env.user in editor_candidates
 
     @api.depends('attendee_ids')
     def _compute_invalid_email_partner_ids(self):


### PR DESCRIPTION
Before this commit, the attendees were not allowed to remove anyone from the event (including themselves) when editing the event in the form view. This was a problem that came after updating the views to OWL and also reverting the PR [#133504](https://github.com/odoo/odoo/pull/133504).

After this commit, the event attendees can perform attendee removals normally because we check inside the compute if it the current attendee was indeed an attendee right before the change is completed.

task-3948322