### PR TITLE
[FIX] mrp: dont mix operations on backorder creation

### DIFF
--- a/addons/mrp/models/mrp_production.py
+++ b/addons/mrp/models/mrp_production.py
@@ -1970,7 +1970,7 @@ class MrpProduction(models.Model):
                 workorder.duration_expected = workorder._get_duration_expected()
 
             # Adapt quantities produced
-            for workorder in production.workorder_ids:
+            for workorder in production.workorder_ids.sorted('id'):
                 initial_workorder_remaining_qty.append(max(initial_qty - workorder.qty_reported_from_previous_wo - workorder.qty_produced, 0))
                 workorder.qty_produced = min(workorder.qty_produced, workorder.qty_production)
             workorders_len = len(production.workorder_ids)

--- a/addons/mrp/tests/test_backorder.py
+++ b/addons/mrp/tests/test_backorder.py
@@ -673,3 +673,54 @@ class TestMrpWorkorderBackorder(TransactionCase):
         })
         cls.bom_finished1.bom_line_ids[0].operation_id = cls.bom_finished1.operation_ids[0].id
         cls.bom_finished1.bom_line_ids[1].operation_id = cls.bom_finished1.operation_ids[1].id
+
+    def test_mrp_backorder_operations(self):
+        """
+        Checks that the operations'data are correclty set on a backorder:
+            - Create a MO for 10 units, validate the op 1 completely and op 2 partially
+            - Create a backorder and validate op 2 partially
+            - Create a backorder and validate it completely
+        """
+        mo_form = Form(self.env['mrp.production'])
+        mo_form.bom_id = self.bom_finished1
+        mo_form.product_qty = 10
+        mo = mo_form.save()
+        mo.action_confirm()
+        op_1, op_2 = mo.workorder_ids
+        with Form(mo) as fmo:
+            fmo.qty_producing = 10
+        op_1.button_start()
+        op_1.button_finish()
+        with Form(mo) as fmo:
+            fmo.qty_producing = 4
+        op_2.button_start()
+        op_2.button_finish()
+        action = mo.button_mark_done()
+        backorder_1 = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder_1.save().action_backorder()
+        bo_1 = mo.procurement_group_id.mrp_production_ids - mo
+        self.assertRecordValues(bo_1.workorder_ids, [
+            {'state': 'cancel', 'qty_remaining': 0.0, 'workcenter_id': op_1.workcenter_id.id},
+            {'state': 'waiting', 'qty_remaining': 6.0, 'workcenter_id': op_2.workcenter_id.id},
+        ])
+        with Form(bo_1) as form_bo_1:
+            form_bo_1.qty_producing = 2
+        op_4 = bo_1.workorder_ids.filtered(lambda wo: wo.state != 'cancel')
+        op_4.button_start()
+        op_4.button_finish()
+        action = bo_1.button_mark_done()
+        self.assertRecordValues(op_4, [{'state': 'done', 'qty_remaining': 4.0}])
+        backorder_2 = Form(self.env['mrp.production.backorder'].with_context(**action['context']))
+        backorder_2.save().action_backorder()
+        bo_2 = mo.procurement_group_id.mrp_production_ids - mo - bo_1
+        self.assertRecordValues(bo_2.workorder_ids, [
+            {'state': 'cancel', 'qty_remaining': 0.0, 'workcenter_id': op_1.workcenter_id.id},
+            {'state': 'waiting', 'qty_remaining': 4.0, 'workcenter_id': op_2.workcenter_id.id},
+        ])
+        op_6 = bo_2.workorder_ids.filtered(lambda wo: wo.state != 'cancel')
+        with Form(bo_2) as form_bo_2:
+            form_bo_2.qty_producing = 4
+        op_6.button_start()
+        op_6.button_finish()
+        bo_2.button_mark_done()
+        self.assertRecordValues(op_6, [{'state': 'done', 'qty_remaining': 0.0}])


### PR DESCRIPTION
### Steps to reproduce:

1. Create a BOM with 2 operations: op 1 and 2
2. Create and confirm an MO for 10 units using that BOM.
3. Put the quantity to 10 then start and done op 1
4. Put the quantity to 2 then start and done op 2
5. Produce and create a backorder
6. Put the quantity to 4 then start and done op 2
7. Produce and create a backorder
#### > instead of 4 units remaining in op 2 we have 4 units remaining in op 1

### Cause of the issue:

The operations of a productions (`mrp.workorder`'s) are ordered by `leave_id`, `date_start` and then `id`:
https://github.com/odoo/odoo/blob/26239b2d0bdbc2f06d50f7739d61c490248b65bb/addons/mrp/models/mrp_workorder.py#L14-L17 Since, in the first backorder, the workorder corresponding to op 1 is cancelled it has an empty `leave_id` and `date_start`. On the other hand, once the partial operation of op 2 has been completed its associated `date_start` is not empty anymore and the order of both operations is therefore swaped. However, when a backorder is created, the quantity of the workorders is set by relying on the order of operations (which is not the same with and without `leave_id`, `date_start`):
https://github.com/odoo/odoo/blob/d826c3782d737fc1724887692b71b27999bf846d/addons/mrp/models/mrp_production.py#L1973-L1983 So that the data is set on the wrong line.

opw-3880963
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
