### PR TITLE
[FIX] account: chart template when no country

### DIFF
--- a/addons/account/models/chart_template.py
+++ b/addons/account/models/chart_template.py
@@ -165,7 +165,11 @@ class AccountChartTemplate(models.AbstractModel):
         if not self.env.is_system():
             raise AccessError(_("Only administrators can install chart templates"))
 
-        module_name = self._get_chart_template_mapping()[template_code].get('module')
+        chart_template_mapping = self._get_chart_template_mapping()[template_code]
+        if not company.country_id:
+            company.country_id = chart_template_mapping.get('country_id')
+
+        module_name = chart_template_mapping.get('module')
         module = self.env['ir.module.module'].search([('name', '=', module_name), ('state', '=', 'uninstalled')])
         if module:
             module.button_immediate_install()

--- a/addons/account/tests/test_chart_template.py
+++ b/addons/account/tests/test_chart_template.py
@@ -871,3 +871,14 @@ class TestChartTemplate(TransactionCase):
         self.assertEqual(2, len(accounts))
         self.assertEqual(self.env.ref('account.account_tag_investing'), accounts[0].tag_ids)
         self.assertEqual({'Test account tag', 'Test account tag 2'}, set(accounts[1].tag_ids.mapped("name")))
+
+    def test_chart_template_company_without_country(self):
+        """
+            In this test we will try to install a chart template to a company without a country. The expected behavior
+            is that the country of the chart template will be set on the company
+        """
+        company = self.env['res.company'].create({'name': 'Test Company Without country'})
+        self.assertFalse(company.country_id)
+        with patch.object(AccountChartTemplate, '_get_chart_template_data', side_effect=test_get_data, autospec=True):
+            self.env['account.chart.template'].try_loading('test', company=company, install_demo=False)
+        self.assertEqual(company.country_id.code, "BE")


### PR DESCRIPTION
Before this commit, when creating a company and directly installing a chart template without putting a country first, the installation of the chart template was giving a traceback.
By updating the country of the company by the one of the chart template, the issues will not happen again.

task: 3945833




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
