### PR TITLE
[FIX] account: fix dedicated credit note sequence

### DIFF
--- a/addons/account/models/account_journal.py
+++ b/addons/account/models/account_journal.py
@@ -126,6 +126,7 @@ class AccountJournal(models.Model):
     country_code = fields.Char(related='company_id.account_fiscal_country_id.code', readonly=True)
 
     refund_sequence = fields.Boolean(string='Dedicated Credit Note Sequence', help="Check this box if you don't want to share the same sequence for invoices and credit notes made from this journal", default=False)
+    change_sequence = fields.Char(string="Change Sequence", compute="_compute_change_sequence", default=False, store=True)
     payment_sequence = fields.Boolean(
         string='Dedicated Payment Sequence',
         compute='_compute_payment_sequence', readonly=False, store=True, precompute=True,
@@ -420,6 +421,13 @@ class AccountJournal(models.Model):
             temp_move = self.env['account.move'].new({'journal_id': journal.id})
             journal.accounting_date = temp_move._get_accounting_date(move_date, has_tax)
 
+    @api.depends("refund_sequence")
+    def _compute_change_sequence(self):
+        for journal in self:
+            if journal.change_sequence:
+                journal.change_sequence = False
+            else:
+                journal.change_sequence = True
 
     @api.onchange('type')
     def _onchange_type_for_alias(self):

--- a/addons/account/models/sequence_mixin.py
+++ b/addons/account/models/sequence_mixin.py
@@ -213,10 +213,12 @@ class SequenceMixin(models.AbstractModel):
             where_string += " AND sequence_prefix = %(with_prefix)s "
             param['with_prefix'] = with_prefix
 
+        name_start_with_condition = "AND sequence_prefix NOT LIKE %(name_start_with)s" if param.get('name_start_with') else ""
+
         query = f"""
                 SELECT {self._sequence_field} FROM {self._table}
                 {where_string}
-                AND sequence_prefix = (SELECT sequence_prefix FROM {self._table} {where_string} ORDER BY id DESC LIMIT 1)
+                AND sequence_prefix = (SELECT sequence_prefix FROM {self._table} {where_string} {name_start_with_condition} ORDER BY id DESC LIMIT 1)
                 ORDER BY sequence_number DESC
                 LIMIT 1
         """
@@ -318,7 +320,6 @@ class SequenceMixin(models.AbstractModel):
                     raise e
         self._compute_split_sequence()
         self.flush_recordset(['sequence_prefix', 'sequence_number'])
-
 
     def _is_last_from_seq_chain(self):
         """Tells whether or not this element is the last one of the sequence chain.


### PR DESCRIPTION
This PR addresses the issue where changing the dedicated sequence on the credit notes feature in the Customer Invoice Journal and Vendor Bill Journal leads to incorrect sequencing of invoices and their credit notes, and vendor bills and their credit notes.

The sequence now correctly follows the order of creation for these documents, based on the value of the dedicated sequence on credit notes. This resolves the observed discrepancies in both use cases outlined in the task specifications.

**task**-3922020

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
