### PR TITLE
[FIX] hr_holidays: multiple validation and refusal of company leave

### DIFF
--- a/addons/hr_holidays/models/hr_leave_allocation.py
+++ b/addons/hr_holidays/models/hr_leave_allocation.py
@@ -787,7 +787,7 @@ class HolidaysAllocation(models.Model):
 
         self.write({'state': 'refuse', 'approver_id': current_employee.id})
         # If a category that created several holidays, cancel all related
-        linked_requests = self.mapped('linked_request_ids')
+        linked_requests = self.linked_request_ids.filtered(lambda alloc: alloc.state in ['confirm', 'validate'])
         if linked_requests:
             linked_requests.action_refuse()
         self.activity_update()

--- a/addons/hr_holidays/tests/test_allocations.py
+++ b/addons/hr_holidays/tests/test_allocations.py
@@ -53,6 +53,11 @@ class TestAllocations(TestHrHolidaysCommon):
         num_of_allocations = self.env['hr.leave.allocation'].search_count([('employee_id', '=', self.employee.id), ('multi_employee', '=', False)])
         self.assertEqual(num_of_allocations, 1)
 
+        # Refuse, validate and re-refuse to test leave linked to the company holiday
+        company_allocation.action_refuse()
+        company_allocation.action_validate()
+        company_allocation.action_refuse()
+
     def test_allocation_multi_employee(self):
         employee_allocation = self.env['hr.leave.allocation'].create({
             'name': 'Bank Holiday',


### PR DESCRIPTION
Steps to reproduce:
-------------------
- create an allocation using "By Company" mode;
- validate
- refuse
- re-validate
- re-refuse

Issue:
------
An "Invalid Operation" occurs with the message:
```
Allocation request must be confirmed or validated in order to refuse it.
```

Cause:
------
When an allocation is refused and revalidated for an entire company, new allocations are created for employees.
These new allocations will be correctly validated, but the old ones will remain refused.

The `linked_request_ids` field is an `One2many` with no domain. This means that all allocations linked to the company allocation will be returned, both validated and refused.

The result is that we will try to refuse allocations that have already been refused.

Solution:
---------
Filter allocations according to the `state` field
to refuse only validated allocations.

opw-3918829