### PR TITLE
[FIX] bus: fix websocket rate limiting tests with noble

### DIFF
--- a/addons/bus/tests/test_websocket_rate_limiting.py
+++ b/addons/bus/tests/test_websocket_rate_limiting.py
@@ -18,6 +18,9 @@ class TestWebsocketRateLimiting(WebsocketCase):
     def test_rate_limiting_base_ok(self):
         ws = self.websocket_connect()
 
+        # slepeing after initial ping frame
+        time.sleep(Websocket.RL_DELAY)
+
         for _ in range(Websocket.RL_BURST + 1):
             ws.send(json.dumps({'event_name': 'test_rate_limiting'}))
             time.sleep(Websocket.RL_DELAY)
@@ -44,14 +47,17 @@ class TestWebsocketRateLimiting(WebsocketCase):
     def test_rate_limiting_opening_burst(self):
         ws = self.websocket_connect()
 
-        # first RL_BURST requests are accepted.
-        for _ in range(Websocket.RL_BURST):
-            ws.send(json.dumps({'event_name': 'test_rate_limiting'}))
+        # slepeing after initial ping frame
+        time.sleep(Websocket.RL_DELAY)
 
-        # sending at a correct rate after burst should be accepted.
-        for _ in range(2):
-            time.sleep(Websocket.RL_DELAY)
-            ws.send(json.dumps({'event_name': 'test_rate_limiting'}))
+        # burst is allowed
+        for _ in range(Websocket.RL_BURST // 2):
+            ws.send(json.dumps({"event_name": "test_rate_limiting"}))
+
+        # as long as the rate is respected afterwards
+        for _ in range(Websocket.RL_BURST):
+            time.sleep(Websocket.RL_DELAY * 2)
+            ws.send(json.dumps({"event_name": "test_rate_limiting"}))
 
     def test_rate_limiting_start_ok_end_ko(self):
         def check_end_ko():


### PR DESCRIPTION
Ubuntu Noble (24.04) now provides [python3-websocket 1.7.0](https://packages.ubuntu.com/noble/python3-websocket). The websocket rate limiting tests asserts that an exception occurs when the code 1013 is returned because this code was not supported in [python3-websocket 1.2.3](https://packages.ubuntu.com/jammy/python3-websocket) provided by Ubuntu Jammy (22.04).

Support was added in [websocket 1.3.0](https://github.com/websocket-client/websocket-client/commit/a28a016584f82cfca30a09a59ecd764569c2fa3f)
With this commit, presence of the status code in the lib is verified and the test is adapted accordingly.

