### PR TITLE
[FIX] crm, phone_validation: hoist regexp phone indexes to mixin

### DIFF
--- a/addons/crm/models/crm_lead.py
+++ b/addons/crm/models/crm_lead.py
@@ -23,7 +23,6 @@ from odoo.tools.misc import get_lang
 from . import crm_stage
 
 _logger = logging.getLogger(__name__)
-_schema = logging.getLogger('odoo.schema')
 
 
 CRM_LEAD_FIELDS_TO_MERGE = [
@@ -741,17 +740,6 @@ class Lead(models.Model):
                            self._table, ['user_id', 'team_id', 'type'])
         tools.create_index(self._cr, 'crm_lead_create_date_team_id_idx',
                            self._table, ['create_date', 'team_id'])
-        phone_pattern = r'[\s\\./\(\)\-]'
-        for field_name in ('phone', 'mobile'):
-            index_name = f'crm_lead_{field_name}_partial_tgm'
-            if tools.index_exists(self._cr, index_name):
-                continue
-            regex_expression = f"regexp_replace(({field_name}::text), %s::text, ''::text, 'g'::text)"
-            self._cr.execute(
-                f'CREATE INDEX "{index_name}" ON "{self._table}" ({regex_expression}) WHERE {field_name} IS NOT NULL',
-                (phone_pattern,)
-            )
-            _schema.debug("Table %r: created index %r (%s)", self._table, index_name, regex_expression)
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/addons/hr_recruitment/models/hr_applicant.py
+++ b/addons/hr_recruitment/models/hr_applicant.py
@@ -114,6 +114,7 @@ class Applicant(models.Model):
     applicant_properties = fields.Properties('Properties', definition='job_id.applicant_properties_definition', copy=True)
 
     def init(self):
+        super().init()
         self.env.cr.execute("""
             CREATE INDEX IF NOT EXISTS hr_applicant_job_id_stage_id_idx
             ON hr_applicant(job_id, stage_id)

--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -65,6 +65,13 @@ class PhoneMixin(models.AbstractModel):
                          tablename=self._table,
                          expressions=[regex_expression],
                          where=f'{fname} IS NOT NULL')
+            # The trigram index covers operators 'like', 'ilike' and '=like' starting with a wildcard
+            create_index(self.env.cr,
+                         indexname=f'{self._table}_{fname}_partial_gin_idx',
+                         tablename=self._table,
+                         method='gin',
+                         expressions=[regex_expression + ' gin_trgm_ops'],
+                         where=f'{fname} IS NOT NULL')
 
     def _search_phone_mobile_search(self, operator, value):
         value = value.strip() if isinstance(value, str) else value

--- a/addons/phone_validation/models/mail_thread_phone.py
+++ b/addons/phone_validation/models/mail_thread_phone.py
@@ -6,6 +6,9 @@ import re
 from odoo import api, fields, models, _
 from odoo.exceptions import AccessError, UserError
 from odoo.osv import expression
+from odoo.tools import create_index
+
+PHONE_REGEX_PATTERN = r'[\s\\./\(\)\-]'
 
 
 class PhoneMixin(models.AbstractModel):
@@ -47,6 +50,22 @@ class PhoneMixin(models.AbstractModel):
             when there is both a mobile and phone field in a model.")
     phone_mobile_search = fields.Char("Phone/Mobile", store=False, search='_search_phone_mobile_search')
 
+    def init(self):
+        super().init()
+        phone_fields = [
+            fname for fname in self._phone_get_number_fields()
+            if fname in self._fields and self._fields[fname].store
+        ]
+        # Add supporting indexes for searching on `phone_mobile_search`
+        for fname in phone_fields:
+            regex_expression = rf"regexp_replace(({fname}::text), '{PHONE_REGEX_PATTERN}'::text, ''::text, 'g'::text)"
+            # The btree index covers operators '=' and '=like' with a known prefix
+            create_index(self.env.cr,
+                         indexname=f'{self._table}_{fname}_partial_tgm',
+                         tablename=self._table,
+                         expressions=[regex_expression],
+                         where=f'{fname} IS NOT NULL')
+
     def _search_phone_mobile_search(self, operator, value):
         value = value.strip() if isinstance(value, str) else value
         phone_fields = [
@@ -67,7 +86,6 @@ class PhoneMixin(models.AbstractModel):
         if self._phone_search_min_length and len(value) < self._phone_search_min_length:
             raise UserError(_('Please enter at least 3 characters when searching a Phone/Mobile number.'))
 
-        pattern = r'[\s\\./\(\)\-]'
         sql_operator = {'=like': 'LIKE', '=ilike': 'ILIKE'}.get(operator, operator)
 
         if value.startswith('+') or value.startswith('00'):
@@ -93,11 +111,11 @@ class PhoneMixin(models.AbstractModel):
                 )
             query = f"SELECT model.id FROM {self._table} model WHERE {where_str};"
 
-            term = re.sub(pattern, '', value[1 if value.startswith('+') else 2:])
+            term = re.sub(PHONE_REGEX_PATTERN, '', value[1 if value.startswith('+') else 2:])
             if operator not in ('=', '!='):  # for like operators
                 term = f'{term}%'
             self._cr.execute(
-                query, (pattern, '00' + term, pattern, '+' + term) * len(phone_fields)
+                query, (PHONE_REGEX_PATTERN, '00' + term, PHONE_REGEX_PATTERN, '+' + term) * len(phone_fields)
             )
         else:
             if operator in expression.NEGATIVE_TERM_OPERATORS:
@@ -111,10 +129,10 @@ class PhoneMixin(models.AbstractModel):
                     for phone_field in phone_fields
                 )
             query = f"SELECT model.id FROM {self._table} model WHERE {where_str};"
-            term = re.sub(pattern, '', value)
+            term = re.sub(PHONE_REGEX_PATTERN, '', value)
             if operator not in ('=', '!='):  # for like operators
                 term = f'%{term}%'
-            self._cr.execute(query, (pattern, term) * len(phone_fields))
+            self._cr.execute(query, (PHONE_REGEX_PATTERN, term) * len(phone_fields))
         res = self._cr.fetchall()
         if not res:
             return [(0, '=', 1)]


### PR DESCRIPTION
The index definition that supports the implementation of `_search_phone_mobile_search` defined in the `PhoneMixin` is created in an `_auto_init` in `crm_lead` of the `crm` module. This means that other models that use the mixin (for ex: `res_partner`) will not get the indexes for it's table, leading to Seq.Scans when searching for a phone number on those models.

By hoisting the index definition to an `init` in the mixin, all models that inherit from the mixin will have the supporting index.

Also add the same custom `trigram` index to support `like/ilike` operators in domains.

task-3942852

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
