### PR TITLE
[IMP] delivery: update hs_code field help text and pot files

### DIFF
--- a/addons/delivery/models/product_template.py
+++ b/addons/delivery/models/product_template.py
@@ -9,7 +9,7 @@ class ProductTemplate(models.Model):
 
     hs_code = fields.Char(
         string="HS Code",
-        help="Standardized code for international shipping and goods declaration. At the moment, only used for the FedEx shipping provider.",
+        help="Standardized code for international shipping and goods declaration. At the moment, only used for FedEx and USPS shipping providers.",
     )
     country_of_origin = fields.Many2one(
         'res.country',

--- a/odoo/addons/base/i18n/base.pot
+++ b/odoo/addons/base/i18n/base.pot
@@ -26282,7 +26282,7 @@ msgstr ""
 
 #. module: base
 #: model:ir.module.module,description:base.module_delivery_usps
-msgid "Send your shippings through USPS and track them online"
+msgid "This is the legacy integration with USPS. Please install the new \"United States Postal Service (USPS) Shipping\" module and uninstall this one as soon as possible."
 msgstr ""
 
 #. module: base
@@ -29782,7 +29782,7 @@ msgstr ""
 
 #. module: base
 #: model:ir.module.module,shortdesc:base.module_delivery_usps
-msgid "United States Postal Service (USPS) Shipping"
+msgid "United States Postal Service (USPS) Shipping (Legacy)"
 msgstr ""
 
 #. module: base


### PR DESCRIPTION
Since HS Code field is now also used in USPS connector, the help text of `hs_code` field on `product_template` needs to be updated. Also the POT file containing module titles and descriptions is updated.

Enterprise PR: odoo/enterprise#63289

Task-3759325

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
