### PR TITLE
deprecate pycompat.csv_reader and pycompat.csv_writer

### DIFF
--- a/addons/web/controllers/export.py
+++ b/addons/web/controllers/export.py
@@ -1,5 +1,5 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
-
+import csv
 import datetime
 import functools
 import io
@@ -534,8 +534,8 @@ class CSVExport(ExportFormat, http.Controller):
         raise UserError(_("Exporting grouped data to csv is not supported."))
 
     def from_data(self, fields, rows):
-        fp = io.BytesIO()
-        writer = pycompat.csv_writer(fp, quoting=1)
+        fp = io.StringIO()
+        writer = csv.writer(fp, quoting=1)
 
         writer.writerow(fields)
 

--- a/odoo/addons/base/wizard/base_export_language.py
+++ b/odoo/addons/base/wizard/base_export_language.py
@@ -3,7 +3,6 @@
 
 import ast
 import base64
-import contextlib
 import io
 
 from odoo import api, fields, models, tools, _
@@ -40,7 +39,7 @@ class BaseLanguageExport(models.TransientModel):
         this = self[0]
         lang = this.lang if this.lang != NEW_LANG_KEY else False
 
-        with contextlib.closing(io.BytesIO()) as buf:
+        with io.BytesIO() as buf:
             if this.export_type == 'model':
                 ids = self.env[this.model_name].search(ast.literal_eval(this.domain)).ids
                 trans_export_records(lang, this.model_name, ids, buf, this.format, self._cr)

--- a/odoo/tools/convert.py
+++ b/odoo/tools/convert.py
@@ -6,6 +6,7 @@ __all__ = [
     'convert_csv_import', 'convert_xml_import'
 ]
 import base64
+import csv
 import io
 import logging
 import os.path
@@ -641,7 +642,7 @@ def convert_csv_import(env, module, fname, csvcontent, idref=None, mode='init',
     env = env(context=dict(env.context, lang=None))
     filename, _ext = os.path.splitext(os.path.basename(fname))
     model = filename.split('-')[0]
-    reader = pycompat.csv_reader(io.BytesIO(csvcontent), quotechar='"', delimiter=',')
+    reader = csv.reader(io.StringIO(csvcontent.decode()), quotechar='"', delimiter=',')
     fields = next(reader)
 
     if not (mode == 'init' or 'id' in fields):

--- a/odoo/tools/misc.py
+++ b/odoo/tools/misc.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import base64
 import collections
+import csv
 import datetime
 import hashlib
 import hmac as hmac_lib
@@ -43,7 +44,6 @@ import odoo.addons
 # There are moved to loglevels until we refactor tools.
 from odoo.loglevels import exception_to_unicode, get_encodings, ustr  # noqa: F401
 
-from . import pycompat
 from .config import config
 from .float_utils import float_round
 from .which import which
@@ -452,8 +452,8 @@ def scan_languages():
     """
     try:
         # read (code, name) from languages in base/data/res.lang.csv
-        with file_open('base/data/res.lang.csv', 'rb') as csvfile:
-            reader = pycompat.csv_reader(csvfile, delimiter=',', quotechar='"')
+        with file_open('base/data/res.lang.csv') as csvfile:
+            reader = csv.reader(csvfile, delimiter=',', quotechar='"')
             fields = next(reader)
             code_index = fields.index("code")
             name_index = fields.index("name")

--- a/odoo/tools/pycompat.py
+++ b/odoo/tools/pycompat.py
@@ -10,6 +10,7 @@ _writer = codecs.getwriter('utf-8')
 
 
 def csv_reader(stream, **params):
+    warnings.warn("Deprecated since Odoo 18.0: can just use `csv.reader` with a text stream or use `TextIOWriter` or `codec.getreader` to transcode.", DeprecationWarning, 2)
     assert not isinstance(stream, io.TextIOBase),\
         "For cross-compatibility purposes, csv_reader takes a bytes stream"
     return csv.reader(_reader(stream), **params)

--- a/odoo/tools/pycompat.py
+++ b/odoo/tools/pycompat.py
@@ -3,6 +3,7 @@
 import csv
 import codecs
 import io
+import warnings
 
 _reader = codecs.getreader('utf-8')
 _writer = codecs.getwriter('utf-8')
@@ -15,6 +16,7 @@ def csv_reader(stream, **params):
 
 
 def csv_writer(stream, **params):
+    warnings.warn("Deprecated since Odoo 18.0: can just use `csv.writer` with a text stream or use `TextIOWriter` or `codec.getwriter` to transcode.", DeprecationWarning, 2)
     assert not isinstance(stream, io.TextIOBase), \
         "For cross-compatibility purposes, csv_writer takes a bytes stream"
     return csv.writer(_writer(stream), **params)

--- a/odoo/tools/translate.py
+++ b/odoo/tools/translate.py
@@ -34,7 +34,6 @@ from psycopg2.extras import Json
 
 import odoo
 from odoo.exceptions import UserError
-from . import pycompat
 from .config import config
 from .misc import file_open, file_path, get_iso_codes, OrderedSet, SKIPPED_ELEMENT_TYPES
 
@@ -780,9 +779,10 @@ def TranslationFileWriter(target, fileformat='po', lang=None):
                       '.csv, .po, or .tgz (received .%s).') % fileformat)
 
 
+_writer = codecs.getwriter('utf-8')
 class CSVFileWriter:
     def __init__(self, target):
-        self.writer = pycompat.csv_writer(target, dialect='UNIX')
+        self.writer = csv.writer(_writer(target), dialect='UNIX')
         # write header first
         self.writer.writerow(("module","type","name","res_id","src","value","comments"))
 


### PR DESCRIPTION
They were useful compatiblity shims but are now pretty useless, all they do is work with byte inputs... which half the time requires encoding the input.