### PR TITLE
[IMP] hr_contract: let employee contract manager see employee contracts

### DIFF
--- a/addons/hr_contract/models/__init__.py
+++ b/addons/hr_contract/models/__init__.py
@@ -9,3 +9,4 @@ from . import res_config_settings
 from . import resource
 from . import resource_resource
 from . import hr_payroll_structure_type
+from . import ir_ui_menu

--- a/addons/hr_contract/models/ir_ui_menu.py
+++ b/addons/hr_contract/models/ir_ui_menu.py
@@ -1,0 +1,16 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+
+from odoo import models
+
+
+class IrUiMenu(models.Model):
+    _inherit = 'ir.ui.menu'
+
+    def _load_menus_blacklist(self):
+        res = super()._load_menus_blacklist()
+        is_contract_employee_manager = self.env.user.has_group('hr_contract.group_hr_contract_employee_manager')
+        is_employee_officer = self.env.user.has_group('hr.group_hr_user')
+        if not is_contract_employee_manager or is_employee_officer:
+            res.append(self.env.ref('hr_contract.menu_hr_employee_contracts').id)
+        return res

--- a/addons/hr_contract/security/security.xml
+++ b/addons/hr_contract/security/security.xml
@@ -9,13 +9,13 @@
         <record id="hr_contract.group_hr_contract_employee_manager" model="res.groups">
             <field name="name">Employee Manager</field>
             <field name="category_id" ref="base.module_category_human_resources_contracts"/>
-            <field name="implied_ids" eval="[(4, ref('hr.group_hr_user'))]"/>
+            <field name="implied_ids" eval="[(4, ref('base.group_user'))]"/>
         </record>
 
         <record id="hr_contract.group_hr_contract_manager" model="res.groups">
             <field name="name">Administrator</field>
             <field name="category_id" ref="base.module_category_human_resources_contracts"/>
-            <field name="implied_ids" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager'))]"/>
+            <field name="implied_ids" eval="[(4, ref('hr_contract.group_hr_contract_employee_manager')), (4, ref('hr.group_hr_user'))]"/>
             <field name="users" eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"/>
         </record>
 

--- a/addons/hr_contract/views/hr_contract_views.xml
+++ b/addons/hr_contract/views/hr_contract_views.xml
@@ -40,7 +40,7 @@
                             class="oe_stat_button"
                             icon="fa-book"
                             type="object"
-                            groups="hr_contract.group_hr_contract_employee_manager"
+                            groups="hr_contract.group_hr_contract_manager"
                             context="{'default_employee_id': id}"
                             invisible="employee_type not in ['employee', 'student', 'trainee']">
                             <div invisible="not first_contract_date" class="o_stat_info">
@@ -386,7 +386,14 @@
             parent="hr.menu_hr_employee_payroll"
             sequence="6"
             groups="hr_contract.group_hr_contract_manager"/>
-        
+
+        <menuitem
+            id="menu_hr_employee_contracts"
+            name="Contracts"
+            action="hr_contract.action_hr_contract"
+            parent="hr.menu_hr_root"
+            sequence="5"/>
+
         <record id="hr.menu_resource_calendar_view" model="ir.ui.menu">
             <field name="parent_id" ref="menu_human_resources_configuration_contract"/>
         </record>


### PR DESCRIPTION
We would like if hr_contract.group_hr_contract_employee_manager rights did not imply hr.group_hr_user. Generally, giving hr.group_hr_user rights to user is too much 'power', and if we could do without it, we should.

Motivation:
Employee manager that conducts appraisals, might benefit from having an access to employee contracts, without giving them HR officer rights.

task-3935801




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
