### PR TITLE
[IMP] stock: back to basic

### DIFF
--- a/addons/mrp/__manifest__.py
+++ b/addons/mrp/__manifest__.py
@@ -48,6 +48,7 @@
         'report/report_stock_rule.xml',
         'report/mrp_zebra_production_templates.xml',
         'report/mrp_workorder_templates.xml',
+        'report/report_stockpicking_operations.xml',
     ],
     'demo': [
         'data/mrp_demo.xml',

--- a/addons/mrp/report/report_stockpicking_operations.xml
+++ b/addons/mrp/report/report_stockpicking_operations.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <data>
+
+        <template id="mrp_report_stock_picking" inherit_id="stock.report_picking">
+            <xpath expr="//table[@t-if='o.move_line_ids and o.move_ids_without_package']/tbody/tr" position="replace">
+                <t t-set="move_lines_with_kit" t-value="o.move_line_ids_without_package.filtered(lambda ml: ml.move_id.bom_line_id.bom_id.type == 'phantom')"/>
+                <t t-if="move_lines_with_kit">
+                    <t t-foreach="move_lines_with_kit.move_id.bom_line_id.bom_id" t-as="kit_section">
+                        <tr>
+                            <td colspan="6" style="font-weight: bold; background-color: lightgray;">
+                                <span t-field="kit_section.product_tmpl_id.display_name"/>
+                            </td>
+                        </tr>
+                        <t t-set="kit_section_move_line" t-value="move_lines_with_kit.filtered(lambda ml: ml.move_id.bom_line_id.bom_id == kit_section)"/>
+                        <tr t-foreach="kit_section_move_line.sorted(lambda ml: (ml.location_id.complete_name, ml.location_dest_id.complete_name))" t-as="ml">
+                            <t t-call="stock.report_picking_move_line"/>
+                        </tr>
+                    </t>
+                </t>
+                <t t-set="move_lines_without_kit" t-value="o.move_line_ids_without_package.filtered(lambda ml: ml.move_id.bom_line_id.bom_id.type != 'phantom')"/>
+                <t t-if="move_lines_without_kit">
+                    <tr t-if="move_lines_with_kit">
+                        <td colspan="6" style="font-weight: bold; background-color: lightgray;">
+                            <span>Products not associated with a kit</span>
+                        </td>
+                    </tr>
+                    <tr t-foreach="move_lines_without_kit.sorted(lambda ml: (ml.location_id.complete_name, ml.location_dest_id.complete_name))" t-as="ml">
+                        <t t-call="stock.report_picking_move_line"/>
+                    </tr>
+                </t>
+            </xpath>
+        </template>
+    </data>
+</odoo>

--- a/addons/product/views/product_packaging_views.xml
+++ b/addons/product/views/product_packaging_views.xml
@@ -10,8 +10,8 @@
                 <field name="product_id"/>
                 <field name="name" string="Packaging"/>
                 <field name="qty"/>
-                <field name="product_uom_id" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
-                <field name="barcode" optional="hide"/>
+                <field name="product_uom_id" string="Unit" options="{'no_open': True, 'no_create': True}" groups="uom.group_uom"/>
+                <field name="barcode" optional="show"/>
                 <field name="company_id" groups="base.group_multi_company" optional="hide"/>
                 <field name="company_id" groups="!base.group_multi_company" invisible="1"/>
             </list>

--- a/addons/purchase/views/product_packaging_views.xml
+++ b/addons/purchase/views/product_packaging_views.xml
@@ -16,7 +16,7 @@
         <field name="model">product.packaging</field>
         <field name="inherit_id" ref="product.product_packaging_tree_view"/>
         <field name="arch" type="xml">
-            <xpath expr="//field[@name='product_uom_id']" position="after">
+            <xpath expr="//field[@name='barcode']" position="after">
                 <field name="purchase" optional="show"/>
             </xpath>
         </field>

--- a/addons/sale/views/product_packaging_views.xml
+++ b/addons/sale/views/product_packaging_views.xml
@@ -17,7 +17,7 @@
         <field name="model">product.packaging</field>
         <field name="inherit_id" ref="product.product_packaging_tree_view"/>
         <field name="arch" type="xml">
-            <field name="product_uom_id" position="after">
+            <field name="barcode" position="after">
                 <field name="sales" optional="show"/>
             </field>
         </field>

--- a/addons/stock/models/stock_picking.py
+++ b/addons/stock/models/stock_picking.py
@@ -1260,6 +1260,9 @@ class StockPicking(models.Model):
                 subtype_id=subtype_id,
             )
 
+    def _get_report_base_filename(self):
+        return _("Delivery Slip - %s", f"{self.partner_id.name} - {self.name}")
+
     def _check_move_lines_map_quant_package(self, package):
         return package._check_move_lines_map_quant(self.move_line_ids.filtered(lambda ml: ml.package_id == package and ml.product_id.is_storable))
 
@@ -1455,6 +1458,22 @@ class StockPicking(models.Model):
         backorder_moves = moves._create_backorder()
         backorder_moves += self.move_ids.filtered(lambda m: m.quantity == 0)
         self._create_backorder(backorder_moves=backorder_moves)
+        action = self.env.ref('stock.stock_picking_action_picking_type')
+        backorder_id = max(self.backorder_ids, key=lambda backorder: backorder['create_date'])
+        return {
+            'type': 'ir.actions.client',
+            'tag': 'display_notification',
+            'params': {
+                'title': _('New transfer created'),
+                'message': '%s',
+                'links': [{
+                    'label': self.backorder_ids[0].name,
+                    'url': f'/web#action={action.id}&id={backorder_id.id}&model=stock.picking&view_type=form'
+                }],
+                'next': {'type': 'ir.actions.act_window_close'},
+                'sticky': False,
+            },
+        }
 
     def _pre_action_done_hook(self):
         for picking in self:

--- a/addons/stock/report/report_stockpicking_operations.xml
+++ b/addons/stock/report/report_stockpicking_operations.xml
@@ -2,6 +2,58 @@
 <odoo>
     <data>
 
+        <template id="report_picking_move_line">
+            <td>
+                <span t-field="ml.product_id.display_name">Customizable Desk</span><br/>
+                <span t-if="ml.product_id.description_picking" t-field="ml.product_id.description_picking"></span>
+            </td>
+            <td class="text-end">
+                <span t-field="ml.quantity">3.00</span>
+                <span t-field="ml.product_uom_id" groups="uom.group_uom">units</span>
+                <span t-if="ml.move_id.product_packaging_id">
+                    <span t-if="o.state != 'done'">
+                        (<span t-field="ml.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.product_packaging_id.name"/>)
+                    </span>
+                    <span t-if="o.state == 'done'">
+                        (<span t-field="ml.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.product_packaging_id.name"/>)
+                    </span>
+                </span>
+            </td>
+            <td t-if="o.picking_type_id.code != 'incoming'" groups="stock.group_stock_multi_locations" class="text-end">
+                <span t-esc="ml.location_id.display_name">WH/Stock</span>
+                    <t t-if="ml.package_id">
+                        <span t-field="ml.package_id">Package A</span>
+                    </t>
+            </td>
+            <td t-if="o.picking_type_id.code != 'outgoing'" groups="stock.group_stock_multi_locations" class="text-end">
+                <div>
+                    <span t-field="ml.location_dest_id">WH/Outgoing</span>
+                    <t t-if="ml.result_package_id">
+                        <span t-field="ml.result_package_id">Package B</span>
+                    </t>
+                </div>
+            </td>
+            <td class=" text-center h6" t-if="has_serial_number">
+                <span t-if="has_serial_number and (ml.lot_id or ml.lot_name)" t-esc="ml.lot_id.name or ml.lot_name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 400, 'height': 100, 'img_style': 'width:100%;height:35px;'}">
+                    <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2 opacity-75 text-muted text-center">
+                        (serial barcode)
+                    </div>
+                </span>
+            </td>
+            <td class="text-center" t-if="has_barcode">
+                <t t-if="product_barcode != ml.product_id.barcode">
+                    <span t-if="ml.product_id and ml.product_id.barcode">
+                        <div t-field="ml.product_id.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 400, 'height': 100, 'quiet': 0, 'img_style': 'height:35px;'}">
+                            <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2 opacity-75 text-muted text-center">
+                                (product barcode)
+                            </div>
+                        </div>
+                    </span>
+                    <t t-set="product_barcode" t-value="ml.product_id.barcode"/>
+                </t>
+            </td>
+        </template>
+
         <template id="report_picking">
             <t t-call="web.html_container">
                 <t t-foreach="docs" t-as="o">
@@ -114,55 +166,7 @@
                                 <tbody>
                                     <!-- In case you come across duplicated lines, ask NIM or LAP -->
                                     <tr t-foreach="o.move_line_ids_without_package.sorted(lambda ml: (ml.location_id.complete_name, ml.location_dest_id.complete_name))" t-as="ml">
-                                        <td>
-                                            <span t-field="ml.product_id.display_name">Customizable Desk</span><br/>
-                                            <span t-if="ml.product_id.description_picking" t-field="ml.product_id.description_picking"></span>
-                                        </td>
-                                        <td class="text-end">
-                                            <span t-field="ml.quantity">3.00</span>
-                                            <span t-field="ml.product_uom_id" groups="uom.group_uom">units</span>
-                                            <span t-if="ml.move_id.product_packaging_id">
-                                                <span t-if="o.state != 'done'">
-                                                    (<span t-field="ml.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.product_packaging_id.name"/>)
-                                                </span>
-                                                <span t-if="o.state == 'done'">
-                                                    (<span t-field="ml.product_packaging_qty" t-options='{"widget": "integer"}'/> <span t-field="ml.move_id.product_packaging_id.name"/>)
-                                                </span>
-                                            </span>
-                                        </td>
-                                        <td t-if="o.picking_type_id.code != 'incoming'" groups="stock.group_stock_multi_locations" class="text-end">
-                                            <span t-esc="ml.location_id.display_name">WH/Stock</span>
-                                                <t t-if="ml.package_id">
-                                                    <span t-field="ml.package_id">Package A</span>
-                                                </t>
-                                        </td>
-                                        <td t-if="o.picking_type_id.code != 'outgoing'" groups="stock.group_stock_multi_locations" class="text-end">
-                                            <div>
-                                                <span t-field="ml.location_dest_id">WH/Outgoing</span>
-                                                <t t-if="ml.result_package_id">
-                                                    <span t-field="ml.result_package_id">Package B</span>
-                                                </t>
-                                            </div>
-                                        </td>
-                                        <td class=" text-center h6" t-if="has_serial_number">
-                                            <span t-if="has_serial_number and (ml.lot_id or ml.lot_name)" t-esc="ml.lot_id.name or ml.lot_name" t-options="{'widget': 'barcode', 'humanreadable': 1, 'width': 400, 'height': 100, 'img_style': 'width:100%;height:35px;'}">
-                                                <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2 opacity-75 text-muted text-center">
-                                                    (serial barcode)
-                                                </div>
-                                            </span>
-                                        </td>
-                                        <td class="text-center" t-if="has_barcode">
-                                            <t t-if="product_barcode != ml.product_id.barcode">
-                                                <span t-if="ml.product_id and ml.product_id.barcode">
-                                                    <div t-field="ml.product_id.barcode" t-options="{'widget': 'barcode', 'symbology': 'auto', 'width': 400, 'height': 100, 'quiet': 0, 'img_style': 'height:35px;'}">
-                                                        <div class="bg-light border-1 rounded d-flex flex-column align-items-center justify-content-center px-1 py-2 opacity-75 text-muted text-center">
-                                                            (product barcode)
-                                                        </div>
-                                                    </div>
-                                                </span>
-                                                <t t-set="product_barcode" t-value="ml.product_id.barcode"/>
-                                            </t>
-                                        </td>
+                                        <t t-call="stock.report_picking_move_line"/>
                                     </tr>
                                   </tbody>
                             </table>

--- a/addons/stock/report/stock_report_views.xml
+++ b/addons/stock/report/stock_report_views.xml
@@ -17,7 +17,7 @@
             <field name="report_type">qweb-pdf</field>
             <field name="report_name">stock.report_deliveryslip</field>
             <field name="report_file">stock.report_deliveryslip</field>
-            <field name="print_report_name">'Delivery Slip - %s - %s' % (object.partner_id.name or '', object.name)</field>
+            <field name="print_report_name">(object._get_report_base_filename())</field>
             <field name="binding_model_id" ref="model_stock_picking"/>
             <field name="binding_type">report</field>
         </record>

--- a/addons/stock_account/views/product_views.xml
+++ b/addons/stock_account/views/product_views.xml
@@ -71,10 +71,8 @@
                     <field name="cost_method" column_invisible="True"/>
                     <field name="avg_cost" string="Unit Cost" optional="show" widget='monetary' options="{'currency_field': 'company_currency_id'}"/>
                     <field name="total_value" string="Total Value" optional="show" widget='monetary' options="{'currency_field': 'company_currency_id'}" sum="Total Value"/>
-                    <button name="%(stock_valuation_layer_action)d" title="Valuation Report" type="action" class="btn-link"
-                        icon="fa-bar-chart" context="{'search_default_product_id': id, 'default_product_id': id}"  invisible="cost_method != 'average'"/>
-                    <button name="%(stock_valuation_layer_report_action)d" title="Valuation Report" type="action" class="btn-link"
-                        icon="fa-bar-chart" context="{'search_default_product_id': id, 'default_product_id': id}"  invisible="cost_method != 'fifo'"/>
+                    <button name="%(stock_account.product_stock_valuation_layer_report_action)d" title="Valuation Report" type="action" class="btn-link"
+                    icon="fa-bar-chart" context="{'search_default_product_id': id, 'default_product_id': id, 'search_default_group_by_product_id': 1}"/>
                 </field>
             </field>
         </record>

--- a/addons/stock_account/views/stock_valuation_layer_views.xml
+++ b/addons/stock_account/views/stock_valuation_layer_views.xml
@@ -179,6 +179,18 @@
         </field>
     </record>
 
+    <record id="product_stock_valuation_layer_tree_inherited" model="ir.ui.view">
+        <field name="name">product.stock.valuation.tree</field>
+        <field name="model">stock.valuation.layer</field>
+        <field name="inherit_id" ref="stock_valuation_layer_tree"/>
+        <field name="mode">primary</field>
+        <field name="arch" type="xml">
+            <xpath expr="//list" position="attributes">
+                <attribute name="expand">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
     <record id="stock_valuation_layer_report_action" model="ir.actions.act_window">
         <field name="name">Stock Valuation</field>
         <field name="res_model">stock.valuation.layer</field>
@@ -186,6 +198,19 @@
         <field name="view_id" ref="stock_valuation_layer_report_tree"/>
         <field name="context">{'search_default_has_remaining_qty': 1}</field>
         <field name="domain">[('product_id.is_storable', '=', True)]</field>
+        <field name="help" type="html">
+            <p class="o_view_nocontent_smiling_face"/>
+            <p>
+                There are no valuation layers. Valuation layers are created when there are product moves that impact the valuation of the stock.
+            </p>
+        </field>
+    </record>
+
+    <record id="product_stock_valuation_layer_report_action" model="ir.actions.act_window">
+        <field name="name">Stock Valuation</field>
+        <field name="res_model">stock.valuation.layer</field>
+        <field name="view_mode">list,form,pivot</field>
+        <field name="view_id" ref="product_stock_valuation_layer_tree_inherited"/>
         <field name="help" type="html">
             <p class="o_view_nocontent_smiling_face"/>
             <p>

--- a/addons/stock_dropshipping/__manifest__.py
+++ b/addons/stock_dropshipping/__manifest__.py
@@ -23,9 +23,11 @@ internal transfer document is needed.
     'depends': ['sale_purchase_stock'],
     'data': [
         'data/stock_data.xml',
+        'data/mail_template_data.xml',
         'views/sale_order_views.xml',
         'views/stock_picking_views.xml',
-        'views/purchase_order_views.xml'
+        'views/purchase_order_views.xml',
+        'views/res_config_settings_views.xml',
     ],
     'demo': [
         'data/stock_dropshipping_demo.xml',

--- a/addons/stock_dropshipping/data/mail_template_data.xml
+++ b/addons/stock_dropshipping/data/mail_template_data.xml
@@ -1,0 +1,47 @@
+<?xml version='1.0' encoding='utf-8'?>
+<odoo>
+    <record id="mail_template_data_delivery_confirmation_dropship" model="mail.template">
+        <field name="name">Shipping: Send by Email</field>
+        <field name="model_id" ref="model_stock_picking"/>
+        <field name="subject">{{ object.company_id.name }} Delivery Order (Ref {{ object.name or 'n/a' }})</field>
+        <field name="partner_to">{{ object.purchase_id.dest_address_id.email and object.purchase_id.dest_address_id.id or object.purchase_id.dest_address_id.parent_id.id }}</field>
+        <field name="description">Sent to the customers when orders are delivered, if the setting is enabled</field>
+        <field name="body_html" type="html">
+            <div style="margin: 0px; padding: 0px;">
+                <p style="margin: 0px; padding: 0px; font-size: 13px;">
+                    Hello <t t-out="object.purchase_id.dest_address_id.name or ''">Brandon Freeman</t>,<br/><br/>
+                    We are glad to inform you that your order has been shipped.
+                    <t t-if="hasattr(object, 'carrier_tracking_ref') and object.carrier_tracking_ref">
+                        Your tracking reference is
+                        <strong>
+                        <t t-if="object.carrier_tracking_url">
+                            <t t-set="multiple_carrier_tracking" t-value="object.get_multiple_carrier_tracking()"/>
+                            <t t-if="multiple_carrier_tracking">
+                                <t t-foreach="multiple_carrier_tracking" t-as="line">
+                                    <br/><a t-att-href="line[1]" target="_blank" t-out="line[0] or ''"></a>
+                                </t>
+                            </t>
+                            <t t-else="">
+                                <a t-attf-href="{{ object.carrier_tracking_url }}" target="_blank" t-out="object.carrier_tracking_ref or ''"></a>.
+                            </t>
+                        </t>
+                        <t t-else="">
+                            <t t-out="object.carrier_tracking_ref or ''"></t>.
+                        </t>
+                        </strong>
+                    </t>
+                    <br/><br/>
+                    Please find your delivery order attached for more details.<br/><br/>
+                    Thank you,
+                    <t t-if="user.signature">
+                        <br />
+                        <t t-out="user.signature or ''">--<br/>Mitchell Admin</t>
+                    </t>
+                </p>
+            </div>
+        </field>
+        <field name="report_template_ids" eval="[(4, ref('stock.action_report_delivery'))]"/>
+        <field name="lang">{{ object.purchase_id.dest_address_id.lang }}</field>
+        <field name="auto_delete" eval="True"/>
+    </record>
+</odoo>

--- a/addons/stock_dropshipping/views/res_config_settings_views.xml
+++ b/addons/stock_dropshipping/views/res_config_settings_views.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="res_config_settings_view_form" model="ir.ui.view">
+        <field name="name">res.config.settings.view.form.inherit.stock.dropshipping</field>
+        <field name="model">res.config.settings</field>
+        <field name="inherit_id" ref="stock.res_config_settings_view_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//setting[@id='stock_move_email']" position="attributes">
+                <attribute name="help">Send an automatic confirmation email when Delivery Orders or Dropships are done</attribute>
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
With this PR :
---------------------------------------------
- Improved the report of the picking operation. Now, whenever we have a product kit, it is shown in a separate section per kit.
- Added functionality to send a confirmation email to the customer for dropshipping deliveries.
- Improved the description of the email confirmation in settings.
- Added a toast notification when splitting a transfer, displaying the new transfer name with a link.
- Added a filter to find a product by its internal reference.
- Improved the packaging list view.
- Added a valuation icon to all products and applied a group by product filter to the valuation view through the valuation icon.

Task-id : 3899862
