### PR TITLE
[IMP] l10n_din5008_sale: address display

### DIFF
--- a/addons/l10n_din5008_sale/models/sale.py
+++ b/addons/l10n_din5008_sale/models/sale.py
@@ -43,11 +43,26 @@ class SaleOrder(models.Model):
     def _compute_l10n_din5008_addresses(self):
         for record in self:
             record.l10n_din5008_addresses = data = []
-            if record.partner_shipping_id == record.partner_invoice_id:
-                data.append((_("Invoicing and Shipping Address:"), record.partner_shipping_id))
-            else:
-                data.append((_("Shipping Address:"), record.partner_shipping_id))
-                data.append((_("Invoicing Address:"), record.partner_invoice_id))
+            commercial_partner = record.partner_id.commercial_partner_id
+            delivery_partner = record.partner_shipping_id
+            invoice_partner = record.partner_invoice_id
+
+            different_partner_count = len((commercial_partner | delivery_partner | invoice_partner).ids)
+            # To avoid repetition in the address block.
+            if different_partner_count <= 1:
+                continue
+            elif different_partner_count == 3:
+                data.extend([(_("Shipping Address:"), delivery_partner), (_("Invoicing Address:"), invoice_partner)])
+                continue
+            elif commercial_partner == invoice_partner:
+                data.append((_("Shipping Address:"), delivery_partner))
+                continue
+            elif commercial_partner == delivery_partner:
+                data.append((_("Invoicing Address:"), invoice_partner))
+                continue
+            elif invoice_partner == delivery_partner:
+                data.append((_("Invoicing and Shipping Address:"), invoice_partner))
+                continue
 
     def check_field_access_rights(self, operation, field_names):
         field_names = super().check_field_access_rights(operation, field_names)


### PR DESCRIPTION
In this commit, we changed the way the addresses were displayed in accounting.
https://github.com/odoo/odoo/commit/28fdcaabda9dc61b352e58e692bc5adf15a08a1e
We now want the same behavior with the sale orders.

task-3951205




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
