### PR TITLE
[FIX] repair: take SO lines from default template

### DIFF
--- a/addons/repair/models/repair.py
+++ b/addons/repair/models/repair.py
@@ -350,7 +350,9 @@ class Repair(models.Model):
                 "warehouse_id": self.picking_type_id.warehouse_id.id,
                 "repair_order_ids": [Command.link(repair.id)],
             })
-        self.env['sale.order'].create(sale_order_values_list)
+        sale_orders = self.env['sale.order'].create(sale_order_values_list)
+        for so in sale_orders:
+            so._onchange_sale_order_template_id()
         # Add Sale Order Lines for 'add' move_ids
         self.move_ids._create_repair_sale_order_line()
         return self.action_view_sale_order()


### PR DESCRIPTION
Problem
---
When creating a sale order from a repair order, if a default quotation template is defined in the settings, its lines are not taken into account.
This happens because the `onchange` that implements the corresponding logic is not called since we create the SO before opening the form.

Steps
---
* create a quotation template with at least 1 line
* set it as the default template
* create a repair order
* create a sale order with the button on the repair order form ==> the line does not appear on the sale order

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
