### PR TITLE
[FIX] web,website: resolve wrongly set default color of color palette

### DIFF
--- a/addons/web/static/src/core/colorpicker/colorpicker.js
+++ b/addons/web/static/src/core/colorpicker/colorpicker.js
@@ -94,9 +94,10 @@ export class Colorpicker extends Component {
                 // `inOwnerDocument`).
                 return;
             }
-            if (newProps.selectedColor) {
-                this.setSelectedColor(newProps.selectedColor);
-            }
+            const newSelectedColor = newProps.selectedColor
+                ? newProps.selectedColor
+                : newProps.defaultColor;
+            this.setSelectedColor(newSelectedColor);
         });
         onWillDestroy(() => {
             this.destroy();
@@ -122,7 +123,10 @@ export class Colorpicker extends Component {
         this.$opacitySlider = this.$el.find(".o_opacity_slider");
         this.$opacitySliderPointer = this.$el.find(".o_opacity_pointer");
 
-        const rgba = convertCSSColorToRgba(this.props.defaultColor);
+        const defaultCssColor = this.props.selectedColor
+            ? this.props.selectedColor
+            : this.props.defaultColor;
+        const rgba = convertCSSColorToRgba(defaultCssColor);
         if (rgba) {
             this._updateRgba(rgba.red, rgba.green, rgba.blue, rgba.opacity);
         }

--- a/addons/website/static/tests/tours/colorpicker.js
+++ b/addons/website/static/tests/tours/colorpicker.js
@@ -1,0 +1,69 @@
+/** @odoo-module **/
+
+import wTourUtils from "@website/js/tours/tour_utils";
+
+function selectColorpickerSwitchPanel(type) {
+    return [
+        {
+            content: "Select text snippet",
+            trigger: "iframe #wrap .s_text_block",
+        },
+        {
+            content: "Click on background-color option",
+            trigger: ".o_we_so_color_palette[data-css-property='background-color']",
+        },
+        {
+            content: "Select type of colorpicker in switch panel",
+            trigger: `.o_we_colorpicker_switch_pane_btn[data-target="${type}"]`,
+        },
+    ]
+}
+
+function checkBackgroundColorWithRGBA(red, green, blue) {
+    return [
+        {
+            content: "Check if the RGBA color matches the selected color",
+            trigger: ".o_rgba_div",
+            run: ({ tip_widget }) => {
+                const rgbaEl = tip_widget.$anchor[0];
+                const red_color = rgbaEl.querySelector(".o_red_input").value;
+                const green_color = rgbaEl.querySelector(".o_green_input").value;
+                const blue_color = rgbaEl.querySelector(".o_blue_input").value;
+                if (red_color != red || green_color != green || blue_color != blue) {
+                    console.error("There may be a problem with the RGBA colorpicker");
+                }
+            }
+        },
+    ]
+}
+
+wTourUtils.registerWebsitePreviewTour("website_background_colorpicker", {
+    test: true,
+    edition: true,
+    url: "/",
+}, () => [
+    wTourUtils.dragNDrop({
+        id: "s_text_block",
+        name: "Text",
+    }),
+    ...selectColorpickerSwitchPanel("gradients"),
+    {
+        content: "Select first gradient element",
+        trigger: ".o_colorpicker_section .o_we_color_btn[data-color='linear-gradient(135deg, rgb(255, 204, 51) 0%, rgb(226, 51, 255) 100%)']",
+    },
+    ...wTourUtils.clickOnSave(),
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    ...selectColorpickerSwitchPanel("gradients"),
+    ...checkBackgroundColorWithRGBA("255", "204", "51"),
+    ...wTourUtils.clickOnSave(),
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    ...selectColorpickerSwitchPanel("custom-colors"),
+    {
+        content: "Select first custom color element",
+        trigger: ".o_colorpicker_section .o_we_color_btn[style='background-color:#65435C;']",
+    },
+    ...wTourUtils.clickOnSave(),
+    ...wTourUtils.clickOnEditAndWaitEditMode(),
+    ...selectColorpickerSwitchPanel("custom-colors"),
+    ...checkBackgroundColorWithRGBA("101", "67", "92"),
+]);

--- a/addons/website/tests/test_ui.py
+++ b/addons/website/tests/test_ui.py
@@ -494,6 +494,9 @@ class TestUi(odoo.tests.HttpCase):
     def test_31_website_edit_megamenu_big_icons_subtitles(self):
         self.start_tour(self.env['website'].get_client_action_url('/'), 'edit_megamenu_big_icons_subtitles', login='admin')
 
+    def test_32_website_background_colorpicker(self):
+        self.start_tour(self.env['website'].get_client_action_url("/"), "website_background_colorpicker", login="admin")
+
     def test_website_media_dialog_image_shape(self):
         self.start_tour("/", 'website_media_dialog_image_shape', login='admin')
 


### PR DESCRIPTION
Steps to reproduce:
1. Take any snippet and select any custom gradient color.
2. Reopen the background color
- The selected custom gradient color is not retained as expected.

Before version 16, we used wysiwyg, which called the start function to set selected colors easily. In version 17, we switched to OwlJS. Now, color picker always setting the default color as selected color. Therefore, it displays the default color instead of the selected color.

![image](https://github.com/odoo/odoo/assets/157009134/5068b12e-3bcf-4c92-b12a-9af5447f07d0)

After this PR, the selected color will be set in the start function by replacing the default color, and updating RGBA values accordingly.

![image](https://github.com/odoo/odoo/assets/157009134/7ba81d39-157f-4e62-8d29-12d8d76c652c)

Task-3631963