### PR TITLE
[FIX] payment: Fix for payment method field

### DIFF
--- a/addons/payment/models/payment_method.py
+++ b/addons/payment/models/payment_method.py
@@ -10,7 +10,7 @@ class PaymentMethod(models.Model):
     _description = "Payment Method"
     _order = 'active desc, sequence, name'
 
-    name = fields.Char(string="Name", required=True)
+    name = fields.Char(string="Name", required=True, translate=True)
     code = fields.Char(
         string="Code", help="The technical code of this payment method.", required=True
     )


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
```
When making a payment on the website, the payment method selection values do not translate to the language set in the website, other than English.

This issue occurs in version 17.0.
```

**Steps to reproduce:**

1. Install the payment module.

2. Set another language on the website (e.g., French).

3. Go to the website, add some products to the cart, and proceed to checkout.

4. On the payment page, in the "Choose a payment method" section, add a payment provider if not already set. Then check if it translated in language set in website.


In version 16.0, the name of payment method was coming from `payment provider` model [ref](https://github.com/odoo/odoo/blob/c8d270c33a032f7c0e872e99b55e977e687edad9/addons/payment/models/payment_provider.py#L24)

Whereas in version 17.0,  the name of payment method was coming from `payment method` model [ref](https://github.com/odoo/odoo/blob/c8d270c33a032f7c0e872e99b55e977e687edad9/addons/payment/models/payment_method.py#L13)

Current behavior before PR:

`Before fix`

![Odoo-Wire-Transfer](https://github.com/odoo/odoo/assets/145324044/65193cba-5b9f-477c-b818-d3cfd894129c)

`After fix`

![Odoo-Wire-Transfer_17](https://github.com/odoo/odoo/assets/145324044/b9a11322-d331-4a65-b5ee-fb8c29f77bab)

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
