### PR TITLE
[FIX] mass_mailing: give fallback body value when user schedule a mail without body

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -1056,7 +1056,7 @@ class MassMailing(models.Model):
             composer_values = {
                 'author_id': author_id,
                 'attachment_ids': [(4, attachment.id) for attachment in mailing.attachment_ids],
-                'body': mailing._prepend_preview(mailing.body_html, mailing.preview),
+                'body': mailing._prepend_preview(mailing.body_html or '', mailing.preview),
                 'subject': mailing.subject,
                 'model': mailing.mailing_model_real,
                 'email_from': mailing.email_from,


### PR DESCRIPTION
This traceback occurs when the user schedules a mail without a `Mail Body` in email marketing.

To reproduce this issue:

1) Install `mass_mail`
2) Create new mailings with `contact_list_ids` and make sure to give
    the value for `preview` in the settings page.
3) Don't select any `Mail Body` templates.
4) Schedule the record with the `previous day`.
5) An Error was encountered in the terminal.

Error:- 
```
TypeError: expected string or bytes-like object
```

A corn job runs when the user `schedules` a mail, in which `action_send_mail` triggers.

In that method while composing values, `body` is used to get values from `mail.body_html`.

https://github.com/odoo/odoo/blob/e37c393d415d686584487f9ad92f062279504cf8/addons/mass_mailing/models/mailing.py#L1043-L1046

Because when the user doesn't select the body template its value will be `false` which leads to the above traceback,
as the `re.search` method is used between preview and body.

https://github.com/odoo/odoo/blob/e37c393d415d686584487f9ad92f062279504cf8/odoo/tools/mail.py#L500

This commit will resolve the issue by giving a fallback value of empty string when the user doesn't select the body template.

sentry-5983589884