### PR TITLE
[FIX] microsoft_calendar: London vs UTC

### DIFF
--- a/addons/microsoft_calendar/models/calendar.py
+++ b/addons/microsoft_calendar/models/calendar.py
@@ -332,11 +332,11 @@ class Meeting(models.Model):
 
         if any(x in fields_to_sync for x in ['allday', 'start', 'date_end', 'stop']):
             if self.allday:
-                start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'Europe/London'}
-                end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'Europe/London'}
+                start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'UTC'}
+                end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'UTC'}
             else:
-                start = {'dateTime': pytz.utc.localize(self.start).isoformat(), 'timeZone': 'Europe/London'}
-                end = {'dateTime': pytz.utc.localize(self.stop).isoformat(), 'timeZone': 'Europe/London'}
+                start = {'dateTime': pytz.utc.localize(self.start).isoformat(), 'timeZone': 'UTC'}
+                end = {'dateTime': pytz.utc.localize(self.stop).isoformat(), 'timeZone': 'UTC'}
 
             values['start'] = start
             values['end'] = end
@@ -459,11 +459,11 @@ class Meeting(models.Model):
         values['type'] = 'occurrence'
 
         if self.allday:
-            start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'Europe/London'}
-            end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'Europe/London'}
+            start = {'dateTime': self.start_date.isoformat(), 'timeZone': 'UTC'}
+            end = {'dateTime': (self.stop_date + relativedelta(days=1)).isoformat(), 'timeZone': 'UTC'}
         else:
-            start = {'dateTime': pytz.utc.localize(self.start).isoformat(), 'timeZone': 'Europe/London'}
-            end = {'dateTime': pytz.utc.localize(self.stop).isoformat(), 'timeZone': 'Europe/London'}
+            start = {'dateTime': pytz.utc.localize(self.start).isoformat(), 'timeZone': 'UTC'}
+            end = {'dateTime': pytz.utc.localize(self.stop).isoformat(), 'timeZone': 'UTC'}
 
         values['start'] = start
         values['end'] = end

--- a/addons/microsoft_calendar/tests/common.py
+++ b/addons/microsoft_calendar/tests/common.py
@@ -147,11 +147,11 @@ class TestCommon(HttpCase):
             },
             'start': {
                 'dateTime': self.start_date.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
-                'timeZone': 'Europe/London'
+                'timeZone': 'UTC'
             },
             'end': {
                 'dateTime': self.end_date.strftime("%Y-%m-%dT%H:%M:%S+00:00"),
-                'timeZone': 'Europe/London'
+                'timeZone': 'UTC'
             },
             'isAllDay': False,
             'isOrganizer': True,

--- a/addons/microsoft_calendar/tests/test_update_events.py
+++ b/addons/microsoft_calendar/tests/test_update_events.py
@@ -157,11 +157,11 @@ class TestUpdateEvents(TestCommon):
                 'type': 'exception',
                 'start': {
                     'dateTime': pytz.utc.localize(new_date).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'end': {
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'isAllDay': False
             },
@@ -332,11 +332,11 @@ class TestUpdateEvents(TestCommon):
                 'type': 'exception',
                 'start': {
                     'dateTime': pytz.utc.localize(new_date).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'end': {
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'isAllDay': False
             },
@@ -404,11 +404,11 @@ class TestUpdateEvents(TestCommon):
                 'type': 'exception',
                 'start': {
                     'dateTime': pytz.utc.localize(new_date).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'end': {
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'isAllDay': False
             },
@@ -471,11 +471,11 @@ class TestUpdateEvents(TestCommon):
                 'type': 'exception',
                 'start': {
                     'dateTime': pytz.utc.localize(new_date).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'end': {
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'isAllDay': False
             },
@@ -562,11 +562,11 @@ class TestUpdateEvents(TestCommon):
                 'type': 'exception',
                 'start': {
                     'dateTime': pytz.utc.localize(new_date).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'end': {
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'isAllDay': False
             },
@@ -625,11 +625,11 @@ class TestUpdateEvents(TestCommon):
                 'type': 'exception',
                 'start': {
                     'dateTime': pytz.utc.localize(new_date).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'end': {
                     'dateTime': pytz.utc.localize(new_date + timedelta(hours=1)).isoformat(),
-                    'timeZone': 'Europe/London'
+                    'timeZone': 'UTC'
                 },
                 'isAllDay': False
             },


### PR DESCRIPTION
Odoo stores events in the UTC time zone.
When bringing events from odoo into outlook calendar (synchronizing), we should ensure that the event is created in the UTC time zone, so two calendars are consistent with each other

Currently, we are requesting event creation in the 'Europe/London' time zone instead of 'UTC'. Isin't it the same?

While 'Europe/London' might seem similar to UTC, they differ in the following ways:
- 'Europe/London' adjusts for daylight saving time, shifting between Greenwich Mean Time and British Summer Time
-  'UTC' maintains a fixed offset of GMT+0 year-round and is unaffected by daylight saving time.

Note: The issue was discovered during the investigation of ticket number opw-3919288, but it is not connected to its resolution.

opw-3919288
