### PR TITLE
[FIX] base_automation: remove model order

### DIFF
--- a/addons/base_automation/models/base_automation.py
+++ b/addons/base_automation/models/base_automation.py
@@ -34,7 +34,6 @@ DATE_RANGE_FACTOR = {
 class BaseAutomation(models.Model):
     _name = 'base.automation'
     _description = 'Automated Action'
-    _order = 'sequence'
 
     action_server_id = fields.Many2one(
         'ir.actions.server', 'Server Actions',


### PR DESCRIPTION
The model `base.automation` is ordered by `sequence` which is not explicitly defined on the model and therefore not a stored field which leads to an error in `_check_order` check.

The model order is already removed in 17.0

1- Start a db in 15.0 with base_automation installed
2- Try to edit the model by adding a manual field
3- An error occurs in [_check_order](https://github.com/odoo/odoo/blob/8a4925d95595d8bcc50f8f6cb0c7c1682aa11f82/odoo/addons/base/models/ir_model.py#L218-L233)


---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
