### PR TITLE
[FIX] mrp: delete link between BoM lines and OP when changing bom in OP

### DIFF
--- a/addons/mrp/models/mrp_routing.py
+++ b/addons/mrp/models/mrp_routing.py
@@ -116,3 +116,10 @@ class MrpRoutingWorkcenter(models.Model):
             return False
         self.ensure_one()
         return tuple(self[key] for key in  ('name', 'company_id', 'workcenter_id', 'time_mode', 'time_cycle_manual', 'bom_product_template_attribute_value_ids'))
+
+    def write(self, values):
+        if 'bom_id' in values:
+            for op in self:
+                op.bom_id.bom_line_ids.filtered(lambda line: line.operation_id == op).operation_id = False
+                op.bom_id.byproduct_ids.filtered(lambda byproduct: byproduct.operation_id == op).operation_id = False
+        return super().write(values)

--- a/addons/mrp/tests/test_bom.py
+++ b/addons/mrp/tests/test_bom.py
@@ -1087,6 +1087,37 @@ class TestBoM(TestMrpCommon):
         self.assertEqual(p2.qty_available, 10.0)
         self.assertEqual(p3.qty_available, 10.0)
 
+    def test_update_bom_in_routing_workcenter(self):
+        """
+        This test checks the behaviour of updating the BoM associated with a routing workcenter,
+        It verifies that the link between the BOM lines and the operation is correctly deleted.
+        """
+        p1, c1, c2, byproduct = self.make_prods(4)
+        bom = self.env['mrp.bom'].create({
+            'product_tmpl_id': p1.product_tmpl_id.id,
+            'product_qty': 1.0,
+            'bom_line_ids': [
+                Command.create({'product_id': c1.id, 'product_qty': 1.0}),
+                Command.create({'product_id': c2.id, 'product_qty': 1.0})
+                ],
+            'byproduct_ids': [
+                Command.create({
+                    'product_id': byproduct.id, 'product_uom_id': byproduct.uom_id.id, 'product_qty': 1.0,
+                }),]
+        })
+        operation = self.env['mrp.routing.workcenter'].create({
+            'name': 'Operation',
+            'workcenter_id': self.env.ref('mrp.mrp_workcenter_1').id,
+            'bom_id': bom.id,
+        })
+        bom.bom_line_ids.operation_id = operation
+        bom.byproduct_ids.operation_id = operation
+        self.assertEqual(operation.bom_id, bom)
+        operation.bom_id = self.bom_1
+        self.assertEqual(operation.bom_id, self.bom_1)
+        self.assertFalse(bom.bom_line_ids.operation_id)
+        self.assertFalse(bom.byproduct_ids.operation_id)
+
     def test_cycle_on_line_creation(self):
         bom_1_finished_product = self.bom_1.product_id
         bom_2_finished_product = self.bom_2.product_id


### PR DESCRIPTION
backport of: https://github.com/odoo/odoo/pull/128821/commits/733eccd37a2f303aa8a6f894625f3ae73a6a1cc3

Steps to reproduce the bug:
- Create a storable product “P1” with BoM
    - Operation: OP1
    - Component: C1, consumed in: OP1

- Navigate to Mrp > Configuration > Operations
- Select OP1 and select another BoM
- return to the BoM of “P1”

Problem:
The BoM line for component "P1" is still linked to OP1,
And a traceback when attempting to duplicate the BoM.

Solution:
Remove the operation from the initial BOM lines

opw-3948817