### PR TITLE
[FIX] spreadsheet: use_global_filter visibility

### DIFF
--- a/addons/spreadsheet/static/src/pivot/pivot_actions.js
+++ b/addons/spreadsheet/static/src/pivot/pivot_actions.js
@@ -1,12 +1,12 @@
 /** @odoo-module */
-import { getFirstPivotFunction, getNumberOfPivotFormulas } from "./pivot_helpers";
+import { getNumberOfPivotFormulas } from "./pivot_helpers";
 
 export const SEE_RECORDS_PIVOT = async (position, env) => {
     const pivotId = env.model.getters.getPivotIdFromPosition(position);
     const { model } = env.model.getters.getPivotDefinition(pivotId);
     const dataSource = await env.model.getters.getAsyncPivotDataSource(pivotId);
 
-    const argsDomain = env.model.getters.getPivotDomainArgsFromPosition(position);
+    const argsDomain = env.model.getters.getPivotDomainArgsFromPosition(position)?.domainArgs;
     const domain = dataSource.getPivotCellDomain(argsDomain);
     const name = await dataSource.getModelLabel();
     await env.services.action.doAction({
@@ -26,7 +26,7 @@ export const SEE_RECORDS_PIVOT = async (position, env) => {
 export const SEE_RECORDS_PIVOT_VISIBLE = (position, env) => {
     const cell = env.model.getters.getCorrespondingFormulaCell(position);
     const evaluatedCell = env.model.getters.getEvaluatedCell(position);
-    const argsDomain = env.model.getters.getPivotDomainArgsFromPosition(position);
+    const argsDomain = env.model.getters.getPivotDomainArgsFromPosition(position)?.domainArgs;
     const pivotId = env.model.getters.getPivotIdFromPosition(position);
     if (!env.model.getters.isExistingPivot(pivotId)) {
         return false;
@@ -55,26 +55,22 @@ export function SET_FILTER_MATCHING_CONDITION(position, env) {
     if (!SEE_RECORDS_PIVOT_VISIBLE(position, env)) {
         return false;
     }
-    const cell = env.model.getters.getCorrespondingFormulaCell(position);
 
     const pivotId = env.model.getters.getPivotIdFromPosition(position);
-    const domainArgs = env.model.getters.getPivotDomainArgsFromPosition(position);
-    if (domainArgs === undefined) {
+    const pivotInfo = env.model.getters.getPivotDomainArgsFromPosition(position);
+    if (pivotInfo?.domainArgs === undefined) {
         return false;
     }
-    const matchingFilters = env.model.getters.getFiltersMatchingPivotArgs(pivotId, domainArgs);
-    const pivotFunction = getFirstPivotFunction(cell.compiledFormula.tokens).functionName;
-    return (
-        (pivotFunction === "ODOO.PIVOT" ||
-            pivotFunction === "ODOO.PIVOT.HEADER" ||
-            pivotFunction === "ODOO.PIVOT.TABLE") &&
-        matchingFilters.length > 0
+    const matchingFilters = env.model.getters.getFiltersMatchingPivotArgs(
+        pivotId,
+        pivotInfo?.domainArgs
     );
+    return pivotInfo?.isHeader && matchingFilters.length > 0;
 }
 
 export function SET_FILTER_MATCHING(position, env) {
     const pivotId = env.model.getters.getPivotIdFromPosition(position);
-    const domainArgs = env.model.getters.getPivotDomainArgsFromPosition(position);
+    const domainArgs = env.model.getters.getPivotDomainArgsFromPosition(position)?.domainArgs;
     const filters = env.model.getters.getFiltersMatchingPivotArgs(pivotId, domainArgs);
     env.model.dispatch("SET_MANY_GLOBAL_FILTER_VALUE", { filters });
 }

--- a/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
+++ b/addons/spreadsheet/static/src/pivot/plugins/pivot_ui_plugin.js
@@ -242,7 +242,7 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
      * as if it was the individual pivot formula
      *
      * @param {{ col: number, row: number, sheetId: string }} position
-     * @returns {(string | number)[] | undefined}
+     * @returns {{domainArgs: (string | number)[], isHeader: boolean} | undefined}
      */
     getPivotDomainArgsFromPosition(position) {
         const cell = this.getters.getCorrespondingFormulaCell(position);
@@ -272,17 +272,18 @@ export class PivotUIPlugin extends spreadsheet.UIPlugin {
             const pivotCol = position.col - mainPosition.col;
             const pivotRow = position.row - mainPosition.row;
             const pivotCell = pivotCells[pivotCol][pivotRow];
-            const domain = pivotCell.domain;
+            let domain = pivotCell.domain;
             if (domain?.at(-2) === "measure") {
-                return domain.slice(0, -2);
+                domain = domain.slice(0, -2);
             }
-            return domain;
+            return { domainArgs: domain, isHeader: pivotCell.isHeader };
         }
-        const domain = args.slice(functionName === "ODOO.PIVOT" ? 2 : 1);
+        let domain = args.slice(functionName === "ODOO.PIVOT" ? 2 : 1);
         if (domain.at(-2) === "measure") {
-            return domain.slice(0, -2);
+            domain = domain.slice(0, -2);
         }
-        return domain;
+        const isHeader = functionName === "ODOO.PIVOT.HEADER";
+        return { domainArgs: domain, isHeader };
     }
 
     /**


### PR DESCRIPTION
The context menu (and clickable cell) `use_global_filter` should take the value of the underlying pivot formula, and apply it to the matching global filters. This works, but was supposed to work only for `ODOO.PIVOT.HEADER` formulas, and not simple `ODOO.PIVOT` formulas.

This commit fixes the visibility of the `use_global_filter` option in the context menu, so that it is only visible for `ODOO.PIVOT.HEADER`.

Also removed/changed tests that were testing that the menu was visible for positional `ODOO.PIVOT` formulas.

Task: [3714696](https://www.odoo.com/web#id=3714696&cids=1&menu_id=4720&action=333&active_id=2328&model=project.task&view_type=form)

Description of the issue/feature this PR addresses:

Current behavior before PR:

Desired behavior after PR is merged:




---
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
