### PR TITLE
[PERF] stock: reduce forecast info query count

### DIFF
--- a/addons/stock/models/stock_move.py
+++ b/addons/stock/models/stock_move.py
@@ -2159,6 +2159,26 @@ Please change the quantity done or the rounding precision of your unit of measur
                                                          order='reservation_date, priority desc, date asc, id asc')
         moves_to_reserve._action_assign()
 
+    def _rollup_move_dests_fetch(self):
+        seen = set(self.ids)
+        self.fetch(['move_dest_ids'])
+        move_dest_ids = set(self.move_dest_ids.ids)
+        while not move_dest_ids.issubset(seen):
+            seen |= move_dest_ids
+            to_visit = self.browse(move_dest_ids)
+            to_visit.fetch(['move_dest_ids'])
+            move_dest_ids = set(to_visit.move_dest_ids.ids)
+
+    def _rollup_move_origs_fetch(self):
+        seen = set(self.ids)
+        self.fetch(['move_orig_ids'])
+        move_orig_ids = set(self.move_orig_ids.ids)
+        while not move_orig_ids.issubset(seen):
+            seen |= move_orig_ids
+            to_visit = self.browse(move_orig_ids)
+            to_visit.fetch(['move_orig_ids'])
+            move_orig_ids = set(to_visit.move_orig_ids.ids)
+
     def _rollup_move_dests(self, seen=False):
         if not seen:
             seen = OrderedSet()

--- a/addons/stock/report/stock_forecasted.py
+++ b/addons/stock/report/stock_forecasted.py
@@ -184,9 +184,8 @@ class StockForecasted(models.AbstractModel):
 
     def _get_report_lines(self, product_template_ids, product_ids, wh_location_ids, wh_stock_location, read=True):
 
-        def _get_out_move_reserved_data(out, ins, used_reserved_moves, currents):
+        def _get_out_move_reserved_data(out, linked_moves, used_reserved_moves, currents):
             reserved_out = 0
-            linked_moves = self.env['stock.move'].browse(out._rollup_move_origs()).filtered(lambda m: m.id not in ins.ids)
             # the move to show when qty is reserved
             reserved_move = self.env['stock.move']
             for move in linked_moves:
@@ -269,11 +268,34 @@ class StockForecasted(models.AbstractModel):
         )
 
         outs = self.env['stock.move'].search(out_domain, order='reservation_date, priority desc, date, id')
+        ins = self.env['stock.move'].search(in_domain, order='priority desc, date, id')
+        # Prewarm cache with rollups
+        outs._rollup_move_origs_fetch()
+        ins._rollup_move_dests_fetch()
+
+        linked_moves_per_out = {}
+        ins_ids = set(ins._ids)
+        for out in outs:
+            linked_move_ids = out._rollup_move_origs() - ins_ids
+            linked_moves_per_out[out] = self.env['stock.move'].browse(linked_move_ids)
+        
+        # Gather all linked moves
+        all_linked_move_ids = {_id for _ids in linked_moves_per_out.values() for _id in _ids._ids}
+        all_linked_moves = self.env['stock.move'].browse(all_linked_move_ids)
+
+        # Prewarm cache with sibling move's state/quantity
+        all_linked_moves.fetch(['move_orig_ids'])
+        all_linked_moves.move_orig_ids.fetch(['move_dest_ids'])
+        all_linked_moves.move_orig_ids.move_dest_ids.fetch(['state', 'quantity'])
+
+        # Share prefetch ids among all linked moves for performance
+        for out, linked_moves in linked_moves_per_out.items():
+            linked_moves_per_out[out] = linked_moves.with_prefetch(all_linked_moves._prefetch_ids)
+
         outs_per_product = defaultdict(list)
         for out in outs:
             outs_per_product[out.product_id.id].append(out)
 
-        ins = self.env['stock.move'].search(in_domain, order='priority desc, date, id')
         ins_per_product = defaultdict(list)
         for in_ in ins:
             ins_per_product[in_.product_id.id].append({
@@ -284,7 +306,7 @@ class StockForecasted(models.AbstractModel):
 
         qties = self.env['stock.quant']._read_group([('location_id', 'in', wh_location_ids), ('quantity', '>', 0), ('product_id', 'in', outs.product_id.ids)],
                                                     ['product_id', 'location_id'], ['quantity:sum'])
-        wh_stock_sub_location_ids = wh_stock_location.search([('id', 'child_of', wh_stock_location.id)]).ids
+        wh_stock_sub_location_ids = set(wh_stock_location.search([('id', 'child_of', wh_stock_location.id)])._ids)
         currents = defaultdict(float)
         for product, location, quantity in qties:
             location_id = location.id
@@ -298,7 +320,7 @@ class StockForecasted(models.AbstractModel):
             used_reserved_moves = defaultdict(float)
             # for all out moves, check for linked moves and count reserved quantity
             for out in out_moves:
-                moves_data[out] = _get_out_move_reserved_data(out, ins, used_reserved_moves, currents)
+                moves_data[out] = _get_out_move_reserved_data(out, linked_moves_per_out[out], used_reserved_moves, currents)
             # another loop to remove qty from current stock after reserved is counted for
             for out in out_moves:
                 data = _get_out_move_taken_from_stock_data(out, currents, moves_data[out])


### PR DESCRIPTION
Improve runtime of `stock.forecasted_product_product._get_report_lines` by reducing total query count, as well as some other minor optimizations.

Reduce query count of `_get_report_lines` by:
1.) Introducing and utilizing two new `stock.move` methods, `_rollup_move_dests_fetch` and `_rollup_move_origs_fetch`. (More details below)
2.) Share _prefetch_ids between linked moves. By grouping their prefetching together we will ensure that fewer unnessesary queries will be made. Without doing this, then for N linked moves there would be at least N queries for each linked move during all the calls to `_get_out_move_reserved_data`. With prefetching we are at least making N/1000 queries, which is much better. Ultimately, it would be most optimal to use `.read` to make only one query up front - but this would likely require a total rework of much of the code in `stock.forecasted_product_product` (as well as modules which inherit from this). Prefetching is much simpler for now, and the gains are good enough to warrant doing it.
3.) Call `fetch` to get the `state` and `quantity` fields from all sibling moves. These could instead be added into the consolidated prefetch_ids. Maybe that is more preferable, but I think `fetch` here is OK because we only need those two fields from the sibling moves.

Other minor optimizations include:
1.) Use sets instead of recordsets where it would make sense to do so. Because, when the `in` operator is used, it is more efficient to use set's `in` (O(1)) vs recordset's `in` (O(N)).
2.) Use `._ids` instead of `.ids` where we can get away with it. In places where we are have freshly searched recordsets, there is no possibility for any NewIds to be present. So it should be safe to use `._ids` here, which avoids some extra constant time work that `.ids` would impose.

`_rollup_move_x_fetch` (x is dests or origs):
These methods are intended to be used to reduce the total number of queries made in situations where you have N moves and you need to call `_rollup_move_x` on all of them. If you do this, for each move you call rollup on, you'd make O(len(P)) queries where P is the longest "path" formed in the tree of moves. Since you do this N times, you'd end up overall with O(N*len(P)) queries. If you call `_rollup_move_x_fetch` on a recordset containing all N moves, it loads all of the moves into the cache that would have to be loaded if you call `_rollup_move_x` on all of them individually. The number of queries `_rollup_move_x_fetch` makes for N records is only O(len(P)), because it is able to traverse the move tree in a breadth first manner for all nodes, loading as many as is possible at each step. Since len(P) is likely to be small for any given database (citation needed), you could effectively consider it constant O(1). Even in the worst case, where all the moves only form a single long path, len(P) will be at most N. Once you then call `_rollup_move_x` on each individual move, because all the moves are already loaded into the cache it will make 0 queries. This leaves us with the following conclusion: `_rollup_move_x` alone is ~O(N) queries, and `_rollup_move_x` with `_rollup_move_x_fetch` beforehand is ~O(1) queries. In the worst case described where len(P)=N, it will degrade to O(N), which would not be any different than before.

Benchmarks:
In the customer's database locally, (after re-adding `components_availability` and `components_availability_state` to their view, which was removed previously as a work-around):

Log line stats for loading the manufacturing order list view:

|                               | # queries       | SQL time     | Odoo time | total time     |
|-------------------------|--------------------|------------------|-----------------|-------------------|
| before commit   | 149128           | 23.736 s       | 46.842 s     | 70.578 s       |
| after commit      | 144                  | 0.914 s         | 11.335 s     | 12.249 s       |
|                               |                         |                       |                     |                       |
| % improvement |  ~915x fewer | ~26x faster  | ~4x faster  | ~5.7x faster |

Before and after commit pretty much all of the Odoo time of the request is spent in `_get_report_lines`, so I don't think it's necessary to provide benchmarks seperately for this function.

Help Ticket # to see also which exhibit this issue:
3818495
3918816
3920584

opw-3769280


I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
