### PR TITLE
[FIX] product: assign seller depending on variant value

### DIFF
--- a/addons/product/models/product_product.py
+++ b/addons/product/models/product_product.py
@@ -631,7 +631,8 @@ class ProductProduct(models.Model):
     #=== BUSINESS METHODS ===#
 
     def _prepare_sellers(self, params=False):
-        return self.seller_ids.filtered(lambda s: s.partner_id.active).sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
+        sellers = self.seller_ids.filtered(lambda s: s.partner_id.active and (not s.product_id or s.product_id == self))
+        return sellers.sorted(lambda s: (s.sequence, -s.min_qty, s.price, s.id))
 
     def _get_filtered_sellers(self, partner_id=False, quantity=0.0, date=None, uom_id=False, params=False):
         self.ensure_one()

--- a/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
+++ b/addons/sale_purchase_stock/tests/test_sale_purchase_stock_flow.py
@@ -143,3 +143,71 @@ class TestSalePurchaseStockFlow(TransactionCase):
         so_2.action_confirm()
         po = self.env['purchase.order'].search([('partner_id', '=', self.vendor.id), ('state', '!=', 'cancel')], limit=1)
         self.assertFalse(po)
+
+    def test_sale_need_purchase_variants(self):
+        """
+        MTO+Buy product with two variants P1 and P2 with a different vendor.
+        Create a SO with 2 lines, one for each variant: 2 PO should be created.
+        """
+
+        att_color = self.env['product.attribute'].create({
+            'name': 'Color',
+            'value_ids': [
+                Command.create({'name': 'red', 'sequence': 1}),
+                Command.create({'name': 'blue', 'sequence': 2}),
+            ],
+        })
+        product_template = self.env['product.template'].create({
+            'name': 'SuperProduct',
+            'route_ids': [Command.set((self.mto_route + self.buy_route).ids)],
+            'attribute_line_ids': [
+                Command.create({
+                    'attribute_id': att_color.id,
+                    'value_ids': att_color.value_ids.ids,
+                }),
+            ],
+        })
+        red_product, blue_product = product_template.product_variant_ids
+        red_vendor, blue_vendor = self.env['res.partner'].create([
+            {'name': 'Super red vendor'},
+            {'name': 'Super blue vendor'},
+        ])
+        self.env['product.supplierinfo'].create([
+            {
+                'product_id': red_product.id,
+                'partner_id': red_vendor.id,
+                'price': 5,
+            },
+            {
+                'product_id': blue_product.id,
+                'partner_id': blue_vendor.id,
+                'price': 10,
+            },
+        ])
+        so = self.env['sale.order'].create({
+            'partner_id': self.customer.id,
+            'order_line': [
+                Command.create({
+                    'name': red_product.name,
+                    'product_id': red_product.id,
+                    'product_uom_qty': 2,
+                    'product_uom': red_product.uom_id.id,
+                    'price_unit': 20,
+                }),
+                Command.create({
+                    'name': blue_product.name,
+                    'product_id': blue_product.id,
+                    'product_uom_qty': 3,
+                    'product_uom': blue_product.uom_id.id,
+                    'price_unit': 30,
+                }),
+            ],
+        })
+        so.action_confirm()
+
+        red_po = self.env['purchase.order'].search([('partner_id', '=', red_vendor.id)], limit=1)
+        self.assertTrue(red_po)
+        self.assertRecordValues(red_po.order_line, [{'product_id': red_product.id, 'product_uom_qty': 2, 'price_unit': 5}])
+        blue_po = self.env['purchase.order'].search([('partner_id', '=', blue_vendor.id)], limit=1)
+        self.assertTrue(blue_po)
+        self.assertRecordValues(blue_po.order_line, [{'product_id': blue_product.id, 'product_uom_qty': 3, 'price_unit': 10}])


### PR DESCRIPTION
### Steps to reproduce:
- Enable multi-step routes in the settings
- Go to Invertory > Configuration > Warehouse Management > Routes
- Unarchive MTO
- Create a product: - Routes: MTO + Buy route - Variants: Color > Black, White
- In the purchase tab of the product create two lines with: - Vendor 1 sells the Black variant - Vendor 2 sells the White variant
- Create and confirm a sale order with 2 lines: - 1 x Black variant - 1 x White variant

### Expected behavior:

Two purchase order should be created:

- 1 x Black variant sold by Vendor 1
- 1 x White variant sold by Vendor 2

### Current behavior:

Only one purchase order is created so that Vendor 1 as the seller of both procurements even thought vendor 2 is the only real potential seller of the white variant.

### Cause of the issue:

Running the procurements of both lines of the Sale order will trigger the `_run_buy` method which will determine the seller by "default": https://github.com/odoo/odoo/blob/3383d5bd68bfc13b7881f72e5adbb7c27a6df30e/addons/purchase_stock/models/stock_rule.py#L70-L72 using the `_prepare_sellers` method. However, it relies solely on the `seller_ids` field of the `product.template` model https://github.com/odoo/odoo/blob/3383d5bd68bfc13b7881f72e5adbb7c27a6df30e/addons/product/models/product_product.py#L633-L634 Since both variants have the same template they will therefore both be associated with the same default seller.

opw-3940786
---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
