### PR TITLE
[IMP] mail: darken seen indicator color

### DIFF
--- a/addons/mail/static/src/core/common/message_seen_indicator.xml
+++ b/addons/mail/static/src/core/common/message_seen_indicator.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <templates xml:space="preserve">
     <t t-name="mail.MessageSeenIndicator">
-        <span class="o-mail-MessageSeenIndicator position-relative d-flex opacity-50" t-att-class="{ 'o-all-seen text-primary': props.message.hasEveryoneSeen }" t-attf-class="{{ props.className }}">
+        <span class="o-mail-MessageSeenIndicator position-relative d-flex" t-att-class="{ 'opacity-50': !props.message.hasEveryoneSeen, 'o-all-seen text-primary': props.message.hasEveryoneSeen }" t-attf-class="{{ props.className }}">
             <t t-if="!props.message.isMessagePreviousToLastSelfMessageSeenByEveryone">
                 <i t-if="props.message.hasSomeoneFetched or props.message.hasSomeoneSeen" class="fa fa-check ps-1"/>
                 <i t-if="props.message.hasSomeoneSeen" class="o-second fa fa-check position-absolute"/>


### PR DESCRIPTION
This PR improves the visibility of the message seen indicator color by removing
the opacity-50 when everyone has seen the message.

Before
![image](https://github.com/odoo/odoo/assets/1810149/c6577f4c-33d3-4d3a-97b5-53bb9473a946)

After
![image](https://github.com/odoo/odoo/assets/1810149/a1102441-5d49-4dfd-9089-ce9c649b3a92)


Task-3915958
