### PR TITLE
[FIX] web_editor: prevent adding rendering classes on the field observer

### DIFF
--- a/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
+++ b/addons/web_editor/static/src/js/wysiwyg/wysiwyg.js
@@ -1200,6 +1200,8 @@ export class Wysiwyg extends Component {
         } else {
             const odooFieldSelector = '[data-oe-model], [data-oe-translation-initial-sha]';
             const $odooFields = this.$editable.find(odooFieldSelector);
+            const renderingClassesSelector = this.odooEditor.options.renderingClasses
+                .map(className => `.${className}`).join(", ");
             this.odooFieldObservers = [];
 
             $odooFields.each((i, field) => {
@@ -1267,7 +1269,13 @@ export class Wysiwyg extends Component {
                     if ($node.hasClass('o_editable_date_field_format_changed')) {
                         $nodes.addClass('o_editable_date_field_format_changed');
                     }
-                    const html = $node.html();
+                    // Ignore the editor's rendering classes when copying field
+                    // content.
+                    const fieldNodeClone = $node[0].cloneNode(true);
+                    for (const node of fieldNodeClone.querySelectorAll(renderingClassesSelector)) {
+                        node.classList.remove(...this.odooEditor.options.renderingClasses);
+                    }
+                    const html = $(fieldNodeClone).html();
                     for (const node of $nodes) {
                         if (node.classList.contains('o_translation_without_style')) {
                             // For generated elements such as the navigation


### PR DESCRIPTION
Steps to reproduce [17.0]:

- Go to website (in "Edit" mode) > Click on the "Contact Us" button
- Save the page > The menu will be saved with the "oe_edited_link" class
applied to it.

Technical explanation (one of many scenarios causing the bug) [1]:

After the website headers redesign in [2], two header navbars were added
(for the desktop view and mobile). Which means that the "Contact Us"
field is duplicated in the DOM.

When clicking on the "Contact Us" desktop link, the `LinkPopoverWidget`
will initialize a popover on it. The bootstrap code is automatically
adding `data-original-title` and 'title' attributes to the targeted link
(see: [3]), and as a consequence, the field observer will take in
consideration the mutations and copy the DOM in the mobile version,
leading to save the link in the same state when the BS popover was
applied to it (with the `oe_edited_link` class).

Remarks:

- This behaviour was detected on 17.0, but we target 15.0 here to prevent
similar issues linked to duplicated fields with links in the DOM.

- The bootstrap attributes mutations (as explained in [1]) are just an
example of many possible mutations (filtered by `observerUnactive()` in
the main editor observer) that can cause the issue... Since we cannot
set filters for all these mutations in the fields' observer, we ignore
the `oe_edited_link` (and all editor's rendering classes) when copying
the field content to solve the issue here. The field observer logic
needs to be refactored to probably disable / enable the fields'
synchronization when the editor's observer is disabled / enabled.

[2]: https://github.com/odoo/odoo/pull/119650
[3]: https://github.com/odoo/odoo/blob/15.0/addons/web/static/lib/bootstrap/js/tooltip.js#L664

opw-3938383