### PR TITLE
[FIX] web: ensure_db compat with werkzeug 3.0

### DIFF
--- a/addons/web/controllers/main.py
+++ b/addons/web/controllers/main.py
@@ -158,7 +158,7 @@ def ensure_db(redirect='/web/database/selector'):
         url_redirect = werkzeug.urls.url_parse(r.base_url)
         if r.query_string:
             # in P3, request.query_string is bytes, the rest is text, can't mix them
-            query_string = iri_to_uri(r.query_string)
+            query_string = iri_to_uri(r.query_string.decode())
             url_redirect = url_redirect.replace(query=query_string)
         request.session.db = db
         abort_and_redirect(url_redirect)


### PR DESCRIPTION
Ubuntu 24.04 Noble ships werkzeug==3.0.1[^1], that version dropped some Py2/Py3 code compatibility to only support Py3. This is the case for the `iri_to_uri` function that since 3.0.0 doesn't support bytes anymore[^2]. Since Odoo 13 only supports Py3 too, it is fine to always decode the query string (which was what `iri_to_uri` was doing anyway).

[^1]: https://packages.ubuntu.com/noble/python3-werkzeug
[^2]: https://werkzeug.palletsprojects.com/en/3.0.x/urls/

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
