### PR TITLE
[FIX] mrp_subcontracting: Reciept show details

### DIFF
--- a/addons/mrp_subcontracting/models/stock_move.py
+++ b/addons/mrp_subcontracting/models/stock_move.py
@@ -158,7 +158,7 @@ class StockMove(models.Model):
         subcontracted product. Otherwise use standard behavior.
         """
         self.ensure_one()
-        if self.state != 'done' and (self._subcontrating_should_be_record() or self._subcontrating_can_be_record()):
+        if self.state != 'done' and self._subcontrating_should_be_record():
             return self._action_record_components()
         action = super(StockMove, self).action_show_details()
         if self.is_subcontract and all(p._has_been_recorded() for p in self._get_subcontract_production()):


### PR DESCRIPTION
Steps to reproduce:
- Create a subcontracted product tracked with unique serial number and untracked components
- Create a purchase order and confirm
- go to the receipt, click on the detailled operations button

Bug:
The record components view opens which prevents the user from generating multiple serials at once

Fix:
only display the record components view if it's mandatory other wise that view can still be accessed by the dedicated 'record components' button

opw-3905188
