### PR TITLE
[FIX] project: remove the 'Assignees' from the 'Sort By:' list in portal view

### DIFF
--- a/addons/project/controllers/portal.py
+++ b/addons/project/controllers/portal.py
@@ -40,7 +40,7 @@ class ProjectCustomerPortal(CustomerPortal):
         searchbar_groupby = self._task_get_searchbar_groupby()
 
         # default sort by value
-        if not sortby:
+        if not sortby or sortby not in searchbar_sortings:
             sortby = 'date'
         order = searchbar_sortings[sortby]['order']
 
@@ -270,7 +270,6 @@ class ProjectCustomerPortal(CustomerPortal):
             'date': {'label': _('Newest'), 'order': 'create_date desc', 'sequence': 1},
             'name': {'label': _('Title'), 'order': 'name', 'sequence': 2},
             'project': {'label': _('Project'), 'order': 'project_id, stage_id', 'sequence': 3},
-            'users': {'label': _('Assignees'), 'order': 'user_ids', 'sequence': 4},
             'stage': {'label': _('Stage'), 'order': 'stage_id, project_id', 'sequence': 5},
             'status': {'label': _('Status'), 'order': 'kanban_state', 'sequence': 6},
             'priority': {'label': _('Priority'), 'order': 'priority desc', 'sequence': 7},
@@ -378,7 +377,7 @@ class ProjectCustomerPortal(CustomerPortal):
             })
 
         # default sort by value
-        if not sortby:
+        if not sortby or sortby not in searchbar_sortings:
             sortby = 'date'
         order = searchbar_sortings[sortby]['order']
 


### PR DESCRIPTION
Remove the 'user_ids' field (Assignees) from the 'Sort By:' options in the
portal view. Since the 'user_ids' field is non-storable, So it cannot be used
for sorting.

To fix this, We have to remove the  'Assignees' from the 'Sort  By:'
list, This involves removing the following option from a dictionary
```'users': {'label': _('Assignees'), 'order': 'user_ids', 'sequence': 4},```
which is returned by  '_task_get_searchbar_sortings'  at [2].

link[2]: https://github.com/odoo/odoo/blob/84333c4fa1382edae188dc05f9837a9992798046/addons/project/controllers/portal.py#L273

sentry - 5405089817
