### PR TITLE
[FIX] sale_stock: clean action context

### DIFF
--- a/addons/sale_stock/models/sale_order.py
+++ b/addons/sale_stock/models/sale_order.py
@@ -225,7 +225,9 @@ class SaleOrder(models.Model):
             picking_id = picking_id[0]
         else:
             picking_id = pickings[0]
-        action['context'] = dict(self._context, default_partner_id=self.partner_id.id, default_picking_type_id=picking_id.picking_type_id.id, default_origin=self.name, default_group_id=picking_id.group_id.id)
+        # View context from sale_renting `rental_schedule_view_form`
+        cleaned_context = {k: v for k, v in self._context.items() if k != 'form_view_ref'}
+        action['context'] = dict(cleaned_context, default_partner_id=self.partner_id.id, default_picking_type_id=picking_id.picking_type_id.id, default_origin=self.name, default_group_id=picking_id.group_id.id)
         return action
 
     def _prepare_invoice(self):


### PR DESCRIPTION
**Current behavior:**
Using the Delivery smart button in a rental order and then clicking on a picking listed causes a traceback in some flows.

**Expected behavior:**
The picking form opens.

**Steps to reproduce:**
*Install sale_stock_renting*
1. Create a new rental order with some rental product and at least 2 storable products

2. Confirm the order and go to the Schedule overview

3. Click on the new order and then on the stock picking smart button (Delivery)

4. Click on any of the pickings listed in the tree view -> Traceback

**Cause of the issue:**
We load the rental order from the Schedule view with some "form_view_ref" context. We still have this context once we navigate to the picking tree view and it results in the incorrect view being loaded and model fields being accessed which don't exist.

**Fix:**
Clean the context in the action before serving the new view.

opw-3813524