### PR TITLE
[FIX] account: Hide Payment Difference when equals Early Payment Discount

### DIFF
--- a/addons/account/wizard/account_payment_register_views.xml
+++ b/addons/account/wizard/account_payment_register_views.xml
@@ -67,7 +67,7 @@
                                    invisible="not can_edit_wizard or (can_group_payments and not group_payment)"/>
                         </group>
                         <group name="group3"
-                               invisible="payment_difference == 0.0 or not can_edit_wizard or can_group_payments and not group_payment">
+                               invisible="payment_difference == 0.0 or early_payment_discount_mode or not can_edit_wizard or can_group_payments and not group_payment">
                             <label for="payment_difference"/>
                             <div>
                                 <field name="payment_difference"/>


### PR DESCRIPTION
When the Payment Difference amount equals Early Payment Discount, Don't show the payment difference field and consider full reconciliation.

task-3944830

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
