### PR TITLE
[FIX] l10n_it_edi: compute l10n_it_tax_representative_partner_id

### DIFF
--- a/addons/l10n_it_edi/models/res_company.py
+++ b/addons/l10n_it_edi/models/res_company.py
@@ -116,3 +116,9 @@ class ResCompany(models.Model):
                 raise ValidationError(_("Your tax representative partner must have a tax number."))
             if not record.l10n_it_tax_representative_partner_id.country_id:
                 raise ValidationError(_("Your tax representative partner must have a country."))
+
+    @api.onchange("l10n_it_has_tax_representative")
+    def _onchange_l10n_it_has_tax_represeentative(self):
+        for company in self:
+            if not company.l10n_it_has_tax_representative:
+                company.l10n_it_tax_representative_partner_id = False


### PR DESCRIPTION
When setting `l10n_it_has_tax_representative` to False,
the field `l10n_it_tax_representative_partner_id` stays set,
this leads to inconsistencies when generating the xml on e-invoicing.

Steps:

- Install l10n_it_edi
- Go to the form view of the italian company
- On E-invoicing tab, check the `l10n_it_has_tax_representative` field,
  set `l10n_it_tax_representative_partner` and save
- Create and confirm an invoice
- Check the xml that has been generated, there is a field
  `RappresentanteFiscale` with `l10n_it_tax_representative_partner`
  infos
- Go back to company form view, uncheck the
  `l10n_it_has_tax_representative` field and save
- Create and confirm an other invoice
- Check the xml generated
-> The field `RappresentanteFiscale`
  is still there, it should not be.

Fix:

Add a compute to `l10n_it_tax_representative_partner` to set it
to False when unchecking `l10n_it_has_tax_representative`

opw-3947519
