### PR TITLE
[FIX] mail: emojipicker horizontal scroll in mobileview

### DIFF
--- a/addons/mail/static/src/core/common/picker_content.xml
+++ b/addons/mail/static/src/core/common/picker_content.xml
@@ -4,7 +4,7 @@
 <t t-name="mail.PickerContent">
     <div class="o-mail-PickerContent d-flex flex-column flex-grow-1 o-min-height-0" t-on-click="onClick">
         <div class="o-mail-PickerContent-picker d-flex flex-grow-1 rounded overflow-auto">
-            <div t-if="props.state.picker === props.PICKERS.EMOJI" class="o-mail-PickerContent-emojiPicker d-flex flex-grow-1">
+            <div t-if="props.state.picker === props.PICKERS.EMOJI" class="o-mail-PickerContent-emojiPicker d-flex flex-grow-1 mw-100">
                 <EmojiPicker close="props.close" onSelect="props.pickers.emoji" state="props.state" storeScroll="props.storeScroll"/>
             </div>
         </div>


### PR DESCRIPTION
**Before this PR:**

When you open Emoji picker in discuss mobile view and screen size is enough small so that the categories tab overflows and shows horizontal scroll. And as it's parent div `o-mail-PickerContent-emojiPicker` doesn't have any fixed width set it's width also increases in response to the categories tab. Which will display the horizontal scroll on the whole parent div instead of the categories tab.

![image](https://github.com/odoo/odoo/assets/99004966/a1fb2e19-36e3-48bc-8b94-ed31e6e61cf6)


**After this PR:**

This commit sets max-width 100% to it's `o-mail-PickerContent-emojiPicker` so, that the scrolling would only take effect on the categories tab.

![image](https://github.com/odoo/odoo/assets/99004966/d17523fd-ccb6-4cd3-83b7-6e9c31e55686)


**task**-[3950434](https://www.odoo.com/odoo/my-tasks/3950434?debug=&cids=2)

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
