### PR TITLE
[IMP] website, web_editor: allow no default value for selection field

### DIFF
--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2332,6 +2332,11 @@ const ListUserValueWidget = UserValueWidget.extend({
         if (id) {
             inputEl.name = id;
         }
+        // Hiding the placeholder options from options list of editor
+        if (id === "" && !this.listTable.hasChildNodes()) {
+            trEl.classList.add("d-none");
+            inputEl.classList.add("o_we_list_placeholder");
+        }
         if (recordData) {
             recordDataSelected = recordData.selected;
             if (recordData.placeholder) {
@@ -2408,6 +2413,9 @@ const ListUserValueWidget = UserValueWidget.extend({
         const trimmed = (str) => str.trim().replace(/\s+/g, " ");
         const values = [...this.listTable.querySelectorAll('.o_we_list_record_name input')].map(el => {
             const id = trimmed(isIdModeName ? el.name : el.value);
+            if (el.classList.contains("o_we_list_placeholder")) {
+                id = "";
+            }
             return Object.assign({
                 id: /^-?[0-9]{1,15}$/.test(id) ? parseInt(id) : id,
                 name: trimmed(el.value),

--- a/addons/web_editor/static/src/js/editor/snippets.options.js
+++ b/addons/web_editor/static/src/js/editor/snippets.options.js
@@ -2412,7 +2412,7 @@ const ListUserValueWidget = UserValueWidget.extend({
         const isIdModeName = this.el.dataset.idMode === "name" || !this.isCustom;
         const trimmed = (str) => str.trim().replace(/\s+/g, " ");
         const values = [...this.listTable.querySelectorAll('.o_we_list_record_name input')].map(el => {
-            const id = trimmed(isIdModeName ? el.name : el.value);
+            let id = trimmed(isIdModeName ? el.name : el.value);
             if (el.classList.contains("o_we_list_placeholder")) {
                 id = "";
             }

--- a/addons/website/static/src/snippets/s_website_form/options.js
+++ b/addons/website/static/src/snippets/s_website_form/options.js
@@ -238,7 +238,7 @@ const FormEditor = options.Class.extend({
         const template = document.createElement('template');
         const renderType = field.type === "tags" ? "many2many" : field.type;
         template.content.append(renderToElement("website.form_field_" + renderType, params));
-        if (!field.noNullOption && field.type == "many2one") {
+        if (!field.noNullOption && field.type === "many2one") {
             template.content.querySelector("option").classList.add("s_website_form_placeholder");
         }
         if (field.description && field.description !== true) {
@@ -1056,15 +1056,22 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
         field.description = !!value; // Will be changed to default description in qweb
         await this._replaceField(field);
     },
-    applyPlaceholder: async function(previewMode, value, params) {
+    async applyPlaceholder(previewMode, value, params) {
         const field = this._getActiveField();
         field.placeholder = value;
         await this._replaceField(field);
     },
-    allowEmpty: async function(previewMode, value, params) {
+    async allowEmpty(previewMode, value, params) {
         const field = this._getActiveField();
         field.noNullOption = !value;
         await this._replaceField(field);
+        // Mark field required if allowEmpty = false.
+        this.$target[0].classList.toggle("s_website_form_required", !value);
+        this.$target[0].querySelectorAll('input, select, textarea').forEach(el => el.toggleAttribute('required', !value));
+        this.trigger_up('option_update', {
+            optionName: 'WebsiteFormEditor',
+            name: 'field_mark',
+        });
     },
     /**
      * Replace the current field with the custom field selected.
@@ -1202,20 +1209,6 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
      */
     renderListItems: async function (previewMode, value, params) {
         let valueList = JSON.parse(value);
-        if (this._getSelect()) {
-            // Default entry only for fields rendered as select.
-            // Remove previous default.
-            valueList = valueList.filter(value => value.id !== "" || value.display_name !== "");
-            // Add default in first position if no default value is set.
-            const hasDefault = valueList.some(value => value.selected);
-            if (valueList.length && !hasDefault) {
-                valueList.unshift({
-                    id: "",
-                    display_name: "",
-                    selected: true,
-                });
-            }
-        }
 
         // Synchronize the possible values with the fields whose visibility
         // depends on the current field
@@ -1313,7 +1306,7 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
             case 'toggleRequired':
                 return this.$target[0].classList.contains(params.activeValue) ? params.activeValue : 'false';
             case 'renderListItems':
-                return JSON.stringify(this._getListItems(true));
+                return JSON.stringify(this._getListItems());
             case 'setVisibilityDependency':
                 return this.$target[0].dataset.visibilityDependency || '';
         }
@@ -1352,11 +1345,13 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
                 }
                 return (['text', 'email', 'tel', 'url', 'search', 'password', 'number'].includes(dependencyEl.type)
                     || dependencyEl.nodeName === 'TEXTAREA') && !['set', '!set'].includes(this.$target[0].dataset.visibilityComparator);
-            case "hidden_condition_option_list":
-                return dependencyEl && (dependencyEl.type === "checkbox" || dependencyEl.type === "radio" || dependencyEl.nodeName === "SELECT")
-                    && !["set", "!set"].includes(this.$target[0].dataset.visibilityComparator);
             case 'hidden_condition_no_text_opt':
-                return dependencyEl && (dependencyEl.type === 'checkbox' || dependencyEl.type === 'radio' || dependencyEl.nodeName === 'SELECT');
+                const isCheckboxRadioOrSelect = dependencyEl &&
+                    (['checkbox', 'radio'].includes(dependencyEl.type) || dependencyEl.nodeName === 'SELECT');
+                if( params.attributeName === "visibilityCondition" ) {
+                    return isCheckboxRadioOrSelect && !['set', '!set'].includes(this.$target[0].dataset.visibilityComparator);
+                }
+                return isCheckboxRadioOrSelect;
             case 'hidden_condition_num_opt':
                 return dependencyEl && dependencyEl.type === 'number';
             case 'hidden_condition_text_opt':
@@ -1386,7 +1381,11 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
             case 'multi_check_display_opt':
                 return !!this._getMultipleInputs();
             case "required_opt":
-                return !["many2one"].includes(this.$target[0].dataset.type) || this.$target[0].querySelector(".s_website_form_placeholder");
+                return !this.$target[0].classList.contains('s_website_form_model_required')
+                    && (
+                        !["many2one"].includes(this.$target[0].dataset.type)
+                        || this.$target[0].querySelector(".s_website_form_placeholder")
+                    );
             case 'hidden_opt':
             case 'type_opt':
                 return !this.$target[0].classList.contains('s_website_form_model_required');
@@ -1704,23 +1703,13 @@ options.registry.WebsiteFieldEditor = FieldEditor.extend({
     },
     /**
      * @private
-     * @param {boolean} removeEmptyValue
      */
-    _getListItems(removeEmptyValue) {
+    _getListItems() {
         const select = this._getSelect();
         const multipleInputs = this._getMultipleInputs();
         let options = [];
         if (select) {
             options = [...select.querySelectorAll('option')];
-            if (
-                removeEmptyValue &&
-                options.length &&
-                options[0].value === "" &&
-                options[0].textContent === "" &&
-                options[0].selected === true
-            ) {
-                options.shift();
-            }
         } else if (multipleInputs) {
             options = [...multipleInputs.querySelectorAll('.checkbox input, .radio input')];
         }

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -382,15 +382,15 @@ registerWebsitePreviewTour("website_form_editor_tour", {
     // Customize custom selection field
     {
         content: "Change Option 1 Label",
-        trigger: 'we-list table input:eq(0)',
+        trigger: 'we-list table input:visible:eq(0)',
         run: "edit Germany",
     }, {
         content: "Change Option 2 Label",
-        trigger: 'we-list table input:eq(1)',
+        trigger: 'we-list table input:visible:eq(1)',
         run: "edit Belgium",
     }, {
         content: "Change first Option 3 label",
-        trigger: 'we-list table input:eq(2)',
+        trigger: 'we-list table input:visible:eq(2)',
         run: "edit France",
     },
     {
@@ -412,12 +412,12 @@ registerWebsitePreviewTour("website_form_editor_tour", {
     },
     {
         content: "Change last Option label",
-        trigger: 'we-list table input:eq(3)',
+        trigger: 'we-list table input:visible:eq(3)',
         // TODO: Fix code to avoid blur event
         run: "edit Canada",
     }, {
         content: "Remove Germany Option",
-        trigger: '.o_we_select_remove_option:eq(0)',
+        trigger: '.o_we_select_remove_option:visible:eq(0)',
         run: "click",
     },
     {
@@ -432,11 +432,11 @@ registerWebsitePreviewTour("website_form_editor_tour", {
         run: "click",
     }, {
         content: "Change last option label with a number",
-        trigger: 'we-list table input:eq(3)',
+        trigger: 'we-list table input:visible:eq(3)',
         run: "edit 44 - UK",
     }, {
         content: "Check that the input value is the full option value",
-        trigger: 'we-list table input:eq(3)',
+        trigger: 'we-list table input:visible:eq(3)',
         run: () => {
             // We need this 'setTimeout' to ensure that the 'input' event of
             // the input has enough time to be executed (see the
@@ -453,11 +453,28 @@ registerWebsitePreviewTour("website_form_editor_tour", {
         trigger: ":iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +
                     ":has(label:contains('State'))" +
                     ":has(select[required])" +
+                    ":has(option:contains('Please choose any one option'))" +
                     ":has(option:contains('Belgium')):not([selected])" +
                     ":has(option:contains('France'))" +
                     ":has(option:contains('Canada'))" +
                     ":has(option:contains('44 - UK'))" +
                     ":not(:has(option:contains('Germany')))",
+        run: function () {},
+    }, {
+        content: "Remove placeholder options.",
+        trigger: "we-button[data-name='form_allow_empty']"
+    }, {
+        content: "Check the resulting snippet without placeholder",
+        trigger: ":iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +
+                    ":has(label:contains('State'))" +
+                    ":has(select[required])" +
+                    ":not(option:contains('Please choose any one option'))" +
+                    ":has(option:contains('Belgium'))" +
+                    ":has(option:contains('France'))" +
+                    ":has(option:contains('Canada'))" +
+                    ":has(option:contains('44 - UK'))" +
+                    ":not(:has(option:contains('Germany')))",
+        run: function () {},
     },
 
     ...addExistingField('attachment_ids', 'file', 'Invoice Scan'),

--- a/addons/website/static/tests/tours/website_form_editor.js
+++ b/addons/website/static/tests/tours/website_form_editor.js
@@ -459,10 +459,13 @@ registerWebsitePreviewTour("website_form_editor_tour", {
                     ":has(option:contains('Canada'))" +
                     ":has(option:contains('44 - UK'))" +
                     ":not(:has(option:contains('Germany')))",
-        run: function () {},
     }, {
         content: "Remove placeholder options.",
-        trigger: "we-button[data-name='form_allow_empty']"
+        trigger: "we-button[data-name='form_allow_empty'] we-checkbox",
+        run: 'click',
+    }, {
+        content: "Check required option should not visible",
+        trigger: "we-button[data-name='required_opt']:not(:visible)"
     }, {
         content: "Check the resulting snippet without placeholder",
         trigger: ":iframe .s_website_form_field.s_website_form_custom.s_website_form_required" +
@@ -474,7 +477,6 @@ registerWebsitePreviewTour("website_form_editor_tour", {
                     ":has(option:contains('Canada'))" +
                     ":has(option:contains('44 - UK'))" +
                     ":not(:has(option:contains('Germany')))",
-        run: function () {},
     },
 
     ...addExistingField('attachment_ids', 'file', 'Invoice Scan'),

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -300,7 +300,7 @@
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                 </we-select>
             </we-row>
-            <we-select class="o_we_large" data-name="hidden_condition_option_list" data-attribute-name="visibilityCondition" data-no-preview="true">
+            <we-select class="o_we_large" data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
                 <!-- checkbox, select, radio possible values -->
             </we-select>
             <we-select class="o_we_large" data-name="hidden_condition_record_opt" data-attribute-name="visibilityCondition" data-no-preview="true">

--- a/addons/website/views/snippets/s_website_form.xml
+++ b/addons/website/views/snippets/s_website_form.xml
@@ -205,6 +205,8 @@
                            data-img="/website/static/src/img/snippets_options/pos_right.svg"/>
             </we-button-group>
             <we-checkbox string="Description" data-toggle-description="true" data-no-preview="true"/>
+            <we-checkbox string="Allow Empty" data-name="form_allow_empty" data-allow-empty="true" data-no-preview="true"/>
+            <we-input string="Placeholder" class="o_we_large" data-apply-placeholder="" data-dependencies="form_allow_empty"/>
             <we-input string="Placeholder" class="o_we_large"
                 data-select-attribute="" data-attribute-name="placeholder"
                 data-apply-to="input[type='text'], input[type='email'], input[type='number'], input[type='tel'], input[type='url'], textarea"/>
@@ -252,6 +254,8 @@
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                     <we-button data-select-data-attribute="contains">Contains</we-button>
                     <we-button data-select-data-attribute="!contains">Doesn't contain</we-button>
+                    <we-button data-select-data-attribute="set">Is set</we-button>
+                    <we-button data-select-data-attribute="!set">Is not set</we-button>
                 </we-select>
                 <we-select data-name="hidden_condition_text_opt" data-attribute-name="visibilityComparator" data-no-preview="true">
                     <!-- str comparator possibilities -->
@@ -296,7 +300,7 @@
                     <we-button data-select-data-attribute="!selected">Is not equal to</we-button>
                 </we-select>
             </we-row>
-            <we-select class="o_we_large" data-name="hidden_condition_no_text_opt" data-attribute-name="visibilityCondition" data-no-preview="true">
+            <we-select class="o_we_large" data-name="hidden_condition_option_list" data-attribute-name="visibilityCondition" data-no-preview="true">
                 <!-- checkbox, select, radio possible values -->
             </we-select>
             <we-select class="o_we_large" data-name="hidden_condition_record_opt" data-attribute-name="visibilityCondition" data-no-preview="true">


### PR DESCRIPTION
Before this commit, users did not have the option to leave the selection field blank in the website form.

In this commit, we introduced a feature that allows users to choose whether they want the selection field to be required or not.

Functions Introduced:

- Added a toggle option that allows users to toggle the placeholder option on or off.
- Added a placeholder input field for dynamic placeholder text.
- In visibility conditions, based on a selection field, enabled the following conditions:
  - Is set
  - Is not set

task-3861126
