### PR TITLE
[IMP] spreadsheet: improve global filter typing

### DIFF
--- a/addons/spreadsheet/static/src/@types/commands.d.ts
+++ b/addons/spreadsheet/static/src/@types/commands.d.ts
@@ -1,117 +1,164 @@
+import { FieldMatching } from "./global_filter.d";
 import {
-  CorePlugin,
-  UIPlugin,
-  DispatchResult,
-  CommandResult,
-  AddPivotCommand,
-  UpdatePivotCommand,
+    CorePlugin,
+    UIPlugin,
+    DispatchResult,
+    CommandResult,
+    AddPivotCommand,
+    UpdatePivotCommand,
+    CancelledReason,
 } from "@odoo/o-spreadsheet";
-import * as CancelledReason from "@spreadsheet/o_spreadsheet/cancelled_reason";
+import * as OdooCancelledReason from "@spreadsheet/o_spreadsheet/cancelled_reason";
 
 type CoreDispatch = CorePlugin["dispatch"];
 type UIDispatch = UIPlugin["dispatch"];
 type CoreCommand = Parameters<CorePlugin["allowDispatch"]>[0];
 type Command = Parameters<UIPlugin["allowDispatch"]>[0];
 
+// TODO look for a way to remove this and use the real import * as OdooCancelledReason
+type OdooCancelledReason = string;
+
 declare module "@spreadsheet" {
-  interface OdooCommandDispatcher {
-    dispatch<
-      T extends OdooCommandTypes,
-      C extends Extract<OdooCommand, { type: T }>
-    >(
-      type: {} extends Omit<C, "type"> ? T : never
-    ): DispatchResult;
-    dispatch<
-      T extends OdooCommandTypes,
-      C extends Extract<OdooCommand, { type: T }>
-    >(
-      type: T,
-      r: Omit<C, "type">
-    ): DispatchResult;
-  }
+    interface OdooCommandDispatcher {
+        dispatch<T extends OdooCommandTypes, C extends Extract<OdooCommand, { type: T }>>(
+            type: {} extends Omit<C, "type"> ? T : never
+        ): OdooDispatchResult;
+        dispatch<T extends OdooCommandTypes, C extends Extract<OdooCommand, { type: T }>>(
+            type: T,
+            r: Omit<C, "type">
+        ): OdooDispatchResult;
+    }
 
-  interface OdooCoreCommandDispatcher {
-    dispatch<
-      T extends OdooCoreCommandTypes,
-      C extends Extract<OdooCoreCommand, { type: T }>
-    >(
-      type: {} extends Omit<C, "type"> ? T : never
-    ): DispatchResult;
-    dispatch<
-      T extends OdooCoreCommandTypes,
-      C extends Extract<OdooCoreCommand, { type: T }>
-    >(
-      type: T,
-      r: Omit<C, "type">
-    ): DispatchResult;
-  }
+    interface OdooCoreCommandDispatcher {
+        dispatch<T extends OdooCoreCommandTypes, C extends Extract<OdooCoreCommand, { type: T }>>(
+            type: {} extends Omit<C, "type"> ? T : never
+        ): OdooDispatchResult;
+        dispatch<T extends OdooCoreCommandTypes, C extends Extract<OdooCoreCommand, { type: T }>>(
+            type: T,
+            r: Omit<C, "type">
+        ): OdooDispatchResult;
+    }
 
-  type OdooCommandTypes = OdooCommand["type"];
-  type OdooCoreCommandTypes = OdooCoreCommand["type"];
+    interface OdooDispatchResult extends DispatchResult {
+        readonly reasons: (CancelledReason | OdooCancelledReason)[];
+        isCancelledBecause(reason: CancelledReason | OdooCancelledReason): boolean;
+    }
 
-  type OdooDispatch = UIDispatch & OdooCommandDispatcher["dispatch"];
-  type OdooCoreDispatch = CoreDispatch & OdooCoreCommandDispatcher["dispatch"];
+    type OdooCommandTypes = OdooCommand["type"];
+    type OdooCoreCommandTypes = OdooCoreCommand["type"];
 
-  // CORE
+    type OdooDispatch = UIDispatch & OdooCommandDispatcher["dispatch"];
+    type OdooCoreDispatch = CoreDispatch & OdooCoreCommandDispatcher["dispatch"];
 
-  export interface ExtendedAddPivotCommand extends AddPivotCommand {
-    pivot: ExtendedPivotCoreDefinition;
-  }
+    // CORE
 
-  export interface ExtendedUpdatePivotCommand extends UpdatePivotCommand {
-    pivot: ExtendedPivotCoreDefinition;
-  }
+    export interface ExtendedAddPivotCommand extends AddPivotCommand {
+        pivot: ExtendedPivotCoreDefinition;
+    }
 
-  export interface AddThreadCommand {
-    type: "ADD_COMMENT_THREAD";
-    threadId: number;
-    sheetId: string;
-    col: number;
-    row: number;
-  }
+    export interface ExtendedUpdatePivotCommand extends UpdatePivotCommand {
+        pivot: ExtendedPivotCoreDefinition;
+    }
 
-  export interface EditThreadCommand {
-    type: "EDIT_COMMENT_THREAD";
-    threadId: number;
-    sheetId: string;
-    col: number;
-    row: number;
-    isResolved: boolean;
-  }
+    export interface AddThreadCommand {
+        type: "ADD_COMMENT_THREAD";
+        threadId: number;
+        sheetId: string;
+        col: number;
+        row: number;
+    }
 
-  export interface DeleteThreadCommand {
-    type: "DELETE_COMMENT_THREAD";
-    threadId: number;
-    sheetId: string;
-    col: number;
-    row: number;
-  }
+    export interface EditThreadCommand {
+        type: "EDIT_COMMENT_THREAD";
+        threadId: number;
+        sheetId: string;
+        col: number;
+        row: number;
+        isResolved: boolean;
+    }
 
-  // this command is deprecated. use UPDATE_PIVOT instead
-  export interface UpdatePivotDomainCommand {
-    type: "UPDATE_ODOO_PIVOT_DOMAIN";
-    pivotId: string;
-    domain: Array;
-  }
+    export interface DeleteThreadCommand {
+        type: "DELETE_COMMENT_THREAD";
+        threadId: number;
+        sheetId: string;
+        col: number;
+        row: number;
+    }
 
-  // UI
+    // this command is deprecated. use UPDATE_PIVOT instead
+    export interface UpdatePivotDomainCommand {
+        type: "UPDATE_ODOO_PIVOT_DOMAIN";
+        pivotId: string;
+        domain: Array;
+    }
 
-  export interface RefreshAllDataSourcesCommand {
-    type: "REFRESH_ALL_DATA_SOURCES";
-  }
+    export interface AddGlobalFilterCommand {
+        type: "ADD_GLOBAL_FILTER";
+        filter: CmdGlobalFilter;
+        [string]: any; // Fields matching
+    }
 
-  type OdooCoreCommand =
-    | ExtendedAddPivotCommand
-    | ExtendedUpdatePivotCommand
-    | UpdatePivotDomainCommand
-    | AddThreadCommand
-    | DeleteThreadCommand
-    | EditThreadCommand;
+    export interface EditGlobalFilterCommand {
+        type: "EDIT_GLOBAL_FILTER";
+        filter: CmdGlobalFilter;
+        [string]: any; // Fields matching
+    }
 
-  export type AllCoreCommand = OdooCoreCommand | CoreCommand;
+    export interface RemoveGlobalFilterCommand {
+        type: "REMOVE_GLOBAL_FILTER";
+        id: string;
+    }
 
-  type OdooLocalCommand = RefreshAllDataSourcesCommand;
-  type OdooCommand = OdooCoreCommand | OdooLocalCommand;
+    export interface MoveGlobalFilterCommand {
+        type: "MOVE_GLOBAL_FILTER";
+        id: string;
+        delta: number;
+    }
 
-  export type AllCommand = OdooCommand | Command;
+    // UI
+
+    export interface RefreshAllDataSourcesCommand {
+        type: "REFRESH_ALL_DATA_SOURCES";
+    }
+
+    export interface SetGlobalFilterValueCommand {
+        type: "SET_GLOBAL_FILTER_VALUE";
+        id: string;
+        value: any;
+        displayNames?: string[];
+    }
+
+    export interface SetManyGlobalFilterValueCommand {
+        type: "SET_MANY_GLOBAL_FILTER_VALUE";
+        filters: { filterId: string; value: any }[];
+    }
+
+    export interface ClearGlobalFilterValueCommand {
+        type: "CLEAR_GLOBAL_FILTER_VALUE";
+        id: string;
+    }
+
+    type OdooCoreCommand =
+        | ExtendedAddPivotCommand
+        | ExtendedUpdatePivotCommand
+        | UpdatePivotDomainCommand
+        | AddThreadCommand
+        | DeleteThreadCommand
+        | EditThreadCommand
+        | AddGlobalFilterCommand
+        | EditGlobalFilterCommand
+        | RemoveGlobalFilterCommand
+        | MoveGlobalFilterCommand;
+
+    export type AllCoreCommand = OdooCoreCommand | CoreCommand;
+
+    type OdooLocalCommand =
+        | RefreshAllDataSourcesCommand
+        | SetGlobalFilterValueCommand
+        | SetManyGlobalFilterValueCommand
+        | ClearGlobalFilterValueCommand;
+
+    type OdooCommand = OdooCoreCommand | OdooLocalCommand;
+
+    export type AllCommand = OdooCommand | Command;
 }

--- a/addons/spreadsheet/static/src/@types/env.d.ts
+++ b/addons/spreadsheet/static/src/@types/env.d.ts
@@ -1,12 +1,11 @@
-import { SpreadsheetChildEnv } from "@odoo/o-spreadsheet";
+import { SpreadsheetChildEnv as SSChildEnv } from "@odoo/o-spreadsheet";
 import { Services } from "services";
 
 declare module "@spreadsheet" {
-  import { Model } from "@odoo/o-spreadsheet";
+    import { Model } from "@odoo/o-spreadsheet";
 
-  export interface SpreadsheetChildEnv extends SpreadsheetChildEnv {
-    model: OdooSpreadsheetModel;
-    services: Services;
-  }
-
+    export interface SpreadsheetChildEnv extends SSChildEnv {
+        model: OdooSpreadsheetModel;
+        services: Services;
+    }
 }

--- a/addons/spreadsheet/static/src/@types/functions.d.ts
+++ b/addons/spreadsheet/static/src/@types/functions.d.ts
@@ -2,7 +2,7 @@ declare module "@spreadsheet" {
     import { AddFunctionDescription, Arg, EvalContext } from "@odoo/o-spreadsheet";
 
     export interface CustomFunctionDescription extends AddFunctionDescription {
-      compute: (this: ExtendedEvalContext, ...args: Arg[]) => any;
+        compute: (this: ExtendedEvalContext, ...args: Arg[]) => any;
     }
 
     interface ExtendedEvalContext extends EvalContext {

--- a/addons/spreadsheet/static/src/@types/getters.d.ts
+++ b/addons/spreadsheet/static/src/@types/getters.d.ts
@@ -1,15 +1,15 @@
 import { CorePlugin, Model, UID } from "@odoo/o-spreadsheet";
 import { ChartOdooMenuPlugin, OdooChartCorePlugin, OdooChartUIPlugin } from "@spreadsheet/chart";
 import { CurrencyPlugin } from "@spreadsheet/currency/plugins/currency";
-import {AccountingPlugin} from "addons/spreadsheet_account/static/src/plugins/accounting_plugin";
+import { AccountingPlugin } from "addons/spreadsheet_account/static/src/plugins/accounting_plugin";
 import { GlobalFiltersCorePlugin, GlobalFiltersUIPlugin } from "@spreadsheet/global_filters";
 import { ListCorePlugin, ListUIPlugin } from "@spreadsheet/list";
 import { IrMenuPlugin } from "@spreadsheet/ir_ui_menu/ir_ui_menu_plugin";
 import { PivotOdooCorePlugin } from "@spreadsheet/pivot";
 import { PivotCoreGlobalFilterPlugin } from "@spreadsheet/pivot/plugins/pivot_core_global_filter_plugin";
 
-type Getters = Model["getters"]
-type CoreGetters = CorePlugin["getters"]
+type Getters = Model["getters"];
+type CoreGetters = CorePlugin["getters"];
 
 /**
  * Union of all getter names of a plugin.
@@ -47,27 +47,28 @@ type GetterNames<Plugin extends { getters: readonly string[] }> = Plugin["getter
  * //   getCellValue: () => ...,
  * // }
  */
-type PluginGetters<Plugin extends { new(...args: unknown[]): any; getters: readonly string[] }> = Pick<InstanceType<Plugin>, GetterNames<Plugin>>;
+type PluginGetters<Plugin extends { new (...args: unknown[]): any; getters: readonly string[] }> =
+    Pick<InstanceType<Plugin>, GetterNames<Plugin>>;
 
 declare module "@spreadsheet" {
-  /**
-   * Add getters from custom plugins defined in odoo
-   */
+    /**
+     * Add getters from custom plugins defined in odoo
+     */
 
-  interface OdooCoreGetters extends CoreGetters { }
-  interface OdooCoreGetters extends PluginGetters<typeof GlobalFiltersCorePlugin> { }
-  interface OdooCoreGetters extends PluginGetters<typeof ListCorePlugin> { }
-  interface OdooCoreGetters extends PluginGetters<typeof OdooChartCorePlugin> { }
-  interface OdooCoreGetters extends PluginGetters<typeof ChartOdooMenuPlugin> { }
-  interface OdooCoreGetters extends PluginGetters<typeof IrMenuPlugin> { }
-  interface OdooCoreGetters extends PluginGetters<typeof PivotOdooCorePlugin> {}
-  interface OdooCoreGetters extends PluginGetters<typeof PivotCoreGlobalFilterPlugin> {}
+    interface OdooCoreGetters extends CoreGetters {}
+    interface OdooCoreGetters extends PluginGetters<typeof GlobalFiltersCorePlugin> {}
+    interface OdooCoreGetters extends PluginGetters<typeof ListCorePlugin> {}
+    interface OdooCoreGetters extends PluginGetters<typeof OdooChartCorePlugin> {}
+    interface OdooCoreGetters extends PluginGetters<typeof ChartOdooMenuPlugin> {}
+    interface OdooCoreGetters extends PluginGetters<typeof IrMenuPlugin> {}
+    interface OdooCoreGetters extends PluginGetters<typeof PivotOdooCorePlugin> {}
+    interface OdooCoreGetters extends PluginGetters<typeof PivotCoreGlobalFilterPlugin> {}
 
-  interface OdooGetters extends Getters { }
-  interface OdooGetters extends OdooCoreGetters { }
-  interface OdooGetters extends PluginGetters<typeof GlobalFiltersUIPlugin> { }
-  interface OdooGetters extends PluginGetters<typeof ListUIPlugin> { }
-  interface OdooGetters extends PluginGetters<typeof OdooChartUIPlugin> { }
-  interface OdooGetters extends PluginGetters<typeof CurrencyPlugin> { }
-  interface OdooGetters extends PluginGetters<typeof AccountingPlugin> { }
+    interface OdooGetters extends Getters {}
+    interface OdooGetters extends OdooCoreGetters {}
+    interface OdooGetters extends PluginGetters<typeof GlobalFiltersUIPlugin> {}
+    interface OdooGetters extends PluginGetters<typeof ListUIPlugin> {}
+    interface OdooGetters extends PluginGetters<typeof OdooChartUIPlugin> {}
+    interface OdooGetters extends PluginGetters<typeof CurrencyPlugin> {}
+    interface OdooGetters extends PluginGetters<typeof AccountingPlugin> {}
 }

--- a/addons/spreadsheet/static/src/@types/global_filter.d.ts
+++ b/addons/spreadsheet/static/src/@types/global_filter.d.ts
@@ -1,0 +1,70 @@
+import { Range, RangeData } from "@odoo/o-spreadsheet";
+
+declare module "@spreadsheet" {
+    export type RangeType = "fixedPeriod" | "relative" | "from_to";
+    export type RelativePeriod =
+        | "last_month"
+        | "last_week"
+        | "last_three_months"
+        | "last_six_months"
+        | "last_year"
+        | "last_three_years"
+        | "year_to_date";
+    export type DateFilterTimePeriod = RelativePeriod | "this_month" | "this_quarter" | "this_year";
+
+    export interface FieldMatching {
+        chain: string;
+        type: string;
+        offset?: number;
+    }
+
+    export interface TextGlobalFilter {
+        type: "text";
+        id: string;
+        label: string;
+        rangeOfAllowedValues?: Range;
+        defaultValue?: string;
+    }
+
+    export interface CmdTextGlobalFilter extends TextGlobalFilter {
+        rangeOfAllowedValues?: RangeData;
+    }
+
+    export interface DateGlobalFilterCommon {
+        type: "date";
+        id: string;
+        label: string;
+    }
+
+    export interface FromToDateGlobalFilter extends DateGlobalFilterCommon {
+        rangeType: "from_to";
+        defaultValue?: number[];
+    }
+
+    export interface RelativeDateGlobalFilter extends DateGlobalFilterCommon {
+        rangeType: "relative";
+        defaultValue?: DateFilterTimePeriod;
+    }
+
+    export interface FixedPeriodDateGlobalFilter extends DateGlobalFilterCommon {
+        rangeType: "fixedPeriod";
+        defaultValue?: { period?: string; yearOffset?: number };
+    }
+
+    export type DateGlobalFilter =
+        | FromToDateGlobalFilter
+        | RelativeDateGlobalFilter
+        | FixedPeriodDateGlobalFilter;
+
+    export interface RelationalGlobalFilter {
+        type: "relation";
+        id: string;
+        label: string;
+        modelName: string;
+        includeChildren: boolean;
+        defaultValue?: "current_user" | number[];
+    }
+
+    export type GlobalFilter = TextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter;
+    export type CmdGlobalFilter = CmdTextGlobalFilter | DateGlobalFilter | RelationalGlobalFilter;
+}

--- a/addons/spreadsheet/static/src/@types/misc.d.ts
+++ b/addons/spreadsheet/static/src/@types/misc.d.ts
@@ -1,0 +1,10 @@
+declare module "@spreadsheet" {
+    export interface Zone {
+        bottom: number;
+        left: number;
+        right: number;
+        top: number;
+    }
+
+    export interface LazyTranslatedString extends String {}
+}

--- a/addons/spreadsheet/static/src/@types/models.d.ts
+++ b/addons/spreadsheet/static/src/@types/models.d.ts
@@ -1,12 +1,16 @@
 declare module "@spreadsheet" {
-  import { Model } from "@odoo/o-spreadsheet";
+    import { Model } from "@odoo/o-spreadsheet";
 
-  export interface OdooSpreadsheetModel extends Model {
-    getters: OdooGetters;
-    dispatch: OdooDispatch;
-  }
+    export interface OdooSpreadsheetModel extends Model {
+        getters: OdooGetters;
+        dispatch: OdooDispatch;
+    }
 
-  export interface OdooSpreadsheetModelConstructor {
-    new (data: object, config: Partial<Model["config"]>, revisions: object[]): OdooSpreadsheetModel;
-  }
+    export interface OdooSpreadsheetModelConstructor {
+        new (
+            data: object,
+            config: Partial<Model["config"]>,
+            revisions: object[]
+        ): OdooSpreadsheetModel;
+    }
 }

--- a/addons/spreadsheet/static/src/@types/pivot.d.ts
+++ b/addons/spreadsheet/static/src/@types/pivot.d.ts
@@ -20,13 +20,10 @@ declare module "@spreadsheet" {
         actionXmlId: string;
     }
 
-    export type ExtendedPivotCoreDefinition =
-        | PivotCoreDefinition
-        | OdooPivotCoreDefinition;
-
+    export type ExtendedPivotCoreDefinition = PivotCoreDefinition | OdooPivotCoreDefinition;
 
     interface OdooPivot<T> extends Pivot<T> {
-      type: ExtendedPivotCoreDefinition["type"];
+        type: ExtendedPivotCoreDefinition["type"];
     }
     export interface GFLocalPivot {
         id: string;
@@ -62,7 +59,6 @@ declare module "@spreadsheet" {
         domain: Array;
         context: Object;
     }
-
 
     /* Params used for the odoo pivot model */
     export interface WebPivotModelParams {

--- a/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
+++ b/addons/spreadsheet/static/src/chart/plugins/odoo_chart_core_plugin.js
@@ -9,7 +9,7 @@ import { OdooCorePlugin } from "@spreadsheet/plugins";
  * @typedef {Object} Chart
  * @property {Object} fieldMatching
  *
- * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").FieldMatching} FieldMatching
+ * @typedef {import("@spreadsheet").FieldMatching} FieldMatching
  */
 
 export class OdooChartCorePlugin extends OdooCorePlugin {

--- a/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_date_from_to_value/filter_date_from_to_value.js
@@ -1,4 +1,4 @@
-/** @odoo-module */
+/** @ts-check */
 
 import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";

--- a/addons/spreadsheet/static/src/global_filters/components/filter_date_value/filter_date_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_date_value/filter_date_value.js
@@ -1,4 +1,4 @@
-/** @odoo-module */
+/** @ts-check */
 
 import { Component, onWillUpdateProps } from "@odoo/owl";
 import { DateTimeInput } from "@web/core/datetime/datetime_input";
@@ -6,6 +6,12 @@ import { monthsOptions } from "@spreadsheet/assets_backend/constants";
 import { QUARTER_OPTIONS } from "@web/search/utils/dates";
 
 const { DateTime } = luxon;
+
+/**
+ * @typedef {Object} DateOption
+ * @property {string} id
+ * @property {string | import("@spreadsheet").LazyTranslatedString} description
+ */
 
 export class DateFilterValue extends Component {
     static template = "spreadsheet_edition.DateFilterValue";
@@ -26,7 +32,7 @@ export class DateFilterValue extends Component {
         /** @type {number|undefined} */
         this.yearOffset = props.yearOffset;
         // date should be undefined if we don't have the yearOffset
-        /** @type {DateTime|undefined} */
+        /** @type {import("@web/core/l10n/dates").DateTime|undefined} */
         this.date =
             this.yearOffset !== undefined
                 ? DateTime.local().plus({ year: this.yearOffset })
@@ -40,7 +46,9 @@ export class DateFilterValue extends Component {
      * @returns {Array<Object>}
      */
     getDateOptions() {
-        return Object.values(QUARTER_OPTIONS).concat(monthsOptions);
+        /** @type {Record<string, DateOption>} */
+        const quarterOptions = QUARTER_OPTIONS;
+        return Object.values(quarterOptions).concat(monthsOptions);
     }
 
     isSelected(periodId) {

--- a/addons/spreadsheet/static/src/global_filters/components/filter_text_value/filter_text_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_text_value/filter_text_value.js
@@ -1,4 +1,4 @@
-/** @odoo-module */
+/** @ts-check */
 
 import { Component } from "@odoo/owl";
 import { _t } from "@web/core/l10n/translation";

--- a/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
+++ b/addons/spreadsheet/static/src/global_filters/components/filter_value/filter_value.js
@@ -1,4 +1,4 @@
-/** @odoo-module */
+/** @ts-check */
 
 import { MultiRecordSelector } from "@web/core/record_selectors/multi_record_selector";
 import { RELATIVE_DATE_RANGE_TYPES } from "@spreadsheet/helpers/constants";

--- a/addons/spreadsheet/static/src/global_filters/helpers.js
+++ b/addons/spreadsheet/static/src/global_filters/helpers.js
@@ -1,4 +1,4 @@
-/** @odoo-module */
+/** @ts-check */
 
 import { serializeDate, serializeDateTime } from "@web/core/l10n/dates";
 import { Domain } from "@web/core/domain";
@@ -7,7 +7,7 @@ import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
 import { RELATIVE_DATE_RANGE_TYPES } from "@spreadsheet/helpers/constants";
 
 /**
- * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").FieldMatching} FieldMatching
+ * @typedef {import("@spreadsheet").FieldMatching} FieldMatching
  */
 
 export function checkFiltersTypeValueCombination(type, value) {
@@ -67,7 +67,7 @@ export function checkFilterFieldMatching(fieldMatchings) {
  *
  * @param {Object} now current time, as luxon time
  * @param {number} offset offset to add to the date
- * @param {"last_month" | "last_week" | "last_year" | "last_three_years"} rangeType
+ * @param {import("@spreadsheet").RelativePeriod} rangeType
  * @param {string} fieldName
  * @param {"date" | "datetime"} fieldType
  *

--- a/addons/spreadsheet/static/src/helpers/odoo_functions_helpers.js
+++ b/addons/spreadsheet/static/src/helpers/odoo_functions_helpers.js
@@ -4,7 +4,7 @@
 /**
  * Extract the data source id (always the first argument) from the function
  * context of the given token.
- * @param {Token} tokenAtCursor
+ * @param {import("@odoo/o-spreadsheet").EnrichedToken} tokenAtCursor
  * @returns {string | undefined}
  */
 export function extractDataSourceId(tokenAtCursor) {

--- a/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
+++ b/addons/spreadsheet/static/src/list/plugins/list_core_plugin.js
@@ -30,7 +30,7 @@ const { getMaxObjectId } = helpers;
  * @property {ListDefinition} definition
  * @property {Object} fieldMatching
  *
- * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").FieldMatching} FieldMatching
+ * @typedef {import("@spreadsheet").FieldMatching} FieldMatching
  */
 
 export class ListCorePlugin extends OdooCorePlugin {

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_core_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_core_global_filter_plugin.js
@@ -6,7 +6,7 @@
  * @typedef {import("@spreadsheet").AllCoreCommand} AllCoreCommand
  * @typedef {import("@spreadsheet").GFLocalPivot} GFLocalPivot
  *
- * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").FieldMatching} FieldMatching
+ * @typedef {import("@spreadsheet").FieldMatching} FieldMatching
  */
 
 import { CommandResult } from "../../o_spreadsheet/cancelled_reason";

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_global_filter_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_global_filter_plugin.js
@@ -11,14 +11,14 @@ const { DateTime } = luxon;
 const { pivotTimeAdapter } = helpers;
 
 /**
- * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").FieldMatching} FieldMatching
+ * @typedef {import("@spreadsheet").FieldMatching} FieldMatching
  * @typedef {import("@odoo/o-spreadsheet").Token} Token
  */
 
 /**
  * Convert pivot period to the related filter value
  *
- * @param {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").RangeType} timeRange
+ * @param {import("@spreadsheet").RangeType} timeRange
  * @param {string} value
  * @returns {object}
  */

--- a/addons/spreadsheet/static/tests/global_filters/global_filter_helper_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filter_helper_test.js
@@ -1,4 +1,4 @@
-/** @odoo-module */
+/** @ts-check */
 import { getRelativeDateDomain } from "@spreadsheet/global_filters/helpers";
 import {
     getDateDomainDurationInDays,

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_chart_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_chart_test.js
@@ -1,12 +1,17 @@
-/** @odoo-module */
+/** @ts-check */
 
 import { globalFiltersFieldMatchers } from "../../src/global_filters/plugins/global_filters_core_plugin";
 import { createSpreadsheetWithChart } from "../utils/chart";
 import { addGlobalFilter, setGlobalFilterValue } from "../utils/commands";
 import { patchDate } from "@web/../tests/helpers/utils";
 
+/**
+ * @typedef {import("@spreadsheet").DateGlobalFilter} DateGlobalFilter
+ */
+
 async function addChartGlobalFilter(model) {
     const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
+    /** @type {DateGlobalFilter}*/
     const filter = {
         id: "42",
         type: "date",
@@ -46,6 +51,8 @@ QUnit.module("spreadsheet > Global filters chart", {}, () => {
         const { model } = await createSpreadsheetWithChart();
         assert.equal(model.getters.getGlobalFilters().length, 0);
         const chartId = model.getters.getChartIds(model.getters.getActiveSheetId())[0];
+
+        /** @type {DateGlobalFilter}*/
         const filter = {
             id: "42",
             type: "date",

--- a/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
+++ b/addons/spreadsheet/static/tests/global_filters/global_filters_model_test.js
@@ -1,4 +1,4 @@
-/** @odoo-module */
+/** @ts-check */
 
 import { nextTick, patchDate, patchTimeZone } from "@web/../tests/helpers/utils";
 import { CommandResult } from "@spreadsheet/o_spreadsheet/cancelled_reason";
@@ -51,7 +51,7 @@ const { DateTime } = luxon;
 const { toZone } = helpers;
 
 /**
- * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").GlobalFilter} GlobalFilter
+ * @typedef {import("@spreadsheet").GlobalFilter} GlobalFilter
  *
  */
 

--- a/addons/spreadsheet/static/tests/utils/chart.js
+++ b/addons/spreadsheet/static/tests/utils/chart.js
@@ -5,7 +5,10 @@ import * as spreadsheet from "@odoo/o-spreadsheet";
 import { createModelWithDataSource } from "./model";
 const uuidGenerator = new spreadsheet.helpers.UuidGenerator();
 
-/** @typedef {import("@odoo/o-spreadsheet").Model} Model */
+/**
+ * @typedef {import("@odoo/o-spreadsheet").Model} Model
+ * @typedef {import("@spreadsheet").OdooSpreadsheetModel} OdooSpreadsheetModel
+ */
 
 /**
  *
@@ -36,7 +39,7 @@ export function insertChartInSpreadsheet(
  * @param {string} [params.type]
  * @param {import("./data").ServerData} [params.serverData]
  *
- * @returns { Promise<{ model: Model, env: Object }>}
+ * @returns { Promise<{ model: OdooSpreadsheetModel, env: Object }>}
  */
 export async function createSpreadsheetWithChart(params = {}) {
     const model = await createModelWithDataSource(params);

--- a/addons/spreadsheet/static/tests/utils/commands.js
+++ b/addons/spreadsheet/static/tests/utils/commands.js
@@ -1,4 +1,4 @@
-/** @odoo-module */
+/** @ts-check */
 
 import * as spreadsheet from "@odoo/o-spreadsheet";
 import { waitForDataLoaded } from "@spreadsheet/helpers/model";
@@ -7,7 +7,10 @@ import { nextTick } from "@web/../tests/helpers/utils";
 const { toCartesian, toZone, lettersToNumber } = spreadsheet.helpers;
 
 /**
- * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").GlobalFilter} GlobalFilter
+ * @typedef {import("@spreadsheet").GlobalFilter} GlobalFilter
+ * @typedef {import("@spreadsheet").CmdGlobalFilter} CmdGlobalFilter
+ * @typedef {import("@spreadsheet").OdooSpreadsheetModel} OdooSpreadsheetModel
+ * @typedef {import("@odoo/o-spreadsheet").UID} UID
  */
 
 /**
@@ -23,8 +26,8 @@ export function selectCell(model, xc, sheetId = model.getters.getActiveSheetId()
 
 /**
  * Add a global filter and ensure the data sources are completely reloaded
- * @param {Model} model
- * @param {{filter: GlobalFilter}} filter
+ * @param {import("@spreadsheet").OdooSpreadsheetModel} model
+ * @param {CmdGlobalFilter} filter
  */
 export async function addGlobalFilter(model, filter, fieldMatchings = {}) {
     const result = model.dispatch("ADD_GLOBAL_FILTER", { filter, ...fieldMatchings });
@@ -112,7 +115,7 @@ export function setCellStyle(model, xc, style, sheetId = model.getters.getActive
 
 /**
  * Add columns
- * @param {Model} model
+ * @param {OdooSpreadsheetModel} model
  * @param {"before"|"after"} position
  * @param {string} column
  * @param {number} quantity
@@ -136,7 +139,7 @@ export function addColumns(
 
 /**
  * Delete columns
- * @param {Model} model
+ * @param {OdooSpreadsheetModel} model
  * @param {string[]} columns
  * @param {UID} sheetId
  */

--- a/addons/spreadsheet/static/tests/utils/global_filter.js
+++ b/addons/spreadsheet/static/tests/utils/global_filter.js
@@ -1,7 +1,7 @@
-/** @odoo-module */
+/** @ts-check */
 
 /**
- * @typedef {import("@spreadsheet/global_filters/plugins/global_filters_core_plugin").GlobalFilter} GlobalFilter
+ * @typedef {import("@spreadsheet").GlobalFilter} GlobalFilter
  *
  */
 

--- a/addons/spreadsheet/static/tests/utils/model.js
+++ b/addons/spreadsheet/static/tests/utils/model.js
@@ -13,7 +13,7 @@ import { OdooDataProvider } from "@spreadsheet/data_sources/odoo_data_provider";
 
 /**
  * @typedef {import("@spreadsheet/../tests/utils/data").ServerData} ServerData
- * @typedef {import("@spreadsheet/o_spreadsheet/o_spreadsheet").Model} Model
+ * @typedef {import("@spreadsheet").OdooSpreadsheetModel} OdooSpreadsheetModel
  */
 
 export function setupDataSourceEvaluation(model) {
@@ -31,6 +31,8 @@ export function setupDataSourceEvaluation(model) {
  * @param {object} [params.modelConfig]
  * @param {ServerData} [params.serverData] Data to be injected in the mock server
  * @param {function} [params.mockRPC] Mock rpc function
+ *
+ * @returns {Promise<OdooSpreadsheetModel>}
  */
 export async function createModelWithDataSource(params = {}) {
     registry.category("services").add("orm", ormService, { force: true });
@@ -43,6 +45,7 @@ export async function createModelWithDataSource(params = {}) {
         mockRPC: params.mockRPC,
     });
     const config = params.modelConfig;
+    /** @type any*/
     const model = new Model(params.spreadsheetData, {
         ...config,
         custom: {

--- a/addons/spreadsheet/static/tests/utils/pivot.js
+++ b/addons/spreadsheet/static/tests/utils/pivot.js
@@ -10,15 +10,19 @@ import { waitForDataLoaded } from "@spreadsheet/helpers/model";
 import { helpers } from "@odoo/o-spreadsheet";
 const { parseDimension } = helpers;
 
-/** @typedef {import("@spreadsheet/o_spreadsheet/o_spreadsheet").Model} Model */
+/**
+ * @typedef {import("@spreadsheet").OdooSpreadsheetModel} OdooSpreadsheetModel
+ * @typedef {import("@spreadsheet").Zone} Zone
+ */
 
 /**
- * @param {Model} model
+ * @param {OdooSpreadsheetModel} model
  * @param {string} pivotId
  * @param {object} params
- * @param {string} params.arch
- * @param {string} params.resModel
- * @param {object} params.serverData
+ * @param {string} [params.arch]
+ * @param {string} [params.resModel]
+ * @param {object} [params.serverData]
+ * @param {string} [params.sheetId]
  * @param {[number, number]} [params.anchor]
  */
 export async function insertPivotInSpreadsheet(model, pivotId, params) {
@@ -71,7 +75,7 @@ export async function insertPivotInSpreadsheet(model, pivotId, params) {
  * @param {string} [params.arch]
  * @param {object} [params.serverData]
  * @param {function} [params.mockRPC]
- * @returns {Promise<{ model: Model, env: object}>}
+ * @returns {Promise<{ model: OdooSpreadsheetModel, env: object, pivotId: string}>}
  */
 export async function createSpreadsheetWithPivot(params = {}) {
     const serverData = params.serverData || getBasicServerData();


### PR DESCRIPTION
This commit fixes & improves the typing of the global filter related files, and enable type checking on the files.

Note that some files are still in red for typing issues:
- in the business code, it's mostly due to wrong typing of LazyTranslatedString
- in the tests, the import of legacy files isn't resolving properly.

Task: [3948130](https://www.odoo.com/web#id=3948130&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
