### PR TITLE
[FIX] base: make the company partners accessible to branches

### DIFF
--- a/addons/purchase/models/purchase_order.py
+++ b/addons/purchase/models/purchase_order.py
@@ -88,8 +88,8 @@ class PurchaseOrder(models.Model):
     date_order = fields.Datetime('Order Deadline', required=True, index=True, copy=False, default=fields.Datetime.now,
         help="Depicts the date within which the Quotation should be confirmed and converted into a purchase order.")
     date_approve = fields.Datetime('Confirmation Date', readonly=True, index=True, copy=False)
-    partner_id = fields.Many2one('res.partner', string='Vendor', required=True, change_default=True, tracking=True, domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", help="You can find a vendor by its Name, TIN, Email or Internal Reference.")
-    dest_address_id = fields.Many2one('res.partner', domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]", string='Dropship Address',
+    partner_id = fields.Many2one('res.partner', string='Vendor', required=True, change_default=True, tracking=True, check_company=True, help="You can find a vendor by its Name, TIN, Email or Internal Reference.")
+    dest_address_id = fields.Many2one('res.partner', check_company=True, string='Dropship Address',
         help="Put an address if you want to deliver directly from the vendor to the customer. "
              "Otherwise, keep empty to deliver to your own company.")
     currency_id = fields.Many2one('res.currency', 'Currency', required=True,

--- a/addons/purchase_requisition/models/purchase_requisition.py
+++ b/addons/purchase_requisition/models/purchase_requisition.py
@@ -49,7 +49,7 @@ class PurchaseRequisition(models.Model):
     name = fields.Char(string='Reference', required=True, copy=False, default='New', readonly=True)
     origin = fields.Char(string='Source Document')
     order_count = fields.Integer(compute='_compute_orders_number', string='Number of Orders')
-    vendor_id = fields.Many2one('res.partner', string="Vendor", domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]")
+    vendor_id = fields.Many2one('res.partner', string="Vendor", check_company=True)
     type_id = fields.Many2one('purchase.requisition.type', string="Agreement Type", required=True, default=_get_type_id)
     ordering_date = fields.Date(string="Ordering Date", tracking=True)
     date_end = fields.Datetime(string='Agreement Deadline', tracking=True)

--- a/addons/sale/models/sale_order.py
+++ b/addons/sale/models/sale_order.py
@@ -63,7 +63,7 @@ class SaleOrder(models.Model):
         string="Customer",
         required=True, change_default=True, index=True,
         tracking=1,
-        domain="[('company_id', 'in', (False, company_id))]")
+        check_company=True)
     state = fields.Selection(
         selection=SALE_ORDER_STATE,
         string="Status",
@@ -139,14 +139,14 @@ class SaleOrder(models.Model):
         string="Invoice Address",
         compute='_compute_partner_invoice_id',
         store=True, readonly=False, required=True, precompute=True,
-        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        check_company=True,
         index='btree_not_null')
     partner_shipping_id = fields.Many2one(
         comodel_name='res.partner',
         string="Delivery Address",
         compute='_compute_partner_shipping_id',
         store=True, readonly=False, required=True, precompute=True,
-        domain="['|', ('company_id', '=', False), ('company_id', '=', company_id)]",
+        check_company=True,
         index='btree_not_null')
 
     fiscal_position_id = fields.Many2one(

--- a/addons/sale/tests/test_sale_prices.py
+++ b/addons/sale/tests/test_sale_prices.py
@@ -436,7 +436,7 @@ class TestSalePrices(SaleCommon):
         # product_1.currency != so currency
         # product_2.cost_currency_id = so currency
         sales_order = product_1_ctxt.with_context(mail_notrack=True, mail_create_nolog=True).env['sale.order'].create({
-            'partner_id': self.env.user.partner_id.id,
+            'partner_id': user_in_other_company.partner_id.id,
             'pricelist_id': pricelist.id,
             'order_line': [
                 Command.create({
@@ -463,7 +463,7 @@ class TestSalePrices(SaleCommon):
         # product_2.cost_currency_id != so currency
         pricelist.currency_id = main_curr
         sales_order = product_1_ctxt.with_context(mail_notrack=True, mail_create_nolog=True).env['sale.order'].create({
-            'partner_id': self.env.user.partner_id.id,
+            'partner_id': user_in_other_company.partner_id.id,
             'pricelist_id': pricelist.id,
             'order_line': [
                 # Verify discount is considered in create hack

--- a/addons/test_mail/tests/test_mail_template.py
+++ b/addons/test_mail/tests/test_mail_template.py
@@ -221,7 +221,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
         """ Test 'send_email' on template in batch """
         self.env.invalidate_all()
         mails = self.env['mail.mail'].sudo()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(934):  # test_mail: 934
+        with self.with_user(self.user_employee.login), self.assertQueryCount(935):  # test_mail: 935
             template = self.test_template.with_env(self.env)
             for record in self.test_records_batch:
                 mails += mails.browse(template.send_mail(record.id))
@@ -317,7 +317,7 @@ class TestMailTemplateLanguages(TestMailTemplateCommon):
 
         self.env.invalidate_all()
         mails = self.env['mail.mail'].sudo()
-        with self.with_user(self.user_employee.login), self.assertQueryCount(52):
+        with self.with_user(self.user_employee.login), self.assertQueryCount(53):
             template = self.test_template.with_env(self.env)
             for record in self.test_records:
                 mails += mails.browse(

--- a/addons/test_mail/tests/test_performance.py
+++ b/addons/test_mail/tests/test_performance.py
@@ -163,7 +163,7 @@ class TestBaseMailPerformance(BaseMailPerformance):
         records = self.env['mail.performance.thread'].search([])
         self.assertEqual(len(records), 5)
 
-        with self.assertQueryCount(admin=2, demo=2):
+        with self.assertQueryCount(admin=3, demo=3):
             # without cache
             for record in records:
                 record.partner_id.country_id.name
@@ -406,7 +406,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, _test_template = self._create_test_records()
         customer = self.env['res.partner'].browse(self.customer.ids)
         attachments = self.env['ir.attachment'].with_user(self.env.user).create(self.test_attachments_vals)
-        with self.assertQueryCount(admin=7, employee=7):
+        with self.assertQueryCount(admin=8, employee=8):
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -527,7 +527,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_template.write({'attachment_ids': [(5, 0)]})
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=35, employee=35):  # tm 23/23 / com 33/33
+        with self.assertQueryCount(admin=36, employee=36):  # tm 23/23 / com 33/33
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -557,7 +557,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         test_record, test_template = self._create_test_records()
 
         customer = self.env['res.partner'].browse(self.customer.ids)
-        with self.assertQueryCount(admin=35, employee=35):  # tm 23/23 / com 32/32
+        with self.assertQueryCount(admin=36, employee=36):  # tm 23/23 / com 32/32
             composer_form = Form(
                 self.env['mail.compose.message'].with_context({
                     'default_composition_mode': 'comment',
@@ -595,7 +595,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
         # use another user already pre-defined with the email notification type,
         # so the ormcache is preserved.
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=42, employee=42):
+        with self.assertQueryCount(admin=43, employee=42):
             record.write({
                 'user_id': self.user_test_email.id,
             })
@@ -604,7 +604,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
     @warmup
     def test_message_assignation_inbox(self):
         record = self.env['mail.test.track'].create({'name': 'Test'})
-        with self.assertQueryCount(admin=23, employee=23):
+        with self.assertQueryCount(admin=24, employee=23):
             record.write({
                 'user_id': self.user_test_inbox.id,
             })
@@ -643,7 +643,7 @@ class TestBaseAPIPerformance(BaseMailPerformance):
             for idx in range(10)
         ])
 
-        with self.assertQueryCount(admin=2, employee=2):
+        with self.assertQueryCount(admin=3, employee=2):
             records._message_log_with_view(
                 'test_mail.mail_template_simple_test',
                 render_values={'partner': self.customer.with_env(self.env)}
@@ -901,7 +901,7 @@ class TestMailAPIPerformance(BaseMailPerformance):
         template = self.env.ref('test_mail.mail_test_container_tpl')
 
         # about 20 (19 ?) queries per additional customer group
-        with self.assertQueryCount(admin=69, employee=68):
+        with self.assertQueryCount(admin=70, employee=68):
             record.message_post_with_source(
                 template,
                 message_type='comment',
@@ -1269,7 +1269,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
         """
         messages_all = self.messages_all.with_env(self.env)
 
-        with self.assertQueryCount(employee=26):
+        with self.assertQueryCount(employee=27):
             res = messages_all.message_format()
 
         self.assertEqual(len(res), 2*2)
@@ -1282,7 +1282,7 @@ class TestMailFormattersPerformance(BaseMailPerformance):
     def test_message_format_single(self):
         message = self.messages_all[0].with_env(self.env)
 
-        with self.assertQueryCount(employee=23):
+        with self.assertQueryCount(employee=24):
             res = message.message_format()
 
         self.assertEqual(len(res), 1)

--- a/addons/test_mail_sms/tests/test_sms_performance.py
+++ b/addons/test_mail_sms/tests/test_sms_performance.py
@@ -119,7 +119,7 @@ class TestSMSMassPerformance(BaseMailPerformance, sms_common.MockSMS):
             'mass_keep_log': False,
         })
 
-        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=54):
+        with self.mockSMSGateway(sms_allow_unlink=True), self.assertQueryCount(employee=55):
             composer.action_send_sms()
 
     @mute_logger('odoo.addons.sms.models.sms_sms')

--- a/addons/website_sale/tests/test_sale_process.py
+++ b/addons/website_sale/tests/test_sale_process.py
@@ -244,8 +244,8 @@ class TestWebsiteSaleCheckoutAddress(TransactionCaseWithUserDemo, HttpCaseWithUs
         self.env.user.company_id = self.company_a
 
         self.demo_user = self.user_demo
-        self.demo_user.company_ids += self.company_c
-        self.demo_user.company_id = self.company_c
+        self.demo_user.company_ids += self.company_b
+        self.demo_user.company_id = self.company_b
         self.demo_partner = self.demo_user.partner_id
 
         self.portal_user = self.user_portal
@@ -275,7 +275,7 @@ class TestWebsiteSaleCheckoutAddress(TransactionCaseWithUserDemo, HttpCaseWithUs
             # 2. Logged in user/internal user, should not edit name or email address of billing
             self.default_address_values['partner_id'] = self.demo_partner.id
             self.WebsiteSaleController.address(**self.default_billing_address_values)
-            self.assertEqual(self.demo_partner.company_id, self.company_c, "Logged in user edited billing (the partner itself) should not get its company modified.")
+            self.assertEqual(self.demo_partner.company_id, self.company_b, "Logged in user edited billing (the partner itself) should not get its company modified.")
             self.assertNotEqual(self.demo_partner.name, self.default_address_values['name'], "Employee cannot change their name during the checkout process.")
             self.assertNotEqual(self.demo_partner.email, self.default_address_values['email'], "Employee cannot change their email during the checkout process.")
 

--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -168,6 +168,7 @@ class Partner(models.Model):
     _order = "complete_name ASC, id DESC"
     _rec_names_search = ['complete_name', 'email', 'ref', 'vat', 'company_registry']  # TODO vat must be sanitized the same way for storing/searching
     _allow_sudo_commands = False
+    _check_company_domain = models.check_company_domain_parent_of
 
     # the partner types that must be added to a partner's complete name, like "Delivery"
     _complete_name_displayed_types = ('invoice', 'delivery', 'other')

--- a/odoo/addons/base/security/base_security.xml
+++ b/odoo/addons/base/security/base_security.xml
@@ -16,7 +16,7 @@
             the multi-company rule because it might interfere with the user's company rule
             and make some users unselectable in relational fields. This means that partners
             of internal users are always visible, not matter the company setting. -->
-            <field name="domain_force">['|', ('partner_share', '=', False), ('company_id', 'in', company_ids + [False])]</field>
+            <field name="domain_force">['|', '|', ('partner_share', '=', False), ('company_id', 'parent_of', company_ids), ('company_id', '=', False)]</field>
         </record>
 
         <record model="ir.rule" id="res_partner_portal_public_rule">

--- a/odoo/addons/base/tests/test_res_partner.py
+++ b/odoo/addons/base/tests/test_res_partner.py
@@ -736,6 +736,26 @@ class TestPartnerAddressCompany(TransactionCase):
         res_bhide = test_partner_bhide.with_context(show_address=1, address_inline=1).display_name
         self.assertEqual(res_bhide, "Atmaram Bhide", "name should contain only name if address is not available, without extra commas")
 
+    def test_accessibility_of_company_partner_from_branch(self):
+        """ Check accessibility of company partner from branch. """
+        company = self.env['res.company'].create({'name': 'company'})
+        branch = self.env['res.company'].create({
+            'name': 'branch',
+            'parent_id': company.id
+        })
+        partner = self.env['res.partner'].create({
+            'name': 'partner',
+            'company_id': company.id
+        })
+        user = self.env['res.users'].create({
+            'name': 'user',
+            'login': 'user',
+            'company_id': branch.id,
+            'company_ids': [branch.id]
+        })
+        record = self.env['res.partner'].with_user(user).search([('id', '=', partner.id)])
+        self.assertEqual(record.id, partner.id)
+
 
 @tagged('res_partner', 'post_install', '-at_install')
 class TestPartnerForm(TransactionCase):

--- a/odoo/addons/test_performance/tests/test_performance.py
+++ b/odoo/addons/test_performance/tests/test_performance.py
@@ -55,7 +55,7 @@ class TestPerformance(SavepointCaseWithUserDemo):
         records = self.env['test_performance.base'].search([])
         self.assertEqual(len(records), 5)
 
-        with self.assertQueryCount(__system__=2, demo=2):
+        with self.assertQueryCount(__system__=3, demo=3):
             # without cache
             for record in records:
                 record.partner_id.country_id.name


### PR DESCRIPTION
Linked enterprise PR: https://github.com/odoo/enterprise/pull/63589

### Steps to reproduce:
- Create a company and a branch
- Create a contact and assign him to the company created
- Switch to the branch and go to the Contact app
- You can't see the contact created

### Cause:
The rule 'res.partner company' does not allow branches to see partners from the parent company.

### Solution:
Change the rule to make partners accessible to branches.
This solution implies changing access rules defined in base to use the 'parent_of' operator. By changing it, I removed a performance improvement introduced in this commit: https://github.com/odoo/odoo/commit/c18b9f44be3d666ca1e082807a2fdfc7ef2049d2. So I needed to change performance tests counting queries to make them pass.

opw-3927295
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
