### PR TITLE
[FIX] point_of_sale: prevent error when changing product tracking

### DIFF
--- a/addons/point_of_sale/static/src/app/store/models.js
+++ b/addons/point_of_sale/static/src/app/store/models.js
@@ -424,14 +424,16 @@ export class Orderline extends PosModel {
         this.set_full_product_name();
         this.id = json.server_id || json.id || orderline_id++;
         orderline_id = Math.max(this.id + 1, orderline_id);
-        var pack_lot_lines = json.pack_lot_ids;
-        for (var i = 0; i < pack_lot_lines.length; i++) {
-            var packlotline = pack_lot_lines[i][2];
-            var pack_lot_line = new Packlotline(
-                { env: this.env },
-                { json: { ...packlotline, order_line: this } }
-            );
-            this.pack_lot_lines.add(pack_lot_line);
+        if (this.has_product_lot) {
+            var pack_lot_lines = json.pack_lot_ids;
+            for (var i = 0; i < pack_lot_lines.length; i++) {
+                var packlotline = pack_lot_lines[i][2];
+                var pack_lot_line = new Packlotline(
+                    { env: this.env },
+                    { json: { ...packlotline, order_line: this } }
+                );
+                this.pack_lot_lines.add(pack_lot_line);
+            }
         }
         this.tax_ids = json.tax_ids && json.tax_ids.length !== 0 ? json.tax_ids[0][2] : undefined;
         this.set_customer_note(json.customer_note);


### PR DESCRIPTION
Before this commit, an error occurred in the following scenario:

- Open Point of Sale and sell a product with lot tracking
- Close/Post the Point of Sale session
- Open the product record and disable tracking in the inventory tab
- Start a new session, click on Orders and sort for Paid orders

opw-3921893

---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
