### PR TITLE
[FIX] l10n_it[_edi_withholding]: split payment vat error

### DIFF
--- a/addons/l10n_it/models/account_tax.py
+++ b/addons/l10n_it/models/account_tax.py
@@ -57,8 +57,8 @@ class AccountTax(models.Model):
         return None
 
     def _l10n_it_filter_kind(self, kind):
-        """ This can be overridden by l10n_it_edi_withholding for different kind of taxes (withholding, pension_fund)."""
-        return self if kind == 'vat' else self.env['account.tax']
+        """ Filters taxes depending on _l10n_it_get_tax_kind. """
+        return self.filtered(lambda tax: tax._l10n_it_get_tax_kind() == kind)
 
     def _l10n_it_is_split_payment(self):
         """ Split payment means that the Public Administration buyer will pay VAT

--- a/addons/l10n_it_edi_withholding/models/account_tax.py
+++ b/addons/l10n_it_edi_withholding/models/account_tax.py
@@ -91,10 +91,6 @@ class AccountTax(models.Model):
                 or (self.l10n_it_pension_fund_type and 'pension_fund')
                 or super()._l10n_it_get_tax_kind())
 
-    def _l10n_it_filter_kind(self, kind):
-        """ Filters taxes depending on _l10n_it_get_tax_kind. """
-        return self.filtered(lambda tax: tax._l10n_it_get_tax_kind() == kind)
-
     @api.constrains('amount', 'l10n_it_withholding_type', 'l10n_it_withholding_reason', 'l10n_it_pension_fund_type')
     def _validate_withholding(self):
         for tax in self:


### PR DESCRIPTION
With an IT Company setup but without the withholding module:
- Set fiscal position to split payment
- Set tax on product to SP type tax
- Click send and print to generate XML

Error: XML generation is blocked with message
"Invoices must have exactly one VAT tax set per line"

This occurs because the system find 2 VAT taxes, but only the positive one should count for the validation

Ticket [link](https://www.odoo.com/web#model=project.task&id=3945046)
opw-3945046
