### PR TITLE
[FIX] point_of_sale: ensure attribute selection pop-up for all variants

### DIFF
--- a/addons/point_of_sale/static/src/app/models/related_models.js
+++ b/addons/point_of_sale/static/src/app/models/related_models.js
@@ -254,14 +254,9 @@ export function createRelatedModels(modelDefs, modelClasses = {}, indexes = {}) 
             }
             ownerRecord[field.name] = recordToConnect;
         } else if (field.type === "one2many") {
-            const prevConnectedRecord = recordToConnect[inverse.name];
-            if (prevConnectedRecord === ownerRecord) {
-                return;
-            }
+            // It's necessary to remove the previous connected in one2many but it would cause issue for inherited one2many field.
+            // Also, we don't do modification in PoS and we can ignore the removing part to prevent issue.
             recordToConnect[inverse.name] = ownerRecord;
-            if (prevConnectedRecord) {
-                removeItem(prevConnectedRecord, field.name, recordToConnect);
-            }
             addItem(ownerRecord, field.name, recordToConnect);
         } else if (field.type === "many2many") {
             addItem(ownerRecord, field.name, recordToConnect);


### PR DESCRIPTION
Prior to this commit, when a product was created with the following:

- An attribute assigned with the Creation Mode set to 'Instantly'
- An attribute assigned with the Creation Mode set to 'Never'

Upon trying to add each variant in the PoS, the pop-up menu to select attributes only appeared for one of the variants.

opw-3921893

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
