### PR TITLE
[FIX] account: user_has_group_validate_bank_account doesn't depends of context

### DIFF
--- a/addons/account/models/res_partner_bank.py
+++ b/addons/account/models/res_partner_bank.py
@@ -93,6 +93,7 @@ class ResPartnerBank(models.Model):
         }
 
     @api.depends('acc_number')
+    @api.depends_context('uid')
     def _compute_user_has_group_validate_bank_account(self):
         user_has_group_validate_bank_account = self.user_has_groups('account.group_validate_bank_account')
         for bank in self:


### PR DESCRIPTION
**Description of the issue/feature this PR addresses:**
Before this commit the field can be wrongly computed in multi user environment.

@oco-odoo 



---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
