### PR TITLE
[FIX] google_calendar: duplicated event 'all day'

### DIFF
--- a/addons/google_calendar/models/google_sync.py
+++ b/addons/google_calendar/models/google_sync.py
@@ -82,12 +82,25 @@ class GoogleSync(models.AbstractModel):
             for vals in vals_list:
                 vals.update({'need_sync': False})
         records = super().create(vals_list)
+        self._handle_allday_recurrences_edge_case(records, vals_list)
 
         google_service = GoogleCalendarService(self.env['google.service'])
         records_to_sync = records.filtered(lambda r: r.need_sync and r.active)
         for record in records_to_sync:
             record.with_user(record._get_event_user())._google_insert(google_service, record._google_values(), timeout=3)
         return records
+
+    def _handle_allday_recurrences_edge_case(self, records, vals_list):
+        """
+        When creating 'All Day' recurrent event, the first event is wrongly synchronized as
+        a single event and then its recurrence creates a duplicated event. We must manually
+        set the 'need_sync' attribute as False in order to avoid this unwanted behavior.
+        """
+        if vals_list and self._name == 'calendar.event':
+            forbid_sync = all(not vals.get('need_sync', True) for vals in vals_list)
+            records_to_skip = records.filtered(lambda r: r.need_sync and r.allday and r.recurrency and not r.recurrence_id)
+            if forbid_sync and records_to_skip:
+                records_to_skip.with_context(send_updates=False).need_sync = False
 
     def unlink(self):
         """We can't delete an event that is also in Google Calendar. Otherwise we would


### PR DESCRIPTION
Before this commit, recurrent events created with the 'All Day' option were duplicating the first event of the recurrence in Google side. This was happening because we wrongly synchronized the single event with Google before the synchronization of its recurrence (which already synchronize the events in Google side itself).

After this commit, the recurrence is created normally using the 'All Day' option. We achieve that by skipping the useless synchronization we were doing in the single event: only the recurrence must be synchronized in this specific flow.

task-3768121