### PR TITLE
[IMP] pos_restaurant: added sequence meal mode

### DIFF
--- a/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
+++ b/addons/point_of_sale/static/src/app/generic_components/orderline/orderline.xml
@@ -4,37 +4,38 @@
         <t t-set="line" t-value="props.line" />
         <li class="orderline d-flex align-items-center lh-sm cursor-pointer" t-attf-class="{{ line.comboParent ? 'border-start border-3 ms-4' : '' }}" t-att-class="props.class">
             <img class="p-2" t-attf-style="width: 4rem; border-radius: 1rem;" t-if="line.imageSrc" t-att-src="line.imageSrc"/>
-            <div class="p-2 d-flex flex-column w-100">
-                <div class="d-flex justify-content-between">
+            <div class="p-2 d-flex w-100 justify-content-between">
+                <div id="orderline-details" class="w-50">
                     <div class="product-name d-inline-block flex-grow-1 fw-bolder pe-1 text-truncate">
                         <span class="text-wrap" t-esc="line.productName"/>
                         <t t-slot="product-name"/>
                     </div>
-                    <div class="product-price d-inline-block text-end price fw-bolder">
-                        <t t-esc="line.price"/>
-                    </div>
-                </div>
-                <ul class="info-list" t-attf-class="{{props.infoListClasses}}">
-                    <li class="price-per-unit">
-                        <em t-esc="line.qty" class="qty fst-normal fw-bolder me-1" /> <t t-if="line.unit" t-esc="line.unit" />
-                        <t t-if="line.price !== 0">
-                            × <s t-esc="line.oldUnitPrice" t-if="line.oldUnitPrice" />
-                            <t t-esc="line.unitPrice" />
+                    <ul class="info-list" t-attf-class="{{props.infoListClasses}}">
+                        <li class="price-per-unit">
+                            <em t-esc="line.qty" class="qty fst-normal fw-bolder me-1" /> <t t-if="line.unit" t-esc="line.unit" />
+                            <t t-if="line.price !== 0">
+                                × <s t-esc="line.oldUnitPrice" t-if="line.oldUnitPrice" />
+                                <t t-esc="line.unitPrice" />
+                            </t>
+                        </li>
+                        <li t-if="line.price !== 0 and line.discount and line.discount !== '0'">
+                            With a <em><t t-esc="line.discount" />% </em> discount
+                        </li>
+                        <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break text-bg-warning text-warning bg-opacity-25">
+                            <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
+                            <t t-esc="line.customerNote" />
+                        </li>
+                        <t t-foreach="line.internalNote?.split?.('\n') or []" t-as="note" t-key="note_index">
+                            <li t-if="note.trim() !== ''" t-esc="note" class="internal-note ms-1 p-2 badge rounded-pill bg-info text-info bg-opacity-25" style="font-size: 0.85rem;" />
                         </t>
-                    </li>
-                    <li t-if="line.price !== 0 and line.discount and line.discount !== '0'">
-                        With a <em><t t-esc="line.discount" />% </em> discount
-                    </li>
-                    <li t-if="line.customerNote" class="customer-note w-100 p-2 my-1 rounded text-break text-bg-warning text-warning bg-opacity-25">
-                        <i class="fa fa-sticky-note me-1" role="img" aria-label="Customer Note" title="Customer Note"/>
-                        <t t-esc="line.customerNote" />
-                    </li>
-                    <t t-foreach="line.internalNote?.split?.('\n') or []" t-as="note" t-key="note_index">
-                        <li t-if="note.trim() !== ''" t-esc="note" class="internal-note ms-1 p-2 badge rounded-pill bg-info text-info bg-opacity-25" style="font-size: 0.85rem;" />
-                    </t>
-                    <li t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />
-                    <t t-slot="default" />
-                </ul>
+                        <li t-foreach="line.packLotLines or []" t-as="lot" t-key="lot_index" t-esc="lot" />
+                        <t t-slot="default" />
+                    </ul>
+                </div>
+                <div class="product-price d-inline-block text-end price fw-bolder flex-grow-1">
+                    <t t-if="line.price === 'free'">Free</t>
+                    <t t-else="" t-esc="line.price"/>
+                </div>
             </div>
         </li>
     </t>

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.js
@@ -33,6 +33,10 @@ export class OrderSummary extends Component {
         return this.pos.get_order();
     }
 
+    get currentLines() {
+        return this.currentOrder.lines;
+    }
+
     async editPackLotLines(line) {
         const isAllowOnlyOneLot = line.product_id.isAllowOnlyOneLot();
         const editedPackLotLines = await this.pos.editLots(

--- a/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
+++ b/addons/point_of_sale/static/src/app/screens/product_screen/order_summary/order_summary.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates id="template" xml:space="preserve">
     <t t-name="point_of_sale.OrderSummary">
-      <OrderWidget lines="currentOrder.lines" t-slot-scope="scope" class="'bg-light'"
+      <OrderWidget lines="currentLines" t-slot-scope="scope" class="'bg-light'"
           total="env.utils.formatCurrency(currentOrder.get_total_with_tax())"
           tax="!env.utils.floatIsZero(currentOrder.get_total_tax()) and env.utils.formatCurrency(currentOrder.get_total_tax()) or ''">
           <t t-set="line" t-value="scope.line" />

--- a/addons/pos_restaurant/__manifest__.py
+++ b/addons/pos_restaurant/__manifest__.py
@@ -23,6 +23,8 @@ This module adds several features to the Point of Sale that are specific to rest
         'views/pos_order_views.xml',
         'views/pos_restaurant_views.xml',
         'views/res_config_settings_views.xml',
+        'views/pos_sequence_stage_views.xml',
+        'views/product_view.xml',
     ],
     'demo': [
         'data/demo_data.xml',

--- a/addons/pos_restaurant/models/__init__.py
+++ b/addons/pos_restaurant/models/__init__.py
@@ -8,3 +8,5 @@ from . import pos_restaurant
 from . import pos_session
 from . import res_config_settings
 from . import account_fiscal_position
+from . import pos_sequence_stage
+from . import product

--- a/addons/pos_restaurant/models/pos_order.py
+++ b/addons/pos_restaurant/models/pos_order.py
@@ -54,3 +54,13 @@ class PosOrder(models.Model):
                 messages.append(('TABLE_ORDER_COUNT', order_count))
         if messages:
             a_config._notify(*messages, private=False)
+
+
+class PosOrderLine(models.Model):
+    _inherit = "pos.order.line"
+
+    pos_sequence_stage_id = fields.Many2one('pos.sequence.stage', string='Sequence Stage')
+
+    @api.model
+    def _load_pos_data_fields(self, config_id):
+        return super()._load_pos_data_fields(config_id) + ['pos_sequence_stage_id']

--- a/addons/pos_restaurant/models/pos_sequence_stage.py
+++ b/addons/pos_restaurant/models/pos_sequence_stage.py
@@ -1,0 +1,14 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+
+from odoo import fields, models
+
+
+class PosSequenceStage(models.Model):
+    _name = 'pos.sequence.stage'
+    _description = 'Allow the user to quickly select the sequence of the meals.'
+    _order = "sequence, name"
+    _inherit = ['pos.load.mixin']
+
+    name = fields.Char('Name', required=True)
+    color = fields.Integer('Color Index', default=0)
+    sequence = fields.Integer(default=1)

--- a/addons/pos_restaurant/models/pos_session.py
+++ b/addons/pos_restaurant/models/pos_session.py
@@ -11,7 +11,7 @@ class PosSession(models.Model):
     def _load_pos_data_models(self, config_id):
         data = super()._load_pos_data_models(config_id)
         if self.config_id.module_pos_restaurant:
-            data += ['restaurant.floor', 'restaurant.table']
+            data += ['restaurant.floor', 'restaurant.table', 'pos.sequence.stage']
         return data
 
     @api.model

--- a/addons/pos_restaurant/models/product.py
+++ b/addons/pos_restaurant/models/product.py
@@ -1,0 +1,15 @@
+# Part of Odoo. See LICENSE file for full copyright and licensing details.
+from odoo import fields, models
+
+
+class ProductTemplate(models.Model):
+    _inherit = 'product.template'
+
+    pos_sequence_stage_ids = fields.Many2many('pos.sequence.stage', string='Sequence Stages', help='The stages that this product can be in the kitchen order sequence.')
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    def _load_pos_data_fields(self, config_id):
+        return super()._load_pos_data_fields(config_id) + ['pos_sequence_stage_ids']

--- a/addons/pos_restaurant/security/ir.model.access.csv
+++ b/addons/pos_restaurant/security/ir.model.access.csv
@@ -3,3 +3,5 @@ access_restaurant_floor,restaurant.floor.user,model_restaurant_floor,point_of_sa
 access_restaurant_floor_manager,restaurant.floor.manager,model_restaurant_floor,point_of_sale.group_pos_manager,1,1,1,1
 access_restaurant_table,restaurant.table.user,model_restaurant_table,point_of_sale.group_pos_user,1,0,0,0
 access_restaurant_table_manager,restaurant.table.manager,model_restaurant_table,point_of_sale.group_pos_manager,1,1,1,1
+access_pos_sequence_stage,restaurant.sequence.stage,model_pos_sequence_stage,point_of_sale.group_pos_user,1,0,0,0
+access_pos_sequence_stage_manager,restaurant.sequence.stage,model_pos_sequence_stage,point_of_sale.group_pos_manager,1,1,1,1

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/order_summary/order_summary.js
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/order_summary/order_summary.js
@@ -1,0 +1,32 @@
+import { useState } from "@odoo/owl";
+import { OrderSummary } from "@point_of_sale/app/screens/product_screen/order_summary/order_summary";
+import { patch } from "@web/core/utils/patch";
+
+patch(OrderSummary.prototype, {
+    setup() {
+        super.setup(...arguments);
+        this.sequenceTooltip = useState({ value: "" });
+    },
+    getSequenceStage(line) {
+        return line.product_id.pos_sequence_stage_ids;
+    },
+    toggleSequenceTooltip(line) {
+        if (this.sequenceTooltip.value === line.uuid) {
+            this.sequenceTooltip.value = "";
+        } else {
+            this.sequenceTooltip.value = line.uuid;
+        }
+    },
+    selectSequenceStage(line, sequenceStage) {
+        if (line.pos_sequence_stage_id === sequenceStage) {
+            line.update({ pos_sequence_stage_id: null });
+            return;
+        }
+        line.update({ pos_sequence_stage_id: sequenceStage });
+    },
+    get currentLines() {
+        return this.currentOrder.lines.sort(
+            (a, b) => a.pos_sequence_stage_id?.sequence - b.pos_sequence_stage_id?.sequence
+        );
+    },
+});

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/order_summary/order_summary.scss
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/order_summary/order_summary.scss
@@ -1,0 +1,3 @@
+.sequence_stage_tooltip {
+    z-index: 1500;
+}

--- a/addons/pos_restaurant/static/src/overrides/components/product_screen/order_summary/order_summary.xml
+++ b/addons/pos_restaurant/static/src/overrides/components/product_screen/order_summary/order_summary.xml
@@ -6,5 +6,26 @@
                 () => line.toggleSkipChange()
             </attribute>
         </xpath>
+        <xpath expr="//Orderline" position="inside">
+            <t t-set-slot="sequence_order">
+                <div t-if="pos.config.module_pos_restaurant and line.product_id.pos_sequence_stage_ids.length">
+                    <div class="sequence-stage-tooltip-btn bg-secondary d-flex align-items-center justify-content-center w-100 rounded p-2 cursor-pointer position-relative"
+                     t-attf-class="o_colorlist_item_color_transparent_{{line.pos_sequence_stage_id?.color or 'none'}}"
+                     t-on-click="() => this.toggleSequenceTooltip(line)">
+                        <span t-esc="line.pos_sequence_stage_id?.name?.substring(0, 1) or 'N/A'" class="fs-5" t-att-class="{'text-black': !line.pos_sequence_stage_id}" style="font-weight: 700 !important"/>
+                        <div t-if="sequenceTooltip.value === line.uuid" class="sequence-stage-tooltip p-1 d-flex rounded border bg-white gap-1 position-absolute top-100 start-50 translate-middle sequence_stage_tooltip">
+                            <div t-foreach="line.product_id.pos_sequence_stage_ids"
+                                t-as="sequenceStage"
+                                t-key="sequenceStage.id"
+                                class="p-3 border rounded"
+                                t-attf-class="o_colorlist_item_color_transparent_{{sequenceStage?.color or 'none'}}"
+                                t-on-click="() => this.selectSequenceStage(line, sequenceStage)">
+                                <span t-esc="sequenceStage.name.substring(0, 1)" class="fs-5" style="font-weight: 700 !important" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </t>
+        </xpath>
     </t>
 </templates>

--- a/addons/pos_restaurant/static/src/overrides/generic_components/orderline/orderline.xml
+++ b/addons/pos_restaurant/static/src/overrides/generic_components/orderline/orderline.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<templates id="template" xml:space="preserve">
+    <t t-name="point_of_sale.Orderline" t-inherit="point_of_sale.Orderline" t-inherit-mode="extension">
+        <xpath expr="//div[@id='orderline-details']" position="after">
+            <t t-slot="sequence_order" />
+        </xpath>
+    </t>
+</templates>

--- a/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
+++ b/addons/pos_restaurant/static/tests/tours/pos_restaurant_tour.js
@@ -335,3 +335,22 @@ registry.category("web_tour.tours").add("MergeTableTour", {
             },
         ].flat(),
 });
+
+registry.category("web_tour.tours").add("SequenceNumberTour", {
+    test: true,
+    steps: () =>
+        [
+            Dialog.confirm("Open session"),
+            FloorScreen.clickTable("4"),
+            ProductScreen.clickDisplayedProduct("Cake"),
+            ProductScreen.clickDisplayedProduct("Coca-Cola"),
+            ProductScreen.openSequenceStageTooltip("Cake"),
+            ProductScreen.selectSequenceStage("F"),
+            ProductScreen.openSequenceStageTooltip("Coca-Cola"),
+            ProductScreen.selectSequenceStage("D"),
+            ProductScreen.verifyFirstOrderline("Coca-Cola"),
+            ProductScreen.clickPayButton(),
+            PaymentScreen.clickPaymentMethod("Bank"),
+            PaymentScreen.clickValidate(),
+        ].flat(),
+});

--- a/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
+++ b/addons/pos_restaurant/static/tests/tours/utils/product_screen_util.js
@@ -50,3 +50,27 @@ export function tableNameShown(table_name) {
         },
     ];
 }
+
+export function openSequenceStageTooltip(lineName) {
+    return {
+        content: "click sequence stage tooltip",
+        trigger: `.orderline:contains('${lineName}') .sequence-stage-tooltip-btn`,
+        run: "click",
+    };
+}
+
+export function selectSequenceStage(stage) {
+    return {
+        content: `select sequence stage ${stage}`,
+        trigger: `.sequence-stage-tooltip span:contains('${stage}')`,
+        run: "click",
+    };
+}
+
+export function verifyFirstOrderline(lineName) {
+    return {
+        content: "verify first orderline",
+        trigger: `.order-container .orderline:first-child:contains('${lineName}')`,
+        run: function () {}, // it's a check
+    };
+}

--- a/addons/pos_restaurant/tests/test_frontend.py
+++ b/addons/pos_restaurant/tests/test_frontend.py
@@ -16,6 +16,7 @@ class TestFrontend(TestPointOfSaleHttpCommon):
         archive_products(cls.env)
 
         drinks_category = cls.env['pos.category'].create({'name': 'Drinks'})
+        foods_category = cls.env['pos.category'].create({'name': 'Foods'})
 
         printer = cls.env['pos.printer'].create({
             'name': 'Preparation Printer',
@@ -117,10 +118,20 @@ class TestFrontend(TestPointOfSaleHttpCommon):
             main_company,
         )
 
+        sequence_stage_drink = cls.env['pos.sequence.stage'].create({
+            'name': 'Drink',
+            'sequence': 1,
+        })
+        sequence_stage_food = cls.env['pos.sequence.stage'].create({
+            'name': 'Food',
+            'sequence': 2,
+        })
+
         cls.env['product.product'].create({
             'available_in_pos': True,
             'list_price': 2.20,
             'name': 'Coca-Cola',
+            'pos_sequence_stage_ids': [(4, sequence_stage_drink.id)],
             'weight': 0.01,
             'pos_categ_ids': [(4, drinks_category.id)],
             'categ_id': cls.env.ref('point_of_sale.product_category_pos').id,
@@ -131,6 +142,7 @@ class TestFrontend(TestPointOfSaleHttpCommon):
             'available_in_pos': True,
             'list_price': 2.20,
             'name': 'Water',
+            'pos_sequence_stage_ids': [(4, sequence_stage_drink.id)],
             'weight': 0.01,
             'pos_categ_ids': [(4, drinks_category.id)],
             'categ_id': cls.env.ref('point_of_sale.product_category_pos').id,
@@ -142,7 +154,19 @@ class TestFrontend(TestPointOfSaleHttpCommon):
             'list_price': 2.20,
             'name': 'Minute Maid',
             'weight': 0.01,
+            'pos_sequence_stage_ids': [(4, sequence_stage_drink.id)],
             'pos_categ_ids': [(4, drinks_category.id)],
+            'categ_id': cls.env.ref('point_of_sale.product_category_pos').id,
+            'taxes_id': [(6, 0, [])],
+        })
+
+        cls.env['product.product'].create({
+            'available_in_pos': True,
+            'list_price': 5.10,
+            'name': 'Cake',
+            'weight': 0.01,
+            'pos_sequence_stage_ids': [(4, sequence_stage_food.id)],
+            'pos_categ_ids': [(4, foods_category.id)],
             'categ_id': cls.env.ref('point_of_sale.product_category_pos').id,
             'taxes_id': [(6, 0, [])],
         })
@@ -282,3 +306,10 @@ class TestFrontend(TestPointOfSaleHttpCommon):
     def test_12_merge_table(self):
         self.pos_config.with_user(self.pos_user).open_ui()
         self.start_pos_tour('MergeTableTour', login="pos_admin")
+
+    def test_13_sequence_number(self):
+        self.pos_config.with_user(self.pos_user).open_ui()
+        self.start_pos_tour('SequenceNumberTour')
+        lines = self.env['pos.order'].search([])[-1].lines
+        self.assertEqual(lines[0].pos_sequence_stage_id.name, 'Drink')
+        self.assertEqual(lines[1].pos_sequence_stage_id.name, 'Food')

--- a/addons/pos_restaurant/views/pos_sequence_stage_views.xml
+++ b/addons/pos_restaurant/views/pos_sequence_stage_views.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<odoo>
+        <record id="view_pos_sequence_stage_tree" model="ir.ui.view">
+            <field name="name">Sequence stage</field>
+            <field name="model">pos.sequence.stage</field>
+            <field name="arch" type="xml">
+                <tree string="Sequence stage" create="1" editable="bottom">
+                    <field name="sequence" widget="handle" />
+                    <field name="name" />
+                    <field name="color" widget="color_picker"/>
+                </tree>
+            </field>
+        </record>
+
+        <record id="action_restaurant_sequence_stage_form" model="ir.actions.act_window">
+            <field name="name">Sequence Stage</field>
+            <field name="res_model">pos.sequence.stage</field>
+            <field name="view_mode">tree</field>
+            <field name="help" type="html">
+              <p class="o_view_nocontent_smiling_face">
+                Add a new sequence stage
+              </p><p>
+                A sequence stage allow the user to quickly select the sequence of the meals. Leads to better priority visibility on the kitchen display/order.
+              </p>
+            </field>
+        </record>
+
+        <menuitem id="menu_sequence_stage_all"
+            parent="point_of_sale.menu_point_config_product"
+            action="action_restaurant_sequence_stage_form"
+            sequence="10"
+            groups="point_of_sale.group_pos_user"/>
+</odoo>

--- a/addons/pos_restaurant/views/product_view.xml
+++ b/addons/pos_restaurant/views/product_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="product_template_form_view" model="ir.ui.view">
+        <field name="name">product.template.form.inherit</field>
+        <field name="model">product.template</field>
+        <field name="inherit_id" ref="product.product_template_form_view"/>
+        <field name="arch" type="xml">
+            <field name="pos_categ_ids" position="after">
+                <field name="pos_sequence_stage_ids" widget="many2many_tags" string="Sequence Stages"/>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
This commit adds a system of meal stages, which are ordered by sequence, allowing the user to order his summary_screen.

Stages can be added via point_of_sale and can be added to specific products.

Once the steps have been configured, the user can then add a step to each order line, which will then be filtered by stage.

taskId: 3895039
