### PR TITLE
[FIX] web: take account decimal point in the input

### DIFF
--- a/addons/web/static/src/views/fields/float_factor/float_factor_field.js
+++ b/addons/web/static/src/views/fields/float_factor/float_factor_field.js
@@ -15,11 +15,7 @@ export class FloatFactorField extends FloatField {
     };
 
     parse(value) {
-        let factorValue = value / this.props.factor;
-        if (this.props.inputType !== "number") {
-            factorValue = factorValue.toString();
-        }
-        return super.parse(factorValue);
+        return super.parse(value) / this.props.factor;
     }
 
     get value() {


### PR DESCRIPTION
Issue:
------
In the input of a float factor field, it is not possible to use the ‘,’ as a decimal point, even if this is defined in the localization.

This is because the value is calculated via:
```js
let factorValue = value / this.props.factor;
```
does not work with `value = ‘x,y’` and will return `NaN`.

Solution:
---------
Parser the value by calling super to fallback on `parseFloat` which takes localization into account.

opw-3932813