### PR TITLE
[FIX] hr_holidays: fix test

### DIFF
--- a/addons/hr_holidays/tests/test_access_rights.py
+++ b/addons/hr_holidays/tests/test_access_rights.py
@@ -753,12 +753,12 @@ class TestAccessRightsUnlink(TestHrHolidaysAccessRightsCommon):
             'holiday_status_id': self.leave_type.id,
             'state': 'confirm',
         }
-        leave = self.request_leave(self.user_employee_id, datetime.now() + relativedelta(days=-4), 1, values)
         with freeze_time('2024-5-23 13:00:00'):
             other_leave = self.request_leave(self.user_employee_id, datetime.now() + relativedelta(hours=-4), 1, values)
             other_leave.with_user(self.user_employee.id).unlink()
-        with self.assertRaises(UserError), self.cr.savepoint():
-            leave.with_user(self.user_employee.id).unlink()
+            leave = self.request_leave(self.user_employee_id, datetime.now() + relativedelta(days=-4), 1, values)
+            with self.assertRaises(UserError), self.cr.savepoint():
+                leave.with_user(self.user_employee.id).unlink()
 
     def test_leave_unlink_validate_by_user(self):
         """ A simple user cannot delete its leave in validate state"""


### PR DESCRIPTION
In the test we create one leave with freezetime and one without. That cause leave overlap.

This commit fixes it and both leaves are created
with freezetime

