### PR TITLE
[FIX] pdf: avoid filling malformed PDF

### DIFF
--- a/odoo/tools/pdf.py
+++ b/odoo/tools/pdf.py
@@ -123,11 +123,16 @@ def fill_form_fields_pdf(writer, form_fields):
         if is_upper_version_pypdf2:
             writer.update_page_form_field_values(page, form_fields)
         else:
-            # This is a known bug on previous version of PyPDF2, fixed in 2.11
+            # Known bug on previous versions of PyPDF2, fixed in 2.11
             if not page.get('/Annots'):
                 _logger.info("No fields to update in this page")
             else:
-                writer.updatePageFormFieldValues(page, form_fields)
+                try:
+                    writer.updatePageFormFieldValues(page, form_fields)
+                except ValueError:
+                    # Known bug on previous versions of PyPDF2 for some PDFs, fixed in 2.4.2
+                    _logger.info("Fields couldn't be filled in this page.")
+                    continue
 
         for raw_annot in page.get('/Annots', []):
             annot = raw_annot.getObject()


### PR DESCRIPTION
Currently, when trying to merge a PDF generated from Google sheet in the PDF quote builder, a traceback happens due to a known problem in older versions of pypdf2. This was fixed in pypdf2 2.4.2 (see: https://github.com/py-pdf/pypdf/commit/02c601c86819578d9796479a1b8953accefea92b ) 

It doesn't seem to happen with other editors, and google sheet doesn't allow the use of form fields anyway.

